### PR TITLE
Improved error message when routing to or from a shim tile with no noc

### DIFF
--- a/lib/AIECreatePathfindFlows.cpp
+++ b/lib/AIECreatePathfindFlows.cpp
@@ -207,7 +207,6 @@ public:
     if(coordToShimMux.count(std::make_pair(col, row))) {
       return coordToShimMux[std::make_pair(col, row)];
     } else {
-      assert(getTile(builder, col, row).isShimNOCTile());
       ShimMuxOp switchboxOp =
         builder.create<ShimMuxOp>(builder.getUnknownLoc(),
                                     getTile(builder, col, row));
@@ -217,6 +216,9 @@ public:
       coordToShimMux[std::make_pair(col, row)] = switchboxOp;
       maxcol = std::max(maxcol, col);
       maxrow = std::max(maxrow, row);
+      // check if the shim tile has noc connection
+      if(!getTile(builder, col, row).isShimNOCTile())
+        switchboxOp.emitError("Attempting to route to or from ShimTile (") << col << ", " << row << "), which has no NOC connection";
       return switchboxOp;
     }
   }


### PR DESCRIPTION
Previously this used assertion which would lead to core dump with little information for debugging. Now it uses MLIR's diagnostic (emitError) for displaying error message. Closes #26 