### PR TITLE
update chess-clang hack

### DIFF
--- a/tools/chess-clang/xchesscc_wrapper
+++ b/tools/chess-clang/xchesscc_wrapper
@@ -12,4 +12,4 @@ export UNWRAPPED_XCHESSCC=$AIETOOLS/bin/unwrapped/lnx64.o/xchesscc
 export LD_LIBRARY_PATH=$AIETOOLS/lib/lnx64.o:$AIETOOLS/lnx64/tools/dot/lib:$LD_LIBRARY_PATH
 # Carefully crafted path so that we can inject other scripts into the chess path, namely chess-clang
 export PATH=$DIR:$AIETOOLS/bin/unwrapped/lnx64.o:$AIETOOLS/tps/lnx64/target/bin/LNa64bin
-$UNWRAPPED_XCHESSCC +P 4 -p me -C Release_LLVM -P $AIETOOLS/data/cervino/lib -d -f $@
+$UNWRAPPED_XCHESSCC +P 4 -p me -C Release_LLVM -Y clang=$DIR/chess-clang -P $AIETOOLS/data/cervino/lib -d -f $@


### PR DESCRIPTION
Newer versions of the chess tools rely less on the path, but provide
an way of specifying alternative versions of tools like clang.