### PR TITLE
Workaround xchesscc by disabling opaque pointers

### DIFF
--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -91,7 +91,7 @@ def run_flow(opts, tmpdirname):
         file_core_ldscript = tmpcorefile(core, "ld.script")
         do_call(['aie-translate', file_with_addresses, '--aie-generate-ldscript', '--tilecol=%d' % corecol, '--tilerow=%d' % corerow, '-o', file_core_ldscript])
         file_core_llvmir = tmpcorefile(core, "ll")
-        do_call(['aie-translate', '--mlir-to-llvmir', file_opt_core, '-o', file_core_llvmir])
+        do_call(['aie-translate', '--mlir-to-llvmir', '--opaque-pointers=0', file_opt_core, '-o', file_core_llvmir])
         file_core_elf = elf_file if elf_file else corefile(".", core, "elf")
         file_core_obj = tmpcorefile(core, "o")
         if(opts.xchesscc):


### PR DESCRIPTION
#123 has several `xchesscc` tests failing with the error message:

```
acdc_project/core_7_3.chesslinked.ll:11:54: error: expected type
@__chess_separator_dummy = external dso_local global ptr, align 4
                                                     ^
```

This is because `xchesscc` does not support [Opaque Pointers](https://llvm.org/docs/OpaquePointers.html) introduced in LLVM 15.  A workaround is proposed in this PR to disable opaque-pointers in `mlir-translate` temporarily.