### PR TITLE
[AIETokenAnalysis] Make internal tile shareable

### DIFF
--- a/lib/AIETokenAnalysis.cpp
+++ b/lib/AIETokenAnalysis.cpp
@@ -185,12 +185,12 @@ Operation *xilinx::AIE::TokenAnalysis::getShareableTileOp(Operation *Op1,
     bool IsW = isWest(col1, row1, col2, row2);
     bool IsN = isNorth(col1, row1, col2, row2);
     bool IsE = isEast(col1, row1, col2, row2);
-    // bool IsInternal = isInternal(col1, row1, col2, row2);
+    bool IsInternal = isInternal(col1, row1, col2, row2);
     bool IsEvenRow = ((row1 % 2) == 0);
 
     if (IsS || IsN || (IsW && !IsEvenRow) || (IsE && IsEvenRow))
       return tiles[coord2];
-    if ((IsW && IsEvenRow) || (IsE && !IsEvenRow))
+    if ((IsW && IsEvenRow) || (IsE && !IsEvenRow) || IsInternal)
       return tiles[coord1];
   }
 


### PR DESCRIPTION
Currently, a token chain inside of one CoreOp is illegal as they don't have shareable tile. I'm not sure whether there's a specific reason for this, but I found the following code is quite common:
```mlir
  ... ...
  %185 = AIE.tile(6, 4)
  %190 = AIE.core(%185)  {
    AIE.useToken @token2(Acquire, 5)
    ... ...
    AIE.useToken @token2(Release, 7)
    AIE.useToken @token2(Acquire, 7)
    affine.for %arg0 = 0 to 32 {
      affine.for %arg1 = 0 to 18 {
        %324 = affine.load %186[%arg0, %arg1] : memref<32x18xf32, #map2>
        affine.store %324, %197[%arg0, %arg1] : memref<32x18xf32, #map2>
      }
    }
    AIE.useToken @token2(Release, 10)
    AIE.end
  }
  %191 = AIE.mem(%185)  {
    %323 = AIE.dmaStart(MM2S0, ^bb1, ^bb2)
  ^bb1:  // 2 preds: ^bb0, ^bb1
    AIE.useToken @token2(Acquire, 7)
    AIE.dmaBd(<%186 : memref<32x18xf32, #map2>, 0, 576>, 0)
    AIE.useToken @token2(Release, 11)
    br ^bb1
  ^bb2:  // pred: ^bb0
    AIE.end
  }
  ... ...
```

Here, `tile(6, 4)` has a fanout of 2. One of the targets is an adjacent AIE, thus is implemented as a loop nests to copy the data. Another one is implemented with MM2S DMA in the MemOp.

I can see several solutions to tackle this:
1) Make internal tile shareable as this PR did;
2) Canonicalize away the `AIE.useToken @token2(Acquire, 7)` in the CoreOp;
3) Remove the `AIE.useToken @token2(Release, 7) -> AIE.useToken @token2(Acquire, 7)` chain from the CoreOp and update the `AIE.useToken @token2(Acquire, 7)` in MemOp to `AIE.useToken @token2(Acquire, 10)`. But this seems weird -- the DMA now depends on the direct memory copy, but actually they can happen together.

Which one is more reasonable?