### PR TITLE
[AIE] Align source code with llvm bebc9695

### DIFF
--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -114,22 +114,22 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
   let extraClassDeclaration = [{
     int getNumSourceConnections(WireBundle bundle);
     int getNumDestConnections(WireBundle bundle);
-    int colIndex() { return col(); }
-    int rowIndex() { return row(); }
-    bool isShimTile() { return row() == 0; }
+    int colIndex() { return getCol(); }
+    int rowIndex() { return getRow(); }
+    bool isShimTile() { return getRow() == 0; }
     bool isShimNOCTile();
     bool isShimPLTile();
     bool isShimNOCorPLTile();
     bool isInternalMemWest() { return ((rowIndex() % 2) == 0); };
     MemOp getMemOp() {
-      auto users = result().getUsers();
+      auto users = getResult().getUsers();
       for(auto user : users)
         if(auto memOp = llvm::dyn_cast<MemOp>(*user))
           return memOp;
       return nullptr;
     }
     CoreOp getCoreOp() {
-      auto users = result().getUsers();
+      auto users = getResult().getUsers();
       for(auto user : users)
         if(auto coreOp = llvm::dyn_cast<CoreOp>(*user))
           return coreOp;
@@ -362,7 +362,7 @@ def AIE_PLIOOp: AIE_Op<"plio", []>, Results<(outs Index)> {
   }];
   let assemblyFormat = [{ `(` $col `)` attr-dict }];
   let extraClassDeclaration = [{
-    int colIndex() { return col(); }
+    int colIndex() { return getCol(); }
   }];
 }
 
@@ -394,10 +394,10 @@ def AIE_ConnectOp: AIE_Op<"connect", [ParentOneOf<["SwitchboxOp", "ShimMuxOp"]> 
     `<` $sourceBundle `:` $sourceChannel `,` $destBundle `:` $destChannel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int sourceIndex() { return sourceChannel(); }
-    int destIndex() { return destChannel(); }
-    Port sourcePort() { return std::make_pair(sourceBundle(), sourceIndex()); }
-    Port destPort() { return std::make_pair(destBundle(), destIndex()); }
+    int sourceIndex() { return getSourceChannel(); }
+    int destIndex() { return getDestChannel(); }
+    Port sourcePort() { return std::make_pair(getSourceBundle(), sourceIndex()); }
+    Port destPort() { return std::make_pair(getDestBundle(), destIndex()); }
   }];
 }
 
@@ -429,8 +429,8 @@ def AIE_FlowOp: AIE_Op<"flow", []> {
     `(` $source `,` $sourceBundle `:` $sourceChannel `,` $dest `,` $destBundle `:` $destChannel `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int sourceIndex() { return sourceChannel(); }
-    int destIndex() { return destChannel(); }
+    int sourceIndex() { return getSourceChannel(); }
+    int destIndex() { return getDestChannel(); }
   }];
   // let builders = [
   //   OpBuilder<(ins "Value":$source, "int":$sourceBundle,
@@ -475,8 +475,8 @@ def AIE_ConnectionOp: AIE_Op<"connection", []> {
     `(` $source `,` $sourceBundle `:` $sourceChannel `,` $dest `,` $destBundle `:` $destChannel `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int sourceIndex() { return sourceChannel(); }
-    int destIndex() { return destChannel(); }
+    int sourceIndex() { return getSourceChannel(); }
+    int destIndex() { return getDestChannel(); }
   }];
   // let builders = [
   //   OpBuilder<(ins "Value":$source, "int":$sourceBundle,
@@ -522,8 +522,8 @@ def AIE_AMSelOp: AIE_Op<"amsel", [HasParent<"SwitchboxOp">]>, Results<(outs Inde
     `<` $arbiterID `>` `(` $msel `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int arbiterIndex() { return arbiterID(); }
-    int getMselValue() { return msel(); }
+    int arbiterIndex() { return getArbiterID(); }
+    int getMselValue() { return getMsel(); }
   }];
 
   let builders = [
@@ -569,8 +569,8 @@ def AIE_MasterSetOp: AIE_Op<"masterset", [HasParent<"SwitchboxOp">]>, Results<(o
     `(` $destBundle `:` $destChannel `,` $amsels `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int destIndex() { return destChannel(); }
-    Port destPort() { return std::make_pair(destBundle(), destIndex()); }
+    int destIndex() { return getDestChannel(); }
+    Port destPort() { return std::make_pair(getDestBundle(), destIndex()); }
   }];
 }
 
@@ -620,8 +620,8 @@ def AIE_PacketRulesOp: AIE_Op<"packetrules", [/*HasParent<"SwitchboxOp">*/
   }];
   let assemblyFormat = [{ `(` $sourceBundle `:` $sourceChannel `)` regions attr-dict }];
   let extraClassDeclaration = [{
-    int sourceIndex() { return sourceChannel(); }
-    Port sourcePort() { return std::make_pair(sourceBundle(), sourceIndex()); }
+    int sourceIndex() { return getSourceChannel(); }
+    Port sourcePort() { return std::make_pair(getSourceBundle(), sourceIndex()); }
   }];
 }
 
@@ -663,8 +663,8 @@ def AIE_PacketRuleOp: AIE_Op<"rule", [HasParent<"PacketRulesOp">]> {
     ```
   }];
   let extraClassDeclaration = [{
-    int maskInt() { return mask(); }
-    int valueInt() { return value(); }
+    int maskInt() { return getMask(); }
+    int valueInt() { return getValue(); }
   }];
   let assemblyFormat = [{
     `(` $mask `,` $value `,` $amsel `)` attr-dict
@@ -714,8 +714,8 @@ def AIE_BroadcastPacketOp: AIE_Op<"broadcast_packet", [SingleBlockImplicitTermin
   let assemblyFormat = [{ `(` $tile `,` $bundle `:` $channel `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int channelIndex() { return channel(); }
-    Port port() { return std::make_pair(bundle(), channelIndex()); }
+    int channelIndex() { return getChannel(); }
+    Port port() { return std::make_pair(getBundle(), channelIndex()); }
   }];
 }
 
@@ -732,7 +732,7 @@ def AIE_BPIDOp: AIE_Op<"bp_id", [SingleBlockImplicitTerminator<"EndOp">]> {
   }];
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let extraClassDeclaration = [{
-    int IDInt() { return ID(); }
+    int IDInt() { return getID(); }
   }];
 }
 
@@ -752,8 +752,8 @@ def AIE_BPDestOp: AIE_Op<"bp_dest", [HasParent<"BPIDOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return channel(); }
-    Port port() { return std::make_pair(bundle(), channelIndex()); }
+    int channelIndex() { return getChannel(); }
+    Port port() { return std::make_pair(getBundle(), channelIndex()); }
   }];
 }
 
@@ -787,8 +787,8 @@ def AIE_MulticastOp: AIE_Op<"multicast", [SingleBlockImplicitTerminator<"EndOp">
   let assemblyFormat = [{ `(` $tile `,` $bundle `:` $channel `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int channelIndex() { return channel(); }
-    Port port() { return std::make_pair(bundle(), channelIndex()); }
+    int channelIndex() { return getChannel(); }
+    Port port() { return std::make_pair(getBundle(), channelIndex()); }
   }];
 }
 
@@ -810,8 +810,8 @@ def AIE_MultiDestOp: AIE_Op<"multi_dest", [HasParent<"MulticastOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return channel(); }
-    Port port() { return std::make_pair(bundle(), channelIndex()); }
+    int channelIndex() { return getChannel(); }
+    Port port() { return std::make_pair(getBundle(), channelIndex()); }
   }];
 }
 
@@ -838,7 +838,7 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int IDInt() { return ID(); }
+    int IDInt() { return getID(); }
   }];
 }
 
@@ -859,8 +859,8 @@ def AIE_PacketSourceOp: AIE_Op<"packet_source", [HasParent<"PacketFlowOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return channel(); }
-    Port port() { return std::make_pair(bundle(), channelIndex()); }
+    int channelIndex() { return getChannel(); }
+    Port port() { return std::make_pair(getBundle(), channelIndex()); }
   }];
 }
 
@@ -882,8 +882,8 @@ def AIE_PacketDestOp: AIE_Op<"packet_dest", [HasParent<"PacketFlowOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return channel(); }
-    Port port() { return std::make_pair(bundle(), channelIndex()); }
+    int channelIndex() { return getChannel(); }
+    Port port() { return std::make_pair(getBundle(), channelIndex()); }
   }];
 }
 
@@ -931,8 +931,7 @@ def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
   }];
 
   let extraClassDeclaration = [{
-    int getPacketType() { return packet_type(); }
-    int getPacketID() { return packet_id(); }
+    int getPacketID() { return getPacketId(); }
   }];
 
 }
@@ -977,10 +976,10 @@ def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
   }];
 
   let extraClassDeclaration = [{
-    int getOffsetValue() { return offset(); }
-    int getLenValue() { return len(); }
-    bool isA() { return (AB() == 0); }
-    bool isB() { return (AB() == 1); }
+    int getOffsetValue() { return getOffset(); }
+    int getLenValue() { return getLen(); }
+    bool isA() { return (getAB() == 0); }
+    bool isB() { return (getAB() == 1); }
   }];
 
   // let builders = [
@@ -1026,18 +1025,18 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "func::FuncOp", "S
   }];
 
   let extraClassDeclaration = [{
-    bool isSend() { return ((static_cast<int32_t>(dmaChan()) == 2) ||
-                            (static_cast<int32_t>(dmaChan()) == 3)); }
-    bool isRecv() { return ((static_cast<int32_t>(dmaChan()) == 0) ||
-                            (static_cast<int32_t>(dmaChan()) == 1)); }
+    bool isSend() { return ((static_cast<int32_t>(getDmaChan()) == 2) ||
+                            (static_cast<int32_t>(getDmaChan()) == 3)); }
+    bool isRecv() { return ((static_cast<int32_t>(getDmaChan()) == 0) ||
+                            (static_cast<int32_t>(getDmaChan()) == 1)); }
     int getSendChannelIndex() {
-      return static_cast<int32_t>(dmaChan()) - 2;
+      return static_cast<int32_t>(getDmaChan()) - 2;
     }
     int getRecvChannelIndex() {
-      return static_cast<int32_t>(dmaChan()) - 0;
+      return static_cast<int32_t>(getDmaChan()) - 0;
     }
     int getChannelNum() {
-      return static_cast<int32_t>(dmaChan());
+      return static_cast<int32_t>(getDmaChan());
     }
   }];
 
@@ -1103,9 +1102,9 @@ def AIE_LockOp: AIE_Op<"lock", []>, Results<(outs Index)> {
   );
   let assemblyFormat = [{ `(` $tile (`,` $lockID^ )? `)` attr-dict }];
   let extraClassDeclaration = [{
-    int getLockID() { 
-      assert(lockID().has_value() && "Lock has no ID value");
-      return lockID().value();
+    int getLockIDValue() { 
+      assert(getLockID().has_value() && "Lock has no ID value");
+      return getLockID().value();
     }
   }];
   let builders = [
@@ -1162,10 +1161,10 @@ def AIE_UseLockOp: AIE_Op<"useLock", []> {
   ];
 
   let extraClassDeclaration = [{
-    bool acquire() { return (action() == LockAction::Acquire); }
-    bool release() { return (action() == LockAction::Release); }
-    int getLockValue() { return value(); }
-    int getTimeout() { if(auto val = blocking()) return (int)*val; else return 1;}
+    bool acquire() { return (getAction() == LockAction::Acquire); }
+    bool release() { return (getAction() == LockAction::Release); }
+    int getLockValue() { return getValue(); }
+    int getTimeout() { if(auto val = getBlocking()) return (int)*val; else return 1;}
   }];
 }
 
@@ -1260,7 +1259,7 @@ def AIE_TokenOp: AIE_Op<"token", [Symbol]> {
   let arguments = (ins I32Attr:$value);
   let assemblyFormat = [{ `(` $value `)` attr-dict }];
   let extraClassDeclaration = [{
-    int getTokenValue() { return value(); }
+    int getTokenValue() { return getValue(); }
   }];
 }
 
@@ -1278,9 +1277,9 @@ def AIE_UseTokenOp: AIE_Op<"useToken", []> {
   let assemblyFormat = [{ $tokenName `(` $action `,` $value `)` attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    bool acquire() { return (action() == LockAction::Acquire); }
-    bool release() { return (action() == LockAction::Release); }
-    int getTokenValue() { return value(); }
+    bool acquire() { return (getAction() == LockAction::Acquire); }
+    bool release() { return (getAction() == LockAction::Release); }
+    int getTokenValue() { return getValue(); }
   }];
 }
 
@@ -1313,12 +1312,12 @@ def AIE_MemcpyOp: AIE_Op<"memcpy", []> {
         attr-dict `:` `(` type($srcBuf) `,` type($dstBuf) `)`
   }];
   let extraClassDeclaration = [{
-    int getAcquireTokenValue() { return acqValue(); }
-    int getReleaseTokenValue() { return relValue(); }
-    int getSrcOffsetValue() { return srcOffset(); }
-    int getDstOffsetValue() { return dstOffset(); }
-    int getSrcLenValue() { return srcLen(); }
-    int getDstLenValue() { return dstLen(); }
+    int getAcquireTokenValue() { return getAcqValue(); }
+    int getReleaseTokenValue() { return getRelValue(); }
+    int getSrcOffsetValue() { return getSrcOffset(); }
+    int getDstOffsetValue() { return getDstOffset(); }
+    int getSrcLenValue() { return getSrcLen(); }
+    int getDstLenValue() { return getDstLen(); }
   }];
 }
 
@@ -1336,8 +1335,8 @@ def AIE_GetStreamOp: AIE_Op<"getStream", [HasParent<"CoreOp">]>,
     `(` $channel `:` type($channel) `)` attr-dict `:` type($streamValue)
   }];
   let extraClassDeclaration = [{
-    bool isWideStream() { return streamValue().getType().isInteger(128); }
-    bool isFloatStream() { return streamValue().getType().isa<FloatType>(); }
+    bool isWideStream() { return getStreamValue().getType().isInteger(128); }
+    bool isFloatStream() { return getStreamValue().getType().isa<FloatType>(); }
   }];
 }
 
@@ -1354,8 +1353,8 @@ def AIE_PutStreamOp: AIE_Op<"putStream", [HasParent<"CoreOp">]> {
     `(` $streamValue `:` type($streamValue) `,` $channel `:` type($channel) `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    bool isWideStream() { return streamValue().getType().isInteger(128); }
-    bool isFloatStream() { return streamValue().getType().isa<FloatType>(); }
+    bool isWideStream() { return getStreamValue().getType().isInteger(128); }
+    bool isFloatStream() { return getStreamValue().getType().isa<FloatType>(); }
   }];
 }
 
@@ -1409,8 +1408,8 @@ def AIE_HerdOp: AIE_Op<"herd", []>, Results<(outs Index)> {
         I32Attr:$height
   );
   let extraClassDeclaration = [{
-    int getHerdWidth()   { return width(); }
-    int getHerdHeight()  { return height(); }
+    int getHerdWidth()   { return getWidth(); }
+    int getHerdHeight()  { return getHeight(); }
     int getNumAIETiles() { return getHerdWidth() * getHerdHeight(); }
     StringAttr name() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
@@ -1446,8 +1445,8 @@ def AIE_PlaceOp: AIE_Op<"place", []> {
   );
   let assemblyFormat = [{ `(` $sourceHerd `,` $destHerd `,` $distX `,` $distY `)` attr-dict }];
   let extraClassDeclaration = [{
-    int getDistXValue() { return distX(); }
-    int getDistYValue() { return distY(); }
+    int getDistXValue() { return getDistX(); }
+    int getDistYValue() { return getDistY(); }
   }];
 }
 
@@ -1469,8 +1468,8 @@ def AIE_RouteOp: AIE_Op<"route", []> {
         `<` $destHerds   `,` $destBundle   `:` $destChannel   `>` `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int getSourceChannelValue()  { return sourceChannel(); }
-    int getDestChannelValue()  { return destChannel(); }
+    int getSourceChannelValue()  { return getSourceChannel(); }
+    int getDestChannelValue()  { return getDestChannel(); }
   }];
 }
 
@@ -1491,9 +1490,9 @@ def AIE_IterOp: AIE_Op<"iter", []>, Results<(outs Index)> {
   );
   let assemblyFormat = [{ `(` $start `,` $end `,` $stride `)` attr-dict }];
   let extraClassDeclaration = [{
-    int getStartValue()  { return start(); }
-    int getEndValue()    { return end(); }
-    int getStrideValue() { return stride(); }
+    int getStartValue()  { return getStart(); }
+    int getEndValue()    { return getEnd(); }
+    int getStrideValue() { return getStride(); }
   }];
   let builders = [
     OpBuilder<(ins "int":$start, "int":$end, "int":$stride), [{
@@ -1568,7 +1567,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", []> {
   }];
 
   let extraClassDeclaration = [{
-    int size() { return elemNumber(); }
+    int size() { return getElemNumber(); }
     TileOp getProducerTileOp();
     TileOp getConsumerTileOp();
   }];
@@ -1611,11 +1610,11 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    Value getAIEObjectFifo() { return fifo(); }
+    Value getAIEObjectFifo() { return getFifo(); }
     AIEObjectFifoType getAIEObjectFifoType() {
       return getAIEObjectFifo().getType().cast<AIEObjectFifoType>();
     }
-    int acqNumber() { return size(); }
+    int acqNumber() { return getSize(); }
   }];
 }
 
@@ -1648,11 +1647,11 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    Value getAIEObjectFifo() { return fifo(); }
+    Value getAIEObjectFifo() { return getFifo(); }
     AIEObjectFifoType getAIEObjectFifoType() {
       return getAIEObjectFifo().getType().cast<AIEObjectFifoType>();
     }
-    int relNumber() { return size(); }
+    int relNumber() { return getSize(); }
   }];
 }
 
@@ -1686,10 +1685,6 @@ def AIE_ObjectFifoSubviewAccessOp : AIE_Op<"objectFifo.subview.access", []> {
   let builders = [
     OpBuilder<(ins "Value":$subview, "size_t":$index)>
   ];
-
-  let extraClassDeclaration = [{
-    int getIndex() { return index(); }
-  }];
 }
 
 def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
@@ -1721,22 +1716,21 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
   let arguments = (
     ins ObjectFifoPort:$port,
         AIE_ObjectFifoType:$fifo,
-        I32Tensor:$acquirePattern,
-        I32Tensor:$releasePattern,
+        I32Tensor:$acquirePatternTensor,
+        I32Tensor:$releasePatternTensor,
         FlatSymbolRefAttr:$callee,
         Index:$length
   );
 
   let assemblyFormat = [{
-    attr-dict `<` $port `>` `(` $fifo `:` type($fifo) `,` $acquirePattern `:` type($acquirePattern) `,` $releasePattern `:` type($releasePattern) `,` $callee `,` $length`)` 
+    attr-dict `<` $port `>` `(` $fifo `:` type($fifo) `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    ObjectFifoPortAttr getPortAttr() { return portAttr(); }
-    DenseIntElementsAttr getAcquirePattern() { return acquirePattern().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
-    DenseIntElementsAttr getReleasePattern() { return releasePattern().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
-    int getProcessLength() { return length().getDefiningOp<arith::ConstantOp>().getValue().cast<IntegerAttr>().getInt(); }
+    DenseIntElementsAttr getAcquirePattern() { return getAcquirePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
+    DenseIntElementsAttr getReleasePattern() { return getReleasePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
+    int getProcessLength() { return getLength().getDefiningOp<arith::ConstantOp>().getValue().cast<IntegerAttr>().getInt(); }
   }];
 }

--- a/include/aie/AIEInterfaces.td
+++ b/include/aie/AIEInterfaces.td
@@ -41,7 +41,7 @@ def Interconnect : OpInterface<"Interconnect"> {
   let methods = [
     InterfaceMethod<[{
       }],
-      "::mlir::Region &", "connections", (ins )
+      "::mlir::Region &", "getConnections", (ins )
     >,
     InterfaceMethod<[{
       }],

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -52,13 +52,13 @@ def AIEVec_AddOp:
   let extraClassDeclaration = [{
     // Get the attributes
     StringRef getStart(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xstart() : zstart(); }
+                            return idx==0 ? getXstart() : getZstart(); }
     StringRef getOffset(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xoffsets() : zoffsets(); }
+                            return idx==0 ? getXoffsets() : getZoffsets(); }
     StringRef getOffsetHi(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xoffsets_hi() : zoffsets_hi(); } 
+                            return idx==0 ? getXoffsetsHi() : getZoffsetsHi(); } 
     StringRef getSquare(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xsquare() : zsquare(); }
+                            return idx==0 ? getXsquare() : getZsquare(); }
     // Get the attribute names
     StringRef getStartAttrName(int idx) { assert(idx==0 || idx==1); 
                             return idx==0 ? "xstart" : "zstart"; }
@@ -94,13 +94,13 @@ def AIEVec_SubOp:
   let extraClassDeclaration = [{
     // Get the attributes
     StringRef getStart(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xstart() : zstart(); }
+                            return idx==0 ? getXstart() : getZstart(); }
     StringRef getOffset(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xoffsets() : zoffsets(); }
+                            return idx==0 ? getXoffsets() : getZoffsets(); }
     StringRef getOffsetHi(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xoffsets_hi() : zoffsets_hi(); } 
+                            return idx==0 ? getXoffsetsHi() : getZoffsetsHi(); } 
     StringRef getSquare(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xsquare() : zsquare(); }
+                            return idx==0 ? getXsquare() : getZsquare(); }
     // Get the attribute names
     StringRef getStartAttrName(int idx) { assert(idx==0 || idx==1); 
                             return idx==0 ? "xstart" : "zstart"; }
@@ -160,15 +160,15 @@ def AIEVec_FMAOp :
   let extraClassDeclaration = [{
     // Get the attributes
     StringRef getStart(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xstart() : zstart(); }
+                        return idx==0 ? getXstart() : getZstart(); }
     StringRef getOffset(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xoffsets() : zoffsets(); }
+                        return idx==0 ? getXoffsets() : getZoffsets(); }
     StringRef getOffsetHi(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xoffsets_hi() : zoffsets_hi(); } 
+                        return idx==0 ? getXoffsetsHi() : getZoffsetsHi(); } 
     StringRef getStep(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xstep() : zstep(); }
+                        return idx==0 ? getXstep() : getZstep(); }
     StringRef getSquare(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xsquare() : zsquare(); }
+                        return idx==0 ? getXsquare() : getZsquare(); }
     // Get the attribute names
     StringRef getStartAttrName(int idx) { assert(idx==0 || idx==1); 
                         return idx==0 ? "xstart" : "zstart"; }
