### PR TITLE
[AIETarget] Support packet stream for ShimDMAs

### DIFF
--- a/lib/Targets/AIETargetXAIEV1.cpp
+++ b/lib/Targets/AIETargetXAIEV1.cpp
@@ -407,6 +407,9 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
       }
     }
     for (auto &block : op.body()) {
+      bool foundBdPacket = false;
+      int packetType = 0;
+      int packetID = 0;
       bool foundBd = false;
       int len = 0;
       uint64_t bytes = 0;
@@ -439,6 +442,12 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
           relEnable = enable;
           relValue = op.getLockValue();
         }
+      }
+
+      for (auto op : block.getOps<DMABDPACKETOp>()) {
+        foundBdPacket = true;
+        packetType = op.getPacketType();
+        packetID = op.getPacketID();
       }
 
       int bdNum = blockMap[&block];
@@ -482,6 +491,13 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
           output << "XAieDma_ShimBdSetNext(&" << dmaName << ", "
                  << " /* bd */ " << bdNum << ", "
                  << " /* nextbd */ " << nextBdNum << ");\n";
+        }
+        if (foundBdPacket) {
+          output << "XAieDma_ShimBdSetPkt(&" << dmaName << ", "
+                 << " /* bd */ " << bdNum << ", "
+                 << " /* en */ " << 1 << ", "
+                 << " /* type */ " << packetType << ", "
+                 << " /* id */ " << packetID << ");\n";
         }
         output << "XAieDma_ShimBdWrite(&" << dmaName << ", "
                << " /* bd */ " << bdNum << ");\n";

