### PR TITLE
Support initialization of locks in MLIR

### DIFF
--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -975,7 +975,9 @@ def AIE_UseLockOp: AIE_Op<"useLock", []> {
   let description = [{
     This operation uses a lock. A lock can be acquired with a value, or release with a value.
     This should be understood as a "blocking" operation.  This lock must appear in a parent op
-    where the tile can be determined (A CoreOp, a ShimDMAOp, or a MemOp).
+    where the tile can be determined (A CoreOp, a ShimDMAOp, or a MemOp).  If the useLock
+    operation appears in a module directly, an initialization to the lock will be generated in
+    the host implementation.
   }];
   let arguments = (
     ins Index:$lock,

--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -497,9 +497,9 @@ int xilinx::AIE::SwitchboxOp::rowIndex() { return getTileOp().rowIndex(); }
 
 template <typename... ParentOpTypes> struct HasSomeParent {
   static LogicalResult verifyTrait(Operation *op) {
-    Operation *operation = op;
+    Operation *operation = op->getParentOp();
     while (operation) {
-      if (llvm::isa<ParentOpTypes...>(operation->getParentOp()))
+      if (llvm::isa<ParentOpTypes...>(operation))
         return success();
       operation = operation->getParentOp();
     }
@@ -511,6 +511,10 @@ template <typename... ParentOpTypes> struct HasSomeParent {
 };
 
 LogicalResult xilinx::AIE::UseLockOp::verify() {
+  // AIE.useLock may be used in a module to set the lock's default value
+  if (llvm::isa<mlir::ModuleOp>((*this)->getParentOp()))
+    return success();
+
   return HasSomeParent<xilinx::AIE::CoreOp, xilinx::AIE::MemOp,
                        xilinx::AIE::ShimDMAOp>::verifyTrait(*this);
 

--- a/lib/Targets/AIETargetXAIEV1.cpp
+++ b/lib/Targets/AIETargetXAIEV1.cpp
@@ -521,10 +521,10 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
     int row = tile.rowIndex();
     int lockID = lock.getLockID();
     if (op.acquire()) {
-      output << "XAieTile_LockAcquire(" << tileDMAInstStr(col, row) << ", "
+      output << "XAieTile_LockAcquire(" << tileInstStr(col, row) << ", "
              << lockID << ", " << lockVal << ", " << timeOut << ");\n";
     } else if (op.release()) {
-      output << "XAieTile_LockRelease(" << tileDMAInstStr(col, row) << ", "
+      output << "XAieTile_LockRelease(" << tileInstStr(col, row) << ", "
              << lockID << ", " << lockVal << ", " << timeOut << ");\n";
     }
   }

--- a/test/unit_tests/22_init_locks/aie.mlir
+++ b/test/unit_tests/22_init_locks/aie.mlir
@@ -1,0 +1,40 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: valid_xchess_license
+// RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib%/ %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
+// RUN: %run_on_board ./test.elf
+
+module @test22_init_locks {
+  %tile13 = AIE.tile(1, 3)
+
+  %buf13_0 = AIE.buffer(%tile13) { sym_name = "a" } : memref<256xi32>
+  %buf13_1 = AIE.buffer(%tile13) { sym_name = "b" } : memref<256xi32>
+
+  %lock13_3 = AIE.lock(%tile13, 3)
+  %lock13_5 = AIE.lock(%tile13, 5)
+  AIE.useLock(%lock13_3, "Acquire", 1)
+
+  %core13 = AIE.core(%tile13) {
+    AIE.useLock(%lock13_3, "Acquire", 1) // acquire for read(e.g. input ping)
+    AIE.useLock(%lock13_5, "Acquire", 0) // acquire for write
+    %idx1 = arith.constant 3 : index
+    %val1 = memref.load %buf13_0[%idx1] : memref<256xi32>
+    %2    = arith.addi %val1, %val1 : i32
+    %3 = arith.addi %2, %val1 : i32
+    %4 = arith.addi %3, %val1 : i32
+    %5 = arith.addi %4, %val1 : i32
+    %idx2 = arith.constant 5 : index
+    memref.store %5, %buf13_1[%idx2] : memref<256xi32>
+    AIE.useLock(%lock13_3, "Release", 0) // release for write
+    AIE.useLock(%lock13_5, "Release", 1) // release for read
+    AIE.end
+  }
+}

--- a/test/unit_tests/22_init_locks/test.cpp
+++ b/test/unit_tests/22_init_locks/test.cpp
@@ -1,0 +1,76 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2020 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define LOCK_TIMEOUT 100
+#define HIGH_ADDR(addr) ((addr & 0xffffffff00000000) >> 32)
+#define LOW_ADDR(addr) (addr & 0x00000000ffffffff)
+#define MLIR_STACK_OFFSET 4096
+
+#include "aie_inc.cpp"
+
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
+
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
+
+  mlir_aie_clear_tile_memory(_xaie, 1, 3);
+
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_configure_dmas(_xaie);
+  mlir_aie_initialize_locks(_xaie);
+
+  int errors = 0;
+  mlir_aie_write_buffer_a(_xaie, 3, 7);
+
+  printf("Start cores\n");
+  mlir_aie_start_cores(_xaie);
+
+  sleep(1);
+
+  mlir_aie_check("Before release lock:", mlir_aie_read_buffer_b(_xaie, 5), 0,
+                 errors);
+
+  printf("Release input buffer lock.\n");
+  mlir_aie_release_lock(_xaie, 1, 3, 3, 1, 0);
+
+  printf("Waiting to acquire output lock for read ...\n");
+  if (!mlir_aie_acquire_lock(_xaie, 1, 3, 5, 1, LOCK_TIMEOUT)) {
+    printf("ERROR: timeout hit!\n");
+  }
+  mlir_aie_check("After acquire lock:", mlir_aie_read_buffer_b(_xaie, 5), 35,
+                 errors);
+
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
+
+  printf("test done.\n");
+  return res;
+}

--- a/test/xaie_target/test_lock_init.mlir
+++ b/test/xaie_target/test_lock_init.mlir
@@ -1,0 +1,22 @@
+//===- test_lock_init.mlir -----------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-generate-xaie %s | FileCheck %s
+// CHECK: XAieTile_LockAcquire(&(ctx->TileInst[3][3]), 0, 1, 1);
+
+module @test_lock_init {
+  %t33 = AIE.tile(3, 3)
+  %l33_0 = AIE.lock(%t33, 0)
+  // When written in the top-level module, the useLock is treated as
+  // an initialization to the lock.  For example, in the operation below,
+  // the lock %l33_0 is to be initialized as Acquired 1 when the host function
+  // mlir_aie_initialize_locks(ctx) is invoked.
+  AIE.useLock(%l33_0, Acquire, 1)
+}


### PR DESCRIPTION
This PR supports the initialization of locks when `AIE.useLock` is written in the top-level module.  This feature was previously partially implemented, but unable to run end-to-end, and has some minor issues.

An example usage could be seen at: https://github.com/Xilinx/mlir-aie/blob/7fe1988fa99d93a5ce337f1deed06865d93a2a5f/test/xaie_target/test_lock_init.mlir