### PR TITLE
Added initial libxaiev2 support.

### DIFF
--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -1,0 +1,747 @@
+//===- AIETargetXAIEV2.cpp --------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Target/LLVMIR/Import.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+#include "mlir/Translation.h"
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/TargetSelect.h"
+
+#include "aie/AIEDialect.h"
+#include "aie/AIENetlistAnalysis.h"
+
+#include "AIETargets.h"
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIE;
+
+namespace xilinx {
+namespace AIE {
+
+static std::string shimDMAInstStr(StringRef col, StringRef index) {
+  std::string str;
+  llvm::raw_string_ostream rss(str);
+  rss << "ShimDMAInst_" << col << "_" << index;
+  return str;
+}
+static std::string tileLocStr(StringRef col, StringRef row) {
+  std::string str;
+  llvm::raw_string_ostream rss(str);
+  rss << "XAie_TileLoc(" << col << "," << row << ")";
+  return str;
+}
+static std::string tileLocStr(int col, int row) {
+  return tileLocStr(std::to_string(col), std::to_string(row));
+}
+static std::string tileDMAInstStr(StringRef col, StringRef row,
+                                  StringRef bdNum) {
+  std::string str;
+  llvm::raw_string_ostream rss(str);
+  rss << "dma_tile" << col << row << "_bd" << bdNum;
+  return str;
+}
+static std::string tileDMAInstStr(int col, int row, int bdNum) {
+  return tileDMAInstStr(std::to_string(col), std::to_string(row),
+                        std::to_string(bdNum));
+}
+static std::string tileDMAInstRefStr(StringRef col, StringRef row,
+                                     StringRef bdNum) {
+  std::string str;
+  llvm::raw_string_ostream rss(str);
+  rss << "&(" << tileDMAInstStr(col, row, bdNum) << ")";
+  return str;
+}
+static std::string tileDMAInstRefStr(int col, int row, int bdNum) {
+  return tileDMAInstRefStr(std::to_string(col), std::to_string(row),
+                           std::to_string(bdNum));
+}
+static std::string tileLockStr(StringRef id, StringRef val) {
+  std::string str;
+  llvm::raw_string_ostream rss(str);
+  // rss << "XAie_Lock(" << id << "," << val << ")";
+  rss << "XAie_LockInit(" << id << "," << val << ")";
+  return str;
+}
+static std::string tileLockStr(int id, int val) {
+  return tileLockStr(std::to_string(id), std::to_string(val));
+}
+static std::string packetStr(StringRef id, StringRef type) {
+  std::string str;
+  llvm::raw_string_ostream rss(str);
+  rss << "XAie_PacketInit(" << id << "," << type << ")";
+  return str;
+}
+static std::string packetStr(int id, int type) {
+  return packetStr(std::to_string(id), std::to_string(type));
+}
+
+mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
+  StringRef enable = "XAIE_ENABLE";
+  StringRef disable = "XAIE_DISABLE";
+  StringRef resetDisable = "XAIE_RESETDISABLE";
+  StringRef deviceInst = "DevInst";       // TODO
+  StringRef deviceInstRef = "&(DevInst)"; // TODO
+
+  DenseMap<std::pair<int, int>, Operation *> tiles;
+  DenseMap<Operation *, CoreOp> cores;
+  DenseMap<Operation *, MemOp> mems;
+  DenseMap<std::pair<Operation *, int>, LockOp> locks;
+  DenseMap<Operation *, SmallVector<BufferOp, 4>> buffers;
+  DenseMap<Operation *, SwitchboxOp> switchboxes;
+
+  NetlistAnalysis NL(module, tiles, cores, mems, locks, buffers, switchboxes);
+  NL.collectTiles(tiles);
+  NL.collectBuffers(buffers);
+
+  //---------------------------------------------------------------------------
+  // mlir_configure_cores
+  //---------------------------------------------------------------------------
+  output << "void mlir_configure_cores() {\n";
+  // Reset each core.  Load the corresponding ELF file, if necessary.
+  for (auto tileOp : module.getOps<TileOp>()) {
+    int col = tileOp.colIndex();
+    int row = tileOp.rowIndex();
+    if (tileOp.isShimTile()) {
+      // Resets no needed with V2 kernel driver
+    } else {
+      // Resets no needed with V2 kernel driver
+      if (auto coreOp = tileOp.getCoreOp()) {
+        std::string fileName;
+        if (auto fileAttr = coreOp->getAttrOfType<StringAttr>("elf_file")) {
+          fileName = std::string(fileAttr.getValue());
+        } else {
+          fileName = std::string("core_") + std::to_string(col) + "_" +
+                     std::to_string(row) + ".elf";
+        }
+        output << "{\n"
+               << "AieRC RC = XAie_LoadElf(" << deviceInstRef << ", "
+               << tileLocStr(col, row) << ", "
+               << "(const char*)\"" << fileName << "\",0);\n";
+        output << "if (RC != XAIE_OK)\n"
+               << "    printf(\"Failed to load elf for Core[%d,%d], ret is "
+                  "%d\\n\", "
+               << std::to_string(col) << ", " << std::to_string(row)
+               << ", RC);\n"
+               << "assert(RC == XAIE_OK);\n"
+               << "}\n";
+      }
+    }
+  }
+  output << "} // mlir_configure_cores\n\n";
+
+  //---------------------------------------------------------------------------
+  // mlir_start_cores
+  //---------------------------------------------------------------------------
+  output << "void mlir_start_cores() {\n";
+  // Start execution of all the cores.
+  for (auto tileOp : module.getOps<TileOp>()) {
+    int col = tileOp.colIndex();
+    int row = tileOp.rowIndex();
+    if (!tileOp.isShimTile()) {
+      output << "XAie_CoreUnreset(" << deviceInstRef << ", "
+             << tileLocStr(col, row) << ");\n";
+      output << "XAie_CoreEnable(" << deviceInstRef << ", "
+             << tileLocStr(col, row) << ");\n";
+    }
+  }
+  output << "} // mlir_start_cores\n\n";
+
+  //---------------------------------------------------------------------------
+  // mlir_configure_dmas
+  //---------------------------------------------------------------------------
+  output << "void mlir_configure_dmas() {\n";
+
+  // DMA configuration
+  // AieRC XAie_DmaDescInit(XAie_DevInst *DevInst, XAie_DmaDesc *DmaDesc,
+  // XAie_LocType Loc); AieRC XAie_DmaSetLock(XAie_DmaDesc *DmaDesc, XAie_Lock
+  // Acq, XAie_Lock Rel); AieRC XAie_DmaSetPkt(XAie_DmaDesc *DmaDesc,
+  // XAie_Packet Pkt); AieRC XAie_DmaSetOutofOrderBdId(XAie_DmaDesc *DmaDesc, u8
+  // OutofOrderBdId); AieRC XAie_DmaSetDoubleBuffer(XAie_DmaDesc *DmaDesc, u64
+  // Addr, XAie_Lock Acq, XAie_Lock Rel); AieRC XAie_DmaSetAddrLen(XAie_DmaDesc
+  // *DmaDesc, u64 Addr, u32 Len); AieRC XAie_DmaSetMultiDimAddr(XAie_DmaDesc
+  // *DmaDesc, XAie_DmaTensor *Tensor, u64 Addr, u32 Len); AieRC
+  // XAie_DmaEnableCompression(XAie_DmaDesc *DmaDesc); AieRC
+  // XAie_DmaSetNextBd(XAie_DmaDesc *DmaDesc, u8 NextBd, u8 EnableNextBd); AieRC
+  // XAie_DmaEnableBd(XAie_DmaDesc *DmaDesc); AieRC
+  // XAie_DmaDisableBd(XAie_DmaDesc *DmaDesc); AieRC XAie_DmaSetAxi(XAie_DmaDesc
+  // *DmaDesc, u8 Smid, u8 BurstLen, u8 Qos,u8 Cache, u8 Secure); AieRC
+  // XAie_DmaSetInterleaveEnable(XAie_DmaDesc *DmaDesc, u8 DoubleBuff, u8
+  // IntrleaveCount, u16 IntrleaveCurr); AieRC XAie_DmaWriteBd(XAie_DevInst
+  // *DevInst, XAie_DmaDesc *DmaDesc, XAie_LocType Loc, u8 BdNum);
+
+  // AieRC XAie_DmaChannelResetAll(XAie_DevInst *DevInst, XAie_LocType Loc,
+  // XAie_DmaChReset Reset); AieRC XAie_DmaChannelReset(XAie_DevInst *DevInst,
+  // XAie_LocType Loc, u8 ChNum, XAie_DmaDirection Dir, XAie_DmaChReset Reset);
+  // AieRC XAie_DmaChannelPauseStream(XAie_DevInst *DevInst, XAie_LocType Loc,
+  // u8 ChNum, XAie_DmaDirection Dir, u8 Pause); AieRC
+  // XAie_DmaChannelPauseMem(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum
+  // XAie_DmaDirection Dir, u8 Pause); AieRC XAie_DmaChannelConfig(XAie_DevInst
+  // *DevInst, XAie_DmaDesc *DmaDesc, XAie_LocType Loc, u8 ChNum,
+  // XAie_DmaDirection Dir, u8 RepeatCount, u8 EnTokenIssue, u8 ControllerId);
+  // AieRC XAie_DmaChannelPushBdToQueue(XAie_DevInst *DevInst, XAie_LocType Loc,
+  // u8 ChNum, XAie_DmaDirection Dir, u8 BdNum); AieRC
+  // XAie_DmaChannelEnable(XAie_DevInst *DevInst, XAie_LocType Loc, u8 ChNum,
+  // XAie_DmaDirection Dir); AieRC XAie_DmaChannelDisable(XAie_DevInst *DevInst,
+  // XAie_LocType Loc, u8 ChNum, XAie_DmaDirection Dir);
+  for (auto memOp : module.getOps<MemOp>()) {
+    int col = memOp.colIndex();
+    int row = memOp.rowIndex();
+    // Reset not needed with V2 kernel driver
+
+    DenseMap<Block *, int> blockMap;
+
+    {
+      // Assign each block a BD number
+      int bdNum = 0;
+      for (auto &block : memOp.body()) {
+        if (!block.getOps<DMABDOp>().empty()) {
+          blockMap[&block] = bdNum;
+          bdNum++;
+        }
+      }
+    }
+    for (auto &block : memOp.body()) {
+      bool foundBdPacket = false;
+      int packetType = 0;
+      int packetID = 0;
+      bool foundBd = false;
+      int lenA = 0;
+      int lenB = 0;
+      int bytesA = 0;
+      int bytesB = 0;
+      int offsetA = 0;
+      int offsetB = 0;
+      int BaseAddrA = 0;
+      int BaseAddrB = 0;
+      bool hasA = false;
+      bool hasB = false;
+      StringRef bufA = "0";
+      StringRef bufB = "0";
+      StringRef AbMode = disable;
+      StringRef FifoMode = disable; // FIXME: when to enable FIFO mode?
+      for (auto op : block.getOps<DMABDOp>()) {
+        foundBd = true;
+        ShapedType bufferType =
+            op.buffer().getType().cast<::mlir::MemRefType>();
+        if (op.isA()) {
+          BaseAddrA = NL.getBufferBaseAddress(op.buffer().getDefiningOp());
+          lenA = op.getLenValue();
+          bytesA = bufferType.getElementTypeBitWidth() / 8;
+          offsetA = op.getOffsetValue();
+          bufA = "XAIEDMA_TILE_BD_ADDRA";
+          hasA = true;
+        }
+        if (op.isB()) {
+          BaseAddrB = NL.getBufferBaseAddress(op.buffer().getDefiningOp());
+          lenB = op.getLenValue();
+          bytesB = bufferType.getElementTypeBitWidth() / 8;
+          offsetB = op.getOffsetValue();
+          bufB = "XAIEDMA_TILE_BD_ADDRB";
+          hasB = true;
+        }
+      }
+
+      if (hasA && hasB) {
+        AbMode = enable;
+        if (lenA != lenB)
+          llvm::errs() << "ABmode must have matching lengths.\n";
+        if (bytesA != bytesB)
+          llvm::errs() << "ABmode must have matching element data types.\n";
+      }
+      int acqValue = 0, relValue = 0;
+      StringRef acqEnable = disable;
+      StringRef relEnable = disable;
+      int lockID;
+      for (auto op : block.getOps<UseLockOp>()) {
+        LockOp lock = dyn_cast<LockOp>(op.lock().getDefiningOp());
+        lockID = lock.getLockID();
+        if (op.acquire()) {
+          acqEnable = enable;
+          acqValue = op.getLockValue();
+        } else if (op.release()) {
+          relEnable = enable;
+          relValue = op.getLockValue();
+        }
+      }
+
+      for (auto op : block.getOps<DMABDPACKETOp>()) {
+        foundBdPacket = true;
+        packetType = op.getPacketType();
+        packetID = op.getPacketID();
+      }
+
+      int bdNum = blockMap[&block];
+      if (foundBd) {
+        // TODO AB mode separated
+
+        // TODO For now, we are going to name each dma desc with loc and bd
+        // which we assume is unique. This is strictly not enforced but in
+        // practice, this is true
+        output << "XAie_DmaDesc " << tileDMAInstStr(col, row, bdNum) << ";\n";
+        output << "XAie_DmaDescInit(" << deviceInstRef << ", "
+               << tileDMAInstRefStr(col, row, bdNum) << ", "
+               << tileLocStr(col, row) << ");\n";
+        output << "XAie_DmaSetLock(" << tileDMAInstRefStr(col, row, bdNum)
+               << ", "
+               << "XAie_LockInit(" << lockID << "," << acqValue << "),"
+               << "XAie_LockInit(" << lockID << "," << relValue << "));\n";
+        output << "XAie_DmaSetAddrLen(" << tileDMAInstRefStr(col, row, bdNum)
+               << ", "
+               << " /* addrA */ "
+               << "0x" << llvm::utohexstr(BaseAddrA + offsetA) << ", "
+               << " /* len */ " << lenA << " * " << bytesA << ");\n";
+
+        if (block.getNumSuccessors() > 0) {
+          Block *nextBlock = block.getSuccessors()[0]; // should have only one
+                                                       // successor block
+          int nextBdNum = blockMap[nextBlock];
+          output << "XAie_DmaSetNextBd(" << tileDMAInstRefStr(col, row, bdNum)
+                 << ", "
+                 << " /* bd */ " << bdNum << ", "
+                 << " /* nextbd */ " << nextBdNum << ");\n";
+        }
+        if (foundBdPacket) {
+          output << "XAie_DmaSetPkt(" << tileDMAInstRefStr(col, row, bdNum)
+                 << ", " << packetStr(packetID, packetType) << ");\n";
+        }
+        output << "XAie_DmaEnableBd(" << tileDMAInstRefStr(col, row, bdNum)
+               << ");\n";
+        output << "XAie_DmaWriteBd(" << deviceInstRef << ", "
+               << tileDMAInstRefStr(col, row, bdNum) << ", "
+               << tileLocStr(col, row) << ", "
+               << " /* bd */ " << bdNum << ");\n";
+      }
+    }
+
+    for (auto &block : memOp.body()) {
+      for (auto op : block.getOps<DMAStartOp>()) {
+        int bdNum = blockMap[op.dest()];
+
+        llvm::StringRef dmaChan = stringifyDMAChan(op.dmaChan());
+        llvm::StringRef dmaDir = dmaChan.substr(0, 4);
+        llvm::StringRef chNum = dmaChan.substr(4, 1);
+
+        output << "XAie_DmaChannelPushBdToQueue(" << deviceInstRef << ", "
+               << tileLocStr(col, row) << ", "
+               << "/* ChNum */" << chNum
+               << ", "
+               // TODO hack until physical dialect changes
+               << "/* dmaDir */ DMA_" << dmaDir << ", "
+               << "/* BdNum */" << bdNum << ");\n";
+        output << "XAie_DmaChannelEnable(" << deviceInstRef << ", "
+               << tileLocStr(col, row) << ", "
+               << "/* ChNum */ " << chNum
+               << ", "
+               // TODO hack until physical dialect changes
+               << "/* dmaDir */ DMA_" << dmaDir << ");\n";
+      }
+    }
+  }
+  // ShimDMA Config
+  int index = 0;
+  for (auto op : module.getOps<ShimDMAOp>()) {
+    int col = op.colIndex();
+    int row = op.rowIndex();
+
+    DenseMap<Block *, int> blockMap;
+
+    {
+      // Assign each block a BD number
+      int bdNum = 0;
+      for (auto &block : op.body()) {
+        if (!block.getOps<DMABDOp>().empty()) {
+          blockMap[&block] = bdNum;
+          bdNum++;
+        }
+      }
+    }
+    for (auto &block : op.body()) {
+      bool foundBd = false;
+      int len = 0;
+      uint64_t bytes = 0;
+      uint64_t offset = 0;
+      uint64_t BaseAddr = 0;
+
+      for (auto op : block.getOps<DMABDOp>()) {
+        foundBd = true;
+        len = op.getLenValue();
+        ShapedType bufferType =
+            op.buffer().getType().cast<::mlir::MemRefType>();
+        bytes = bufferType.getElementTypeBitWidth() / 8;
+        BaseAddr = NL.getBufferBaseAddress(op.buffer().getDefiningOp());
+        offset = op.getOffsetValue();
+      }
+
+      int acqValue = 0, relValue = 0;
+      bool hasLock = false;
+      StringRef acqEnable = disable;
+      StringRef relEnable = disable;
+      int lockID = 0;
+      for (auto op : block.getOps<UseLockOp>()) {
+        LockOp lock = dyn_cast<LockOp>(op.lock().getDefiningOp());
+        lockID = lock.getLockID();
+        hasLock = true;
+        if (op.acquire()) {
+          acqEnable = enable;
+          acqValue = op.getLockValue();
+        } else if (op.release()) {
+          relEnable = enable;
+          relValue = op.getLockValue();
+        }
+      }
+
+      int bdNum = blockMap[&block];
+      if (foundBd) {
+        output << "XAie_DmaDescInit(" << deviceInstRef << ", "
+               << tileDMAInstRefStr(col, row, bdNum) << ", "
+               << tileLocStr(col, row) << ");\n";
+
+        if (hasLock)
+          output << "XAie_DmaSetLock(" << tileDMAInstRefStr(col, row, bdNum)
+                 << ", "
+                 << "XAie_LockInit(" << lockID << "," << acqValue << "),"
+                 << "XAie_LockInit(" << lockID << "," << relValue << "));\n";
+        uint64_t address = BaseAddr + offset;
+        output << "XAie_DmaSetAddrLen(" << tileDMAInstRefStr(col, row, bdNum)
+               << ", "
+               << " /* addr */ "
+               << "0x" << llvm::utohexstr(address) << ", "
+               << " /* len */ " << len << " * " << bytes << ");\n";
+
+        output << "XAie_DmaSetAxi(" << deviceInstRef << ", "
+               << "/* smid */ 0, "
+               << "/* burstlen */ 4, "
+               << "/* QoS */ 0 , "
+               << "/* Cache */ 0, "
+               << "/* Secure */ " << enable << ");\n";
+
+        if (block.getNumSuccessors() > 0) {
+          Block *nextBlock = block.getSuccessors()[0]; // should have only one
+                                                       // successor block
+          int nextBdNum = blockMap[nextBlock];
+          // void XAieDma_ShimBdSetNext(XAieDma_Shim *DmaInstPtr, u8
+          // BdNum, u8 NextBd);
+          output << "XAie_DmaSetNextBd(" << tileDMAInstRefStr(col, row, bdNum)
+                 << ", "
+                 << " /* bd */ " << bdNum << ", "
+                 << " /* nextbd */ " << nextBdNum << ");\n";
+        }
+        output << "XAie_DmaEnableBd(" << tileDMAInstRefStr(col, row, bdNum)
+               << ");\n";
+        output << "XAie_DmaWriteBd(" << deviceInstRef << ", "
+               << tileDMAInstRefStr(col, row, bdNum) << ", "
+               << tileLocStr(col, row) << ", "
+               << " /* bd */ " << bdNum << ");\n";
+      }
+    }
+
+    for (auto &block : op.body()) {
+      for (auto op : block.getOps<DMAStartOp>()) {
+        int bdNum = blockMap[op.dest()];
+
+        llvm::StringRef dmaChan = stringifyDMAChan(op.dmaChan());
+        llvm::StringRef dmaDir = dmaChan.substr(0, 4);
+        llvm::StringRef chNum = dmaChan.substr(4, 1);
+
+        output << "XAie_DmaChannelPushBdToQueue(" << deviceInstRef << ", "
+               << tileLocStr(col, row) << ", "
+               << "/* ChNum */" << chNum
+               << ", "
+               // TODO hack until physical dialect changes
+               << "/* dmaDir */ DMA_" << dmaDir << ", "
+               << "/* BdNum */" << bdNum << ");\n";
+        output << "XAie_DmaChannelEnable(" << deviceInstRef << ", "
+               << tileLocStr(col, row) << ", "
+               << "/* ChNum */ " << chNum
+               << ", "
+               // TODO hack until physical dialect changes
+               << "/* dmaDir */ DMA_" << dmaDir << ");\n";
+      }
+    }
+  }
+  output << "} // mlir_configure_dmas\n\n";
+
+  //---------------------------------------------------------------------------
+  // mlir_initialize_locks
+  //---------------------------------------------------------------------------
+  output << "void mlir_initialize_locks() {\n";
+  // Lock configuration
+  for (auto op : module.getOps<UseLockOp>()) {
+    int lockVal = op.getLockValue();
+    int timeOut = op.getTimeout();
+    LockOp lock = dyn_cast<LockOp>(op.lock().getDefiningOp());
+    TileOp tile = dyn_cast<TileOp>(lock.tile().getDefiningOp());
+    int col = tile.colIndex();
+    int row = tile.rowIndex();
+    int lockID = lock.getLockID();
+    if (op.acquire()) {
+      output << "XAie_LockAcquire(" << deviceInstRef << ", "
+             << tileLocStr(col, row) << ", " << tileLockStr(lockID, lockVal)
+             << ", " << timeOut << ");\n";
+    } else if (op.release()) {
+      output << "XAie_LockRelease(" << deviceInstRef << ", "
+             << tileLocStr(col, row) << ", " << tileLockStr(lockID, lockVal)
+             << ", " << timeOut << ");\n";
+    }
+  }
+  output << "} // mlir_initialize_locks\n";
+
+  //---------------------------------------------------------------------------
+  // mlir_configure_switchboxes
+  //---------------------------------------------------------------------------
+  output << "void mlir_configure_switchboxes() {\n";
+  output << "  int x, y;\n";
+
+  // StreamSwitch (switchbox) configuration
+  for (auto switchboxOp : module.getOps<SwitchboxOp>()) {
+    Region &r = switchboxOp.connections();
+    Block &b = r.front();
+    bool isEmpty = b.getOps<ConnectOp>().empty() &&
+                   b.getOps<MasterSetOp>().empty() &&
+                   b.getOps<PacketRulesOp>().empty();
+    bool isParam = false;
+
+    if (isa<TileOp>(switchboxOp.tile().getDefiningOp())) {
+      int col = switchboxOp.colIndex();
+      int row = switchboxOp.rowIndex();
+      if (!isEmpty) {
+        output << "// Core Stream Switch column " << col << " row " << row
+               << "\n";
+        output << "x = " << col << ";\n";
+        output << "y = " << row << ";\n";
+      }
+    } else if (AIE::SelectOp sel = dyn_cast<AIE::SelectOp>(
+                   switchboxOp.tile().getDefiningOp())) {
+      // parameterize streamswitch's configuration
+      isParam = true;
+      HerdOp sourceHerd = dyn_cast<HerdOp>(sel.startHerd().getDefiningOp());
+      std::string sourceHerdName(sourceHerd.name().getValue());
+
+      IterOp iterX = dyn_cast<IterOp>(sel.iterX().getDefiningOp());
+      IterOp iterY = dyn_cast<IterOp>(sel.iterY().getDefiningOp());
+      int startXValue = iterX.getStartValue();
+      int endXValue = iterX.getEndValue();
+      int strideXValue = iterX.getStrideValue();
+      int startYValue = iterY.getStartValue();
+      int endYValue = iterY.getEndValue();
+      int strideYValue = iterY.getStrideValue();
+
+      std::string startX(sourceHerdName + "_X + " +
+                         std::to_string(startXValue));
+      std::string endX(sourceHerdName + "_X + " + std::to_string(endXValue));
+      std::string startY(sourceHerdName + "_Y + " +
+                         std::to_string(startYValue));
+      std::string endY(sourceHerdName + "_Y + " + std::to_string(endYValue));
+
+      output << "for (x = " << startX << "; x < " << endX
+             << "; x += " << strideXValue << ") {\n";
+      output << "for (y = " << startY << "; y < " << endY
+             << "; y += " << strideYValue << ") {\n";
+    }
+
+    for (auto connectOp : b.getOps<ConnectOp>()) {
+      output << "XAie_StrmConnCctEnable(" << deviceInstRef << ", "
+             << tileLocStr("x", "y") << ", "
+             << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
+             << connectOp.sourceIndex() << ", "
+             << stringifyWireBundle(connectOp.destBundle()).upper() << ", "
+             << connectOp.destIndex() << ");\n";
+    }
+
+    for (auto connectOp : b.getOps<MasterSetOp>()) {
+      int mask = 0;
+      int arbiter = -1;
+      for (auto val : connectOp.amsels()) {
+        AMSelOp amsel = dyn_cast<AMSelOp>(val.getDefiningOp());
+        arbiter = amsel.arbiterIndex();
+        int msel = amsel.getMselValue();
+        mask |= (1 << msel);
+      }
+
+      output << "XAie_StrmPktSwMstrPortEnable(" << deviceInstRef << ", "
+             << tileLocStr("x", "y") << ", "
+             << stringifyWireBundle(connectOp.destBundle()).upper() << ", "
+             << connectOp.destIndex() << ", "
+             << "/* drop_header */ "
+             << "XAIE_SS_PKT_DROP_HEADER"
+             << ", " // TODO is this right default???
+             << "/* arbiter */ " << arbiter << ", "
+             << "/* MSelEn */ 1);\n"; // TODO do I need mask instead???
+    }
+
+    for (auto connectOp : b.getOps<PacketRulesOp>()) {
+      int slot = 0;
+      Block &block = connectOp.rules().front();
+      for (auto slotOp : block.getOps<PacketRuleOp>()) {
+        AMSelOp amselOp = dyn_cast<AMSelOp>(slotOp.amsel().getDefiningOp());
+        int arbiter = amselOp.arbiterIndex();
+        int msel = amselOp.getMselValue();
+        output << "XAie_StrmPktSwSlavePortEnable(" << deviceInstRef << ", "
+               << tileLocStr("x", "y") << ", "
+               << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
+               << connectOp.sourceIndex() << ");\n";
+
+        // TODO Need to better define packet id,type used here
+        output << "XAie_StrmPktSwSlaveSlotEnable(" << deviceInstRef << ", "
+               << tileLocStr("x", "y") << ", "
+               << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
+               << connectOp.sourceIndex() << ", "
+               << "/* slot */ " << slot << ", "
+               << "/* packet */ " << packetStr(slotOp.valueInt(), /*type*/ 0)
+               << ", "
+               << "/* mask */ "
+               << "0x" << llvm::utohexstr(slotOp.maskInt()) << ", "
+               << "/* msel */ " << msel << ", "
+               << "/* arbiter */ " << arbiter << ");\n";
+        slot++;
+      }
+    }
+
+    if (isParam) {
+      output << "}\n";
+      output << "}\n";
+    }
+  }
+  for (auto op : module.getOps<ShimMuxOp>()) {
+    Region &r = op.connections();
+    Block &b = r.front();
+    bool isEmpty = b.getOps<ConnectOp>().empty();
+
+    if (isa<TileOp>(op.tile().getDefiningOp())) {
+      int col = op.colIndex();
+      int row = op.rowIndex();
+      if (!isEmpty) {
+        output << "// ShimMux column " << col << " row " << row << "\n";
+        output << "// NOTE ShimMux always connects from the south as "
+               << "directions are defined relative to the tile stream "
+               << "switch\n";
+        output << "x = " << col << ";\n";
+        output << "y = " << row << ";\n";
+      }
+    }
+
+    for (auto connectOp : b.getOps<ConnectOp>()) {
+      if (connectOp.sourceBundle() == WireBundle::North) {
+        // demux!
+        output << "XAie_EnableShimDmaToAieStrmPort(" << deviceInstRef << ", "
+               << tileLocStr("x", "y") << ", "
+               << stringifyWireBundle(connectOp.sourceBundle()).back()
+               << ");\n";
+      } else if (connectOp.destBundle() == WireBundle::North) {
+        // mux
+        output << "XAie_EnableShimAieToDmaStrmPort(" << deviceInstRef << ", "
+               << tileLocStr("x", "y") << ", "
+               << stringifyWireBundle(connectOp.sourceBundle()).back()
+               << ");\n";
+      }
+    }
+  }
+  for (auto switchboxOp : module.getOps<ShimSwitchboxOp>()) {
+    Region &r = switchboxOp.connections();
+    Block &b = r.front();
+    bool isEmpty = b.getOps<ConnectOp>().empty();
+    int col = switchboxOp.col();
+    if (!isEmpty) {
+      output << "// Shim Switch column " << col << "\n";
+    }
+    for (auto connectOp : b.getOps<ConnectOp>()) {
+      output << "XAie_StrmConnCctEnable(" << deviceInstRef << ", "
+             << tileLocStr(col, 0) << ", "
+             << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
+             << connectOp.sourceIndex() << ", "
+             << stringifyWireBundle(connectOp.destBundle()).upper() << ", "
+             << connectOp.destIndex() << ");\n";
+    }
+  }
+
+  output << "} // mlir_configure_switchboxes\n\n";
+
+  //---------------------------------------------------------------------------
+  // Output Buffer Accessors
+  //---------------------------------------------------------------------------
+  for (auto tile : tiles) {
+    Operation *tileOp = tile.second;
+    std::pair<int, int> coord = NL.getCoord(tileOp);
+    int col = coord.first;
+    int row = coord.second;
+    auto loc = tileLocStr(col, row);
+
+    auto bufferAccessor = [&](Optional<TileID> tile, BufferOp buf) {
+      // int32_t mlir_read_buffer_a13(int index) {
+      // void mlir_write_buffer_a13(int index, int32_t value) {
+      std::string bufName(buf.name().getValue());
+      Type t = buf.getType();
+      Type et;
+      std::string typestr;
+      if (auto memrefType = t.dyn_cast<MemRefType>()) {
+        et = memrefType.getElementType();
+        if (et.isInteger(32))
+          typestr = "int32_t";
+        else if (et.isF32())
+          typestr = "float";
+        else {
+          output << "// buffer " << bufName << " with unsupported type " << t
+                 << ";\n";
+          return; // Unsupported type
+        }
+
+      } else {
+        output << "// buffer " << bufName << " with unsupported type " << t
+               << ";\n";
+        return; // Unsupported type
+      }
+
+      output << "const int " << bufName
+             << "_offset = " << NL.getBufferBaseAddress(buf) << ";\n";
+      output << typestr << " mlir_read_buffer_" << bufName << "(int index) {\n";
+      output << "u32 value; auto rc = XAie_DataMemRdWord(" << deviceInstRef
+             << ", " << loc << ", " << bufName
+             << "_offset + (index*4), &value);\n";
+      if (et.isInteger(32))
+        output << "  return value;\n";
+      else if (et.isF32()) {
+        output << "  union caster { int32_t i; float f; };\n";
+        output << "  caster c; c.i = value;\n";
+        output << "  return c.f;\n";
+      }
+      output << "}\n";
+      output << "void mlir_write_buffer_" << bufName << "(int index, "
+             << typestr << " value) {\n";
+      if (et.isInteger(32))
+        output << "  int32_t int_value = value;\n";
+      else if (et.isF32()) {
+        output << "  union caster { int32_t i; float f; };\n";
+        output << "  caster c; c.f = value;\n";
+        output << "  int32_t int_value = c.i;\n";
+      }
+      output << "u32 rc =    XAie_DataMemWrWord(" << deviceInstRef << ", "
+             << loc << ", " << bufName << "_offset + (index*4), int_value);\n";
+      output << "}\n";
+    };
+
+    // if(tiles.count(tile.getValue()))
+    for (auto buf : buffers[tileOp])
+      bufferAccessor(coord, buf);
+    // };
+  }
+  return success();
+}
+} // namespace AIE
+} // namespace xilinx

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -322,29 +322,43 @@ SECTIONS
       registry.insert<VectorDialect>();
       registry.insert<LLVM::LLVMDialect>();
     });