--- a/test/unit_tests/21_shim_dma_packet/aie.mlir
+++ b/test/unit_tests/21_shim_dma_packet/aie.mlir
@@ -1,0 +1,214 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aiecc.py --pathfinder --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
+// RUN: %run_on_board ./test.elf
+
+// A single kernel 32x32x32 GEMM using GMIO.
+module @kernel_gemm  {
+  %3 = AIE.tile(27, 0)
+  %4 = AIE.switchbox(%3)  {
+    %43 = AIE.amsel<0> (0)
+    %44 = AIE.masterset(West : 0, %43)
+    AIE.packetrules(DMA : 0)  {
+      AIE.rule(31, 2, %43)
+    }
+  }
+  %5 = AIE.lock(%3, 0)
+  %6 = AIE.external_buffer 16384 {sym_name = "buf0"} : memref<32x32xi32>
+  %7 = AIE.core(%3)  {
+    AIE.useLock(%5, Acquire, 0)
+    AIE.useLock(%5, Release, 1)
+    AIE.end
+  }
+  %8 = AIE.shimDMA(%3)  {
+    %43 = AIE.dmaStart(MM2S0, ^bb1, ^bb2)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%5, Acquire, 1)
+    AIE.dmaBdPacket(0, 2)
+    AIE.dmaBd(<%6 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%5, Release, 0)
+    br ^bb1
+  ^bb2:  // pred: ^bb0
+    AIE.end
+  }
+  %9 = AIE.tile(26, 0)
+  %10 = AIE.switchbox(%9)  {
+    %43 = AIE.amsel<0> (0)
+    %44 = AIE.masterset(West : 0, %43)
+    AIE.packetrules(DMA : 1)  {
+      AIE.rule(31, 3, %43)
+    }
+    AIE.packetrules(East : 0)  {
+      AIE.rule(31, 2, %43)
+    }
+    AIE.connect<South : 3, North : 0>
+    AIE.connect<West : 0, South : 2>
+  }
+  %11 = AIE.lock(%9, 2)
+  %12 = AIE.lock(%9, 1)
+  %13 = AIE.lock(%9, 0)
+  %14 = AIE.external_buffer 20480 {sym_name = "buf1"} : memref<32x32xi32>
+  %15 = AIE.external_buffer 24576 {sym_name = "buf2"} : memref<32x32xi32>
+  %16 = AIE.external_buffer 28672 {sym_name = "buf3"} : memref<32x32xi32>
+  %17 = AIE.core(%9)  {
+    AIE.useLock(%12, Acquire, 0)
+    AIE.useLock(%13, Acquire, 1)
+    AIE.useLock(%11, Acquire, 0)
+    AIE.useLock(%11, Release, 1)
+    AIE.useLock(%13, Release, 0)
+    AIE.useLock(%12, Release, 1)
+    AIE.end
+  }
+  %18 = AIE.shimDMA(%9)  {
+    %43 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%13, Acquire, 0)
+    AIE.dmaBd(<%16 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%13, Release, 1)
+    br ^bb1
+  ^bb2:  // pred: ^bb0
+    %44 = AIE.dmaStart(MM2S0, ^bb3, ^bb4)
+  ^bb3:  // 2 preds: ^bb2, ^bb3
+    AIE.useLock(%11, Acquire, 1)
+    AIE.dmaBd(<%15 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%11, Release, 0)
+    br ^bb3
+  ^bb4:  // pred: ^bb2
+    %45 = AIE.dmaStart(MM2S1, ^bb5, ^bb6)
+  ^bb5:  // 2 preds: ^bb4, ^bb5
+    AIE.useLock(%12, Acquire, 1)
+    AIE.dmaBdPacket(0, 3)
+    AIE.dmaBd(<%14 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%12, Release, 0)
+    br ^bb5
+  ^bb6:  // pred: ^bb4
+    AIE.end
+  }
+  %19 = AIE.tile(25, 2) {polyaie.leaf}
+  %20 = AIE.lock(%19, 15)
+  %21 = AIE.switchbox(%19)  {
+    %43 = AIE.amsel<0> (0)
+    %44 = AIE.masterset(DMA : 1, %43)
+    AIE.packetrules(South : 0)  {
+      AIE.rule(30, 2, %43)
+    }
+    AIE.connect<East : 0, DMA : 0>
+    AIE.connect<DMA : 0, South : 0>
+  }
+  %22 = AIE.lock(%19, 3)
+  %23 = AIE.lock(%19, 2)
+  %24 = AIE.lock(%19, 1)
+  %25 = AIE.lock(%19, 0)
+  %26 = AIE.buffer(%19) {sym_name = "buf4"} : memref<32x32xi32>
+  %27 = AIE.buffer(%19) {sym_name = "buf5"} : memref<32x32xi32>
+  %28 = AIE.buffer(%19) {sym_name = "buf6"} : memref<32x32xi32>
+  %29 = AIE.buffer(%19) {sym_name = "buf7"} : memref<32x32xi32>
+  %30 = AIE.buffer(%19) {sym_name = "buf8"} : memref<32x32xi32>
+  %31 = AIE.buffer(%19) {sym_name = "buf9"} : memref<32x32xi32>
+  %32 = AIE.core(%19)  {
+    AIE.useLock(%23, Acquire, 1)
+    AIE.useLock(%24, Acquire, 1)
+    AIE.useLock(%25, Acquire, 0)
+    AIE.useLock(%22, Acquire, 1)
+    affine.for %arg0 = 0 to 32 {
+      affine.for %arg1 = 0 to 32 {
+        %43 = affine.load %30[%arg0, %arg1] : memref<32x32xi32>
+        affine.store %43, %27[%arg0, %arg1] : memref<32x32xi32>
+      }
+    }
+    affine.for %arg0 = 0 to 32 {
+      affine.for %arg1 = 0 to 32 {
+        %43 = affine.load %31[%arg0, %arg1] : memref<32x32xi32>
+        affine.store %43, %28[%arg0, %arg1] : memref<32x32xi32>
+      }
+      affine.for %arg1 = 0 to 32 {
+        %43 = affine.load %29[%arg0, %arg1] : memref<32x32xi32>
+        affine.store %43, %26[%arg0, %arg1] : memref<32x32xi32>
+        affine.for %arg2 = 0 to 32 {
+          %44 = affine.load %26[%arg0, %arg1] : memref<32x32xi32>
+          %45 = affine.load %28[%arg0, %arg2] : memref<32x32xi32>
+          %46 = affine.load %27[%arg2, %arg1] : memref<32x32xi32>
+          %47 = arith.muli %45, %46 : i32
+          %48 = arith.addi %44, %47 : i32
+          affine.store %48, %26[%arg0, %arg1] : memref<32x32xi32>
+        }
+      }
+    }
+    AIE.useLock(%22, Release, 0)
+    AIE.useLock(%25, Release, 1)
+    AIE.useLock(%24, Release, 0)
+    AIE.useLock(%23, Release, 0)
+    AIE.useLock(%20, Release, 1)
+    AIE.end
+  }
+  %33 = AIE.mem(%19)  {
+    %43 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%22, Acquire, 0)
+    AIE.dmaBd(<%31 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%22, Release, 1)
+    br ^bb1
+  ^bb2:  // pred: ^bb0
+    %44 = AIE.dmaStart(S2MM1, ^bb3, ^bb5)
+  ^bb3:  // 2 preds: ^bb2, ^bb4
+    AIE.useLock(%24, Acquire, 0)
+    AIE.dmaBdPacket(0, 2)
+    AIE.dmaBd(<%29 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%24, Release, 1)
+    br ^bb4
+  ^bb4:  // pred: ^bb3
+    AIE.useLock(%23, Acquire, 0)
+    AIE.dmaBdPacket(0, 3)
+    AIE.dmaBd(<%30 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%23, Release, 1)
+    br ^bb3
+  ^bb5:  // pred: ^bb2
+    %45 = AIE.dmaStart(MM2S0, ^bb6, ^bb7)
+  ^bb6:  // 2 preds: ^bb5, ^bb6
+    AIE.useLock(%25, Acquire, 1)
+    AIE.dmaBd(<%26 : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%25, Release, 0)
+    br ^bb6
+  ^bb7:  // pred: ^bb5
+    AIE.end
+  }
+  %34 = AIE.tile(25, 0)
+  %35 = AIE.switchbox(%34)  {
+    %43 = AIE.amsel<0> (0)
+    %44 = AIE.masterset(North : 0, %43)
+    AIE.packetrules(East : 0)  {
+      AIE.rule(30, 2, %43)
+    }
+    AIE.connect<North : 0, East : 0>
+  }
+  %36 = AIE.tile(25, 1)
+  %37 = AIE.switchbox(%36)  {
+    %43 = AIE.amsel<0> (0)
+    %44 = AIE.masterset(North : 0, %43)
+    AIE.packetrules(South : 0)  {
+      AIE.rule(30, 2, %43)
+    }
+    AIE.connect<North : 0, South : 0>
+  }
+  %38 = AIE.tile(26, 1)
+  %39 = AIE.tile(26, 2)
+  %40 = AIE.switchbox(%38)  {
+    AIE.connect<South : 0, North : 0>
+  }
+  %41 = AIE.switchbox(%39)  {
+    AIE.connect<South : 0, West : 0>
+  }
+  %42 = AIE.shimmux(%9)  {
+    AIE.connect<DMA : 0, North : 3>
+    AIE.connect<North : 2, DMA : 0>
+  }
+}
+

