### PR TITLE
Another adaptation between modern LLVM and Chess

### DIFF
--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -95,6 +95,7 @@ def run_flow(opts, tmpdirname):
           do_call(['sed', '-i', 's/noundef//', file_core_llvmir_chesslinked])
           # Formal function argument names not used in older LLVM
           do_call(['sed', '-i', '-E', '/define .*@/ s/%[0-9]*//g', file_core_llvmir_chesslinked])
+          do_call(['sed', '-i', '-E', 's/mustprogress//g', file_core_llvmir_chesslinked])
           if(opts.xbridge):
             do_call(['xchesscc_wrapper', '-d', '-f', '+P', '4', file_core_llvmir_chesslinked, '+l', file_core_bcf, '-o', file_core_elf])
           else:


### PR DESCRIPTION
Without this patch, chess fails to parse the wrapper-linked LLVM IR of some test cases:
```
Command Output (stdout):
--
Error encountered while running: xchesscc_wrapper -d -f +P 4 acdc_project/core_2_3.chesslinked.ll +l acdc_project/core_2_3.bcf -o ./core_2_3.elf

--
Command Output (stderr):
--
... ...
acdc_project/core_2_3.chesslinked.ll:61:53: error: unterminated attribute group
attributes #0 = { nofree nosync nounwind willreturn mustprogress }
                                                    ^
1 error generated.
xchesscc Failed 
The Program xchesscc has encountered an unexpected error exiting ... xchesscc Failed
```
According to the [LLVM language reference](https://llvm.org/docs/LangRef.html#function-attributes), at least it should be safe to remove this attribute for the regression test cases:
> This attribute indicates that the function is required to return, unwind, or interact with the environment in an observable way e.g. via a volatile memory access, I/O, or other synchronization. The mustprogress attribute is intended to model the requirements of the first section of [intro.progress] of the C++ Standard. As a consequence, a loop in a function with the mustprogress attribute can be assumed to terminate if it does not interact with the environment in an observable way, and terminating loops without side-effects can be removed. If a mustprogress function does not satisfy this contract, the behavior is undefined. This attribute does not apply transitively to callees, but does apply to call sites within the function. **Note that willreturn implies mustprogress.**