### PR TITLE
Remove aievec.acc and replace it with vector

### DIFF
--- a/include/aie/Dialect/AIEVec/AIEVecUtils.h
+++ b/include/aie/Dialect/AIEVec/AIEVecUtils.h
@@ -61,40 +61,29 @@ inline int32_t getVectorSizeInBits(VectorType type) {
   return veclen;
 }
 
-// Return true if the incoming type is accumulator type
-inline bool isAccType(Type type) { return type.isa<AccType>(); }
-
 // Return true if this is an operation defined in AIE dialect
 inline bool isAIEOp(Operation *op) {
   return llvm::isa<AIEVecDialect>(op->getDialect());
 }
 
-// Create an AIE accumulator type. If the incoming type is vector, then the
-// #lanes are copied from it. Otherwise, a scalar accumulator type is created.
-inline AccType getAccType(Type type) {
-  Type stype = type;
-  unsigned lanes = 1;
-  // If the type was vector type, get the number of lanes and the underflying
-  // element type
-  if (VectorType vtype = type.dyn_cast<VectorType>()) {
-    stype = vtype.getElementType();
-    lanes = getVectorLaneSize(vtype);
-  }
+// Determine the output type for a vector operation based on whether
+// it operates on integer or floating point data.
+inline VectorType getVectorOpDestType(VectorType type) {
+    Type stype = type.getElementType();
 
-  // Now create the accumulator type. We currently only support i48 and i80
-  // type accumulator
-  AccType acc;
-  if (IntegerType itype = stype.dyn_cast<IntegerType>()) {
-    assert(itype.getWidth() <= 64);
-    unsigned width = itype.getWidth() <= 16 ? 48 : 80;
-    Type ctype = mlir::IntegerType::get(itype.getContext(), width);
-    acc = AccType::get(lanes, ctype);
-  } else if (stype.isa<FloatType>())
-    acc = AccType::get(lanes, stype);
-  else
-    llvm_unreachable("Unsupported accumulator type");
+    if (IntegerType itype = stype.dyn_cast<IntegerType>()) {
+      // Integer vector types are sized for the appropriate accumulators
+      assert(itype.getWidth() <= 64);
+      unsigned width = itype.getWidth() <= 16 ? 48 : 80;
 
-  return acc;
+      Type ctype = mlir::IntegerType::get(itype.getContext(), width);
+      return VectorType::get(type.getShape(), ctype);
+    } else if (stype.isa<FloatType>())
+      // Floating point vector types are returned as is since the floating point
+      // operations write back to registers and not accumulators
+      return type;
+    else
+      llvm_unreachable("Unsupported destination type");
 }
 
 } // end namespace aievec

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -117,8 +117,7 @@ def AIEVec_FMAOp :
   AIEVec_Op<"mac", [
     NoSideEffect
   ]>,
