### PR TITLE
Use vector instead of AccType for float Mul + FMA

### DIFF
--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -117,7 +117,7 @@ def AIEVec_FMAOp :
   AIEVec_Op<"mac", [
     NoSideEffect
   ]>,
-  Arguments<(ins AnyVector:$lhs, AnyVector:$rhs, AIEVec_Acc:$acc,
+  Arguments<(ins AnyVector:$lhs, AnyVector:$rhs, AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$acc,
                DefaultValuedStrAttr<StrAttr, "">:$xstart,
                DefaultValuedStrAttr<StrAttr, "">:$xoffsets,
                DefaultValuedStrAttr<StrAttr, "">:$xoffsets_hi,
@@ -129,7 +129,7 @@ def AIEVec_FMAOp :
                DefaultValuedStrAttr<StrAttr, "">:$zstep,
                DefaultValuedStrAttr<StrAttr, "">:$zsquare,
                DefaultValuedAttr<BoolAttr, "false">:$fmsub)>,
-  Results<(outs AIEVec_Acc:$result)> {
+  Results<(outs AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$result)> {
   let summary = "AIE vector fused multiply-add";
   let description = [{
     Xilinx-specific multiply-add operation. It multiplies two 1-D vectors,
@@ -199,7 +199,7 @@ def AIEVec_MulOp:
                DefaultValuedStrAttr<StrAttr, "">:$zoffsets_hi,
                DefaultValuedStrAttr<StrAttr, "">:$zstep,
                DefaultValuedStrAttr<StrAttr, "">:$zsquare)>,
-  Results<(outs AIEVec_Acc:$result)> {
+  Results<(outs AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$result)> {
   let summary = "AIE vector multiply";
   let description = [{
     Xilinx-specific multiply operation that multiplies two 1-D vectors.

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -117,7 +117,8 @@ def AIEVec_FMAOp :
   AIEVec_Op<"mac", [
     NoSideEffect
   ]>,
-  Arguments<(ins AnyVector:$lhs, AnyVector:$rhs, AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$acc,
+  Arguments<(ins AnyVector:$lhs, AnyVector:$rhs,
+               AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$acc,
                DefaultValuedStrAttr<StrAttr, "">:$xstart,
                DefaultValuedStrAttr<StrAttr, "">:$xoffsets,
                DefaultValuedStrAttr<StrAttr, "">:$xoffsets_hi,
@@ -135,8 +136,8 @@ def AIEVec_FMAOp :
     Xilinx-specific multiply-add operation. It multiplies two 1-D vectors,
     and adds the result to an accumulator. The vector sizes are at least 
     256 bits, and the left operand vector is at least twice the size of 
-    right operand vector. The lhs and rhs are 8/16/32 bits; the result
-    and acc are 48-bit or 80-bit accumulator. 
+    right operand vector. For integers, the lhs and rhs are 8/16/32 bits;
+    the result and acc are 48-bit or 80-bit accumulator.
     `$result = `$lhs * $rhs + $acc`.
     Note: the same operator can be used as fmsub operator by setting the 
     'fmsub' bool to true.
@@ -204,8 +205,8 @@ def AIEVec_MulOp:
   let description = [{
     Xilinx-specific multiply operation that multiplies two 1-D vectors.
     The vector sizes are at least 256 bits, and the left operand vector 
-    is at least twice the size of right operand vector. The lhs and rhs 
-    are 8/16/32 bits, and result is a 48-bit or 80-bit accumulator. 
+    is at least twice the size of right operand vector. For integers, the
+    lhs and rhs are 8/16/32 bits, and result is a 48-bit or 80-bit accumulator.
     `$result = `$lhs * $rhs`.
   }];
   let builders = [

--- a/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
@@ -336,8 +336,11 @@ inline LogicalResult verifyAccType(T op, aievec::AccType resultType);
 template <>
 inline LogicalResult verifyAccType(aievec::FMAOp op,
                                    aievec::AccType resultType) {
-  bool isInt = op.lhs().getType().dyn_cast<VectorType>()
-                 .getElementType().isa<IntegerType>();
+  bool isInt = op.lhs()
+                   .getType()
+                   .dyn_cast<VectorType>()
+                   .getElementType()
+                   .isa<IntegerType>();
   aievec::AccType accType = op.acc().getType().dyn_cast<aievec::AccType>();
   if (isInt && !accType)
     return op.emitError("requires accumulator type");
@@ -400,15 +403,14 @@ template <typename T> LogicalResult verifyMulFMAOp(T op) {
   // Determine if it is an integer or float operation
   bool isInt = lhsType.getElementType().isa<IntegerType>();
 
-  VectorType resultVecType = op.result().getType()
-                               .template dyn_cast<VectorType>();
-  aievec::AccType resultAccType = op.result().getType()
-                                    .template dyn_cast<aievec::AccType>();
+  VectorType resultVecType =
+      op.result().getType().template dyn_cast<VectorType>();
+  aievec::AccType resultAccType =
+      op.result().getType().template dyn_cast<aievec::AccType>();
   if (isInt && !resultAccType)
     return op.emitError("requires accumulator type");
   else if (!isInt && !resultVecType)
     return op.emitError("requires vector type");
-
 
   // Additional checks for FMA op
   if (!isInt && failed(verifyAccType(op, resultAccType)))
@@ -417,15 +419,15 @@ template <typename T> LogicalResult verifyMulFMAOp(T op) {
   // Get the width of the underlying scalars of all the vectors
   Type ltype = lhsType.getElementType();
   Type rtype = rhsType.getElementType();
-  Type atype = isInt ? resultAccType.getValueType() :
-                       resultVecType.getElementType();
+  Type atype =
+      isInt ? resultAccType.getValueType() : resultVecType.getElementType();
   unsigned ltypeWidth = ltype.getIntOrFloatBitWidth();
   unsigned rtypeWidth = rtype.getIntOrFloatBitWidth();
   unsigned atypeWidth = atype.getIntOrFloatBitWidth();
 
   // Checks on the number of lanes
-  unsigned accLanes = isInt ? resultAccType.getLanes() :
-                              getVectorLaneSize(resultVecType);
+  unsigned accLanes =
+      isInt ? resultAccType.getLanes() : getVectorLaneSize(resultVecType);
   unsigned rhsLanes = getVectorLaneSize(rhsType);
   unsigned lhsLanes = getVectorLaneSize(lhsType);
 
@@ -528,8 +530,8 @@ ParseResult parseMulFMAOp(OpAsmParser &parser, OperationState &result,
     }
   }
 
-  return isInt ? parser.addTypeToList(accTypeAcc, result.types):
-                 parser.addTypeToList(accTypeVec, result.types);
+  return isInt ? parser.addTypeToList(accTypeAcc, result.types)
+               : parser.addTypeToList(accTypeVec, result.types);
 }
 
 ParseResult MulOp::parse(OpAsmParser &parser, OperationState &result) {

--- a/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
+++ b/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
@@ -646,8 +646,11 @@ static Operation *generateFMAOp(vector::FMAOp fmaOp, AIEOpAttributes &opAttr,
 
   // If the accumulator is not of type aievec::AccType for integer FMA
   // we need to generate a ups instruction.
-  bool isInt = fmaOp.getLhs().getType().cast<VectorType>()
-                    .getElementType().isa<IntegerType>();
+  bool isInt = fmaOp.getLhs()
+                   .getType()
+                   .cast<VectorType>()
+                   .getElementType()
+                   .isa<IntegerType>();
   Value acc = fmaOp.getAcc();
   // If i8xi8_pairedOp is true, then we are trying to generated the paired FMA
   // op for i8xi8 scheme. Find the paired accumulator.

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -880,10 +880,10 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
 
   std::string opname;
   // Create opname based on the result type
-  bool isInt = lhs.getType().cast<VectorType>()
-                  .getElementType().isa<IntegerType>();
-  aievec::AccType accType = mulOp.result().getType()
-                                 .dyn_cast<aievec::AccType>();
+  bool isInt =
+      lhs.getType().cast<VectorType>().getElementType().isa<IntegerType>();
+  aievec::AccType accType =
+      mulOp.result().getType().dyn_cast<aievec::AccType>();
   VectorType vecType = mulOp.result().getType().dyn_cast<VectorType>();
   Type eltType = isInt ? accType.getValueType() : vecType.getElementType();
   if (!simpleScheme) {
@@ -1039,10 +1039,10 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
 
   std::string opname;
   // Create opname based on the result type
-  bool isInt = lhs.getType().cast<VectorType>()
-                  .getElementType().isa<IntegerType>();
-  aievec::AccType accType = fmaOp.result().getType()
-                                 .dyn_cast<aievec::AccType>();
+  bool isInt =
+      lhs.getType().cast<VectorType>().getElementType().isa<IntegerType>();
+  aievec::AccType accType =
+      fmaOp.result().getType().dyn_cast<aievec::AccType>();
   VectorType vecType = fmaOp.result().getType().dyn_cast<VectorType>();
   Type eltType = isInt ? accType.getValueType() : vecType.getElementType();
   if (!simpleScheme) {

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -880,9 +880,12 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
 
   std::string opname;
   // Create opname based on the result type
-  aievec::AccType accType = mulOp.result().getType().cast<aievec::AccType>();
-  unsigned lanes = accType.getLanes();
-  Type eltType = accType.getValueType();
+  bool isInt = lhs.getType().cast<VectorType>()
+                  .getElementType().isa<IntegerType>();
+  aievec::AccType accType = mulOp.result().getType()
+                                 .dyn_cast<aievec::AccType>();
+  VectorType vecType = mulOp.result().getType().dyn_cast<VectorType>();
+  Type eltType = isInt ? accType.getValueType() : vecType.getElementType();
   if (!simpleScheme) {
     if (auto iType = eltType.dyn_cast<IntegerType>()) {
       if (iType.getWidth() == 80)
@@ -892,7 +895,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
   }
   opname += "mul";
   if (!simpleScheme && !eltType.isa<FloatType>())
-    opname += std::to_string(lanes);
+    opname += std::to_string(accType.getLanes());
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -1036,9 +1039,12 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
 
   std::string opname;
   // Create opname based on the result type
-  aievec::AccType accType = fmaOp.result().getType().cast<aievec::AccType>();
-  unsigned lanes = accType.getLanes();
-  Type eltType = accType.getValueType();
+  bool isInt = lhs.getType().cast<VectorType>()
+                  .getElementType().isa<IntegerType>();
+  aievec::AccType accType = fmaOp.result().getType()
+                                 .dyn_cast<aievec::AccType>();
+  VectorType vecType = fmaOp.result().getType().dyn_cast<VectorType>();
+  Type eltType = isInt ? accType.getValueType() : vecType.getElementType();
   if (!simpleScheme) {
     if (auto iType = eltType.dyn_cast<IntegerType>()) {
       if (iType.getWidth() == 80)
@@ -1048,7 +1054,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
   }
   opname += fmaOp.fmsub() ? "msc" : "mac";
   if (!simpleScheme && !eltType.isa<FloatType>())
-    opname += std::to_string(lanes);
+    opname += std::to_string(accType.getLanes());
 
   raw_indented_ostream &os = emitter.ostream();
 

--- a/test/Targets/AIEVecToCpp/translate_conv2d_uij_f32.mlir
+++ b/test/Targets/AIEVecToCpp/translate_conv2d_uij_f32.mlir
@@ -21,25 +21,23 @@ func @conv2d_0(%arg0: memref<?x?xf32>, %arg1: memref<?xf32>, %arg2: memref<?x?xf
     scf.for %arg4 = %c0_3 to %1 step %c8_4 {
       %6 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<8xf32>
       %7 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
-      %8 = aievec.ups %6 {shift = 10 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-      %9 = aievec.mac %7, %2, %8 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+      %8 = aievec.mac %7, %2, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
       %c1_5 = arith.constant 1 : index
-      %10 = arith.addi %arg4, %c1_5 : index
-      %11 = aievec.upd %arg0[%arg3, %10], %7 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
-      %12 = aievec.mac %11, %2, %9 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %13 = aievec.mac %11, %2, %12 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %14 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
-      %15 = aievec.mac %14, %2, %13 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %16 = aievec.upd %arg0[%4, %10], %14 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
-      %17 = aievec.mac %16, %2, %15 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %18 = aievec.mac %16, %2, %17 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %19 = aievec.upd %arg0[%5, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
-      %20 = aievec.mac %19, %2, %18 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %21 = aievec.upd %arg0[%5, %10], %19 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
-      %22 = aievec.mac %21, %2, %20 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %23 = aievec.mac %21, %3, %22 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %24 = aievec.srs %23 {shift = 10 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-      vector.transfer_write %24, %arg2[%arg3, %arg4] : vector<8xf32>, memref<?x?xf32>
+      %9 = arith.addi %arg4, %c1_5 : index
+      %10 = aievec.upd %arg0[%arg3, %9], %7 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
+      %11 = aievec.mac %10, %2, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %12 = aievec.mac %10, %2, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %13 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
+      %14 = aievec.mac %13, %2, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %15 = aievec.upd %arg0[%4, %9], %13 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
+      %16 = aievec.mac %15, %2, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %17 = aievec.mac %15, %2, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %18 = aievec.upd %arg0[%5, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
+      %19 = aievec.mac %18, %2, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %20 = aievec.upd %arg0[%5, %9], %18 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
+      %21 = aievec.mac %20, %2, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %22 = aievec.mac %20, %3, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      vector.transfer_write %22, %arg2[%arg3, %arg4] : vector<8xf32>, memref<?x?xf32>
     }
   }
   return
@@ -112,25 +110,23 @@ func @conv2d_1(%arg0: memref<?x256xf32>, %arg1: memref<?xf32>, %arg2: memref<?x2
     scf.for %arg4 = %c0_2 to %c256 step %c8_3 {
       %5 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<8xf32>
       %6 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
-      %7 = aievec.ups %5 {shift = 10 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-      %8 = aievec.mac %6, %1, %7 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+      %7 = aievec.mac %6, %1, %5 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
       %c1_4 = arith.constant 1 : index
-      %9 = arith.addi %arg4, %c1_4 : index
-      %10 = aievec.upd %arg0[%arg3, %9], %6 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
-      %11 = aievec.mac %10, %1, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %12 = aievec.mac %10, %1, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %13 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
-      %14 = aievec.mac %13, %1, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %15 = aievec.upd %arg0[%3, %9], %13 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
-      %16 = aievec.mac %15, %1, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %17 = aievec.mac %15, %1, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %18 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
-      %19 = aievec.mac %18, %1, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %20 = aievec.upd %arg0[%4, %9], %18 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
-      %21 = aievec.mac %20, %1, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %22 = aievec.mac %20, %2, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-      %23 = aievec.srs %22 {shift = 10 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-      vector.transfer_write %23, %arg2[%arg3, %arg4] : vector<8xf32>, memref<?x256xf32>
+      %8 = arith.addi %arg4, %c1_4 : index
+      %9 = aievec.upd %arg0[%arg3, %8], %6 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
+      %10 = aievec.mac %9, %1, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %11 = aievec.mac %9, %1, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %12 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
+      %13 = aievec.mac %12, %1, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %14 = aievec.upd %arg0[%3, %8], %12 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
+      %15 = aievec.mac %14, %1, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %16 = aievec.mac %14, %1, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %17 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
+      %18 = aievec.mac %17, %1, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %19 = aievec.upd %arg0[%4, %8], %17 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
+      %20 = aievec.mac %19, %1, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      %21 = aievec.mac %19, %2, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+      vector.transfer_write %21, %arg2[%arg3, %arg4] : vector<8xf32>, memref<?x256xf32>
     }
   }
   return

--- a/test/aievec/conv2d_f32.mlir
+++ b/test/aievec/conv2d_f32.mlir
@@ -40,22 +40,20 @@ func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xf32>, vector<8xf32>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %6 = aievec.mac %5, %0, %4 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
-//CHECK-NEXT: %8 = arith.addi %arg4, %c1_5 : index
-//CHECK-NEXT: %9 = aievec.upd %arg0[%arg3, %8], %5 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %12 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %14 = aievec.upd %arg0[%2, %8], %12 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %17 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %19 = aievec.upd %arg0[%3, %8], %17 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT: vector.transfer_write %22, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>
+//CHECK-NEXT: %7 = arith.addi %arg4, %c1_5 : index
+//CHECK-NEXT: %8 = aievec.upd %arg0[%arg3, %7], %5 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %9 = aievec.mac %8, %0, %6 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %10 = aievec.mac %8, %0, %9 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %11 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %12 = aievec.mac %11, %0, %10 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %13 = aievec.upd %arg0[%2, %7], %11 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %14 = aievec.mac %13, %0, %12 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %15 = aievec.mac %13, %0, %14 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %16 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %17 = aievec.mac %16, %0, %15 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %18 = aievec.upd %arg0[%3, %7], %16 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %19 = aievec.mac %18, %0, %17 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %20 = aievec.mac %18, %1, %19 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: vector.transfer_write %20, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>

--- a/test/aievec/conv2d_msc_uij_f32_noinit.mlir
+++ b/test/aievec/conv2d_msc_uij_f32_noinit.mlir
@@ -84,22 +84,21 @@ func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046
 //CHECK-NEXT: %c8_4 = arith.constant 8 : index
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %6 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %7 = aievec.upd %arg0[%arg3, %6], %4 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %6], %10 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %15 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %17 = aievec.upd %arg0[%3, %6], %15 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %20 = aievec.srs %19 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT: vector.transfer_write %20, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>
+//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: vector.transfer_write %19, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>
 

--- a/test/aievec/conv2d_uij_f32.mlir
+++ b/test/aievec/conv2d_uij_f32.mlir
@@ -89,22 +89,20 @@ func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xf32>, vector<8xf32>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %6 = aievec.mac %5, %0, %4 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
-//CHECK-NEXT: %8 = arith.addi %arg4, %c1_5 : index
-//CHECK-NEXT: %9 = aievec.upd %arg0[%arg3, %8], %5 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %12 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %14 = aievec.upd %arg0[%2, %8], %12 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %17 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %19 = aievec.upd %arg0[%3, %8], %17 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT: vector.transfer_write %22, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>
+//CHECK-NEXT: %7 = arith.addi %arg4, %c1_5 : index
+//CHECK-NEXT: %8 = aievec.upd %arg0[%arg3, %7], %5 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %9 = aievec.mac %8, %0, %6 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %10 = aievec.mac %8, %0, %9 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %11 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %12 = aievec.mac %11, %0, %10 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %13 = aievec.upd %arg0[%2, %7], %11 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %14 = aievec.mac %13, %0, %12 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %15 = aievec.mac %13, %0, %14 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %16 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %17 = aievec.mac %16, %0, %15 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %18 = aievec.upd %arg0[%3, %7], %16 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
+//CHECK-NEXT: %19 = aievec.mac %18, %0, %17 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %20 = aievec.mac %18, %1, %19 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: vector.transfer_write %20, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>

--- a/test/aievec/conv2d_uij_f32_noinit.mlir
+++ b/test/aievec/conv2d_uij_f32_noinit.mlir
@@ -84,21 +84,20 @@ func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046
 //CHECK-NEXT: %c8_4 = arith.constant 8 : index
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %6 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %7 = aievec.upd %arg0[%arg3, %6], %4 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %6], %10 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %15 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %17 = aievec.upd %arg0[%3, %6], %15 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xf32>, vector<16xf32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %20 = aievec.srs %19 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT: vector.transfer_write %20, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>
+//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: vector.transfer_write %19, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<2046x2046xf32>

--- a/test/aievec/conv2d_uij_f32_unbounded.mlir
+++ b/test/aievec/conv2d_uij_f32_unbounded.mlir
@@ -95,25 +95,23 @@ func @conv2d_0 (%A: memref<?x?xf32>, %B: memref<?xf32>, %C: memref<?x?xf32>) {
 //CHECK-NEXT: scf.for %arg4 = %c0_3 to %1 step %c8_4 {
 //CHECK-NEXT: %6 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<8xf32>
 //CHECK-NEXT: %7 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
-//CHECK-NEXT: %8 = aievec.ups %6 {shift = 0 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %9 = aievec.mac %7, %2, %8 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT: %8 = aievec.mac %7, %2, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
-//CHECK-NEXT: %10 = arith.addi %arg4, %c1_5 : index
-//CHECK-NEXT: %11 = aievec.upd %arg0[%arg3, %10], %7 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
-//CHECK-NEXT: %12 = aievec.mac %11, %2, %9 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %13 = aievec.mac %11, %2, %12 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %14 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
-//CHECK-NEXT: %15 = aievec.mac %14, %2, %13 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %16 = aievec.upd %arg0[%4, %10], %14 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
-//CHECK-NEXT: %17 = aievec.mac %16, %2, %15 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %18 = aievec.mac %16, %2, %17 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %19 = aievec.upd %arg0[%5, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
-//CHECK-NEXT: %20 = aievec.mac %19, %2, %18 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %21 = aievec.upd %arg0[%5, %10], %19 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
-//CHECK-NEXT: %22 = aievec.mac %21, %2, %20 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %23 = aievec.mac %21, %3, %22 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT: %24 = aievec.srs %23 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT: vector.transfer_write %24, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<?x?xf32>
+//CHECK-NEXT: %9 = arith.addi %arg4, %c1_5 : index
+//CHECK-NEXT: %10 = aievec.upd %arg0[%arg3, %9], %7 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
+//CHECK-NEXT: %11 = aievec.mac %10, %2, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %12 = aievec.mac %10, %2, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %13 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
+//CHECK-NEXT: %14 = aievec.mac %13, %2, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %15 = aievec.upd %arg0[%4, %9], %13 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
+//CHECK-NEXT: %16 = aievec.mac %15, %2, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %17 = aievec.mac %15, %2, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %18 = aievec.upd %arg0[%5, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xf32>, vector<16xf32>
+//CHECK-NEXT: %19 = aievec.mac %18, %2, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %20 = aievec.upd %arg0[%5, %9], %18 {index = 1 : i8, offset = 224 : si32} : memref<?x?xf32>, vector<16xf32>
+//CHECK-NEXT: %21 = aievec.mac %20, %2, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: %22 = aievec.mac %20, %3, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT: vector.transfer_write %22, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<?x?xf32>
 
 
 //CHECK-LABEL: func @conv2d_1(%arg0: memref<?x256xf32>, %arg1: memref<?xf32>, %arg2: memref<?x256xf32>) {
@@ -210,22 +208,20 @@ func @conv2d_1 (%A: memref<?x256xf32>, %B: memref<?xf32>, %C: memref<?x256xf32>)
 //CHECK-NEXT scf.for %arg4 = %c0_2 to %c256 step %c8_3 {
 //CHECK-NEXT %5 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<8xf32>
 //CHECK-NEXT %6 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
-//CHECK-NEXT %7 = aievec.ups %5 {shift = 0 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %8 = aievec.mac %6, %1, %7 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT %7 = aievec.mac %6, %1, %5 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT %c1_4 = arith.constant 1 : index
-//CHECK-NEXT %9 = arith.addi %arg4, %c1_4 : index
-//CHECK-NEXT %10 = aievec.upd %arg0[%arg3, %9], %6 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
-//CHECK-NEXT %11 = aievec.mac %10, %1, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %12 = aievec.mac %10, %1, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %13 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
-//CHECK-NEXT %14 = aievec.mac %13, %1, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %15 = aievec.upd %arg0[%3, %9], %13 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
-//CHECK-NEXT %16 = aievec.mac %15, %1, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %17 = aievec.mac %15, %1, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %18 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
-//CHECK-NEXT %19 = aievec.mac %18, %1, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %20 = aievec.upd %arg0[%4, %9], %18 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
-//CHECK-NEXT %21 = aievec.mac %20, %1, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %22 = aievec.mac %20, %2, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT %23 = aievec.srs %22 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT vector.transfer_write %23, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<?x256xf32>
+//CHECK-NEXT %8 = arith.addi %arg4, %c1_4 : index
+//CHECK-NEXT %9 = aievec.upd %arg0[%arg3, %8], %6 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
+//CHECK-NEXT %10 = aievec.mac %9, %1, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT %11 = aievec.mac %9, %1, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT %12 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
+//CHECK-NEXT %13 = aievec.mac %12, %1, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT %14 = aievec.upd %arg0[%3, %8], %12 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
+//CHECK-NEXT %15 = aievec.mac %14, %1, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT %16 = aievec.mac %14, %1, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT %17 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xf32>, vector<16xf32>
+//CHECK-NEXT %18 = aievec.mac %17, %1, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT %19 = aievec.upd %arg0[%4, %8], %17 {index = 1 : i8, offset = 224 : si32} : memref<?x256xf32>, vector<16xf32>
+//CHECK-NEXT %20 = aievec.mac %19, %1, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT %21 = aievec.mac %19, %2, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT vector.transfer_write %21, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<?x256xf32>

--- a/test/aievec/linalg_conv2d_f32.mlir
+++ b/test/aievec/linalg_conv2d_f32.mlir
@@ -38,55 +38,53 @@ func @conv_2d(%input: memref<10x3x256x256xf32>, %filter: memref<10x3x3x3xf32>, %
 //CHECK-NEXT:       scf.for %arg6 = %c0_9 to %c254_10 step %c8 {
 //CHECK-NEXT:         %6 = aievec.upd %arg0[%arg3, %c0, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
 //CHECK-NEXT:         %7 = aievec.upd %arg2[%arg3, %arg4, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x10x254x254xf32>, vector<8xf32>
-//CHECK-NEXT:         %8 = aievec.ups %7 {shift = 0 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %9 = aievec.mac %6, %0, %8 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT:         %8 = aievec.mac %6, %0, %7 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT:         %c1_11 = arith.constant 1 : index
-//CHECK-NEXT:         %10 = arith.addi %arg6, %c1_11 : index
-//CHECK-NEXT:         %11 = aievec.upd %arg0[%arg3, %c0, %arg5, %10], %6 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %12 = aievec.mac %11, %0, %9 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %13 = aievec.mac %11, %0, %12 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %14 = aievec.upd %arg0[%arg3, %c0, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %16 = aievec.upd %arg0[%arg3, %c0, %4, %10], %14 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %17 = aievec.mac %16, %0, %15 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %18 = aievec.mac %16, %0, %17 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %19 = aievec.upd %arg0[%arg3, %c0, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %21 = aievec.upd %arg0[%arg3, %c0, %5, %10], %19 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %22 = aievec.mac %21, %0, %20 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %23 = aievec.mac %21, %1, %22 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %24 = aievec.upd %arg0[%arg3, %c1, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %25 = aievec.mac %24, %1, %23 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %26 = aievec.upd %arg0[%arg3, %c1, %arg5, %10], %24 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %27 = aievec.mac %26, %1, %25 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %28 = aievec.mac %26, %1, %27 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %29 = aievec.upd %arg0[%arg3, %c1, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %30 = aievec.mac %29, %1, %28 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %31 = aievec.upd %arg0[%arg3, %c1, %4, %10], %29 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %32 = aievec.mac %31, %1, %30 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %33 = aievec.mac %31, %1, %32 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %34 = aievec.upd %arg0[%arg3, %c1, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %35 = aievec.mac %34, %1, %33 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %36 = aievec.upd %arg0[%arg3, %c1, %5, %10], %34 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %37 = aievec.mac %36, %2, %35 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %38 = aievec.mac %36, %2, %37 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %39 = aievec.upd %arg0[%arg3, %c2, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %40 = aievec.mac %39, %2, %38 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %41 = aievec.upd %arg0[%arg3, %c2, %arg5, %10], %39 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %42 = aievec.mac %41, %2, %40 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %43 = aievec.mac %41, %2, %42 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %44 = aievec.upd %arg0[%arg3, %c2, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %45 = aievec.mac %44, %2, %43 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %46 = aievec.upd %arg0[%arg3, %c2, %4, %10], %44 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %47 = aievec.mac %46, %2, %45 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %48 = aievec.mac %46, %2, %47 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %49 = aievec.upd %arg0[%arg3, %c2, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %50 = aievec.mac %49, %3, %48 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %51 = aievec.upd %arg0[%arg3, %c2, %5, %10], %49 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %52 = aievec.mac %51, %3, %50 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %53 = aievec.mac %51, %3, %52 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %54 = aievec.srs %53 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT:         vector.transfer_write %54, %arg2[%arg3, %arg4, %arg5, %arg6] {in_bounds = [true]} : vector<8xf32>, memref<10x10x254x254xf32>
+//CHECK-NEXT:         %9 = arith.addi %arg6, %c1_11 : index
+//CHECK-NEXT:         %10 = aievec.upd %arg0[%arg3, %c0, %arg5, %9], %6 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %11 = aievec.mac %10, %0, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %12 = aievec.mac %10, %0, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %13 = aievec.upd %arg0[%arg3, %c0, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %14 = aievec.mac %13, %0, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %15 = aievec.upd %arg0[%arg3, %c0, %4, %9], %13 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %16 = aievec.mac %15, %0, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %17 = aievec.mac %15, %0, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %18 = aievec.upd %arg0[%arg3, %c0, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %19 = aievec.mac %18, %0, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %20 = aievec.upd %arg0[%arg3, %c0, %5, %9], %18 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %21 = aievec.mac %20, %0, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %22 = aievec.mac %20, %1, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %23 = aievec.upd %arg0[%arg3, %c1, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %24 = aievec.mac %23, %1, %22 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %25 = aievec.upd %arg0[%arg3, %c1, %arg5, %9], %23 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %26 = aievec.mac %25, %1, %24 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %27 = aievec.mac %25, %1, %26 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %28 = aievec.upd %arg0[%arg3, %c1, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %29 = aievec.mac %28, %1, %27 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %30 = aievec.upd %arg0[%arg3, %c1, %4, %9], %28 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %31 = aievec.mac %30, %1, %29 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %32 = aievec.mac %30, %1, %31 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %33 = aievec.upd %arg0[%arg3, %c1, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %34 = aievec.mac %33, %1, %32 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %35 = aievec.upd %arg0[%arg3, %c1, %5, %9], %33 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %36 = aievec.mac %35, %2, %34 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %37 = aievec.mac %35, %2, %36 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %38 = aievec.upd %arg0[%arg3, %c2, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %39 = aievec.mac %38, %2, %37 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %40 = aievec.upd %arg0[%arg3, %c2, %arg5, %9], %38 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %41 = aievec.mac %40, %2, %39 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %42 = aievec.mac %40, %2, %41 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %43 = aievec.upd %arg0[%arg3, %c2, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %44 = aievec.mac %43, %2, %42 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %45 = aievec.upd %arg0[%arg3, %c2, %4, %9], %43 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %46 = aievec.mac %45, %2, %44 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %47 = aievec.mac %45, %2, %46 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %48 = aievec.upd %arg0[%arg3, %c2, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %49 = aievec.mac %48, %3, %47 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %50 = aievec.upd %arg0[%arg3, %c2, %5, %9], %48 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %51 = aievec.mac %50, %3, %49 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %52 = aievec.mac %50, %3, %51 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         vector.transfer_write %52, %arg2[%arg3, %arg4, %arg5, %arg6] {in_bounds = [true]} : vector<8xf32>, memref<10x10x254x254xf32>
 //CHECK-NEXT:       }
 //CHECK-NEXT:     }
 //CHECK-NEXT:   }

--- a/test/aievec/pointwise_mult_f32.mlir
+++ b/test/aievec/pointwise_mult_f32.mlir
@@ -6,7 +6,7 @@ func @pointwise_mult (%A: memref<2048xf32>, %B: memref<2048xf32>, %C: memref<204
        %a = affine.load %A[%arg0] : memref<2048xf32>
        %b = affine.load %B[%arg0] : memref<2048xf32>
        //CHECK: %2 = aievec.concat %0, %0 : vector<8xf32>, vector<16xf32>
-       //CHECK: %3 = aievec.mul %2, %1 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x76543210", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+       //CHECK: %3 = aievec.mul %2, %1 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x76543210", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
        %c = arith.mulf %a, %b : f32
        affine.store %c, %C[%arg0] : memref<2048xf32>
     }

--- a/test/aievec/test_linalg_conv2d.mlir
+++ b/test/aievec/test_linalg_conv2d.mlir
@@ -207,55 +207,53 @@ func @conv_2d(%arg0: memref<10x3x256x256xf32>, %arg1: memref<10x3x3x3xf32>, %arg
 //CHECK-NEXT:       scf.for %arg6 = %c0_9 to %c254_10 step %c8 {
 //CHECK-NEXT:         %6 = aievec.upd %arg0[%arg3, %c0, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
 //CHECK-NEXT:         %7 = aievec.upd %arg2[%arg3, %arg4, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x10x254x254xf32>, vector<8xf32>
-//CHECK-NEXT:         %8 = aievec.ups %7 {shift = 0 : i8} : vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %9 = aievec.mac %6, %0, %8 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
+//CHECK-NEXT:         %8 = aievec.mac %6, %0, %7 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
 //CHECK-NEXT:         %c1_11 = arith.constant 1 : index
-//CHECK-NEXT:         %10 = arith.addi %arg6, %c1_11 : index
-//CHECK-NEXT:         %11 = aievec.upd %arg0[%arg3, %c0, %arg5, %10], %6 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %12 = aievec.mac %11, %0, %9 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %13 = aievec.mac %11, %0, %12 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %14 = aievec.upd %arg0[%arg3, %c0, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %16 = aievec.upd %arg0[%arg3, %c0, %4, %10], %14 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %17 = aievec.mac %16, %0, %15 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %18 = aievec.mac %16, %0, %17 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %19 = aievec.upd %arg0[%arg3, %c0, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %21 = aievec.upd %arg0[%arg3, %c0, %5, %10], %19 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %22 = aievec.mac %21, %0, %20 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %23 = aievec.mac %21, %1, %22 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %24 = aievec.upd %arg0[%arg3, %c1, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %25 = aievec.mac %24, %1, %23 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %26 = aievec.upd %arg0[%arg3, %c1, %arg5, %10], %24 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %27 = aievec.mac %26, %1, %25 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %28 = aievec.mac %26, %1, %27 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %29 = aievec.upd %arg0[%arg3, %c1, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %30 = aievec.mac %29, %1, %28 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %31 = aievec.upd %arg0[%arg3, %c1, %4, %10], %29 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %32 = aievec.mac %31, %1, %30 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %33 = aievec.mac %31, %1, %32 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %34 = aievec.upd %arg0[%arg3, %c1, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %35 = aievec.mac %34, %1, %33 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %36 = aievec.upd %arg0[%arg3, %c1, %5, %10], %34 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %37 = aievec.mac %36, %2, %35 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %38 = aievec.mac %36, %2, %37 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %39 = aievec.upd %arg0[%arg3, %c2, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %40 = aievec.mac %39, %2, %38 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %41 = aievec.upd %arg0[%arg3, %c2, %arg5, %10], %39 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %42 = aievec.mac %41, %2, %40 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %43 = aievec.mac %41, %2, %42 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %44 = aievec.upd %arg0[%arg3, %c2, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %45 = aievec.mac %44, %2, %43 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %46 = aievec.upd %arg0[%arg3, %c2, %4, %10], %44 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %47 = aievec.mac %46, %2, %45 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %48 = aievec.mac %46, %2, %47 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %49 = aievec.upd %arg0[%arg3, %c2, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %50 = aievec.mac %49, %3, %48 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %51 = aievec.upd %arg0[%arg3, %c2, %5, %10], %49 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
-//CHECK-NEXT:         %52 = aievec.mac %51, %3, %50 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %53 = aievec.mac %51, %3, %52 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, !aievec.acc<8xf32>
-//CHECK-NEXT:         %54 = aievec.srs %53 {shift = 0 : i8} : !aievec.acc<8xf32>, vector<8xf32>
-//CHECK-NEXT:         vector.transfer_write %54, %arg2[%arg3, %arg4, %arg5, %arg6] {in_bounds = [true]} : vector<8xf32>, memref<10x10x254x254xf32>
+//CHECK-NEXT:         %9 = arith.addi %arg6, %c1_11 : index
+//CHECK-NEXT:         %10 = aievec.upd %arg0[%arg3, %c0, %arg5, %9], %6 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %11 = aievec.mac %10, %0, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %12 = aievec.mac %10, %0, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %13 = aievec.upd %arg0[%arg3, %c0, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %14 = aievec.mac %13, %0, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %15 = aievec.upd %arg0[%arg3, %c0, %4, %9], %13 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %16 = aievec.mac %15, %0, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %17 = aievec.mac %15, %0, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %18 = aievec.upd %arg0[%arg3, %c0, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %19 = aievec.mac %18, %0, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %20 = aievec.upd %arg0[%arg3, %c0, %5, %9], %18 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %21 = aievec.mac %20, %0, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %22 = aievec.mac %20, %1, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %23 = aievec.upd %arg0[%arg3, %c1, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %24 = aievec.mac %23, %1, %22 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %25 = aievec.upd %arg0[%arg3, %c1, %arg5, %9], %23 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %26 = aievec.mac %25, %1, %24 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %27 = aievec.mac %25, %1, %26 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %28 = aievec.upd %arg0[%arg3, %c1, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %29 = aievec.mac %28, %1, %27 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %30 = aievec.upd %arg0[%arg3, %c1, %4, %9], %28 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %31 = aievec.mac %30, %1, %29 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %32 = aievec.mac %30, %1, %31 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %33 = aievec.upd %arg0[%arg3, %c1, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %34 = aievec.mac %33, %1, %32 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %35 = aievec.upd %arg0[%arg3, %c1, %5, %9], %33 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %36 = aievec.mac %35, %2, %34 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %37 = aievec.mac %35, %2, %36 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %38 = aievec.upd %arg0[%arg3, %c2, %arg5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %39 = aievec.mac %38, %2, %37 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %40 = aievec.upd %arg0[%arg3, %c2, %arg5, %9], %38 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %41 = aievec.mac %40, %2, %39 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "3"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %42 = aievec.mac %40, %2, %41 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "4"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %43 = aievec.upd %arg0[%arg3, %c2, %4, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %44 = aievec.mac %43, %2, %42 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "5"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %45 = aievec.upd %arg0[%arg3, %c2, %4, %9], %43 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %46 = aievec.mac %45, %2, %44 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "6"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %47 = aievec.mac %45, %2, %46 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "7"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %48 = aievec.upd %arg0[%arg3, %c2, %5, %arg6] {index = 0 : i8, offset = 0 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %49 = aievec.mac %48, %3, %47 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %50 = aievec.upd %arg0[%arg3, %c2, %5, %9], %48 {index = 1 : i8, offset = 224 : si32} : memref<10x3x256x256xf32>, vector<16xf32>
+//CHECK-NEXT:         %51 = aievec.mac %50, %3, %49 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         %52 = aievec.mac %50, %3, %51 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xf32>, vector<8xf32>, vector<8xf32>
+//CHECK-NEXT:         vector.transfer_write %52, %arg2[%arg3, %arg4, %arg5, %arg6] {in_bounds = [true]} : vector<8xf32>, memref<10x10x254x254xf32>
 //CHECK-NEXT:       }
 //CHECK-NEXT:     }
 //CHECK-NEXT:   }


### PR DESCRIPTION
The AIEVec Mul and FMA ops use the AIEVec AccType to model the
accumulators of the integer path. These accumulators are only present
in the integer path. In order to move data between vector registers
and accumulators AIEVec UPS and SRS ops are inserted.

Prior to this commit both integer and floating point AIEVec Mul and FMAs
use the AIEVec AccType. However, as a result of the floating point
AIEVec Mul and FMA ops outputting AIEVec AccTypes, AIEVec UPS
and SRS ops are unnecessarily inserted (and later ignored).

This commit has floating point AIEVec Muls and FMAs output normal
vectors instead of AIEVec AccTypes, and in doing so clean up the
floating point path so that the unnecessary AIEVec UPS and SRS ops
are not inserted.