### PR TITLE
[AIE][AIEVec] Structure aie-vectorize as a pipeline

### DIFF
--- a/docs/AIEVectorization.md
+++ b/docs/AIEVectorization.md
@@ -46,7 +46,7 @@ The super-vectorizer blocks the loop by a factor of 8, replacing scalar operatio
 The ['AIE Vectorize' pass](https://xilinx.github.io/mlir-aie/AIEVecPasses.html) in this repository transforms the above vector code into AIEngine-specific vector operations, represented in the [AIEVec Dialect](https://xilinx.github.io/mlir-aie/AIEVecOps.html).  These operations use types that are directly implementable in the AIEngine architecture and represent device specific features, such as the vector permute network.
 
 ```
-aie-opt -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-vectorize < pointwise_mult_f32.mlir
+aie-opt -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-affine-vectorize < pointwise_mult_f32.mlir
 ```
 ```
   func.func @pointwise_mult(%arg0: memref<2048xf32>, %arg1: memref<2048xf32>, %arg2: memref<2048xf32>) {
@@ -67,7 +67,7 @@ aie-opt -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --a
 
 This code can be translated to C++ code that can be included in a Vitis design:
 ```
-aie-opt -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize < ../../aie/test/aievec/pointwise_mult_f32.mlir | aie-translate --aievec-to-cpp
+aie-opt -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize < ../../aie/test/aievec/pointwise_mult_f32.mlir | aie-translate --aievec-to-cpp
 ```
 ```
 void pointwise_mult(float * restrict v1, float * restrict v2, float * restrict v3) {
@@ -92,7 +92,7 @@ void pointwise_mult(float * restrict v1, float * restrict v2, float * restrict v
 
 The AIEngine architecture supports a number of different datatypes, typically supporting different vector sizes.  For 16-bit values we can vectorize with 
 ```
-aie-opt -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize < pointwise_mult_i16.mlir
+aie-opt -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize < pointwise_mult_i16.mlir
 ```
 ```
 func.func @pointwise_mult (%A: memref<2048xi16>, %B: memref<2048xi16>, %C: memref<2048xi16>) {
@@ -127,7 +127,7 @@ Results in:
 More complex algorithms with multiple loops can be more challenging to vectorize.  Finding a good vectorization scheme may require exploring a number of different vectorization possibilities.  Often it is beneficial to unroll inner loops whose bounds are too small to vectorize.  For instance, in a 2-D convolution, typical in machine learning, unrolling small loops results in a good vectorization strategy:
 
 ```
-aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize < conv2d_i32.mlir
+aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize < conv2d_i32.mlir
 ```
 ```
   func.func @conv2d(%arg0: memref<2048x2048xi32>, %arg1: memref<9xi32>, %arg2: memref<2046x2046xi32>) {
@@ -220,10 +220,10 @@ Resulting in
 
 Running the whole pipeline, we get:
 ```
-mlir-clang --function=conv2d conv2d_i32.c -S --raise-scf-to-affine | aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-vectorize | aie-translate --aievec-to-cpp
+mlir-clang --function=conv2d conv2d_i32.c -S --raise-scf-to-affine | aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-affine-vectorize | aie-translate --aievec-to-cpp
 ```
 ```
-mlir-clang --function=conv2d conv2d_i32.c -S --raise-scf-to-affine | aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-vectorize | aie-translate --aievec-to-cpp
+mlir-clang --function=conv2d conv2d_i32.c -S --raise-scf-to-affine | aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-affine-vectorize | aie-translate --aievec-to-cpp
 void conv2d(int32_t * restrict v4, size_t m1, int32_t * restrict v5, size_t m2, int32_t * restrict v6, size_t m3) {
   size_t v7 = 0;
   size_t v8 = 2;

--- a/include/aie/Dialect/AIEVec/Pipelines/Passes.h
+++ b/include/aie/Dialect/AIEVec/Pipelines/Passes.h
@@ -1,0 +1,69 @@
+//===- Passes.h - AIE Vector pipeline entry points --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes of all AIE vector pipelines.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H
+#define AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H
+
+#include "aie/Dialect/AIEVec/Transforms/Passes.h"
+#include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Pass/PassOptions.h"
+
+namespace xilinx {
+namespace aievec {
+
+/// Options for the "aie-affine-vectorize" pipeline. The pass, as it is, only
+/// accepts a small subset of the parameters for all the sub-passes
+struct AIEAffineVectorizeOptions
+    : public PassPipelineOptions<AIEAffineVectorizeOptions> {
+  // Affine supervectorizer options
+
+  // AIE vectorize options. Keep in sync with AIEVectorizePass options
+  PassOptions::Option<unsigned> shiftParam{
+      *this, "shift",
+      llvm::cl::desc("Shift parameter for rounding and saturation"),
+      llvm::cl::init(0)};
+  PassOptions::Option<unsigned> zeroOffset{
+      *this, "zero-offset",
+      llvm::cl::desc("Zero offset for indicating the location of zeroes in "
+                     "convolution filter (useful for 16x16 scheme)"),
+      llvm::cl::init(0)};
+  PassOptions::Option<unsigned> dupFactor{
+      *this, "dup-factor",
+      llvm::cl::desc("Duplication factor for each value in convolution filter "
+                     "(useful for 8x8 scheme)"),
+      llvm::cl::init(2)};
+
+  /// Project out the options for `createAIEVectorizePass`
+  AIEVectorizeOptions getAIEVectorizeOptions() const {
+    return AIEVectorizeOptions{shiftParam, zeroOffset, dupFactor};
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Building and Registering.
+//===----------------------------------------------------------------------===//
+
+/// Adds the "aie-affine-vectorize" pipeline to the `OpPassManager`. This
+/// is pipeline takes an affine scalar code, vectorizes it, and lowers it to
+/// the AIE vector representation.
+void buildAIEAffineVectorizer(OpPassManager &pm,
+                              const AIEAffineVectorizeOptions &options);
+
+/// Registers all pipelines for the AIE Vector dialect.
+void registerAIEVecPipelines();
+
+} // end namespace aievec
+} // end namespace xilinx
+
+#endif // AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H

--- a/include/aie/Dialect/AIEVec/Transforms/Passes.h
+++ b/include/aie/Dialect/AIEVec/Transforms/Passes.h
@@ -49,10 +49,9 @@ class VectorDialect;
 namespace xilinx {
 namespace aievec {
 
+#define GEN_PASS_DECL_AIEVECTORIZE
 #define GEN_PASS_CLASSES
 #include "aie/Dialect/AIEVec/Transforms/Passes.h.inc"
-
-std::unique_ptr<Pass> createAIEVectorizePass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/aie/Dialect/AIEVec/Transforms/Passes.td
+++ b/include/aie/Dialect/AIEVec/Transforms/Passes.td
@@ -18,7 +18,6 @@ include "mlir/Pass/PassBase.td"
 def AIEVectorize : Pass<"aie-vectorize", "ModuleOp"> {
   let summary = "Vectorize the output of affine "
                 "supervectorizer to AIE vector abstraction";
-  let constructor = "xilinx::aievec::createAIEVectorizePass()";
   let dependentDialects = ["AffineDialect", 
                            "xilinx::aievec::AIEVecDialect",
                            "arith::ArithDialect",

--- a/test/Targets/AIEVecToCpp/polygeist_conv2d_i32.mlir
+++ b/test/Targets/AIEVecToCpp/polygeist_conv2d_i32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-vectorize | aie-translate --aievec-to-cpp > %t.cpp
+// RUN: aie-opt --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8 vectorize-reductions" --aie-affine-vectorize | aie-translate --aievec-to-cpp > %t.cpp
 
 module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.endianness", "little">, #dlti.dl_entry<i64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f80, dense<128> : vector<2xi32>>, #dlti.dl_entry<i1, dense<8> : vector<2xi32>>, #dlti.dl_entry<i8, dense<8> : vector<2xi32>>, #dlti.dl_entry<i16, dense<16> : vector<2xi32>>, #dlti.dl_entry<i32, dense<32> : vector<2xi32>>, #dlti.dl_entry<f16, dense<16> : vector<2xi32>>, #dlti.dl_entry<f64, dense<64> : vector<2xi32>>, #dlti.dl_entry<f128, dense<128> : vector<2xi32>>>, llvm.data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", llvm.target_triple = "x86_64-unknown-linux-gnu"} {
   func.func @conv2d(%arg0: memref<?x272xi32>, %arg1: memref<?x3xi32>, %arg2: memref<?x256xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -21,3 +21,4 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.endianness"
     return
   }
 }
+

--- a/test/aievec/conv2d_f32.mlir
+++ b/test/aievec/conv2d_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xf32>, %arg1: memref<9xf32>, %arg2: memref<2046x2046xf32>) {
 func.func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046xf32>) {

--- a/test/aievec/conv2d_i16.mlir
+++ b/test/aievec/conv2d_i16.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="zero-offset=4" -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="zero-offset=4" -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi16>, %arg1: memref<12xi16>, %arg2: memref<2046x2046xi16>) {
 func.func @conv2d (%A: memref<2048x2048xi16>, %B: memref<12xi16>, %C: memref<2046x2046xi16>) {

--- a/test/aievec/conv2d_i32.mlir
+++ b/test/aievec/conv2d_i32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi32>, %arg1: memref<9xi32>, %arg2: memref<2046x2046xi32>) {
 func.func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046xi32>) {

--- a/test/aievec/conv2d_i8.mlir
+++ b/test/aievec/conv2d_i8.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize -split-input-file | FileCheck %s
+// RUN: aie-opt %s --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
 func.func @conv2d (%A: memref<18x288xi8>, %B: memref<48xi8>, %C: memref<16x256xi8>) {

--- a/test/aievec/conv2d_msc_uij_f32_noinit.mlir
+++ b/test/aievec/conv2d_msc_uij_f32_noinit.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xf32>, %arg1: memref<9xf32>, %arg2: memref<2046x2046xf32>) {
 func.func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046xf32>) {

--- a/test/aievec/conv2d_msc_uij_i32_noinit.mlir
+++ b/test/aievec/conv2d_msc_uij_i32_noinit.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi32>, %arg1: memref<9xi32>, %arg2: memref<2046x2046xi32>) {
 func.func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046xi32>) {

--- a/test/aievec/conv2d_uij_f32.mlir
+++ b/test/aievec/conv2d_uij_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xf32>, %arg1: memref<9xf32>, %arg2: memref<2046x2046xf32>) {
 func.func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046xf32>) {
@@ -111,7 +111,7 @@ func.func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046
 // -unaligned-loads-check=true. The reason is that in transfer_read %arg2[%arg3, %arg4],
 // dim 1's memref shape size(2046) is not divisible by the vector lanes(8).
 
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -split-input-file 2>&1 | FileCheck %s -check-prefix=ALIGNMENT
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -split-input-file 2>&1 | FileCheck %s -check-prefix=ALIGNMENT
 
 // ALIGNMENT: vector.transfer_read's shape size of index 1 is not divisible by number of vector lanes.
 // ALIGNMENT: Cannot apply aie-vectorize to func.func because alignment check has failed.                         

--- a/test/aievec/conv2d_uij_f32_noinit.mlir
+++ b/test/aievec/conv2d_uij_f32_noinit.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xf32>, %arg1: memref<9xf32>, %arg2: memref<2046x2046xf32>) {
 func.func @conv2d (%A: memref<2048x2048xf32>, %B: memref<9xf32>, %C: memref<2046x2046xf32>) {

--- a/test/aievec/conv2d_uij_f32_unbounded.mlir
+++ b/test/aievec/conv2d_uij_f32_unbounded.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @conv2d_0
 func.func @conv2d_0 (%A: memref<?x?xf32>, %B: memref<?xf32>, %C: memref<?x?xf32>) {

--- a/test/aievec/conv2d_uij_i16.mlir
+++ b/test/aievec/conv2d_uij_i16.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=0 zero-offset=4" -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=0 zero-offset=4" -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi16>, %arg1: memref<12xi16>, %arg2: memref<2046x2046xi16>) {
 func.func @conv2d (%A: memref<2048x2048xi16>, %B: memref<12xi16>, %C: memref<2046x2046xi16>) {

--- a/test/aievec/conv2d_uij_i16_noinit.mlir
+++ b/test/aievec/conv2d_uij_i16_noinit.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=10 zero-offset=4" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=10 zero-offset=4" -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @conv2d(%arg0: memref<18x288xi16>, %arg1: memref<12xi16>, %arg2: memref<16x256xi16>) {
 func.func @conv2d (%A: memref<18x288xi16>, %B: memref<12xi16>, %C: memref<16x256xi16>) {

--- a/test/aievec/conv2d_uij_i16_unbounded.mlir
+++ b/test/aievec/conv2d_uij_i16_unbounded.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=0 zero-offset=4" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=0 zero-offset=4" -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d_0
 func.func @conv2d_0 (%A: memref<?x?xi16>, %B: memref<?xi16>, %C: memref<?x?xi16>) {

--- a/test/aievec/conv2d_uij_i32.mlir
+++ b/test/aievec/conv2d_uij_i32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi32>, %arg1: memref<9xi32>, %arg2: memref<2046x2046xi32>) {
 func.func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046xi32>) {

--- a/test/aievec/conv2d_uij_i32_noinit.mlir
+++ b/test/aievec/conv2d_uij_i32_noinit.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi32>, %arg1: memref<9xi32>, %arg2: memref<2046x2046xi32>) {
 func.func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046xi32>) {

--- a/test/aievec/conv2d_uij_i32_unbounded.mlir
+++ b/test/aievec/conv2d_uij_i32_unbounded.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d_0
 func.func @conv2d_0 (%A: memref<?x?xi32>, %B: memref<?xi32>, %C: memref<?x?xi32>) {

--- a/test/aievec/conv2d_uij_i8.mlir
+++ b/test/aievec/conv2d_uij_i8.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=10" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=10" -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
 func.func @conv2d (%A: memref<18x288xi8>, %B: memref<48xi8>, %C: memref<16x256xi8>) {

--- a/test/aievec/conv2d_uij_i8_noinit.mlir
+++ b/test/aievec/conv2d_uij_i8_noinit.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=10" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=10" -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
 func.func @conv2d (%A: memref<18x288xi8>, %B: memref<48xi8>, %C: memref<16x256xi8>) {

--- a/test/aievec/conv2d_uj_i16.mlir
+++ b/test/aievec/conv2d_uj_i16.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=0 zero-offset=4" -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=0 zero-offset=4" -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi16>, %arg1: memref<3x3xi16>, %arg2: memref<2046x2046xi16>) {
 func.func @conv2d (%A: memref<2048x2048xi16>, %B: memref<3x3xi16>, %C: memref<2046x2046xi16>) {

--- a/test/aievec/conv2d_uj_i32.mlir
+++ b/test/aievec/conv2d_uj_i32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi32>, %arg1: memref<3x3xi32>, %arg2: memref<2046x2046xi32>) {
 func.func @conv2d (%A: memref<2048x2048xi32>, %B: memref<3x3xi32>, %C: memref<2046x2046xi32>) {

--- a/test/aievec/gemm64_tile448_unroll8_unaligned_loads.mlir
+++ b/test/aievec/gemm64_tile448_unroll8_unaligned_loads.mlir
@@ -3,7 +3,7 @@
 // (affine.for %arg7 = #map0(%arg4) to #map1(%arg4))'s upper bound’s affine_map(<(d0) -> (d0 + 4)>)
 // result's offset(4) is not divisible by the vector lane size(8).
 
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize 2>&1 | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Loop upper bound's affine map offset of inner index of vector.transfer_read is not divisible by number of vector lanes.
 // CHECK-LABEL: Cannot apply aie-vectorize to func.func because alignment check has failed.
@@ -75,76 +75,83 @@ module {
   }
 }
 
-// CHECK:       #map = affine_map<(d0) -> (d0)>
-// CHECK:       #map1 = affine_map<(d0) -> (d0 + 4)>
-// CHECK:       #map2 = affine_map<(d0, d1) -> (0)>
-// CHECK:       #map3 = affine_map<(d0) -> (d0 + 1)>
-// CHECK:       #map4 = affine_map<(d0) -> (d0 + 2)>
-// CHECK:       #map5 = affine_map<(d0) -> (d0 + 3)>
-// CHECK:       #map6 = affine_map<(d0) -> (d0 + 5)>
-// CHECK:       #map7 = affine_map<(d0) -> (d0 + 6)>
-// CHECK:       #map8 = affine_map<(d0) -> (d0 + 7)>
-// CHECK:       module {
-// CHECK:         func.func @matmul(%[[VAL_0:.*]]: memref<64x64xf32>, %[[VAL_1:.*]]: memref<64x64xf32>, %[[VAL_2:.*]]: memref<64x64xf32>) {
-// CHECK:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           affine.for %[[VAL_4:.*]] = 0 to 64 step 4 {
-// CHECK:             affine.for %[[VAL_5:.*]] = 0 to 64 step 4 {
-// CHECK:               affine.for %[[VAL_6:.*]] = 0 to 64 step 8 {
-// CHECK:                 affine.for %[[VAL_7:.*]] = #map(%[[VAL_4]]) to #map1(%[[VAL_4]]) {
-// CHECK:                   affine.for %[[VAL_8:.*]] = #map(%[[VAL_5]]) to #map1(%[[VAL_5]]) step 8 {
-// CHECK:                     %[[VAL_9:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_6]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_10:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_6]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_11:.*]] = arith.mulf %[[VAL_9]], %[[VAL_10]] : vector<8xf32>
-// CHECK:                     %[[VAL_12:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_7]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_13:.*]] = arith.addf %[[VAL_12]], %[[VAL_11]] : vector<8xf32>
-// CHECK:                     %[[VAL_14:.*]] = affine.apply #map3(%[[VAL_6]])
-// CHECK:                     %[[VAL_15:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_14]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_16:.*]] = affine.apply #map3(%[[VAL_6]])
-// CHECK:                     %[[VAL_17:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_16]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_18:.*]] = arith.mulf %[[VAL_15]], %[[VAL_17]] : vector<8xf32>
-// CHECK:                     %[[VAL_19:.*]] = arith.addf %[[VAL_13]], %[[VAL_18]] : vector<8xf32>
-// CHECK:                     %[[VAL_20:.*]] = affine.apply #map4(%[[VAL_6]])
-// CHECK:                     %[[VAL_21:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_20]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_22:.*]] = affine.apply #map4(%[[VAL_6]])
-// CHECK:                     %[[VAL_23:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_22]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_24:.*]] = arith.mulf %[[VAL_21]], %[[VAL_23]] : vector<8xf32>
-// CHECK:                     %[[VAL_25:.*]] = arith.addf %[[VAL_19]], %[[VAL_24]] : vector<8xf32>
-// CHECK:                     %[[VAL_26:.*]] = affine.apply #map5(%[[VAL_6]])
-// CHECK:                     %[[VAL_27:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_26]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_28:.*]] = affine.apply #map5(%[[VAL_6]])
-// CHECK:                     %[[VAL_29:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_28]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_30:.*]] = arith.mulf %[[VAL_27]], %[[VAL_29]] : vector<8xf32>
-// CHECK:                     %[[VAL_31:.*]] = arith.addf %[[VAL_25]], %[[VAL_30]] : vector<8xf32>
-// CHECK:                     %[[VAL_32:.*]] = affine.apply #map1(%[[VAL_6]])
-// CHECK:                     %[[VAL_33:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_32]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_34:.*]] = affine.apply #map1(%[[VAL_6]])
-// CHECK:                     %[[VAL_35:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_34]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_36:.*]] = arith.mulf %[[VAL_33]], %[[VAL_35]] : vector<8xf32>
-// CHECK:                     %[[VAL_37:.*]] = arith.addf %[[VAL_31]], %[[VAL_36]] : vector<8xf32>
-// CHECK:                     %[[VAL_38:.*]] = affine.apply #map6(%[[VAL_6]])
-// CHECK:                     %[[VAL_39:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_38]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_40:.*]] = affine.apply #map6(%[[VAL_6]])
-// CHECK:                     %[[VAL_41:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_40]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_42:.*]] = arith.mulf %[[VAL_39]], %[[VAL_41]] : vector<8xf32>
-// CHECK:                     %[[VAL_43:.*]] = arith.addf %[[VAL_37]], %[[VAL_42]] : vector<8xf32>
-// CHECK:                     %[[VAL_44:.*]] = affine.apply #map7(%[[VAL_6]])
-// CHECK:                     %[[VAL_45:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_44]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_46:.*]] = affine.apply #map7(%[[VAL_6]])
-// CHECK:                     %[[VAL_47:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_46]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_48:.*]] = arith.mulf %[[VAL_45]], %[[VAL_47]] : vector<8xf32>
-// CHECK:                     %[[VAL_49:.*]] = arith.addf %[[VAL_43]], %[[VAL_48]] : vector<8xf32>
-// CHECK:                     %[[VAL_50:.*]] = affine.apply #map8(%[[VAL_6]])
-// CHECK:                     %[[VAL_51:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_7]], %[[VAL_50]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map2} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_52:.*]] = affine.apply #map8(%[[VAL_6]])
-// CHECK:                     %[[VAL_53:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_52]], %[[VAL_8]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                     %[[VAL_54:.*]] = arith.mulf %[[VAL_51]], %[[VAL_53]] : vector<8xf32>
-// CHECK:                     %[[VAL_55:.*]] = arith.addf %[[VAL_49]], %[[VAL_54]] : vector<8xf32>
-// CHECK:                     vector.transfer_write %[[VAL_55]], %[[VAL_2]]{{\[}}%[[VAL_7]], %[[VAL_8]]] {in_bounds = [true]} : vector<8xf32>, memref<64x64xf32>
-// CHECK:                   }
-// CHECK:                 }
-// CHECK:               }
-// CHECK:             }
-// CHECK:           }
-// CHECK:           return
-// CHECK:         }
-// CHECK:       }
+//CHECK-LABEL:#map = affine_map<(d0, d1) -> (0)>
+//CHECK-NEXT: module {
+//CHECK-NEXT:  func.func @matmul(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>, %arg2: memref<64x64xf32>) {
+//CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f32
+//CHECK-NEXT:    %c0 = arith.constant 0 : index
+//CHECK-NEXT:    %c64 = arith.constant 64 : index
+//CHECK-NEXT:    %c4 = arith.constant 4 : index
+//CHECK-NEXT:    scf.for %arg3 = %c0 to %c64 step %c4 {
+//CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+//CHECK-NEXT:      %c64_1 = arith.constant 64 : index
+//CHECK-NEXT:      %c4_2 = arith.constant 4 : index
+//CHECK-NEXT:      scf.for %arg4 = %c0_0 to %c64_1 step %c4_2 {
+//CHECK-NEXT:        %c0_3 = arith.constant 0 : index
+//CHECK-NEXT:        %c64_4 = arith.constant 64 : index
+//CHECK-NEXT:        %c8 = arith.constant 8 : index
+//CHECK-NEXT:        scf.for %arg5 = %c0_3 to %c64_4 step %c8 {
+//CHECK-NEXT:          %c1 = arith.constant 1 : index
+//CHECK-NEXT:          %0 = arith.addi %arg5, %c1 : index
+//CHECK-NEXT:          %c2 = arith.constant 2 : index
+//CHECK-NEXT:          %1 = arith.addi %arg5, %c2 : index
+//CHECK-NEXT:          %c3 = arith.constant 3 : index
+//CHECK-NEXT:          %2 = arith.addi %arg5, %c3 : index
+//CHECK-NEXT:          %c4_5 = arith.constant 4 : index
+//CHECK-NEXT:          %3 = arith.addi %arg5, %c4_5 : index
+//CHECK-NEXT:          %c5 = arith.constant 5 : index
+//CHECK-NEXT:          %4 = arith.addi %arg5, %c5 : index
+//CHECK-NEXT:          %c6 = arith.constant 6 : index
+//CHECK-NEXT:          %5 = arith.addi %arg5, %c6 : index
+//CHECK-NEXT:          %c7 = arith.constant 7 : index
+//CHECK-NEXT:          %6 = arith.addi %arg5, %c7 : index
+//CHECK-NEXT:          %c4_6 = arith.constant 4 : index
+//CHECK-NEXT:          %7 = arith.addi %arg3, %c4_6 : index
+//CHECK-NEXT:          %c1_7 = arith.constant 1 : index
+//CHECK-NEXT:          scf.for %arg6 = %arg3 to %7 step %c1_7 {
+//CHECK-NEXT:            %c4_8 = arith.constant 4 : index
+//CHECK-NEXT:            %8 = arith.addi %arg4, %c4_8 : index
+//CHECK-NEXT:            %c8_9 = arith.constant 8 : index
+//CHECK-NEXT:            scf.for %arg7 = %arg4 to %8 step %c8_9 {
+//CHECK-NEXT:              %9 = vector.transfer_read %arg0[%arg6, %arg5], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %10 = vector.transfer_read %arg1[%arg5, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %11 = arith.mulf %9, %10 : vector<8xf32>
+//CHECK-NEXT:              %12 = vector.transfer_read %arg2[%arg6, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %13 = arith.addf %12, %11 : vector<8xf32>
+//CHECK-NEXT:              %14 = vector.transfer_read %arg0[%arg6, %0], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %15 = vector.transfer_read %arg1[%0, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %16 = arith.mulf %14, %15 : vector<8xf32>
+//CHECK-NEXT:              %17 = arith.addf %13, %16 : vector<8xf32>
+//CHECK-NEXT:              %18 = vector.transfer_read %arg0[%arg6, %1], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %19 = vector.transfer_read %arg1[%1, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %20 = arith.mulf %18, %19 : vector<8xf32>
+//CHECK-NEXT:              %21 = arith.addf %17, %20 : vector<8xf32>
+//CHECK-NEXT:              %22 = vector.transfer_read %arg0[%arg6, %2], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %23 = vector.transfer_read %arg1[%2, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %24 = arith.mulf %22, %23 : vector<8xf32>
+//CHECK-NEXT:              %25 = arith.addf %21, %24 : vector<8xf32>
+//CHECK-NEXT:              %26 = vector.transfer_read %arg0[%arg6, %3], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %27 = vector.transfer_read %arg1[%3, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %28 = arith.mulf %26, %27 : vector<8xf32>
+//CHECK-NEXT:              %29 = arith.addf %25, %28 : vector<8xf32>
+//CHECK-NEXT:              %30 = vector.transfer_read %arg0[%arg6, %4], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %31 = vector.transfer_read %arg1[%4, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %32 = arith.mulf %30, %31 : vector<8xf32>
+//CHECK-NEXT:              %33 = arith.addf %29, %32 : vector<8xf32>
+//CHECK-NEXT:              %34 = vector.transfer_read %arg0[%arg6, %5], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %35 = vector.transfer_read %arg1[%5, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %36 = arith.mulf %34, %35 : vector<8xf32>
+//CHECK-NEXT:              %37 = arith.addf %33, %36 : vector<8xf32>
+//CHECK-NEXT:              %38 = vector.transfer_read %arg0[%arg6, %6], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %39 = vector.transfer_read %arg1[%6, %arg7], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:              %40 = arith.mulf %38, %39 : vector<8xf32>
+//CHECK-NEXT:              %41 = arith.addf %37, %40 : vector<8xf32>
+//CHECK-NEXT:              vector.transfer_write %41, %arg2[%arg6, %arg7] {in_bounds = [true]} : vector<8xf32>, memref<64x64xf32>
+//CHECK-NEXT:            }
+//CHECK-NEXT:          }
+//CHECK-NEXT:        }
+//CHECK-NEXT:      }
+//CHECK-NEXT:    }
+//CHECK-NEXT:    return
+//CHECK-NEXT:  }
+//CHECK-NEXT:}

--- a/test/aievec/gemm64_unroll4_unaligned_loads.mlir
+++ b/test/aievec/gemm64_unroll4_unaligned_loads.mlir
@@ -2,7 +2,7 @@
 // because in transfer_read %arg0[%arg3, %arg5], the lowest dim(%arg5)'s corresponding
 // loop step(4) is not divisible by the vector lanes(8).
 
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize 2>&1 | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Loop step of inner index of vector.transfer_read is not divisible by number of vector lanes.
 // CHECK-LABEL: Cannot apply aie-vectorize to func.func because alignment check has failed.
@@ -43,44 +43,49 @@ module {
   }
 }
 
-
-// CHECK:       #map = affine_map<(d0, d1) -> (0)>
-// CHECK:       #map1 = affine_map<(d0) -> (d0 + 1)>
-// CHECK:       #map2 = affine_map<(d0) -> (d0 + 2)>
-// CHECK:       #map3 = affine_map<(d0) -> (d0 + 3)>
-// CHECK:       module {
-// CHECK:         func.func @matmul(%[[VAL_0:.*]]: memref<64x64xf32>, %[[VAL_1:.*]]: memref<64x64xf32>, %[[VAL_2:.*]]: memref<64x64xf32>) {
-// CHECK:           %[[VAL_3:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK:           affine.for %[[VAL_4:.*]] = 0 to 64 {
-// CHECK:             affine.for %[[VAL_5:.*]] = 0 to 64 step 8 {
-// CHECK:               affine.for %[[VAL_6:.*]] = 0 to 64 step 4 {
-// CHECK:                 %[[VAL_7:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_6]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_8:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_6]], %[[VAL_5]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_9:.*]] = arith.mulf %[[VAL_7]], %[[VAL_8]] : vector<8xf32>
-// CHECK:                 %[[VAL_10:.*]] = vector.transfer_read %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_5]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_11:.*]] = arith.addf %[[VAL_10]], %[[VAL_9]] : vector<8xf32>
-// CHECK:                 %[[VAL_12:.*]] = affine.apply #map1(%[[VAL_6]])
-// CHECK:                 %[[VAL_13:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_12]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_14:.*]] = affine.apply #map1(%[[VAL_6]])
-// CHECK:                 %[[VAL_15:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_14]], %[[VAL_5]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_16:.*]] = arith.mulf %[[VAL_13]], %[[VAL_15]] : vector<8xf32>
-// CHECK:                 %[[VAL_17:.*]] = arith.addf %[[VAL_11]], %[[VAL_16]] : vector<8xf32>
-// CHECK:                 %[[VAL_18:.*]] = affine.apply #map2(%[[VAL_6]])
-// CHECK:                 %[[VAL_19:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_18]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_20:.*]] = affine.apply #map2(%[[VAL_6]])
-// CHECK:                 %[[VAL_21:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_20]], %[[VAL_5]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_22:.*]] = arith.mulf %[[VAL_19]], %[[VAL_21]] : vector<8xf32>
-// CHECK:                 %[[VAL_23:.*]] = arith.addf %[[VAL_17]], %[[VAL_22]] : vector<8xf32>
-// CHECK:                 %[[VAL_24:.*]] = affine.apply #map3(%[[VAL_6]])
-// CHECK:                 %[[VAL_25:.*]] = vector.transfer_read %[[VAL_0]]{{\[}}%[[VAL_4]], %[[VAL_24]]], %[[VAL_3]] {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_26:.*]] = affine.apply #map3(%[[VAL_6]])
-// CHECK:                 %[[VAL_27:.*]] = vector.transfer_read %[[VAL_1]]{{\[}}%[[VAL_26]], %[[VAL_5]]], %[[VAL_3]] {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
-// CHECK:                 %[[VAL_28:.*]] = arith.mulf %[[VAL_25]], %[[VAL_27]] : vector<8xf32>
-// CHECK:                 %[[VAL_29:.*]] = arith.addf %[[VAL_23]], %[[VAL_28]] : vector<8xf32>
-// CHECK:                 vector.transfer_write %[[VAL_29]], %[[VAL_2]]{{\[}}%[[VAL_4]], %[[VAL_5]]] {in_bounds = [true]} : vector<8xf32>, memref<64x64xf32>
-// CHECK:               }
-// CHECK:             }
-// CHECK:           }
-// CHECK:           return
-// CHECK:         }
-// CHECK:       }
+//CHECK-LABEL:#map = affine_map<(d0, d1) -> (0)>
+//CHECK-NEXT: module {
+//CHECK-NEXT:  func.func @matmul(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>, %arg2: memref<64x64xf32>) {
+//CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f32
+//CHECK-NEXT:    %c0 = arith.constant 0 : index
+//CHECK-NEXT:    %c64 = arith.constant 64 : index
+//CHECK-NEXT:    %c1 = arith.constant 1 : index
+//CHECK-NEXT:    scf.for %arg3 = %c0 to %c64 step %c1 {
+//CHECK-NEXT:      %c0_0 = arith.constant 0 : index
+//CHECK-NEXT:      %c64_1 = arith.constant 64 : index
+//CHECK-NEXT:      %c8 = arith.constant 8 : index
+//CHECK-NEXT:      scf.for %arg4 = %c0_0 to %c64_1 step %c8 {
+//CHECK-NEXT:        %c0_2 = arith.constant 0 : index
+//CHECK-NEXT:        %c64_3 = arith.constant 64 : index
+//CHECK-NEXT:        %c4 = arith.constant 4 : index
+//CHECK-NEXT:        scf.for %arg5 = %c0_2 to %c64_3 step %c4 {
+//CHECK-NEXT:          %0 = vector.transfer_read %arg0[%arg3, %arg5], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %1 = vector.transfer_read %arg1[%arg5, %arg4], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %2 = arith.mulf %0, %1 : vector<8xf32>
+//CHECK-NEXT:          %3 = vector.transfer_read %arg2[%arg3, %arg4], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %4 = arith.addf %3, %2 : vector<8xf32>
+//CHECK-NEXT:          %c1_4 = arith.constant 1 : index
+//CHECK-NEXT:          %5 = arith.addi %arg5, %c1_4 : index
+//CHECK-NEXT:          %6 = vector.transfer_read %arg0[%arg3, %5], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %7 = vector.transfer_read %arg1[%5, %arg4], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %8 = arith.mulf %6, %7 : vector<8xf32>
+//CHECK-NEXT:          %9 = arith.addf %4, %8 : vector<8xf32>
+//CHECK-NEXT:          %c2 = arith.constant 2 : index
+//CHECK-NEXT:          %10 = arith.addi %arg5, %c2 : index
+//CHECK-NEXT:          %11 = vector.transfer_read %arg0[%arg3, %10], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %12 = vector.transfer_read %arg1[%10, %arg4], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %13 = arith.mulf %11, %12 : vector<8xf32>
+//CHECK-NEXT:          %14 = arith.addf %9, %13 : vector<8xf32>
+//CHECK-NEXT:          %c3 = arith.constant 3 : index
+//CHECK-NEXT:          %15 = arith.addi %arg5, %c3 : index
+//CHECK-NEXT:          %16 = vector.transfer_read %arg0[%arg3, %15], %cst {in_bounds = [true], permutation_map = #map} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %17 = vector.transfer_read %arg1[%15, %arg4], %cst {in_bounds = [true]} : memref<64x64xf32>, vector<8xf32>
+//CHECK-NEXT:          %18 = arith.mulf %16, %17 : vector<8xf32>
+//CHECK-NEXT:          %19 = arith.addf %14, %18 : vector<8xf32>
+//CHECK-NEXT:          vector.transfer_write %19, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<8xf32>, memref<64x64xf32>
+//CHECK-NEXT:        }
+//CHECK-NEXT:      }
+//CHECK-NEXT:    }
+//CHECK-NEXT:    return
+//CHECK-NEXT:  }
+//CHECK-NEXT:}

--- a/test/aievec/linalg_conv2d_f32.mlir
+++ b/test/aievec/linalg_conv2d_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s --convert-linalg-to-affine-loops --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s --convert-linalg-to-affine-loops --affine-loop-unroll="unroll-full unroll-full-threshold=3" --canonicalize -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //The affine dialect code is generated from the following linalg operator, with the maps inlined. 
 //CHECK-LABEL: func.func @conv_2d(%arg0: memref<10x3x256x256xf32>, %arg1: memref<10x3x3x3xf32>, %arg2: memref<10x10x254x254xf32>) {

--- a/test/aievec/mul_mul_f32.mlir
+++ b/test/aievec/mul_mul_f32.mlir
@@ -1,7 +1,7 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=10" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=10" -split-input-file | FileCheck %s
 // XFAIL: *
 
-func @mul_mul (%A: memref<2048xf32>, %B: memref<2048xf32>, %C: memref<2048xf32>, %cc: f32) {
+func.func @mul_mul (%A: memref<2048xf32>, %B: memref<2048xf32>, %C: memref<2048xf32>, %cc: f32) {
 // CHECK-LABEL: func @mul_mul
 // CHECK:  %2 = aievec.upd %arg0[%arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048xf32>, vector<8xf32>
 // CHECK:  %3 = aievec.upd %arg1[%arg4] {index = 0 : i8, offset = 0 : si32} : memref<2048xf32>, vector<8xf32>

--- a/test/aievec/pointwise_mult_f32.mlir
+++ b/test/aievec/pointwise_mult_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=10" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=10" -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @pointwise_mult(%arg0: memref<2048xf32>, %arg1: memref<2048xf32>, %arg2: memref<2048xf32>) {
 func.func @pointwise_mult (%A: memref<2048xf32>, %B: memref<2048xf32>, %C: memref<2048xf32>) {

--- a/test/aievec/pointwise_mult_i16.mlir
+++ b/test/aievec/pointwise_mult_i16.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=10" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=10" -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @pointwise_mult(%arg0: memref<2048xi16>, %arg1: memref<2048xi16>, %arg2: memref<2048xi16>) {
 func.func @pointwise_mult (%A: memref<2048xi16>, %B: memref<2048xi16>, %C: memref<2048xi16>) {

--- a/test/aievec/test_add_i16.mlir
+++ b/test/aievec/test_add_i16.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --aie-vectorize -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --aie-affine-vectorize -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<256xi16>, %arg1: memref<1xi16>, %arg2: memref<256xi16>) {
 func.func @conv2d (%A: memref<256xi16>, %B: memref<1xi16>, %C: memref<256xi16>) {

--- a/test/aievec/test_linalg_conv2d.mlir
+++ b/test/aievec/test_linalg_conv2d.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv_2d(%arg0: memref<10x3x256x256xf32>, %arg1: memref<10x3x3x3xf32>, %arg2: memref<10x10x254x254xf32>) {
 func.func @conv_2d(%arg0: memref<10x3x256x256xf32>, %arg1: memref<10x3x3x3xf32>, %arg2: memref<10x10x254x254xf32>) {

--- a/test/aievec/test_reassoc.mlir
+++ b/test/aievec/test_reassoc.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=0" -unaligned-loads-check=false -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=0" -unaligned-loads-check=false -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<2048x2048xi32>, %arg1: memref<9xi32>, %arg2: memref<2046x2046xi32>) {
 func.func @conv2d (%A: memref<2048x2048xi32>, %B: memref<9xi32>, %C: memref<2046x2046xi32>) {

--- a/test/aievec/test_reassoc_add.mlir
+++ b/test/aievec/test_reassoc_add.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @conv2d(%arg0: memref<256xi32>, %arg1: memref<1xi32>, %arg2: memref<256xi32>) {
 func.func @conv2d (%A: memref<256xi32>, %B: memref<1xi32>, %C: memref<256xi32>) {

--- a/test/aievec/test_reassoc_mult.mlir
+++ b/test/aievec/test_reassoc_mult.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -split-input-file | FileCheck %s
 
 // CHECK-LABEL: func.func @conv2d(%arg0: memref<256xi32>, %arg1: memref<1xi32>, %arg2: memref<256xi32>) {
 func.func @conv2d (%A: memref<256xi32>, %B: memref<1xi32>, %C: memref<256xi32>) {

--- a/test/aievec/test_srs.mlir
+++ b/test/aievec/test_srs.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize -split-input-file | FileCheck %s
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize -split-input-file | FileCheck %s
 
 //CHECK-LABEL: func.func @conv2d(%arg0: memref<128xi32>, %arg1: memref<8xi32>, %arg2: memref<126xi32>) {
 func.func @conv2d (%A: memref<128xi32>, %B: memref<8xi32>, %C: memref<126xi32>) {

--- a/test/unit_tests/aievec_tests/float_dynamic_sized_memref/conv2d_uij_f32_unbounded.mlir
+++ b/test/unit_tests/aievec_tests/float_dynamic_sized_memref/conv2d_uij_f32_unbounded.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/float.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
 

--- a/test/unit_tests/aievec_tests/float_static_sized_memref/conv2d_uij_f32_noinit.mlir
+++ b/test/unit_tests/aievec_tests/float_static_sized_memref/conv2d_uij_f32_noinit.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/float.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
 

--- a/test/unit_tests/aievec_tests/i16xi16_dynamic_sized_memref/conv2d_uij_i16_unbounded.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_dynamic_sized_memref/conv2d_uij_i16_unbounded.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=10 zero-offset=4" | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=10 zero-offset=4" | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/i16xi16.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
 

--- a/test/unit_tests/aievec_tests/i16xi16_gemm/gemm64_int16_unroll32.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_gemm/gemm64_int16_unroll32.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" -aieml=true --aie-vectorize | aie-translate -aieml=true --aievec-to-cpp -o gen_aie-ml.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" -aieml=true --aie-affine-vectorize | aie-translate -aieml=true --aievec-to-cpp -o gen_aie-ml.cc
 //RUN: xchesscc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/testbench.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"
 

--- a/test/unit_tests/aievec_tests/i16xi16_static_sized_memref/conv2d_uij_i16_noinit.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_static_sized_memref/conv2d_uij_i16_noinit.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=10 zero-offset=4" | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=10 zero-offset=4" | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/i16xi16.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
 

--- a/test/unit_tests/aievec_tests/i32xi32_dynamic_sized_memref/conv2d_uij_i32_unbounded.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_dynamic_sized_memref/conv2d_uij_i32_unbounded.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=10" | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=10" | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/i32xi32.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
 

--- a/test/unit_tests/aievec_tests/i32xi32_gemm/gemm64_int_unroll16.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_gemm/gemm64_int_unroll16.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" -aieml=true --aie-vectorize | aie-translate -aieml=true --aievec-to-cpp -o gen_aie-ml.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" -aieml=true --aie-affine-vectorize | aie-translate -aieml=true --aievec-to-cpp -o gen_aie-ml.cc
 //RUN: xchesscc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/testbench.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"
 module {

--- a/test/unit_tests/aievec_tests/i32xi32_static_sized_memref/conv2d_uij_i32_noinit.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_static_sized_memref/conv2d_uij_i32_noinit.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-vectorize="shift=10" | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=8" --aie-affine-vectorize="shift=10" | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/i32xi32.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
  

--- a/test/unit_tests/aievec_tests/i8xi8_dynamic_sized_memref/conv2d_uij_i8_unbounded.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_dynamic_sized_memref/conv2d_uij_i8_unbounded.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=0 dup-factor=2" | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=0 dup-factor=2" | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/i8xi8.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
 

--- a/test/unit_tests/aievec_tests/i8xi8_static_sized_memref/conv2d_uij_i8_noinit.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_static_sized_memref/conv2d_uij_i8_noinit.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: valid_xchess_license
-// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=0 dup-factor=2" | aie-translate --aievec-to-cpp -o gen.cc
+// RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-affine-vectorize="shift=0 dup-factor=2" | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc -f -g +s -p me -P ${CARDANO}/data/cervino/lib +w work +o work -I%S -I. %S/i8xi8.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xca_udm_dbg -qf -T -P ${CARDANO}/data/cervino/lib -t "%S/../profiling.tcl ./work/a.out"
 

--- a/tools/aie-opt/aie-opt.cpp
+++ b/tools/aie-opt/aie-opt.cpp
@@ -25,6 +25,7 @@
 #include "aie/AIEPasses.h"
 #include "aie/Dialect/ADF/ADFDialect.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
+#include "aie/Dialect/AIEVec/Pipelines/Passes.h"
 #include "aie/Dialect/AIEVec/Transforms/Passes.h"
 
 using namespace llvm;
@@ -35,6 +36,7 @@ int main(int argc, char **argv) {
   registerAllPasses();
   aie::registerAIEPasses();
   xilinx::aievec::registerAIEVecPasses();
+  xilinx::aievec::registerAIEVecPipelines();
 
   DialectRegistry registry;
   registerAllDialects(registry);


### PR DESCRIPTION
Right now, the AIEVectorize pass is monolithic and makes poor use of MLIR infrastructure. This is the first of a series of patches aimed at modernizing the pass and making it easier to tweak and extend.

I've changed the name from aie-vectorize to aie-affine-vectorize in anticipation of the next patch, which will embed the affine supervectorizer into the pipeline.

In the future, AIEVectorize should also be renamed to something like LowerVectorToAIEVector, which matches better the semantics of the pass.

Also in the future, the pass should be split into a series of conversion and analysis passes that compose better, so we can build more vectorization options reusing the existing code.