### PR TITLE
Improve aiecc build speed.

### DIFF
--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -116,6 +116,7 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
     int getNumDestConnections(WireBundle bundle);
     int colIndex() { return getCol(); }
     int rowIndex() { return getRow(); }
+    TileID getTileID() { return std::make_pair(getCol(), getRow()); }
     bool isShimTile() { return getRow() == 0; }
     bool isShimNOCTile();
     bool isShimPLTile();
@@ -173,7 +174,8 @@ def AIE_EndOp: AIE_Op<"end", [Terminator]> {
   let assemblyFormat = [{ attr-dict }];
 }
 
-def AIE_SwitchboxOp: AIE_Op<"switchbox", [Interconnect, SingleBlockImplicitTerminator<"EndOp">]>,
+def AIE_SwitchboxOp: AIE_Op<"switchbox", [Interconnect, TileElement,
+                                          SingleBlockImplicitTerminator<"EndOp">]>,
                      Results<(outs Index)> {
   let arguments = (
     ins Index:$tile
@@ -241,7 +243,7 @@ def AIE_ShimSwitchboxOp: AIE_Op<"shimswitchbox", [SingleBlockImplicitTerminator<
   ];
 }
 
-def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect,
+def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect, TileElement,
                                       SingleBlockImplicitTerminator<"EndOp">]>,
                          Results<(outs Index)> {
   let arguments = (
@@ -278,7 +280,8 @@ def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect,
  ];
 }
 
-def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint/*, CallableOpInterface*/]>,
+def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint, TileElement
+                                      /*, CallableOpInterface*/]>,
                          Results<(outs Index)> {
   let arguments = (
     ins Index:$tile
@@ -316,7 +319,7 @@ def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint/*, CallableOpInterface*/]>,
   }];
 }
 