@@ -225,15 +225,15 @@ def AIEVec_MulOp:
   let extraClassDeclaration = [{
     // Get the attributes
     StringRef getStart(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xstart() : zstart(); }
+                            return idx==0 ? getXstart() : getZstart(); }
     StringRef getOffset(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xoffsets() : zoffsets(); }
+                            return idx==0 ? getXoffsets() : getZoffsets(); }
     StringRef getOffsetHi(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xoffsets_hi() : zoffsets_hi(); } 
+                            return idx==0 ? getXoffsetsHi() : getZoffsetsHi(); } 
     StringRef getStep(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xstep() : zstep(); }
+                            return idx==0 ? getXstep() : getZstep(); }
     StringRef getSquare(int idx) { assert(idx==0 || idx==1); 
-                            return idx==0 ? xsquare() : zsquare(); }
+                            return idx==0 ? getXsquare() : getZsquare(); }
     // Get the attribute names
     StringRef getStartAttrName(int idx) { assert(idx==0 || idx==1); 
                             return idx==0 ? "xstart" : "zstart"; }
@@ -383,13 +383,13 @@ def AIEVec_SelectOp:
   let extraClassDeclaration = [{
     // Get the attributes
     StringRef getStart(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xstart() : ystart(); }
+                        return idx==0 ? getXstart() : getYstart(); }
     StringRef getOffset(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xoffsets() : yoffsets(); }
+                        return idx==0 ? getXoffsets() : getYoffsets(); }
     StringRef getOffsetHi(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xoffsets_hi() : yoffsets_hi(); } 
+                        return idx==0 ? getXoffsetsHi() : getYoffsetsHi(); } 
     StringRef getSquare(int idx) { assert(idx==0 || idx==1); 
-                        return idx==0 ? xsquare() : ysquare(); }
+                        return idx==0 ? getXsquare() : getYsquare(); }
     // Get the attribute names
     StringRef getStartAttrName(int idx) { assert(idx==0 || idx==1); 
                         return idx==0 ? "xstart" : "ystart"; }

