### PR TITLE
Bump LLVM to 4b553297ef3ee4dc2119d5429adf3072e90fac38

### DIFF
--- a/include/aie/AIENormalizeAddressSpaces.td
+++ b/include/aie/AIENormalizeAddressSpaces.td
@@ -19,8 +19,8 @@ def toDefaultAddressSpace : NativeCodeCall<"TypeAttr::get(memRefToDefaultAddress
 def hasNonDefaultAddressSpace : Constraint<
     CPred<"$0.getValue().cast<MemRefType>().getMemorySpace() != 0">,
     "has non-default address space">;
-def : Pat<(MemRef_GlobalOp $sym_name, $sym_visibility, $type, $initial_value, $constant),
-        (MemRef_GlobalOp $sym_name, $sym_visibility, (toDefaultAddressSpace $type), $initial_value, $constant),
+def : Pat<(MemRef_GlobalOp $sym_name, $sym_visibility, $type, $initial_value, $constant, $alignment),
+        (MemRef_GlobalOp $sym_name, $sym_visibility, (toDefaultAddressSpace $type), $initial_value, $constant, $alignment),
         [(hasNonDefaultAddressSpace $type)],
         (addBenefit 20)>;
 

--- a/include/aie/AIEPasses.td
+++ b/include/aie/AIEPasses.td
@@ -64,7 +64,7 @@ def AIECreateCores : Pass<"aie-create-cores", "ModuleOp"> {
       ...
       return
     }