--- a/test/unit_tests/21_shim_dma_packet/test.cpp
+++ b/test/unit_tests/21_shim_dma_packet/test.cpp
@@ -1,0 +1,112 @@
+
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Automatically generated file for MLIR-AIE host kernel.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+#define MLIR_STACK_OFFSET 4096
+
+#include "aie_inc.cpp"
+
+int main(int argc, char *argv[]) {
+  int32_t arg0[32][32];
+  int32_t arg1[32][32];
+  int32_t arg2[32][32];
+  unsigned iter_num = 1;
+
+  printf("Configure AIE array...\n");
+
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
+
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_initialize_locks(_xaie);
+  mlir_aie_configure_dmas(_xaie);
+
+  printf("Initialize buffers...\n");
+
+  int fd = open("/dev/mem", O_RDWR | O_SYNC);
+  assert(fd != -1 && "memory is not available");
+
+  mlir_aie_clear_tile_memory(_xaie, 25, 2);
+
+  unsigned bufIdx;
+
+  int32_t *buf0_ptr = (int32_t *)mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                                      MAP_SHARED, fd, 0x4000);
+  bufIdx = 0;
+  for (int64_t idx0 = 0; idx0 < 32; ++idx0)
+    for (int64_t idx1 = 0; idx1 < 32; ++idx1)
+      buf0_ptr[bufIdx++] = arg0[idx0][idx1];
+
+  int32_t *buf1_ptr = (int32_t *)mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                                      MAP_SHARED, fd, 0x5000);
+  bufIdx = 0;
+  for (int64_t idx0 = 0; idx0 < 32; ++idx0)
+    for (int64_t idx1 = 0; idx1 < 32; ++idx1)
+      buf1_ptr[bufIdx++] = arg2[idx0][idx1];
+
+  int32_t *buf2_ptr = (int32_t *)mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                                      MAP_SHARED, fd, 0x6000);
+  bufIdx = 0;
+  for (int64_t idx0 = 0; idx0 < 32; ++idx0)
+    for (int64_t idx1 = 0; idx1 < 32; ++idx1)
+      buf2_ptr[bufIdx++] = arg1[idx0][idx1];
+
+  bool results[1];
+
+  for (auto &result : results)
+    result = false;
+
+  auto kernel_complete = [&]() {
+    bool flag = true;
+    for (auto result : results) {
+      flag &= result;
+      // printf("%d ", result);
+    }
+    // printf("\n");
+    return flag;
+  };
+
+  printf("Start cores...\n");
+  mlir_aie_start_cores(_xaie);
+
+  printf("Release locks...\n\n");
+  mlir_aie_release_lock(_xaie, 27, 0, 0, 1, 0);
+  mlir_aie_release_lock(_xaie, 26, 0, 2, 1, 0);
+  mlir_aie_release_lock(_xaie, 26, 0, 1, 1, 0);
+
+  while (!kernel_complete()) {
+    if (mlir_aie_acquire_lock(_xaie, 26, 0, 0, 1, 0))
+      results[0] = true;
+  }
+
+  int32_t *buf3_ptr = (int32_t *)mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                                      MAP_SHARED, fd, 0x7000);
+  bufIdx = 0;
+  for (int64_t idx0 = 0; idx0 < 32; ++idx0)
+    for (int64_t idx1 = 0; idx1 < 32; ++idx1)
+      arg0[idx0][idx1] = buf3_ptr[bufIdx++];
+
+  mlir_aie_release_lock(_xaie, 26, 0, 0, 0, 0);
+
+  mlir_aie_deinit_libxaie(_xaie);
+
+  printf("Complete compute.\n");
+}

