### PR TITLE
Emit error if a DMA block uses multiple locks/states

### DIFF
--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -503,10 +503,42 @@ template <typename... ParentOpTypes> struct HasSomeParent {
         return success();
       operation = operation->getParentOp();
     }
-    return op->emitOpError()
-           << "expects some parent op "
-           << (sizeof...(ParentOpTypes) != 1 ? "to be one of '" : "'")
-           << llvm::makeArrayRef({ParentOpTypes::getOperationName()...}) << "'";
+    return failure();
+  }
+};
+
+struct UsesOneLockInDMABlock {
+  static LogicalResult verifyTrait(Operation *op) {
+    auto block = op->getBlock();
+    int lockID = -1;
+    for (auto op : block->getOps<xilinx::AIE::UseLockOp>()) {
+      auto lock = dyn_cast<xilinx::AIE::LockOp>(op.lock().getDefiningOp());
+      if (lockID != -1 && lockID != lock.getLockID())
+        return failure();
+      lockID = lock.getLockID();
+    }
+    return success();
+  }
+};
+
+struct AcquireReleaseOneStateInDMABlock {
+  static LogicalResult verifyTrait(Operation *op) {
+    auto block = op->getBlock();
+    int acqValue = -1, relValue = -1;
+    for (auto op : block->getOps<xilinx::AIE::UseLockOp>()) {
+      if (op.acquire()) {
+        if (acqValue != -1 && acqValue != op.getLockValue()) {
+          return failure();
+        }
+        acqValue = op.getLockValue();
+      } else if (op.release()) {
+        if (relValue != -1 && relValue != op.getLockValue()) {
+          return failure();
+        }
+        relValue = op.getLockValue();
+      }
+    }
+    return success();
   }
 };
 
@@ -515,17 +547,31 @@ LogicalResult xilinx::AIE::UseLockOp::verify() {
   if (llvm::isa<mlir::ModuleOp>((*this)->getParentOp()))
     return success();
 
-  return HasSomeParent<xilinx::AIE::CoreOp, xilinx::AIE::MemOp,
-                       xilinx::AIE::ShimDMAOp>::verifyTrait(*this);
+  // Otherwise, AIE.useLock should be inside CoreOp, MemOp, or ShimDMAOp
+  if (HasSomeParent<xilinx::AIE::MemOp, xilinx::AIE::ShimDMAOp>::verifyTrait(
+          *this)
+          .succeeded()) {
+    if (!(*this)->getBlock())
+      return (*this)->emitOpError("is not in a block.");
 
-  //  xilinx::AIE::LockOp lockOp =
-  //  dyn_cast_or_null<xilinx::AIE::LockOp>(op.lock().getDefiningOp());
-  //   if (!lockOp) {
-  //     op.emitOpError() << "Expected LockOp!\n";
-  // //    return failure();
-  //   }
+    if (UsesOneLockInDMABlock::verifyTrait(*this).failed())
+      return (*this)->emitOpError(
+          "used in a DMA block that have multiple locks.");
 
-  return success();
+    if (AcquireReleaseOneStateInDMABlock::verifyTrait(*this).failed())
+      return (*this)->emitOpError(
+          "acquires/releases the lock in a DMA block from/to multiple states.");
+
+    return success();
+
+  } else if (HasSomeParent<xilinx::AIE::CoreOp>::verifyTrait(*this)
+                 .succeeded()) {
+    return success();
+
+  } else {
+    return (*this)->emitOpError() << "expects some parent op to be one of "
+                                  << "AIE::core, AIE::mem, or AIE::shimDMA";
+  }
 }
 
 #include "aie/AIEEnums.cpp.inc"