-  Arguments<(ins AnyVector:$lhs, AnyVector:$rhs,
-               AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$acc,
+  Arguments<(ins AnyVector:$lhs, AnyVector:$rhs, AnyVector:$acc,
                DefaultValuedStrAttr<StrAttr, "">:$xstart,
                DefaultValuedStrAttr<StrAttr, "">:$xoffsets,
                DefaultValuedStrAttr<StrAttr, "">:$xoffsets_hi,
@@ -130,7 +129,7 @@ def AIEVec_FMAOp :
                DefaultValuedStrAttr<StrAttr, "">:$zstep,
                DefaultValuedStrAttr<StrAttr, "">:$zsquare,
                DefaultValuedAttr<BoolAttr, "false">:$fmsub)>,
-  Results<(outs AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$result)> {
+  Results<(outs AnyVector:$result)> {
   let summary = "AIE vector fused multiply-add";
   let description = [{
     Xilinx-specific multiply-add operation. It multiplies two 1-D vectors,
@@ -200,7 +199,7 @@ def AIEVec_MulOp:
                DefaultValuedStrAttr<StrAttr, "">:$zoffsets_hi,
                DefaultValuedStrAttr<StrAttr, "">:$zstep,
                DefaultValuedStrAttr<StrAttr, "">:$zsquare)>,
-  Results<(outs AnyTypeOf<[AIEVec_Acc, VectorOf<[F32]>]>:$result)> {
+  Results<(outs AnyVector:$result)> {
   let summary = "AIE vector multiply";
   let description = [{
     Xilinx-specific multiply operation that multiplies two 1-D vectors.
@@ -255,7 +254,7 @@ def AIEVec_UPSOp:
   ]>, 
   Arguments<(ins AnyVector:$source, 
           DefaultValuedAttr<Confined<I8Attr, [IntNonNegative]>, "0">:$shift)>,
-  Results<(outs AIEVec_Acc:$result)> {
+  Results<(outs AnyVector:$result)> {
   let summary = "AIE ups";
   let description = [{
     Xilinx-specific upshift intrinsic. Moves data from AIE vector data type
@@ -273,7 +272,7 @@ def AIEVec_SRSOp:
   AIEVec_Op<"srs", [
     NoSideEffect
   ]>, 
-  Arguments<(ins AIEVec_Acc:$source, 
+  Arguments<(ins AnyVector:$source,
           DefaultValuedAttr<Confined<I8Attr, [IntNonNegative]>, "0">:$shift)>,
   Results<(outs AnyVector:$result)> {
   let summary = "AIE srs";

--- a/include/aie/Dialect/AIEVec/IR/AIEVecTypes.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecTypes.td
@@ -25,20 +25,4 @@ class AIEVec_Type<string name, string typeMnemonic,
   let mnemonic = typeMnemonic;
 }
 
-//===----------------------------------------------------------------------===//
-// Accumulation Types
-//===----------------------------------------------------------------------===//
-
-def AIEVec_Acc : AIEVec_Type<"Acc", "acc"> {
-  let summary = "scalar or vector 48/80 bit accumulator type";
-  let parameters = (ins "int32_t":$lanes, "Type":$valueType);
-  let builders = [
-    TypeBuilderWithInferredContext<(ins "int32_t":$lanes, "Type":$valueType), [{
-      return $_get(valueType.getContext(), lanes, valueType);
-    }]>
-  ];
-  let skipDefaultBuilders = 1;
-  let hasCustomAssemblyFormat = 1;
-}
-
 #endif // AIEVEC_TYPES

--- a/lib/Dialect/AIEVec/IR/AIEVecTypes.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecTypes.cpp
@@ -39,27 +39,3 @@ void AIEVecDialect::registerTypes() {
 bool AIEVecType::classof(Type type) {
   return llvm::isa<AIEVecDialect>(type.getDialect());
 }
-
-//===----------------------------------------------------------------------===//
-// AIE Accumulator Types
-//===----------------------------------------------------------------------===//
-
-mlir::Type AccType::parse(mlir::AsmParser &parser) {
-  int32_t lanes;
-  Type ty;
-  if (parser.parseLess() || parser.parseInteger(lanes) ||
-      parser.parseXInDimensionList() || parser.parseType(ty) ||
-      parser.parseGreater()) {
-    parser.emitError(parser.getNameLoc(), "failed to parse AccType");
-    return Type();
-  }
-  return AccType::get(lanes, ty);
-}
-
-void AccType::print(mlir::AsmPrinter &printer) const {
-  printer << "<";
-  printer << getLanes();
-  printer << "x";
-  printer.printType(getValueType());
-  printer << '>';
-}

--- a/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
+++ b/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
@@ -327,6 +327,32 @@ static bool isWellFormedVectorOp(Operation *Op) {
   return true;
 }
 
+// Given an AIEOp, determines if an operation writes to an accumulator
+// based on operation type and operand types
+static bool writesToAccumulator(Operation *op) {
+    // Integer muls and FMAs write to accumulator
+    if (!isAIEOp(op)) {
+      return false;
+    } else if (isa<aievec::MulOp>(op)) {
+      auto mulOp = dyn_cast<aievec::MulOp>(op);
+      auto lhsType = mulOp.lhs().getType().cast<VectorType>()
+                        .getElementType();
+      auto rhsType = mulOp.rhs().getType().cast<VectorType>()
+                        .getElementType();
+      return !lhsType.isa<FloatType>() && !rhsType.isa<FloatType>();
+    } else if (isa<aievec::FMAOp>(op)) {
+      auto fmaOp = dyn_cast<aievec::FMAOp>(op);
+      auto lhsType = fmaOp.lhs().getType().cast<VectorType>()
+                        .getElementType();
+      auto rhsType = fmaOp.rhs().getType().cast<VectorType>()
+                        .getElementType();
+      return !lhsType.isa<FloatType>() && !rhsType.isa<FloatType>();
+    } else if (isa<aievec::UPSOp>(op))
+      return true;
+    else
+      return false;
+}
+
 //===----------------------------------------------------------------------===//
 // Manipulate affine expressions
 //===----------------------------------------------------------------------===//
@@ -480,12 +506,13 @@ static std::pair<AffineExpr, int32_t> getBaseAndOffset(AffineExpr expr) {
 // output should be a vector of element type `scalarType`.
 static aievec::SRSOp generateSRSOp(Value source, Type scalarType,
                                    VectState *state, Location loc) {
-  // The source should be accumulator type
+  // The source should write to accumulator
   Type accType = source.getType();
-  assert(isAccType(accType) && "srs source should be accumulator type");
+  assert(writesToAccumulator(source.getDefiningOp()) &&
+    "srs source should write to accumulator");
 
   // Get the number of lanes
-  unsigned lanes = accType.cast<AccType>().getLanes();
+  unsigned lanes = getVectorLaneSize(accType.cast<VectorType>());
   // Now generate the new vector type for the SRS intrinsic
   VectorType srsType = createVectorType(lanes, scalarType);
   // Create the SRS op
@@ -501,9 +528,9 @@ static aievec::SRSOp generateSRSOp(Value source, Type scalarType,
 static aievec::UPSOp generateUPSOp(Value source, VectState *state,
                                    Location loc) {
   Type sourceType = source.getType();
-  assert(!isAccType(sourceType) && "ups source should not be accumulator");
-
-  AccType accType = getAccType(sourceType);
+  Type accType = getVectorOpDestType(sourceType.cast<VectorType>());
+  assert(!writesToAccumulator(source.getDefiningOp()) &&
+    "ups source should not be accumulator");
 
   // Create a new UPS instruction
   aievec::UPSOp upsOp =
@@ -644,13 +671,6 @@ static Operation *generateFMAOp(vector::FMAOp fmaOp, AIEOpAttributes &opAttr,
   assert(opAttr.start.size() == opAttr.offset.size() &&
          opAttr.start.size() == 2);
 
-  // If the accumulator is not of type aievec::AccType for integer FMA
-  // we need to generate a ups instruction.
-  bool isInt = fmaOp.getLhs()
-                   .getType()
-                   .cast<VectorType>()
-                   .getElementType()
-                   .isa<IntegerType>();
   Value acc = fmaOp.getAcc();
   // If i8xi8_pairedOp is true, then we are trying to generated the paired FMA
   // op for i8xi8 scheme. Find the paired accumulator.
@@ -659,7 +679,16 @@ static Operation *generateFMAOp(vector::FMAOp fmaOp, AIEOpAttributes &opAttr,
     if (state->pairedOp.count(defOp))
       acc = state->pairedOp[defOp]->getResult(0);
   }
-  if (isInt && !isAccType(acc.getType())) {
+
+  // We need to generate a UPS op for the integer path if the accumulator is
+  // coming from a vector register.
+  bool isInt = fmaOp.getLhs()
+                   .getType()
+                   .cast<VectorType>()
+                   .getElementType()
+                   .isa<IntegerType>();
+
+  if (isInt && !writesToAccumulator(acc.getDefiningOp())) {
     acc = generateUPSOp(acc, state, fmaOp->getLoc());
     LLVM_DEBUG(llvm::dbgs()
                << "\n\nCreated UPS op " << acc << " to move the output of "
@@ -694,7 +723,7 @@ static Operation *generateFMAOp(vector::FMAOp fmaOp, AIEOpAttributes &opAttr,
 }
 
 // Generate a MUL operation in AIE dialect. This operation will have the start
-// and offset fields for each operand. The output will be in an accumulator.
+// and offset fields for each operand.
 template <typename T>
 static Operation *generateMulOp(T mulOp, AIEOpAttributes &opAttr,
                                 VectState *state) {
@@ -703,12 +732,8 @@ static Operation *generateMulOp(T mulOp, AIEOpAttributes &opAttr,
   assert(opAttr.start.size() == opAttr.offset.size() &&
          opAttr.start.size() == 2);
 
-  // If the return type is not accumulator type already, create a new
-  // accumulator type for return value of integer types.
-  Type opType = mulOp.getType();
-  if (!isAccType(opType) &&
-      opType.cast<VectorType>().getElementType().isa<IntegerType>())
-    opType = getAccType(opType);
+  Type opType = getVectorOpDestType(mulOp.getType().
+                  template cast<VectorType>());
 
   // If the lhs operand vector is not >= twice the rhs operand vector, then use
   // concat operator.
@@ -954,10 +979,6 @@ int32_t computeStartInAIEVec(Operation *op, VectState *state) {
 static Operation *concatAndInterleave_i8xi8(Operation *source1,
                                             Operation *source2,
                                             VectState *state, Location loc) {
-  // Both the input sources must be accumulators
-  assert(isAccType(source1->getResult(0).getType()) &&
-         isAccType(source2->getResult(0).getType()));
-
   // The source values are in accumulator. So generate SRS intrinsic to convert
   // the accumulator output to vector output. We want the output to be in
   // v16int16 vector, since select operation does not operate on v16int8
@@ -1960,9 +1981,8 @@ static void insertSRSOp(Operation *Op, VectState *state) {
   if (Op->use_empty() || Op->getNumResults() == 0)
     return;
 
-  // The operation must be in AIE dialect, and its result should be accumulator
-  // type.
-  assert(isAIEOp(Op) && llvm::any_of(Op->getResultTypes(), isAccType));
+  // The operation must write to an accumulator
+  assert(writesToAccumulator(Op));
 
   // Check if any user of this operation is a non-AIE op. If any user of this
   // operation is non-AIE op, then we need to generate SRS op to move value
@@ -2020,9 +2040,8 @@ static void insertSRSOp(Operation *Op, VectState *state) {
 // vector.
 static void insertSRSOpsInFunc(func::FuncOp func, VectState *state) {
   func.walk([&](mlir::Operation *op) {
-    // Check if we need to insert an SRS op if (1) the op is in AIE dialect,
-    // and (2) the result of the op is accumulator type.
-    if (isAIEOp(op) && llvm::any_of(op->getResultTypes(), isAccType))
+    // Insert an SRS op if the op outputs to an accumulator
+    if (writesToAccumulator(op))
       insertSRSOp(op, state);
   });
 }

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -228,13 +228,12 @@ static bool skippedOp(Operation *op, CppEmitter &emitter,
   // skip op 2 : some aievec::srs for float types
   if (auto srsOp = dyn_cast<aievec::SRSOp>(op)) {
     // Get the datatype of the source accumulator and result vector
-    aievec::AccType accType = srsOp.source().getType().cast<aievec::AccType>();
-    Type eltType = accType.getValueType();
-    VectorType vecType = srsOp.result().getType().cast<VectorType>();
+    VectorType accType = srsOp.source().getType().cast<VectorType>();
+    Type eltType = accType.getElementType();
     Value source = srsOp.source();
     // If the underlying element types are float, then we do not really need an
     // srs op if source of srsOp has only one use.
-    if (eltType.isa<FloatType>() && vecType.getElementType().isa<FloatType>() &&
+    if (eltType.isa<FloatType>() && accType.getElementType().isa<FloatType>() &&
         source.getDefiningOp()->hasOneUse()) {
       StringRef srcName = emitter.getOrCreateName(source);
       emitter.setName(srsOp->getResult(0), srcName);
@@ -244,13 +243,12 @@ static bool skippedOp(Operation *op, CppEmitter &emitter,
   // skip op 3 : some aievec::ups for float ops
   else if (auto upsOp = dyn_cast<aievec::UPSOp>(op)) {
     // Get the datatype of the source vector and result accumulator
-    aievec::AccType accType = upsOp.result().getType().cast<aievec::AccType>();
-    Type eltType = accType.getValueType();
-    VectorType vecType = upsOp.source().getType().cast<VectorType>();
+    VectorType accType = upsOp.result().getType().cast<VectorType>();
+    Type eltType = accType.getElementType();
     Value source = upsOp.source();
     // If the underlying element types are float, then we do not really need a
     // ups op if the source accumulator has only one use.
-    if (eltType.isa<FloatType>() && vecType.getElementType().isa<FloatType>() &&
+    if (eltType.isa<FloatType>() && accType.getElementType().isa<FloatType>() &&
         source.getDefiningOp()->hasOneUse()) {
       StringRef srcName = emitter.getOrCreateName(source);
       emitter.setName(upsOp->getResult(0), srcName);
@@ -579,13 +577,12 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
   if (!emitter.hasValueInScope(source))
     return failure();
 
-  aievec::AccType accType = upsOp.result().getType().cast<aievec::AccType>();
-  Type eltType = accType.getValueType();
-  VectorType vecType = upsOp.source().getType().cast<VectorType>();
+  VectorType accType = upsOp.source().getType().cast<VectorType>();
+  Type eltType = accType.getElementType();
 
   // If the underlying element types are float, then we do not really need a
   // ups op. We can simply generate an assignment
-  if (eltType.isa<FloatType>() && vecType.getElementType().isa<FloatType>()) {
+  if (eltType.isa<FloatType>()) {
     os << emitter.getOrCreateName(source);
     return success();
   }
@@ -610,9 +607,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::SRSOp srsOp) {
   int32_t shift = srsOp.shift();
 
   // Get the datatype of the source accumulator and result vector
-  aievec::AccType accType = srsOp.source().getType().cast<aievec::AccType>();
-  Type eltType = accType.getValueType();
-  VectorType vecType = srsOp.result().getType().cast<VectorType>();
+  VectorType accType = srsOp.source().getType().cast<VectorType>();
+  Type eltType = accType.getElementType();
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -626,14 +622,14 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::SRSOp srsOp) {
 
   // If the underlying element types are float, then we do not really need an
   // srs op. We can simply generate an assignment
-  if (eltType.isa<FloatType>() && vecType.getElementType().isa<FloatType>()) {
+  if (eltType.isa<FloatType>()) {
     os << emitter.getOrCreateName(source);
     return success();
   }
 
   // Otheriwse, get the datatype width of the source accumulator and result
   // vector
-  unsigned resultWidth = getElementSizeInBits(vecType);
+  unsigned resultWidth = getElementSizeInBits(accType);
   unsigned srcWidth = 0;
   if (auto iType = eltType.dyn_cast<IntegerType>())
     srcWidth = iType.getWidth();
@@ -880,12 +876,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
 
   std::string opname;
   // Create opname based on the result type
-  bool isInt =
-      lhs.getType().cast<VectorType>().getElementType().isa<IntegerType>();
-  aievec::AccType accType =
-      mulOp.result().getType().dyn_cast<aievec::AccType>();
-  VectorType vecType = mulOp.result().getType().dyn_cast<VectorType>();
-  Type eltType = isInt ? accType.getValueType() : vecType.getElementType();
+  VectorType accType = mulOp.result().getType().cast<VectorType>();
+  Type eltType = accType.getElementType();
   if (!simpleScheme) {
     if (auto iType = eltType.dyn_cast<IntegerType>()) {
       if (iType.getWidth() == 80)
@@ -895,7 +887,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
   }
   opname += "mul";
   if (!simpleScheme && !eltType.isa<FloatType>())
-    opname += std::to_string(accType.getLanes());
+    opname += std::to_string(getVectorLaneSize(accType));
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -1039,12 +1031,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
 
   std::string opname;
   // Create opname based on the result type
-  bool isInt =
-      lhs.getType().cast<VectorType>().getElementType().isa<IntegerType>();
-  aievec::AccType accType =
-      fmaOp.result().getType().dyn_cast<aievec::AccType>();
-  VectorType vecType = fmaOp.result().getType().dyn_cast<VectorType>();
-  Type eltType = isInt ? accType.getValueType() : vecType.getElementType();
+  VectorType accType = fmaOp.result().getType().cast<VectorType>();
+  Type eltType = accType.getElementType();
   if (!simpleScheme) {
     if (auto iType = eltType.dyn_cast<IntegerType>()) {
       if (iType.getWidth() == 80)
@@ -1054,7 +1042,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
   }
   opname += fmaOp.fmsub() ? "msc" : "mac";
   if (!simpleScheme && !eltType.isa<FloatType>())
-    opname += std::to_string(accType.getLanes());
+    opname += std::to_string(getVectorLaneSize(accType));
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -2002,15 +1990,6 @@ LogicalResult CppEmitter::emitType(Location loc, Type type, bool stdintType) {
       return failure();
     os << "v" << std::to_string(tType.getDimSize(tType.getRank() - 1));
     if (failed(emitType(loc, tType.getElementType(), false)))
-      return failure();
-    return success();
-  }
-  // AccType: printed as v'lane''eltType'
-  if (auto tType = type.dyn_cast<aievec::AccType>()) {
-    unsigned lanes = tType.getLanes();
-    if (lanes > 1)
-      os << "v" << lanes;
-    if (failed(emitType(loc, tType.getValueType(), false)))
       return failure();
     return success();
   }

--- a/test/aievec/conv2d_i16.mlir
+++ b/test/aievec/conv2d_i16.mlir
@@ -39,16 +39,16 @@ func @conv2d (%A: memref<2048x2048xi16>, %B: memref<12xi16>, %C: memref<2046x204
 //CHECK-NEXT: %3 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xi16>, vector<16xi16>
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4], %4 {index = 1 : i8, offset = 256 : si32} : memref<2048x2048xi16>, vector<32xi16>
-//CHECK-NEXT: %6 = aievec.ups %3 {shift = 0 : i8} : vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %8 = aievec.mac %5, %0, %7 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %6 = aievec.ups %3 {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %8 = aievec.mac %5, %0, %7 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %9 = aievec.upd %arg0[%1, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%1, %arg4], %9 {index = 1 : i8, offset = 256 : si32} : memref<2048x2048xi16>, vector<32xi16>
-//CHECK-NEXT: %11 = aievec.mac %10, %0, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %12 = aievec.mac %10, %0, %11 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %11 = aievec.mac %10, %0, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %12 = aievec.mac %10, %0, %11 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %13 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %14 = aievec.upd %arg0[%2, %arg4], %13 {index = 1 : i8, offset = 256 : si32} : memref<2048x2048xi16>, vector<32xi16>
-//CHECK-NEXT: %15 = aievec.mac %14, %0, %12 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %17 = aievec.srs %16 {shift = 0 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %15 = aievec.mac %14, %0, %12 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %17 = aievec.srs %16 {shift = 0 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: vector.transfer_write %17, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<2046x2046xi16>

--- a/test/aievec/conv2d_i32.mlir
+++ b/test/aievec/conv2d_i32.mlir
@@ -40,22 +40,22 @@ func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xi32>, vector<8xi32>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %8 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %9 = aievec.upd %arg0[%arg3, %8], %5 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %14 = aievec.upd %arg0[%2, %8], %12 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %17 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %19 = aievec.upd %arg0[%3, %8], %17 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %22, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<2046x2046xi32>

--- a/test/aievec/conv2d_i8.mlir
+++ b/test/aievec/conv2d_i8.mlir
@@ -40,17 +40,17 @@ func @conv2d (%A: memref<18x288xi8>, %B: memref<48xi8>, %C: memref<16x256xi8>) {
 //CHECK-NEXT:   scf.for %arg4 = %c0_2 to %c256 step %c16_3 {
 //CHECK-NEXT:     %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<16x256xi8>, vector<16xi8>
 //CHECK-NEXT:     %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT:     %6 = aievec.ups %4 {shift = 0 : i8} : vector<16xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT:     %7 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT:     %8 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
+//CHECK-NEXT:     %6 = aievec.ups %4 {shift = 0 : i8} : vector<16xi8>, vector<16xi48>
+//CHECK-NEXT:     %7 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT:     %8 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
 //CHECK-NEXT:     %9 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT:     %10 = aievec.mac %0, %9, %7 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT:     %11 = aievec.mac %0, %9, %8 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
+//CHECK-NEXT:     %10 = aievec.mac %0, %9, %7 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT:     %11 = aievec.mac %0, %9, %8 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
 //CHECK-NEXT:     %12 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT:     %13 = aievec.mac %1, %12, %10 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT:     %14 = aievec.mac %1, %12, %11 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT:     %15 = aievec.srs %13 {shift = 0 : i8} : !aievec.acc<16xi48>, vector<16xi16>
-//CHECK-NEXT:     %16 = aievec.srs %14 {shift = 0 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT:     %13 = aievec.mac %1, %12, %10 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT:     %14 = aievec.mac %1, %12, %11 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT:     %15 = aievec.srs %13 {shift = 0 : i8} : vector<16xi48>, vector<16xi16>
+//CHECK-NEXT:     %16 = aievec.srs %14 {shift = 0 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT:     %17 = aievec.concat %15, %16 : vector<16xi16>, vector<32xi16>
 //CHECK-NEXT:     %18 = aievec.select %17 {select = "0xcccccccc", xoffsets = "0x0c080400", xoffsets_hi = "0x0", xsquare = "0x1010", xstart = "0", yoffsets = "0x0c080400", yoffsets_hi = "0x0", ysquare = "0x1010", ystart = "4"} : vector<32xi16>, vector<32xi16>
 //CHECK-NEXT:     %19 = aievec.ext %18 {index = 0 : i8} : vector<32xi16>, vector<16xi16>

--- a/test/aievec/conv2d_msc_uij_i32_noinit.mlir
+++ b/test/aievec/conv2d_msc_uij_i32_noinit.mlir
@@ -84,22 +84,22 @@ func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046
 //CHECK-NEXT: %c8_4 = arith.constant 8 : index
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %6 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %7 = aievec.upd %arg0[%arg3, %6], %4 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %6], %10 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %15 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {fmsub = true, xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %17 = aievec.upd %arg0[%3, %6], %15 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %20 = aievec.srs %19 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {fmsub = true, xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {fmsub = true, xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %20 = aievec.srs %19 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %20, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<2046x2046xi32>
 

--- a/test/aievec/conv2d_uij_i16.mlir
+++ b/test/aievec/conv2d_uij_i16.mlir
@@ -88,16 +88,16 @@ func @conv2d (%A: memref<2048x2048xi16>, %B: memref<12xi16>, %C: memref<2046x204
 //CHECK-NEXT: %3 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xi16>, vector<16xi16>
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4], %4 {index = 1 : i8, offset = 256 : si32} : memref<2048x2048xi16>, vector<32xi16>
-//CHECK-NEXT: %6 = aievec.ups %3 {shift = 0 : i8} : vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %8 = aievec.mac %5, %0, %7 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %6 = aievec.ups %3 {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %8 = aievec.mac %5, %0, %7 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %9 = aievec.upd %arg0[%1, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%1, %arg4], %9 {index = 1 : i8, offset = 256 : si32} : memref<2048x2048xi16>, vector<32xi16>
-//CHECK-NEXT: %11 = aievec.mac %10, %0, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %12 = aievec.mac %10, %0, %11 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %11 = aievec.mac %10, %0, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %12 = aievec.mac %10, %0, %11 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %13 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %14 = aievec.upd %arg0[%2, %arg4], %13 {index = 1 : i8, offset = 256 : si32} : memref<2048x2048xi16>, vector<32xi16>
-//CHECK-NEXT: %15 = aievec.mac %14, %0, %12 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %17 = aievec.srs %16 {shift = 0 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %15 = aievec.mac %14, %0, %12 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %17 = aievec.srs %16 {shift = 0 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: vector.transfer_write %17, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<2046x2046xi16>

--- a/test/aievec/conv2d_uij_i16_noinit.mlir
+++ b/test/aievec/conv2d_uij_i16_noinit.mlir
@@ -83,15 +83,15 @@ func @conv2d (%A: memref<18x288xi16>, %B: memref<12xi16>, %C: memref<16x256xi16>
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c256 step %c16_3 {
 //CHECK-NEXT: %3 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<32xi16>
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4], %3 {index = 1 : i8, offset = 256 : si32} : memref<18x288xi16>, vector<32xi16>
-//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %6 = aievec.mac %4, %0, %5 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %6 = aievec.mac %4, %0, %5 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %7 = aievec.upd %arg0[%1, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<32xi16>
 //CHECK-NEXT: %8 = aievec.upd %arg0[%1, %arg4], %7 {index = 1 : i8, offset = 256 : si32} : memref<18x288xi16>, vector<32xi16>
-//CHECK-NEXT: %9 = aievec.mac %8, %0, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %10 = aievec.mac %8, %0, %9 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %9 = aievec.mac %8, %0, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %10 = aievec.mac %8, %0, %9 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %11 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<32xi16>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %arg4], %11 {index = 1 : i8, offset = 256 : si32} : memref<18x288xi16>, vector<32xi16>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %10 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %15 = aievec.srs %14 {shift = 10 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %10 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %15 = aievec.srs %14 {shift = 10 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: vector.transfer_write %15, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<16x256xi16>

--- a/test/aievec/conv2d_uij_i16_unbounded.mlir
+++ b/test/aievec/conv2d_uij_i16_unbounded.mlir
@@ -94,18 +94,18 @@ func @conv2d_0 (%A: memref<?x?xi16>, %B: memref<?xi16>, %C: memref<?x?xi16>) {
 //CHECK-NEXT: %5 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi16>, vector<16xi16>
 //CHECK-NEXT: %6 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi16>, vector<32xi16>
 //CHECK-NEXT: %7 = aievec.upd %arg0[%arg3, %arg4], %6 {index = 1 : i8, offset = 256 : si32} : memref<?x?xi16>, vector<32xi16>
-//CHECK-NEXT: %8 = aievec.ups %5 {shift = 0 : i8} : vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %9 = aievec.mac %7, %2, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %10 = aievec.mac %7, %2, %9 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %8 = aievec.ups %5 {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %9 = aievec.mac %7, %2, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %10 = aievec.mac %7, %2, %9 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %11 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi16>, vector<32xi16>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%3, %arg4], %11 {index = 1 : i8, offset = 256 : si32} : memref<?x?xi16>, vector<32xi16>
-//CHECK-NEXT: %13 = aievec.mac %12, %2, %10 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %14 = aievec.mac %12, %2, %13 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %13 = aievec.mac %12, %2, %10 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %14 = aievec.mac %12, %2, %13 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %15 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi16>, vector<32xi16>
 //CHECK-NEXT: %16 = aievec.upd %arg0[%4, %arg4], %15 {index = 1 : i8, offset = 256 : si32} : memref<?x?xi16>, vector<32xi16>
-//CHECK-NEXT: %17 = aievec.mac %16, %2, %14 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %18 = aievec.mac %16, %2, %17 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %19 = aievec.srs %18 {shift = 0 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %17 = aievec.mac %16, %2, %14 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %18 = aievec.mac %16, %2, %17 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %19 = aievec.srs %18 {shift = 0 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: vector.transfer_write %19, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<?x?xi16>
 
 
@@ -200,16 +200,16 @@ func @conv2d_1 (%A: memref<?x256xi16>, %B: memref<?xi16>, %C: memref<?x256xi16>)
 //CHECK-NEXT: %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi16>, vector<16xi16>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi16>, vector<32xi16>
 //CHECK-NEXT: %6 = aievec.upd %arg0[%arg3, %arg4], %5 {index = 1 : i8, offset = 256 : si32} : memref<?x256xi16>, vector<32xi16>
-//CHECK-NEXT: %7 = aievec.ups %4 {shift = 0 : i8} : vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %8 = aievec.mac %6, %1, %7 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %9 = aievec.mac %6, %1, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %7 = aievec.ups %4 {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %8 = aievec.mac %6, %1, %7 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %9 = aievec.mac %6, %1, %8 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi16>, vector<32xi16>
 //CHECK-NEXT: %11 = aievec.upd %arg0[%2, %arg4], %10 {index = 1 : i8, offset = 256 : si32} : memref<?x256xi16>, vector<32xi16>
-//CHECK-NEXT: %12 = aievec.mac %11, %1, %9 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %13 = aievec.mac %11, %1, %12 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %12 = aievec.mac %11, %1, %9 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %13 = aievec.mac %11, %1, %12 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %14 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi16>, vector<32xi16>
 //CHECK-NEXT: %15 = aievec.upd %arg0[%3, %arg4], %14 {index = 1 : i8, offset = 256 : si32} : memref<?x256xi16>, vector<32xi16>
-//CHECK-NEXT: %16 = aievec.mac %15, %1, %13 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %17 = aievec.mac %15, %1, %16 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %18 = aievec.srs %17 {shift = 0 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %16 = aievec.mac %15, %1, %13 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %17 = aievec.mac %15, %1, %16 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %18 = aievec.srs %17 {shift = 0 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: vector.transfer_write %18, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<?x256xi16>

--- a/test/aievec/conv2d_uij_i32.mlir
+++ b/test/aievec/conv2d_uij_i32.mlir
@@ -89,22 +89,22 @@ func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xi32>, vector<8xi32>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %8 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %9 = aievec.upd %arg0[%arg3, %8], %5 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %14 = aievec.upd %arg0[%2, %8], %12 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %17 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %19 = aievec.upd %arg0[%3, %8], %17 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %22, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<2046x2046xi32>

--- a/test/aievec/conv2d_uij_i32_noinit.mlir
+++ b/test/aievec/conv2d_uij_i32_noinit.mlir
@@ -84,22 +84,22 @@ func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046
 //CHECK-NEXT: %c8_4 = arith.constant 8 : index
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %5 = aievec.mul %4, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %6 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %7 = aievec.upd %arg0[%arg3, %6], %4 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %8 = aievec.mac %7, %0, %5 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %9 = aievec.mac %7, %0, %8 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %11 = aievec.mac %10, %0, %9 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %6], %10 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %14 = aievec.mac %12, %0, %13 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %15 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %16 = aievec.mac %15, %0, %14 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %17 = aievec.upd %arg0[%3, %6], %15 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %20 = aievec.srs %19 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %19 = aievec.mac %17, %1, %18 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %20 = aievec.srs %19 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %20, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<2046x2046xi32>
 

--- a/test/aievec/conv2d_uij_i32_unbounded.mlir
+++ b/test/aievec/conv2d_uij_i32_unbounded.mlir
@@ -95,24 +95,24 @@ func @conv2d_0 (%A: memref<?x?xi32>, %B: memref<?xi32>, %C: memref<?x?xi32>) {
 //CHECK-NEXT: scf.for %arg4 = %c0_3 to %1 step %c8_4 {
 //CHECK-NEXT: %6 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi32>, vector<8xi32>
 //CHECK-NEXT: %7 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi32>, vector<16xi32>
-//CHECK-NEXT: %8 = aievec.ups %6 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %9 = aievec.mac %7, %2, %8 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %8 = aievec.ups %6 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %9 = aievec.mac %7, %2, %8 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %10 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %11 = aievec.upd %arg0[%arg3, %10], %7 {index = 1 : i8, offset = 224 : si32} : memref<?x?xi32>, vector<16xi32>
-//CHECK-NEXT: %12 = aievec.mac %11, %2, %9 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %13 = aievec.mac %11, %2, %12 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %12 = aievec.mac %11, %2, %9 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %13 = aievec.mac %11, %2, %12 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %14 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi32>, vector<16xi32>
-//CHECK-NEXT: %15 = aievec.mac %14, %2, %13 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %15 = aievec.mac %14, %2, %13 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %16 = aievec.upd %arg0[%4, %10], %14 {index = 1 : i8, offset = 224 : si32} : memref<?x?xi32>, vector<16xi32>
-//CHECK-NEXT: %17 = aievec.mac %16, %2, %15 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %18 = aievec.mac %16, %2, %17 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %17 = aievec.mac %16, %2, %15 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %18 = aievec.mac %16, %2, %17 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %19 = aievec.upd %arg0[%5, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x?xi32>, vector<16xi32>
-//CHECK-NEXT: %20 = aievec.mac %19, %2, %18 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %20 = aievec.mac %19, %2, %18 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %21 = aievec.upd %arg0[%5, %10], %19 {index = 1 : i8, offset = 224 : si32} : memref<?x?xi32>, vector<16xi32>
-//CHECK-NEXT: %22 = aievec.mac %21, %2, %20 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %23 = aievec.mac %21, %3, %22 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %24 = aievec.srs %23 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %22 = aievec.mac %21, %2, %20 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %23 = aievec.mac %21, %3, %22 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %24 = aievec.srs %23 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %24, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<?x?xi32>
 
 
@@ -210,22 +210,22 @@ func @conv2d_1 (%A: memref<?x256xi32>, %B: memref<?xi32>, %C: memref<?x256xi32>)
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c256 step %c8_3 {
 //CHECK-NEXT: %5 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi32>, vector<8xi32>
 //CHECK-NEXT: %6 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi32>, vector<16xi32>
-//CHECK-NEXT: %7 = aievec.ups %5 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %8 = aievec.mac %6, %1, %7 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %7 = aievec.ups %5 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %8 = aievec.mac %6, %1, %7 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_4 = arith.constant 1 : index
 //CHECK-NEXT: %9 = arith.addi %arg4, %c1_4 : index
 //CHECK-NEXT: %10 = aievec.upd %arg0[%arg3, %9], %6 {index = 1 : i8, offset = 224 : si32} : memref<?x256xi32>, vector<16xi32>
-//CHECK-NEXT: %11 = aievec.mac %10, %1, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %12 = aievec.mac %10, %1, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %11 = aievec.mac %10, %1, %8 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %12 = aievec.mac %10, %1, %11 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %13 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi32>, vector<16xi32>
-//CHECK-NEXT: %14 = aievec.mac %13, %1, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %14 = aievec.mac %13, %1, %12 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %15 = aievec.upd %arg0[%3, %9], %13 {index = 1 : i8, offset = 224 : si32} : memref<?x256xi32>, vector<16xi32>
-//CHECK-NEXT: %16 = aievec.mac %15, %1, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %17 = aievec.mac %15, %1, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %16 = aievec.mac %15, %1, %14 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %17 = aievec.mac %15, %1, %16 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %18 = aievec.upd %arg0[%4, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<?x256xi32>, vector<16xi32>
-//CHECK-NEXT: %19 = aievec.mac %18, %1, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %19 = aievec.mac %18, %1, %17 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %20 = aievec.upd %arg0[%4, %9], %18 {index = 1 : i8, offset = 224 : si32} : memref<?x256xi32>, vector<16xi32>
-//CHECK-NEXT: %21 = aievec.mac %20, %1, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %22 = aievec.mac %20, %2, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %23 = aievec.srs %22 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %21 = aievec.mac %20, %1, %19 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %22 = aievec.mac %20, %2, %21 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %23 = aievec.srs %22 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %23, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<?x256xi32>

--- a/test/aievec/conv2d_uij_i8.mlir
+++ b/test/aievec/conv2d_uij_i8.mlir
@@ -89,17 +89,17 @@ func @conv2d (%A: memref<18x288xi8>, %B: memref<48xi8>, %C: memref<16x256xi8>) {
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c256 step %c16_3 {
 //CHECK-NEXT: %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<16x256xi8>, vector<16xi8>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT: %6 = aievec.ups %4 {shift = 10 : i8} : vector<16xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %7 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %8 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
+//CHECK-NEXT: %6 = aievec.ups %4 {shift = 10 : i8} : vector<16xi8>, vector<16xi48>
+//CHECK-NEXT: %7 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %8 = aievec.mac %0, %5, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
 //CHECK-NEXT: %9 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT: %10 = aievec.mac %0, %9, %7 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %11 = aievec.mac %0, %9, %8 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
+//CHECK-NEXT: %10 = aievec.mac %0, %9, %7 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %11 = aievec.mac %0, %9, %8 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT: %13 = aievec.mac %1, %12, %10 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %14 = aievec.mac %1, %12, %11 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %15 = aievec.srs %13 {shift = 10 : i8} : !aievec.acc<16xi48>, vector<16xi16>
-//CHECK-NEXT: %16 = aievec.srs %14 {shift = 10 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %13 = aievec.mac %1, %12, %10 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %14 = aievec.mac %1, %12, %11 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %15 = aievec.srs %13 {shift = 10 : i8} : vector<16xi48>, vector<16xi16>
+//CHECK-NEXT: %16 = aievec.srs %14 {shift = 10 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: %17 = aievec.concat %15, %16 : vector<16xi16>, vector<32xi16>
 //CHECK-NEXT: %18 = aievec.select %17 {select = "0xcccccccc", xoffsets = "0x0c080400", xoffsets_hi = "0x0", xsquare = "0x1010", xstart = "0", yoffsets = "0x0c080400", yoffsets_hi = "0x0", ysquare = "0x1010", ystart = "4"} : vector<32xi16>, vector<32xi16>
 //CHECK-NEXT: %19 = aievec.ext %18 {index = 0 : i8} : vector<32xi16>, vector<16xi16>

--- a/test/aievec/conv2d_uij_i8_noinit.mlir
+++ b/test/aievec/conv2d_uij_i8_noinit.mlir
@@ -84,16 +84,16 @@ func @conv2d (%A: memref<18x288xi8>, %B: memref<48xi8>, %C: memref<16x256xi8>) {
 //CHECK-NEXT: %c16_3 = arith.constant 16 : index
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c256 step %c16_3 {
 //CHECK-NEXT: %4 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT: %5 = aievec.mul %0, %4 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %6 = aievec.mul %0, %4 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
+//CHECK-NEXT: %5 = aievec.mul %0, %4 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %6 = aievec.mul %0, %4 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "0", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
 //CHECK-NEXT: %7 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT: %8 = aievec.mac %0, %7, %5 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %9 = aievec.mac %0, %7, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
+//CHECK-NEXT: %8 = aievec.mac %0, %7, %5 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %9 = aievec.mac %0, %7, %6 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "16", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
 //CHECK-NEXT: %10 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-//CHECK-NEXT: %11 = aievec.mac %1, %10, %8 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %12 = aievec.mac %1, %10, %9 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, !aievec.acc<16xi48>
-//CHECK-NEXT: %13 = aievec.srs %11 {shift = 10 : i8} : !aievec.acc<16xi48>, vector<16xi16>
-//CHECK-NEXT: %14 = aievec.srs %12 {shift = 10 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %11 = aievec.mac %1, %10, %8 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "0", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %12 = aievec.mac %1, %10, %9 {xoffsets = "0x00000000", xsquare = "0x1010", xstart = "32", xstep = "4", zoffsets = "0x43322110", zsquare = "0x2110", zstart = "8", zstep = "2"} : vector<64xi8>, vector<32xi8>, vector<16xi48>
+//CHECK-NEXT: %13 = aievec.srs %11 {shift = 10 : i8} : vector<16xi48>, vector<16xi16>
+//CHECK-NEXT: %14 = aievec.srs %12 {shift = 10 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: %15 = aievec.concat %13, %14 : vector<16xi16>, vector<32xi16>
 //CHECK-NEXT: %16 = aievec.select %15 {select = "0xcccccccc", xoffsets = "0x0c080400", xoffsets_hi = "0x0", xsquare = "0x1010", xstart = "0", yoffsets = "0x0c080400", yoffsets_hi = "0x0", ysquare = "0x1010", ystart = "4"} : vector<32xi16>, vector<32xi16>
 //CHECK-NEXT: %17 = aievec.ext %16 {index = 0 : i8} : vector<32xi16>, vector<16xi16>

--- a/test/aievec/conv2d_uj_i16.mlir
+++ b/test/aievec/conv2d_uj_i16.mlir
@@ -44,7 +44,7 @@ func @conv2d (%A: memref<2048x2048xi16>, %B: memref<3x3xi16>, %C: memref<2046x20
 //CHECK-NEXT: %c16 = arith.constant 16 : index
 //CHECK-NEXT: scf.for %arg4 = %c0_1 to %c2046_2 step %c16 {
 //CHECK-NEXT: %0 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xi16>, vector<16xi16>
-//CHECK-NEXT: %1 = aievec.ups %0 {shift = 0 : i8} : vector<16xi16>, !aievec.acc<16xi48>
+//CHECK-NEXT: %1 = aievec.ups %0 {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
 //CHECK-NEXT: %c0_3 = arith.constant 0 : index
 //CHECK-NEXT: %c3 = arith.constant 3 : index
 //CHECK-NEXT: %c1_4 = arith.constant 1 : index
@@ -53,8 +53,8 @@ func @conv2d (%A: memref<2048x2048xi16>, %B: memref<3x3xi16>, %C: memref<2046x20
 //CHECK-NEXT: %3 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %4 = aievec.upd %arg0[%2, %arg4], %3 {index = 1 : i8, offset = 256 : si32} : memref<2048x2048xi16>, vector<32xi16>
 //CHECK-NEXT: %5 = aievec.upd %arg1[%arg5, %c0] {index = 0 : i8, offset = 0 : si32} : memref<3x3xi16>, vector<16xi16>
-//CHECK-NEXT: %6 = aievec.mac %4, %5, %1 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %7 = aievec.mac %4, %5, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, !aievec.acc<16xi48>
-//CHECK-NEXT: %8 = aievec.srs %7 {shift = 0 : i8} : !aievec.acc<16xi48>, vector<16xi16>
+//CHECK-NEXT: %6 = aievec.mac %4, %5, %1 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %7 = aievec.mac %4, %5, %6 {xoffsets = "0x03020100", xoffsets_hi = "0x07060504", xsquare = "0x2110", xstart = "2", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"} : vector<32xi16>, vector<16xi16>, vector<16xi48>
+//CHECK-NEXT: %8 = aievec.srs %7 {shift = 0 : i8} : vector<16xi48>, vector<16xi16>
 //CHECK-NEXT: vector.transfer_write %8, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<2046x2046xi16>
 

--- a/test/aievec/conv2d_uj_i32.mlir
+++ b/test/aievec/conv2d_uj_i32.mlir
@@ -44,7 +44,7 @@ func @conv2d (%A: memref<2048x2048xi32>, %B: memref<3x3xi32>, %C: memref<2046x20
 //CHECK-NEXT: %c8 = arith.constant 8 : index
 //CHECK-NEXT: scf.for %arg4 = %c0_1 to %c2046_2 step %c8 {
 //CHECK-NEXT: %0 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xi32>, vector<8xi32>
-//CHECK-NEXT: %1 = aievec.ups %0 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %1 = aievec.ups %0 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_3 = arith.constant 1 : index
 //CHECK-NEXT: %2 = arith.addi %arg4, %c1_3 : index
 //CHECK-NEXT: %c0_4 = arith.constant 0 : index
@@ -54,10 +54,10 @@ func @conv2d (%A: memref<2048x2048xi32>, %B: memref<3x3xi32>, %C: memref<2046x20
 //CHECK-NEXT: %3 = arith.addi %arg3, %arg5 : index
 //CHECK-NEXT: %4 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
 //CHECK-NEXT: %5 = aievec.upd %arg1[%arg5, %c0] {index = 0 : i8, offset = 0 : si32} : memref<3x3xi32>, vector<8xi32>
-//CHECK-NEXT: %6 = aievec.mac %4, %5, %1 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %6 = aievec.mac %4, %5, %1 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %7 = aievec.upd %arg0[%3, %2], %4 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %8 = aievec.mac %7, %5, %6 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %9 = aievec.mac %7, %5, %8 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %10 = aievec.srs %9 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %8 = aievec.mac %7, %5, %6 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %9 = aievec.mac %7, %5, %8 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %10 = aievec.srs %9 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %10, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<2046x2046xi32>
 

--- a/test/aievec/pointwise_mult_i16.mlir
+++ b/test/aievec/pointwise_mult_i16.mlir
@@ -5,7 +5,7 @@ func @pointwise_mult (%A: memref<2048xi16>, %B: memref<2048xi16>, %C: memref<204
     affine.for %arg0 = 0 to 2048 {
        %a = affine.load %A[%arg0] : memref<2048xi16>
        %b = affine.load %B[%arg0] : memref<2048xi16>
-       //CHECK: %2 = aievec.mul %0, %1 : vector<16xi16>, vector<16xi16>, !aievec.acc<16xi48>
+       //CHECK: %2 = aievec.mul %0, %1 : vector<16xi16>, vector<16xi16>, vector<16xi48>
        %c = arith.muli %a, %b : i16
        affine.store %c, %C[%arg0] : memref<2048xi16>
     }

--- a/test/aievec/test_reassoc.mlir
+++ b/test/aievec/test_reassoc.mlir
@@ -89,22 +89,22 @@ func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046
 //CHECK-NEXT: scf.for %arg4 = %c0_2 to %c2046_3 step %c8_4 {
 //CHECK-NEXT: %4 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2046x2046xi32>, vector<8xi32>
 //CHECK-NEXT: %5 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %6 = aievec.ups %4 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %7 = aievec.mac %5, %0, %6 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %c1_5 = arith.constant 1 : index
 //CHECK-NEXT: %8 = arith.addi %arg4, %c1_5 : index
 //CHECK-NEXT: %9 = aievec.upd %arg0[%arg3, %8], %5 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %10 = aievec.mac %9, %0, %7 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "1"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %11 = aievec.mac %9, %0, %10 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %12 = aievec.upd %arg0[%2, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %13 = aievec.mac %12, %0, %11 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "3"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %14 = aievec.upd %arg0[%2, %8], %12 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %15 = aievec.mac %14, %0, %13 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %16 = aievec.mac %14, %0, %15 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "5"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %17 = aievec.upd %arg0[%3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+//CHECK-NEXT: %18 = aievec.mac %17, %0, %16 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "6"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
 //CHECK-NEXT: %19 = aievec.upd %arg0[%3, %8], %17 {index = 1 : i8, offset = 224 : si32} : memref<2048x2048xi32>, vector<16xi32>
-//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
-//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+//CHECK-NEXT: %20 = aievec.mac %19, %0, %18 {xoffsets = "0x76543210", xstart = "1", zoffsets = "0x00000000", zstart = "7"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %21 = aievec.mac %19, %1, %20 {xoffsets = "0x76543210", xstart = "2", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+//CHECK-NEXT: %22 = aievec.srs %21 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
 //CHECK-NEXT: vector.transfer_write %22, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xi32>, memref<2046x2046xi32>

--- a/test/aievec/test_reassoc_add.mlir
+++ b/test/aievec/test_reassoc_add.mlir
@@ -5,9 +5,9 @@ func @conv2d (%A: memref<256xi32>, %B: memref<1xi32>, %C: memref<256xi32>) {
     affine.for %arg0 = 0 to 256 {
       %a1 = affine.load %A[%arg0] : memref<256xi32>
       %b1 = affine.load %B[0] : memref<1xi32>
-      //CHECK: %2 = aievec.ups %1 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
+      //CHECK: %2 = aievec.ups %1 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
       //CHECK: %3 = aievec.concat %1, %1 : vector<8xi32>, vector<16xi32>
-      //CHECK: %4 = aievec.mac %3, %0, %2 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+      //CHECK: %4 = aievec.mac %3, %0, %2 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
       %c1 = arith.muli %b1, %a1 : i32
       %d1 = arith.addi %c1, %a1 : i32 
       affine.store %d1, %C[%arg0] : memref<256xi32>

--- a/test/aievec/test_reassoc_mult.mlir
+++ b/test/aievec/test_reassoc_mult.mlir
@@ -6,7 +6,7 @@ func @conv2d (%A: memref<256xi32>, %B: memref<1xi32>, %C: memref<256xi32>) {
       %a1 = affine.load %A[%arg0] : memref<256xi32>
       %b1 = affine.load %B[0] : memref<1xi32>
       //CHECK: %2 = aievec.concat %1, %1 : vector<8xi32>, vector<16xi32>
-      //CHECK: %3 = aievec.mul %2, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+      //CHECK: %3 = aievec.mul %2, %0 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
       %p1 = arith.muli %b1, %a1 : i32
       affine.store %p1, %C[%arg0] : memref<256xi32>
     }

--- a/test/aievec/test_srs.mlir
+++ b/test/aievec/test_srs.mlir
@@ -11,15 +11,15 @@ func @conv2d (%A: memref<128xi32>, %B: memref<8xi32>, %C: memref<126xi32>) {
     affine.for %arg3 = 0 to 126 {
       //CHECK-NEXT: %1 = aievec.upd %arg2[%arg3] {index = 0 : i8, offset = 0 : si32} : memref<126xi32>, vector<8xi32>
       //CHECK-NEXT: %2 = aievec.upd %arg0[%arg3] {index = 0 : i8, offset = 0 : si32} : memref<128xi32>, vector<8xi32>
-      //CHECK-NEXT: %3 = aievec.ups %1 {shift = 0 : i8} : vector<8xi32>, !aievec.acc<8xi80>
+      //CHECK-NEXT: %3 = aievec.ups %1 {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
       %ci = affine.load %C[%arg3] : memref<126xi32>
       %a = affine.load %A[%arg3] : memref<128xi32>
       %b = affine.load %B[0] : memref<8xi32>
       //CHECK-NEXT: %4 = aievec.concat %2, %2 : vector<8xi32>, vector<16xi32>
-      //CHECK-NEXT: %5 = aievec.mac %4, %0, %3 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, !aievec.acc<8xi80>
+      //CHECK-NEXT: %5 = aievec.mac %4, %0, %3 {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000", zstart = "0"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
       %p = arith.muli %a, %b : i32
       %co = arith.addi %ci, %p : i32
-      //CHECK-NEXT: %6 = aievec.srs %5 {shift = 0 : i8} : !aievec.acc<8xi80>, vector<8xi32>
+      //CHECK-NEXT: %6 = aievec.srs %5 {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
       //CHECK-NEXT: %7 = aievec.add %6, %6 : vector<8xi32>, vector<8xi32>, vector<8xi32>
       %co1 = arith.addi %co, %co : i32
       //CHECK-NEXT: vector.transfer_write %7, %arg2[%arg3] {in_bounds = [true]} : vector<8xi32>, memref<126xi32>


### PR DESCRIPTION
The aievec.acc type does not offer much benefit in modeling the
integer accumulator while at the same time complicating the code as
ops need to handle conversions between aievec.acc and vector as well
as needing special cases to deal with aievec.acc and vector separately.

Issue #101