-    %a = constant 0 : i32
+    %a = arith.constant 0 : i32
     call @aie_task(%buf, %a) { aie.x = 1, aie.y = 1 } : (memref<256xi32>, i32) -> ()
 
     ```
@@ -73,7 +73,7 @@ def AIECreateCores : Pass<"aie-create-cores", "ModuleOp"> {
     %0 = AIE.tile(1, 1)
     %1 = AIE.buffer(%0) : memref<256xi32>
     %2 = AIE.buffer(%0) : memref<1xi32>
-    %c0_i32 = constant 0 : i32
+    %c0_i32 = arith.constant 0 : i32
     %5 = AIE.core(%0) {
       ...
     }

--- a/lib/AIECreateCores.cpp
+++ b/lib/AIECreateCores.cpp
@@ -35,7 +35,7 @@ struct RemoveAIEFuncs : public OpConversionPattern<FuncOp> {
   }
 
   LogicalResult
-  matchAndRewrite(FuncOp op, ArrayRef<Value> operands,
+  matchAndRewrite(FuncOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
     if (funcs.find(op) == funcs.end())
@@ -54,7 +54,7 @@ struct RemoveAIECalls : public OpConversionPattern<CallOp> {
       : OpConversionPattern<CallOp>(context, benefit), module(m) {}
 
   LogicalResult
-  matchAndRewrite(CallOp op, ArrayRef<Value> operands,
+  matchAndRewrite(CallOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
     if (!op->getAttr("aie.x") || !op->getAttr("aie.y"))
@@ -183,8 +183,8 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
               assert(t.getShape()[0] == 1 &&
                      "Expected MemRefType of single element");
 
-              Value zero =
-                  builder.create<ConstantIndexOp>(builder.getUnknownLoc(), 0);
+              Value zero = builder.create<arith::ConstantIndexOp>(
+                  builder.getUnknownLoc(), 0);
               auto loadOp = builder.create<memref::LoadOp>(
                   builder.getUnknownLoc(), arg.getType(), buf, zero);
               mapper.map(arg, loadOp);

--- a/lib/AIECreateFlows.cpp
+++ b/lib/AIECreateFlows.cpp
@@ -139,7 +139,7 @@ struct RouteFlows : public OpConversionPattern<AIE::FlowOp> {
              PatternBenefit benefit = 1)
       : OpConversionPattern<FlowOp>(context, benefit), module(m), analysis(a) {}
 
-  LogicalResult match(Operation *op) const override { return success(); }
+  LogicalResult match(AIE::FlowOp op) const override { return success(); }
 
   void addConnection(ConversionPatternRewriter &rewriter,
                      // could be a shim-mux or a switchbox.
@@ -238,7 +238,7 @@ struct RouteFlows : public OpConversionPattern<AIE::FlowOp> {
     }
   }
 
-  void rewrite(AIE::FlowOp op, ArrayRef<Value> operands,
+  void rewrite(AIE::FlowOp op, OpAdaptor adaptor,
                ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
     WireBundle sourceBundle = op.sourceBundle();

--- a/lib/AIECreateLocks.cpp
+++ b/lib/AIECreateLocks.cpp
@@ -41,7 +41,7 @@ struct Token2LockLowering : public OpConversionPattern<UseTokenOp> {
         acqLocks(acqLocks), relLocks(relLocks), lockChains(lockChains) {}
 
   LogicalResult
-  matchAndRewrite(UseTokenOp op, ArrayRef<Value> operands,
+  matchAndRewrite(UseTokenOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
     Operation *parentOp = op->getParentOp();

--- a/lib/AIECreatePacketFlows.cpp
+++ b/lib/AIECreatePacketFlows.cpp
@@ -27,13 +27,14 @@ using namespace xilinx::AIE;
 template <typename MyOp>
 struct AIEOpRemoval : public OpConversionPattern<MyOp> {
   using OpConversionPattern<MyOp>::OpConversionPattern;
+  using OpAdaptor = typename MyOp::Adaptor;
   ModuleOp &module;
 
   AIEOpRemoval(MLIRContext *context, ModuleOp &m, PatternBenefit benefit = 1)
       : OpConversionPattern<MyOp>(context, benefit), module(m) {}
 
   LogicalResult
-  matchAndRewrite(MyOp op, ArrayRef<Value> operands,
+  matchAndRewrite(MyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
 

--- a/lib/AIECreatePathfindFlows.cpp
+++ b/lib/AIECreatePathfindFlows.cpp
@@ -269,7 +269,7 @@ struct ConvertFlowsToInterconnect : public OpConversionPattern<AIE::FlowOp> {
       : OpConversionPattern<AIE::FlowOp>(context, benefit), module(m),
         analyzer(a) {}
 
-  LogicalResult match(Operation *op) const override { return success(); }
+  LogicalResult match(AIE::FlowOp op) const override { return success(); }
 
   void addConnection(ConversionPatternRewriter &rewriter,
                      // could be a shim-mux or a switchbox.
@@ -293,7 +293,7 @@ struct ConvertFlowsToInterconnect : public OpConversionPattern<AIE::FlowOp> {
                << outIndex << "\n");
   }
 
-  void rewrite(AIE::FlowOp flowOp, ArrayRef<Value> operands,
+  void rewrite(AIE::FlowOp flowOp, OpAdaptor adaptor,
                ConversionPatternRewriter &rewriter) const override {
     Operation *Op = flowOp.getOperation();
 

--- a/lib/AIEHerdRouting.cpp
+++ b/lib/AIEHerdRouting.cpp
@@ -24,13 +24,14 @@ using namespace xilinx::AIE;
 template <typename MyOp>
 struct AIEOpRemoval : public OpConversionPattern<MyOp> {
   using OpConversionPattern<MyOp>::OpConversionPattern;
+  using OpAdaptor = typename MyOp::Adaptor;
   ModuleOp &module;
 
   AIEOpRemoval(MLIRContext *context, ModuleOp &m, PatternBenefit benefit = 1)
       : OpConversionPattern<MyOp>(context, benefit), module(m) {}
 
   LogicalResult
-  matchAndRewrite(MyOp op, ArrayRef<Value> operands,
+  matchAndRewrite(MyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
 

--- a/lib/AIELowerMemcpy.cpp
+++ b/lib/AIELowerMemcpy.cpp
@@ -66,7 +66,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
   }
 
   LogicalResult
-  matchAndRewrite(MemcpyOp op, ArrayRef<Value> operands,
+  matchAndRewrite(MemcpyOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
     Value srcBuf = op.srcBuf();

--- a/lib/AIENormalizeAddressSpaces.cpp
+++ b/lib/AIENormalizeAddressSpaces.cpp
@@ -25,7 +25,7 @@ Type memRefToDefaultAddressSpace(Type t) {
   auto memRefType = t.dyn_cast<MemRefType>();
   if (memRefType && memRefType.getMemorySpace() != 0)
     return MemRefType::get(memRefType.getShape(), memRefType.getElementType(),
-                           memRefType.getAffineMaps(), 0 /* Address Space */);
+                           memRefType.getLayout(), 0 /* Address Space */);
   else
     return t;
 }

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -133,6 +133,7 @@ void registerAIETranslations() {
         registry.insert<memref::MemRefDialect>();
         registry.insert<VectorDialect>();
         registry.insert<LLVM::LLVMDialect>();
+        registry.insert<arith::ArithmeticDialect>();
       });
 
   ///// ld.script format:
@@ -251,6 +252,7 @@ SECTIONS
         registry.insert<memref::MemRefDialect>();
         registry.insert<VectorDialect>();
         registry.insert<LLVM::LLVMDialect>();
+        registry.insert<arith::ArithmeticDialect>();
       });
 
   //   _entry_point _main_init
@@ -328,6 +330,7 @@ SECTIONS
         registry.insert<memref::MemRefDialect>();
         registry.insert<VectorDialect>();
         registry.insert<LLVM::LLVMDialect>();
+        registry.insert<arith::ArithmeticDialect>();
       });
 
   TranslateFromMLIRRegistration registrationCoreList(
@@ -354,6 +357,7 @@ SECTIONS
         registry.insert<memref::MemRefDialect>();
         registry.insert<VectorDialect>();
         registry.insert<LLVM::LLVMDialect>();
+        registry.insert<arith::ArithmeticDialect>();
       });
   TranslateFromMLIRRegistration registrationXAIE(
       "aie-generate-xaie",
@@ -369,6 +373,7 @@ SECTIONS
         registry.insert<memref::MemRefDialect>();
         registry.insert<VectorDialect>();
         registry.insert<LLVM::LLVMDialect>();
+        registry.insert<arith::ArithmeticDialect>();
       });
   TranslateFromMLIRRegistration registrationXJSON(
       "aie-flows-to-json",
@@ -381,6 +386,7 @@ SECTIONS
         registry.insert<memref::MemRefDialect>();
         registry.insert<VectorDialect>();
         registry.insert<LLVM::LLVMDialect>();
+        registry.insert<arith::ArithmeticDialect>();
       });
 }
 } // namespace AIE

--- a/test/create-cores/hello_world.mlir
+++ b/test/create-cores/hello_world.mlir
@@ -40,15 +40,15 @@
 // CHECK:   AIE.token(0) {sym_name = "token0"}
 // CHECK:   %8 = AIE.core(%0) {
 // CHECK:     AIE.useToken @token0(Acquire, 0)
-// CHECK:     %c16 = constant 16 : index
-// CHECK:     %c1_i32 = constant 1 : i32
+// CHECK:     %c16 = arith.constant 16 : index
+// CHECK:     %c1_i32 = arith.constant 1 : i32
 // CHECK:     memref.store %c1_i32, %1[%c16] : memref<512xi32>
 // CHECK:     AIE.useToken @token0(Release, 1)
 // CHECK:     AIE.end
 // CHECK:   }
 // CHECK:   %9 = AIE.core(%3) {
 // CHECK:     AIE.useToken @token0(Acquire, 2)
-// CHECK:     %c16 = constant 16 : index
+// CHECK:     %c16 = arith.constant 16 : index
 // CHECK:     %10 = memref.load %4[%c16] : memref<512xi32>
 // CHECK:     AIE.useToken @token0(Release, 3)
 // CHECK:     AIE.end
@@ -68,8 +68,8 @@ module @hello_world {
 
   func @producer(%arg0: memref<512xi32>) -> () {
     AIE.useToken @token0(Acquire, 0)
-    %i = constant 16 : index
-    %val = constant 1 : i32
+    %i = arith.constant 16 : index
+    %val = arith.constant 1 : i32
     memref.store %val, %arg0[%i] : memref<512xi32>
     AIE.useToken @token0(Release, 1)
     return
@@ -77,7 +77,7 @@ module @hello_world {
 
   func @consumer(%arg0: memref<512xi32>) -> () {
     AIE.useToken @token0(Acquire, 2)
-    %i = constant 16 : index
+    %i = arith.constant 16 : index
     %val = memref.load %arg0[%i] : memref<512xi32>
     AIE.useToken @token0(Release, 3)
     return

--- a/test/create-cores/test_core1.mlir
+++ b/test/create-cores/test_core1.mlir
@@ -21,11 +21,11 @@
 // CHECK-NEXT:    func @host_task() {
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %c0_i32 = constant 0 : i32
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT:    %5 = AIE.core(%0) {
-// CHECK-NEXT:      %c0 = constant 0 : index
+// CHECK-NEXT:      %c0 = arith.constant 0 : index
 // CHECK-NEXT:      %6 = memref.load %2[%c0] : memref<1xi32>
-// CHECK-NEXT:      %c10 = constant 10 : index
+// CHECK-NEXT:      %c10 = arith.constant 10 : index
 // CHECK-NEXT:      memref.store %6, %1[%c10] : memref<256xi32>
 // CHECK-NEXT:      AIE.end
 // CHECK-NEXT:    }
@@ -41,7 +41,7 @@ module @test_core1 {
   %buf = memref.alloc() : memref<256xi32>
 
   func @aie_task(%arg0: memref<256xi32>, %arg1: i32) -> () {
-    %i = constant 10 : index
+    %i = arith.constant 10 : index
     memref.store %arg1, %arg0[%i] : memref<256xi32>
     return
   }
@@ -50,7 +50,7 @@ module @test_core1 {
     return
   }
 
-  %a = constant 0 : i32
+  %a = arith.constant 0 : i32
   call @aie_task(%buf, %a) { aie.x = 1, aie.y = 1 } : (memref<256xi32>, i32) -> ()
   call @host_task() : () -> ()
 }

--- a/test/create-flows/vecmul_4x4.mlir
+++ b/test/create-flows/vecmul_4x4.mlir
@@ -139,7 +139,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %10[%arg0] : memref<64xi32, 2>
       %201 = affine.load %8[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %6[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%5, Release, 1)
@@ -193,7 +193,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %23[%arg0] : memref<64xi32, 2>
       %201 = affine.load %21[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %19[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%18, Release, 1)
@@ -247,7 +247,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %36[%arg0] : memref<64xi32, 2>
       %201 = affine.load %34[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %32[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%31, Release, 1)
@@ -301,7 +301,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %49[%arg0] : memref<64xi32, 2>
       %201 = affine.load %47[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %45[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%44, Release, 1)
@@ -354,7 +354,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %61[%arg0] : memref<64xi32, 2>
       %201 = affine.load %59[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %57[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%56, Release, 1)
@@ -407,7 +407,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %73[%arg0] : memref<64xi32, 2>
       %201 = affine.load %71[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %69[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%68, Release, 1)
@@ -461,7 +461,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %86[%arg0] : memref<64xi32, 2>
       %201 = affine.load %84[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %82[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%81, Release, 1)
@@ -515,7 +515,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %99[%arg0] : memref<64xi32, 2>
       %201 = affine.load %97[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %95[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%94, Release, 1)
@@ -568,7 +568,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %111[%arg0] : memref<64xi32, 2>
       %201 = affine.load %109[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %107[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%106, Release, 1)
@@ -621,7 +621,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %123[%arg0] : memref<64xi32, 2>
       %201 = affine.load %121[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %119[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%118, Release, 1)
@@ -675,7 +675,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %136[%arg0] : memref<64xi32, 2>
       %201 = affine.load %134[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %132[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%131, Release, 1)
@@ -728,7 +728,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %148[%arg0] : memref<64xi32, 2>
       %201 = affine.load %146[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %144[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%143, Release, 1)
@@ -780,7 +780,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %159[%arg0] : memref<64xi32, 2>
       %201 = affine.load %157[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %155[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%154, Release, 1)
@@ -833,7 +833,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %171[%arg0] : memref<64xi32, 2>
       %201 = affine.load %169[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %167[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%166, Release, 1)
@@ -887,7 +887,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %184[%arg0] : memref<64xi32, 2>
       %201 = affine.load %182[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %180[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%179, Release, 1)
@@ -941,7 +941,7 @@ module @vecmul_4x4  {
     affine.for %arg0 = 0 to 64 {
       %200 = affine.load %197[%arg0] : memref<64xi32, 2>
       %201 = affine.load %195[%arg0] : memref<64xi32, 2>
-      %202 = muli %200, %201 : i32
+      %202 = arith.muli %200, %201 : i32
       affine.store %202, %193[%arg0] : memref<64xi32, 2>
     }
     AIE.useLock(%192, Release, 1)

--- a/test/example0.mlir
+++ b/test/example0.mlir
@@ -101,11 +101,11 @@ module @example0 {
     AIE.useLock(%l33_0, Acquire, 0)
 
     // code
-    %val0 = constant 16 : i32
-    %0 = constant 0 : i32
+    %val0 = arith.constant 16 : i32
+    %0 = arith.constant 0 : i32
     AIE.putStream(%0 : i32, %val0 : i32)
     %val1 = AIE.getStream(%0 : i32) : i128
-    %val2 = constant 1 : i384
+    %val2 = arith.constant 1 : i384
     AIE.putCascade(%val2: i384)
 
     AIE.useLock(%l33_0, Release, 1)

--- a/test/example1.mlir
+++ b/test/example1.mlir
@@ -39,8 +39,8 @@ module @example1 {
     AIE.useToken @token1(Acquire, 0)
 
     // code
-    %i = constant 8: index
-    //%k = constant 1: i32
+    %i = arith.constant 8: index
+    //%k = arith.constant 1: i32
     memref.store %arg1, %arg0[%i] : memref<256xi32>
     //store %k, %arg0[%i] : memref<256xi32>
 
@@ -71,7 +71,7 @@ module @example1 {
     return
   }
 
-  %t0 = constant 19 : i32
+  %t0 = arith.constant 19 : i32
   call @task0(%buf0, %t0) { aie.x = 3, aie.y = 3 } : (memref<256xi32>, i32) -> ()
   call @task1(%buf1) { aie.x = 4, aie.y = 2 } : (memref<256xi32>) -> ()
   call @task2(%buf2) { aie.x = 4, aie.y = 4 } : (memref<256xi32>) -> ()

--- a/test/foldinterface.mlir
+++ b/test/foldinterface.mlir
@@ -12,7 +12,7 @@
 
 // RUN: aie-opt %s -canonicalize | FileCheck %s
 // CHECK: AIE.core
-// CHECK: constant
+// CHECK: arith.constant
 module @aie.herd_0  {
   %0 = AIE.tile(8, 3)
   %1 = AIE.buffer(%0) {sym_name = "b2"} : memref<32x32xi32>
@@ -23,9 +23,9 @@ module @aie.herd_0  {
   ^bb1:  // pred: ^bb0
     br ^bb2
   ^bb2:  // pred: ^bb1
-    %c32 = constant 32 : index
-    %c0 = constant 0 : index
-    %c64 = constant 64 : index
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
     scf.for %arg0 = %c0 to %c64 step %c32 {
       affine.for %arg1 = 0 to 32 {
         affine.for %arg2 = 0 to 32 {
@@ -33,8 +33,8 @@ module @aie.herd_0  {
             %5 = affine.load %3[%arg1, %arg3] : memref<32x32xi32>
             %6 = affine.load %2[%arg3, %arg2] : memref<32x32xi32>
             %7 = affine.load %1[%arg1, %arg2] : memref<32x32xi32>
-            %8 = muli %5, %6 : i32
-            %9 = addi %7, %8 : i32
+            %8 = arith.muli %5, %6 : i32
+            %9 = arith.addi %7, %8 : i32
             affine.store %9, %1[%arg1, %arg2] : memref<32x32xi32>
           }
         }

--- a/test/lower-to-standard/lower_buffer.mlir
+++ b/test/lower-to-standard/lower_buffer.mlir
@@ -13,8 +13,8 @@
 // CHECK33:    memref.global "public" @a : memref<4xi32>
 // CHECK33-LABEL:  func @core33() {
 // CHECK33:    %0 = memref.get_global @a : memref<4xi32>
-// CHECK33:    %c0 = constant 0 : index
-// CHECK33:    %c377_i32 = constant 377 : i32
+// CHECK33:    %c0 = arith.constant 0 : index
+// CHECK33:    %c377_i32 = arith.constant 377 : i32
 // CHECK33:    memref.store %c377_i32, %0[%c0] : memref<4xi32>
 // CHECK33:    return
 // CHECK33:  }
@@ -22,7 +22,7 @@
 // CHECK43:    memref.global "public" @a : memref<4xi32>
 // CHECK43-LABEL:  func @core43() {
 // CHECK43:    %0 = memref.get_global @a : memref<4xi32>
-// CHECK43:    %c0 = constant 0 : index
+// CHECK43:    %c0 = arith.constant 0 : index
 // CHECK43:    %1 = memref.load %0[%c0] : memref<4xi32>
 // CHECK43:    return
 // CHECK43:  }
@@ -31,15 +31,15 @@ module @codegen1 {
   %t33 = AIE.tile(3, 3)
   %a = AIE.buffer(%t33) { sym_name = "a" } : memref<4xi32>
   %core33 = AIE.core(%t33) {
-    %0 = constant 0 : index
-    %377 = constant 377 : i32
+    %0 = arith.constant 0 : index
+    %377 = arith.constant 377 : i32
     memref.store %377, %a[%0] : memref<4xi32>
     AIE.end
   }
   %t34 = AIE.tile(4, 3)
 
   %core34 = AIE.core(%t34) {
-    %0 = constant 0 : index
+    %0 = arith.constant 0 : index
     %1 = memref.load %a[%0] : memref<4xi32>
 //    AIE.debug(%1 : i32)
     AIE.end

--- a/test/lower-to-standard/lower_buffer_and_lock.mlir
+++ b/test/lower-to-standard/lower_buffer_and_lock.mlir
@@ -29,17 +29,17 @@ module @test_core_llvm1 {
   %buf11_0  = AIE.buffer(%tile11) { sym_name = "a" } : memref<256xi32>
 
   %core11 = AIE.core(%tile11) {
-    AIE.useLock(%lock11_8, Acquire, 0)
-    %0 = constant 1 : i32
-    %i = constant 16 : index
+    AIE.useLock(%lock11_8, Acquire, 0, 0)
+    %0 = arith.constant 1 : i32
+    %i = arith.constant 16 : index
     memref.store %0, %buf11_0[%i] : memref<256xi32>
     AIE.useLock(%lock11_8, Release, 1)
     AIE.end
   }
 
   %core12 = AIE.core(%tile12) {
-    AIE.useLock(%lock11_8, Acquire, 1)
-    %i = constant 16 : index
+    AIE.useLock(%lock11_8, Acquire, 1, 0)
+    %i = arith.constant 16 : index
     %0 = memref.load %buf11_0[%i] : memref<256xi32>
     AIE.useLock(%lock11_8, Release, 0)
     AIE.end

--- a/test/lower-to-standard/lower_buffer_and_lock.mlir
+++ b/test/lower-to-standard/lower_buffer_and_lock.mlir
@@ -29,7 +29,7 @@ module @test_core_llvm1 {
   %buf11_0  = AIE.buffer(%tile11) { sym_name = "a" } : memref<256xi32>
 
   %core11 = AIE.core(%tile11) {
-    AIE.useLock(%lock11_8, Acquire, 0, 0)
+    AIE.useLock(%lock11_8, Acquire, 0)
     %0 = arith.constant 1 : i32
     %i = arith.constant 16 : index
     memref.store %0, %buf11_0[%i] : memref<256xi32>
@@ -38,7 +38,7 @@ module @test_core_llvm1 {
   }
 
   %core12 = AIE.core(%tile12) {
-    AIE.useLock(%lock11_8, Acquire, 1, 0)
+    AIE.useLock(%lock11_8, Acquire, 1)
     %i = arith.constant 16 : index
     %0 = memref.load %buf11_0[%i] : memref<256xi32>
     AIE.useLock(%lock11_8, Release, 0)

--- a/test/lower-to-standard/lower_dma.mlir
+++ b/test/lower-to-standard/lower_dma.mlir
@@ -69,11 +69,11 @@ module @example0 {
   %c33 = AIE.core(%t33) {
     AIE.useLock(%l33_0, Acquire, 0)
     // code
-    %val0 = constant 16 : i32
-    %0 = constant 0 : i32
+    %val0 = arith.constant 16 : i32
+    %0 = arith.constant 0 : i32
     AIE.putStream(%0 : i32, %val0 : i32)
     %val1 = AIE.getStream(%0 : i32) : i128
-    %val2 = constant 1 : i384
+    %val2 = arith.constant 1 : i384
     AIE.putCascade(%val2: i384)
     AIE.useLock(%l33_0, Release, 1)
     AIE.end

--- a/test/lower-to-standard/lower_stream.mlir
+++ b/test/lower-to-standard/lower_stream.mlir
@@ -12,13 +12,13 @@
 // RUN: aie-opt --aie-standard-lowering="tilecol=2 tilerow=1" %s | FileCheck --check-prefix=CHECK21 %s
 
 //CHECK11:  func @core11() {
-//CHECK11:    %c0_i32 = constant 0 : i32
-//CHECK11:    %c1_i32 = constant 1 : i32
-//CHECK11:    %c16_i32 = constant 16 : i32
-//CHECK11:    %c32_i128 = constant 32 : i128
+//CHECK11:    %c0_i32 = arith.constant 0 : i32
+//CHECK11:    %c1_i32 = arith.constant 1 : i32
+//CHECK11:    %c16_i32 = arith.constant 16 : i32
+//CHECK11:    %c32_i128 = arith.constant 32 : i128
 //CHECK11:    call @llvm.aie.put.ms(%c0_i32, %c16_i32) : (i32, i32) -> ()
 //CHECK11:    call @llvm.aie.put.wms(%c1_i32, %c32_i128) : (i32, i128) -> ()
-//CHECK11:    %c64_i384 = constant 64 : i384
+//CHECK11:    %c64_i384 = arith.constant 64 : i384
 //CHECK11:    call @llvm.aie.put.mcd(%c64_i384) : (i384) -> ()
 //CHECK11:    return
 //CHECK11:  }
@@ -28,11 +28,11 @@
 //CHECK11:  }
 
 //CHECK21:  func @core21() {
-//CHECK21:    %c0_i32 = constant 0 : i32
-//CHECK21:    %c1_i32 = constant 1 : i32
+//CHECK21:    %c0_i32 = arith.constant 0 : i32
+//CHECK21:    %c1_i32 = arith.constant 1 : i32
 //CHECK21:    %0 = call @llvm.aie.get.ss(%c0_i32) : (i32) -> i32
 //CHECK21:    %1 = call @llvm.aie.get.ss(%c1_i32) : (i32) -> i32
-//CHECK21:    %2 = addi %0, %1 : i32
+//CHECK21:    %2 = arith.addi %0, %1 : i32
 //CHECK21:    %3 = call @llvm.aie.get.scd() : () -> i384
 //CHECK21:    return
 //CHECK21:  }
@@ -49,24 +49,24 @@ module @test_core_llvm0 {
   %tile21 = AIE.tile(2, 1)
 
   %core11 = AIE.core(%tile11) {
-    %0 = constant 0 : i32
-    %1 = constant 1 : i32
-    %val0 = constant 16 : i32
-    %val1 = constant 32 : i128
+    %0 = arith.constant 0 : i32
+    %1 = arith.constant 1 : i32
+    %val0 = arith.constant 16 : i32
+    %val1 = arith.constant 32 : i128
     AIE.putStream(%val0 : i32,  %0 : i32)
     AIE.putStream(%val1 : i128, %1 : i32)
-    %val2 = constant 64 : i384
+    %val2 = arith.constant 64 : i384
     AIE.putCascade(%val2 : i384)
     AIE.end
   }
 
   %core21 = AIE.core(%tile21) {
-    %0 = constant 0 : i32
-    %1 = constant 1 : i32
+    %0 = arith.constant 0 : i32
+    %1 = arith.constant 1 : i32
     //%val0 = AIE.getStream(0) : i32
     %val0 = AIE.getStream(%0 : i32) : i32
     %val1 = AIE.getStream(%1 : i32) : i32
-    %2 = addi %val0, %val1 : i32
+    %2 = arith.addi %val0, %val1 : i32
     %3 = AIE.getCascade() : i384
     AIE.end
   }

--- a/test/unit_tests/00_itsalive/aie.mlir
+++ b/test/unit_tests/00_itsalive/aie.mlir
@@ -16,9 +16,9 @@ module @test00_itsalive {
   %buf12_0 = AIE.buffer(%tile12) { sym_name = "a", address = 0 } : memref<256xi32>
 
   %core12 = AIE.core(%tile12) {
-    %val1 = constant 1 : i32
-    %idx1 = constant 3 : index
-    %2 = addi %val1, %val1 : i32
+    %val1 = arith.constant 1 : i32
+    %idx1 = arith.constant 3 : index
+    %2 = arith.addi %val1, %val1 : i32
     AIE.end
   }
 }

--- a/test/unit_tests/01_memory_read_write/aie.mlir
+++ b/test/unit_tests/01_memory_read_write/aie.mlir
@@ -17,15 +17,15 @@ module @test01_memory_read_write {
   %buf13_0 = AIE.buffer(%tile13) { sym_name = "a" } : memref<256xi32>
 
   %core13 = AIE.core(%tile13) {
-    %val1 = constant 7 : i32
-    %idx1 = constant 3 : index
-    %2 = addi %val1, %val1 : i32
+    %val1 = arith.constant 7 : i32
+    %idx1 = arith.constant 3 : index
+    %2 = arith.addi %val1, %val1 : i32
     memref.store %2, %buf13_0[%idx1] : memref<256xi32>
-    %val2 = constant 8 : i32
-    %idx2 = constant 5 : index
+    %val2 = arith.constant 8 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %val2, %buf13_0[%idx2] : memref<256xi32>
     %val3 = memref.load %buf13_0[%idx1] : memref<256xi32>
-    %idx3 = constant 9 : index
+    %idx3 = arith.constant 9 : index
     memref.store %val3,%buf13_0[%idx3] : memref<256xi32>
     AIE.end
   }

--- a/test/unit_tests/03_sync_with_locks/aie.mlir
+++ b/test/unit_tests/03_sync_with_locks/aie.mlir
@@ -23,13 +23,13 @@ module @test03_sync_with_locks {
   %core13 = AIE.core(%tile13) {
     AIE.useLock(%lock13_3, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock13_5, "Acquire", 0) // acquire for write
-    %idx1 = constant 3 : index
+    %idx1 = arith.constant 3 : index
     %val1 = memref.load %buf13_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf13_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock13_3, "Release", 0) // release for write
     AIE.useLock(%lock13_5, "Release", 1) // release for read

--- a/test/unit_tests/04_shared_memory/aie.mlir
+++ b/test/unit_tests/04_shared_memory/aie.mlir
@@ -26,13 +26,13 @@ module @test04_shared_memory {
   %core13 = AIE.core(%tile13) {
     AIE.useLock(%lock13_3, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock13_5, "Acquire", 0) // acquire for write
-    %idx1 = constant 3 : index
+    %idx1 = arith.constant 3 : index
     %val1 = memref.load %buf13_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf13_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock13_3, "Release", 0) // release for write
     AIE.useLock(%lock13_5, "Release", 1) // release for read
@@ -40,15 +40,21 @@ module @test04_shared_memory {
   }
 
   %core14 = AIE.core(%tile14) {
+<<<<<<< HEAD
     AIE.useLock(%lock13_5, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock14_7, "Acquire", 0) // acquire for write
     %idx1 = constant 5 : index
+=======
+    AIE.useLock(%lock13_5, "Acquire", 1, 0) // acquire for read(e.g. input ping)
+    AIE.useLock(%lock14_7, "Acquire", 0, 0) // acquire for write
+    %idx1 = arith.constant 5 : index
+>>>>>>> Bump LLVM to 4b553297ef3ee4dc2119d5429adf3072e90fac38
     %val1 = memref.load %buf13_1[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf14_0[%idx2] : memref<256xi32>
     AIE.useLock(%lock13_5, "Release", 0) // release for write
     AIE.useLock(%lock14_7, "Release", 1) // release for read

--- a/test/unit_tests/04_shared_memory/aie.mlir
+++ b/test/unit_tests/04_shared_memory/aie.mlir
@@ -40,15 +40,9 @@ module @test04_shared_memory {
   }
 
   %core14 = AIE.core(%tile14) {
-<<<<<<< HEAD
     AIE.useLock(%lock13_5, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock14_7, "Acquire", 0) // acquire for write
-    %idx1 = constant 5 : index
-=======
-    AIE.useLock(%lock13_5, "Acquire", 1, 0) // acquire for read(e.g. input ping)
-    AIE.useLock(%lock14_7, "Acquire", 0, 0) // acquire for write
     %idx1 = arith.constant 5 : index
->>>>>>> Bump LLVM to 4b553297ef3ee4dc2119d5429adf3072e90fac38
     %val1 = memref.load %buf13_1[%idx1] : memref<256xi32>
     %2    = arith.addi %val1, %val1 : i32
     %3 = arith.addi %2, %val1 : i32

--- a/test/unit_tests/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/04_shared_memory/aie_row.mlir
@@ -25,13 +25,13 @@ module @test4_row_shared_memory {
   %core13 = AIE.core(%tile13) {
     AIE.useLock(%lock13_3, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock13_5, "Acquire", 0) // acquire for write
-    %idx1 = constant 3 : index
+    %idx1 = arith.constant 3 : index
     %val1 = memref.load %buf13_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf13_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock13_3, "Release", 0) // release for write
     AIE.useLock(%lock13_5, "Release", 1) // release for read
@@ -40,15 +40,21 @@ module @test4_row_shared_memory {
 
 
   %core23 = AIE.core(%tile23) {
+<<<<<<< HEAD
     AIE.useLock(%lock13_5, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock23_7, "Acquire", 0) // acquire for write
     %idx1 = constant 3 : index
+=======
+    AIE.useLock(%lock13_5, "Acquire", 1, 0) // acquire for read(e.g. input ping)
+    AIE.useLock(%lock23_7, "Acquire", 0, 0) // acquire for write
+    %idx1 = arith.constant 3 : index
+>>>>>>> Bump LLVM to 4b553297ef3ee4dc2119d5429adf3072e90fac38
     %val1 = memref.load %buf13_1[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf23_0[%idx2] : memref<256xi32>
     AIE.useLock(%lock13_5, "Release", 0) // release for write
     AIE.useLock(%lock23_7, "Release", 1) // release for read

--- a/test/unit_tests/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/04_shared_memory/aie_row.mlir
@@ -40,15 +40,9 @@ module @test4_row_shared_memory {
 
 
   %core23 = AIE.core(%tile23) {
-<<<<<<< HEAD
     AIE.useLock(%lock13_5, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock23_7, "Acquire", 0) // acquire for write
-    %idx1 = constant 3 : index
-=======
-    AIE.useLock(%lock13_5, "Acquire", 1, 0) // acquire for read(e.g. input ping)
-    AIE.useLock(%lock23_7, "Acquire", 0, 0) // acquire for write
     %idx1 = arith.constant 3 : index
->>>>>>> Bump LLVM to 4b553297ef3ee4dc2119d5429adf3072e90fac38
     %val1 = memref.load %buf13_1[%idx1] : memref<256xi32>
     %2    = arith.addi %val1, %val1 : i32
     %3 = arith.addi %2, %val1 : i32

--- a/test/unit_tests/05_tiledma/aie.mlir
+++ b/test/unit_tests/05_tiledma/aie.mlir
@@ -47,15 +47,9 @@ module @test05_tiledma {
   }
 
   %core33 = AIE.core(%tile33) {
-<<<<<<< HEAD
     AIE.useLock(%lock33_6, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock33_7, "Acquire", 0) // acquire for write
-    %idx1 = constant 5 : index
-=======
-    AIE.useLock(%lock33_6, "Acquire", 1, 0) // acquire for read(e.g. input ping)
-    AIE.useLock(%lock33_7, "Acquire", 0, 0) // acquire for write
     %idx1 = arith.constant 5 : index
->>>>>>> Bump LLVM to 4b553297ef3ee4dc2119d5429adf3072e90fac38
     %val1 = memref.load %buf33_0[%idx1] : memref<256xi32>
     %2    = arith.addi %val1, %val1 : i32
     %3 = arith.addi %2, %val1 : i32

--- a/test/unit_tests/05_tiledma/aie.mlir
+++ b/test/unit_tests/05_tiledma/aie.mlir
@@ -33,13 +33,13 @@ module @test05_tiledma {
   %core13 = AIE.core(%tile13) {
     AIE.useLock(%lock13_3, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock13_5, "Acquire", 0) // acquire for write
-    %idx1 = constant 3 : index
+    %idx1 = arith.constant 3 : index
     %val1 = memref.load %buf13_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf13_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock13_3, "Release", 0) // release for write
     AIE.useLock(%lock13_5, "Release", 1) // release for read
@@ -47,15 +47,21 @@ module @test05_tiledma {
   }
 
   %core33 = AIE.core(%tile33) {
+<<<<<<< HEAD
     AIE.useLock(%lock33_6, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock33_7, "Acquire", 0) // acquire for write
     %idx1 = constant 5 : index
+=======
+    AIE.useLock(%lock33_6, "Acquire", 1, 0) // acquire for read(e.g. input ping)
+    AIE.useLock(%lock33_7, "Acquire", 0, 0) // acquire for write
+    %idx1 = arith.constant 5 : index
+>>>>>>> Bump LLVM to 4b553297ef3ee4dc2119d5429adf3072e90fac38
     %val1 = memref.load %buf33_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf33_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock33_6, "Release", 0) // release for write
     AIE.useLock(%lock33_7, "Release", 1) // release for read

--- a/test/unit_tests/08_stream_broadcast/aie.mlir
+++ b/test/unit_tests/08_stream_broadcast/aie.mlir
@@ -43,13 +43,13 @@ module @test08_stream_broadcast {
   %core13 = AIE.core(%tile13) {
     AIE.useLock(%lock13_3, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock13_5, "Acquire", 0) // acquire for write
-    %idx1 = constant 3 : index
+    %idx1 = arith.constant 3 : index
     %val1 = memref.load %buf13_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf13_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock13_3, "Release", 0) // release for write
     AIE.useLock(%lock13_5, "Release", 1) // release for read
@@ -79,13 +79,13 @@ module @test08_stream_broadcast {
   %core32 = AIE.core(%tile32) {
     AIE.useLock(%lock32_6, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock32_7, "Acquire", 0) // acquire for write
-    %idx1 = constant 5 : index
+    %idx1 = arith.constant 5 : index
     %val1 = memref.load %buf32_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-//    %4 = addi %3, %val1 : i32
-//    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+//    %4 = arith.addi %3, %val1 : i32
+//    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %3, %buf32_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock32_6, "Release", 0) // release for write
     AIE.useLock(%lock32_7, "Release", 1) // release for read
@@ -114,13 +114,13 @@ module @test08_stream_broadcast {
   %core33 = AIE.core(%tile33) {
     AIE.useLock(%lock33_6, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock33_7, "Acquire", 0) // acquire for write
-    %idx1 = constant 5 : index
+    %idx1 = arith.constant 5 : index
     %val1 = memref.load %buf33_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-//    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+//    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %4, %buf33_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock33_6, "Release", 0) // release for write
     AIE.useLock(%lock33_7, "Release", 1) // release for read
@@ -149,13 +149,13 @@ module @test08_stream_broadcast {
   %core34 = AIE.core(%tile34) {
     AIE.useLock(%lock34_6, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock34_7, "Acquire", 0) // acquire for write
-    %idx1 = constant 5 : index
+    %idx1 = arith.constant 5 : index
     %val1 = memref.load %buf34_0[%idx1] : memref<256xi32>
-    %2    = addi %val1, %val1 : i32
-    %3 = addi %2, %val1 : i32
-    %4 = addi %3, %val1 : i32
-    %5 = addi %4, %val1 : i32
-    %idx2 = constant 5 : index
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
     memref.store %5, %buf34_1[%idx2] : memref<256xi32>
     AIE.useLock(%lock34_6, "Release", 0) // release for write
     AIE.useLock(%lock34_7, "Release", 1) // release for read

--- a/test/unit_tests/10_scalar_fp/aie.mlir
+++ b/test/unit_tests/10_scalar_fp/aie.mlir
@@ -17,15 +17,15 @@ module @test {
   %buf13_0 = AIE.buffer(%tile13) { sym_name = "a" } : memref<256xf32>
 
   %core13 = AIE.core(%tile13) {
-    %val1 = constant 7.0 : f32
-    %idx1 = constant 3 : index
-    %2 = addf %val1, %val1 : f32
+    %val1 = arith.constant 7.0 : f32
+    %idx1 = arith.constant 3 : index
+    %2 = arith.addf %val1, %val1 : f32
     memref.store %2, %buf13_0[%idx1] : memref<256xf32>
-    %val2 = constant 8.0 : f32
-    %idx2 = constant 5 : index
+    %val2 = arith.constant 8.0 : f32
+    %idx2 = arith.constant 5 : index
     memref.store %val2, %buf13_0[%idx2] : memref<256xf32>
     %val3 = memref.load %buf13_0[%idx1] : memref<256xf32>
-    %idx3 = constant 9 : index
+    %idx3 = arith.constant 9 : index
     memref.store %val3,%buf13_0[%idx3] : memref<256xf32>
     AIE.end
   }

--- a/test/unit_tests/11_vector_fp/aie.mlir
+++ b/test/unit_tests/11_vector_fp/aie.mlir
@@ -17,24 +17,24 @@ module @test {
   %buf13_0 = AIE.buffer(%tile13) { sym_name = "a" } : memref<256xf32>
 
   %core13 = AIE.core(%tile13) {
-    %c0 = constant 0 : index
-    %c64 = constant 64 : index
-    %c8 = constant 8 : index
-    %val1 = constant 7.0 : f32
-    %idx1 = constant 3 : index
-    %2 = addf %val1, %val1 : f32
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c8 = arith.constant 8 : index
+    %val1 = arith.constant 7.0 : f32
+    %idx1 = arith.constant 3 : index
+    %2 = arith.addf %val1, %val1 : f32
     memref.store %2, %buf13_0[%idx1] : memref<256xf32>
-    %val2 = constant 8.0 : f32
-    %idx2 = constant 5 : index
+    %val2 = arith.constant 8.0 : f32
+    %idx2 = arith.constant 5 : index
     memref.store %val2, %buf13_0[%idx2] : memref<256xf32>
     %val3 = memref.load %buf13_0[%idx1] : memref<256xf32>
-    %idx3 = constant 9 : index
+    %idx3 = arith.constant 9 : index
     memref.store %val3,%buf13_0[%idx3] : memref<256xf32>
     scf.for %arg0 = %c0 to %c64 step %c8 {
-      %cst = constant 0.000000e+00 : f32
+      %cst = arith.constant 0.000000e+00 : f32
       %59 = vector.transfer_read %buf13_0[%arg0], %cst : memref<256xf32>, vector<8xf32>
       %60 = vector.transfer_read %buf13_0[%arg0], %cst : memref<256xf32>, vector<8xf32>
-      %61 = mulf %59, %60 : vector<8xf32>
+      %61 = arith.mulf %59, %60 : vector<8xf32>
       vector.transfer_write %61, %buf13_0[%arg0] : vector<8xf32>, memref<256xf32>
     }
     AIE.end

--- a/test/unit_tests/15_prime_sieve/aie.mlir
+++ b/test/unit_tests/15_prime_sieve/aie.mlir
@@ -27,16 +27,16 @@ module @test15_prime_sieve {
   %buf16_0 = AIE.buffer(%tile16) { sym_name = "prime5" } : memref<256xi32>
 
   %core13 = AIE.core(%tile13) {
-    %c0 = constant 0 : index
-    %c1 = constant 1 : index
-    %c64 = constant 64 : index
-    %sum_0 = constant 2 : i32
-    %t = constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %sum_0 = arith.constant 2 : i32
+    %t = arith.constant 1 : i32
 
     // output integers starting with 2...
     scf.for %arg0 = %c0 to %c64 step %c1
       iter_args(%sum_iter = %sum_0) -> (i32) {
-      %sum_next = addi %sum_iter, %t : i32
+      %sum_next = arith.addi %sum_iter, %t : i32
       memref.store %sum_iter, %buf13_0[%arg0] : memref<256xi32>
       scf.yield %sum_next : i32
     }
@@ -44,10 +44,10 @@ module @test15_prime_sieve {
     AIE.end
   }
   func @do_sieve(%bufin: memref<256xi32>, %bufout:memref<256xi32>) -> () {
-    %c0 = constant 0 : index
-    %c1 = constant 1 : index
-    %c64 = constant 64 : index
-    %count_0 = constant 0 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %count_0 = arith.constant 0 : i32
 
     // The first number we receive is prime
     %prime = memref.load %bufin[%c0] : memref<256xi32>
@@ -59,19 +59,19 @@ module @test15_prime_sieve {
       %in_val = memref.load %bufin[%in_iter] : memref<256xi32>
 
       // Potential next counters
-      %count_inc = addi %count_iter, %prime: i32
-      %in_inc = addi %in_iter, %c1 : index
-      %out_inc = addi %out_iter, %c1 : index
+      %count_inc = arith.addi %count_iter, %prime: i32
+      %in_inc = arith.addi %in_iter, %c1 : index
+      %out_inc = arith.addi %out_iter, %c1 : index
 
       // Compare the input value with the counter
-      %b = cmpi "slt", %in_val, %count_iter : i32
+      %b = arith.cmpi "slt", %in_val, %count_iter : i32
       %count_next, %in_next, %out_next = scf.if %b -> (i32, index, index) {
         // Input is less than counter.
         // Pass along the input and continue to the next one.
         memref.store %in_val, %bufout[%out_iter] : memref<256xi32>
         scf.yield %count_iter, %in_inc, %out_inc : i32, index, index
       } else {
-        %b2 = cmpi "eq", %in_val, %count_iter : i32
+        %b2 = arith.cmpi "eq", %in_val, %count_iter : i32
         %in_next = scf.if %b2 -> (index) {
           // Input is equal to the counter.
           // Increment the counter and continue to the next input.

--- a/test/unit_tests/17_shim_dma_with_core/aie.mlir
+++ b/test/unit_tests/17_shim_dma_with_core/aie.mlir
@@ -31,17 +31,17 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   // func private @func(%A: memref<256xi32>, %B: memref<256xi32>, %C: i32) -> ()
 
   %c13 = AIE.core(%t73) { 
-    %buffer_size =  constant 256 : i32
+    %buffer_size =  arith.constant 256 : i32
 
-    %lb = constant 0 : index
-    %ub = constant 4 : index
-    %step = constant 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 4 : index
+    %step = arith.constant 1 : index
     
-    %sum_0 = constant 0 : i32
-    %inc = constant 1 : i32
-    %c0 = constant 0 : index
-    %c1 = constant 1 : index
-    %c64 = constant 64 : index
+    %sum_0 = arith.constant 0 : i32
+    %inc = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
     scf.for %iv = %lb to %ub step %step {
       
       AIE.useLock(%lock_a_ping, "Acquire", 1) // acquire for read
@@ -50,7 +50,7 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       scf.for %arg0 = %c0 to %c64 step %c1
         iter_args(%sum_iter = %sum_0) -> (i32) {
         %i = memref.load %buf_a_ping[%arg0] : memref<64xi32>
-        %i2 = addi %i, %inc : i32
+        %i2 = arith.addi %i, %inc : i32
         memref.store %i2, %buf_b_ping[%arg0] : memref<64xi32>
         scf.yield %i : i32
       }
@@ -63,7 +63,7 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       scf.for %arg0 = %c0 to %c64 step %c1
         iter_args(%sum_iter = %sum_0) -> (i32) {
         %i = memref.load %buf_a_pong[%arg0] : memref<64xi32>
-        %i2 = addi %i, %inc : i32
+        %i2 = arith.addi %i, %inc : i32
         memref.store %i2, %buf_b_pong[%arg0] : memref<64xi32>
         scf.yield %i : i32
       }

--- a/test/unit_tests/18_target_triple/aie.mlir
+++ b/test/unit_tests/18_target_triple/aie.mlir
@@ -32,7 +32,7 @@ module attributes {llvm.target_triple = "x86_64-unknown-linux-gnu"}  {
     %val0 = affine.load %buf_b[] : memref<i32>
     affine.for %arg0 = 0 to 16 {
       %val1 = affine.load %buf_a[%arg0] : memref<16xi32>
-      %val2 = addi %val0, %val1 : i32
+      %val2 = arith.addi %val0, %val1 : i32
       affine.store %val2, %buf_a[%arg0] : memref<16xi32>
     }
     AIE.end

--- a/test/unit_tests/19_shim_dma_with_core_routed/aie.mlir
+++ b/test/unit_tests/19_shim_dma_with_core_routed/aie.mlir
@@ -29,17 +29,17 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   // func private @func(%A: memref<256xi32>, %B: memref<256xi32>, %C: i32) -> ()
 
   %c13 = AIE.core(%t73) { 
-    %buffer_size =  constant 256 : i32
+    %buffer_size =  arith.constant 256 : i32
 
-    %lb = constant 0 : index
-    %ub = constant 4 : index
-    %step = constant 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 4 : index
+    %step = arith.constant 1 : index
     
-    %sum_0 = constant 0 : i32
-    %inc = constant 1 : i32
-    %c0 = constant 0 : index
-    %c1 = constant 1 : index
-    %c64 = constant 64 : index
+    %sum_0 = arith.constant 0 : i32
+    %inc = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
     scf.for %iv = %lb to %ub step %step {
       
       AIE.useLock(%lock_a_ping, "Acquire", 1) // acquire for read
@@ -48,7 +48,7 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       scf.for %arg0 = %c0 to %c64 step %c1
         iter_args(%sum_iter = %sum_0) -> (i32) {
         %i = memref.load %buf_a_ping[%arg0] : memref<64xi32>
-        %i2 = addi %i, %inc : i32
+        %i2 = arith.addi %i, %inc : i32
         memref.store %i2, %buf_b_ping[%arg0] : memref<64xi32>
         scf.yield %i : i32
       }
@@ -61,7 +61,7 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       scf.for %arg0 = %c0 to %c64 step %c1
         iter_args(%sum_iter = %sum_0) -> (i32) {
         %i = memref.load %buf_a_pong[%arg0] : memref<64xi32>
-        %i2 = addi %i, %inc : i32
+        %i2 = arith.addi %i, %inc : i32
         memref.store %i2, %buf_b_pong[%arg0] : memref<64xi32>
         scf.yield %i : i32
       }

--- a/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/aie.mlir
@@ -34,8 +34,8 @@ module {
   } { link_with="kernel.o" }
   
   %core14 = AIE.core(%tile14) {
-    %val1 = constant 7 : i32
-    %idx1 = constant 0 : index
+    %val1 = arith.constant 7 : i32
+    %idx1 = arith.constant 0 : index
     memref.store %val1, %buf14_0[%idx1] : memref<256xi32>
     // AIE.useLock(%lock14_7, "Acquire", 0) // acquire for write
     call @do_mac(%buf14_0) : (memref<256xi32>) -> ()

--- a/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
@@ -33,9 +33,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   %c13 = AIE.core(%t73) { 
     
-    %lb = constant 0 : index
-    %ub = constant 1 : index
-    %step = constant 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 1 : index
+    %step = arith.constant 1 : index
     
     scf.for %iv = %lb to %ub step %step {
       

--- a/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
@@ -33,17 +33,17 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   func private @func(%A: memref<64xi32>, %B: memref<64xi32>, %C: i32) -> ()
 
   %c13 = AIE.core(%t73) { 
-    %buffer_size =  constant 64 : i32
+    %buffer_size =  arith.constant 64 : i32
 
-    %lb = constant 0 : index
-    %ub = constant 4 : index
-    %step = constant 1 : index
+    %lb = arith.constant 0 : index
+    %ub = arith.constant 4 : index
+    %step = arith.constant 1 : index
     
-    %sum_0 = constant 0 : i32
-    %inc = constant 1 : i32
-    %c0 = constant 0 : index
-    %c1 = constant 1 : index
-    %c64 = constant 64 : index
+    %sum_0 = arith.constant 0 : i32
+    %inc = arith.constant 1 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
     scf.for %iv = %lb to %ub step %step {
       
       AIE.useLock(%lock_a_ping, "Acquire", 1) // acquire for read

--- a/tools/aie-opt/aie-opt.cpp
+++ b/tools/aie-opt/aie-opt.cpp
@@ -48,6 +48,7 @@ int main(int argc, char **argv) {
   registry.insert<memref::MemRefDialect>();
   registry.insert<xilinx::AIE::AIEDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::arith::ArithmeticDialect>();
 
   return failed(MlirOptMain(argc, argv, "MLIR modular optimizer driver\n",
                             registry,

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -88,8 +88,10 @@ def run_flow(opts, tmpdirname):
         do_call(['aie-translate', file_with_addresses, '--aie-generate-ldscript', '--tilecol=%d' % corecol, '--tilerow=%d' % corerow, '-o', file_core_ldscript])
         file_core_llvmir = tmpcorefile(core, "ll")
         do_call(['aie-translate', '--mlir-to-llvmir', file_opt_core, '-o', file_core_llvmir])
+        file_core_llvmir_opted = tmpcorefile(core, "opted.ll")
+        do_call(['opt', '-O2', '-S', file_core_llvmir, '-o', file_core_llvmir_opted])
         file_core_llvmir_stripped = tmpcorefile(core, "stripped.ll")
-        do_call(['opt', '-O2', '-strip', '-S', file_core_llvmir, '-o', file_core_llvmir_stripped])
+        do_call(['opt', '-strip', '-S', file_core_llvmir_opted, '-o', file_core_llvmir_stripped])
         file_core_elf = elf_file if elf_file else corefile(".", core, "elf")
         file_core_obj = tmpcorefile(core, "o")
         if(opts.xchesscc):

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -12,7 +12,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export commithash=984e270a9a7063c370bcc80ee1fb3ec874d92b93
+export commithash=4b553297ef3ee4dc2119d5429adf3072e90fac38
 
 git clone --depth 1 https://github.com/llvm/llvm-project.git llvm
 pushd llvm


### PR DESCRIPTION
This patch aligns the LLVM version with CIRCT to make use of the `handshake` dialect in CIRCT.

Several main changes:
1. Arithmetic dialect:
    - Rename `constant` to `arith.constant`, `addi` to `arith.addi`, etc. in all test cases
    - Register Arithmetic dialect in `aie-opt` and `aie-translate`
2. OpConversionPattern class:
    - `matchAndRewrite` and `rewrite` methods now take `OpAdaptor` as input instead of operands list `ArrayRef<Value>`
    - Overridable `match` method now takes the concrete operation as input instead of `Operation *`

All tests passed on my machine, hope this can pass the CI 🙏As most of changes come from clang-format, I'll file another formatting PR to make this patch cleaner.