### PR TITLE
Update llvm to 798fa4b4

### DIFF
--- a/test/lower-to-standard/lower_stream.mlir
+++ b/test/lower-to-standard/lower_stream.mlir
@@ -15,7 +15,7 @@
 //CHECK11:    %c0_i32 = arith.constant 0 : i32
 //CHECK11:    %c1_i32 = arith.constant 1 : i32
 //CHECK11:    %c16_i32 = arith.constant 16 : i32
-//CHECK11:    %c32_i128 = arith.cogitnstant 32 : i128
+//CHECK11:    %c32_i128 = arith.constant 32 : i128
 //CHECK11:    call @llvm.aie.put.ms(%c0_i32, %c16_i32) : (i32, i32) -> ()
 //CHECK11:    call @llvm.aie.put.wms(%c1_i32, %c32_i128) : (i32, i128) -> ()
 //CHECK11:    %c64_i384 = arith.constant 64 : i384

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -93,8 +93,7 @@ class flow_runner:
       llvmir_chesslinked = llvmir + "chesslinked.ll"
       # Note that chess-clang comes from a time before opaque pointers
       #await self.do_call(task, ['clang', "-Xclang -no-opaque-pointers", llvmir_chesshack, self.chess_intrinsic_wrapper, '-S', '-emit-llvm', '-o', llvmir_chesslinked])
-      global llvmlink
-      await self.do_call(task, [llvmlink, '--opaque-pointers=0', llvmir_chesshack, self.chess_intrinsic_wrapper, '-S', '-o', llvmir_chesslinked])
+      await self.do_call(task, ['llvm-link', '--opaque-pointers=0', llvmir_chesshack, self.chess_intrinsic_wrapper, '-S', '-o', llvmir_chesslinked])
       await self.do_call(task, ['sed', '-i', 's/noundef//', llvmir_chesslinked])
       # Formal function argument names not used in older LLVM
       await self.do_call(task, ['sed', '-i', '-E', '/define .*@/ s/%[0-9]*//g', llvmir_chesslinked])
@@ -343,11 +342,6 @@ def main(builtin_params={}):
     # Assume that aie-opt, etc. binaries are relative to this script.
     aie_path = os.path.join(thispath, '..')
     peano_path = os.path.join(opts.peano_install_dir, 'bin')
-    global llvmlink
-    if(os.path.exists(opts.peano_install_dir)):
-      llvmlink = os.path.join(thispath, peano_path, 'llvm-link')
-    else:
-      llvmlink = 'llvm-link'
 
     if('VITIS' not in os.environ):
       # Try to find vitis in the path

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -101,6 +101,18 @@ class flow_runner:
       await self.do_call(task, ['sed', '-i', '-E', 's/mustprogress//g', llvmir_chesslinked])
       await self.do_call(task, ['sed', '-i', '-E', 's/poison/undef/g', llvmir_chesslinked])
       await self.do_call(task, ['sed', '-i', '-E', 's/nocallback//g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(none\)/readnone/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(read\)/readonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(write\)/writeonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(argmem: readwrite\)/argmemonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(argmem: read\)/argmemonly readonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(argmem: write\)/argmemonly writeonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(inaccessiblemem: readwrite\)/inaccessiblememonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(inaccessiblemem: read\)/inaccessiblememonly readonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(inaccessiblemem: write\)/inaccessiblememonly writeonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(argmem: readwrite, inaccessiblemem: readwrite\)/inaccessiblemem_or_argmemonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(argmem: read, inaccessiblemem: read\)/inaccessiblemem_or_argmemonly readonly/g', llvmir_chesslinked])
+      await self.do_call(task, ['sed', '-i', '-E', 's/memory\(argmem: write, inaccessiblemem: write\)/inaccessiblemem_or_argmemonly writeonly/g', llvmir_chesslinked])
       return llvmir_chesslinked
 
   async def prepare_for_chesshack(self, task):

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -12,7 +12,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export commithash=74fb770de9399d7258a8eda974c93610cfde698e
+export commithash=798fa4b415eea55c868ae42b874083cb9886991e
 
 git clone --depth 1 https://github.com/Xilinx/cmakeModules cmakeModules/cmakeModulesXilinx
 export CMAKE_MODULE_PATH=`pwd`/cmakeModules/cmakeModulesXilinx


### PR DESCRIPTION
No changes needed to build.

This update is still missing fixes to chess-clang which are required due to upstream changes to the .ll format