### PR TITLE
Change to .gitignore to account for new mlir-aie build instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build*
+/install*
 .vscode
 __pycache__
 


### PR DESCRIPTION
In the updated build script for mlir-aie, the "install" folder is created outside the "build" folder. This PR accounts for that change.