### PR TITLE
Use system version of opt and llvm-link

### DIFF
--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -194,7 +194,7 @@ def main(builtin_params={}):
         vitis_path = os.path.dirname(vitis_bin_path)
         os.environ['VITIS'] = vitis_path
         print("Found Vitis at " + vitis_path)
-        os.environ['PATH'] = os.pathsep.join([vitis_bin_path, os.environ['PATH']])
+        os.environ['PATH'] = os.pathsep.join([os.environ['PATH'], vitis_bin_path])
  
     if('VITIS' in os.environ):
       vitis_path = os.environ['VITIS']
@@ -206,7 +206,10 @@ def main(builtin_params={}):
       os.environ['AIETOOLS'] = aietools_path
 
       aietools_bin_path = os.path.join(aietools_path, "bin")
-      os.environ['PATH'] = os.pathsep.join([aietools_bin_path, os.environ['PATH']])
+      os.environ['PATH'] = os.pathsep.join([
+        os.environ['PATH'],
+        aietools_bin_path,
+        vitis_bin_path])
 
     # This path should be generated from cmake
     os.environ['PATH'] = os.pathsep.join([aie_path, os.environ['PATH']])


### PR DESCRIPTION
This PR prefers the system (or, `PATH`) version of `opt` and `llvm-link`, when installed or built, to the Vitis version.  This PR also fixes issues raised by Jinming and Andra.  When the Vitis environment is set up, the Vitis version of `llvm-link` will be used, which leads to errors.