### PR TITLE
Add verification of Mul/FMA result's types against operands' and simplify writesToAccumulator()

### DIFF
--- a/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
@@ -413,10 +413,17 @@ template <typename T> LogicalResult verifyMulFMAOp(T op) {
 
   // The datatype of accumulator must always be greater width
   if (atype.isa<IntegerType>()) {
+    if (!ltype.isa<IntegerType>())
+      return op.emitError("Integer result must have integer operands");
+
     if (ltypeWidth >= atypeWidth || rtypeWidth >= atypeWidth)
       return op.emitError("the element type of accumulator must have "
                           "wider width than that of the operand vectors");
   } else if (atype.isa<FloatType>()) {
+    if (!ltype.isa<FloatType>())
+      return op.emitError("Floating point result must have "
+                          "floating point operands");
+
     if (ltypeWidth != atypeWidth || rtypeWidth != atypeWidth)
       return op.emitError("the element type of accumulator must be "
                           "same width as the operand vectors");

--- a/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
+++ b/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
@@ -333,16 +333,18 @@ static bool writesToAccumulator(Operation *op) {
   // Integer muls and FMAs write to accumulator
   if (!isAIEOp(op)) {
     return false;
-  } else if (isa<aievec::MulOp>(op)) {
-    auto mulOp = dyn_cast<aievec::MulOp>(op);
-    auto lhsType = mulOp.lhs().getType().cast<VectorType>().getElementType();
-    auto rhsType = mulOp.rhs().getType().cast<VectorType>().getElementType();
-    return !lhsType.isa<FloatType>() && !rhsType.isa<FloatType>();
-  } else if (isa<aievec::FMAOp>(op)) {
-    auto fmaOp = dyn_cast<aievec::FMAOp>(op);
-    auto lhsType = fmaOp.lhs().getType().cast<VectorType>().getElementType();
-    auto rhsType = fmaOp.rhs().getType().cast<VectorType>().getElementType();
-    return !lhsType.isa<FloatType>() && !rhsType.isa<FloatType>();
+  } else if (auto mulOp = dyn_cast<aievec::MulOp>(op)) {
+    return mulOp.result()
+        .getType()
+        .cast<VectorType>()
+        .getElementType()
+        .isa<IntegerType>();
+  } else if (auto fmaOp = dyn_cast<aievec::FMAOp>(op)) {
+    return fmaOp.result()
+        .getType()
+        .cast<VectorType>()
+        .getElementType()
+        .isa<IntegerType>();
   } else if (isa<aievec::UPSOp>(op))
     return true;
   else


### PR DESCRIPTION
This PR piggybacks off of #113 off of this discussion:
> Is there a constraint that the left and right operands are both float or both int?

> In `AIEVecOps.cpp`, the `verifyMulFMAOp()` function does check to see that the left and right operand's element types are the same, but not the result's. Another option prior to separating the ops would be to look at the result's type.

The first commit adds some needed verification of the result element type against that of the operands, as the operand and result element types' widths are compared. The second commit takes advantage of the check from the first and simplifies the logic determining whether a Mul or FMA op writes to an accumulator register by checking the result's element type instead that of the operands among other streamlining.

My intent is for these two commits to be discrete and unsquashed.