--- a/test/xaie_target/shim_dma_packet.mlir
+++ b/test/xaie_target/shim_dma_packet.mlir
@@ -1,0 +1,42 @@
+//===- shim_dma_packet.mlir ------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
+
+// CHECK-LABEL: void mlir_aie_configure_dmas(aie_libxaie_ctx_t* ctx) {
+// CHECK: XAieDma_Shim ShimDMAInst_7_0;
+// CHECK: XAieDma_ShimInitialize(&(ctx->TileInst[7][0]), &ShimDMAInst_7_0);
+// CHECK: XAieDma_ShimBdSetLock(&ShimDMAInst_7_0,  /* bd */ 0,  /* lockID */ 0, XAIE_ENABLE,  /* release */ 0, XAIE_ENABLE,  /* acquire */ 1);
+// CHECK: XAieDma_ShimBdSetAddr(&ShimDMAInst_7_0,  /* bd */ 0, HIGH_ADDR((u64)0x4000), LOW_ADDR((u64)0x4000),  /* len */ 1024 * 4);
+// CHECK: XAieDma_ShimBdSetAxi(&ShimDMAInst_7_0, /* bd */ 0, /* smid */ 0, /* burstlen */ 4, /* QOS */ 0, /* Cache */ 0, /* secure */ XAIE_ENABLE);
+// CHECK: XAieDma_ShimBdSetNext(&ShimDMAInst_7_0,  /* bd */ 0,  /* nextbd */ 0);
+// CHECK: XAieDma_ShimBdSetPkt(&ShimDMAInst_7_0,  /* bd */ 0,  /* en */ 1,  /* type */ 0,  /* id */ 2);
+// CHECK: XAieDma_ShimBdWrite(&ShimDMAInst_7_0,  /* bd */ 0);
+// CHECK: XAieDma_ShimSetStartBd(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_MM2S0,  /* bd */ 0);
+// CHECK: XAieDma_ShimChControl(&ShimDMAInst_7_0, XAIEDMA_TILE_CHNUM_MM2S0, /* PauseStream */ XAIE_DISABLE, /* PauseMM */ XAIE_DISABLE, /* Enable */ XAIE_ENABLE);
+
+module {
+  %buf = AIE.external_buffer 16384 : memref<32x32xi32>
+
+  %tile70 = AIE.tile(7, 0)
+  %lock70 = AIE.lock(%tile70, 0)
+
+  %shimdma70 = AIE.shimDMA(%tile70)  {
+    AIE.dmaStart(MM2S0, ^bb1, ^bb2)
+  ^bb1:  // 2 preds: ^bb0, ^bb1
+    AIE.useLock(%lock70, Acquire, 1)
+    AIE.dmaBdPacket(0, 2)
+    AIE.dmaBd(<%buf : memref<32x32xi32>, 0, 1024>, 0)
+    AIE.useLock(%lock70, Release, 0)
+    br ^bb1
+  ^bb2:  // pred: ^bb0
+    AIE.end
+  }
+}


### PR DESCRIPTION
This patch sets the packet bit when DMABDPacketOp is found in the ShimDMAOp region.

This patch also adds a 32x32x32 GEMM unit test. Unfortunately, currently this test case doesn't work on board -- the AIE stalls waiting for the shim DMA to send out the packet.

The layout of the design:
![image](https://user-images.githubusercontent.com/17632034/152198066-56e65409-0d77-4eb3-939f-2a467d79f4a5.png)
