### PR TITLE
[aiecc] Replace poison with undef for chess-linked LLVM IR

### DIFF
--- a/test/unit_tests/18_target_triple/aie.mlir
+++ b/test/unit_tests/18_target_triple/aie.mlir
@@ -1,0 +1,40 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
+// RUN: %run_on_board ./test.elf
+
+// When this IR is lowered to LLVM, the affine.load operation resulting "%val0"
+// is converted to the following LLVM IR due to the "x86_64-unknown-linux-gnu"
+// target triple:
+//    %1 = load i32, i32* @b, align 4
+//    %3 = insertelement <4 x i32> poison, i32 %1, i32 0
+//    %4 = shufflevector <4 x i32> %3, <4 x i32> poison, <4 x i32> zeroinitializer
+//
+// However, the "poison" value cannot be properly handled by xchesscc. This test
+// is intended to test whether the poison->undef replacement in aiecc works
+// correctly.
+
+module attributes {llvm.target_triple = "x86_64-unknown-linux-gnu"}  {
+  %tile32 = AIE.tile(1, 3)
+
+  %buf_a = AIE.buffer(%tile32) {sym_name = "a"} : memref<16xi32>
+  %buf_b = AIE.buffer(%tile32) {sym_name = "b"} : memref<i32>
+
+  %core32 = AIE.core(%tile32)  {
+    %val0 = affine.load %buf_b[] : memref<i32>
+    affine.for %arg0 = 0 to 16 {
+      %val1 = affine.load %buf_a[%arg0] : memref<16xi32>
+      %val2 = addi %val0, %val1 : i32
+      affine.store %val2, %buf_a[%arg0] : memref<16xi32>
+    }
+    AIE.end
+  }
+}

--- a/test/unit_tests/18_target_triple/test.cpp
+++ b/test/unit_tests/18_target_triple/test.cpp
@@ -1,0 +1,81 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2020 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MLIR_STACK_OFFSET 4096
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  ACDC_clear_tile_memory(TileInst[1][3]);
+
+  mlir_configure_cores();
+  mlir_configure_switchboxes();
+  mlir_initialize_locks();
+  mlir_configure_dmas();
+
+  int errors = 0;
+
+  mlir_write_buffer_b(0, 11);
+  ACDC_check("Before memory writes: ", mlir_read_buffer_b(0), 11, errors);
+  ACDC_check("Before memory writes: ", mlir_read_buffer_a(0), 0, errors);
+
+  mlir_start_cores();
+
+  ACDC_check("After memory writes: ", mlir_read_buffer_a(0), 11, errors);
+
+  if (!errors) {
+    printf("PASS!\n");
+    return 0;
+  } else {
+    printf("Fail!\n");
+    return -1;
+  }
+  printf("test done.\n");
+}

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -103,6 +103,7 @@ def run_flow(opts, tmpdirname):
           # Formal function argument names not used in older LLVM
           do_call(['sed', '-i', '-E', '/define .*@/ s/%[0-9]*//g', file_core_llvmir_chesslinked])
           do_call(['sed', '-i', '-E', 's/mustprogress//g', file_core_llvmir_chesslinked])
+          do_call(['sed', '-i', '-E', 's/poison/undef/g', file_core_llvmir_chesslinked])
           if(opts.xbridge):
             link_with_obj = extract_input_files(file_core_bcf)
             do_call(['xchesscc_wrapper', '-d', '-f', '+P', '4', file_core_llvmir_chesslinked, link_with_obj, '+l', file_core_bcf, '-o', file_core_elf])


### PR DESCRIPTION
This is a quick fix to the issue mentioned in #41. The generated executable has been tested on board.