### PR TITLE
Fix: Errors in object FIFO tests when compiled in Release mode

### DIFF
--- a/lib/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/AIEObjectFifoStatefulTransform.cpp
@@ -189,7 +189,7 @@ struct AIEObjectFifoStatefulTransformPass
                                &endBlock);
 
     // create Bd blocks
-    Block *succ;
+    Block *succ = nullptr;
     Block *curr = bdBlock;
     int blockIndex = 0;
     for (int i = 0; i < numBlocks; i++) {
@@ -520,29 +520,21 @@ struct AIEObjectFifoStatefulTransformPass
   /// the maximum number of elements (of the original objectFifo) acquired
   /// by a process running on given tile. If no CoreOp exists for this tile
   /// return 0.
-  int findObjectFifoSize(ModuleOp &m, TileOp tile, ObjectFifoCreateOp objFifo) {
+  int findObjectFifoSize(ModuleOp &m, Value tile, ObjectFifoCreateOp objFifo) {
 
     if (objFifo.size() == 0)
       return 0;
 
-    CoreOp *core = nullptr;
+    int maxAcquire = 0;
     for (auto coreOp : m.getOps<CoreOp>()) {
-      if ((coreOp.tile().getDefiningOp<TileOp>()) == tile) {
-        core = &coreOp;
-        break;
+      if (coreOp.tile() == tile) {
+        coreOp.walk([&](ObjectFifoAcquireOp acqOp) {
+          if (acqOp.fifo().getDefiningOp<ObjectFifoCreateOp>() == objFifo)
+            if (acqOp.acqNumber() > maxAcquire)
+              maxAcquire = acqOp.acqNumber();
+        });
       }
     }
-
-    if (core == nullptr)
-      return 0;
-
-    int maxAcquire = 0;
-    core->walk([&](ObjectFifoAcquireOp acqOp) {
-      if (acqOp.fifo().getDefiningOp<ObjectFifoCreateOp>() == objFifo) {
-        if (acqOp.acqNumber() > maxAcquire)
-          maxAcquire = acqOp.acqNumber();
-      }
-    });
 
     if (maxAcquire > 0) {
       if ((maxAcquire == 1) && (objFifo.size() == 1)) {
@@ -581,9 +573,9 @@ struct AIEObjectFifoStatefulTransformPass
       } else {
         // Find max acquire number for producer and consumer of objectFifo.
         int prodMaxAcquire =
-            findObjectFifoSize(m, createOp.getProducerTileOp(), createOp);
+            findObjectFifoSize(m, createOp.producerTile(), createOp);
         int consMaxAcquire =
-            findObjectFifoSize(m, createOp.getConsumerTileOp(), createOp);
+            findObjectFifoSize(m, createOp.consumerTile(), createOp);
 
         // objectFifos between non-adjacent tiles must be split into two new
         // ones, their elements will be created in next iterations

--- a/lib/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/AIEObjectFifoStatefulTransform.cpp
@@ -527,9 +527,9 @@ struct AIEObjectFifoStatefulTransformPass
 
     int maxAcquire = 0;
     for (auto coreOp : m.getOps<CoreOp>()) {
-      if (coreOp.tile() == tile) {
+      if (coreOp.getTile() == tile) {
         coreOp.walk([&](ObjectFifoAcquireOp acqOp) {
-          if (acqOp.fifo().getDefiningOp<ObjectFifoCreateOp>() == objFifo)
+          if (acqOp.getFifo().getDefiningOp<ObjectFifoCreateOp>() == objFifo)
             if (acqOp.acqNumber() > maxAcquire)
               maxAcquire = acqOp.acqNumber();
         });
@@ -573,9 +573,9 @@ struct AIEObjectFifoStatefulTransformPass
       } else {
         // Find max acquire number for producer and consumer of objectFifo.
         int prodMaxAcquire =
-            findObjectFifoSize(m, createOp.producerTile(), createOp);
+            findObjectFifoSize(m, createOp.getProducerTile(), createOp);
         int consMaxAcquire =
-            findObjectFifoSize(m, createOp.consumerTile(), createOp);
+            findObjectFifoSize(m, createOp.getConsumerTile(), createOp);
 
         // objectFifos between non-adjacent tiles must be split into two new
         // ones, their elements will be created in next iterations

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.aie.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.aie.mlir
@@ -14,87 +14,89 @@
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
 // CHECK: module @non_adjacency {
-// CHECK:    %0 = AIE.tile(1, 2)
-// CHECK:    %1 = AIE.tile(3, 3)
-// CHECK:    AIE.flow(%0, DMA : 0, %1, DMA : 1)
-// CHECK:    %2 = AIE.buffer(%0) {sym_name = "buff0"} : memref<16xi32>
-// CHECK:    %3 = AIE.lock(%0, 0)
-// CHECK:    %4 = AIE.buffer(%0) {sym_name = "buff1"} : memref<16xi32>
-// CHECK:    %5 = AIE.lock(%0, 1)
-// CHECK:    %6 = AIE.mem(%0) {
-// CHECK:      %14 = AIE.dmaStart(MM2S0, ^bb1, ^bb3)
-// CHECK:    ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:      AIE.useLock(%3, Acquire, 1)
-// CHECK:      AIE.dmaBd(<%2 : memref<16xi32>, 0, 16>, 0)
-// CHECK:      AIE.useLock(%3, Release, 0)
-// CHECK:      cf.br ^bb2
-// CHECK:    ^bb2:  // pred: ^bb1
-// CHECK:      AIE.useLock(%5, Acquire, 1)
-// CHECK:      AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
-// CHECK:      AIE.useLock(%5, Release, 0)
-// CHECK:      cf.br ^bb1
-// CHECK:    ^bb3:  // pred: ^bb0
-// CHECK:      AIE.end
-// CHECK:    }
-// CHECK:    %7 = AIE.buffer(%1) {sym_name = "buff2"} : memref<16xi32>
-// CHECK:    %8 = AIE.lock(%1, 0)
-// CHECK:    %9 = AIE.buffer(%1) {sym_name = "buff3"} : memref<16xi32>
-// CHECK:    %10 = AIE.lock(%1, 1)
-// CHECK:    %11 = AIE.mem(%1) {
-// CHECK:      %14 = AIE.dmaStart(S2MM1, ^bb1, ^bb3)
-// CHECK:    ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:      AIE.useLock(%8, Acquire, 0)
-// CHECK:      AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
-// CHECK:      AIE.useLock(%8, Release, 1)
-// CHECK:      cf.br ^bb2
-// CHECK:    ^bb2:  // pred: ^bb1
-// CHECK:      AIE.useLock(%10, Acquire, 0)
-// CHECK:      AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
-// CHECK:      AIE.useLock(%10, Release, 1)
-// CHECK:      cf.br ^bb1
-// CHECK:    ^bb3:  // pred: ^bb0
-// CHECK:      AIE.end
-// CHECK:    }
-// CHECK:    func.func @some_work(%arg0: memref<16xi32>) {
-// CHECK:      return
-// CHECK:    }
-// CHECK:    %12 = AIE.core(%0) {
-// CHECK:      %c0 = arith.constant 0 : index
-// CHECK:      %c1 = arith.constant 1 : index
-// CHECK:      %c12 = arith.constant 12 : index
-// CHECK:      %c2 = arith.constant 2 : index
-// CHECK:      scf.for %arg0 = %c0 to %c12 step %c2 {
-// CHECK:        AIE.useLock(%3, Acquire, 0)
-// CHECK:        func.call @some_work(%2) : (memref<16xi32>) -> ()
-// CHECK:        AIE.useLock(%3, Release, 1)
-// CHECK:        AIE.useLock(%5, Acquire, 0)
-// CHECK:        func.call @some_work(%4) : (memref<16xi32>) -> ()
-// CHECK:        AIE.useLock(%5, Release, 1)
-// CHECK:      }
-// CHECK:      AIE.end
-// CHECK:    }
-// CHECK:    %13 = AIE.core(%1) {
-// CHECK:      %c0 = arith.constant 0 : index
-// CHECK:      %c1 = arith.constant 1 : index
-// CHECK:      %c12 = arith.constant 12 : index
-// CHECK:      %c2 = arith.constant 2 : index
-// CHECK:      scf.for %arg0 = %c0 to %c12 step %c2 {
-// CHECK:        AIE.useLock(%8, Acquire, 1)
-// CHECK:        func.call @some_work(%7) : (memref<16xi32>) -> ()
-// CHECK:        AIE.useLock(%8, Release, 0)
-// CHECK:        AIE.useLock(%10, Acquire, 1)
-// CHECK:        func.call @some_work(%9) : (memref<16xi32>) -> ()
-// CHECK:        AIE.useLock(%10, Release, 0)
-// CHECK:      }
-// CHECK:      AIE.end
-// CHECK:    }
-// CHECK:  }
+// CHECK:   %0 = AIE.tile(1, 2)
+// CHECK:   %1 = AIE.tile(3, 3)
+// CHECK:   AIE.multicast(%0, DMA : 0) {
+// CHECK:     AIE.multi_dest<%1, DMA : 0>
+// CHECK:   }
+// CHECK:   %2 = AIE.buffer(%0) {sym_name = "buff0"} : memref<16xi32>
+// CHECK:   %3 = AIE.lock(%0, 0)
+// CHECK:   %4 = AIE.buffer(%0) {sym_name = "buff1"} : memref<16xi32>
+// CHECK:   %5 = AIE.lock(%0, 1)
+// CHECK:   %6 = AIE.buffer(%1) {sym_name = "buff2"} : memref<16xi32>
+// CHECK:   %7 = AIE.lock(%1, 0)
+// CHECK:   %8 = AIE.buffer(%1) {sym_name = "buff3"} : memref<16xi32>
+// CHECK:   %9 = AIE.lock(%1, 1)
+// CHECK:   func.func @some_work(%arg0: memref<16xi32>) {
+// CHECK:     return
+// CHECK:   }
+// CHECK:   %10 = AIE.core(%0) {
+// CHECK:     %c0 = arith.constant 0 : index
+// CHECK:     %c1 = arith.constant 1 : index
+// CHECK:     %c12 = arith.constant 12 : index
+// CHECK:     %c2 = arith.constant 2 : index
+// CHECK:     scf.for %arg0 = %c0 to %c12 step %c2 {
+// CHECK:       AIE.useLock(%3, Acquire, 0)
+// CHECK:       func.call @some_work(%2) : (memref<16xi32>) -> ()
+// CHECK:       AIE.useLock(%3, Release, 1)
+// CHECK:       AIE.useLock(%5, Acquire, 0)
+// CHECK:       func.call @some_work(%4) : (memref<16xi32>) -> ()
+// CHECK:       AIE.useLock(%5, Release, 1)
+// CHECK:     }
+// CHECK:     AIE.end
+// CHECK:   }
+// CHECK:   %11 = AIE.core(%1) {
+// CHECK:     %c0 = arith.constant 0 : index
+// CHECK:     %c1 = arith.constant 1 : index
+// CHECK:     %c12 = arith.constant 12 : index
+// CHECK:     %c2 = arith.constant 2 : index
+// CHECK:     scf.for %arg0 = %c0 to %c12 step %c2 {
+// CHECK:       AIE.useLock(%7, Acquire, 1)
+// CHECK:       func.call @some_work(%6) : (memref<16xi32>) -> ()
+// CHECK:       AIE.useLock(%7, Release, 0)
+// CHECK:       AIE.useLock(%9, Acquire, 1)
+// CHECK:       func.call @some_work(%8) : (memref<16xi32>) -> ()
+// CHECK:       AIE.useLock(%9, Release, 0)
+// CHECK:     }
+// CHECK:     AIE.end
+// CHECK:   }
+// CHECK:   %12 = AIE.mem(%0) {
+// CHECK:     %14 = AIE.dmaStart(MM2S0, ^bb1, ^bb3)
+// CHECK:   ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:     AIE.useLock(%3, Acquire, 1)
+// CHECK:     AIE.dmaBd(<%2 : memref<16xi32>, 0, 16>, 0)
+// CHECK:     AIE.useLock(%3, Release, 0)
+// CHECK:     cf.br ^bb2
+// CHECK:   ^bb2:  // pred: ^bb1
+// CHECK:     AIE.useLock(%5, Acquire, 1)
+// CHECK:     AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:     AIE.useLock(%5, Release, 0)
+// CHECK:     cf.br ^bb1
+// CHECK:   ^bb3:  // pred: ^bb0
+// CHECK:     AIE.end
+// CHECK:   }
+// CHECK:   %13 = AIE.mem(%1) {
+// CHECK:     %14 = AIE.dmaStart(S2MM0, ^bb1, ^bb3)
+// CHECK:   ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:     AIE.useLock(%7, Acquire, 0)
+// CHECK:     AIE.dmaBd(<%6 : memref<16xi32>, 0, 16>, 0)
+// CHECK:     AIE.useLock(%7, Release, 1)
+// CHECK:     cf.br ^bb2
+// CHECK:   ^bb2:  // pred: ^bb1
+// CHECK:     AIE.useLock(%9, Acquire, 0)
+// CHECK:     AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:     AIE.useLock(%9, Release, 1)
+// CHECK:     cf.br ^bb1
+// CHECK:   ^bb3:  // pred: ^bb0
+// CHECK:     AIE.end
+// CHECK:   }
+// CHECK: }
 
 module @non_adjacency {
     %tile12 = AIE.tile(1, 2)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, %tile33, 2) : !AIE.objectFifo<memref<16xi32>>
+    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.aie.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.aie.mlir
@@ -10,93 +10,90 @@
 // 
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: andrab
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
 // CHECK: module @non_adjacency {
-// CHECK:   %0 = AIE.tile(1, 2)
-// CHECK:   %1 = AIE.tile(3, 3)
-// CHECK:   AIE.multicast(%0, DMA : 0) {
-// CHECK:     AIE.multi_dest<%1, DMA : 0>
-// CHECK:   }
-// CHECK:   %2 = AIE.buffer(%0) {sym_name = "buff0"} : memref<16xi32>
-// CHECK:   %3 = AIE.lock(%0, 0)
-// CHECK:   %4 = AIE.buffer(%0) {sym_name = "buff1"} : memref<16xi32>
-// CHECK:   %5 = AIE.lock(%0, 1)
-// CHECK:   %6 = AIE.buffer(%1) {sym_name = "buff2"} : memref<16xi32>
-// CHECK:   %7 = AIE.lock(%1, 0)
-// CHECK:   %8 = AIE.buffer(%1) {sym_name = "buff3"} : memref<16xi32>
-// CHECK:   %9 = AIE.lock(%1, 1)
-// CHECK:   func.func @some_work(%arg0: memref<16xi32>) {
-// CHECK:     return
-// CHECK:   }
-// CHECK:   %10 = AIE.core(%0) {
-// CHECK:     %c0 = arith.constant 0 : index
-// CHECK:     %c1 = arith.constant 1 : index
-// CHECK:     %c12 = arith.constant 12 : index
-// CHECK:     %c2 = arith.constant 2 : index
-// CHECK:     scf.for %arg0 = %c0 to %c12 step %c2 {
-// CHECK:       AIE.useLock(%3, Acquire, 0)
-// CHECK:       func.call @some_work(%2) : (memref<16xi32>) -> ()
-// CHECK:       AIE.useLock(%3, Release, 1)
-// CHECK:       AIE.useLock(%5, Acquire, 0)
-// CHECK:       func.call @some_work(%4) : (memref<16xi32>) -> ()
-// CHECK:       AIE.useLock(%5, Release, 1)
-// CHECK:     }
-// CHECK:     AIE.end
-// CHECK:   }
-// CHECK:   %11 = AIE.core(%1) {
-// CHECK:     %c0 = arith.constant 0 : index
-// CHECK:     %c1 = arith.constant 1 : index
-// CHECK:     %c12 = arith.constant 12 : index
-// CHECK:     %c2 = arith.constant 2 : index
-// CHECK:     scf.for %arg0 = %c0 to %c12 step %c2 {
-// CHECK:       AIE.useLock(%7, Acquire, 1)
-// CHECK:       func.call @some_work(%6) : (memref<16xi32>) -> ()
-// CHECK:       AIE.useLock(%7, Release, 0)
-// CHECK:       AIE.useLock(%9, Acquire, 1)
-// CHECK:       func.call @some_work(%8) : (memref<16xi32>) -> ()
-// CHECK:       AIE.useLock(%9, Release, 0)
-// CHECK:     }
-// CHECK:     AIE.end
-// CHECK:   }
-// CHECK:   %12 = AIE.mem(%0) {
-// CHECK:     %14 = AIE.dmaStart(MM2S0, ^bb1, ^bb3)
-// CHECK:   ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:     AIE.useLock(%3, Acquire, 1)
-// CHECK:     AIE.dmaBd(<%2 : memref<16xi32>, 0, 16>, 0)
-// CHECK:     AIE.useLock(%3, Release, 0)
-// CHECK:     cf.br ^bb2
-// CHECK:   ^bb2:  // pred: ^bb1
-// CHECK:     AIE.useLock(%5, Acquire, 1)
-// CHECK:     AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
-// CHECK:     AIE.useLock(%5, Release, 0)
-// CHECK:     cf.br ^bb1
-// CHECK:   ^bb3:  // pred: ^bb0
-// CHECK:     AIE.end
-// CHECK:   }
-// CHECK:   %13 = AIE.mem(%1) {
-// CHECK:     %14 = AIE.dmaStart(S2MM0, ^bb1, ^bb3)
-// CHECK:   ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:     AIE.useLock(%7, Acquire, 0)
-// CHECK:     AIE.dmaBd(<%6 : memref<16xi32>, 0, 16>, 0)
-// CHECK:     AIE.useLock(%7, Release, 1)
-// CHECK:     cf.br ^bb2
-// CHECK:   ^bb2:  // pred: ^bb1
-// CHECK:     AIE.useLock(%9, Acquire, 0)
-// CHECK:     AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
-// CHECK:     AIE.useLock(%9, Release, 1)
-// CHECK:     cf.br ^bb1
-// CHECK:   ^bb3:  // pred: ^bb0
-// CHECK:     AIE.end
-// CHECK:   }
-// CHECK: }
+// CHECK:    %0 = AIE.tile(1, 2)
+// CHECK:    %1 = AIE.tile(3, 3)
+// CHECK:    AIE.flow(%0, DMA : 0, %1, DMA : 1)
+// CHECK:    %2 = AIE.buffer(%0) {sym_name = "buff0"} : memref<16xi32>
+// CHECK:    %3 = AIE.lock(%0, 0)
+// CHECK:    %4 = AIE.buffer(%0) {sym_name = "buff1"} : memref<16xi32>
+// CHECK:    %5 = AIE.lock(%0, 1)
+// CHECK:    %6 = AIE.mem(%0) {
+// CHECK:      %14 = AIE.dmaStart(MM2S0, ^bb1, ^bb3)
+// CHECK:    ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:      AIE.useLock(%3, Acquire, 1)
+// CHECK:      AIE.dmaBd(<%2 : memref<16xi32>, 0, 16>, 0)
+// CHECK:      AIE.useLock(%3, Release, 0)
+// CHECK:      cf.br ^bb2
+// CHECK:    ^bb2:  // pred: ^bb1
+// CHECK:      AIE.useLock(%5, Acquire, 1)
+// CHECK:      AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:      AIE.useLock(%5, Release, 0)
+// CHECK:      cf.br ^bb1
+// CHECK:    ^bb3:  // pred: ^bb0
+// CHECK:      AIE.end
+// CHECK:    }
+// CHECK:    %7 = AIE.buffer(%1) {sym_name = "buff2"} : memref<16xi32>
+// CHECK:    %8 = AIE.lock(%1, 0)
+// CHECK:    %9 = AIE.buffer(%1) {sym_name = "buff3"} : memref<16xi32>
+// CHECK:    %10 = AIE.lock(%1, 1)
+// CHECK:    %11 = AIE.mem(%1) {
+// CHECK:      %14 = AIE.dmaStart(S2MM1, ^bb1, ^bb3)
+// CHECK:    ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:      AIE.useLock(%8, Acquire, 0)
+// CHECK:      AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
+// CHECK:      AIE.useLock(%8, Release, 1)
+// CHECK:      cf.br ^bb2
+// CHECK:    ^bb2:  // pred: ^bb1
+// CHECK:      AIE.useLock(%10, Acquire, 0)
+// CHECK:      AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:      AIE.useLock(%10, Release, 1)
+// CHECK:      cf.br ^bb1
+// CHECK:    ^bb3:  // pred: ^bb0
+// CHECK:      AIE.end
+// CHECK:    }
+// CHECK:    func.func @some_work(%arg0: memref<16xi32>) {
+// CHECK:      return
+// CHECK:    }
+// CHECK:    %12 = AIE.core(%0) {
+// CHECK:      %c0 = arith.constant 0 : index
+// CHECK:      %c1 = arith.constant 1 : index
+// CHECK:      %c12 = arith.constant 12 : index
+// CHECK:      %c2 = arith.constant 2 : index
+// CHECK:      scf.for %arg0 = %c0 to %c12 step %c2 {
+// CHECK:        AIE.useLock(%3, Acquire, 0)
+// CHECK:        func.call @some_work(%2) : (memref<16xi32>) -> ()
+// CHECK:        AIE.useLock(%3, Release, 1)
+// CHECK:        AIE.useLock(%5, Acquire, 0)
+// CHECK:        func.call @some_work(%4) : (memref<16xi32>) -> ()
+// CHECK:        AIE.useLock(%5, Release, 1)
+// CHECK:      }
+// CHECK:      AIE.end
+// CHECK:    }
+// CHECK:    %13 = AIE.core(%1) {
+// CHECK:      %c0 = arith.constant 0 : index
+// CHECK:      %c1 = arith.constant 1 : index
+// CHECK:      %c12 = arith.constant 12 : index
+// CHECK:      %c2 = arith.constant 2 : index
+// CHECK:      scf.for %arg0 = %c0 to %c12 step %c2 {
+// CHECK:        AIE.useLock(%8, Acquire, 1)
+// CHECK:        func.call @some_work(%7) : (memref<16xi32>) -> ()
+// CHECK:        AIE.useLock(%8, Release, 0)
+// CHECK:        AIE.useLock(%10, Acquire, 1)
+// CHECK:        func.call @some_work(%9) : (memref<16xi32>) -> ()
+// CHECK:        AIE.useLock(%10, Release, 0)
+// CHECK:      }
+// CHECK:      AIE.end
+// CHECK:    }
+// CHECK:  }
 
 module @non_adjacency {
     %tile12 = AIE.tile(1, 2)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2) : !AIE.objectFifo<memref<16xi32>>
+    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, %tile33, 2) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.aie.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.aie.mlir
@@ -10,7 +10,6 @@
 // 
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: andrab
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
 // CHECK: module @non_adjacency {


### PR DESCRIPTION
Currently, object FIFO tests that involve non-adjacent AIE tiles are disabled as they encounter an error when compiled in Release mode. This PR introduces a fix.