-    TranslateFromMLIRRegistration
-    registrationXAIE("aie-generate-xaie", [](ModuleOp module, raw_ostream &output) {
+  TranslateFromMLIRRegistration registrationXAIE(
+      "aie-generate-xaie",
+      [](ModuleOp module, raw_ostream &output) {
         return AIETranslateToXAIEV1(module, output);
-    },
-    [](DialectRegistry &registry) {
-      registry.insert<xilinx::AIE::AIEDialect>();
-      registry.insert<StandardOpsDialect>();
-      registry.insert<memref::MemRefDialect>();
-      registry.insert<VectorDialect>();
-      registry.insert<LLVM::LLVMDialect>();
-    });                
+      },
+      [](DialectRegistry &registry) {
+        registry.insert<xilinx::AIE::AIEDialect>();
+        registry.insert<StandardOpsDialect>();
+        registry.insert<memref::MemRefDialect>();
+        registry.insert<VectorDialect>();
+        registry.insert<LLVM::LLVMDialect>();
+      });
+  TranslateFromMLIRRegistration registrationXAIEv2(
+      "aie-generate-xaiev2",
+      [](ModuleOp module, raw_ostream &output) {
+        return AIETranslateToXAIEV2(module, output);
+      },
+      [](DialectRegistry &registry) {
+        registry.insert<xilinx::AIE::AIEDialect>();
+        registry.insert<StandardOpsDialect>();
+        registry.insert<memref::MemRefDialect>();
+        registry.insert<VectorDialect>();
+        registry.insert<LLVM::LLVMDialect>();
+      });
 
