### PR TITLE
Fix bug in --aie-create-packet-flows

### DIFF
--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -487,7 +487,8 @@ def AIE_AMSelOp: AIE_Op<"amsel", [HasParent<"SwitchboxOp">]>, Results<(outs Inde
           AIE.rule(0x1F, 0x10, %a0_0)
         }
     ```
-    This code associates arbiter 5 with msel=3.  A packet-switched connection is made routing traffic from the South:0 port to the East:0 port using this arbiter.
+    This code associates arbiter 5 with msel=3.  A packet-switched connection is made routing
+    traffic from the South:0 port to the East:0 port using this arbiter.
     There are 6 arbiters per switchbox and 4 possible master select values.
     See also [MasterSetOp](#aiemasterset-aiemastersetop),
     [PacketRulesOp](#aiepacketrules-aiepacketrulesop), and

--- a/test/create-packet-flows/test_create_packet_flows5.mlir
+++ b/test/create-packet-flows/test_create_packet_flows5.mlir
@@ -19,7 +19,7 @@
 // CHECK:       AIE.rule(31, 2, %2)
 // CHECK:     }
 // CHECK:     AIE.packetrules(West : 0) {
-// CHECK:       AIE.rule(30, 1, %2)
+// CHECK:       AIE.rule(30, 0, %2)
 // CHECK:     }
 // CHECK:   }
 // CHECK: }


### PR DESCRIPTION
Previously we didn't mask the ID field, but this will prevent
some correct matches.

Closes #75