### PR TITLE
Canonicalize before going into aie-translate

### DIFF
--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -81,7 +81,8 @@ def run_flow(opts, tmpdirname):
                             '--aie-vector-opt',
                             '--convert-vector-to-llvm',
                             '--convert-memref-to-llvm',
-                            '--convert-std-to-llvm=use-bare-ptr-memref-call-conv', file_core, '-o', file_opt_core])
+                            '--convert-std-to-llvm=use-bare-ptr-memref-call-conv',
+                            '--canonicalize', '--cse', file_core, '-o', file_opt_core])
         file_core_bcf = tmpcorefile(core, "bcf")
         do_call(['aie-translate', file_with_addresses, '--aie-generate-bcf', '--tilecol=%d' % corecol, '--tilerow=%d' % corerow, '-o', file_core_bcf])
         file_core_ldscript = tmpcorefile(core, "ld.script")


### PR DESCRIPTION
Eliminate builtin.unrealized_conversion_cast ops that are causing many errors in the unit tests.