--- a/lib/AIEAssignLockIDs.cpp
+++ b/lib/AIEAssignLockIDs.cpp
@@ -46,17 +46,17 @@ struct AIEAssignLockIDsPass
     // value to the key is a pair with the current potential lockID and a set
     // that stores the currently assigned lockIDs.
     for (auto lock : m.getOps<LockOp>()) {
-      if (lock.lockID().has_value()) {
-        Operation *lock_tile = lock.tile().getDefiningOp();
+      if (lock.getLockID().has_value()) {
+        Operation *lock_tile = lock.getTile().getDefiningOp();
         tileToLastID[lock_tile].first = 0;
-        tileToLastID[lock_tile].second.insert(lock.getLockID());
+        tileToLastID[lock_tile].second.insert(lock.getLockIDValue());
       }
     }
 
     // The second pass scans for locks with no lockIDs and assigns locks.
     for (auto lock : m.getOps<LockOp>()) {
-      Operation *lock_tile = lock.tile().getDefiningOp();
-      if (!lock.lockID().has_value()) {
+      Operation *lock_tile = lock.getTile().getDefiningOp();
+      if (!lock.getLockID().has_value()) {
         if (tileToLastID.find(lock_tile) == tileToLastID.end()) {
           // If the tile operation corresponding to the lock does not exist in
           // the data structure, initialize the lockID with 0 with an empty set.

--- a/lib/AIECoreToStandard.cpp
+++ b/lib/AIECoreToStandard.cpp
@@ -66,7 +66,7 @@ struct AIEDebugOpToStdLowering : public OpConversionPattern<DebugOp> {
     auto func = module.lookupSymbol<func::FuncOp>(funcName);
     assert(func && "Could not find the intrinsic function!");
     SmallVector<Value, 1> args;
-    args.push_back(op.arg());
+    args.push_back(op.getArg());
     rewriter.create<func::CallOp>(rewriter.getUnknownLoc(), func, args);
     rewriter.eraseOp(Op);
     return success();
@@ -98,8 +98,8 @@ struct AIEPutStreamToStdLowering : public OpConversionPattern<PutStreamOp> {
     auto putMSFunc = module.lookupSymbol<func::FuncOp>(funcName);
     assert(putMSFunc && "Could not find the intrinsic function!");
     SmallVector<Value, 2> args;
-    args.push_back(op.channel());
-    args.push_back(op.streamValue());
+    args.push_back(op.getChannel());
+    args.push_back(op.getStreamValue());
     rewriter.create<func::CallOp>(rewriter.getUnknownLoc(), putMSFunc, args);
     rewriter.eraseOp(Op);
     return success();
@@ -128,7 +128,7 @@ struct AIEGetStreamToStdLowering : public OpConversionPattern<GetStreamOp> {
     auto getSSFunc = module.lookupSymbol<func::FuncOp>(funcName);
     assert(getSSFunc && "Could not find the intrinsic function!");
     SmallVector<Value, 2> args;
-    args.push_back(op.channel());
+    args.push_back(op.getChannel());
     auto getSSCall = rewriter.create<func::CallOp>(rewriter.getUnknownLoc(),
                                                    getSSFunc, args);
     rewriter.replaceOp(op, getSSCall.getResult(0));
@@ -153,7 +153,7 @@ struct AIEPutCascadeToStdLowering : public OpConversionPattern<PutCascadeOp> {
     auto putMCDFunc = module.lookupSymbol<func::FuncOp>(funcName);
     assert(putMCDFunc && "Could not find the intrinsic function!");
     SmallVector<Value, 2> args;
-    args.push_back(op.cascadeValue());
+    args.push_back(op.getCascadeValue());
     rewriter.create<func::CallOp>(rewriter.getUnknownLoc(), putMCDFunc, args);
     rewriter.eraseOp(Op);
     return success();
@@ -205,7 +205,7 @@ struct AIEUseLockToStdLowering : public OpConversionPattern<UseLockOp> {
 
       args.push_back(rewriter.create<arith::IndexCastOp>(
           useLock.getLoc(), IntegerType::get(rewriter.getContext(), 32),
-          useLock.lock()));
+          useLock.getLock()));
       args.push_back(rewriter.create<arith::ConstantOp>(
           useLock.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(useLock.getLockValue())));
@@ -253,7 +253,7 @@ struct AIECoreToStandardFunc : public OpConversionPattern<CoreOp> {
         rewriter.getUnknownLoc(), coreName,
         FunctionType::get(rewriter.getContext(), {}, {}));
 
-    rewriter.cloneRegionBefore(op.body(), coreFunc.getBody(),
+    rewriter.cloneRegionBefore(op.getBody(), coreFunc.getBody(),
                                coreFunc.getBody().begin(), mapper);
 
     // Create a main function that just calls the core function above.

--- a/lib/AIECreateCores.cpp
+++ b/lib/AIECreateCores.cpp
@@ -135,7 +135,7 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
 
         MemOp mem = builder.create<MemOp>(builder.getUnknownLoc(),
                                           builder.getIndexType(), tile);
-        Region &r = mem.body();
+        Region &r = mem.getBody();
         Block *endBlock = builder.createBlock(&r);
 
         // block terminator
@@ -161,12 +161,12 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
           if (!cores[tileOp]) {
             core = builder.create<CoreOp>(builder.getUnknownLoc(),
                                           builder.getIndexType(), tile);
-            Region &r = core.body();
+            Region &r = core.getBody();
             currentBlock = builder.createBlock(&r);
             builder.setInsertionPointToStart(currentBlock);
           } else {
             core = cores[tileOp];
-            currentBlock = &core.body().back();
+            currentBlock = &core.getBody().back();
             builder.setInsertionPoint(currentBlock->getTerminator());
           }
 

--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -383,11 +383,11 @@ AIEDialect::AIEDialect(mlir::MLIRContext *ctx)
 
 // ObjectFifoCreateOp
 xilinx::AIE::TileOp xilinx::AIE::ObjectFifoCreateOp::getProducerTileOp() {
-  return cast<xilinx::AIE::TileOp>(producerTile().getDefiningOp());
+  return cast<xilinx::AIE::TileOp>(getProducerTile().getDefiningOp());
 }
 
 xilinx::AIE::TileOp xilinx::AIE::ObjectFifoCreateOp::getConsumerTileOp() {
-  return cast<xilinx::AIE::TileOp>(consumerTile().getDefiningOp());
+  return cast<xilinx::AIE::TileOp>(getConsumerTile().getDefiningOp());
 }
 
 // ObjectFifoAcquireOp
@@ -427,7 +427,7 @@ LogicalResult xilinx::AIE::ObjectFifoRegisterProcessOp::verify() {
 }
 
 LogicalResult xilinx::AIE::TileOp::verify() {
-  auto users = result().getUsers();
+  auto users = getResult().getUsers();
   bool found = false;
   for (auto user : users) {
     if (llvm::isa<xilinx::AIE::SwitchboxOp>(*user)) {
@@ -441,7 +441,7 @@ LogicalResult xilinx::AIE::TileOp::verify() {
 }
 
 LogicalResult xilinx::AIE::SwitchboxOp::verify() {
-  Region &body = connections();
+  Region &body = getConnections();
   DenseSet<xilinx::AIE::Port> sourceset;
   DenseSet<xilinx::AIE::Port> destset;
   assert(getOperation()->getNumRegions());
@@ -449,11 +449,11 @@ LogicalResult xilinx::AIE::SwitchboxOp::verify() {
   for (auto &ops : body.front()) {
     if (auto connectOp = dyn_cast<xilinx::AIE::ConnectOp>(ops)) {
       xilinx::AIE::Port source =
-          std::make_pair(connectOp.sourceBundle(), connectOp.sourceIndex());
+          std::make_pair(connectOp.getSourceBundle(), connectOp.sourceIndex());
       sourceset.insert(source);
 
       xilinx::AIE::Port dest =
-          std::make_pair(connectOp.destBundle(), connectOp.destIndex());
+          std::make_pair(connectOp.getDestBundle(), connectOp.destIndex());
       if (destset.count(dest)) {
         return connectOp.emitOpError("targets same destination ")
                << stringifyWireBundle(dest.first) << dest.second
@@ -465,25 +465,25 @@ LogicalResult xilinx::AIE::SwitchboxOp::verify() {
         connectOp.emitOpError("source index cannot be less than zero");
       }
       if (connectOp.sourceIndex() >=
-          getNumSourceConnections(connectOp.sourceBundle())) {
+          getNumSourceConnections(connectOp.getSourceBundle())) {
         connectOp.emitOpError("source index for source bundle ")
-            << stringifyWireBundle(connectOp.sourceBundle())
+            << stringifyWireBundle(connectOp.getSourceBundle())
             << " must be less than "
-            << getNumSourceConnections(connectOp.sourceBundle());
+            << getNumSourceConnections(connectOp.getSourceBundle());
       }
       if (connectOp.destIndex() < 0) {
         connectOp.emitOpError("dest index cannot be less than zero");
       }
       if (connectOp.destIndex() >=
-          getNumDestConnections(connectOp.destBundle())) {
+          getNumDestConnections(connectOp.getDestBundle())) {
         connectOp.emitOpError("dest index for dest bundle ")
-            << stringifyWireBundle(connectOp.destBundle())
+            << stringifyWireBundle(connectOp.getDestBundle())
             << " must be less than "
-            << getNumDestConnections(connectOp.destBundle());
+            << getNumDestConnections(connectOp.getDestBundle());
       }
     } else if (auto connectOp = dyn_cast<xilinx::AIE::MasterSetOp>(ops)) {
       xilinx::AIE::Port dest =
-          std::make_pair(connectOp.destBundle(), connectOp.destIndex());
+          std::make_pair(connectOp.getDestBundle(), connectOp.destIndex());
       if (destset.count(dest)) {
         return connectOp.emitOpError("targets same destination ")
                << stringifyWireBundle(dest.first) << dest.second
@@ -495,15 +495,15 @@ LogicalResult xilinx::AIE::SwitchboxOp::verify() {
         connectOp.emitOpError("dest index cannot be less than zero");
       }
       if (connectOp.destIndex() >=
-          getNumDestConnections(connectOp.destBundle())) {
+          getNumDestConnections(connectOp.getDestBundle())) {
         connectOp.emitOpError("dest index for dest bundle ")
-            << stringifyWireBundle(connectOp.destBundle())
+            << stringifyWireBundle(connectOp.getDestBundle())
             << " must be less than "
-            << getNumDestConnections(connectOp.destBundle());
+            << getNumDestConnections(connectOp.getDestBundle());
       }
 
       int arbiter = -1;
-      for (auto val : connectOp.amsels()) {
+      for (auto val : connectOp.getAmsels()) {
         auto amsel = dyn_cast<xilinx::AIE::AMSelOp>(val.getDefiningOp());
         if ((arbiter != -1) && (arbiter != amsel.arbiterIndex()))
           connectOp.emitOpError(
@@ -512,7 +512,7 @@ LogicalResult xilinx::AIE::SwitchboxOp::verify() {
       }
     } else if (auto connectOp = dyn_cast<xilinx::AIE::PacketRulesOp>(ops)) {
       xilinx::AIE::Port source =
-          std::make_pair(connectOp.sourceBundle(), connectOp.sourceIndex());
+          std::make_pair(connectOp.getSourceBundle(), connectOp.sourceIndex());
       if (sourceset.count(source)) {
         return connectOp.emitOpError("packet switched source ")
                << stringifyWireBundle(source.first) << source.second
@@ -531,7 +531,7 @@ LogicalResult xilinx::AIE::SwitchboxOp::verify() {
 }
 
 LogicalResult xilinx::AIE::ShimSwitchboxOp::verify() {
-  Region &body = connections();
+  Region &body = getConnections();
   DenseSet<xilinx::AIE::Port> destset;
   assert(getOperation()->getNumRegions());
   assert(!body.empty());
@@ -539,7 +539,7 @@ LogicalResult xilinx::AIE::ShimSwitchboxOp::verify() {
   for (auto &ops : body.front()) {
     if (auto connectOp = dyn_cast<xilinx::AIE::ConnectOp>(ops)) {
       xilinx::AIE::Port dest =
-          std::make_pair(connectOp.destBundle(), connectOp.destIndex());
+          std::make_pair(connectOp.getDestBundle(), connectOp.destIndex());
       if (destset.count(dest)) {
         return connectOp.emitOpError("targets same destination ")
                << stringifyWireBundle(dest.first) << dest.second
@@ -557,7 +557,7 @@ LogicalResult xilinx::AIE::ShimSwitchboxOp::verify() {
 }
 
 LogicalResult xilinx::AIE::ShimMuxOp::verify() {
-  Region &body = connections();
+  Region &body = getConnections();
   DenseSet<xilinx::AIE::Port> destset;
   assert(getOperation()->getNumRegions());
   assert(!body.empty());
@@ -569,7 +569,7 @@ LogicalResult xilinx::AIE::ShimMuxOp::verify() {
   for (auto &ops : body.front()) {
     if (auto connectOp = dyn_cast<xilinx::AIE::ConnectOp>(ops)) {
       xilinx::AIE::Port dest =
-          std::make_pair(connectOp.destBundle(), connectOp.destIndex());
+          std::make_pair(connectOp.getDestBundle(), connectOp.destIndex());
       if (destset.count(dest)) {
         return connectOp.emitOpError("targets same destination ")
                << stringifyWireBundle(dest.first) << dest.second
@@ -626,7 +626,7 @@ int xilinx::AIE::ShimMuxOp::getNumDestConnections(WireBundle bundle) {
   }
 }
 xilinx::AIE::TileOp xilinx::AIE::ShimMuxOp::getTileOp() {
-  return cast<xilinx::AIE::TileOp>(tile().getDefiningOp());
+  return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 int xilinx::AIE::ShimMuxOp::colIndex() { return getTileOp().colIndex(); }
 int xilinx::AIE::ShimMuxOp::rowIndex() { return getTileOp().rowIndex(); }
@@ -634,7 +634,7 @@ int xilinx::AIE::ShimMuxOp::rowIndex() { return getTileOp().rowIndex(); }
 // ShimDMAOp
 LogicalResult xilinx::AIE::ShimDMAOp::verify() {
   assert(getOperation()->getNumRegions() == 1 && "ShimDMAOp has zero region!");
-  assert(!body().empty() && "ShimDMAOp should have non-empty body");
+  assert(!getBody().empty() && "ShimDMAOp should have non-empty body");
   auto tileOp = getTileOp();
   if (!tileOp.isShimNOCTile())
     return emitOpError("must be in a ShimTile with a NOC connection");
@@ -642,13 +642,13 @@ LogicalResult xilinx::AIE::ShimDMAOp::verify() {
   return success();
 }
 xilinx::AIE::TileOp xilinx::AIE::ShimDMAOp::getTileOp() {
-  return cast<TileOp>(tile().getDefiningOp());
+  return cast<TileOp>(getTile().getDefiningOp());
 }
 int xilinx::AIE::ShimDMAOp::colIndex() { return getTileOp().colIndex(); }
 int xilinx::AIE::ShimDMAOp::rowIndex() { return getTileOp().rowIndex(); }
 
 LogicalResult xilinx::AIE::MulticastOp::verify() {
-  Region &body = ports();
+  Region &body = getPorts();
   assert(getOperation()->getNumRegions());
   assert(!body.empty());
   for (auto &ops : body.front()) {
@@ -663,7 +663,7 @@ LogicalResult xilinx::AIE::MulticastOp::verify() {
 }
 
 LogicalResult xilinx::AIE::BroadcastPacketOp::verify() {
-  Region &body = ports();
+  Region &body = getPorts();
   assert(getOperation()->getNumRegions());
   assert(!body.empty());
   for (auto &ops : body.front()) {
@@ -678,7 +678,7 @@ LogicalResult xilinx::AIE::BroadcastPacketOp::verify() {
 }
 
 LogicalResult xilinx::AIE::PacketFlowOp::verify() {
-  Region &body = ports();
+  Region &body = getPorts();
   // DenseSet<xilinx::AIE::Port> destset;
   assert(getOperation()->getNumRegions());
   assert(!body.empty());
@@ -697,7 +697,7 @@ LogicalResult xilinx::AIE::PacketFlowOp::verify() {
 // CoreOp
 LogicalResult xilinx::AIE::CoreOp::verify() {
   assert(getOperation()->getNumRegions() == 1 && "CoreOp has zero region!");
-  assert(!body().empty() && "CoreOp should have non-empty body");
+  assert(!getBody().empty() && "CoreOp should have non-empty body");
 
   return success();
 }
@@ -706,7 +706,7 @@ int xilinx::AIE::CoreOp::colIndex() { return getTileOp().colIndex(); }
 
 int xilinx::AIE::CoreOp::rowIndex() { return getTileOp().rowIndex(); }
 xilinx::AIE::TileOp xilinx::AIE::CoreOp::getTileOp() {
-  return cast<xilinx::AIE::TileOp>(tile().getDefiningOp());
+  return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 
 // BufferOp
@@ -715,7 +715,7 @@ int64_t xilinx::AIE::BufferOp::getAllocationSize() {
   return type.getNumElements() * type.getElementTypeBitWidth() / 8;
 }
 xilinx::AIE::TileOp xilinx::AIE::BufferOp::getTileOp() {
-  return cast<xilinx::AIE::TileOp>(tile().getDefiningOp());
+  return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 
 // MemOp
@@ -723,12 +723,12 @@ LogicalResult xilinx::AIE::MemOp::verify() {
   llvm::SmallSet<xilinx::AIE::DMAChan, 4> used_channels;
 
   assert(getOperation()->getNumRegions() == 1 && "MemOp has zero region!");
-  assert(!body().empty() && "MemOp should have non-empty body");
+  assert(!getBody().empty() && "MemOp should have non-empty body");
 
-  for (auto &bodyOp : body().getOps()) {
+  for (auto &bodyOp : getBody().getOps()) {
     // check for duplicate DMA channels within the same MemOp
     if (auto DMA_start = dyn_cast<xilinx::AIE::DMAStartOp>(bodyOp)) {
-      auto DMA_chan = DMA_start.dmaChan();
+      auto DMA_chan = DMA_start.getDmaChan();
       if (used_channels.contains(DMA_chan))
         DMA_start.emitOpError()
             << "Duplicate DMA channel " << stringifyDMAChan(DMA_chan)
@@ -747,14 +747,14 @@ LogicalResult xilinx::AIE::MemOp::verify() {
 }
 
 int xilinx::AIE::MemOp::colIndex() {
-  Operation *Op = tile().getDefiningOp();
+  Operation *Op = getTile().getDefiningOp();
   xilinx::AIE::TileOp tile = dyn_cast<xilinx::AIE::TileOp>(Op);
 
   return tile.colIndex();
 }
 
 int xilinx::AIE::MemOp::rowIndex() {
-  Operation *Op = tile().getDefiningOp();
+  Operation *Op = getTile().getDefiningOp();
   xilinx::AIE::TileOp tile = dyn_cast<xilinx::AIE::TileOp>(Op);
 
   return tile.rowIndex();
@@ -763,13 +763,13 @@ int xilinx::AIE::MemOp::rowIndex() {
 /// Returns the region on the current operation that is callable. This may
 /// return null in the case of an external callable object, e.g. an external
 /// function.
-Region *xilinx::AIE::MemOp::getCallableRegion() { return &(body()); }
+Region *xilinx::AIE::MemOp::getCallableRegion() { return &(getBody()); }
 
 /// Returns the results types that the callable region produces when executed.
 ArrayRef<Type> xilinx::AIE::MemOp::getCallableResults() { return getType(); }
 
 xilinx::AIE::TileOp xilinx::AIE::SwitchboxOp::getTileOp() {
-  return cast<xilinx::AIE::TileOp>(tile().getDefiningOp());
+  return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 int xilinx::AIE::SwitchboxOp::colIndex() { return getTileOp().colIndex(); }
 int xilinx::AIE::SwitchboxOp::rowIndex() { return getTileOp().rowIndex(); }
@@ -791,10 +791,10 @@ struct UsesOneLockInDMABlock {
     auto block = op->getBlock();
     int lockID = -1;
     for (auto op : block->getOps<xilinx::AIE::UseLockOp>()) {
-      auto lock = dyn_cast<xilinx::AIE::LockOp>(op.lock().getDefiningOp());
-      if (lockID != -1 && lockID != lock.getLockID())
+      auto lock = dyn_cast<xilinx::AIE::LockOp>(op.getLock().getDefiningOp());
+      if (lockID != -1 && lockID != lock.getLockIDValue())
         return failure();
-      lockID = lock.getLockID();
+      lockID = lock.getLockIDValue();
     }
     return success();
   }
@@ -977,9 +977,9 @@ int TileOp::getNumDestConnections(WireBundle bundle) {
 static llvm::SmallDenseSet<unsigned, 16> noc_columns = {
     2, 3, 6, 7, 10, 11, 18, 19, 26, 27, 34, 35, 42, 43, 46, 47};
 bool TileOp::isShimNOCTile() {
-  return isShimTile() && noc_columns.contains(col());
+  return isShimTile() && noc_columns.contains(getCol());
 }
 bool TileOp::isShimPLTile() { return isShimNOCorPLTile() && !isShimNOCTile(); }
-bool TileOp::isShimNOCorPLTile() { return isShimTile() && (col() > 0); }
+bool TileOp::isShimNOCorPLTile() { return isShimTile() && (getCol() > 0); }
 } // namespace AIE
 } // namespace xilinx

--- a/lib/AIEHerdRouting.cpp
+++ b/lib/AIEHerdRouting.cpp
@@ -220,8 +220,8 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
 
     for (auto placeOp : m.getOps<PlaceOp>()) {
       placeOps.push_back(placeOp);
-      Operation *sourceHerd = placeOp.sourceHerd().getDefiningOp();
-      Operation *destHerd = placeOp.destHerd().getDefiningOp();
+      Operation *sourceHerd = placeOp.getSourceHerd().getDefiningOp();
+      Operation *destHerd = placeOp.getDestHerd().getDefiningOp();
       int distX = placeOp.getDistXValue();
       int distY = placeOp.getDistYValue();
       distances[std::make_pair(sourceHerd, destHerd)] =
@@ -234,24 +234,25 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
       routeOps.push_back(routeOp);
 
       AIE::SelectOp sourceHerds =
-          dyn_cast<AIE::SelectOp>(routeOp.sourceHerds().getDefiningOp());
+          dyn_cast<AIE::SelectOp>(routeOp.getSourceHerds().getDefiningOp());
       AIE::SelectOp destHerds =
-          dyn_cast<AIE::SelectOp>(routeOp.destHerds().getDefiningOp());
-      WireBundle sourceBundle = routeOp.sourceBundle();
-      WireBundle destBundle = routeOp.destBundle();
+          dyn_cast<AIE::SelectOp>(routeOp.getDestHerds().getDefiningOp());
+      WireBundle sourceBundle = routeOp.getSourceBundle();
+      WireBundle destBundle = routeOp.getDestBundle();
       int sourceChannel = routeOp.getSourceChannelValue();
       int destChannel = routeOp.getDestChannelValue();
 
       HerdOp sourceHerd =
-          dyn_cast<HerdOp>(sourceHerds.startHerd().getDefiningOp());
+          dyn_cast<HerdOp>(sourceHerds.getStartHerd().getDefiningOp());
       IterOp sourceIterX =
-          dyn_cast<IterOp>(sourceHerds.iterX().getDefiningOp());
+          dyn_cast<IterOp>(sourceHerds.getIterX().getDefiningOp());
       IterOp sourceIterY =
-          dyn_cast<IterOp>(sourceHerds.iterY().getDefiningOp());
+          dyn_cast<IterOp>(sourceHerds.getIterY().getDefiningOp());
 
-      HerdOp destHerd = dyn_cast<HerdOp>(destHerds.startHerd().getDefiningOp());
-      IterOp destIterX = dyn_cast<IterOp>(destHerds.iterX().getDefiningOp());
-      IterOp destIterY = dyn_cast<IterOp>(destHerds.iterY().getDefiningOp());
+      HerdOp destHerd =
+          dyn_cast<HerdOp>(destHerds.getStartHerd().getDefiningOp());
+      IterOp destIterX = dyn_cast<IterOp>(destHerds.getIterX().getDefiningOp());
+      IterOp destIterY = dyn_cast<IterOp>(destHerds.getIterY().getDefiningOp());
 
       int sourceStartX = sourceIterX.getStartValue();
       int sourceEndX = sourceIterX.getEndValue();
@@ -328,9 +329,9 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
                                                         herd, iterx, itery);
       SwitchboxOp swbox =
           builder.create<SwitchboxOp>(builder.getUnknownLoc(), sel);
-      swbox.ensureTerminator(swbox.connections(), builder,
+      swbox.ensureTerminator(swbox.getConnections(), builder,
                              builder.getUnknownLoc());
-      Block &b = swbox.connections().front();
+      Block &b = swbox.getConnections().front();
       builder.setInsertionPoint(b.getTerminator());
 
       for (auto connect : connects) {

--- a/lib/AIELocalizeLocks.cpp
+++ b/lib/AIELocalizeLocks.cpp
@@ -35,7 +35,7 @@ struct AIELocalizeLocksPass
     for (auto coreOp : moduleOp.getOps<CoreOp>()) {
       // Collect the locks used in this core.
 
-      TileOp thisTile = dyn_cast<TileOp>(coreOp.tile().getDefiningOp());
+      TileOp thisTile = dyn_cast<TileOp>(coreOp.getTile().getDefiningOp());
       int col = thisTile.colIndex();
       int row = thisTile.rowIndex();
 
@@ -54,7 +54,7 @@ struct AIELocalizeLocksPass
         int dstRow = tile.rowIndex();
         int cardinalMemOffset = 0;
 
-        for (auto user : tile.result().getUsers())
+        for (auto user : tile.getResult().getUsers())
           if (auto lock = dyn_cast<LockOp>(user)) {
             if (isMemSouth(col, row, dstCol, dstRow))
               cardinalMemOffset = 0;
@@ -67,10 +67,10 @@ struct AIELocalizeLocksPass
             else
               llvm_unreachable("Found illegal lock user!");
 
-            int localLockIndex = cardinalMemOffset + lock.getLockID();
+            int localLockIndex = cardinalMemOffset + lock.getLockIDValue();
 
             OpBuilder builder =
-                OpBuilder::atBlockBegin(&(coreOp.body().front()));
+                OpBuilder::atBlockBegin(&(coreOp.getBody().front()));
 
             Value coreLockIDValue = builder.create<arith::ConstantIndexOp>(
                 builder.getUnknownLoc(), localLockIndex);

--- a/lib/AIELowerMemcpy.cpp
+++ b/lib/AIELowerMemcpy.cpp
@@ -25,10 +25,10 @@ using namespace xilinx;
 using namespace xilinx::AIE;
 
 static TileOp srcTileOp(xilinx::AIE::MemcpyOp op) {
-  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.srcTile().getDefiningOp());
+  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.getSrcTile().getDefiningOp());
 }
 static TileOp dstTileOp(xilinx::AIE::MemcpyOp op) {
-  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.dstTile().getDefiningOp());
+  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.getDstTile().getDefiningOp());
 }
 
 struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
@@ -43,7 +43,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
                              DMAChan dmaChannel,
                              ConversionPatternRewriter &rewriter) const {
 
-    Region &r = mem.body();
+    Region &r = mem.getBody();
     Block &endBlock = r.back();
     Block *dmaBlock = rewriter.createBlock(&endBlock);
     Block *bdBlock = rewriter.createBlock(&endBlock);
@@ -69,10 +69,10 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
   LogicalResult matchAndRewrite(MemcpyOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     Operation *Op = op.getOperation();
-    Value srcBuf = op.srcBuf();
-    Value dstBuf = op.dstBuf();
+    Value srcBuf = op.getSrcBuf();
+    Value dstBuf = op.getDstBuf();
 
-    StringRef tokenName = op.tokenName();
+    StringRef tokenName = op.getTokenName();
     int acquireTknVal = op.getAcquireTokenValue();
     int releaseTknVal = op.getReleaseTokenValue();
     int srcOffset = op.getSrcOffsetValue();
@@ -109,17 +109,17 @@ struct AIELowerMemcpyPass : public AIELowerMemcpyBase<AIELowerMemcpyPass> {
     DenseMap<Value, int> destChannel;
     for (auto op : m.getOps<MemcpyOp>()) {
       builder.setInsertionPoint(op);
-      TileOp srcTile = dyn_cast<TileOp>(op.srcTile().getDefiningOp());
-      TileOp dstTile = dyn_cast<TileOp>(op.dstTile().getDefiningOp());
+      TileOp srcTile = dyn_cast<TileOp>(op.getSrcTile().getDefiningOp());
+      TileOp dstTile = dyn_cast<TileOp>(op.getDstTile().getDefiningOp());
       // TODO: perhaps a better approach is to not assert here, but rather have
       // a subsequent pass that legally relocates the ports
-      assert(destChannel[op.dstTile()] <= 2 &&
+      assert(destChannel[op.getDstTile()] <= 2 &&
              "Could not allocate more than two dest. channel when creating "
              "FlowOp");
       builder.create<FlowOp>(builder.getUnknownLoc(), srcTile, WireBundle::DMA,
                              0, dstTile, WireBundle::DMA,
-                             destChannel[op.dstTile()]);
-      destChannel[op.dstTile()]++;
+                             destChannel[op.getDstTile()]);
+      destChannel[op.getDstTile()]++;
     }
 
     ConversionTarget target(getContext());

--- a/lib/AIELowerMulticast.cpp
+++ b/lib/AIELowerMulticast.cpp
@@ -40,13 +40,14 @@ struct AIELowerMulticastPass : public AIEMulticastBase<AIELowerMulticastPass> {
     OpBuilder builder = OpBuilder::atBlockEnd(m.getBody());
 
     for (auto multicast : m.getOps<MulticastOp>()) {
-      Region &r = multicast.ports();
+      Region &r = multicast.getPorts();
       Block &b = r.front();
       Port sourcePort = multicast.port();
-      TileOp srcTile = dyn_cast<TileOp>(multicast.tile().getDefiningOp());
+      TileOp srcTile = dyn_cast<TileOp>(multicast.getTile().getDefiningOp());
       for (Operation &Op : b.getOperations()) {
         if (MultiDestOp multiDest = dyn_cast<MultiDestOp>(Op)) {
-          TileOp destTile = dyn_cast<TileOp>(multiDest.tile().getDefiningOp());
+          TileOp destTile =
+              dyn_cast<TileOp>(multiDest.getTile().getDefiningOp());
           Port destPort = multiDest.port();
           builder.create<FlowOp>(builder.getUnknownLoc(), srcTile,
                                  sourcePort.first, sourcePort.second, destTile,

--- a/lib/AIENetlistAnalysis.cpp
+++ b/lib/AIENetlistAnalysis.cpp
@@ -44,7 +44,7 @@ void xilinx::AIE::NetlistAnalysis::collectTiles(
 void xilinx::AIE::NetlistAnalysis::collectCores(
     DenseMap<Operation *, CoreOp> &cores) {
   for (auto core : module.getOps<CoreOp>()) {
-    Operation *tileOp = core.tile().getDefiningOp();
+    Operation *tileOp = core.getTile().getDefiningOp();
     assert(cores.count(tileOp) == 0 &&
            "Invalid netlist! Expected 1-1 mapping of tile and core");
     cores[tileOp] = core;
@@ -54,7 +54,7 @@ void xilinx::AIE::NetlistAnalysis::collectCores(
 void xilinx::AIE::NetlistAnalysis::collectMems(
     DenseMap<Operation *, MemOp> &mems) {
   for (auto mem : module.getOps<MemOp>()) {
-    Operation *tileOp = mem.tile().getDefiningOp();
+    Operation *tileOp = mem.getTile().getDefiningOp();
     assert(mems.count(tileOp) == 0 &&
            "Invalid netlist! Expected 1-1 mapping of tile and mem");
     mems[tileOp] = mem;
@@ -64,8 +64,8 @@ void xilinx::AIE::NetlistAnalysis::collectMems(
 void xilinx::AIE::NetlistAnalysis::collectLocks(
     DenseMap<std::pair<Operation *, int>, LockOp> &locks) {
   for (auto lock : module.getOps<LockOp>()) {
-    Operation *tileOp = lock.tile().getDefiningOp();
-    int lockID = lock.getLockID();
+    Operation *tileOp = lock.getTile().getDefiningOp();
+    int lockID = lock.getLockIDValue();
     assert(locks.count(std::make_pair(tileOp, lockID)) == 0 &&
            "Invalid netlist! Expected 1-1 mapping of (tile, lockID) and lock");
     locks[std::make_pair(tileOp, lockID)] = lock;
@@ -76,7 +76,7 @@ void xilinx::AIE::NetlistAnalysis::collectBuffers(
     DenseMap<Operation *, SmallVector<BufferOp, 4>> &buffers) {
 
   for (auto buffer : module.getOps<BufferOp>()) {
-    Operation *tileOp = buffer.tile().getDefiningOp();
+    Operation *tileOp = buffer.getTile().getDefiningOp();
     buffers[tileOp].push_back(buffer);
   }
 }
@@ -85,7 +85,7 @@ void xilinx::AIE::NetlistAnalysis::collectSwitchboxes(
     DenseMap<Operation *, SwitchboxOp> &switchboxes) {
 
   for (auto switchbox : module.getOps<SwitchboxOp>()) {
-    Operation *tileOp = switchbox.tile().getDefiningOp();
+    Operation *tileOp = switchbox.getTile().getDefiningOp();
     assert(switchboxes.count(tileOp) == 0 &&
            "Invalid netlist! Expected 1-1 mapping of tile and switchbox");
     switchboxes[tileOp] = switchbox;
@@ -104,12 +104,12 @@ xilinx::AIE::NetlistAnalysis::getCoord(Operation *Op) const {
     return std::make_pair(op.colIndex(), op.rowIndex());
 
   if (LockOp op = dyn_cast<LockOp>(Op)) {
-    TileOp tile = dyn_cast<TileOp>(op.tile().getDefiningOp());
+    TileOp tile = dyn_cast<TileOp>(op.getTile().getDefiningOp());
     return std::make_pair(tile.colIndex(), tile.rowIndex());
   }
 
   if (BufferOp op = dyn_cast<BufferOp>(Op)) {
-    TileOp tile = dyn_cast<TileOp>(op.tile().getDefiningOp());
+    TileOp tile = dyn_cast<TileOp>(op.getTile().getDefiningOp());
     return std::make_pair(tile.colIndex(), tile.rowIndex());
   }
 
@@ -139,9 +139,9 @@ bool xilinx::AIE::NetlistAnalysis::validateCoreOrMemRegion(
     Operation *CoreOrMemOp) {
   Region *r = nullptr;
   if (CoreOp core = dyn_cast<CoreOp>(CoreOrMemOp))
-    r = &core.body();
+    r = &core.getBody();
   else if (MemOp mem = dyn_cast<MemOp>(CoreOrMemOp))
-    r = &mem.body();
+    r = &mem.getBody();
 
   assert(r && "Expected non-null region!");
 
@@ -197,9 +197,9 @@ void xilinx::AIE::NetlistAnalysis::collectBufferUsage() {
   for (auto CoreOrMemOp : CoreOrMemOps) {
     Region *r = nullptr;
     if (CoreOp core = dyn_cast<CoreOp>(CoreOrMemOp))
-      r = &core.body();
+      r = &core.getBody();
     else if (MemOp mem = dyn_cast<MemOp>(CoreOrMemOp))
-      r = &mem.body();
+      r = &mem.getBody();
 
     assert(r && "Expected non-null region!");
 
@@ -216,7 +216,7 @@ void xilinx::AIE::NetlistAnalysis::collectBufferUsage() {
 void xilinx::AIE::NetlistAnalysis::collectDMAUsage() {
   for (auto map : mems) {
     MemOp mem = map.second;
-    Region &r = mem.body();
+    Region &r = mem.getBody();
     Block *endBlock = &r.back();
     for (auto op : r.getOps<cf::CondBranchOp>()) {
       DMAStartOp dmaSt =
@@ -228,12 +228,12 @@ void xilinx::AIE::NetlistAnalysis::collectDMAUsage() {
 
       while (curBd != endBlock) {
         for (auto bdOp : curBd->getOps<DMABDOp>()) {
-          Operation *buf = bdOp.buffer().getDefiningOp();
+          Operation *buf = bdOp.getBuffer().getDefiningOp();
           if (std::find(dma2BufMap[dmaSt].begin(), dma2BufMap[dmaSt].end(),
                         buf) != dma2BufMap[dmaSt].end())
             continue;
 
-          dma2BufMap[dmaSt].push_back(bdOp.buffer().getDefiningOp());
+          dma2BufMap[dmaSt].push_back(bdOp.getBuffer().getDefiningOp());
         }
         curBd = curBd->getSuccessors()[0];
       }
@@ -258,7 +258,7 @@ xilinx::AIE::NetlistAnalysis::getBufferBaseAddress(Operation *bufOp) const {
   if (auto buf = dyn_cast<BufferOp>(bufOp)) {
     return buf.address();
   } else if (auto buf = dyn_cast<ExternalBufferOp>(bufOp)) {
-    return buf.address();
+    return buf.getAddress();
   } else {
     llvm_unreachable("unknown buffer type");
   }
@@ -278,19 +278,19 @@ SmallVector<Operation *, 4> xilinx::AIE::NetlistAnalysis::getNextConnectOps(
   WireBundle nextSrcBundle;
   int nextSrcIndex = currentConnect.destIndex();
 
-  if (currentConnect.destBundle() == WireBundle::South) {
+  if (currentConnect.getDestBundle() == WireBundle::South) {
     nextCol = col;
     nextRow = row - 1;
     nextSrcBundle = WireBundle::North;
-  } else if (currentConnect.destBundle() == WireBundle::West) {
+  } else if (currentConnect.getDestBundle() == WireBundle::West) {
     nextCol = col - 1;
     nextRow = row;
     nextSrcBundle = WireBundle::East;
-  } else if (currentConnect.destBundle() == WireBundle::North) {
+  } else if (currentConnect.getDestBundle() == WireBundle::North) {
     nextCol = col;
     nextRow = row + 1;
     nextSrcBundle = WireBundle::South;
-  } else if (currentConnect.destBundle() == WireBundle::East) {
+  } else if (currentConnect.getDestBundle() == WireBundle::East) {
     nextCol = col + 1;
     nextRow = row;
     nextSrcBundle = WireBundle::West;
@@ -306,7 +306,7 @@ SmallVector<Operation *, 4> xilinx::AIE::NetlistAnalysis::getNextConnectOps(
   SwitchboxOp nextSwbox = dyn_cast<SwitchboxOp>(nextSwboxOp);
 
   for (auto connect : nextSwbox.getOps<ConnectOp>()) {
-    if (connect.sourceBundle() == nextSrcBundle &&
+    if (connect.getSourceBundle() == nextSrcBundle &&
         connect.sourceIndex() == nextSrcIndex) {
       nextConnectOps.push_back(connect);
     }
@@ -353,7 +353,7 @@ xilinx::AIE::NetlistAnalysis::findDestConnectOps(ConnectOp source,
     ArrayRef<Operation *> nextConnectOps(getNextConnectOps(visitor));
     for (auto nextConnectOp : nextConnectOps) {
       ConnectOp nextConnect = dyn_cast<ConnectOp>(nextConnectOp);
-      if (nextConnect.destBundle() != destBundle)
+      if (nextConnect.getDestBundle() != destBundle)
         workList.push_back(nextConnect);
       else
         dests.push_back(nextConnect);
@@ -378,9 +378,9 @@ void xilinx::AIE::NetlistAnalysis::dmaAnalysis() {
 
     Operation *srcMemOp = srcDmaOp->getParentOp();
     MemOp srcMem = dyn_cast<MemOp>(srcMemOp);
-    SwitchboxOp swbox = switchboxes[srcMem.tile().getDefiningOp()];
+    SwitchboxOp swbox = switchboxes[srcMem.getTile().getDefiningOp()];
     for (auto connect : swbox.getOps<ConnectOp>()) {
-      WireBundle srcBundle = connect.sourceBundle();
+      WireBundle srcBundle = connect.getSourceBundle();
       int srcIndex = connect.sourceIndex();
       if (!(srcBundle == WireBundle::DMA && srcIndex == srcChannelIndex))
         continue;
@@ -393,7 +393,7 @@ void xilinx::AIE::NetlistAnalysis::dmaAnalysis() {
         ConnectOp destConnect = dyn_cast<ConnectOp>(destConnectOp);
         SwitchboxOp destSwbox =
             dyn_cast<SwitchboxOp>(destConnect->getParentOp());
-        Operation *destMemOp = mems[destSwbox.tile().getDefiningOp()];
+        Operation *destMemOp = mems[destSwbox.getTile().getDefiningOp()];
         int destChannelIndex = destConnect.destIndex();
         Operation *destDmaOp =
             dmas[std::make_pair(destMemOp, destChannelIndex)];
@@ -410,7 +410,7 @@ void xilinx::AIE::NetlistAnalysis::lockAnalysis() {
 
   module.getBodyRegion().walk([&](Operation *Op) {
     if (auto op = dyn_cast<UseLockOp>(Op)) {
-      Value lock = op.lock();
+      Value lock = op.getLock();
       if (op.acquire()) {
         visitors[lock].push_back(op);
       } else if (op.release()) {

--- a/lib/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/AIEObjectFifoStatefulTransform.cpp
@@ -69,8 +69,8 @@ public:
     // go over the locks created for each tile and update the index in
     // locksPerTile
     for (auto lockOp : module.getOps<LockOp>()) {
-      auto tile = lockOp.tile();
-      auto lockID = lockOp.getLockID();
+      auto tile = lockOp.getTile();
+      auto lockID = lockOp.getLockIDValue();
 
       locksPerTile[std::make_pair(tile, lockID)] = 1;
     }
@@ -173,7 +173,7 @@ struct AIEObjectFifoStatefulTransformPass
     builder.setInsertionPointAfter(locksPerFifo[op].back());
     MemOp producerMem =
         builder.create<MemOp>(builder.getUnknownLoc(), op.getProducerTileOp());
-    Region &r = producerMem.body();
+    Region &r = producerMem.getBody();
     r.push_back(new Block);
     Block &endBlock = r.back();
     Block *dmaBlock = builder.createBlock(&endBlock);
@@ -327,7 +327,7 @@ struct AIEObjectFifoStatefulTransformPass
               checkSplitFifo(acqOp.getOperation());
               found = true;
               ObjectFifoCreateOp op =
-                  acqOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
+                  acqOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
               objFifoSizes.insert(op.size());
             }
           }
@@ -434,7 +434,7 @@ struct AIEObjectFifoStatefulTransformPass
       int lockID = acc[op];
       builder.create<UseLockOp>(builder.getUnknownLoc(),
                                 locksPerFifo[op][lockID], lockMode, lockAction);
-      acc[op] = (lockID + 1) % op.elemNumber();
+      acc[op] = (lockID + 1) % op.getElemNumber();
     }
   }
 
@@ -458,12 +458,12 @@ struct AIEObjectFifoStatefulTransformPass
     ObjectFifoPort port;
     if (isa<ObjectFifoAcquireOp>(op)) {
       ObjectFifoAcquireOp acqOp = dyn_cast<ObjectFifoAcquireOp>(op);
-      parentFifo = acqOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
-      port = acqOp.port();
+      parentFifo = acqOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
+      port = acqOp.getPort();
     } else if (isa<ObjectFifoReleaseOp>(op)) {
       ObjectFifoReleaseOp relOp = dyn_cast<ObjectFifoReleaseOp>(op);
-      parentFifo = relOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
-      port = relOp.port();
+      parentFifo = relOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
+      port = relOp.getPort();
     } else {
       assert(false && "checkSplitFifo() must be called on either "
                       "ObjectFifoAcquireOp or ObjectFifoReleaseOp");
@@ -486,12 +486,12 @@ struct AIEObjectFifoStatefulTransformPass
     ObjectFifoPort port;
     if (isa<ObjectFifoAcquireOp>(op)) {
       ObjectFifoAcquireOp acqOp = dyn_cast<ObjectFifoAcquireOp>(op);
-      objFifo = acqOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
-      port = acqOp.port();
+      objFifo = acqOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
+      port = acqOp.getPort();
     } else if (isa<ObjectFifoReleaseOp>(op)) {
       ObjectFifoReleaseOp relOp = dyn_cast<ObjectFifoReleaseOp>(op);
-      objFifo = relOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
-      port = relOp.port();
+      objFifo = relOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
+      port = relOp.getPort();
     } else {
       assert(false && "checkCorrectPort() must be called on either "
                       "ObjectFifoAcquireOp or ObjectFifoReleaseOp");
@@ -504,13 +504,13 @@ struct AIEObjectFifoStatefulTransformPass
         assert(false && "ObjectFifoAcquireOp or ObjectFifoReleaseOp must be "
                         "used inside a CoreOp");
     }
-    auto coreTile = dyn_cast<CoreOp>(coreOp).tile();
+    auto coreTile = dyn_cast<CoreOp>(coreOp).getTile();
     if (port == ObjectFifoPort::Produce) {
-      if (coreTile != objFifo.producerTile())
+      if (coreTile != objFifo.getProducerTile())
         assert(false && "Producer port of objectFifo accessed by core running "
                         "on non-producer tile");
     } else if (port == ObjectFifoPort::Consume) {
-      if (coreTile != objFifo.consumerTile())
+      if (coreTile != objFifo.getConsumerTile())
         assert(false && "Consumer port of objectFifo accessed by core running "
                         "on non-consumer tile");
     }
@@ -527,7 +527,7 @@ struct AIEObjectFifoStatefulTransformPass
 
     CoreOp *core = nullptr;
     for (auto coreOp : m.getOps<CoreOp>()) {
-      if ((coreOp.tile().getDefiningOp<TileOp>()) == tile) {
+      if ((coreOp.getTile().getDefiningOp<TileOp>()) == tile) {
         core = &coreOp;
         break;
       }
@@ -538,7 +538,7 @@ struct AIEObjectFifoStatefulTransformPass
 
     int maxAcquire = 0;
     core->walk([&](ObjectFifoAcquireOp acqOp) {
-      if (acqOp.fifo().getDefiningOp<ObjectFifoCreateOp>() == objFifo) {
+      if (acqOp.getFifo().getDefiningOp<ObjectFifoCreateOp>() == objFifo) {
         if (acqOp.acqNumber() > maxAcquire)
           maxAcquire = acqOp.acqNumber();
       }
@@ -590,11 +590,11 @@ struct AIEObjectFifoStatefulTransformPass
         builder.setInsertionPointAfter(createOp);
         AIEObjectFifoType fifo = createOp.getType().cast<AIEObjectFifoType>();
         ObjectFifoCreateOp producerFifo = builder.create<ObjectFifoCreateOp>(
-            builder.getUnknownLoc(), fifo, createOp.producerTile(),
-            createOp.producerTile(), prodMaxAcquire);
+            builder.getUnknownLoc(), fifo, createOp.getProducerTile(),
+            createOp.getProducerTile(), prodMaxAcquire);
         ObjectFifoCreateOp consumerFifo = builder.create<ObjectFifoCreateOp>(
-            builder.getUnknownLoc(), fifo, createOp.consumerTile(),
-            createOp.consumerTile(), consMaxAcquire);
+            builder.getUnknownLoc(), fifo, createOp.getConsumerTile(),
+            createOp.getConsumerTile(), consMaxAcquire);
 
         // record that this objectFifo was split
         splitFifos[createOp] = std::make_pair(producerFifo, consumerFifo);
@@ -611,9 +611,9 @@ struct AIEObjectFifoStatefulTransformPass
 
       // create flow between tiles
       builder.setInsertionPointAfter(parentFifo);
-      builder.create<FlowOp>(builder.getUnknownLoc(), parentFifo.producerTile(),
-                             WireBundle::DMA, 0, parentFifo.consumerTile(),
-                             WireBundle::DMA, 1);
+      builder.create<FlowOp>(builder.getUnknownLoc(),
+                             parentFifo.getProducerTile(), WireBundle::DMA, 0,
+                             parentFifo.getConsumerTile(), WireBundle::DMA, 1);
 
       // create MemOps and DMA channels
       createDMA(builder, childProducerFifo, DMAChan::MM2S0, 0);
@@ -656,8 +656,8 @@ struct AIEObjectFifoStatefulTransformPass
 
         builder.setInsertionPointAfter(releaseOp);
         ObjectFifoCreateOp op =
-            releaseOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
-        auto port = releaseOp.port();
+            releaseOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
+        auto port = releaseOp.getPort();
 
         // update index of next element to release for this objectFifo
         updateAndReturnIndex(relPerFifo, op);
@@ -681,9 +681,9 @@ struct AIEObjectFifoStatefulTransformPass
         checkCorrectPort(acquireOp.getOperation());
 
         builder.setInsertionPointAfter(acquireOp);
-        auto port = acquireOp.port();
+        auto port = acquireOp.getPort();
         ObjectFifoCreateOp op =
-            acquireOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
+            acquireOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
 
         // index of next element to acquire for this objectFifo
         int start = updateAndReturnIndex(
@@ -695,7 +695,7 @@ struct AIEObjectFifoStatefulTransformPass
         int numRel = 0;
         for (auto relOp : releaseOps) {
           ObjectFifoCreateOp otherOp =
-              relOp.fifo().getDefiningOp<ObjectFifoCreateOp>();
+              relOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
           // TODO: operations may not be in the same block: currently only
           // support one block level of difference
           if (op == otherOp) {
@@ -768,7 +768,7 @@ struct AIEObjectFifoStatefulTransformPass
         // create subview: buffers that were already acquired + new acquires
         for (int i = 0; i < numCreate; i++) {
           acquiredIndices.push_back(start);
-          start = (start + 1) % op.elemNumber();
+          start = (start + 1) % op.getElemNumber();
         }
         std::vector<BufferOp *> subviewRefs;
         for (auto index : acquiredIndices) {
@@ -783,13 +783,13 @@ struct AIEObjectFifoStatefulTransformPass
       //===----------------------------------------------------------------------===//
       coreOp.walk([&](ObjectFifoSubviewAccessOp accessOp) {
         ObjectFifoAcquireOp acqOp =
-            accessOp.subview().getDefiningOp<ObjectFifoAcquireOp>();
-        auto users = accessOp.output().getUsers();
+            accessOp.getSubview().getDefiningOp<ObjectFifoAcquireOp>();
+        auto users = accessOp.getOutput().getUsers();
         assert((size_t)accessOp.getIndex() < subviews[acqOp].size() &&
                "Index out of bounds for subview: accessed farther than number "
                "of acquired elements.");
         for (auto user : users) {
-          user->replaceUsesOfWith(accessOp.output(),
+          user->replaceUsesOfWith(accessOp.getOutput(),
                                   *subviews[acqOp][accessOp.getIndex()]);
         }
       });

--- a/lib/AIETokenAnalysis.cpp
+++ b/lib/AIETokenAnalysis.cpp
@@ -36,7 +36,7 @@ void xilinx::AIE::TokenAnalysis::runAnalysis() {
   std::map<StringRef, SmallVector<UseTokenOp, 4>> visitors;
   module.getBodyRegion().walk([&](Operation *Op) {
     if (auto op = dyn_cast<UseTokenOp>(Op)) {
-      StringRef tokenName = op.tokenName();
+      StringRef tokenName = op.getTokenName();
       assert(tokenSymbols.find(tokenName) != tokenSymbols.end() &&
              "Token not found!");
       if (op.acquire()) {
@@ -50,7 +50,7 @@ void xilinx::AIE::TokenAnalysis::runAnalysis() {
         }
       }
     } else if (auto op = dyn_cast<MemcpyOp>(Op)) {
-      StringRef tokenName = op.tokenName();
+      StringRef tokenName = op.getTokenName();
       assert(tokenSymbols.find(tokenName) != tokenSymbols.end() &&
              "Token not found!");
       Operation *Op = op.getOperation();
@@ -71,7 +71,7 @@ void xilinx::AIE::TokenAnalysis::runAnalysis() {
 
       for (auto pair : tokenPairs) {
         if (UseTokenOp aop = dyn_cast<UseTokenOp>(pair.first)) {
-          if (tokenName == aop.tokenName() && Op == aop.getOperation()) {
+          if (tokenName == aop.getTokenName() && Op == aop.getOperation()) {
             isReleased = true;
             break;
           }

--- a/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
@@ -39,10 +39,10 @@ void AIEVecDialect::initialize() {
 // Print out UPD op.
 void UPDOp::print(OpAsmPrinter &p) {
   // Print the source memref
-  p << " " << source() << "[" << indices() << "]";
+  p << " " << getSource() << "[" << getIndices() << "]";
   // Now print the optional vector that links upd idx=1 with idx=0
-  if (vector())
-    p << ", " << vector();
+  if (getVector())
+    p << ", " << getVector();
 
   // Print the attributes, but don't print the operand segment sizes
   SmallVector<StringRef, 3> elidedAttrs;
@@ -50,25 +50,25 @@ void UPDOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
 
   // And now print the types
-  p << " : " << source().getType() << ", " << result().getType();
+  p << " : " << getSource().getType() << ", " << getResult().getType();
 }
 
 // Verify UPD op.
 LogicalResult UPDOp::verify() {
   // Verify the types: source is memref, and result is vector
-  MemRefType sourceType = source().getType().dyn_cast<MemRefType>();
-  VectorType resultType = result().getType().dyn_cast<VectorType>();
+  MemRefType sourceType = getSource().getType().dyn_cast<MemRefType>();
+  VectorType resultType = getResult().getType().dyn_cast<VectorType>();
   if (!sourceType)
     return emitError("requires memref type");
   if (!resultType)
     return emitError("requires vector type");
-  if (indices().empty())
+  if (getIndices().empty())
     return emitError("upd source cannot come from scalar value");
 
   // If this UPD op is linked to another UPD op, then verify that the linked
   // vector and the result vector match.
-  if (vector()) {
-    Type vecType = vector().getType().dyn_cast<VectorType>();
+  if (getVector()) {
+    Type vecType = getVector().getType().dyn_cast<VectorType>();
     if (vecType != resultType)
       return emitError("result types of linked UPD ops do not match");
   }
@@ -137,20 +137,20 @@ ParseResult UPDOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print out SRS op.
 void SRSOp::print(OpAsmPrinter &p) {
   // Print the source accumulator
-  p << " " << source();
+  p << " " << getSource();
 
   // Print the attributes
   p.printOptionalAttrDict((*this)->getAttrs());
 
   // And now print the types
-  p << " : " << source().getType() << ", " << result().getType();
+  p << " : " << getSource().getType() << ", " << getResult().getType();
 }
 
 // Verify SRS op.
 LogicalResult SRSOp::verify() {
   // Verify the types
-  VectorType sourceType = source().getType().dyn_cast<VectorType>();
-  VectorType resultType = result().getType().dyn_cast<VectorType>();
+  VectorType sourceType = getSource().getType().dyn_cast<VectorType>();
+  VectorType resultType = getResult().getType().dyn_cast<VectorType>();
   if (!sourceType)
     return emitError("requires accumulator type");
   if (!resultType)
@@ -223,20 +223,20 @@ ParseResult SRSOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print out UPS op.
 void UPSOp::print(OpAsmPrinter &p) {
   // Print the source vector
-  p << " " << source();
+  p << " " << getSource();
 
   // Print the attributes
   p.printOptionalAttrDict((*this)->getAttrs());
 
   // And now print the types
-  p << " : " << source().getType() << ", " << result().getType();
+  p << " : " << getSource().getType() << ", " << getResult().getType();
 }
 
 // Verify UPS op.
 LogicalResult UPSOp::verify() {
   // Verify the types
-  VectorType sourceType = source().getType().dyn_cast<VectorType>();
-  VectorType resultType = result().getType().dyn_cast<VectorType>();
+  VectorType sourceType = getSource().getType().dyn_cast<VectorType>();
+  VectorType resultType = getResult().getType().dyn_cast<VectorType>();
   if (!sourceType)
     return emitError("requires vector type");
   if (!resultType)
@@ -313,7 +313,7 @@ ParseResult UPSOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print the accumulator
 template <typename T> inline void printAccumulator(OpAsmPrinter &p, T op);
 template <> inline void printAccumulator(OpAsmPrinter &p, aievec::FMAOp op) {
-  p << ", " << op.acc();
+  p << ", " << op.getAcc();
 }
 template <> inline void printAccumulator(OpAsmPrinter &p, aievec::MulOp op) {}
 
@@ -323,7 +323,7 @@ inline void elideFMSubAttr(T op, SmallVector<StringRef, 10> &elidedAttrs);
 template <>
 inline void elideFMSubAttr(aievec::FMAOp op,
                            SmallVector<StringRef, 10> &elidedAttrs) {
-  if (!op.fmsub())
+  if (!op.getFmsub())
     elidedAttrs.push_back(op.getSubAttrName());
 }
 template <>
@@ -333,9 +333,9 @@ inline void elideFMSubAttr(aievec::MulOp,
 // Print out Mul and FMA op.
 template <typename T> static void printMulFMAOp(OpAsmPrinter &p, T op) {
   // Print the left operand
-  p << " " << op.lhs();
+  p << " " << op.getLhs();
   // Print the right operand
-  p << ", " << op.rhs();
+  p << ", " << op.getRhs();
   // For fma op, print the accumulator
   printAccumulator(p, op);
 
@@ -357,8 +357,8 @@ template <typename T> static void printMulFMAOp(OpAsmPrinter &p, T op) {
   p.printOptionalAttrDict(op->getAttrs(), elidedAttrs);
 
   // And now print the types
-  p << " : " << op.lhs().getType() << ", " << op.rhs().getType();
-  p << ", " << op.result().getType();
+  p << " : " << op.getLhs().getType() << ", " << op.getRhs().getType();
+  p << ", " << op.getResult().getType();
 }
 
 void MulOp::print(OpAsmPrinter &p) { printMulFMAOp<aievec::MulOp>(p, *this); }
@@ -370,13 +370,14 @@ void aievec::FMAOp::print(OpAsmPrinter &p) {
 // Verify Mul and FMA op.
 template <typename T> LogicalResult verifyMulFMAOp(T op) {
   // Verify the types
-  VectorType lhsType = op.lhs().getType().template dyn_cast<VectorType>();
-  VectorType rhsType = op.rhs().getType().template dyn_cast<VectorType>();
+  VectorType lhsType = op.getLhs().getType().template dyn_cast<VectorType>();
+  VectorType rhsType = op.getRhs().getType().template dyn_cast<VectorType>();
 
   if (!lhsType || !rhsType)
     return op.emitError("requires vector type");
 
-  VectorType resultType = op.result().getType().template dyn_cast<VectorType>();
+  VectorType resultType =
+      op.getResult().getType().template dyn_cast<VectorType>();
   if (!resultType)
     return op.emitError("requires vector type");
 
@@ -509,9 +510,9 @@ ParseResult FMAOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print out Add and Sub op.
 template <typename T> void printAddSubOp(OpAsmPrinter &p, T op) {
   // Print the lhs operand
-  p << " " << op.lhs();
+  p << " " << op.getLhs();
   // Print the rhs operand
-  p << ", " << op.rhs();
+  p << ", " << op.getRhs();
 
   // Print the attributes, but don't print attributes that are empty strings
   SmallVector<StringRef, 10> elidedAttrs;
@@ -528,8 +529,8 @@ template <typename T> void printAddSubOp(OpAsmPrinter &p, T op) {
   p.printOptionalAttrDict(op->getAttrs(), elidedAttrs);
 
   // And now print the types
-  p << " : " << op.lhs().getType() << ", " << op.rhs().getType();
-  p << ", " << op.result().getType();
+  p << " : " << op.getLhs().getType() << ", " << op.getRhs().getType();
+  p << ", " << op.getResult().getType();
 }
 
 void aievec::AddOp::print(OpAsmPrinter &p) {
@@ -543,9 +544,10 @@ void aievec::SubOp::print(OpAsmPrinter &p) {
 // Verify Add and Sub op.
 template <typename T> LogicalResult verifyAddSubOp(T op) {
   // Verify the types
-  VectorType resultType = op.result().getType().template dyn_cast<VectorType>();
-  VectorType lhsType = op.lhs().getType().template dyn_cast<VectorType>();
-  VectorType rhsType = op.rhs().getType().template dyn_cast<VectorType>();
+  VectorType resultType =
+      op.getResult().getType().template dyn_cast<VectorType>();
+  VectorType lhsType = op.getLhs().getType().template dyn_cast<VectorType>();
+  VectorType rhsType = op.getRhs().getType().template dyn_cast<VectorType>();
 
   if (!lhsType || !rhsType || !resultType)
     return op.emitError("requires vector type");
@@ -619,29 +621,31 @@ ParseResult SubOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print out Concat op.
 void ConcatOp::print(OpAsmPrinter &p) {
   // Print the source vectors
-  assert(!sources().empty() && "concat source empty");
-  p << " " << sources();
+  assert(!getSources().empty() && "concat source empty");
+  p << " " << getSources();
 
   // Print the attributes
   p.printOptionalAttrDict((*this)->getAttrs());
 
   // And now print the types
-  p << " : " << sources().getTypes().front() << ", " << result().getType();
+  p << " : " << getSources().getTypes().front() << ", "
+    << getResult().getType();
 }
 
 // Verify Concat op.
 LogicalResult ConcatOp::verify() {
   // Must be concatenating at least two sources
-  if (sources().size() < 2)
+  if (getSources().size() < 2)
     return emitError("Must concatenate at least two vectors");
 
   // Verify the types
-  VectorType sourceType = sources().getTypes().front().dyn_cast<VectorType>();
-  VectorType resultType = result().getType().dyn_cast<VectorType>();
+  VectorType sourceType =
+      getSources().getTypes().front().dyn_cast<VectorType>();
+  VectorType resultType = getResult().getType().dyn_cast<VectorType>();
   if (!sourceType || !resultType)
     return emitError("requires vector type");
 
-  SmallVector<Value, 8> srcs(sources().begin(), sources().end());
+  SmallVector<Value, 8> srcs(getSources().begin(), getSources().end());
   // All the sources must have the same type
   for (auto source : srcs) {
     VectorType type = source.getType().dyn_cast<VectorType>();
@@ -707,20 +711,20 @@ ParseResult ConcatOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print out Ext op.
 void ExtOp::print(OpAsmPrinter &p) {
   // Print the source vector
-  p << " " << source();
+  p << " " << getSource();
 
   // Print the attributes
   p.printOptionalAttrDict((*this)->getAttrs());
 
   // And now print the types
-  p << " : " << source().getType() << ", " << result().getType();
+  p << " : " << getSource().getType() << ", " << getResult().getType();
 }
 
 // Verify Ext op.
 LogicalResult ExtOp::verify() {
   // Verify the types
-  VectorType sourceType = source().getType().dyn_cast<VectorType>();
-  VectorType resultType = result().getType().dyn_cast<VectorType>();
+  VectorType sourceType = getSource().getType().dyn_cast<VectorType>();
+  VectorType resultType = getResult().getType().dyn_cast<VectorType>();
   if (!sourceType || !resultType)
     return emitError("requires vector type");
 
@@ -738,7 +742,7 @@ LogicalResult ExtOp::verify() {
 
   // Verify validity of index
   unsigned factor = sourceLanes / resultLanes;
-  if (index() >= factor)
+  if (getIndex() >= factor)
     return emitError("index out of bounds");
 
   // The datatype of source and result must match
@@ -792,10 +796,10 @@ ParseResult ExtOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print out select op.
 void aievec::SelectOp::print(OpAsmPrinter &p) {
   // Print the xbuff
-  p << " " << xbuff();
+  p << " " << getXbuff();
   // Print the start, offsets, etc. for xbuff
-  if (ybuff())
-    p << ", " << ybuff();
+  if (getYbuff())
+    p << ", " << getYbuff();
 
   // Print the attributes, but don't print attributes that are empty strings
   SmallVector<StringRef, 10> elidedAttrs;
@@ -812,17 +816,17 @@ void aievec::SelectOp::print(OpAsmPrinter &p) {
   p.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
 
   // And now print the types
-  p << " : " << xbuff().getType();
-  if (ybuff())
-    p << ", " << ybuff().getType();
-  p << ", " << result().getType();
+  p << " : " << getXbuff().getType();
+  if (getYbuff())
+    p << ", " << getYbuff().getType();
+  p << ", " << getResult().getType();
 }
 
 // Verify select op.
 LogicalResult aievec::SelectOp::verify() {
   // Verify the types
-  VectorType resultType = result().getType().dyn_cast<VectorType>();
-  VectorType xbuffType = xbuff().getType().dyn_cast<VectorType>();
+  VectorType resultType = getResult().getType().dyn_cast<VectorType>();
+  VectorType xbuffType = getXbuff().getType().dyn_cast<VectorType>();
 
   if (!resultType || !xbuffType)
     return emitError("requires vector type");
@@ -834,8 +838,8 @@ LogicalResult aievec::SelectOp::verify() {
     return emitError("types of result and xbuff must match");
 
   // If yuff is present, its vector type should be same as xbuff
-  if (ybuff()) {
-    VectorType ybuffType = ybuff().getType().dyn_cast<VectorType>();
+  if (getYbuff()) {
+    VectorType ybuffType = getYbuff().getType().dyn_cast<VectorType>();
     if (xbuffType != ybuffType)
       return emitError("types of xbuff and ybuff must match");
   }
@@ -905,13 +909,13 @@ ParseResult SelectOp::parse(OpAsmParser &parser, OperationState &result) {
 // Print out Pack and Unpack op.
 template <typename T> static void printPackUnpackOp(OpAsmPrinter &p, T op) {
   // Print the source vector
-  p << " " << op.source();
+  p << " " << op.getSource();
 
   // Print the attributes
   p.printOptionalAttrDict(op->getAttrs());
 
   // And now print the types
-  p << " : " << op.source().getType() << ", " << op.result().getType();
+  p << " : " << op.getSource().getType() << ", " << op.getResult().getType();
 }
 
 void PackOp::print(OpAsmPrinter &p) { printPackUnpackOp<PackOp>(p, *this); }
@@ -921,8 +925,10 @@ void UnpackOp::print(OpAsmPrinter &p) { printPackUnpackOp<UnpackOp>(p, *this); }
 // Verify Pack and Unpack op.
 template <typename T> LogicalResult verifyPackUnpackOp(T op) {
   // Verify the types
-  VectorType sourceType = op.source().getType().template dyn_cast<VectorType>();
-  VectorType resultType = op.result().getType().template dyn_cast<VectorType>();
+  VectorType sourceType =
+      op.getSource().getType().template dyn_cast<VectorType>();
+  VectorType resultType =
+      op.getResult().getType().template dyn_cast<VectorType>();
   if (!sourceType || !resultType)
     return op.emitError("requires vector type");
 

--- a/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
+++ b/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
@@ -338,13 +338,13 @@ static bool writesToAccumulator(Operation *op) {
   if (!isAIEOp(op)) {
     return false;
   } else if (auto mulOp = dyn_cast<aievec::MulOp>(op)) {
-    return mulOp.result()
+    return mulOp.getResult()
         .getType()
         .cast<VectorType>()
         .getElementType()
         .isa<IntegerType>();
   } else if (auto fmaOp = dyn_cast<aievec::FMAOp>(op)) {
-    return fmaOp.result()
+    return fmaOp.getResult()
         .getType()
         .cast<VectorType>()
         .getElementType()
@@ -858,7 +858,7 @@ generateUPDOp(TransferReadOp readOp,
       updOp = state->builder.create<aievec::UPDOp>(
           readOp.getLoc(), updVecType, readOp.getSource(), indices,
           start - offset, idx - 1,
-          updOp ? updOp.result() : TypedValue<VectorType>(nullptr));
+          updOp ? updOp.getResult() : TypedValue<VectorType>(nullptr));
 
       LLVM_DEBUG(llvm::dbgs() << "\n\nCreated UPD op " << updOp
                               << " for read op " << readOp);

--- a/lib/Targets/ADFGenerateCppGraph.cpp
+++ b/lib/Targets/ADFGenerateCppGraph.cpp
@@ -110,12 +110,12 @@ struct GraphWriter {
         int targetIndex = userOperand.getOperandNumber();
         if (auto kernel = dyn_cast<KernelOp>(userOp)) {
           auto funcOp = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
-              driverOp, kernel.calleeAttr());
+              driverOp, kernel.getCalleeAttr());
           Type opType = funcOp.getFunctionType().getInput(targetIndex);
           std::string targetKernelName = kernelOp2VarName[kernel];
           output << indent << "connect<" << getConnectionTypeString(opType)
                  << "> ";
-          output << getTempNetName() << " (" << driverOp.name() << ", "
+          output << getTempNetName() << " (" << driverOp.getName() << ", "
                  << targetKernelName << ".in[" << targetIndex << "]);\n";
         }
 
@@ -137,7 +137,7 @@ struct GraphWriter {
         int targetIndex = userOperand.getOperandNumber();
         if (auto kernel = dyn_cast<KernelOp>(userOp)) {
           auto funcOp = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
-              kernel, kernel.calleeAttr());
+              kernel, kernel.getCalleeAttr());
           Type opType = funcOp.getFunctionType().getInput(targetIndex);
           auto targetKernelName = kernelOp2VarName[kernel];
           output << indent << "connect<" << getConnectionTypeString(opType)
@@ -147,12 +147,12 @@ struct GraphWriter {
                  << targetIndex << "]);\n";
         } else if (auto outputOp = dyn_cast<GraphOutputOp>(userOp)) {
           auto funcOp = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
-              source, source.calleeAttr());
+              source, source.getCalleeAttr());
           Type opType = funcOp.getFunctionType().getInput(sourceIndex);
           output << indent << "connect<" << getConnectionTypeString(opType)
                  << "> ";
           output << getTempNetName() << " (" << sourceKernelName << ".out["
-                 << sourceIndex << "], " << outputOp.name() << ");\n";
+                 << sourceIndex << "], " << outputOp.getName() << ");\n";
         }
 
         // todo: kernel should not drive graph input, add an mlir verifier
@@ -192,7 +192,7 @@ struct GraphWriter {
   void writeClass(ADF::GraphOp graph) {
     output << "#include <adf.h>\n";
     output << "using namespace adf;\n";
-    output << "class " << graph.name() << " : public graph {\n";
+    output << "class " << graph.getName() << " : public graph {\n";
     output << "private:\n";
     int kCnt = 1;
     {
@@ -211,13 +211,13 @@ struct GraphWriter {
     output << "\npublic:\n";
     Indent indent;
     for (auto op : graph.getBody()->getOps<GraphInputOp>())
-      output << indent << "input_port " << op.name() << ";\n";
+      output << indent << "input_port " << op.getName() << ";\n";
     for (auto op : graph.getBody()->getOps<GraphOutputOp>())
-      output << indent << "output_port " << op.name() << ";\n";
+      output << indent << "output_port " << op.getName() << ";\n";
     for (auto op : graph.getBody()->getOps<GraphInOutOp>())
-      output << indent << "inout_port " << op.name() << ";\n";
+      output << indent << "inout_port " << op.getName() << ";\n";
 
-    output << "\n" << indent << graph.name() << "() {\n";
+    output << "\n" << indent << graph.getName() << "() {\n";
     // initialize the kernel instances in the adf c++ graph
     {
       Indent indent;
@@ -225,7 +225,7 @@ struct GraphWriter {
         for (Block &block : region.getBlocks())
           for (auto kernel : block.getOps<KernelOp>()) {
             output << indent << kernelOp2VarName[kernel] << " = kernel::create("
-                   << kernel.callee().str() << ");\n";
+                   << kernel.getCallee().str() << ");\n";
           }
     }
 

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -213,14 +213,14 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
     {
       // Assign each block a BD number
       int bdNum = 0;
-      for (auto &block : memOp.body()) {
+      for (auto &block : memOp.getBody()) {
         if (!block.getOps<DMABDOp>().empty()) {
           blockMap[&block] = bdNum;
           bdNum++;
         }
       }
     }
-    for (auto &block : memOp.body()) {
+    for (auto &block : memOp.getBody()) {
       bool foundBdPacket = false;
       int packetType = 0;
       int packetID = 0;
@@ -242,9 +242,9 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       for (auto op : block.getOps<DMABDOp>()) {
         foundBd = true;
         ShapedType bufferType =
-            op.buffer().getType().cast<::mlir::MemRefType>();
+            op.getBuffer().getType().cast<::mlir::MemRefType>();
         if (op.isA()) {
-          BaseAddrA = NL.getBufferBaseAddress(op.buffer().getDefiningOp());
+          BaseAddrA = NL.getBufferBaseAddress(op.getBuffer().getDefiningOp());
           lenA = op.getLenValue();
           bytesA = bufferType.getElementTypeBitWidth() / 8;
           offsetA = op.getOffsetValue();
@@ -252,7 +252,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
           hasA = true;
         }
         if (op.isB()) {
-          BaseAddrB = NL.getBufferBaseAddress(op.buffer().getDefiningOp());
+          BaseAddrB = NL.getBufferBaseAddress(op.getBuffer().getDefiningOp());
           lenB = op.getLenValue();
           bytesB = bufferType.getElementTypeBitWidth() / 8;
           offsetB = op.getOffsetValue();
@@ -273,8 +273,8 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       StringRef relEnable = disable;
       int lockID;
       for (auto op : block.getOps<UseLockOp>()) {
-        LockOp lock = dyn_cast<LockOp>(op.lock().getDefiningOp());
-        lockID = lock.getLockID();
+        LockOp lock = dyn_cast<LockOp>(op.getLock().getDefiningOp());
+        lockID = lock.getLockIDValue();
         if (op.acquire()) {
           acqEnable = enable;
           acqValue = op.getLockValue();
@@ -334,11 +334,11 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       }
     }
 
-    for (auto &block : memOp.body()) {
+    for (auto &block : memOp.getBody()) {
       for (auto op : block.getOps<DMAStartOp>()) {
-        int bdNum = blockMap[op.dest()];
+        int bdNum = blockMap[op.getDest()];
 
-        llvm::StringRef dmaChan = stringifyDMAChan(op.dmaChan());
+        llvm::StringRef dmaChan = stringifyDMAChan(op.getDmaChan());
         llvm::StringRef dmaDir = dmaChan.substr(0, 4);
         llvm::StringRef chNum = dmaChan.substr(4, 1);
 
@@ -371,14 +371,14 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
     {
       // Assign each block a BD number
       int bdNum = 0;
-      for (auto &block : op.body()) {
+      for (auto &block : op.getBody()) {
         if (!block.getOps<DMABDOp>().empty()) {
           blockMap[&block] = bdNum;
 
           uint64_t BaseAddr = 0;
           uint64_t offset = 0;
           for (auto op : block.getOps<DMABDOp>()) {
-            BaseAddr = NL.getBufferBaseAddress(op.buffer().getDefiningOp());
+            BaseAddr = NL.getBufferBaseAddress(op.getBuffer().getDefiningOp());
             offset = op.getOffsetValue();
           }
           uint64_t address = BaseAddr + offset;
@@ -406,7 +406,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
 
     output << "void mlir_aie_configure_shimdma_" << col << row << "(" << ctx_p
            << ") {\n";
-    for (auto &block : op.body()) {
+    for (auto &block : op.getBody()) {
       bool foundBdPacket = false;
       int packetType = 0;
       int packetID = 0;
@@ -420,9 +420,9 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
         foundBd = true;
         len = op.getLenValue();
         ShapedType bufferType =
-            op.buffer().getType().cast<::mlir::MemRefType>();
+            op.getBuffer().getType().cast<::mlir::MemRefType>();
         bytes = bufferType.getElementTypeBitWidth() / 8;
-        BaseAddr = NL.getBufferBaseAddress(op.buffer().getDefiningOp());
+        BaseAddr = NL.getBufferBaseAddress(op.getBuffer().getDefiningOp());
         offset = op.getOffsetValue();
       }
 
@@ -432,8 +432,8 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       StringRef relEnable = disable;
       int lockID = 0;
       for (auto op : block.getOps<UseLockOp>()) {
-        LockOp lock = dyn_cast<LockOp>(op.lock().getDefiningOp());
-        lockID = lock.getLockID();
+        LockOp lock = dyn_cast<LockOp>(op.getLock().getDefiningOp());
+        lockID = lock.getLockIDValue();
         hasLock = true;
         if (op.acquire()) {
           acqEnable = enable;
@@ -503,11 +503,11 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       }
     }
 
-    for (auto &block : op.body()) {
+    for (auto &block : op.getBody()) {
       for (auto op : block.getOps<DMAStartOp>()) {
-        int bdNum = blockMap[op.dest()];
+        int bdNum = blockMap[op.getDest()];
 
-        llvm::StringRef dmaChan = stringifyDMAChan(op.dmaChan());
+        llvm::StringRef dmaChan = stringifyDMAChan(op.getDmaChan());
         llvm::StringRef dmaDir = dmaChan.substr(0, 4);
         llvm::StringRef chNum = dmaChan.substr(4, 1);
 
@@ -537,11 +537,11 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   for (auto op : module.getOps<UseLockOp>()) {
     int lockVal = op.getLockValue();
     int timeOut = op.getTimeout();
-    LockOp lock = dyn_cast<LockOp>(op.lock().getDefiningOp());
-    TileOp tile = dyn_cast<TileOp>(lock.tile().getDefiningOp());
+    LockOp lock = dyn_cast<LockOp>(op.getLock().getDefiningOp());
+    TileOp tile = dyn_cast<TileOp>(lock.getTile().getDefiningOp());
     int col = tile.colIndex();
     int row = tile.rowIndex();
-    int lockID = lock.getLockID();
+    int lockID = lock.getLockIDValue();
     if (op.acquire()) {
       output << "XAie_LockAcquire(" << deviceInstRef << ", "
              << tileLocStr(col, row) << ", " << tileLockStr(lockID, lockVal)
@@ -562,14 +562,14 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
 
   // StreamSwitch (switchbox) configuration
   for (auto switchboxOp : module.getOps<SwitchboxOp>()) {
-    Region &r = switchboxOp.connections();
+    Region &r = switchboxOp.getConnections();
     Block &b = r.front();
     bool isEmpty = b.getOps<ConnectOp>().empty() &&
                    b.getOps<MasterSetOp>().empty() &&
                    b.getOps<PacketRulesOp>().empty();
     bool isParam = false;
 
-    if (isa<TileOp>(switchboxOp.tile().getDefiningOp())) {
+    if (isa<TileOp>(switchboxOp.getTile().getDefiningOp())) {
       int col = switchboxOp.colIndex();
       int row = switchboxOp.rowIndex();
       if (!isEmpty) {
@@ -579,14 +579,14 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
         output << "y = " << row << ";\n";
       }
     } else if (AIE::SelectOp sel = dyn_cast<AIE::SelectOp>(
-                   switchboxOp.tile().getDefiningOp())) {
+                   switchboxOp.getTile().getDefiningOp())) {
       // parameterize streamswitch's configuration
       isParam = true;
-      HerdOp sourceHerd = dyn_cast<HerdOp>(sel.startHerd().getDefiningOp());
+      HerdOp sourceHerd = dyn_cast<HerdOp>(sel.getStartHerd().getDefiningOp());
       std::string sourceHerdName(sourceHerd.name().getValue());
 
-      IterOp iterX = dyn_cast<IterOp>(sel.iterX().getDefiningOp());
-      IterOp iterY = dyn_cast<IterOp>(sel.iterY().getDefiningOp());
+      IterOp iterX = dyn_cast<IterOp>(sel.getIterX().getDefiningOp());
+      IterOp iterY = dyn_cast<IterOp>(sel.getIterY().getDefiningOp());
       int startXValue = iterX.getStartValue();
       int endXValue = iterX.getEndValue();
       int strideXValue = iterX.getStrideValue();
@@ -610,26 +610,26 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
     for (auto connectOp : b.getOps<ConnectOp>()) {
       output << "XAie_StrmConnCctEnable(" << deviceInstRef << ", "
              << tileLocStr("x", "y") << ", "
-             << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
+             << stringifyWireBundle(connectOp.getSourceBundle()).upper() << ", "
              << connectOp.sourceIndex() << ", "
-             << stringifyWireBundle(connectOp.destBundle()).upper() << ", "
+             << stringifyWireBundle(connectOp.getDestBundle()).upper() << ", "
              << connectOp.destIndex() << ");\n";
     }
 
     for (auto connectOp : b.getOps<MasterSetOp>()) {
       int mask = 0;
       int arbiter = -1;
-      for (auto val : connectOp.amsels()) {
+      for (auto val : connectOp.getAmsels()) {
         AMSelOp amsel = dyn_cast<AMSelOp>(val.getDefiningOp());
         arbiter = amsel.arbiterIndex();
         int msel = amsel.getMselValue();
         mask |= (1 << msel);
       }
-      bool isdma = (connectOp.destBundle() == WireBundle::DMA);
+      bool isdma = (connectOp.getDestBundle() == WireBundle::DMA);
 
       output << "XAie_StrmPktSwMstrPortEnable(" << deviceInstRef << ", "
              << tileLocStr("x", "y") << ", "
-             << stringifyWireBundle(connectOp.destBundle()).upper() << ", "
+             << stringifyWireBundle(connectOp.getDestBundle()).upper() << ", "
              << connectOp.destIndex() << ", "
              << "/* drop_header */ "
              << (isdma ? "XAIE_SS_PKT_DROP_HEADER"
@@ -642,21 +642,21 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
 
     for (auto connectOp : b.getOps<PacketRulesOp>()) {
       int slot = 0;
-      Block &block = connectOp.rules().front();
+      Block &block = connectOp.getRules().front();
       for (auto slotOp : block.getOps<PacketRuleOp>()) {
-        AMSelOp amselOp = dyn_cast<AMSelOp>(slotOp.amsel().getDefiningOp());
+        AMSelOp amselOp = dyn_cast<AMSelOp>(slotOp.getAmsel().getDefiningOp());
         int arbiter = amselOp.arbiterIndex();
         int msel = amselOp.getMselValue();
         output << "XAie_StrmPktSwSlavePortEnable(" << deviceInstRef << ", "
                << tileLocStr("x", "y") << ", "
-               << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
-               << connectOp.sourceIndex() << ");\n";
+               << stringifyWireBundle(connectOp.getSourceBundle()).upper()
+               << ", " << connectOp.sourceIndex() << ");\n";
 
         // TODO Need to better define packet id,type used here
         output << "XAie_StrmPktSwSlaveSlotEnable(" << deviceInstRef << ", "
                << tileLocStr("x", "y") << ", "
-               << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
-               << connectOp.sourceIndex() << ", "
+               << stringifyWireBundle(connectOp.getSourceBundle()).upper()
+               << ", " << connectOp.sourceIndex() << ", "
                << "/* slot */ " << slot << ", "
                << "/* packet */ " << packetStr(slotOp.valueInt(), /*type*/ 0)
                << ", "
@@ -674,11 +674,11 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
     }
   }
   for (auto op : module.getOps<ShimMuxOp>()) {
-    Region &r = op.connections();
+    Region &r = op.getConnections();
     Block &b = r.front();
     bool isEmpty = b.getOps<ConnectOp>().empty();
 
-    if (isa<TileOp>(op.tile().getDefiningOp())) {
+    if (isa<TileOp>(op.getTile().getDefiningOp())) {
       int col = op.colIndex();
       int row = op.rowIndex();
       if (!isEmpty) {
@@ -692,7 +692,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
     }
 
     for (auto connectOp : b.getOps<ConnectOp>()) {
-      if (connectOp.sourceBundle() == WireBundle::North) {
+      if (connectOp.getSourceBundle() == WireBundle::North) {
         // demux!
         output
             << "XAie_EnableAieToShimDmaStrmPort(" << deviceInstRef << ", "
@@ -701,7 +701,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
             //               <<
             //               stringifyWireBundle(connectOp.sourceBundle()).upper()
             << connectOp.sourceIndex() << ");\n";
-      } else if (connectOp.destBundle() == WireBundle::North) {
+      } else if (connectOp.getDestBundle() == WireBundle::North) {
         // mux
         output
             << "XAie_EnableShimDmaToAieStrmPort(" << deviceInstRef << ", "
@@ -714,19 +714,19 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
     }
   }
   for (auto switchboxOp : module.getOps<ShimSwitchboxOp>()) {
-    Region &r = switchboxOp.connections();
+    Region &r = switchboxOp.getConnections();
     Block &b = r.front();
     bool isEmpty = b.getOps<ConnectOp>().empty();
-    int col = switchboxOp.col();
+    int col = switchboxOp.getCol();
     if (!isEmpty) {
       output << "// Shim Switch column " << col << "\n";
     }
     for (auto connectOp : b.getOps<ConnectOp>()) {
       output << "XAie_StrmConnCctEnable(" << deviceInstRef << ", "
              << tileLocStr(col, 0) << ", "
-             << stringifyWireBundle(connectOp.sourceBundle()).upper() << ", "
+             << stringifyWireBundle(connectOp.getSourceBundle()).upper() << ", "
              << connectOp.sourceIndex() << ", "
-             << stringifyWireBundle(connectOp.destBundle()).upper() << ", "
+             << stringifyWireBundle(connectOp.getDestBundle()).upper() << ", "
              << connectOp.destIndex() << ");\n";
     }
   }

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -228,9 +228,9 @@ static bool skippedOp(Operation *op, CppEmitter &emitter,
   // skip op 2 : some aievec::srs for float types
   if (auto srsOp = dyn_cast<aievec::SRSOp>(op)) {
     // Get the datatype of the source accumulator and result vector
-    VectorType accType = srsOp.source().getType().cast<VectorType>();
+    VectorType accType = srsOp.getSource().getType().cast<VectorType>();
     Type eltType = accType.getElementType();
-    Value source = srsOp.source();
+    Value source = srsOp.getSource();
     // If the underlying element types are float, then we do not really need an
     // srs op if source of srsOp has only one use.
     if (eltType.isa<FloatType>() && accType.getElementType().isa<FloatType>() &&
@@ -243,9 +243,9 @@ static bool skippedOp(Operation *op, CppEmitter &emitter,
   // skip op 3 : some aievec::ups for float ops
   else if (auto upsOp = dyn_cast<aievec::UPSOp>(op)) {
     // Get the datatype of the source vector and result accumulator
-    VectorType accType = upsOp.result().getType().cast<VectorType>();
+    VectorType accType = upsOp.getResult().getType().cast<VectorType>();
     Type eltType = accType.getElementType();
-    Value source = upsOp.source();
+    Value source = upsOp.getSource();
     // If the underlying element types are float, then we do not really need a
     // ups op if the source accumulator has only one use.
     if (eltType.isa<FloatType>() && accType.getElementType().isa<FloatType>() &&
@@ -455,28 +455,28 @@ static LogicalResult printOperation(CppEmitter &emitter, T binOp) {
 
 // Print the AIE dialect UPD op
 static LogicalResult printOperation(CppEmitter &emitter, aievec::UPDOp updOp) {
-  Value source = updOp.source();
+  Value source = updOp.getSource();
   // If the source is not already emitted, error out
   if (!emitter.hasValueInScope(source))
     return failure();
 
   // Construct the access expression using memref shape and indices
-  auto indices = updOp.indices();
+  auto indices = updOp.getIndices();
   std::string access;
   if (failed(createLinearizedAccess(emitter, source, indices, access)))
     return failure();
 
   raw_indented_ostream &os = emitter.ostream();
-  Value result = updOp.result();
-  VectorType resultType = updOp.result().getType().cast<VectorType>();
+  Value result = updOp.getResult();
+  VectorType resultType = updOp.getResult().getType().cast<VectorType>();
   int32_t vecSizeInBits = getVectorSizeInBits(resultType);
   int32_t elementSizeInBits = getElementSizeInBits(resultType);
 
   // If the UPD op had an offset, add it to the access expr
-  if (updOp.offset() != 0) {
-    if (std::abs(updOp.offset()) % elementSizeInBits)
+  if (updOp.getOffset() != 0) {
+    if (std::abs(updOp.getOffset()) % elementSizeInBits)
       return failure();
-    int32_t updOffset = updOp.offset() / elementSizeInBits;
+    int32_t updOffset = updOp.getOffset() / elementSizeInBits;
     access += updOffset > 0 ? " + " : " - ";
     access += std::to_string(std::abs(updOffset));
   }
@@ -497,7 +497,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPDOp updOp) {
       os << " + " << access;
     os << ")";
   } else {
-    Value vector = updOp.vector();
+    Value vector = updOp.getVector();
     // If this is the first upd op (between idx=0 and idx=1), then generate
     // declaration
     if (!vector) {
@@ -545,7 +545,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPDOp updOp) {
     os << "(";
     os << emitter.getOrCreateName(result);
     os << ", ";
-    os << std::to_string(updOp.index());
+    os << std::to_string(updOp.getIndex());
     os << ", ";
     os << "*(";
     if (failed(emitter.emitType(updOp->getLoc(), updType)))
@@ -564,8 +564,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPDOp updOp) {
 
 // Print the UPS intrinsic
 static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
-  Value source = upsOp.source();
-  int32_t shift = upsOp.shift();
+  Value source = upsOp.getSource();
+  int32_t shift = upsOp.getShift();
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -577,7 +577,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
   if (!emitter.hasValueInScope(source))
     return failure();
 
-  VectorType accType = upsOp.result().getType().cast<VectorType>();
+  VectorType accType = upsOp.getResult().getType().cast<VectorType>();
   Type eltType = accType.getElementType();
 
   // If the underlying element types are float, then we do not really need a
@@ -603,11 +603,11 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
 
 // Generate the srs intrinsic
 static LogicalResult printOperation(CppEmitter &emitter, aievec::SRSOp srsOp) {
-  Value source = srsOp.source();
-  int32_t shift = srsOp.shift();
+  Value source = srsOp.getSource();
+  int32_t shift = srsOp.getShift();
 
   // Get the datatype of the source accumulator and result vector
-  VectorType accType = srsOp.source().getType().cast<VectorType>();
+  VectorType accType = srsOp.getSource().getType().cast<VectorType>();
   Type eltType = accType.getElementType();
 
   raw_indented_ostream &os = emitter.ostream();
@@ -651,8 +651,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::SRSOp srsOp) {
 
 // Generate the ext intrinsic
 static LogicalResult printOperation(CppEmitter &emitter, aievec::ExtOp extOp) {
-  Value source = extOp.source();
-  int8_t index = extOp.index();
+  Value source = extOp.getSource();
+  int8_t index = extOp.getIndex();
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -660,7 +660,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::ExtOp extOp) {
   if (failed(emitter.emitAssignPrefix(*extOp)))
     return failure();
   // Print the version of ext
-  VectorType resultType = extOp.result().getType().cast<VectorType>();
+  VectorType resultType = extOp.getResult().getType().cast<VectorType>();
   int32_t vecSizeInBits = getVectorSizeInBits(resultType);
   assert(vecSizeInBits == 128 || vecSizeInBits == 256 || vecSizeInBits == 512);
   os << (vecSizeInBits == 128   ? "ext_v"
@@ -680,7 +680,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::ExtOp extOp) {
 // Generate the concat intrinsic
 static LogicalResult printOperation(CppEmitter &emitter,
                                     aievec::ConcatOp concatOp) {
-  SmallVector<Value> sources = concatOp.sources();
+  SmallVector<Value> sources = concatOp.getSources();
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -708,7 +708,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
 // Generate the select intrinsic
 static LogicalResult printOperation(CppEmitter &emitter,
                                     aievec::SelectOp selectOp) {
-  Value xbuff = selectOp.xbuff();
+  Value xbuff = selectOp.getXbuff();
   assert(xbuff && "xbuff empty in select op");
 
   raw_indented_ostream &os = emitter.ostream();
@@ -718,7 +718,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
     return failure();
 
   // Determine if we want to geneate select32, or select16, or select8
-  VectorType xbuffType = selectOp.xbuff().getType().cast<VectorType>();
+  VectorType xbuffType = selectOp.getXbuff().getType().cast<VectorType>();
   int32_t elementSizeInBits = getElementSizeInBits(xbuffType);
   assert(elementSizeInBits == 16 || elementSizeInBits == 32 ||
          elementSizeInBits == 64);
@@ -728,8 +728,8 @@ static LogicalResult printOperation(CppEmitter &emitter,
                                    : "select8");
   os << "(";
   // Print select bits
-  assert(!selectOp.select().empty());
-  os << selectOp.select();
+  assert(!selectOp.getSelect().empty());
+  os << selectOp.getSelect();
   // xbuff should have already been emitted
   if (!emitter.hasValueInScope(xbuff))
     return failure();
@@ -737,17 +737,17 @@ static LogicalResult printOperation(CppEmitter &emitter,
   os << ", ";
   os << emitter.getOrCreateName(xbuff);
   // Print attributes related to lower lane selection
-  if (!selectOp.xstart().empty())
-    os << ", " << selectOp.xstart();
-  if (!selectOp.xoffsets().empty())
-    os << ", " << selectOp.xoffsets();
-  if (!selectOp.xoffsets_hi().empty())
-    os << ", " << selectOp.xoffsets_hi();
-  if (!selectOp.xsquare().empty())
-    os << ", " << selectOp.xsquare();
+  if (!selectOp.getXstart().empty())
+    os << ", " << selectOp.getXstart();
+  if (!selectOp.getXoffsets().empty())
+    os << ", " << selectOp.getXoffsets();
+  if (!selectOp.getXoffsetsHi().empty())
+    os << ", " << selectOp.getXoffsetsHi();
+  if (!selectOp.getXsquare().empty())
+    os << ", " << selectOp.getXsquare();
   // If ybuff is not null, print it
-  if (selectOp.ybuff()) {
-    Value ybuff = selectOp.ybuff();
+  if (selectOp.getYbuff()) {
+    Value ybuff = selectOp.getYbuff();
     // ybuff should have already been emitted
     if (!emitter.hasValueInScope(ybuff))
       return failure();
@@ -756,14 +756,14 @@ static LogicalResult printOperation(CppEmitter &emitter,
     os << emitter.getOrCreateName(ybuff);
   }
   // Print attributes related to higher lane selection
-  if (!selectOp.ystart().empty())
-    os << ", " << selectOp.ystart();
-  if (!selectOp.yoffsets().empty())
-    os << ", " << selectOp.yoffsets();
-  if (!selectOp.yoffsets_hi().empty())
-    os << ", " << selectOp.yoffsets_hi();
-  if (!selectOp.ysquare().empty())
-    os << ", " << selectOp.ysquare();
+  if (!selectOp.getYstart().empty())
+    os << ", " << selectOp.getYstart();
+  if (!selectOp.getYoffsets().empty())
+    os << ", " << selectOp.getYoffsets();
+  if (!selectOp.getYoffsetsHi().empty())
+    os << ", " << selectOp.getYoffsetsHi();
+  if (!selectOp.getYsquare().empty())
+    os << ", " << selectOp.getYsquare();
 
   os << ")";
   return success();
@@ -772,7 +772,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
 // Generate the pack intrinsic
 static LogicalResult printOperation(CppEmitter &emitter,
                                     aievec::PackOp packOp) {
-  Value source = packOp.source();
+  Value source = packOp.getSource();
 
   raw_indented_ostream &os = emitter.ostream();
 
@@ -781,7 +781,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
     return failure();
 
   // Determine the flavor of result
-  VectorType sourceType = packOp.source().getType().cast<VectorType>();
+  VectorType sourceType = packOp.getSource().getType().cast<VectorType>();
   Type scalarType = sourceType.getElementType();
   os << (scalarType.isUnsignedInteger() ? "upack" : "pack");
   os << "(";
@@ -802,7 +802,7 @@ static LogicalResult printAddOrSubOperand(CppEmitter &emitter, T op,
     return failure();
 
   // The operand should have already been emitted
-  Value operand = opNum == 0 ? op.lhs() : op.rhs();
+  Value operand = opNum == 0 ? op.getLhs() : op.getRhs();
   if (!emitter.hasValueInScope(operand))
     return failure();
 
@@ -835,7 +835,7 @@ static LogicalResult printFMAOrMulOperand(CppEmitter &emitter, T op,
     return failure();
 
   // The operand should have already been emitted
-  Value operand = opNum == 0 ? op.lhs() : op.rhs();
+  Value operand = opNum == 0 ? op.getLhs() : op.getRhs();
   if (!emitter.hasValueInScope(operand))
     return failure();
 
@@ -864,8 +864,8 @@ static LogicalResult printFMAOrMulOperand(CppEmitter &emitter, T op,
 
 // Generate the Mul op
 static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
-  auto lhs = mulOp.lhs();
-  auto rhs = mulOp.rhs();
+  auto lhs = mulOp.getLhs();
+  auto rhs = mulOp.getRhs();
 
   // The sources should have already been emitted
   if (!emitter.hasValueInScope(lhs) || !emitter.hasValueInScope(rhs))
@@ -876,7 +876,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
 
   std::string opname;
   // Create opname based on the result type
-  VectorType resType = mulOp.result().getType().cast<VectorType>();
+  VectorType resType = mulOp.getResult().getType().cast<VectorType>();
   Type eltType = resType.getElementType();
   if (!simpleScheme) {
     if (auto iType = eltType.dyn_cast<IntegerType>()) {
@@ -909,8 +909,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::MulOp mulOp) {
 
 // Generate the Add op
 static LogicalResult printOperation(CppEmitter &emitter, aievec::AddOp addOp) {
-  auto lhs = addOp.lhs();
-  auto rhs = addOp.rhs();
+  auto lhs = addOp.getLhs();
+  auto rhs = addOp.getRhs();
 
   // The sources should have already been emitted
   if (!emitter.hasValueInScope(lhs) || !emitter.hasValueInScope(rhs))
@@ -923,7 +923,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::AddOp addOp) {
     return failure();
 
   // Get the scalar type of result vector
-  VectorType resultType = addOp.result().getType().cast<VectorType>();
+  VectorType resultType = addOp.getResult().getType().cast<VectorType>();
   unsigned lanes = getVectorLaneSize(resultType);
   Type elementType = resultType.getElementType();
   bool floatType = elementType.isa<FloatType>();
@@ -963,8 +963,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::AddOp addOp) {
 
 // Generate the Sub op
 static LogicalResult printOperation(CppEmitter &emitter, aievec::SubOp subOp) {
-  auto lhs = subOp.lhs();
-  auto rhs = subOp.rhs();
+  auto lhs = subOp.getLhs();
+  auto rhs = subOp.getRhs();
 
   // The sources should have already been emitted
   if (!emitter.hasValueInScope(lhs) || !emitter.hasValueInScope(rhs))
@@ -977,7 +977,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::SubOp subOp) {
     return failure();
 
   // Get the scalar type of result vector
-  VectorType resultType = subOp.result().getType().cast<VectorType>();
+  VectorType resultType = subOp.getResult().getType().cast<VectorType>();
   unsigned lanes = getVectorLaneSize(resultType);
   Type elementType = resultType.getElementType();
   bool floatType = elementType.isa<FloatType>();
@@ -1017,9 +1017,9 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::SubOp subOp) {
 
 // Generate the FMA op
 static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
-  auto acc = fmaOp.acc();
-  auto lhs = fmaOp.lhs();
-  auto rhs = fmaOp.rhs();
+  auto acc = fmaOp.getAcc();
+  auto lhs = fmaOp.getLhs();
+  auto rhs = fmaOp.getRhs();
 
   // The sources should have already been emitted
   if (!emitter.hasValueInScope(acc) || !emitter.hasValueInScope(lhs) ||
@@ -1031,7 +1031,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
 
   std::string opname;
   // Create opname based on the result type
-  VectorType resType = fmaOp.result().getType().cast<VectorType>();
+  VectorType resType = fmaOp.getResult().getType().cast<VectorType>();
   Type eltType = resType.getElementType();
   if (!simpleScheme) {
     if (auto iType = eltType.dyn_cast<IntegerType>()) {
@@ -1040,7 +1040,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::FMAOp fmaOp) {
     } else if (eltType.isa<FloatType>())
       opname = "fp";
   }
-  opname += fmaOp.fmsub() ? "msc" : "mac";
+  opname += fmaOp.getFmsub() ? "msc" : "mac";
   if (!simpleScheme && !eltType.isa<FloatType>())
     opname += std::to_string(getVectorLaneSize(resType));
 

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -12,7 +12,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export commithash=d2613d5bb5dca0624833e4747f67db6fe3236ce8
+export commithash=bebc96956b76bdbc36f1d82a788c810e5b12e2c5
 
 git clone --depth 1 https://github.com/Xilinx/cmakeModules cmakeModules/cmakeModulesXilinx
 export CMAKE_MODULE_PATH=`pwd`/cmakeModules/cmakeModulesXilinx


### PR DESCRIPTION
This patch aligns the mlir-aie code with the llvm version currently used by torch-mlir (bebc96956b76bdbc36f1d82a788c810e5b12e2c5).

The main issue in the update is a change in the name of the autogenerated (tablegen) "getter" methods for dialect ops. Further cleaning up of naming might be desirable.