### PR TITLE
Added initial set of benchmarks for AIE. 

### DIFF
--- a/runtime_lib/test_library.cpp
+++ b/runtime_lib/test_library.cpp
@@ -11,8 +11,8 @@
 // This file contains common libraries used for testing.
 
 #include "test_library.h"
-#include <stdio.h>
 #include <cmath>
+#include <stdio.h>
 
 extern "C" {
 extern aie_libxaie_ctx_t *ctx /* = nullptr*/;
@@ -481,18 +481,21 @@ void mlir_aie_print_dma_status(aie_libxaie_ctx_t *ctx, int col, int row) {
   u32 mm2s_ch0_running = dma_mm2s_status & 0x3;
   u32 mm2s_ch1_running = (dma_mm2s_status >> 2) & 0x3;
 
-  printf("DMA [%d, %d] mm2s_status/ctrl is %08X %08X, s2mm_status is %08X %08X, BD0_Addr_A is %08X, BD0_control is %08X\n",col, row, dma_mm2s_status, dma_mm2s_control, dma_s2mm_status, dma_s2mm_control, dma_bd0_a, dma_bd0_control);
-  for (int bd=0;bd<8;bd++) {
+  printf("DMA [%d, %d] mm2s_status/ctrl is %08X %08X, s2mm_status is %08X "
+         "%08X, BD0_Addr_A is %08X, BD0_control is %08X\n",
+         col, row, dma_mm2s_status, dma_mm2s_control, dma_s2mm_status,
+         dma_s2mm_control, dma_bd0_a, dma_bd0_control);
+  for (int bd = 0; bd < 8; bd++) {
     u32 dma_bd_addr_a =
         XAieGbl_Read32(tile->TileAddr + 0x0001D000 + (0x20 * bd));
     u32 dma_bd_control =
         XAieGbl_Read32(tile->TileAddr + 0x0001D018 + (0x20 * bd));
     if (dma_bd_control & 0x80000000) {
-      printf("BD %d valid\n",bd);
-      int current_s2mm_ch0 = (dma_s2mm_status >> 16) & 0xf;  
-      int current_s2mm_ch1 = (dma_s2mm_status >> 20) & 0xf;  
-      int current_mm2s_ch0 = (dma_mm2s_status >> 16) & 0xf;  
-      int current_mm2s_ch1 = (dma_mm2s_status >> 20) & 0xf;  
+      printf("BD %d valid\n", bd);
+      int current_s2mm_ch0 = (dma_s2mm_status >> 16) & 0xf;
+      int current_s2mm_ch1 = (dma_s2mm_status >> 20) & 0xf;
+      int current_mm2s_ch0 = (dma_mm2s_status >> 16) & 0xf;
+      int current_mm2s_ch1 = (dma_mm2s_status >> 20) & 0xf;
 
       if (s2mm_ch0_running && bd == current_s2mm_ch0) {
         printf(" * Current BD for s2mm channel 0\n");
@@ -510,47 +513,48 @@ void mlir_aie_print_dma_status(aie_libxaie_ctx_t *ctx, int col, int row) {
       if (dma_bd_control & 0x08000000) {
         u32 dma_packet =
             XAieGbl_Read32(tile->TileAddr + 0x0001D010 + (0x20 * bd));
-        printf("   Packet mode: %02X\n",dma_packet & 0x1F);
+        printf("   Packet mode: %02X\n", dma_packet & 0x1F);
       }
-      int words_to_transfer = 1+(dma_bd_control & 0x1FFF);
-      int base_address = dma_bd_addr_a  & 0x1FFF;
-      printf("   Transfering %d 32 bit words to/from %06X\n",words_to_transfer, base_address);
+      int words_to_transfer = 1 + (dma_bd_control & 0x1FFF);
+      int base_address = dma_bd_addr_a & 0x1FFF;
+      printf("   Transfering %d 32 bit words to/from %06X\n", words_to_transfer,
+             base_address);
 
       printf("   ");
-      for (int w=0;w<7; w++) {
+      for (int w = 0; w < 7; w++) {
         printf("%08X ", XAieTile_DmReadWord(tile, (base_address + w) * 4));
       }
       printf("\n");
       if (dma_bd_addr_a & 0x40000) {
         u32 lock_id = (dma_bd_addr_a >> 22) & 0xf;
-        printf("   Acquires lock %d ",lock_id);
-        if (dma_bd_addr_a & 0x10000) 
-          printf("with value %d ",(dma_bd_addr_a >> 17) & 0x1);
+        printf("   Acquires lock %d ", lock_id);
+        if (dma_bd_addr_a & 0x10000)
+          printf("with value %d ", (dma_bd_addr_a >> 17) & 0x1);
 
         printf("currently ");
         u32 locks = XAieGbl_Read32(tile->TileAddr + 0x0001EF00);
-        u32 two_bits = (locks >> (lock_id*2)) & 0x3;
+        u32 two_bits = (locks >> (lock_id * 2)) & 0x3;
         if (two_bits) {
           u32 acquired = two_bits & 0x1;
           u32 value = two_bits & 0x2;
           if (acquired)
             printf("Acquired ");
-          printf(value?"1":"0");
-        }
-        else printf("0");
+          printf(value ? "1" : "0");
+        } else
+          printf("0");
         printf("\n");
-
       }
       if (dma_bd_control & 0x30000000) { // FIFO MODE
         int FIFO = (dma_bd_control >> 28) & 0x3;
         u32 dma_fifo_counter = XAieGbl_Read32(tile->TileAddr + 0x0001DF20);
-        printf("   Using FIFO Cnt%d : %08X\n",FIFO, dma_fifo_counter);
+        printf("   Using FIFO Cnt%d : %08X\n", FIFO, dma_fifo_counter);
       }
     }
   }
 }
 
-/// Print the status of a core represented by the given tile, at the given coordinates.
+/// Print the status of a core represented by the given tile, at the given
+/// coordinates.
 void mlir_aie_print_tile_status(aie_libxaie_ctx_t *ctx, int col, int row) {
   // int col = tile.ColId;
   // int row = tile.RowId;
@@ -615,8 +619,8 @@ void mlir_aie_print_tile_status(aie_libxaie_ctx_t *ctx, int col, int row) {
 }
 
 static void clear_range(u64 TileAddr, u64 low, u64 high) {
-  for (int i=low; i<=high; i+=4) {
-    XAieGbl_Write32(TileAddr+i, 0);
+  for (int i = low; i <= high; i += 4) {
+    XAieGbl_Write32(TileAddr + i, 0);
     // int x = XAieGbl_Read32(TileAddr+i);
     // if(x != 0) {
     //   printf("@%x = %x\n", i, x);
@@ -670,11 +674,10 @@ void mlir_aie_clear_shim_config(aie_libxaie_ctx_t *ctx, int col, int row) {
   clear_range(TileAddr, 0x3F200, 0x3F37C);
 }
 
-void computeStats(u32 performance_counter[], int n){
+void computeStats(u32 performance_counter[], int n) {
   u32 total_0 = 0;
 
-  for (int i = 0; i < n; i ++)
-  {
+  for (int i = 0; i < n; i++) {
     total_0 += performance_counter[i];
   }
 
@@ -682,15 +685,13 @@ void computeStats(u32 performance_counter[], int n){
 
   float sdev_0 = 0;
 
-  for (int i = 0; i < n; i ++)
-  {
+  for (int i = 0; i < n; i++) {
     sdev_0 += std::pow(((float)performance_counter[i] - mean_0), 2);
   }
 
   sdev_0 = std::sqrt(sdev_0 / n);
 
   printf("Mean and Standard Devation: %f, %f \n", mean_0, sdev_0);
-  
 }
 
 #endif

--- a/runtime_lib/test_library.cpp
+++ b/runtime_lib/test_library.cpp
@@ -12,6 +12,7 @@
 
 #include "test_library.h"
 #include <stdio.h>
+#include <cmath>
 
 extern "C" {
 extern aie_libxaie_ctx_t *ctx /* = nullptr*/;
@@ -667,6 +668,29 @@ void mlir_aie_clear_shim_config(aie_libxaie_ctx_t *ctx, int col, int row) {
   clear_range(TileAddr, 0x3F100, 0x3F15C);
   // Stream Switch slave slot config
   clear_range(TileAddr, 0x3F200, 0x3F37C);
+}
+
+void computeStats(u32 performance_counter[], int n){
+  u32 total_0 = 0;
+
+  for (int i = 0; i < n; i ++)
+  {
+    total_0 += performance_counter[i];
+  }
+
+  float mean_0 = (float)total_0 / n;
+
+  float sdev_0 = 0;
+
+  for (int i = 0; i < n; i ++)
+  {
+    sdev_0 += std::pow(((float)performance_counter[i] - mean_0), 2);
+  }
+
+  sdev_0 = std::sqrt(sdev_0 / n);
+
+  printf("Mean and Standard Devation: %f, %f \n", mean_0, sdev_0);
+  
 }
 
 #endif

--- a/runtime_lib/test_library.h
+++ b/runtime_lib/test_library.h
@@ -9,10 +9,10 @@
 //===----------------------------------------------------------------------===//
 #ifndef AIE_TEST_LIBRARY_H
 #define AIE_TEST_LIBRARY_H
+#include <cmath>
 #include <stdio.h>
 #include <stdlib.h>
 #include <xaiengine.h>
-#include <cmath>
 
 extern "C" {
 
@@ -87,7 +87,6 @@ struct aie_libxaie_ctx_t {
 #define MODE_PL 1
 #define MODE_MEM 2
 
-
 //#define HIGH_ADDR(addr)	((addr & 0xffffffff00000000) >> 32)
 //#define LOW_ADDR(addr)	(addr & 0x00000000ffffffff)
 
@@ -139,57 +138,61 @@ void mlir_aie_clear_config(aie_libxaie_ctx_t *ctx, int col, int row);
 void mlir_aie_clear_shim_config(aie_libxaie_ctx_t *ctx, int col, int row);
 
 // class for using events and PF cpounters
-class EventMon{
-    public:
-        EventMon(struct XAieGbl_Tile *_tilePtr, u32 _pfc, u32 _startE, u32 _endE, u32 _resetE, u8 _mode){
-            tilePtr = _tilePtr;
-            pfc = _pfc;
-            mode = _mode; // 0: Core, 1: PL, 2, Mem
-            if(mode == MODE_CORE){
-                XAieTileCore_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);}
-            else if(mode == MODE_PL){
-                XAieTilePl_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);}
-            else{
-                XAieTileMem_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);}
-            
-        }
-        void set(){
-            if(mode == MODE_CORE){
-                start = XAieTileCore_PerfCounterGet(tilePtr, pfc);}
-            else if(mode == MODE_PL){
-                start = XAieTilePl_PerfCounterGet(tilePtr, pfc);}
-            else{
-                start = XAieTileMem_PerfCounterGet(tilePtr, pfc);}
-        }
-        u32 read(){
-            if(mode == MODE_CORE){
-                return XAieTileCore_PerfCounterGet(tilePtr, pfc);}
-            else if(mode == MODE_PL){
-                return XAieTilePl_PerfCounterGet(tilePtr, pfc);}
-            else{
-                return XAieTileMem_PerfCounterGet(tilePtr, pfc);}
-        }
-        u32 diff(){
-            u32 end;
-            if(mode == MODE_CORE){
-                end = XAieTileCore_PerfCounterGet(tilePtr, pfc);}
-            else if(mode == MODE_PL){
-                end = XAieTilePl_PerfCounterGet(tilePtr, pfc);}
-            else{
-                end = XAieTileMem_PerfCounterGet(tilePtr, pfc);}
-            if(end < start){
-                printf("WARNING: EventMon: performance counter wrapped!\n");
-                return 0; // TODO: fix this
-            }
-            else{
-                return end - start;
-            }
-        }
-    private:
-        u32 start;
-        u32 pfc;
-        u8 mode;
-        struct XAieGbl_Tile *tilePtr;
+class EventMon {
+public:
+  EventMon(struct XAieGbl_Tile *_tilePtr, u32 _pfc, u32 _startE, u32 _endE,
+           u32 _resetE, u8 _mode) {
+    tilePtr = _tilePtr;
+    pfc = _pfc;
+    mode = _mode; // 0: Core, 1: PL, 2, Mem
+    if (mode == MODE_CORE) {
+      XAieTileCore_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);
+    } else if (mode == MODE_PL) {
+      XAieTilePl_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);
+    } else {
+      XAieTileMem_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);
+    }
+  }
+  void set() {
+    if (mode == MODE_CORE) {
+      start = XAieTileCore_PerfCounterGet(tilePtr, pfc);
+    } else if (mode == MODE_PL) {
+      start = XAieTilePl_PerfCounterGet(tilePtr, pfc);
+    } else {
+      start = XAieTileMem_PerfCounterGet(tilePtr, pfc);
+    }
+  }
+  u32 read() {
+    if (mode == MODE_CORE) {
+      return XAieTileCore_PerfCounterGet(tilePtr, pfc);
+    } else if (mode == MODE_PL) {
+      return XAieTilePl_PerfCounterGet(tilePtr, pfc);
+    } else {
+      return XAieTileMem_PerfCounterGet(tilePtr, pfc);
+    }
+  }
+  u32 diff() {
+    u32 end;
+    if (mode == MODE_CORE) {
+      end = XAieTileCore_PerfCounterGet(tilePtr, pfc);
+    } else if (mode == MODE_PL) {
+      end = XAieTilePl_PerfCounterGet(tilePtr, pfc);
+    } else {
+      end = XAieTileMem_PerfCounterGet(tilePtr, pfc);
+    }
+    if (end < start) {
+      printf("WARNING: EventMon: performance counter wrapped!\n");
+      return 0; // TODO: fix this
+    } else {
+      return end - start;
+    }
+  }
+
+private:
+  u32 start;
+  u32 pfc;
+  u8 mode;
+  struct XAieGbl_Tile *tilePtr;
 };
 
 void computeStats(u32 performance_counter[], int n);

--- a/runtime_lib/test_library.h
+++ b/runtime_lib/test_library.h
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <xaiengine.h>
+#include <cmath>
 
 extern "C" {
 
@@ -82,6 +83,11 @@ struct aie_libxaie_ctx_t {
 #define XAIE_NUM_COLS 50
 #define XAIE_ADDR_ARRAY_OFF 0x800
 
+#define MODE_CORE 0
+#define MODE_PL 1
+#define MODE_MEM 2
+
+
 //#define HIGH_ADDR(addr)	((addr & 0xffffffff00000000) >> 32)
 //#define LOW_ADDR(addr)	(addr & 0x00000000ffffffff)
 
@@ -131,6 +137,62 @@ void mlir_aie_clear_config(aie_libxaie_ctx_t *ctx, int col, int row);
 
 /// Zero out the configuration memory of the shim tile.
 void mlir_aie_clear_shim_config(aie_libxaie_ctx_t *ctx, int col, int row);
+
+// class for using events and PF cpounters
+class EventMon{
+    public:
+        EventMon(struct XAieGbl_Tile *_tilePtr, u32 _pfc, u32 _startE, u32 _endE, u32 _resetE, u8 _mode){
+            tilePtr = _tilePtr;
+            pfc = _pfc;
+            mode = _mode; // 0: Core, 1: PL, 2, Mem
+            if(mode == MODE_CORE){
+                XAieTileCore_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);}
+            else if(mode == MODE_PL){
+                XAieTilePl_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);}
+            else{
+                XAieTileMem_PerfCounterControl(tilePtr, pfc, _startE, _endE, _resetE);}
+            
+        }
+        void set(){
+            if(mode == MODE_CORE){
+                start = XAieTileCore_PerfCounterGet(tilePtr, pfc);}
+            else if(mode == MODE_PL){
+                start = XAieTilePl_PerfCounterGet(tilePtr, pfc);}
+            else{
+                start = XAieTileMem_PerfCounterGet(tilePtr, pfc);}
+        }
+        u32 read(){
+            if(mode == MODE_CORE){
+                return XAieTileCore_PerfCounterGet(tilePtr, pfc);}
+            else if(mode == MODE_PL){
+                return XAieTilePl_PerfCounterGet(tilePtr, pfc);}
+            else{
+                return XAieTileMem_PerfCounterGet(tilePtr, pfc);}
+        }
+        u32 diff(){
+            u32 end;
+            if(mode == MODE_CORE){
+                end = XAieTileCore_PerfCounterGet(tilePtr, pfc);}
+            else if(mode == MODE_PL){
+                end = XAieTilePl_PerfCounterGet(tilePtr, pfc);}
+            else{
+                end = XAieTileMem_PerfCounterGet(tilePtr, pfc);}
+            if(end < start){
+                printf("WARNING: EventMon: performance counter wrapped!\n");
+                return 0; // TODO: fix this
+            }
+            else{
+                return end - start;
+            }
+        }
+    private:
+        u32 start;
+        u32 pfc;
+        u8 mode;
+        struct XAieGbl_Tile *tilePtr;
+};
+
+void computeStats(u32 performance_counter[], int n);
 
 } // extern "C"
 #endif

--- a/test/benchmarks/01_DDR_SHIM_LM_FillRate/aie.mlir
+++ b/test/benchmarks/01_DDR_SHIM_LM_FillRate/aie.mlir
@@ -1,0 +1,55 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark01_DDR_SHIM_fill_rate {
+
+
+  %t70 = AIE.tile(7, 0)
+  %t71 = AIE.tile(7, 1)
+  //%t72 = AIE.tile(7, 2)
+
+  %buffer = AIE.external_buffer 0x020100004000 : memref<7168xi32>
+
+  // Fixup
+  %sw = AIE.switchbox(%t70) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux = AIE.shimmux(%t70) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ 
+
+ %swdma = AIE.switchbox(%t71) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+
+  
+
+  %buf71_0 = AIE.buffer(%t71) {sym_name = "buf71_0" } : memref<7168xi32>
+
+  %l71_0 = AIE.lock(%t71, 0)
+  %l71_1 = AIE.lock(%t71, 1)
+
+
+
+   %m71 = AIE.mem(%t71) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l71_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf71_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l71_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+}
+

--- a/test/benchmarks/01_DDR_SHIM_LM_FillRate/test.cpp
+++ b/test/benchmarks/01_DDR_SHIM_LM_FillRate/test.cpp
@@ -1,0 +1,148 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int n = 1;
+  u32 pc2_times[n];
+
+  for (int iters = 0; iters < n; iters++) {
+
+    auto col = 7;
+
+    size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+    XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                             XAIE_ADDR_ARRAY_OFF);
+    XAieGbl_HwInit(&AieConfig);
+    AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+    XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+    ACDC_print_tile_status(TileInst[7][1]);
+
+    // Run auto generated config functions
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+
+    static XAieGbl_MemInst *IO_Mem;
+    u32 *ddr_ptr;
+
+#define DMA_COUNT 7168
+
+    IO_Mem = XAieGbl_MemInit(0);
+    ddr_ptr = (u32 *)XAieGbl_MemGetPaddr(IO_Mem);
+    printf("Start address of ddr buffer = %p\n", ddr_ptr);
+    for (int i = 0; i < DMA_COUNT; i++) {
+      // if ( i < 10){
+      //   printf("%p\n", ddr_ptr + i);
+      // }
+      XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr + i), i + 1);
+    }
+
+    u32 *ddr_ptr2 = ddr_ptr + DMA_COUNT;
+    printf("DDR_PTR NEW, %p \n", ddr_ptr2);
+
+    printf("Acquired before");
+    // XAieTile_LockAcquire(&(TileInst[7][1]), 0, 0, 0);
+    mlir_configure_dmas();
+
+    XAieDma_Shim ShimDMAInst_7_0;
+    XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_7_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0, /* bd */ 0, HIGH_ADDR((u64)ddr_ptr),
+                          LOW_ADDR((u64)ddr_ptr), /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_7_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_7_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_7_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_7_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    // We're going to stamp over the memory
+    for (int i = 0; i < DMA_COUNT; i++) {
+      mlir_write_buffer_buf71_0(i, 0xdeadbeef);
+    }
+
+    XAieTilePl_EventBroadcast(&TileInst[7][0], 2,
+                              XAIETILE_EVENT_SHIM_LOCK_1_ACQUIRED_NOC); // Start
+    XAieTilePl_EventBroadcast(&TileInst[7][0], 3,
+                              XAIETILE_EVENT_SHIM_LOCK_1_RELEASE_NOC); // Stop
+
+    EventMon pc2(&TileInst[7][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc2.set();
+
+    // iterate over the buffer
+    usleep(1000);
+    XAieTile_LockRelease(&(TileInst[7][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+
+    usleep(2000);
+
+    pc2_times[iters] = pc2.diff();
+
+    int errors = 0;
+    for (int i = 0; i < DMA_COUNT; i++) {
+      uint32_t d = mlir_read_buffer_buf71_0(i);
+      if (d != (i + 1)) {
+        errors++;
+        printf("mismatch %x != 1 + %x\n", d, i);
+      }
+    }
+  }
+
+  computeStats(pc2_times, n);
+}

--- a/test/benchmarks/02_LM_SHIM_DDR_FillRate/aie.mlir
+++ b/test/benchmarks/02_LM_SHIM_DDR_FillRate/aie.mlir
@@ -1,0 +1,49 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark_02_LM2DDR {
+  %t70 = AIE.tile(7, 0)
+  %t71 = AIE.tile(7, 1)
+ 
+
+  %lock_a_ping = AIE.lock(%t71, 3) // a_ping
+
+  %buf71_0 = AIE.buffer(%t71) {sym_name = "buf71_0" } : memref<7168xi32>
+
+ %m71 = AIE.mem(%t71) {
+      %srcDma = AIE.dmaStart("MM2S1", ^bd0, ^end)
+    ^bd0:
+      AIE.useLock(%lock_a_ping, "Acquire", 0, 0)
+      AIE.dmaBd(<%buf71_0 : memref<7168xi32>, 0, 7168>, 0)
+      AIE.useLock(%lock_a_ping, "Release", 1, 0)
+      br ^end
+    ^end:
+      AIE.end
+  }
+
+  // Shim DMA connection to kernel
+  %sw2 = AIE.switchbox(%t71){
+    AIE.connect<"DMA" : 1, "South" : 2>
+  }
+
+  
+  %sw1  = AIE.switchbox(%t70) {
+    AIE.connect<"North" : 2, "South" : 2>
+  }
+  %mux1 = AIE.shimmux  (%t70) {
+    AIE.connect<"South" : 2, "DMA" : 0>
+  }
+
+  //Declare the buffers
+  %buffer_out = AIE.external_buffer 0x020100006000 : memref<7168xi32>
+
+
+
+}

--- a/test/benchmarks/02_LM_SHIM_DDR_FillRate/test.cpp
+++ b/test/benchmarks/02_LM_SHIM_DDR_FillRate/test.cpp
@@ -1,0 +1,138 @@
+
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+
+  for (int iters = 0; iters < n; iters++) {
+
+    printf("test start.\n");
+
+    size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+    XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                             XAIE_ADDR_ARRAY_OFF);
+    XAieGbl_HwInit(&AieConfig);
+    AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+    XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    XAieTile_LockAcquire(&(TileInst[7][0]), 2, 0, 0);
+    XAieTile_LockAcquire(&(TileInst[7][1]), 3, 0, 0);
+
+#define DMA_COUNT 7168
+
+    static XAieGbl_MemInst *IO_Mem;
+    u32 *ddr_ptr;
+    IO_Mem = XAieGbl_MemInit(0);
+    ddr_ptr = (u32 *)XAieGbl_MemGetPaddr(IO_Mem);
+    printf("Start address of ddr buffer = %p\n", ddr_ptr);
+    for (int i = 0; i < DMA_COUNT; i++) {
+      XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr + i), i + 1);
+    }
+
+    for (int i = 0; i < DMA_COUNT; i++) {
+      mlir_write_buffer_buf71_0(i, 0x04);
+    }
+
+    mlir_configure_dmas();
+
+    XAieDma_Shim ShimDMAInst_7_0;
+    XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_7_0, /* bd */ 0, /* lockID */ 2,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100006000), LOW_ADDR((u64)0x20100006000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0, /* bd */ 0, HIGH_ADDR((u64)ddr_ptr),
+                          LOW_ADDR((u64)ddr_ptr), /* len */ 7168 * 4);
+
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_7_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 0,
+                         /* secure */ XAIE_ENABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_7_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_7_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_S2MM0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_7_0, XAIEDMA_TILE_CHNUM_S2MM0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    int errors = 0;
+
+    ACDC_check("Before", mlir_read_buffer_buf71_0(3), 4, errors);
+
+    XAieTileMem_EventBroadcast(&TileInst[7][1], 2,
+                               XAIETILE_EVENT_MEM_LOCK_3_ACQUIRED); // Start
+
+    EventMon pc0(&TileInst[7][0], 0, XAIETILE_EVENT_SHIM_LOCK_2_ACQUIRED_NOC,
+                 XAIETILE_EVENT_SHIM_LOCK_2_RELEASE_NOC,
+                 XAIETILE_EVENT_SHIM_NONE, MODE_PL);
+    pc0.set();
+
+    XAieTile_LockRelease(&(TileInst[7][1]), 3, 0, 0);
+    usleep(1000);
+    XAieTile_LockRelease(&(TileInst[7][0]), 2, 1,
+                         0); // for triggering the timer
+    usleep(2000);
+    pc0_times[iters] = pc0.diff();
+
+    printf("After Lock Release \n");
+    ACDC_print_tile_status(TileInst[7][1]);
+
+    for (int i = 0; i < DMA_COUNT; i++) {
+      printf("%x \n", XAieGbl_MemRead32(IO_Mem, (u64)(ddr_ptr + i)));
+      break;
+    }
+  }
+
+  computeStats(pc0_times, n);
+}

--- a/test/benchmarks/03_Flood_DDR/aie.mlir
+++ b/test/benchmarks/03_Flood_DDR/aie.mlir
@@ -1,0 +1,478 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark03_Flood_DDR {
+
+
+  %t20 = AIE.tile(2, 0)
+  %t21 = AIE.tile(2, 1)
+
+  %sw2 = AIE.switchbox(%t20) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux2 = AIE.shimmux(%t20) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma2 = AIE.switchbox(%t21) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf21_0 = AIE.buffer(%t21) {sym_name = "buf21_0" } : memref<7168xi32>
+  %l21_0 = AIE.lock(%t21, 0)
+
+   %m21 = AIE.mem(%t21) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l21_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf21_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l21_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+  %t30 = AIE.tile(3, 0)
+  %t31 = AIE.tile(3, 1)
+
+  %sw3 = AIE.switchbox(%t30) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux3 = AIE.shimmux(%t30) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma3 = AIE.switchbox(%t31) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf31_0 = AIE.buffer(%t31) {sym_name = "buf31_0" } : memref<7168xi32>
+  %l31_0 = AIE.lock(%t31, 0)
+
+   %m31 = AIE.mem(%t31) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l31_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf31_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l31_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+  %t60 = AIE.tile(6, 0)
+  %t61 = AIE.tile(6, 1)
+
+  %sw6 = AIE.switchbox(%t60) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux6 = AIE.shimmux(%t60) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma6 = AIE.switchbox(%t61) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf61_0 = AIE.buffer(%t61) {sym_name = "buf61_0" } : memref<7168xi32>
+  %l61_0 = AIE.lock(%t61, 0)
+
+   %m61 = AIE.mem(%t61) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l61_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf61_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l61_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+
+  %t70 = AIE.tile(7, 0)
+  %t71 = AIE.tile(7, 1)
+
+
+  %sw = AIE.switchbox(%t70) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux = AIE.shimmux(%t70) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+
+ %swdma = AIE.switchbox(%t71) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf71_0 = AIE.buffer(%t71) {sym_name = "buf71_0" } : memref<7168xi32>
+
+  %l71_0 = AIE.lock(%t71, 0)
+
+
+
+   %m71 = AIE.mem(%t71) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l71_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf71_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l71_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+  %t100 = AIE.tile(10, 0)
+  %t101 = AIE.tile(10, 1)
+
+
+  %sw10 = AIE.switchbox(%t100) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux10 = AIE.shimmux(%t100) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+
+ %swdma10 = AIE.switchbox(%t101) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf101_0 = AIE.buffer(%t101) {sym_name = "buf101_0" } : memref<7168xi32>
+
+  %l101_0 = AIE.lock(%t101, 0)
+
+
+
+   %m101 = AIE.mem(%t101) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l101_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf101_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l101_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+  %t110 = AIE.tile(11, 0)
+  %t111 = AIE.tile(11, 1)
+
+  %sw11 = AIE.switchbox(%t110) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux11 = AIE.shimmux(%t110) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma11 = AIE.switchbox(%t111) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf111_0 = AIE.buffer(%t111) {sym_name = "buf111_0" } : memref<7168xi32>
+  %l111_0 = AIE.lock(%t111, 0)
+
+   %m111 = AIE.mem(%t111) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l111_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf111_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l111_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   
+
+  %t180 = AIE.tile(18, 0)
+  %t181 = AIE.tile(18, 1)
+
+  %sw18 = AIE.switchbox(%t180) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux18 = AIE.shimmux(%t180) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma18 = AIE.switchbox(%t181) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf181_0 = AIE.buffer(%t181) {sym_name = "buf181_0" } : memref<7168xi32>
+  %l181_0 = AIE.lock(%t181, 0)
+
+   %m181 = AIE.mem(%t181) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l181_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf181_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l181_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   
+
+  %t190 = AIE.tile(19, 0)
+  %t191 = AIE.tile(19, 1)
+
+  %sw19 = AIE.switchbox(%t190) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux19 = AIE.shimmux(%t190) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma19 = AIE.switchbox(%t191) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf191_0 = AIE.buffer(%t191) {sym_name = "buf191_0" } : memref<7168xi32>
+  %l191_0 = AIE.lock(%t191, 0)
+
+   %m191 = AIE.mem(%t191) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l191_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf191_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l191_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   %t260 = AIE.tile(26, 0)
+  %t261 = AIE.tile(26, 1)
+
+  %sw26 = AIE.switchbox(%t260) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux26 = AIE.shimmux(%t260) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma26 = AIE.switchbox(%t261) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf261_0 = AIE.buffer(%t261) {sym_name = "buf261_0" } : memref<7168xi32>
+  %l261_0 = AIE.lock(%t261, 0)
+
+   %m261 = AIE.mem(%t261) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l261_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf261_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l261_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   %t270 = AIE.tile(27, 0)
+  %t271 = AIE.tile(27, 1)
+
+  %sw27 = AIE.switchbox(%t270) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux27 = AIE.shimmux(%t270) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma27 = AIE.switchbox(%t271) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf271_0 = AIE.buffer(%t271) {sym_name = "buf271_0" } : memref<7168xi32>
+  %l271_0 = AIE.lock(%t271, 0)
+
+   %m271 = AIE.mem(%t271) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l271_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf271_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l271_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   %t340 = AIE.tile(34, 0)
+  %t341 = AIE.tile(34, 1)
+
+  %sw34 = AIE.switchbox(%t340) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux34 = AIE.shimmux(%t340) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma34 = AIE.switchbox(%t341) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf341_0 = AIE.buffer(%t341) {sym_name = "buf341_0" } : memref<7168xi32>
+  %l341_0 = AIE.lock(%t341, 0)
+
+   %m341 = AIE.mem(%t341) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l341_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf341_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l341_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+
+  %t350 = AIE.tile(35, 0)
+  %t351 = AIE.tile(35, 1)
+
+  %sw35 = AIE.switchbox(%t350) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux35 = AIE.shimmux(%t350) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma35 = AIE.switchbox(%t351) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf351_0 = AIE.buffer(%t351) {sym_name = "buf351_0" } : memref<7168xi32>
+  %l351_0 = AIE.lock(%t351, 0)
+
+   %m351 = AIE.mem(%t351) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l351_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf351_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l351_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   %t420 = AIE.tile(42, 0)
+  %t421 = AIE.tile(42, 1)
+
+  %sw42 = AIE.switchbox(%t420) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux42 = AIE.shimmux(%t420) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma42 = AIE.switchbox(%t421) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf421_0 = AIE.buffer(%t421) {sym_name = "buf421_0" } : memref<7168xi32>
+  %l421_0 = AIE.lock(%t421, 0)
+
+   %m421 = AIE.mem(%t421) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l421_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf421_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l421_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   %t430 = AIE.tile(43, 0)
+  %t431 = AIE.tile(43, 1)
+
+  %sw43 = AIE.switchbox(%t430) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux43 = AIE.shimmux(%t430) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma43 = AIE.switchbox(%t431) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf431_0 = AIE.buffer(%t431) {sym_name = "buf431_0" } : memref<7168xi32>
+  %l431_0 = AIE.lock(%t431, 0)
+
+   %m431 = AIE.mem(%t431) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l431_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf431_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l431_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   %t460 = AIE.tile(46, 0)
+  %t461 = AIE.tile(46, 1)
+
+  %sw46 = AIE.switchbox(%t460) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux46 = AIE.shimmux(%t460) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma46 = AIE.switchbox(%t461) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf461_0 = AIE.buffer(%t461) {sym_name = "buf461_0" } : memref<7168xi32>
+  %l461_0 = AIE.lock(%t461, 0)
+
+   %m461 = AIE.mem(%t461) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l461_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf461_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l461_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+   %t470 = AIE.tile(47, 0)
+  %t471 = AIE.tile(47, 1)
+
+  %sw47 = AIE.switchbox(%t470) {
+    AIE.connect<"South" : 3, "North" : 3>
+  }
+  %mux47 = AIE.shimmux(%t470) {
+    AIE.connect<"DMA" : 0, "South": 3>
+  }
+
+ %swdma47 = AIE.switchbox(%t471) {
+    AIE.connect<"South" : 3, "DMA" : 0>
+  }
+
+  %buf471_0 = AIE.buffer(%t471) {sym_name = "buf471_0" } : memref<7168xi32>
+  %l471_0 = AIE.lock(%t471, 0)
+
+   %m471 = AIE.mem(%t471) {
+      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+       ^bd0:
+        AIE.useLock(%l471_0, "Acquire", 0, 0)
+        AIE.dmaBd(<%buf471_0 : memref< 7168xi32>, 0, 7168>, 0)
+        AIE.useLock(%l471_0, "Release", 1, 0)
+        br ^end
+      ^end:
+      AIE.end
+   }
+
+}

--- a/test/benchmarks/03_Flood_DDR/test.cpp
+++ b/test/benchmarks/03_Flood_DDR/test.cpp
@@ -1,0 +1,681 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+#define DMA_COUNT 7168
+
+int main(int argc, char *argv[]) {
+
+  int n = 1;
+  u32 pc7_times[n];
+  u32 pc6_times[n];
+  u32 pc2_times[n];
+  u32 pc3_times[n];
+  u32 pc10_times[n];
+  u32 pc11_times[n];
+  u32 pc18_times[n];
+  u32 pc19_times[n];
+  u32 pc26_times[n];
+  u32 pc27_times[n];
+  u32 pc34_times[n];
+  u32 pc35_times[n];
+  u32 pc42_times[n];
+  u32 pc43_times[n];
+  u32 pc46_times[n];
+  u32 pc47_times[n];
+
+  static XAieGbl_MemInst *IO_Mem;
+  IO_Mem = XAieGbl_MemInit(0);
+
+  u32 *ddr_ptr2;
+  ddr_ptr2 = (u32 *)XAieGbl_MemGetPaddr(IO_Mem);
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr2 + i), i + 1);
+  }
+
+  u32 *ddr_ptr3 = ddr_ptr2 + DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr3 + i), i + 1);
+  }
+
+  u32 *ddr_ptr6 = ddr_ptr2 + 2 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr6 + i), i + 1);
+  }
+
+  u32 *ddr_ptr7 = ddr_ptr2 + 3 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr7 + i), i + 1);
+  }
+
+  u32 *ddr_ptr10 = ddr_ptr2 + 4 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr10 + i), i + 1);
+  }
+
+  u32 *ddr_ptr11 = ddr_ptr2 + 5 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr11 + i), i + 1);
+  }
+
+  u32 *ddr_ptr18 = ddr_ptr2 + 6 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr18 + i), i + 1);
+  }
+
+  u32 *ddr_ptr19 = ddr_ptr2 + 7 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr19 + i), i + 1);
+  }
+
+  u32 *ddr_ptr26 = ddr_ptr2 + 8 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr26 + i), i + 1);
+  }
+
+  u32 *ddr_ptr27 = ddr_ptr2 + 9 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr27 + i), i + 1);
+  }
+
+  u32 *ddr_ptr34 = ddr_ptr2 + 10 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr34 + i), i + 1);
+  }
+
+  u32 *ddr_ptr35 = ddr_ptr2 + 11 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr35 + i), i + 1);
+  }
+
+  u32 *ddr_ptr42 = ddr_ptr2 + 12 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr42 + i), i + 1);
+  }
+
+  u32 *ddr_ptr43 = ddr_ptr2 + 13 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr43 + i), i + 1);
+  }
+
+  u32 *ddr_ptr46 = ddr_ptr2 + 14 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr46 + i), i + 1);
+  }
+
+  u32 *ddr_ptr47 = ddr_ptr2 + 15 * DMA_COUNT;
+  for (int i = 0; i < DMA_COUNT; i++) {
+    XAieGbl_MemWrite32(IO_Mem, (u64)(ddr_ptr47 + i), i + 1);
+  }
+
+  for (int iters = 0; iters < n; iters++) {
+
+    size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+    XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                             XAIE_ADDR_ARRAY_OFF);
+    XAieGbl_HwInit(&AieConfig);
+    AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+    XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+    // Run auto generated config functions
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    XAieDma_Shim ShimDMAInst_2_0;
+    XAieDma_ShimInitialize(&(TileInst[2][0]), &ShimDMAInst_2_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_2_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_2_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr2), LOW_ADDR((u64)ddr_ptr2),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_2_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_2_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_2_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_2_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_2_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_3_0;
+    XAieDma_ShimInitialize(&(TileInst[3][0]), &ShimDMAInst_3_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_3_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_3_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr3), LOW_ADDR((u64)ddr_ptr3),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_3_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_3_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_3_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_3_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_3_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_6_0;
+    XAieDma_ShimInitialize(&(TileInst[6][0]), &ShimDMAInst_6_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_6_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_6_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr6), LOW_ADDR((u64)ddr_ptr6),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_6_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_6_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_6_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_6_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_6_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_7_0;
+    XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_7_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr7), LOW_ADDR((u64)ddr_ptr7),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_7_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_7_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_7_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_7_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_10_0;
+    XAieDma_ShimInitialize(&(TileInst[10][0]), &ShimDMAInst_10_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_10_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_10_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr10), LOW_ADDR((u64)ddr_ptr10),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_10_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_10_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_10_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_10_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_10_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_11_0;
+    XAieDma_ShimInitialize(&(TileInst[11][0]), &ShimDMAInst_11_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_11_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_11_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr11), LOW_ADDR((u64)ddr_ptr11),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_11_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_11_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_11_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_11_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_11_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_18_0;
+    XAieDma_ShimInitialize(&(TileInst[18][0]), &ShimDMAInst_18_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_18_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_18_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr18), LOW_ADDR((u64)ddr_ptr18),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_18_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_18_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_18_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_18_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_18_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_19_0;
+    XAieDma_ShimInitialize(&(TileInst[19][0]), &ShimDMAInst_19_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_19_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_19_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr19), LOW_ADDR((u64)ddr_ptr19),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_19_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_19_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_19_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_19_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_19_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_26_0;
+    XAieDma_ShimInitialize(&(TileInst[26][0]), &ShimDMAInst_26_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_26_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_26_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr26), LOW_ADDR((u64)ddr_ptr26),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_26_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_26_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_26_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_26_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_26_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_27_0;
+    XAieDma_ShimInitialize(&(TileInst[27][0]), &ShimDMAInst_27_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_27_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_27_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr27), LOW_ADDR((u64)ddr_ptr27),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_27_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_27_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_27_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_27_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_27_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_34_0;
+    XAieDma_ShimInitialize(&(TileInst[34][0]), &ShimDMAInst_34_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_34_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_34_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr34), LOW_ADDR((u64)ddr_ptr34),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_34_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_34_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_34_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_34_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_34_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_35_0;
+    XAieDma_ShimInitialize(&(TileInst[35][0]), &ShimDMAInst_35_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_35_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_35_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr35), LOW_ADDR((u64)ddr_ptr35),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_35_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_35_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_35_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_35_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_35_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_42_0;
+    XAieDma_ShimInitialize(&(TileInst[42][0]), &ShimDMAInst_42_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_42_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_42_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr42), LOW_ADDR((u64)ddr_ptr42),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_42_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_42_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_42_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_42_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_42_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_43_0;
+    XAieDma_ShimInitialize(&(TileInst[43][0]), &ShimDMAInst_43_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_43_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_43_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr43), LOW_ADDR((u64)ddr_ptr43),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_43_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_43_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_43_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_43_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_43_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_46_0;
+    XAieDma_ShimInitialize(&(TileInst[46][0]), &ShimDMAInst_46_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_46_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_46_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr46), LOW_ADDR((u64)ddr_ptr46),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_46_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_46_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_46_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_46_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_46_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    XAieDma_Shim ShimDMAInst_47_0;
+    XAieDma_ShimInitialize(&(TileInst[47][0]), &ShimDMAInst_47_0);
+    XAieDma_ShimBdSetLock(&ShimDMAInst_47_0, /* bd */ 0, /* lockID */ 1,
+                          XAIE_ENABLE, /* release */ 0, XAIE_ENABLE,
+                          /* acquire */ 1);
+    // XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0,
+    // HIGH_ADDR((u64)0x20100004000), LOW_ADDR((u64)0x20100004000),  /* len */
+    // 256 * 4);
+    XAieDma_ShimBdSetAddr(&ShimDMAInst_47_0, /* bd */ 0,
+                          HIGH_ADDR((u64)ddr_ptr47), LOW_ADDR((u64)ddr_ptr47),
+                          /* len */ 7168 * 4);
+    XAieDma_ShimBdSetAxi(&ShimDMAInst_47_0, /* bd */ 0, /* smid */ 0,
+                         /* burstlen */ 16, /* QOS */ 0, /* Cache */ 1,
+                         /* secure */ XAIE_DISABLE);
+    XAieDma_ShimBdSetNext(&ShimDMAInst_47_0, /* bd */ 0, /* nextbd */ 0);
+    XAieDma_ShimBdWrite(&ShimDMAInst_47_0, /* bd */ 0);
+    XAieDma_ShimSetStartBd(&ShimDMAInst_47_0, XAIEDMA_SHIM_CHNUM_MM2S0,
+                           /* bd */ 0);
+    XAieDma_ShimChControl(&ShimDMAInst_47_0, XAIEDMA_TILE_CHNUM_MM2S0,
+                          /* PauseStream */ XAIE_DISABLE,
+                          /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+    // We're going to stamp over the memory
+    for (int i = 0; i < DMA_COUNT; i++) {
+      mlir_write_buffer_buf21_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf31_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf61_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf71_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf101_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf111_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf181_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf191_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf261_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf271_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf341_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf351_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf421_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf431_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf461_0(i, 0xdeadbeef);
+      mlir_write_buffer_buf471_0(i, 0xdeadbeef);
+    }
+
+    XAieTilePl_EventBroadcast(&TileInst[2][0], 2,
+                              XAIETILE_EVENT_SHIM_LOCK_1_ACQUIRED_NOC); // Start
+
+    EventMon pc2(&TileInst[2][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc2.set();
+    EventMon pc3(&TileInst[3][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc3.set();
+    EventMon pc6(&TileInst[6][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc6.set();
+    EventMon pc7(&TileInst[7][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc7.set();
+    EventMon pc10(&TileInst[10][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc10.set();
+    EventMon pc11(&TileInst[11][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc11.set();
+    EventMon pc18(&TileInst[18][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc18.set();
+    EventMon pc19(&TileInst[19][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc19.set();
+    EventMon pc26(&TileInst[26][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc26.set();
+    EventMon pc27(&TileInst[27][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc27.set();
+    EventMon pc34(&TileInst[34][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc34.set();
+    EventMon pc35(&TileInst[35][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc35.set();
+    EventMon pc42(&TileInst[42][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc42.set();
+    EventMon pc43(&TileInst[43][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc43.set();
+    EventMon pc46(&TileInst[46][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc46.set();
+    EventMon pc47(&TileInst[47][1], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                  XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                  MODE_MEM);
+    pc47.set();
+
+    // iterate over the buffer
+    usleep(1000);
+    XAieTile_LockRelease(&(TileInst[2][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[3][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[6][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[7][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[10][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[11][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[18][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[19][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[26][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[27][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[34][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[35][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[42][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[43][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[46][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+    XAieTile_LockRelease(&(TileInst[47][0]), 1, 1,
+                         0); // Release lock for reading from DDR
+
+    usleep(5000);
+    pc2_times[iters] = pc2.diff();
+    pc3_times[iters] = pc3.diff();
+    pc6_times[iters] = pc6.diff();
+    pc7_times[iters] = pc7.diff();
+    pc10_times[iters] = pc10.diff();
+    pc11_times[iters] = pc11.diff();
+    pc18_times[iters] = pc18.diff();
+    pc19_times[iters] = pc19.diff();
+    pc26_times[iters] = pc26.diff();
+    pc27_times[iters] = pc27.diff();
+    pc34_times[iters] = pc34.diff();
+    pc35_times[iters] = pc35.diff();
+    pc42_times[iters] = pc42.diff();
+    pc43_times[iters] = pc43.diff();
+    pc46_times[iters] = pc46.diff();
+    pc47_times[iters] = pc47.diff();
+
+    int errors = 0;
+  }
+
+  computeStats(pc2_times, n);
+  computeStats(pc3_times, n);
+  computeStats(pc6_times, n);
+  computeStats(pc7_times, n);
+  computeStats(pc10_times, n);
+  computeStats(pc11_times, n);
+  computeStats(pc18_times, n);
+  computeStats(pc19_times, n);
+  computeStats(pc26_times, n);
+  computeStats(pc27_times, n);
+  computeStats(pc34_times, n);
+  computeStats(pc35_times, n);
+  computeStats(pc42_times, n);
+  computeStats(pc43_times, n);
+  computeStats(pc46_times, n);
+  computeStats(pc47_times, n);
+}

--- a/test/benchmarks/04_Tile_Tile_FillRate/aie.mlir
+++ b/test/benchmarks/04_Tile_Tile_FillRate/aie.mlir
@@ -1,0 +1,53 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @test04_tile_tiledma {
+  %tile13 = AIE.tile(1, 3)
+  %tile14 = AIE.tile(1, 4)
+ 
+
+  %buf13_0 = AIE.buffer(%tile13) { sym_name = "a13" } : memref<512xi32>
+
+
+  %lock13_5 = AIE.lock(%tile13, 5) // interbuffer lock
+
+  AIE.switchbox(%tile13) { AIE.connect<"DMA": 0, "North": 1> }
+  AIE.switchbox(%tile14) { AIE.connect<"South": 1, "DMA": 1> }
+
+
+  %mem13 = AIE.mem(%tile13) {
+    %dma0 = AIE.dmaStart("MM2S0", ^bd0, ^end)
+    ^bd0:
+      AIE.useLock(%lock13_5, "Acquire", 1, 0)
+      AIE.dmaBd(<%buf13_0 : memref<512xi32>, 0, 512>, 0)
+      AIE.useLock(%lock13_5, "Release", 0, 0)
+      br ^end // point to the next BD, or termination
+    ^end:
+      AIE.end
+  }
+
+  %lock14_6 = AIE.lock(%tile14, 6) // interbuffer lock
+  %lock14_7 = AIE.lock(%tile14, 7) // interbuffer lock
+  %buf14_0 = AIE.buffer(%tile14) { sym_name = "a14" } : memref<512xi32>
+  %buf14_1 = AIE.buffer(%tile14) { sym_name = "b14" } : memref<256xi32>
+
+  %mem14 = AIE.mem(%tile14) {
+    %dma0 = AIE.dmaStart("S2MM1", ^bd0, ^end)
+    ^bd0:
+      AIE.useLock(%lock14_6, "Acquire", 0, 0)
+      AIE.dmaBd(<%buf14_0: memref<512xi32>, 0, 512>, 0)
+      AIE.useLock(%lock14_6, "Release", 1, 0)
+      br ^end // point to the next BD, or termination
+    ^end:
+      AIE.end
+  }
+
+
+}

--- a/test/benchmarks/04_Tile_Tile_FillRate/test.cpp
+++ b/test/benchmarks/04_Tile_Tile_FillRate/test.cpp
@@ -1,0 +1,145 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define LOCK_TIMEOUT 100
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MLIR_STACK_OFFSET 4096
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
+
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+  u32 pc2_times[n];
+  u32 pc3_times[n];
+
+  for (int iters = 0; iters < n; iters++) {
+
+    size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+    XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                             XAIE_ADDR_ARRAY_OFF);
+    XAieGbl_HwInit(&AieConfig);
+    AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+    XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+
+    printf("Acquire input buffer lock first.\n");
+    XAieTile_LockAcquire(&(TileInst[1][3]), 5, 0, 0);
+
+    mlir_configure_dmas();
+    mlir_initialize_locks();
+
+    ACDC_clear_tile_memory(TileInst[1][3]);
+    ACDC_clear_tile_memory(TileInst[1][4]);
+
+#define DMA_COUNT 512
+
+    for (int i = 0; i < DMA_COUNT; i++) {
+      mlir_write_buffer_a13(i, i + 1);
+      mlir_write_buffer_a14(i, 0xdeadbeef);
+    }
+
+    // Destination Tile
+    EventMon pc0(&TileInst[1][4], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_DMA_S2MM_1_FINISHED_BD,
+                 XAIETILE_EVENT_MEM_NONE, MODE_MEM);
+    pc0.set();
+    EventMon pc1(&TileInst[1][4], 1, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_LOCK_6_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc1.set();
+
+    // Source Tile
+    EventMon pc2(&TileInst[1][3], 0, XAIETILE_EVENT_MEM_LOCK_5_ACQUIRED,
+                 XAIETILE_EVENT_MEM_DMA_MM2S_0_FINISHED_BD,
+                 XAIETILE_EVENT_MEM_NONE, MODE_MEM);
+    pc2.set();
+    EventMon pc3(&TileInst[1][3], 1, XAIETILE_EVENT_MEM_LOCK_5_ACQUIRED,
+                 XAIETILE_EVENT_MEM_LOCK_5_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc3.set();
+
+    XAieTileMem_EventBroadcast(&TileInst[1][3], 2,
+                               XAIETILE_EVENT_MEM_LOCK_5_ACQUIRED); // Start
+
+    XAieTile_LockRelease(&(TileInst[1][3]), 5, 1, 0);
+    usleep(100);
+
+    pc0_times[iters] = pc0.diff();
+    pc1_times[iters] = pc1.diff();
+    pc2_times[iters] = pc2.diff();
+    pc3_times[iters] = pc3.diff();
+
+    for (int i = 0; i < DMA_COUNT; i++) {
+      uint32_t d = mlir_read_buffer_a13(i);
+      if (d != (i + 1)) {
+        printf("Not Matched");
+      }
+    }
+
+    int errors = 0;
+    for (int i = 0; i < DMA_COUNT; i++) {
+      uint32_t d = mlir_read_buffer_a14(i);
+      if (d != (i + 1)) {
+        errors++;
+        printf("mismatch %x != 1 + %x\n", d, i);
+        break;
+      }
+    }
+  }
+
+  printf("\nSource MM2S Finished ");
+  computeStats(pc2_times, n);
+  printf("Source Lock Released ");
+  computeStats(pc3_times, n);
+  printf("Destination S2MM Finished ");
+  computeStats(pc0_times, n);
+  printf("Destination Lock Released ");
+  computeStats(pc1_times, n);
+}

--- a/test/benchmarks/05_Core_Startup/aie.mlir
+++ b/test/benchmarks/05_Core_Startup/aie.mlir
@@ -1,0 +1,19 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark03_core_startup {
+  %tile13 = AIE.tile(1, 3)
+
+  %buf13_0 = AIE.buffer(%tile13) { sym_name = "a" } : memref<256xi32>
+
+  %core13 = AIE.core(%tile13) {
+    AIE.end
+  }
+}

--- a/test/benchmarks/05_Core_Startup/test.cpp
+++ b/test/benchmarks/05_Core_Startup/test.cpp
@@ -1,0 +1,84 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MLIR_STACK_OFFSET 4096
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+
+  for (int iters = 0; iters < n; iters++) {
+
+    size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+    XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                             XAIE_ADDR_ARRAY_OFF);
+    XAieGbl_HwInit(&AieConfig);
+    AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+    XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+    ACDC_clear_tile_memory(TileInst[1][3]);
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    EventMon pc0(&TileInst[1][3], 0, XAIETILE_EVENT_CORE_ACTIVE,
+                 XAIETILE_EVENT_CORE_DISABLED, XAIETILE_EVENT_CORE_NONE,
+                 MODE_CORE);
+
+    pc0.set();
+
+    mlir_start_cores();
+    usleep(1000);
+
+    pc0_times[iters] = pc0.diff();
+  }
+
+  computeStats(pc0_times, n);
+}

--- a/test/benchmarks/06_Buffer_Store/aie.mlir
+++ b/test/benchmarks/06_Buffer_Store/aie.mlir
@@ -1,0 +1,22 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark06_buffer_store {
+  %tile13 = AIE.tile(1, 3)
+
+  %buf13_0 = AIE.buffer(%tile13) { sym_name = "a" } : memref<256xi32>
+
+  %core13 = AIE.core(%tile13) {
+    %val1 = constant 7 : i32
+    %idx1 = constant 3 : index
+    memref.store %val1, %buf13_0[%idx1] : memref<256xi32>
+    AIE.end
+  }
+}

--- a/test/benchmarks/06_Buffer_Store/test.cpp
+++ b/test/benchmarks/06_Buffer_Store/test.cpp
@@ -1,0 +1,88 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MLIR_STACK_OFFSET 4096
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+
+  int n = 1;
+  u32 pc0_times[n];
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  int errors = 0;
+  for (int iters = 0; iters < n; iters++) {
+
+    ACDC_clear_tile_memory(TileInst[1][3]);
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+    EventMon pc0(&TileInst[1][3], 0, XAIETILE_EVENT_CORE_ACTIVE,
+                 XAIETILE_EVENT_CORE_DISABLED, XAIETILE_EVENT_CORE_NONE,
+                 MODE_CORE);
+
+    pc0.set();
+
+    ACDC_print_tile_status(TileInst[1][3]);
+
+    mlir_start_cores();
+    pc0_times[iters] = pc0.diff();
+    printf("result: %u", pc0_times[iters]);
+
+    int errors = 0;
+
+    ACDC_check("After memory writes. Check [3]=14", mlir_read_buffer_a(3), 7,
+               errors);
+  }
+  computeStats(pc0_times, n);
+}

--- a/test/benchmarks/07_Lock_Acquire/aie.mlir
+++ b/test/benchmarks/07_Lock_Acquire/aie.mlir
@@ -1,0 +1,20 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark07_lock_acquire {
+  %tile13 = AIE.tile(1, 3)
+
+  %l13_0 = AIE.lock(%tile13, 0)
+
+AIE.core(%tile13) {
+    AIE.useLock(%l13_0, "Acquire", 0 , 0)
+    AIE.end
+  }
+}

--- a/test/benchmarks/07_Lock_Acquire/test.cpp
+++ b/test/benchmarks/07_Lock_Acquire/test.cpp
@@ -1,0 +1,86 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MLIR_STACK_OFFSET 4096
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+
+  printf("test start.\n");
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  for (int iters = 0; iters < n; iters++) {
+
+    ACDC_clear_tile_memory(TileInst[1][3]);
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    EventMon pc0(&TileInst[1][3], 0, XAIETILE_EVENT_CORE_ACTIVE,
+                 XAIETILE_EVENT_CORE_DISABLED, XAIETILE_EVENT_CORE_NONE,
+                 MODE_CORE);
+
+    pc0.set();
+
+    mlir_start_cores();
+    usleep(100);
+    pc0_times[iters] = pc0.diff();
+
+    int errors = 0;
+  }
+  computeStats(pc0_times, n);
+}

--- a/test/benchmarks/08_Lock_Release/aie.mlir
+++ b/test/benchmarks/08_Lock_Release/aie.mlir
@@ -1,0 +1,20 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark06_lock_release {
+  %tile13 = AIE.tile(1, 3)
+
+  %l13_0 = AIE.lock(%tile13, 0)
+
+AIE.core(%tile13) {
+    AIE.useLock(%l13_0, "Release", 0 , 0)
+    AIE.end
+  }
+}

--- a/test/benchmarks/08_Lock_Release/test.cpp
+++ b/test/benchmarks/08_Lock_Release/test.cpp
@@ -1,0 +1,85 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MLIR_STACK_OFFSET 4096
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+
+  printf("test start.\n");
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  for (int iters = 0; iters < n; iters++) {
+
+    ACDC_clear_tile_memory(TileInst[1][3]);
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    EventMon pc0(&TileInst[1][3], 0, XAIETILE_EVENT_CORE_ACTIVE,
+                 XAIETILE_EVENT_CORE_DISABLED, XAIETILE_EVENT_CORE_NONE,
+                 MODE_CORE);
+
+    pc0.set();
+
+    mlir_start_cores();
+    pc0_times[iters] = pc0.diff();
+
+    int errors = 0;
+  }
+  computeStats(pc0_times, n);
+}

--- a/test/benchmarks/09_Shim_Broadcast_Horizontal/aie.mlir
+++ b/test/benchmarks/09_Shim_Broadcast_Horizontal/aie.mlir
@@ -1,0 +1,17 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark09_shim_broadcast {
+
+  %t70 = AIE.tile(7, 0)
+  %t3 = AIE.tile(3,0)
+  %60 = AIE.tile(6,0)
+
+}

--- a/test/benchmarks/09_Shim_Broadcast_Horizontal/test.cpp
+++ b/test/benchmarks/09_Shim_Broadcast_Horizontal/test.cpp
@@ -1,0 +1,112 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+#define BRAM_ADDR (0x4000 + 0x020100000000LL)
+#define DMA_COUNT 512
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+  u32 pc2_times[n];
+  u32 pc3_times[n];
+
+  int total_errors = 0;
+
+  auto col = 7;
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  for (int iters = 0; iters < n; iters++) {
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+
+    XAieTile_LockAcquire(&(TileInst[7][2]), 1, 0, 0);
+    XAieTile_LockAcquire(&(TileInst[7][2]), 2, 0, 0);
+
+    mlir_configure_dmas();
+
+    XAieTilePl_EventBroadcast(
+        &TileInst[6][0], 2, XAIETILE_EVENT_SHIM_DMA_S2MM_0_ERROR_NOC); // Start
+    XAieTilePl_EventBroadcast(&TileInst[7][0], 3,
+                              XAIETILE_EVENT_MEM_LOCK_0_RELEASE); // Stop
+
+    // Track time between two broadcast events in destination tiles (7,3) and
+    // (7,4)
+    EventMon pc0(&TileInst[5][0], 0, XAIETILE_EVENT_SHIM_BROADCAST_A_2,
+                 XAIETILE_EVENT_SHIM_BROADCAST_A_3, XAIETILE_EVENT_SHIM_NONE,
+                 MODE_PL);
+    pc0.set();
+
+    EventMon pc1(&TileInst[7][0], 1, XAIETILE_EVENT_SHIM_BROADCAST_A_2,
+                 XAIETILE_EVENT_MEM_LOCK_0_RELEASE, XAIETILE_EVENT_SHIM_NONE,
+                 MODE_PL);
+    pc1.set();
+
+    // Start Test by generating events in Source Tile
+    XAieTilePl_EventGenerate(&TileInst[6][0],
+                             XAIETILE_EVENT_SHIM_DMA_S2MM_0_ERROR_NOC);
+    XAieTilePl_EventGenerate(&TileInst[7][0],
+                             XAIETILE_EVENT_MEM_LOCK_0_RELEASE);
+
+    usleep(200);
+
+    ACDC_print_tile_status(TileInst[7][3]);
+
+    pc0_times[iters] = pc0.diff();
+    pc1_times[iters] = pc1.diff();
+  }
+
+  computeStats(pc0_times, n);
+  computeStats(pc1_times, n);
+}

--- a/test/benchmarks/10_Tile_Broadcast_Horizontal/aie.mlir
+++ b/test/benchmarks/10_Tile_Broadcast_Horizontal/aie.mlir
@@ -1,0 +1,19 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark10_tile_broadcast_horizontal {
+  %t63 = AIE.tile(6, 3)
+  %t73 = AIE.tile(7, 3)
+  %t83 = AIE.tile(8,3)
+  
+
+}
+  
+

--- a/test/benchmarks/10_Tile_Broadcast_Horizontal/test.cpp
+++ b/test/benchmarks/10_Tile_Broadcast_Horizontal/test.cpp
@@ -1,0 +1,106 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+#define BRAM_ADDR (0x4000 + 0x020100000000LL)
+#define DMA_COUNT 512
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+  u32 pc2_times[n];
+  u32 pc3_times[n];
+
+  int total_errors = 0;
+
+  auto col = 7;
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  for (int iters = 0; iters < n; iters++) {
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    XAieTileCore_EventBroadcast(&TileInst[7][3], 2,
+                                XAIETILE_EVENT_CORE_FP_OVERFLOW); // Start
+    XAieTileCore_EventBroadcast(&TileInst[8][3], 3,
+                                XAIETILE_EVENT_CORE_FP_UNDERFLOW); // Stop
+
+    EventMon pc0(&TileInst[6][3], 0, XAIETILE_EVENT_CORE_BROADCAST_2,
+                 XAIETILE_EVENT_CORE_BROADCAST_3, XAIETILE_EVENT_CORE_NONE,
+                 MODE_CORE);
+    pc0.set();
+
+    EventMon pc1(&TileInst[8][3], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_BROADCAST_3, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc1.set();
+
+    usleep(100);
+
+    // Start Test by generating events in Source Tile
+    XAieTileCore_EventGenerate(&TileInst[7][3],
+                               XAIETILE_EVENT_CORE_FP_OVERFLOW);
+    XAieTileCore_EventGenerate(&TileInst[8][3],
+                               XAIETILE_EVENT_CORE_FP_UNDERFLOW);
+
+    ACDC_print_tile_status(TileInst[7][3]);
+
+    pc0_times[iters] = pc0.diff();
+    pc1_times[iters] = pc1.diff();
+  }
+
+  computeStats(pc0_times, n);
+  computeStats(pc1_times, n);
+}

--- a/test/benchmarks/11_Tile_Broadcast_Vertical/aie.mlir
+++ b/test/benchmarks/11_Tile_Broadcast_Vertical/aie.mlir
@@ -1,0 +1,19 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark11_tile_broadcast_vertical {
+  %t72 = AIE.tile(7, 2)
+  %t73 = AIE.tile(7, 3)
+  %t74 = AIE.tile(7,4)
+  %t75 = AIE.tile(7,5)
+  
+
+}
+ 

--- a/test/benchmarks/11_Tile_Broadcast_Vertical/test.cpp
+++ b/test/benchmarks/11_Tile_Broadcast_Vertical/test.cpp
@@ -1,0 +1,109 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+#define BRAM_ADDR (0x4000 + 0x020100000000LL)
+#define DMA_COUNT 512
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+  u32 pc2_times[n];
+  u32 pc3_times[n];
+
+  int total_errors = 0;
+
+  auto col = 7;
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  for (int iters = 0; iters < n; iters++) {
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    XAieTileCore_EventBroadcast(&TileInst[7][3], 2,
+                                XAIETILE_EVENT_CORE_FP_OVERFLOW); // Start
+    XAieTileCore_EventBroadcast(&TileInst[7][4], 3,
+                                XAIETILE_EVENT_CORE_FP_UNDERFLOW); // Stop
+
+    // Track time between two broadcast events in destination tiles (7,3) and
+    // (7,4)
+    EventMon pc0(&TileInst[7][4], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_BROADCAST_3, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc0.set();
+
+    EventMon pc1(&TileInst[7][2], 1, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_BROADCAST_3, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc1.set();
+
+    usleep(100);
+
+    // Start Test by generating events in Source Tile
+    XAieTileCore_EventGenerate(&TileInst[7][3],
+                               XAIETILE_EVENT_CORE_FP_OVERFLOW);
+    XAieTileCore_EventGenerate(&TileInst[7][4],
+                               XAIETILE_EVENT_CORE_FP_UNDERFLOW);
+
+    ACDC_print_tile_status(TileInst[7][3]);
+
+    pc0_times[iters] = pc0.diff();
+    pc1_times[iters] = pc1.diff();
+  }
+  printf("\nTime of First Signal: ");
+  computeStats(pc1_times, n);
+  printf("\nTime of Second Signal: ");
+  computeStats(pc0_times, n);
+}

--- a/test/benchmarks/12_Stream_Delay/aie.mlir
+++ b/test/benchmarks/12_Stream_Delay/aie.mlir
@@ -1,0 +1,60 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @test12_stream_delay {
+  %tile13 = AIE.tile(1, 3)
+  %tile23 = AIE.tile(2, 3)
+  %tile33 = AIE.tile(3, 3)
+
+  %tile43 = AIE.tile(4, 3)
+
+
+  %buf13_0 = AIE.buffer(%tile13) { sym_name = "a13" } : memref<512xi32>
+
+
+  %lock13_5 = AIE.lock(%tile13, 5) // interbuffer lock
+
+  AIE.switchbox(%tile13) { AIE.connect<"DMA": 0, "East": 1> }
+  AIE.switchbox(%tile23) { AIE.connect<"West": 1, "East": 1> }
+  AIE.switchbox(%tile33) { AIE.connect<"West": 1, "East": 1> }
+  AIE.switchbox(%tile43) { AIE.connect<"West": 1, "DMA": 1> }
+
+
+  %mem13 = AIE.mem(%tile13) {
+    %dma0 = AIE.dmaStart("MM2S0", ^bd0, ^end)
+    ^bd0:
+      AIE.useLock(%lock13_5, "Acquire", 1, 0)
+      AIE.dmaBd(<%buf13_0 : memref<512xi32>, 0, 512>, 0)
+      AIE.useLock(%lock13_5, "Release", 0, 0)
+      br ^end 
+    ^end:
+      AIE.end
+  }
+
+  %lock43_6 = AIE.lock(%tile43, 6) // interbuffer lock
+  %lock43_7 = AIE.lock(%tile43, 7) // interbuffer lock
+  %buf43_0 = AIE.buffer(%tile43) { sym_name = "a43" } : memref<512xi32>
+  %buf43_1 = AIE.buffer(%tile43) { sym_name = "b43" } : memref<256xi32>
+
+  %mem43 = AIE.mem(%tile43) {
+
+
+     %dma0 = AIE.dmaStart("S2MM1", ^bd0, ^end)
+    ^bd0:
+      AIE.useLock(%lock43_6, "Acquire", 0, 0)
+      AIE.dmaBd(<%buf43_0: memref<512xi32>, 0, 512>, 0)
+      AIE.useLock(%lock43_6, "Release", 1, 0)
+      br ^end 
+    ^end:
+      AIE.end
+  }
+
+
+}

--- a/test/benchmarks/12_Stream_Delay/test.cpp
+++ b/test/benchmarks/12_Stream_Delay/test.cpp
@@ -1,0 +1,145 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define LOCK_TIMEOUT 100
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MLIR_STACK_OFFSET 4096
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
+
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+  u32 pc2_times[n];
+  u32 pc3_times[n];
+
+  for (int iters = 0; iters < n; iters++) {
+
+    size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+    XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                             XAIE_ADDR_ARRAY_OFF);
+    XAieGbl_HwInit(&AieConfig);
+    AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+    XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+
+    printf("Acquire input buffer lock first.\n");
+    XAieTile_LockAcquire(&(TileInst[1][3]), 5, 0, 0);
+
+    mlir_configure_dmas();
+    mlir_initialize_locks();
+
+    ACDC_clear_tile_memory(TileInst[1][3]);
+    ACDC_clear_tile_memory(TileInst[2][3]);
+
+#define DMA_COUNT 512
+
+    for (int i = 0; i < DMA_COUNT; i++) {
+      mlir_write_buffer_a13(i, i + 1);
+      mlir_write_buffer_a43(i, 0xdeadbeef);
+    }
+
+    // Destination Tile
+    EventMon pc0(&TileInst[4][3], 0, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_DMA_S2MM_1_FINISHED_BD,
+                 XAIETILE_EVENT_MEM_NONE, MODE_MEM);
+    pc0.set();
+    EventMon pc1(&TileInst[4][3], 1, XAIETILE_EVENT_MEM_BROADCAST_2,
+                 XAIETILE_EVENT_MEM_LOCK_6_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc1.set();
+
+    // Source Tile
+    EventMon pc2(&TileInst[1][3], 0, XAIETILE_EVENT_MEM_LOCK_5_ACQUIRED,
+                 XAIETILE_EVENT_MEM_DMA_MM2S_0_FINISHED_BD,
+                 XAIETILE_EVENT_MEM_NONE, MODE_MEM);
+    pc2.set();
+    EventMon pc3(&TileInst[1][3], 1, XAIETILE_EVENT_MEM_LOCK_5_ACQUIRED,
+                 XAIETILE_EVENT_MEM_LOCK_5_RELEASE, XAIETILE_EVENT_MEM_NONE,
+                 MODE_MEM);
+    pc3.set();
+
+    XAieTileMem_EventBroadcast(&TileInst[1][3], 2,
+                               XAIETILE_EVENT_MEM_LOCK_5_ACQUIRED); // Start
+
+    XAieTile_LockRelease(&(TileInst[1][3]), 5, 1, 0);
+    usleep(100);
+
+    pc0_times[iters] = pc0.diff();
+    pc1_times[iters] = pc1.diff();
+    pc2_times[iters] = pc2.diff();
+    pc3_times[iters] = pc3.diff();
+
+    for (int i = 0; i < DMA_COUNT; i++) {
+      uint32_t d = mlir_read_buffer_a13(i);
+      if (d != (i + 1)) {
+        printf("Not Matched");
+      }
+    }
+
+    int errors = 0;
+    for (int i = 0; i < DMA_COUNT; i++) {
+      uint32_t d = mlir_read_buffer_a43(i);
+      if (d != (i + 1)) {
+        errors++;
+        printf("mismatch %x != 1 + %x\n", d, i);
+        break;
+      }
+    }
+    printf("\nHello\n");
+
+    printf("Destination Tile: %u, %u\n", pc0.diff(), pc1.diff());
+
+    printf("Source Tile: %u, %u\n", pc2.diff(), pc3.diff());
+  }
+  computeStats(pc0_times, n);
+  computeStats(pc1_times, n);
+  computeStats(pc2_times, n);
+  computeStats(pc3_times, n);
+}

--- a/test/benchmarks/13_Program_Counter/aie.mlir
+++ b/test/benchmarks/13_Program_Counter/aie.mlir
@@ -1,0 +1,26 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark13_program_counter {
+  %t73 = AIE.tile(7, 3)
+
+
+  %buf73_0 = AIE.buffer(%t73) { sym_name = "a" } : memref<256xi32>
+
+  %core73 = AIE.core(%t73) {
+    %val1 = constant 7 : i32
+    %idx1 = constant 3 : index
+    %2 = addi %val1, %val1 : i32
+    memref.store %2, %buf73_0[%idx1] : memref<256xi32>
+
+    AIE.end
+  }
+
+}

--- a/test/benchmarks/13_Program_Counter/test.cpp
+++ b/test/benchmarks/13_Program_Counter/test.cpp
@@ -1,0 +1,113 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+#define BRAM_ADDR (0x4000 + 0x020100000000LL)
+#define DMA_COUNT 512
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+  u32 pc2_times[n];
+
+  int total_errors = 0;
+
+  // soft reset hack initially
+  devmemRW32(0xF70A000C, 0xF9E8D7C6, true);
+  devmemRW32(0xF70A0000, 0x04000000, true);
+  devmemRW32(0xF70A0004, 0x040381B1, true);
+  devmemRW32(0xF70A0000, 0x04000000, true);
+  devmemRW32(0xF70A0004, 0x000381B1, true);
+  devmemRW32(0xF70A000C, 0x12341234, true);
+
+  auto col = 7;
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  for (int iters = 0; iters < n; iters++) {
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    // EventMon pc0(&TileInst[7][3], 0, XAIETILE_EVENT_CORE_ACTIVE,
+    // XAIETILE_EVENT_CORE_DISABLED, XAIETILE_EVENT_CORE_NONE, MODE_CORE);
+    // pc0.set();
+
+    XAieTileCore_EventPCEvent(&TileInst[7][3], XAIETILE_EVENT_CORE_PC_EVENT0,
+                              0x00, 1);
+    XAieTileCore_EventPCEvent(&TileInst[7][3], XAIETILE_EVENT_CORE_PC_EVENT1,
+                              0x088, 1);
+
+    EventMon pc1(&TileInst[7][3], 1, XAIETILE_EVENT_CORE_PC_0,
+                 XAIETILE_EVENT_CORE_PC_1, XAIETILE_EVENT_CORE_NONE, MODE_CORE);
+    pc1.set();
+
+    ACDC_print_tile_status(TileInst[7][3]);
+
+    mlir_start_cores();
+
+    u_int32_t pc0_reg = XAieGbl_Read32(TileInst[7][3].TileAddr + 0x32020);
+    u_int32_t pc1_reg = XAieGbl_Read32(TileInst[7][3].TileAddr + 0x32024);
+
+    u_int32_t event_status = XAieGbl_Read32(TileInst[7][3].TileAddr + 0x34200);
+
+    // printf("\n PC0 and PC1: %x, %x \n", pc0_reg, pc1_reg);
+    printf("\n Event Status: %x\n", event_status);
+
+    ACDC_print_tile_status(TileInst[7][3]);
+    // printf("PC0: %x ", pc0.diff());
+    pc1_times[iters] = pc1.diff();
+  }
+
+  computeStats(pc1_times, n);
+}

--- a/test/benchmarks/14_Timer/aie.mlir
+++ b/test/benchmarks/14_Timer/aie.mlir
@@ -1,0 +1,26 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module @benchmark14_timer {
+  %t73 = AIE.tile(7, 3)
+
+
+  %buf73_0 = AIE.buffer(%t73) { sym_name = "a" } : memref<256xi32>
+
+  %core73 = AIE.core(%t73) {
+    %val1 = constant 7 : i32
+    %idx1 = constant 3 : index
+    %2 = addi %val1, %val1 : i32
+    memref.store %2, %buf73_0[%idx1] : memref<256xi32>
+
+    AIE.end
+  }
+
+}

--- a/test/benchmarks/14_Timer/test.cpp
+++ b/test/benchmarks/14_Timer/test.cpp
@@ -1,0 +1,88 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define XAIE_NUM_ROWS 8
+#define XAIE_NUM_COLS 50
+#define XAIE_ADDR_ARRAY_OFF 0x800
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+
+#define MAP_SIZE 16UL
+#define MAP_MASK (MAP_SIZE - 1)
+
+#define BRAM_ADDR (0x4000 + 0x020100000000LL)
+#define DMA_COUNT 512
+
+namespace {
+
+XAieGbl_Config *AieConfigPtr; /**< AIE configuration pointer */
+XAieGbl AieInst;              /**< AIE global instance */
+XAieGbl_HwCfg AieConfig;      /**< AIE HW configuration instance */
+XAieGbl_Tile TileInst[XAIE_NUM_COLS][XAIE_NUM_ROWS +
+                                     1]; /**< Instantiates AIE array of
+                                            [XAIE_NUM_COLS] x [XAIE_NUM_ROWS] */
+XAieDma_Tile TileDMAInst[XAIE_NUM_COLS][XAIE_NUM_ROWS + 1];
+
+#include "aie_inc.cpp"
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int n = 1;
+  u32 pc0_times[n];
+  u32 pc1_times[n];
+  u32 pc2_times[n];
+
+  int total_errors = 0;
+
+  // soft reset hack initially
+  devmemRW32(0xF70A000C, 0xF9E8D7C6, true);
+  devmemRW32(0xF70A0000, 0x04000000, true);
+  devmemRW32(0xF70A0004, 0x040381B1, true);
+  devmemRW32(0xF70A0000, 0x04000000, true);
+  devmemRW32(0xF70A0004, 0x000381B1, true);
+  devmemRW32(0xF70A000C, 0x12341234, true);
+
+  auto col = 7;
+
+  size_t aie_base = XAIE_ADDR_ARRAY_OFF << 14;
+  XAIEGBL_HWCFG_SET_CONFIG((&AieConfig), XAIE_NUM_ROWS, XAIE_NUM_COLS,
+                           XAIE_ADDR_ARRAY_OFF);
+  XAieGbl_HwInit(&AieConfig);
+  AieConfigPtr = XAieGbl_LookupConfig(XPAR_AIE_DEVICE_ID);
+  XAieGbl_CfgInitialize(&AieInst, &TileInst[0][0], AieConfigPtr);
+
+  for (int iters = 0; iters < n; iters++) {
+
+    mlir_configure_cores();
+    mlir_configure_switchboxes();
+    mlir_initialize_locks();
+    mlir_configure_dmas();
+
+    u_int32_t timer1 = XAieGbl_Read32(TileInst[7][3].TileAddr + 0x000340F8);
+    mlir_start_cores();
+    u_int32_t timer2 = XAieGbl_Read32(TileInst[7][3].TileAddr + 0x000340F8);
+
+    printf("\n Timer for Starting the Core: %d\n", timer2 - timer1);
+  }
+}

--- a/test/benchmarks/README.md
+++ b/test/benchmarks/README.md
@@ -1,0 +1,74 @@
+# Benchmarks
+This section provides example benchmark tests for measuring various aspects of the AIE, including data transfer, fill rate, and calibration measurements.
+# Measurement Tools
+## Performance Counters
+
+Most of the benchmarks use performance counters for measurements. The performance counters can be used by specifying a start event, a stop event, and a reset event. The performance counter will trigger when the start event occurs, stop counting when the stop event occurs, and reset when the reset event occurs. We usually tie the performance counters to a lock acquire/lock release in memory so that we can time how long it takes for data to transfer.
+
+## Program Counters
+Program counters take in a start address of the assembly instruction and the stop address of the assembly instruction and measure the number of cycles between those two instructions.
+
+## Timers
+We can read the timer register to obtain the current timer value of an AI engine.
+  
+# Benchmark Tests
+
+## Fill Rate Tests
+
+  
+
+These tests consist of benchmarks that measure the rate of data transfer across the AI Engine. They use performance counters in order to perform the measurements.
+
+  
+
+Tests 1, 2, 3, and 4 show different fill-rate tests.
+
+  
+
+## Core Measurements
+
+  
+
+These tests consist of benchmarks that measure operations in the core. They use performance counters in order to perform the measurements.
+
+
+
+Tests 5, 6, 7, and 8 show different core measurements.
+
+  
+
+## Calibration Tests
+
+  
+
+These tests measure various calibration measurements of the broadcast and stream delay. They measure how long the broadcast signal takes to travel, as well as the stream delay when sending data across tiles. They use performance counters in order to perform the measurements.
+
+
+Tests 9, 10, 11, and 12 show different calibration measurements.
+
+  
+
+## Other Measurement Examples
+
+
+Test 13 shows the use of program counters for measuring operations in the AIE core.
+  
+Test 14 shows the use of timers, which can be used in order to measure the current timer value in an AIE tile.
+
+
+## Benchmark Results on the VCK190
+
+| Benchmark | Description                                                                                       | Result (cycles) @ 1GHz                     |
+|-----------|---------------------------------------------------------------------------------------------------|--------------------------------------------|
+| 01        | Measures the data transfer speed from the DDR to Local Memory in a tile                           | For 4096x4 bytes of data: 4437 ± 153.8     |
+| 02        | Measures the data transfer speed from the Local Memory in a tile to the DDR                       | For 4096x4 bytes of data: 4096 ± 4148      |
+| 03        | Measures the data transfer speed for 16 parallel DDR to Local Memory transfers                    | For 7168x4 bytes of data:  29389 ± 2984    |
+| 04        | Measures the data transfer speed from a source tile local memory to destination tile local memory | 530                                        |
+| 05        | Measures the cycles it takes a core to initialize                                                 | 52                                         |
+| 06        | Measures the cycles it takes for a store operation in the AIE core                                | 57 (including initialization)              |
+| 07        | Measures the cycles it takes for a lock acquire operation in the AIE core                         | 57 (including initialization)              |
+| 08        | Measures the cycles it takes for a lock release operation in the AIE core                         | 57 (including initialization)              |
+| 09        | Measures the cycles it take for the Shim to broadcast to other shim tiles                         | 4                                          |
+| 10        | Measures the cycles it takes for a tile to broadcast horizontally (Each AIE tile has a core and memory module, with 16 broadcast wires horizontally and 32 vertically. Broadcast signals horizontally need to pass through both modules to travel to the next tile)                                | 2 per core/memory module                   |
+| 11        | Measures the cycles it takes for a tile to broadcast vertically                                   | 2 per tile                                 |
+| 12        | Measures the delay of transferring data on the stream                                             | 2 per node (North, South, East, West)      |


### PR DESCRIPTION
Recommitted this with proper formatting and resolving issues.

The runtime lib is updated with the performance counter class that allows the use of performance counters. The benchmarks and calibration tests have been added to the test/ folder, along with a README that discusses the individual benchmarks and explains the measurement tools.