### PR TITLE
Allow useLock operations in functions

### DIFF
--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -796,7 +796,7 @@ LogicalResult xilinx::AIE::UseLockOp::verify() {
   if (llvm::isa<mlir::ModuleOp>((*this)->getParentOp()))
     return success();
 
-  // Otherwise, AIE.useLock should be inside CoreOp, MemOp, or ShimDMAOp
+  // Otherwise, AIE.useLock should be inside MemOp, or ShimDMAOp,
   if (HasSomeParent<xilinx::AIE::MemOp, xilinx::AIE::ShimDMAOp>::verifyTrait(
           *this)
           .succeeded()) {
@@ -813,13 +813,14 @@ LogicalResult xilinx::AIE::UseLockOp::verify() {
 
     return success();
 
-  } else if (HasSomeParent<xilinx::AIE::CoreOp>::verifyTrait(*this)
+  // Or it can be in a CoreOp, or some FuncOp called from a CoreOp
+  } else if (HasSomeParent<xilinx::AIE::CoreOp, func::FuncOp>::verifyTrait(*this)
                  .succeeded()) {
     return success();
 
   } else {
     return (*this)->emitOpError() << "expects some parent op to be one of "
-                                  << "AIE::core, AIE::mem, or AIE::shimDMA";
+                                  << "AIE::core, func::func, AIE::mem, or AIE::shimDMA";
   }
 }
 

--- a/test/lower-to-standard/useLock_in_func.mlir
+++ b/test/lower-to-standard/useLock_in_func.mlir
@@ -1,0 +1,30 @@
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering="tilecol=1 tilerow=3" %s | FileCheck --check-prefix=CHECK %s
+
+// CHECK: module @test attributes {llvm.target_triple = "aie"} {
+// CHECK:   func.func private @kernel(%arg0: index) {
+// CHECK-NEXT:     %0 = arith.index_cast %arg0 : index to i32
+// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:     call @llvm.aie.lock.acquire.reg(%0, %c0_i32) : (i32, i32) -> ()
+// CHECK-NEXT:     return
+// CHECK:   }
+// CHECK:   func.func @core13() {
+// CHECK:     %c48 = arith.constant 48 : index
+// CHECK:     call @kernel(%c48) : (index) -> ()
+// CHECK:     return
+// CHECK:   }
+// CHECK: }
+
+module @test {
+  %tile13 = AIE.tile(1, 3)
+  %lock13_3 = AIE.lock(%tile13, 0)
+
+  func.func private @kernel(%lock : index) {
+    AIE.useLock(%lock, "Acquire", 0)
+    return
+  }
+
+  %core13 = AIE.core(%tile13) {
+    func.call @kernel(%lock13_3) : (index) -> ()
+    AIE.end
+  }
+}


### PR DESCRIPTION
With the --localize-locks pass converting locks into integer indexes,
we no longer need to be restricted to useLock operations existing
primarily in CoreOps.  Instead, we can simply pass around the correct
integer indexes.