### PR TITLE
Edits to correctly implement flows to/from ShimDMAs

### DIFF
--- a/lib/AIECreatePathfindFlows.cpp
+++ b/lib/AIECreatePathfindFlows.cpp
@@ -317,7 +317,7 @@ ConvertFlowsToInterconnect(
             shim_ch = (srcChannel == 0 ? 3 : 7); // must be either DMA0 -> N3 or DMA1 -> N7
           else if(srcChannel >= 3) shim_ch = srcChannel + 1;
           addConnection(rewriter, cast<Interconnect>(shimMuxOp.getOperation()), flowOp,
-            srcBundle, srcChannel, WireBundle::North, shim_ch);
+            srcBundle, srcChannel, WireBundle::South, shim_ch);
         }
         for(auto it = s.second.begin(); it != s.second.end(); it++) {
           WireBundle bundle = (*it).first;
@@ -337,7 +337,7 @@ ConvertFlowsToInterconnect(
             addConnection(rewriter, cast<Interconnect>(swOp.getOperation()), flowOp,
               s.first.first, s.first.second, WireBundle::South, shim_ch);
             addConnection(rewriter, cast<Interconnect>(shimMuxOp.getOperation()), flowOp,
-              WireBundle::North, shim_ch, bundle, channel);
+              WireBundle::South, shim_ch, bundle, channel);
           } else {
             // otherwise, regular switchbox connection
             addConnection(rewriter, cast<Interconnect>(swOp.getOperation()), flowOp,

--- a/lib/Targets/AIETargetXAIEV1.cpp
+++ b/lib/Targets/AIETargetXAIEV1.cpp
@@ -722,7 +722,7 @@ static std::string clear_range(int col, int row, int low, int high) {
           // XAieTile_ShimStrmMuxConfig(&(TileInst[col][0]), XAIETILE_SHIM_STRM_MUX_SOUTH3, XAIETILE_SHIM_STRM_MUX_DMA);
           // XAieTile_ShimStrmDemuxConfig(&(TileInst[col][0]), XAIETILE_SHIM_STRM_DEM_SOUTH3, XAIETILE_SHIM_STRM_DEM_DMA);
           for (auto connectOp : b.getOps<ConnectOp>()) {
-            if(connectOp.sourceBundle() == WireBundle::South) {
+            if(connectOp.destBundle() == WireBundle::DMA) {
               // demux!
               output << "XAieTile_ShimStrmDemuxConfig(" <<
                         tileInstStr("x", "y") << ",\n";


### PR DESCRIPTION
Changed pathfinder flow writing from North to South direction and updated the Mux/Demux logic to check for the DMA WireBundle. 