### PR TITLE
Tile DMA 2D X and Y address generation 

### DIFF
--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -739,6 +739,53 @@ def DMAChan: I32EnumAttr<"DMAChan", "DMA Channel number",
   let cppNamespace = "xilinx::AIE";
 }
 
+def AIE_DMABD2DOp: AIE_Op<"dmaBd2D", []> {
+  let summary = "Enable 2D (X and Y) addressing scheme for a dma block descriptor";
+  let description = [{
+    This operation enables 2 dimensional address generation for a block descriptor for DMA operations. 
+    In particular, it specifies the offset, increment and wrap in the X and Y dimension.
+    
+    This operation must be used in an MLIR block that lives inside a MemOp's region, and before AIE.dmaBd.
+    The block descriptor specifies what lock to use and the buffer configuration.
+
+    Example:
+    ```
+      // this defines a BD that uses lock %lck0 and buffer %buf0
+      ^bd5:
+        AIE.useLock(%lck, "Acquire", 0, 0)
+        AIE.dmaBd2D(4, 1, 8, 1, 8, 4)
+        AIE.dmaBd(<$buf0 : memref<8x4xi32>, 0, 32>, 1)
+        AIE.useLock(%lck, "Release", 1, 0)
+        br ^bd6 // point to the next Block, which is also a different Block Descriptor
+
+    ```
+    
+  }];
+
+  let arguments = (
+    ins I32Attr:$X_offset,
+        I32Attr:$X_increment,
+        I32Attr:$X_wrap,
+        I32Attr:$Y_offset,
+        I32Attr:$Y_increment,
+        I32Attr:$Y_wrap
+  );
+
+  let assemblyFormat = [{
+    `(` $X_offset `,` $X_increment `,` $X_wrap `,` $Y_offset `,` $Y_increment `,` $Y_wrap  `)` attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    int getXOffset() { return X_offset(); }
+    int getXIncrement() { return X_increment(); }
+    int getXWrap() { return X_wrap(); }
+    int getYOffset() { return Y_offset(); }
+    int getYIncrement() { return Y_increment(); }
+    int getYWrap() { return Y_wrap(); }
+  }];
+
+}
+
 def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
   let summary = "Enable packet headers for a dma block descriptor";
   let description = [{

--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -788,7 +788,7 @@ def AIE_DMABD2DOp: AIE_Op<"dmaBd2D", []> {
 
     Offset = value to add to the address for each increment
     Wrap = how many increments before wrapping
-    Offset = how many stream beats before increment
+    Increment = how many stream beats before increment
 
     The address is generated according to the following formulas: 
       Address = Base Address + Xn + Yn

--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -739,53 +739,6 @@ def DMAChan: I32EnumAttr<"DMAChan", "DMA Channel number",
   let cppNamespace = "xilinx::AIE";
 }
 
-def AIE_DMABD2DOp: AIE_Op<"dmaBd2D", []> {
-  let summary = "Enable 2D (X and Y) addressing scheme for a dma block descriptor";
-  let description = [{
-    This operation enables 2 dimensional address generation for a block descriptor for DMA operations. 
-    In particular, it specifies the offset, increment and wrap in the X and Y dimension.
-    
-    This operation must be used in an MLIR block that lives inside a MemOp's region, and before AIE.dmaBd.
-    The block descriptor specifies what lock to use and the buffer configuration.
-
-    Example:
-    ```
-      // this defines a BD that uses lock %lck0 and buffer %buf0
-      ^bd5:
-        AIE.useLock(%lck, "Acquire", 0, 0)
-        AIE.dmaBd2D(4, 1, 8, 1, 8, 4)
-        AIE.dmaBd(<$buf0 : memref<8x4xi32>, 0, 32>, 1)
-        AIE.useLock(%lck, "Release", 1, 0)
-        br ^bd6 // point to the next Block, which is also a different Block Descriptor
-
-    ```
-    
-  }];
-
-  let arguments = (
-    ins I32Attr:$X_offset,
-        I32Attr:$X_increment,
-        I32Attr:$X_wrap,
-        I32Attr:$Y_offset,
-        I32Attr:$Y_increment,
-        I32Attr:$Y_wrap
-  );
-
-  let assemblyFormat = [{
-    `(` $X_offset `,` $X_increment `,` $X_wrap `,` $Y_offset `,` $Y_increment `,` $Y_wrap  `)` attr-dict
-  }];
-
-  let extraClassDeclaration = [{
-    int getXOffset() { return X_offset(); }
-    int getXIncrement() { return X_increment(); }
-    int getXWrap() { return X_wrap(); }
-    int getYOffset() { return Y_offset(); }
-    int getYIncrement() { return Y_increment(); }
-    int getYWrap() { return Y_wrap(); }
-  }];
-
-}
-
 def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
   let summary = "Enable packet headers for a dma block descriptor";
   let description = [{
@@ -821,6 +774,64 @@ def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
   let extraClassDeclaration = [{
     int getPacketType() { return packet_type(); }
     int getPacketID() { return packet_id(); }
+  }];
+
+}
+
+def AIE_DMABD2DOp: AIE_Op<"dmaBd2D", []> {
+  let summary = "Enable 2D (X and Y) addressing scheme for a dma block descriptor";
+  let description = [{
+    This operation enables 2 dimensional address generation for a block descriptor for DMA operations. 
+    In particular, it specifies the offset, increment and wrap in the X and Y dimension.
+
+    AIE.dmaBd2d(X_offset, X_increment, X_wrap, Y_offset, Y_increment, Y_wrap)
+
+    Offset = value to add to the address for each increment
+    Wrap = how many increments before wrapping
+    Offset = how many stream beats before increment
+
+    The address is generated according to the following formulas: 
+      Address = Base Address + Xn + Yn
+        Xn = Xoffset * (( n / Xincrement) mod Xwrap)
+        Yn = Xoffset * (( n / Yincrement) mod Ywrap)
+    
+    This operation must be used in an MLIR block that lives inside a MemOp's region, and before AIE.dmaBd.
+    The block descriptor specifies what lock to use and the buffer configuration.
+
+    Example:
+    ```
+      // this defines a BD that uses lock %lck0 and buffer %buf0
+      ^bd5:
+        AIE.useLock(%lck, "Acquire", 0, 0)
+        AIE.dmaBd2D(4, 1, 8, 1, 8, 4)
+        AIE.dmaBd(<$buf0 : memref<4x8xi32>, 0, 32>, 1)
+        AIE.useLock(%lck, "Release", 1, 0)
+        br ^bd6 // point to the next Block, which is also a different Block Descriptor
+
+    ```
+    
+  }];
+
+  let arguments = (
+    ins I32Attr:$X_offset,
+        I32Attr:$X_increment,
+        I32Attr:$X_wrap,
+        I32Attr:$Y_offset,
+        I32Attr:$Y_increment,
+        I32Attr:$Y_wrap
+  );
+
+  let assemblyFormat = [{
+    `(` $X_offset `,` $X_increment `,` $X_wrap `,` $Y_offset `,` $Y_increment `,` $Y_wrap  `)` attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    int getXOffset() { return X_offset(); }
+    int getXIncrement() { return X_increment(); }
+    int getXWrap() { return X_wrap(); }
+    int getYOffset() { return Y_offset(); }
+    int getYIncrement() { return Y_increment(); }
+    int getYWrap() { return Y_wrap(); }
   }];
 
 }

--- a/test/xaie_target/tileDMA2D.mlir
+++ b/test/xaie_target/tileDMA2D.mlir
@@ -1,0 +1,46 @@
+//===- tileDMA.mlir --------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
+
+// CHECK: void mlir_configure_dmas() {
+// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 0,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_X, /* incr */ 1, /* wrap */ 8, /* ofst */ 4);
+// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 0,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_Y, /* incr */ 8, /* wrap */ 4, /* ofst */ 1);
+// CHECK: XAieDma_TileBdWrite(&(TileDMAInst[7][2]),  /* bd */ 0);
+// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 1,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_X, /* incr */ 1, /* wrap */ 8, /* ofst */ 4);
+// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 1,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_Y, /* incr */ 8, /* wrap */ 4, /* ofst */ 1);
+// CHECK: XAieDma_TileBdWrite(&(TileDMAInst[7][2]),  /* bd */ 1);
+
+module @aie_module  {
+  %0 = AIE.tile(7, 2)
+  %24 = AIE.buffer(%0) {address = 4096 : i32, sym_name = "buf6"} : memref<8x4xi32, 2>
+  %25 = AIE.lock(%0, 0)
+  %26 = AIE.buffer(%0) {address = 4224 : i32, sym_name = "buf7"} : memref<8x4xi32, 2>
+  %27 = AIE.lock(%0, 1)
+  %28 = AIE.mem(%0)  {
+    %38 = AIE.dmaStart(S2MM0, ^bb1, ^bb3)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%25, Acquire, 0, 0)
+    AIE.dmaBd2D(4, 1, 8, 1, 8, 4)
+    AIE.dmaBd(<%24 : memref<8x4xi32, 2>, 0, 32>, 0)
+    AIE.useLock(%25, Release, 1, 0)
+    br ^bb1
+  ^bb2:  // pred: ^bb3
+    AIE.end
+  ^bb3:  // pred: ^bb0
+    %39 = AIE.dmaStart(MM2S0, ^bb4, ^bb2)
+  ^bb4:  // 2 preds: ^bb3, ^bb4
+    AIE.useLock(%27, Acquire, 1, 0)
+    AIE.dmaBd2D(4, 1, 8, 1, 8, 4)
+    AIE.dmaBd(<%26 : memref<8x4xi32, 2>, 0, 32>, 0)
+    AIE.useLock(%27, Release, 0, 0)
+    br ^bb4
+  }
+}

--- a/test/xaie_target/tileDMA2D.mlir
+++ b/test/xaie_target/tileDMA2D.mlir
@@ -18,18 +18,23 @@
 // CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 1,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_Y, /* incr */ 8, /* wrap */ 4, /* ofst */ 1);
 // CHECK: XAieDma_TileBdWrite(&(TileDMAInst[7][2]),  /* bd */ 1);
 
+//
+// This test configures the tile DMA buffer descriptor to transpose an 8x4xi32
+// input matrix as it is writted to the tile's local memory. It returns the
+// matrix to its original arrangement when it is output to the stream.
+//
 module @aie_module  {
   %0 = AIE.tile(7, 2)
-  %24 = AIE.buffer(%0) {address = 4096 : i32, sym_name = "buf6"} : memref<8x4xi32, 2>
+  %24 = AIE.buffer(%0) {address = 4096 : i32, sym_name = "buf6"} : memref<4x8xi32, 2>
   %25 = AIE.lock(%0, 0)
-  %26 = AIE.buffer(%0) {address = 4224 : i32, sym_name = "buf7"} : memref<8x4xi32, 2>
+  %26 = AIE.buffer(%0) {address = 4224 : i32, sym_name = "buf7"} : memref<4x8xi32, 2>
   %27 = AIE.lock(%0, 1)
   %28 = AIE.mem(%0)  {
     %38 = AIE.dmaStart(S2MM0, ^bb1, ^bb3)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%25, Acquire, 0, 0)
     AIE.dmaBd2D(4, 1, 8, 1, 8, 4)
-    AIE.dmaBd(<%24 : memref<8x4xi32, 2>, 0, 32>, 0)
+    AIE.dmaBd(<%24 : memref<4x8xi32, 2>, 0, 32>, 0)
     AIE.useLock(%25, Release, 1, 0)
     br ^bb1
   ^bb2:  // pred: ^bb3
@@ -39,7 +44,7 @@ module @aie_module  {
   ^bb4:  // 2 preds: ^bb3, ^bb4
     AIE.useLock(%27, Acquire, 1, 0)
     AIE.dmaBd2D(4, 1, 8, 1, 8, 4)
-    AIE.dmaBd(<%26 : memref<8x4xi32, 2>, 0, 32>, 0)
+    AIE.dmaBd(<%26 : memref<4x8xi32, 2>, 0, 32>, 0)
     AIE.useLock(%27, Release, 0, 0)
     br ^bb4
   }

--- a/test/xaie_target/tileDMA2D.mlir
+++ b/test/xaie_target/tileDMA2D.mlir
@@ -10,17 +10,17 @@
 
 // RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
 
-// CHECK: void mlir_configure_dmas() {
-// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 0,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_X, /* incr */ 1, /* wrap */ 8, /* ofst */ 4);
-// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 0,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_Y, /* incr */ 8, /* wrap */ 4, /* ofst */ 1);
-// CHECK: XAieDma_TileBdWrite(&(TileDMAInst[7][2]),  /* bd */ 0);
-// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 1,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_X, /* incr */ 1, /* wrap */ 8, /* ofst */ 4);
-// CHECK: XAieDma_TileBdSetXy2d(&(TileDMAInst[7][2]),  /* bd */ 1,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_Y, /* incr */ 8, /* wrap */ 4, /* ofst */ 1);
-// CHECK: XAieDma_TileBdWrite(&(TileDMAInst[7][2]),  /* bd */ 1);
+// CHECK: void mlir_aie_configure_dmas(aie_libxaie_ctx_t* ctx) {
+// CHECK: XAieDma_TileBdSetXy2d(&(ctx->TileDMAInst[7][2]),  /* bd */ 0,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_X, /* incr */ 1, /* wrap */ 8, /* ofst */ 4);
+// CHECK: XAieDma_TileBdSetXy2d(&(ctx->TileDMAInst[7][2]),  /* bd */ 0,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_Y, /* incr */ 8, /* wrap */ 4, /* ofst */ 1);
+// CHECK: XAieDma_TileBdWrite(&(ctx->TileDMAInst[7][2]),  /* bd */ 0);
+// CHECK: XAieDma_TileBdSetXy2d(&(ctx->TileDMAInst[7][2]),  /* bd */ 1,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_X, /* incr */ 1, /* wrap */ 8, /* ofst */ 4);
+// CHECK: XAieDma_TileBdSetXy2d(&(ctx->TileDMAInst[7][2]),  /* bd */ 1,  /* xyType */ XAIEDMA_TILE_BD_2DDMA_Y, /* incr */ 8, /* wrap */ 4, /* ofst */ 1);
+// CHECK: XAieDma_TileBdWrite(&(ctx->TileDMAInst[7][2]),  /* bd */ 1);
 
 //
 // This test configures the tile DMA buffer descriptor to transpose an 8x4xi32
-// input matrix as it is writted to the tile's local memory. It returns the
+// input matrix as it is written to the tile's local memory. It returns the
 // matrix to its original arrangement when it is output to the stream.
 //
 module @aie_module  {


### PR DESCRIPTION
Introduced the dmaBd2D op supporting X and Y addressing mode in the tile DMA. This allows for many different addressing schemes to reorganize data at the 32-bit stream beat granularity. For example, transposed matrix addressing. 