### PR TITLE
Teach aiecc.py to use elf_file attribute

### DIFF
--- a/docs/AIEDesignPatterns.md
+++ b/docs/AIEDesignPatterns.md
@@ -203,7 +203,7 @@ In the host code, lets write to the buffer 71:
 // We're going to stamp over the memory
 
 for (int i = 0; i < DMA_COUNT; i++){
-	mlir_write_buffer_a71(i, 0xdeadbeef);
+	mlir_aie_write_buffer_a71(ctx, i, 0xdeadbeef);
 }
 ```
 
@@ -322,7 +322,7 @@ We can write to buffer a and program the SHIM DMA using the XAIE API:
 
 for (int i=0; i<DMA_COUNT; i++) {
 	uint32_t d = i+1;
-	mlir_write_buffer_a(i, d);
+	mlir_aie_write_buffer_a(ctx, i, d);
 }
 
 // Program the ShimDMA to write from stream to memory

--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -282,9 +282,8 @@ def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint]>, Results<(outs Index)> {
     This operation represents an AIEngine processor core belonging to a tile.
     The region of a CoreOp contains code that gets run on the AIE core.  This code will
     typically be outlined into the LLVM dialect, eventually resulting in a binary file
-    for each core.  If an elf file already exists for a core, the name of this file can
-    be specified using the 'elf_file' attribute, in which case the contents of the region
-    are ignored.
+    for each core.  The name of this file can be be specified using the 'elf_file'
+    attribute.
 
     Examples:
     ```

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -314,7 +314,11 @@ SECTIONS
           int col = tileOp.colIndex();
           int row = tileOp.rowIndex();
           if (auto coreOp = tileOp.getCoreOp()) {
-            output << '(' << std::to_string(col) << ',' << std::to_string(row) << "),";
+            std::string elf_file = "None";
+            if (auto fileAttr = coreOp->getAttrOfType<StringAttr>("elf_file"))
+              elf_file = "\"" + std::string(fileAttr.getValue()) + "\"";
+            output << '(' << std::to_string(col) << ',' << std::to_string(row)
+                   << ',' << elf_file << "),";
           }
         }
         output << "]\n";

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -57,7 +57,7 @@ def run_flow(opts, tmpdirname):
       do_call(['sed', '-i', 's/noalias_sidechannel[^,]*,//', chess_intrinsic_wrapper])
 
     def corefile(dirname, core, ext):
-        (corecol, corerow) = core
+        (corecol, corerow, _) = core
         return os.path.join(dirname, 'core_%d_%d.%s' % (corecol, corerow, ext))
 
     def tmpcorefile(core, ext):
@@ -71,9 +71,9 @@ def run_flow(opts, tmpdirname):
         return ' '.join(t.stdout.split())
 
     def process_core(core):
-        (corecol, corerow) = core
+        (corecol, corerow, elf_file) = core
         file_core = tmpcorefile(core, "mlir")
-        do_call(['aie-opt', '--aie-standard-lowering=tilecol=%d tilerow=%d' % core, file_with_addresses, '-o', file_core])
+        do_call(['aie-opt', '--aie-standard-lowering=tilecol=%d tilerow=%d' % core[0:2], file_with_addresses, '-o', file_core])
         file_opt_core = tmpcorefile(core, "opt.mlir")
         do_call(['aie-opt', '--aie-normalize-address-spaces',
                             '--canonicalize',
@@ -90,7 +90,7 @@ def run_flow(opts, tmpdirname):
         do_call(['aie-translate', '--mlir-to-llvmir', file_opt_core, '-o', file_core_llvmir])
         file_core_llvmir_stripped = tmpcorefile(core, "stripped.ll")
         do_call(['opt', '-O2', '-strip', '-S', file_core_llvmir, '-o', file_core_llvmir_stripped])
-        file_core_elf = corefile(".", core, "elf")
+        file_core_elf = elf_file if elf_file else corefile(".", core, "elf")
         file_core_obj = tmpcorefile(core, "o")
         if(opts.xchesscc):
           file_core_llvmir_chesshack = tmpcorefile(core, "chesshack.ll")


### PR DESCRIPTION
The libxae backend does the right thing for the 'elf_file' attribute but it's ignored by aiecc.py. I'm not super thrilled about using an eval of a string to pass information but that's how the existing code worked.