-    TranslateFromMLIRRegistration
-    registrationXJSON("aie-flows-to-json", [](ModuleOp module, raw_ostream &output) {
-      return AIEFlowsToJSON(module, output);
-    },
-    [](DialectRegistry &registry) {
-      registry.insert<xilinx::AIE::AIEDialect>();
-      registry.insert<StandardOpsDialect>();
-      registry.insert<memref::MemRefDialect>();
-      registry.insert<VectorDialect>();
-      registry.insert<LLVM::LLVMDialect>();
-    });                
+  TranslateFromMLIRRegistration registrationXJSON(
+      "aie-flows-to-json",
+      [](ModuleOp module, raw_ostream &output) {
+        return AIEFlowsToJSON(module, output);
+      },
+      [](DialectRegistry &registry) {
+        registry.insert<xilinx::AIE::AIEDialect>();
+        registry.insert<StandardOpsDialect>();
+        registry.insert<memref::MemRefDialect>();
+        registry.insert<VectorDialect>();
+        registry.insert<LLVM::LLVMDialect>();
+      });
   }
 }
 }

--- a/lib/Targets/AIETargets.h
+++ b/lib/Targets/AIETargets.h
@@ -13,6 +13,8 @@
 namespace xilinx {
 namespace AIE {
 mlir::LogicalResult AIETranslateToXAIEV1(mlir::ModuleOp module, llvm::raw_ostream &output);
+mlir::LogicalResult AIETranslateToXAIEV2(mlir::ModuleOp module,
+                                         llvm::raw_ostream &output);
 mlir::LogicalResult AIEFlowsToJSON(mlir::ModuleOp module, llvm::raw_ostream &output);
 }
 }

