### PR TITLE
Enable check-aie in CI

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -58,7 +58,7 @@ jobs:
         run: utils/build-llvm.sh
 
       # Build the repo test target in debug mode to build and test.
-      - name: Build (Assert)
+      - name: Build and test (Assert)
         run: |
           mkdir build_assert
           cd build_assert
@@ -75,9 +75,10 @@ jobs:
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           ninja
+          ninja check-aie
 
       # Build the repo test target in release mode to build and test.
-      - name: Build (Release)
+      - name: Build and test (Release)
         run: |
           mkdir build_release
           cd build_release
@@ -92,6 +93,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ \
             -DLLVM_EXTERNAL_LIT=`pwd`/../llvm/build/bin/llvm-lit
           make -j$(nproc)
+          make check-aie
 
   lint-repo:
     name: Check code format

--- a/test/unit_tests/00_itsalive/aie.mlir
+++ b/test/unit_tests/00_itsalive/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py %s
 
 module @test00_itsalive {

--- a/test/unit_tests/01_memory_read_write/aie.mlir
+++ b/test/unit_tests/01_memory_read_write/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/02_lock_acquire_release/aie.mlir
+++ b/test/unit_tests/02_lock_acquire_release/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/03_sync_with_locks/aie.mlir
+++ b/test/unit_tests/03_sync_with_locks/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib%/ %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/04_shared_memory/aie.mlir
+++ b/test/unit_tests/04_shared_memory/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib%/ %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/04_shared_memory/aie_row.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --tmpdir=%t --sysroot=%VITIS_SYSROOT% %s -I%S/../../../runtime_lib/ %S/../../../runtime_lib/test_library.cpp %S/test.cpp -o test.elf
 
 module @test4_row_shared_memory {

--- a/test/unit_tests/05_tiledma/aie.mlir
+++ b/test/unit_tests/05_tiledma/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib%/ %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/08_stream_broadcast/aie.mlir
+++ b/test/unit_tests/08_stream_broadcast/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/09_simple_shim_dma/aie.mlir
+++ b/test/unit_tests/09_simple_shim_dma/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/10_scalar_fp/aie.mlir
+++ b/test/unit_tests/10_scalar_fp/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/11_vector_fp/aie.mlir
+++ b/test/unit_tests/11_vector_fp/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/14_stream_packet/aie.mlir
+++ b/test/unit_tests/14_stream_packet/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/15_prime_sieve/aie.mlir
+++ b/test/unit_tests/15_prime_sieve/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/17_shim_dma_with_core/aie.mlir
+++ b/test/unit_tests/17_shim_dma_with_core/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 //  clang -O2 --target=aie -c %S/kernel.cc
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/18_simple_shim_dma_routed/aie.mlir
+++ b/test/unit_tests/18_simple_shim_dma_routed/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/19_shim_dma_with_core_routed/aie.mlir
+++ b/test/unit_tests/19_shim_dma_with_core_routed/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 //  clang -O2 --target=aie -c %S/kernel.cc
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/20_shim_dma_broadcast/aie.mlir
+++ b/test/unit_tests/20_shim_dma_broadcast/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --pathfinder --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 

--- a/test/unit_tests/21_target_triple/aie.mlir
+++ b/test/unit_tests/21_target_triple/aie.mlir
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: valid_xchess_license
 // RUN: aiecc.py --sysroot=%VITIS_SYSROOT% %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 


### PR DESCRIPTION
The current CI does not perform basic tests.  This PR enables `check-aie` to make sure basic checks without the requirement of `xchess` are performed on all PRs.