### PR TITLE
Add aiecc command line option for host target architecture

### DIFF
--- a/tools/aiecc/aiecc/cl_arguments.py
+++ b/tools/aiecc/aiecc/cl_arguments.py
@@ -66,6 +66,10 @@ def parse_args():
             default=aie_disable_compile,
             action='store_false',
             help='Disable compiling of AIE code')
+    parser.add_argument('--host-target',
+            dest="host_target",
+            default="aarch64-linux-gnu",
+            help='Target architecture of the host program')
     parser.add_argument('--compile-host',
             dest="compile_host",
             default=not host_disable_compile,

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -151,15 +151,19 @@ def run_flow(opts, tmpdirname):
       if not opts.compile_host:
         return
 
-      cmd = ['clang','--target=aarch64-linux-gnu', '-std=c++11']
+      if(opts.host_target):
+        cmd = ['clang','--target=%s' % opts.host_target, '-std=c++11']
+      else:
+        cmd = ['clang','--target=aarch64-linux-gnu', '-std=c++11']
       if(opts.sysroot):
         cmd += ['--sysroot=%s' % opts.sysroot]
       if(opts.xaie == 2):
         cmd += ['-DLIBXAIENGINEV2']
-        cmd += ['-I%s/usr/include/c++/10.2.0' % opts.sysroot]
-        cmd += ['-I%s/usr/include/c++/10.2.0/aarch64-xilinx-linux' % opts.sysroot]
-        cmd += ['-I%s/usr/include/c++/10.2.0/backward' % opts.sysroot]
-        cmd += ['-L%s/usr/lib/aarch64-xilinx-linux/10.2.0' % opts.sysroot]
+        if(opts.host_target == 'aarch64-linux-gnu'):
+          cmd += ['-I%s/usr/include/c++/10.2.0' % opts.sysroot]
+          cmd += ['-I%s/usr/include/c++/10.2.0/aarch64-xilinx-linux' % opts.sysroot]
+          cmd += ['-I%s/usr/include/c++/10.2.0/backward' % opts.sysroot]
+          cmd += ['-L%s/usr/lib/aarch64-xilinx-linux/10.2.0' % opts.sysroot]
         cmd += ['-I%s/opt/xaienginev2/include' % opts.sysroot]
         cmd += ['-L%s/opt/xaienginev2/lib' % opts.sysroot]
       else:


### PR DESCRIPTION
This allows users to optionally pass command line arguments to compile the host program for alternative architectures. The default is aarch64-linux-gnu but as an example x86_64-amd-linux-gnu could be specified. 