--- a/test/xaie_target/test_error_dma_multi_lock.mlir
+++ b/test/xaie_target/test_error_dma_multi_lock.mlir
@@ -1,0 +1,30 @@
+//===- test_error_dma_multi_lock.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: (aie-translate --aie-generate-xaie %s 2>&1 || true) | FileCheck %s
+// CHECK: used in a DMA block that have multiple locks.
+
+module @test_error_dma_multi_lock {
+  %t33 = AIE.tile(3, 3)
+  %l33_0 = AIE.lock(%t33, 0)
+  %l33_1 = AIE.lock(%t33, 1)
+  AIE.mem(%t33) {
+    AIE.dmaStart(MM2S0, ^bb1, ^end)
+  ^bb1:
+    AIE.useLock(%l33_0, Acquire, 1)
+    // This should fail because only one lock can be used in a DmaBd
+    AIE.useLock(%l33_1, Acquire, 1)
+    AIE.useLock(%l33_0, Release, 0)
+    AIE.useLock(%l33_1, Release, 0)
+    cf.br ^end
+  ^end:
+    AIE.end
+  }
+}

--- a/test/xaie_target/test_error_dma_multi_state.mlir
+++ b/test/xaie_target/test_error_dma_multi_state.mlir
@@ -1,0 +1,29 @@
+//===- test_error_dma_multi_state.mlir -------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: (aie-translate --aie-generate-xaie %s 2>&1 || true) | FileCheck %s
+// CHECK: acquires/releases the lock in a DMA block from/to multiple states.
+
+module @test_error_dma_multi_state {
+  %t33 = AIE.tile(3, 3)
+  %l33_0 = AIE.lock(%t33, 0)
+  AIE.mem(%t33) {
+    AIE.dmaStart(MM2S0, ^bb1, ^end)
+  ^bb1:
+    AIE.useLock(%l33_0, Acquire, 0)
+    // This should fail because only one state can be acquired in a DmaBd
+    AIE.useLock(%l33_0, Acquire, 1)
+    AIE.useLock(%l33_0, Release, 0)
+    AIE.useLock(%l33_0, Release, 1)
+    cf.br ^end
+  ^end:
+    AIE.end
+  }
+}

--- a/test/xaie_target/test_error_shimdma_multi_lock.mlir
+++ b/test/xaie_target/test_error_shimdma_multi_lock.mlir
@@ -1,0 +1,30 @@
+//===- test_error_shimdma_multi_lock.mlir ----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: (aie-translate --aie-generate-xaie %s 2>&1 || true) | FileCheck %s
+// CHECK: used in a DMA block that have multiple locks.
+
+module @test_error_shimdma_multi_lock {
+  %t30 = AIE.tile(3, 0)
+  %l30_0 = AIE.lock(%t30, 0)
+  %l30_1 = AIE.lock(%t30, 1)
+  AIE.shimDMA(%t30) {
+    AIE.dmaStart(MM2S0, ^bb1, ^end)
+  ^bb1:
+    AIE.useLock(%l30_0, Acquire, 1)
+    // This should fail because only one state can be acquired in a ShimBd
+    AIE.useLock(%l30_1, Acquire, 1)
+    AIE.useLock(%l30_0, Release, 0)
+    AIE.useLock(%l30_1, Release, 0)
+    cf.br ^end
+  ^end:
+    AIE.end
+  }
+}

--- a/test/xaie_target/test_error_shimdma_multi_state.mlir
+++ b/test/xaie_target/test_error_shimdma_multi_state.mlir
@@ -1,0 +1,29 @@
+//===- test_error_shimdma_multi_state.mlir ---------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: (aie-translate --aie-generate-xaie %s 2>&1 || true) | FileCheck %s
+// CHECK: acquires/releases the lock in a DMA block from/to multiple states.
+
+module @test_error_shimdma_multi_state {
+  %t30 = AIE.tile(3, 0)
+  %l30_0 = AIE.lock(%t30, 0)
+  AIE.shimDMA(%t30) {
+    AIE.dmaStart(MM2S0, ^bb1, ^end)
+  ^bb1:
+    AIE.useLock(%l30_0, Acquire, 0)
+    // This should fail because only one lock can be used in a ShimBd
+    AIE.useLock(%l30_0, Acquire, 1)
+    AIE.useLock(%l30_0, Release, 0)
+    AIE.useLock(%l30_0, Release, 1)
+    cf.br ^end
+  ^end:
+    AIE.end
+  }
+}


### PR DESCRIPTION
This PR performs a sanity check and emits an error if the user uses multiple locks in one single (Shim)DMA block, which is not supported in the XAIE library.  It also emits an error if the user attempts to acquire/release the lock from/to multiple states in a single block.