### PR TITLE
Added the ability to extend pathfinder flows to/from PLIO in shim tiles.

### DIFF
--- a/docs/AIERouting.md
+++ b/docs/AIERouting.md
@@ -11,7 +11,7 @@ Define the AIE tiles you want to communicate between. Here Tile (7,1) will be th
 %t72 = AIE.tile(7, 2)
 %t73 = AIE.tile(7, 3)
 ```
-Set up a switchboxes to connect the DMA to the stream:
+Set up a switchboxes to connect the AIE Tile DMA to the stream:
 ```
 %sw71 = AIE.switchbox(%t71) {
 	AIE.connect<"DMA" : 0, "North" : 1>
@@ -19,7 +19,7 @@ Set up a switchboxes to connect the DMA to the stream:
 ```
 The AIE.connect function must exist inside an AIE.switchbox or AIE.shimmux operation. The numbers designate the source and destination channel number of the stream that we are trying to connect.
 
-The switchbox in tile (7,1) connects the DMA channel 0 to North channel 1. If we define a switchbox in tile (7,2) as so:
+The switchbox in tile (7,1) connects the Tile DMA channel 0 to North channel 1. If we define a switchbox in tile (7,2) as so:
  ```
 %sw72 = AIE.switchbox(%t72) {
 	AIE.connect<"South" : 1, "DMA" : 0>
@@ -38,11 +38,14 @@ The stream will automatically be connected, due to the fact that North 1 in tile
 
 as long as we don't have duplicate destinations.
 
-## AIE Shimmux 
+## AIE ShimMux 
 
-Shim tiles are special tiles at row 0 of the AIE array. You can configure a switch in the Shim tile using 'shimmux' in addition to the switchbox operations:
+Shim tiles are special tiles at row 0 of the AIE array. There are two variants of Shim tiles, Shim NoC tile and Shim PL tile. You can connect to the device's PL through PLIO in any Shim tile. Shim DMAs are present in shim NoC tiles to transfer data between DDR and the AIE tile array. 
+
+Shim DMAs and some PLIO must be connected through a ShimMux before connecting to the rest of the array with a switchbox operation. You can configure a switch in the Shim NoC tile using 'shimmux' in addition to the switchbox operations:
 
  ```
+%t70 = AIE.tile(7, 0) // (Column, Row)
 %sw70 = AIE.shimmux(%t70) {
 	AIE.connect<"North" : 2, "DMA" : 1>
 }
@@ -84,6 +87,13 @@ Flows can also be used to connect Shim DMAs to Tile DMAs over a distance:
 ```
 AIE.flow(%t70, "DMA" : 0, %t73, "DMA" : 0)
 AIE.flow(%t73, "DMA" : 1, %t70, "DMA" : 0)
+```
+
+Similarly, flows can be used to connect to/from the PL over a distance: 
+
+```
+AIE.flow(%t70, "PLIO" : 0, %t73, "DMA" : 0)
+AIE.flow(%t73, "DMA" : 1, %t70, "PLIO" : 4)
 ```
 
 ## Visualizing Routing

--- a/lib/Targets/AIETargetXAIEV1.cpp
+++ b/lib/Targets/AIETargetXAIEV1.cpp
@@ -712,9 +712,14 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
         output << "\tXAIETILE_SHIM_STRM_DEM_SOUTH"
                << // NOTE hardcoded to SOUTH to match definitions
                   //      from libxaie
-            connectOp.sourceIndex() << ",\n"
-               << "\tXAIETILE_SHIM_STRM_DEM_"
-               << stringifyWireBundle(connectOp.destBundle()).upper() << ");\n";
+            connectOp.sourceIndex() << ",\n";
+        if (connectOp.destBundle() == WireBundle::PLIO) {
+          output << "\tXAIETILE_SHIM_STRM_DEM_PL);\n";
+        } else {
+          output << "\tXAIETILE_SHIM_STRM_DEM_"
+                 << stringifyWireBundle(connectOp.destBundle()).upper()
+                 << ");\n";
+        }
       } else if (connectOp.destBundle() == WireBundle::North) {
         // mux
         output << "XAieTile_ShimStrmMuxConfig(" << tileInstStr("x", "y")
@@ -722,10 +727,14 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
         output << "\tXAIETILE_SHIM_STRM_MUX_SOUTH"
                << // NOTE hardcoded to SOUTH to match definitions
                   //      from libxaie
-            connectOp.destIndex() << ",\n"
-               << "\tXAIETILE_SHIM_STRM_MUX_"
-               << stringifyWireBundle(connectOp.sourceBundle()).upper()
-               << ");\n";
+            connectOp.destIndex() << ",\n";
+        if (connectOp.sourceBundle() == WireBundle::PLIO) {
+          output << "\tXAIETILE_SHIM_STRM_MUX_PL);\n";
+        } else {
+          output << "\tXAIETILE_SHIM_STRM_MUX_"
+                 << stringifyWireBundle(connectOp.sourceBundle()).upper()
+                 << ");\n";
+        }
       }
     }
   }

--- a/test/create-flows/more_flows_shim.mlir
+++ b/test/create-flows/more_flows_shim.mlir
@@ -1,0 +1,93 @@
+//===- more_flows_shim.mlir ------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-create-pathfinder-flows %s | FileCheck %s
+// CHECK: module
+// CHECK: %[[T70:.*]] = AIE.tile(7, 0)
+// CHECK: %[[T71:.*]] = AIE.tile(7, 1)
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T70]])  {
+// CHECK:    AIE.connect<North : 0, South : 2>
+// CHECK:  }
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T71]])  {
+// CHECK:    AIE.connect<North : 0, South : 0>
+// CHECK:  }
+// CHECK:  %{{.*}} = AIE.shimmux(%[[T70]])  {
+// CHECK:    AIE.connect<North : 2, PLIO : 2>
+// CHECK:  }
+
+module {
+  %t70 = AIE.tile(7, 0)
+  %t71 = AIE.tile(7, 1)
+  AIE.flow(%t71, North : 0, %t70, PLIO : 2)
+}
+
+// -----
+
+// CHECK: module
+// CHECK: %[[T60:.*]] = AIE.tile(6, 0)
+// CHECK: %[[T61:.*]] = AIE.tile(6, 1)
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T60]])  {
+// CHECK:    AIE.connect<South : 6, North : 0>
+// CHECK:  }
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T61]])  {
+// CHECK:    AIE.connect<South : 0, DMA : 1>
+// CHECK:  }
+// CHECK:  %{{.*}} = AIE.shimmux(%[[T60]])  {
+// CHECK:    AIE.connect<PLIO : 6, North : 6>
+// CHECK:  }
+
+module {
+  %t60 = AIE.tile(6, 0)
+  %t61 = AIE.tile(6, 1)
+  AIE.flow(%t60, PLIO : 6, %t61, DMA : 1)
+}
+
+// -----
+
+// CHECK: module
+// CHECK: %[[T40:.*]] = AIE.tile(4, 0)
+// CHECK: %[[T41:.*]] = AIE.tile(4, 1)
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T40]])  {
+// CHECK:    AIE.connect<North : 0, South : 3>
+// CHECK:    AIE.connect<South : 4, North : 0>
+// CHECK:  }
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T41]])  {
+// CHECK:    AIE.connect<North : 0, South : 0>
+// CHECK:    AIE.connect<South : 0, North : 0>
+// CHECK:  }
+
+module {
+  %t40 = AIE.tile(4, 0)
+  %t41 = AIE.tile(4, 1)
+  AIE.flow(%t41, North : 0, %t40, PLIO : 3)
+  AIE.flow(%t40, PLIO : 4, %t41, North : 0)
+}
+
+// -----
+
+// CHECK: module
+// CHECK: %[[T100:.*]] = AIE.tile(10, 0)
+// CHECK: %[[T101:.*]] = AIE.tile(10, 1)
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T100]])  {
+// CHECK:    AIE.connect<North : 0, South : 4>
+// CHECK:  }
+// CHECK:  %{{.*}} = AIE.switchbox(%[[T101]])  {
+// CHECK:    AIE.connect<North : 0, South : 0>
+// CHECK:  }
+// CHECK:  %{{.*}} = AIE.shimmux(%[[T100]])  {
+// CHECK:    AIE.connect<North : 4, NOC : 2>
+// CHECK:  }
+
+module {
+  %t100 = AIE.tile(10, 0)
+  %t101 = AIE.tile(10, 1)
+  AIE.flow(%t101, North : 0, %t100, NOC : 2)
+}
+

--- a/test/create-flows/more_flows_shim.mlir
+++ b/test/create-flows/more_flows_shim.mlir
@@ -8,6 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+//
+// These tests verify pathfinder routing flows to/from PLIO in shim tiles.  
+//
+
 // RUN: aie-opt --split-input-file --aie-create-pathfinder-flows %s | FileCheck %s
 // CHECK: module
 // CHECK: %[[T70:.*]] = AIE.tile(7, 0)
@@ -22,6 +26,8 @@
 // CHECK:    AIE.connect<North : 2, PLIO : 2>
 // CHECK:  }
 
+// Tile 7,0 is a shim NoC tile that has a ShimMux.
+// The ShimMux must be configured for streams to PLIO 2,3,4,5
 module {
   %t70 = AIE.tile(7, 0)
   %t71 = AIE.tile(7, 1)
@@ -43,6 +49,8 @@ module {
 // CHECK:    AIE.connect<PLIO : 6, North : 6>
 // CHECK:  }
 
+// Tile 6,0 is a shim NoC tile that has a ShimMux.
+// The ShimMux must be configured for streams from PLIO 2,3,6,7
 module {
   %t60 = AIE.tile(6, 0)
   %t61 = AIE.tile(6, 1)
@@ -63,6 +71,7 @@ module {
 // CHECK:    AIE.connect<South : 0, North : 0>
 // CHECK:  }
 
+// Tile 4,0 is a shim PL tile and does not contain a ShimMux.
 module {
   %t40 = AIE.tile(4, 0)
   %t41 = AIE.tile(4, 1)
@@ -85,6 +94,8 @@ module {
 // CHECK:    AIE.connect<North : 4, NOC : 2>
 // CHECK:  }
 
+// Tile 10,0 is a shim NoC tile that has a ShimMux.
+// The ShimMux must be configured for streams to NOC 0,1,2,3
 module {
   %t100 = AIE.tile(10, 0)
   %t101 = AIE.tile(10, 1)

--- a/test/create-flows/simple_flows_shim.mlir
+++ b/test/create-flows/simple_flows_shim.mlir
@@ -18,10 +18,6 @@
 // CHECK:  %{{.*}} = AIE.switchbox(%[[T21]])  {
 // CHECK:    AIE.connect<North : 0, South : 0>
 // CHECK:  }
-// CHECK:  %{{.*}} = AIE.shimmux(%[[T20]])  {
-// CHECK:    AIE.connect<North : 0, PLIO : 0>
-// CHECK:  }
-
 module {
   %t23 = AIE.tile(2, 1)
   %t22 = AIE.tile(2, 0)

--- a/test/xaie_target/plio_shim.mlir
+++ b/test/xaie_target/plio_shim.mlir
@@ -8,6 +8,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+//
+// This tests the lowering from AIE.switchbox ops to configuration register
+// writes for LibXAIEV1. This test targets PL shim tiles that only contain
+// stream switches that connect the AIE array to PL.
+//
+
 // RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
 
 // CHECK: mlir_configure_switchboxes

--- a/test/xaie_target/plio_shim.mlir
+++ b/test/xaie_target/plio_shim.mlir
@@ -1,0 +1,34 @@
+//===- plio_shim.mlir ------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
+
+// CHECK: mlir_configure_switchboxes
+// CHECK: XAieTile_StrmConnectCct(&(TileInst[x][y]),
+// CHECK:   XAIETILE_STRSW_SPORT_SOUTH(&(TileInst[x][y]), 4),
+// CHECK:   XAIETILE_STRSW_MPORT_NORTH(&(TileInst[x][y]), 0),
+// CHECK:   XAIE_ENABLE);
+// CHECK: XAieTile_StrmConnectCct(&(TileInst[x][y]),
+// CHECK:   XAIETILE_STRSW_SPORT_NORTH(&(TileInst[x][y]), 0),
+// CHECK:   XAIETILE_STRSW_MPORT_SOUTH(&(TileInst[x][y]), 2),
+// CHECK:   XAIE_ENABLE);
+
+module {
+  %t40 = AIE.tile(4, 0)
+  %t41 = AIE.tile(4, 1)
+  %4 = AIE.switchbox(%t40)  {
+    AIE.connect<South : 4, North : 0>
+    AIE.connect<North : 0, South : 2>
+  }
+  %5 = AIE.switchbox(%t41)  {
+    AIE.connect<South : 0, North : 0>
+    AIE.connect<North : 0, South : 0>
+  }
+}

--- a/test/xaie_target/plio_shimmux.mlir
+++ b/test/xaie_target/plio_shimmux.mlir
@@ -1,0 +1,30 @@
+//===- plio_shimmux.mlir ---------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
+
+// CHECK: mlir_configure_switchboxes
+// CHECK: XAieTile_ShimStrmDemuxConfig(&(TileInst[x][y]),
+// CHECK:        XAIETILE_SHIM_STRM_DEM_SOUTH2,
+// CHECK:        XAIETILE_SHIM_STRM_DEM_PL);
+
+module {
+  %t20 = AIE.tile(2, 0)
+  %t21 = AIE.tile(2, 1)
+  %4 = AIE.switchbox(%t20)  {
+    AIE.connect<North : 0, South : 2>
+  }
+  %5 = AIE.switchbox(%t21)  {
+    AIE.connect<North : 0, South : 0>
+  }
+  %6 = AIE.shimmux(%t20)  {
+    AIE.connect<North : 2, PLIO : 2>
+  }
+}

--- a/test/xaie_target/plio_shimmux.mlir
+++ b/test/xaie_target/plio_shimmux.mlir
@@ -8,6 +8,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+//
+// This tests the lowering from AIE.switchbox ops to configuration register
+// writes for LibXAIEV1. This test targets NoC shim tiles that must configure
+// stream switches, and for some PLIOs the shimmux, to connect AIE array 
+// streams to PL.
+//
+
 // RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
 
 // CHECK: mlir_configure_switchboxes


### PR DESCRIPTION
Added flows to/from all shim tiles for PLIO connections. Most PLIOs just configure the stream switch to direct streams to/from PLIO, shim noc tiles require shimmux configuration for some PLIOs as well. 