-def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint]>, Results<(outs Index)> {
+def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint, TileElement]>, Results<(outs Index)> {
   let arguments = (
     ins Index:$tile
   );
@@ -1061,7 +1064,7 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "func::FuncOp", "S
 
 // MemOps are not actually Callable, but we want to inline code into them, so we have to 
 // implement CallableOpInterface
-def AIE_MemOp: AIE_Op<"mem", [FlowEndPoint, CallableOpInterface]>,
+def AIE_MemOp: AIE_Op<"mem", [TileElement, FlowEndPoint, CallableOpInterface]>,
                      Results<(outs Index)> {
   let summary = "Declare a memory op";
   let description = [{
@@ -1093,6 +1096,7 @@ def AIE_MemOp: AIE_Op<"mem", [FlowEndPoint, CallableOpInterface]>,
   let extraClassDeclaration = [{
     int colIndex();
     int rowIndex();
+    TileOp getTileOp();
     int maxSizeInBytes() { return 32768; }
     // CallableOpInterface
     Region *getCallableRegion();
@@ -1105,7 +1109,7 @@ def AIE_MemOp: AIE_Op<"mem", [FlowEndPoint, CallableOpInterface]>,
   ];
 }
 
-def AIE_LockOp: AIE_Op<"lock", []>, Results<(outs Index)> {
+def AIE_LockOp: AIE_Op<"lock", [TileElement]>, Results<(outs Index)> {
   let summary = "Declare a physical lock";
   let description = [{
     This operation creates a physical lock. For this operation the lockID variable is optional. 
@@ -1160,6 +1164,7 @@ def AIE_LockOp: AIE_Op<"lock", []>, Results<(outs Index)> {
         $_builder.getI32IntegerAttr(lockID));
       }]>
   ];
+  let hasVerifier = 1;
   // let hasCanonicalizer = 1;
 }
 
@@ -1213,7 +1218,7 @@ def AIE_UseLockOp: AIE_Op<"useLock", []> {
   }];
 }
 
-def AIE_BufferOp: AIE_Op<"buffer", []>, Results<(outs AnyMemRef)> {
+def AIE_BufferOp: AIE_Op<"buffer", [TileElement]>, Results<(outs AnyMemRef)> {
   let summary = "Declare a buffer";
   let description = [{
     This operation instantiates a buffer that belongs to a Memory Module of a tile.
@@ -1230,6 +1235,7 @@ def AIE_BufferOp: AIE_Op<"buffer", []>, Results<(outs AnyMemRef)> {
   );
   let results = (outs AnyMemRef:$buffer);
   let assemblyFormat = [{ `(` $tile `)` attr-dict `:` type($buffer) }];
+  let hasVerifier = 1;
   let extraClassDeclaration = [{
     bool hasName() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
@@ -1260,7 +1266,7 @@ def AIE_BufferOp: AIE_Op<"buffer", []>, Results<(outs AnyMemRef)> {
     int64_t getAllocationSize();
     TileOp getTileOp();
   }];
-  }
+}
 
 def AIE_ExternalBufferOp: AIE_Op<"external_buffer", []>, Results<(outs AnyMemRef)> {
   let summary = "Declare a buffer in external memory";

--- a/include/aie/AIEDialect.h
+++ b/include/aie/AIEDialect.h
@@ -43,6 +43,12 @@ class FlowEndPoint : public OpTrait::TraitBase<ConcreteType, FlowEndPoint> {};
 } // namespace OpTrait
 } // namespace mlir
 
+namespace xilinx {
+namespace AIE {
+typedef std::pair<int, int> TileID;
+}
+} // namespace xilinx
+
 /// Include the generated interface declarations.
 #include "aie/AIEInterfaces.h.inc"
 
@@ -161,7 +167,6 @@ public:
 
 typedef std::pair<WireBundle, int> Port;
 typedef std::pair<Port, Port> Connect;
-typedef std::pair<int, int> TileID;
 typedef std::pair<DMAChannelDir, int> DMAChannel;
 
 bool isValidTile(TileID src);

--- a/include/aie/AIEInterfaces.td
+++ b/include/aie/AIEInterfaces.td
@@ -63,3 +63,22 @@ def Interconnect : OpInterface<"Interconnect"> {
     >
   ];
 }
+
+def TileElement : OpInterface<"TileElement"> {
+  let description = [{
+    Interface for operations that exist in a TileOp.
+  }];
+  let cppNamespace = "::xilinx::AIE";
+  let methods = [
+    InterfaceMethod<[{
+        Return the location of the Tile where the element is located.
+      }],
+      "xilinx::AIE::TileID", "getTileID", (ins ),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        ConcreteOp op = cast<ConcreteOp>(this->getOperation());
+        return op.getTileOp().getTileID();
+      }]
+    >
+  ];
+}

--- a/include/aie/AIEPasses.td
+++ b/include/aie/AIEPasses.td
@@ -40,11 +40,13 @@ def AIECoreToStandard : Pass<"aie-standard-lowering", "ModuleOp"> {
   let summary = "Lowering operations in AIE cores' regions to Standard";
   let description = [{
 
-    Outline code inside a particular AIE.core operation into the llvm dialect.
+    Outline code inside AIE.core operations into the llvm dialect.
     BufferOp operations are converted to a GlobalMemrefOp and references to
     those buffers are converted to GetGlobalMemrefOp.  Other AIE operations
     inside the cores are generally lowered to appropriate function intrinsics.
     Other AIE operations (e.g. CoreOp, TileOp, LockOp) outside the core are removed.
+
+    Optionally, tileCol and tileRow can specify a single core to export
 
   }];
   let options = [

--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -163,6 +163,49 @@ bool isLegalMemAffinity(int coreCol, int coreRow, int memCol, int memRow) {
   return IsMemSouth || IsMemNorth || IsMemWest || IsMemEast;
 }
 
+// Walk the operation hierarchy until we find a containing TileElement.
+// If no parent is a TileElement, then return null.
+static xilinx::AIE::TileElement getParentTileElement(Operation *op) {
+  auto parent = op->getParentOp();
+  while (!llvm::isa_and_nonnull<mlir::ModuleOp>(parent)) {
+    if (auto element = llvm::dyn_cast<xilinx::AIE::TileElement>(parent))
+      return element;
+    parent = parent->getParentOp();
+  }
+  return llvm::dyn_cast<xilinx::AIE::TileElement>(parent);
+}
+
+struct UsesAreAccessable {
+  static LogicalResult verifyTrait(Operation *op) {
+    auto thisElement = cast<xilinx::AIE::TileElement>(op);
+    auto thisID = thisElement.getTileID();
+    auto users = op->getResult(0).getUsers();
+    for (auto user : users) {
+      // AIE.useLock may be used in a module to set the lock's default value
+      if (llvm::isa_and_nonnull<mlir::ModuleOp>(user->getParentOp()))
+        return success();
+      if (auto element = getParentTileElement(user)) {
+
+        auto tileID = element.getTileID();
+        if (!xilinx::AIE::isLegalMemAffinity(tileID.first, tileID.second,
+                                             thisID.first, thisID.second))
+          return (op->emitOpError("in Column ")
+                  << thisID.first << " and Row " << thisID.second
+                  << " is accessed from an unreachable tile in Column "
+                  << tileID.first << " and Row " << tileID.second)
+                     .attachNote(user->getLoc())
+                 << "user";
+      } else {
+        // This should probably be caught elsewhere as well.
+        return op->emitOpError("is accessed outside of a tile")
+                   .attachNote(user->getLoc())
+               << "user";
+      }
+    }
+    return success();
+  }
+};
+
 namespace detail {
 /// This class represents the internal storage of the AIE `ObjectFifoType`.
 struct AIEObjectFifoTypeStorage : public mlir::TypeStorage {
@@ -715,6 +758,12 @@ int64_t xilinx::AIE::BufferOp::getAllocationSize() {
 xilinx::AIE::TileOp xilinx::AIE::BufferOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
+LogicalResult xilinx::AIE::BufferOp::verify() {
+  auto result = UsesAreAccessable::verifyTrait(*this);
+  if (result.failed())
+    return result;
+  return success();
+}
 
 // MemOp
 LogicalResult xilinx::AIE::MemOp::verify() {
@@ -745,6 +794,9 @@ LogicalResult xilinx::AIE::MemOp::verify() {
   return success();
 }
 
+xilinx::AIE::TileOp xilinx::AIE::MemOp::getTileOp() {
+  return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
+}
 int xilinx::AIE::MemOp::colIndex() {
   Operation *Op = getTile().getDefiningOp();
   xilinx::AIE::TileOp tile = dyn_cast<xilinx::AIE::TileOp>(Op);
@@ -785,6 +837,34 @@ template <typename... ParentOpTypes> struct HasSomeParent {
   }
 };
 
+xilinx::AIE::TileOp xilinx::AIE::LockOp::getTileOp() {
+  return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
+}
+int xilinx::AIE::LockOp::colIndex() { return getTileOp().colIndex(); }
+int xilinx::AIE::LockOp::rowIndex() { return getTileOp().rowIndex(); }
+
+LogicalResult xilinx::AIE::LockOp::verify() {
+  auto result = UsesAreAccessable::verifyTrait(*this);
+  if (result.failed())
+    return result;
+  return success();
+}
+
+struct UsesReachableLock {
+  static LogicalResult verifyTrait(Operation *op) {
+    auto useLock = dyn_cast<xilinx::AIE::UseLockOp>(op);
+    auto lock =
+        dyn_cast<xilinx::AIE::LockOp>(useLock.getLock().getDefiningOp());
+    auto parent = dyn_cast<xilinx::AIE::TileElement>(useLock->getParentOp());
+    auto tileID = parent.getTileID();
+
+    if (!xilinx::AIE::isLegalMemAffinity(tileID.first, tileID.second,
+                                         lock.colIndex(), lock.rowIndex()))
+      return failure();
+    return success();
+  }
+};
+
 struct UsesOneLockInDMABlock {
   static LogicalResult verifyTrait(Operation *op) {
     auto block = op->getBlock();
@@ -819,12 +899,6 @@ struct AcquireReleaseOneStateInDMABlock {
     return success();
   }
 };
-
-xilinx::AIE::TileOp xilinx::AIE::LockOp::getTileOp() {
-  return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
-}
-int xilinx::AIE::LockOp::colIndex() { return getTileOp().colIndex(); }
-int xilinx::AIE::LockOp::rowIndex() { return getTileOp().rowIndex(); }
 
 LogicalResult xilinx::AIE::UseLockOp::verify() {
   // AIE.useLock may be used in a module to set the lock's default value

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -250,6 +250,8 @@ SECTIONS
                 auto fileName = std::string(fileAttr.getValue());
                 output << "INPUT(" << fileName << ")\n";
               }
+              output << "PROVIDE(_main = core" << tile.getCol() << tile.getRow()
+                     << ");\n";
             }
           }
         return success();
@@ -301,8 +303,11 @@ SECTIONS
         // _include _file rom.o
         for (auto tile : module.getOps<TileOp>())
           if (tile.colIndex() == tileCol && tile.rowIndex() == tileRow) {
+            std::string corefunc = std::string("core") +
+                                   std::to_string(tile.getCol()) +
+                                   std::to_string(tile.getRow());
             output << "_entry_point _main_init\n";
-            output << "_symbol      _main _after _main_init\n";
+            output << "_symbol " << corefunc << " _after _main_init\n";
             output << "_symbol      _main_init 0\n";
             output << "_reserved DMb      0x00000 0x20000 //Don't put data in "
                       "code memory\n";
@@ -331,6 +336,8 @@ SECTIONS
                 output << "_include _file " << fileName << "\n";
               }
             }
+            output << "_resolve _main core" << tile.getCol() << tile.getRow()
+                   << "\n";
           }
         return success();
       },

--- a/test/create-locks/test_lock3.mlir
+++ b/test/create-locks/test_lock3.mlir
@@ -32,7 +32,7 @@
 // CHECK-NEXT:    %10 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK-NEXT:  ^bb1:
 // CHECK-NEXT:    AIE.useLock(%1, Acquire, 0)
-// CHECK-NEXT:    AIE.dmaBd(<%4 : memref<256xi32>, 0, 256>, 0)
+// CHECK-NEXT:    AIE.dmaBd(<%5 : memref<256xi32>, 0, 256>, 0)
 // CHECK-NEXT:    AIE.useLock(%1, Release, 1)
 // CHECK-NEXT:    cf.br ^bb2
 // CHECK-NEXT:  ^bb2:
@@ -78,7 +78,7 @@ module @test_lock3 {
       %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
-      AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)
+      AIE.dmaBd(<%buf44 : memref<256xi32>, 0, 256>, 0)
       AIE.useToken @token0(Release, 2)
       cf.br ^end
     ^end:

--- a/test/dialect/badbuffer.mlir
+++ b/test/dialect/badbuffer.mlir
@@ -1,0 +1,24 @@
+//===- simple.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aiecc.py %s |& FileCheck %s
+// CHECK: error: 'AIE.buffer' op in Column 1 and Row 1 is accessed from an unreachable tile in Column 4 and Row 4
+
+module @test {
+  %t1 = AIE.tile(1, 1)
+  %t2 = AIE.tile(4, 4)
+  %b1 = AIE.buffer(%t1) { sym_name = "a" } : memref<16xi32>
+  %core = AIE.core(%t2) {
+    %val1 = arith.constant 1 : i32
+    %idx1 = arith.constant 3 : index
+    memref.store %val1, %b1[%idx1] : memref<16xi32>
+    AIE.end
+  }
+}

--- a/test/dialect/badlock.mlir
+++ b/test/dialect/badlock.mlir
@@ -1,0 +1,22 @@
+//===- assign-lockIDs.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aiecc.py %s |& FileCheck %s
+// CHECK: error: 'AIE.lock' op in Column 4 and Row 4 is accessed from an unreachable tile in Column 1 and Row 1
+module @test {
+  %t1 = AIE.tile(1, 1)
+  %t2 = AIE.tile(4, 4)
+  %lock = AIE.lock(%t2, 3) { sym_name = "lock1" }
+
+  AIE.core(%t1) {
+    AIE.useLock(%lock, "Acquire", 1)
+    AIE.end
+  }
+}

--- a/test/dialect/badlockdma.mlir
+++ b/test/dialect/badlockdma.mlir
@@ -1,0 +1,27 @@
+//===- assign-lockIDs.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aiecc.py %s |& FileCheck %s
+// CHECK: error: 'AIE.lock' op in Column 4 and Row 4 is accessed from an unreachable tile in Column 1 and Row 1
+module @test {
+  %t1 = AIE.tile(1, 1)
+  %t2 = AIE.tile(4, 4)
+  %lock = AIE.lock(%t2, 3) { sym_name = "lock1" }
+
+  %mem13 = AIE.mem(%t1) {
+    %dma0 = AIE.dmaStart("MM2S", 0, ^bd0, ^end)
+    ^bd0:
+      AIE.useLock(%lock, "Acquire", 1)
+      AIE.useLock(%lock, "Release", 0)
+      cf.br ^end // point to the next BD, or termination
+    ^end:
+      AIE.end
+  }
+}

--- a/test/dialect/badlockfunc.mlir
+++ b/test/dialect/badlockfunc.mlir
@@ -1,0 +1,22 @@
+//===- assign-lockIDs.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aiecc.py %s |& FileCheck %s
+// CHECK: error: 'AIE.lock' op is accessed outside of a tile
+module @test {
+  %t1 = AIE.tile(1, 1)
+  %t2 = AIE.tile(4, 4)
+  %lock = AIE.lock(%t2, 3) { sym_name = "lock1" }
+
+  func.func @task3() -> () {
+    AIE.useLock(%lock, "Acquire", 1)
+    return
+  }
+}

--- a/test/generate-mmap/test_mmap0.mlir
+++ b/test/generate-mmap/test_mmap0.mlir
@@ -38,8 +38,8 @@
 // CHECK: _symbol c 0x38050 1024
 
 // BCF44: _entry_point _main_init
-// BCF44: _symbol      _main _after _main_init
-// BCF44: _symbol      _main_init 0
+// BCF44: _symbol core44 _after _main_init
+// BCF44: _symbol _main_init 0
 // BCF44: _reserved DMb      0x00000 0x20000 //Don't put data in code memory
 // BCF44: _symbol z 0x20000 0x20
 // BCF44: _extern z

--- a/test/lower-to-standard/lower_buffer.mlir
+++ b/test/lower-to-standard/lower_buffer.mlir
@@ -8,21 +8,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-standard-lowering="tilecol=3 tilerow=3" %s | FileCheck --check-prefix=CHECK33 %s
-// RUN: aie-opt --aie-standard-lowering="tilecol=4 tilerow=3" %s | FileCheck --check-prefix=CHECK43 %s
-// CHECK33:    memref.global "public" @a : memref<4xi32>
+// RUN: aie-opt --aie-standard-lowering="tilecol=3 tilerow=3" %s | FileCheck --check-prefixes=CHECKALL,CHECK33 %s
+// RUN: aie-opt --aie-standard-lowering="tilecol=4 tilerow=3" %s | FileCheck --check-prefixes=CHECKALL,CHECK43 %s
+// RUN: aie-opt --aie-standard-lowering %s | FileCheck --check-prefixes=CHECKALL,CHECK33,CHECK43 %s
+
+// CHECKALL:    memref.global "public" @a : memref<4xi32>
 // CHECK33-LABEL:  func.func @core33() {
-// CHECK33:    %0 = memref.get_global @a : memref<4xi32>
 // CHECK33:    %c0 = arith.constant 0 : index
 // CHECK33:    %c377_i32 = arith.constant 377 : i32
+// CHECK33:    %0 = memref.get_global @a : memref<4xi32>
 // CHECK33:    memref.store %c377_i32, %0[%c0] : memref<4xi32>
 // CHECK33:    return
 // CHECK33:  }
 
-// CHECK43:    memref.global "public" @a : memref<4xi32>
 // CHECK43-LABEL:  func.func @core43() {
-// CHECK43:    %0 = memref.get_global @a : memref<4xi32>
 // CHECK43:    %c0 = arith.constant 0 : index
+// CHECK43:    %0 = memref.get_global @a : memref<4xi32>
 // CHECK43:    %1 = memref.load %0[%c0] : memref<4xi32>
 // CHECK43:    return
 // CHECK43:  }

--- a/test/lower-to-standard/lower_buffer_and_lock.mlir
+++ b/test/lower-to-standard/lower_buffer_and_lock.mlir
@@ -20,15 +20,15 @@
 module @test_core_llvm1 {
 // CHECK11:  memref.global "public" @a : memref<256xi32>
 // CHECK11:  func.func @core11() {
-// CHECK11:    %0 = memref.get_global @a : memref<256xi32>
-// CHECK11:    memref.assume_alignment %0, 32 : memref<256xi32>
 // CHECK11:    %c56 = arith.constant 56 : index
-// CHECK11:    %1 = arith.index_cast %c56 : index to i32
+// CHECK11:    %0 = arith.index_cast %c56 : index to i32
 // CHECK11:    %c0_i32 = arith.constant 0 : i32
-// CHECK11:    call @llvm.aie.lock.acquire.reg(%1, %c0_i32) : (i32, i32) -> ()
+// CHECK11:    call @llvm.aie.lock.acquire.reg(%0, %c0_i32) : (i32, i32) -> ()
 // CHECK11:    %c1_i32 = arith.constant 1 : i32
 // CHECK11:    %c16 = arith.constant 16 : index
-// CHECK11:    memref.store %c1_i32, %0[%c16] : memref<256xi32>
+// CHECK11:    %1 = memref.get_global @a : memref<256xi32>
+// CHECK11:    memref.assume_alignment %1, 32 : memref<256xi32>
+// CHECK11:    memref.store %c1_i32, %1[%c16] : memref<256xi32>
 // CHECK11:    %2 = arith.index_cast %c56 : index to i32
 // CHECK11:    %c1_i32_0 = arith.constant 1 : i32
 // CHECK11:    call @llvm.aie.lock.release.reg(%2, %c1_i32_0) : (i32, i32) -> ()
@@ -37,14 +37,14 @@ module @test_core_llvm1 {
 
 // CHECK12:  memref.global "public" @a : memref<256xi32>
 // CHECK12:  func.func @core12() {
-// CHECK12:    %0 = memref.get_global @a : memref<256xi32>
-// CHECK12:    memref.assume_alignment %0, 32 : memref<256xi32>
 // CHECK12:    %c8 = arith.constant 8 : index
-// CHECK12:    %1 = arith.index_cast %c8 : index to i32
+// CHECK12:    %0 = arith.index_cast %c8 : index to i32
 // CHECK12:    %c1_i32 = arith.constant 1 : i32
-// CHECK12:    call @llvm.aie.lock.acquire.reg(%1, %c1_i32) : (i32, i32) -> ()
+// CHECK12:    call @llvm.aie.lock.acquire.reg(%0, %c1_i32) : (i32, i32) -> ()
 // CHECK12:    %c16 = arith.constant 16 : index
-// CHECK12:    %2 = memref.load %0[%c16] : memref<256xi32>
+// CHECK12:    %1 = memref.get_global @a : memref<256xi32>
+// CHECK12:    memref.assume_alignment %1, 32 : memref<256xi32>
+// CHECK12:    %2 = memref.load %1[%c16] : memref<256xi32>
 // CHECK12:    %3 = arith.index_cast %c8 : index to i32
 // CHECK12:    %c0_i32 = arith.constant 0 : i32
 // CHECK12:    call @llvm.aie.lock.release.reg(%3, %c0_i32) : (i32, i32) -> ()

--- a/test/lower-to-standard/lower_dma.mlir
+++ b/test/lower-to-standard/lower_dma.mlir
@@ -33,7 +33,7 @@ module @example0 {
   %l33_1 = AIE.lock(%t33, 1)
   %l43_0 = AIE.lock(%t43, 0)
 
-  %buf33 = AIE.buffer(%t11) { sym_name = "a" } : memref<256xi32>
+  %buf33 = AIE.buffer(%t33) { sym_name = "a" } : memref<256xi32>
   %buf43 = AIE.buffer(%t43) { sym_name = "b" } : memref<256xi32>
 
   %m33 = AIE.mem(%t33) {

--- a/test/lower-to-standard/lower_stream.mlir
+++ b/test/lower-to-standard/lower_stream.mlir
@@ -22,10 +22,6 @@
 //CHECK11:    call @llvm.aie.put.mcd(%c64_i384) : (i384) -> ()
 //CHECK11:    return
 //CHECK11:  }
-//CHECK11:  func.func @_main() {
-//CHECK11:    call @core11() : () -> ()
-//CHECK11:    return
-//CHECK11:  }
 
 //CHECK21:  func.func @core21() {
 //CHECK21:    %c0_i32 = arith.constant 0 : i32
@@ -36,11 +32,6 @@
 //CHECK21:    %3 = call @llvm.aie.get.scd() : () -> i384
 //CHECK21:    return
 //CHECK21:  }
-//CHECK21:  func.func @_main() {
-//CHECK21:    call @core21() : () -> ()
-//CHECK21:    return
-//CHECK21:  }
-
 
 // Test LLVM lowering to some AIE scalar intrinsic functions (streams, cascades)
 // Each core's region is lowered to LLVM Dialect

--- a/test/unit_tests/chess_compiler_tests/00_itsalive/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/00_itsalive/aie.mlir
@@ -9,7 +9,12 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: valid_xchess_license
-// RUN: aiecc.py --xchesscc --xbridge %s
+// RUN: aiecc.py --no-unified --xchesscc    --xbridge %s
+// RUN: aiecc.py --unified    --xchesscc    --xbridge %s
+// RUN: aiecc.py --no-unified --no-xchesscc --xbridge %s
+// RUN: aiecc.py --unified    --no-xchesscc --xbridge %s
+// RUN: aiecc.py --no-unified --xchesscc    --no-xbridge %s
+// RUN: aiecc.py --unified    --xchesscc    --no-xbridge %s
 
 module @test00_itsalive {
   %tile12 = AIE.tile(1, 2)

--- a/tools/aiecc/aiecc/cl_arguments.py
+++ b/tools/aiecc/aiecc/cl_arguments.py
@@ -114,6 +114,16 @@ def parse_args():
             default=False,
             action='store_true',
             help='Profile commands to find the most expensive executions.')
+    parser.add_argument('--unified',
+            dest="unified",
+            default=aie_unified_compile,
+            action='store_true',
+            help='Compile all cores together in a single process')
+    parser.add_argument('--no-unified',
+            dest="unified",
+            default=not aie_unified_compile,
+            action='store_false',
+            help='Compile cores independently in separate processes')
     parser.add_argument('-n',
             dest="execute",
             default=True,

--- a/tools/aiecc/aiecc/configure.py.in
+++ b/tools/aiecc/aiecc/configure.py.in
@@ -9,4 +9,5 @@ aie_link_with_xchesscc = @CONFIG_LINK_WITH_XCHESSCC@
 aie_compile_with_xchesscc = @CONFIG_COMPILE_WITH_XCHESSCC@
 aie_disable_link = @CONFIG_DISABLE_LINK@
 aie_disable_compile = @CONFIG_DISABLE_COMPILE@
+aie_unified_compile = True
 host_disable_compile = @CONFIG_DISABLE_HOST_COMPILE@


### PR DESCRIPTION
It turns out that lots of compile jobs isn't always the right thing.  
For the prime sieve example (336 cores), a unified build runs in about 3 seconds, compared to 9 seconds for a parallel build. (on xsjsda131, with a release build of acdc)  This is essentially how long it takes to compile the ARM code, so making it run any faster becomes pointless.

Using xchesscc + xbridge, a unified build is about 2 minutes, while a parallel build is over 3 minutes. (on xsjrdevl167, 56 cores, debug build of acdc)

These are relatively beefy machines.  Running with less cores only makes a unified build an even better idea.