--- a/lib/Targets/CMakeLists.txt
+++ b/lib/Targets/CMakeLists.txt
@@ -8,6 +8,7 @@
 add_mlir_library(AIETargets
   AIETargets.cpp
   AIETargetXAIEV1.cpp
+  AIETargetXAIEV2.cpp
   AIEFlowsToJSON.cpp
   ADDITIONAL_HEADER_DIRS
   ${AIE_BINARY_DIR}/include

--- a/runtime_lib/test_library.cpp
+++ b/runtime_lib/test_library.cpp
@@ -13,6 +13,260 @@
 #include "test_library.h"
 #include <stdio.h>
 
+#ifdef LIBXAIENGINEV2
+
+void ACDC_dump_tile_memory(XAie_DevInst *DevInst, XAie_LocType loc) {
+  int col = loc.Col;
+  int row = loc.Row;
+  for (int i = 0; i < 0x2000; i++) {
+    uint32_t d;
+    AieRC rc = XAie_DataMemRdWord(DevInst, loc, (i * 4), &d);
+    if (rc != XAIE_OK)
+      printf("Tile[%d][%d]: mem[%d] = %d\n", col, row, i, d);
+  }
+}
+
+void ACDC_clear_tile_memory(XAie_DevInst *DevInst, XAie_LocType loc) {
+  int col = loc.Col;
+  int row = loc.Row;
+  for (int i = 0; i < 0x2000; i++) {
+    XAie_DataMemWrWord(DevInst, loc, (i * 4), 0);
+  }
+}
+
+void ACDC_print_dma_status(XAie_DevInst *DevInst, XAie_LocType loc) {
+  int col = loc.Col;
+  int row = loc.Row;
+  u64 tileAddr = _XAie_GetTileAddr(DevInst, row, col);
+
+  u32 dma_mm2s_status;
+  XAie_Read32(DevInst, tileAddr + 0x0001DF10, &dma_mm2s_status);
+  u32 dma_s2mm_status;
+  XAie_Read32(DevInst, tileAddr + 0x0001DF00, &dma_s2mm_status);
+  u32 dma_mm2s0_control;
+  XAie_Read32(DevInst, tileAddr + 0x0001DE10, &dma_mm2s0_control);
+  u32 dma_mm2s1_control;
+  XAie_Read32(DevInst, tileAddr + 0x0001DE18, &dma_mm2s1_control);
+  u32 dma_s2mm0_control;
+  XAie_Read32(DevInst, tileAddr + 0x0001DE00, &dma_s2mm0_control);
+  u32 dma_s2mm1_control;
+  XAie_Read32(DevInst, tileAddr + 0x0001DE08, &dma_s2mm1_control);
+  u32 dma_bd0_a;
+  XAie_Read32(DevInst, tileAddr + 0x0001D000, &dma_bd0_a);
+  u32 dma_bd0_control;
+  XAie_Read32(DevInst, tileAddr + 0x0001D018, &dma_bd0_control);
+
+  u32 s2mm_ch0_running = dma_s2mm_status & 0x3;
+  u32 s2mm_ch1_running = (dma_s2mm_status >> 2) & 0x3;
+  u32 mm2s_ch0_running = dma_mm2s_status & 0x3;
+  u32 mm2s_ch1_running = (dma_mm2s_status >> 2) & 0x3;
+
+  printf("DMA [%d, %d] mm2s_status/0ctrl/1ctrl is %08X %02X %02X, "
+         "s2mm_status/0ctrl/1ctrl is %08X %02X %02X, BD0_Addr_A is %08X, "
+         "BD0_control is %08X\n",
+         col, row, dma_mm2s_status, dma_mm2s0_control, dma_mm2s1_control,
+         dma_s2mm_status, dma_s2mm0_control, dma_s2mm1_control, dma_bd0_a,
+         dma_bd0_control);
+  for (int bd = 0; bd < 8; bd++) {
+    u32 dma_bd_addr_a;
+    XAie_Read32(DevInst, tileAddr + 0x0001D000 + (0x20 * bd), &dma_bd_addr_a);
+    u32 dma_bd_control;
+    XAie_Read32(DevInst, tileAddr + 0x0001D018 + (0x20 * bd), &dma_bd_control);
+    if (dma_bd_control & 0x80000000) {
+      printf("BD %d valid\n", bd);
+      int current_s2mm_ch0 = (dma_s2mm_status >> 16) & 0xf;
+      int current_s2mm_ch1 = (dma_s2mm_status >> 20) & 0xf;
+      int current_mm2s_ch0 = (dma_mm2s_status >> 16) & 0xf;
+      int current_mm2s_ch1 = (dma_mm2s_status >> 20) & 0xf;
+
+      if (s2mm_ch0_running && bd == current_s2mm_ch0) {
+        printf(" * Current BD for s2mm channel 0\n");
+      }
+      if (s2mm_ch1_running && bd == current_s2mm_ch1) {
+        printf(" * Current BD for s2mm channel 1\n");
+      }
+      if (mm2s_ch0_running && bd == current_mm2s_ch0) {
+        printf(" * Current BD for mm2s channel 0\n");
+      }
+      if (mm2s_ch1_running && bd == current_mm2s_ch1) {
+        printf(" * Current BD for mm2s channel 1\n");
+      }
+
+      if (dma_bd_control & 0x08000000) {
+        u32 dma_packet;
+        XAie_Read32(DevInst, tileAddr + 0x0001D010 + (0x20 * bd), &dma_packet);
+        printf("   Packet mode: %02X\n", dma_packet & 0x1F);
+      }
+      int words_to_transfer = 1 + (dma_bd_control & 0x1FFF);
+      int base_address = dma_bd_addr_a & 0x1FFF;
+      printf("   Transfering %d 32 bit words to/from %06X\n", words_to_transfer,
+             base_address);
+
+      printf("   ");
+      for (int w = 0; w < 7; w++) {
+        u32 tmpd;
+        XAie_DataMemRdWord(DevInst, loc, (base_address + w) * 4, &tmpd);
+        printf("%08X ", tmpd);
+      }
+      printf("\n");
+      if (dma_bd_addr_a & 0x40000) {
+        u32 lock_id = (dma_bd_addr_a >> 22) & 0xf;
+        printf("   Acquires lock %d ", lock_id);
+        if (dma_bd_addr_a & 0x10000)
+          printf("with value %d ", (dma_bd_addr_a >> 17) & 0x1);
+
+        printf("currently ");
+        u32 locks;
+        XAie_Read32(DevInst, tileAddr + 0x0001EF00, &locks);
+        u32 two_bits = (locks >> (lock_id * 2)) & 0x3;
+        if (two_bits) {
+          u32 acquired = two_bits & 0x1;
+          u32 value = two_bits & 0x2;
+          if (acquired)
+            printf("Acquired ");
+          printf(value ? "1" : "0");
+        } else
+          printf("0");
+        printf("\n");
+      }
+      if (dma_bd_control & 0x30000000) { // FIFO MODE
+        int FIFO = (dma_bd_control >> 28) & 0x3;
+        u32 dma_fifo_counter;
+        XAie_Read32(DevInst, tileAddr + 0x0001DF20, &dma_fifo_counter);
+        printf("   Using FIFO Cnt%d : %08X\n", FIFO, dma_fifo_counter);
+      }
+    }
+  }
+}
+
+/// Print the status of a core represented by the given tile, at the given
+/// coordinates.
+void ACDC_print_tile_status(XAie_DevInst *DevInst, XAie_LocType loc) {
+  int col = loc.Col;
+  int row = loc.Row;
+  u64 tileAddr = _XAie_GetTileAddr(DevInst, row, col);
+  u32 status, coreTimerLow, PC, LR, SP, locks, R0, R4;
+
+  XAie_Read32(DevInst, tileAddr + 0x032004, &status);
+  XAie_Read32(DevInst, tileAddr + 0x0340F8, &coreTimerLow);
+  XAie_Read32(DevInst, tileAddr + 0x00030280, &PC);
+  XAie_Read32(DevInst, tileAddr + 0x000302B0, &LR);
+  XAie_Read32(DevInst, tileAddr + 0x000302A0, &SP);
+  XAie_Read32(DevInst, tileAddr + 0x0001EF00, &locks);
+  u32 trace_status;
+  XAie_Read32(DevInst, tileAddr + 0x000140D8, &trace_status);
+
+  XAie_Read32(DevInst, tileAddr + 0x00030000, &R0);
+  XAie_Read32(DevInst, tileAddr + 0x00030040, &R4);
+  printf("Core [%d, %d] status is %08X, timer is %u, PC is %08X, locks are "
+         "%08X, LR is %08X, SP is %08X, R0 is %08X,R4 is %08X\n",
+         col, row, status, coreTimerLow, PC, locks, LR, SP, R0, R4);
+  printf("Core [%d, %d] trace status is %08X\n", col, row, trace_status);
+
+  for (int lock = 0; lock < 16; lock++) {
+    u32 two_bits = (locks >> (lock * 2)) & 0x3;
+    if (two_bits) {
+      printf("Lock %d: ", lock);
+      u32 acquired = two_bits & 0x1;
+      u32 value = two_bits & 0x2;
+      if (acquired)
+        printf("Acquired ");
+      printf(value ? "1" : "0");
+      printf("\n");
+    }
+  }
+
+  const char *core_status_strings[] = {"Enabled",
+                                       "In Reset",
+                                       "Memory Stall S",
+                                       "Memory Stall W",
+                                       "Memory Stall N",
+                                       "Memory Stall E",
+                                       "Lock Stall S",
+                                       "Lock Stall W",
+                                       "Lock Stall N",
+                                       "Lock Stall E",
+                                       "Stream Stall S",
+                                       "Stream Stall W",
+                                       "Stream Stall N",
+                                       "Stream Stall E",
+                                       "Cascade Stall Master",
+                                       "Cascade Stall Slave",
+                                       "Debug Halt",
+                                       "ECC Error",
+                                       "ECC Scrubbing",
+                                       "Error Halt",
+                                       "Core Done"};
+  printf("Core Status: ");
+  for (int i = 0; i <= 20; i++) {
+    if ((status >> i) & 0x1)
+      printf("%s ", core_status_strings[i]);
+  }
+  printf("\n");
+}
+
+static void clear_range(XAie_DevInst *DevInst, u64 tileAddr, u64 low,
+                        u64 high) {
+  for (int i = low; i <= high; i += 4) {
+    XAie_Write32(DevInst, tileAddr + i, 0);
+    // int x = XAie_Read32(DevInst,tileAddr+i);
+    // if(x != 0) {
+    //   printf("@%x = %x\n", i, x);
+    //   XAie_Write32(DevInst,tileAddr+i, 0);
+    // }
+  }
+}
+void ACDC_clear_config(XAie_DevInst *DevInst, XAie_LocType loc) {
+  int col = loc.Col;
+  int row = loc.Row;
+  u64 tileAddr = _XAie_GetTileAddr(DevInst, row, col);
+
+  // Put the core in reset first, otherwise bus collisions
+  // result in arm bus errors.
+  // TODO Check if this works
+  XAie_CoreDisable(DevInst, loc);
+
+  // Program Memory
+  clear_range(DevInst, tileAddr, 0x20000, 0x200FF);
+  // TileDMA
+  clear_range(DevInst, tileAddr, 0x1D000, 0x1D1F8);
+  XAie_Write32(DevInst, tileAddr + 0x1DE00, 0);
+  XAie_Write32(DevInst, tileAddr + 0x1DE08, 0);
+  XAie_Write32(DevInst, tileAddr + 0x1DE10, 0);
+  XAie_Write32(DevInst, tileAddr + 0x1DE08, 0);
+  // Stream Switch master config
+  clear_range(DevInst, tileAddr, 0x3F000, 0x3F060);
+  // Stream Switch slave config
+  clear_range(DevInst, tileAddr, 0x3F100, 0x3F168);
+  // Stream Switch slave slot config
+  clear_range(DevInst, tileAddr, 0x3F200, 0x3F3AC);
+
+  // TODO Check if this works
+  XAie_CoreEnable(DevInst, loc);
+}
+
+void ACDC_clear_shim_config(XAie_DevInst *DevInst, XAie_LocType loc) {
+  int col = loc.Col;
+  int row = loc.Row;
+  u64 tileAddr = _XAie_GetTileAddr(DevInst, row, col);
+
+  // ShimDMA
+  clear_range(DevInst, tileAddr, 0x1D000, 0x1D13C);
+  XAie_Write32(DevInst, tileAddr + 0x1D140, 0);
+  XAie_Write32(DevInst, tileAddr + 0x1D148, 0);
+  XAie_Write32(DevInst, tileAddr + 0x1D150, 0);
+  XAie_Write32(DevInst, tileAddr + 0x1D158, 0);
+
+  // Stream Switch master config
+  clear_range(DevInst, tileAddr, 0x3F000, 0x3F058);
+  // Stream Switch slave config
+  clear_range(DevInst, tileAddr, 0x3F100, 0x3F15C);
+  // Stream Switch slave slot config
+  clear_range(DevInst, tileAddr, 0x3F200, 0x3F37C);
+}
+
+#else
+
 void ACDC_dump_tile_memory(struct XAieGbl_Tile &tile) {
     int col = tile.ColId;
     int row = tile.RowId;
@@ -214,3 +468,5 @@ void ACDC_clear_shim_config(struct XAieGbl_Tile &tile) {
     // Stream Switch slave slot config
     clear_range(TileAddr, 0x3F200, 0x3F37C);
 }
+
+#endif

--- a/runtime_lib/test_library.h
+++ b/runtime_lib/test_library.h
@@ -14,6 +14,27 @@
 #define ACDC_check(s, r, v, errors) if(r != v) {printf("ERROR %s: %s expected %d, but was %d!\n", s, #r, v, r); errors++;}
 #define ACDC_check_float(s, r, v, errors) if(r != v) {printf("ERROR %s: %s expected %f, but was %f!\n", s, #r, v, r); errors++;}
 
+#ifdef LIBXAIENGINEV2
+
+/// Dump the contents of the memory associated with the given tile.
+void ACDC_dump_tile_memory(XAie_DevInst *DevInst, XAie_LocType loc);
+
+/// Clear the contents of the memory associated with the given tile.
+void ACDC_clear_tile_memory(XAie_DevInst *DevInst, XAie_LocType loc);
+
+/// Print the status of a dma represented by the given tile.
+void ACDC_print_dma_status(XAie_DevInst *DevInst, XAie_LocType loc);
+
+/// Print the status of a core represented by the given tile.
+void ACDC_print_tile_status(XAie_DevInst *DevInst, XAie_LocType loc);
+
+/// Zero out the program and configuration memory of the tile.
+void ACDC_clear_config(XAie_DevInst *DevInst, XAie_LocType loc);
+
+/// Zero out the configuration memory of the shim tile.
+void ACDC_clear_shim_config(XAie_DevInst *DevInst, XAie_LocType loc);
+
+#else
 /// Dump the contents of the memory associated with the given tile.
 void ACDC_dump_tile_memory(struct XAieGbl_Tile &tile);
 
@@ -31,3 +52,4 @@ void ACDC_clear_config(struct XAieGbl_Tile &tile);
 
 /// Zero out the configuration memory of the shim tile.
 void ACDC_clear_shim_config(struct XAieGbl_Tile &tile);
+#endif


### PR DESCRIPTION
These edits and new v2 target file adds initial support for libxaiev2 drivers. Additional changes will be needed to fully enable libxaiev2 as a target. As of now, v1 drivers is targeted by default, but this PR allows v2 driver generation if aie-translate is passed the --aie-generate-xaiev2 option.