### PR TITLE
Add aie dialect python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
 option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
 option(AIE_INCLUDE_INTEGRATION_TESTS
        "Generate build targets for the mlir-aie integration tests." OFF)
+option(AIE_ENABLE_BINDINGS_PYTHON "Enable MLIR python bindings." OFF)
 
 find_package(MLIR REQUIRED CONFIG)
 find_package(Boost REQUIRED)
@@ -88,11 +89,35 @@ add_dependencies(aie-headers mlir-headers)
 add_custom_target(docs ALL)
 add_dependencies(docs mlir-doc)
 
+# python install directory
+if (AIE_ENABLE_BINDINGS_PYTHON)
+
+  if(NOT AIE_PYTHON_PACKAGES_DIR)
+    set(AIE_PYTHON_PACKAGES_DIR "${CMAKE_CURRENT_BINARY_DIR}/python")
+  endif()
+
+  # python install directory
+  if(NOT AIE_PYTHON_INSTALL_DIR)
+    set(AIE_PYTHON_INSTALL_DIR "python")
+  endif()
+
+  # setup python
+  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+  include(MLIRDetectPythonEnv)
+  mlir_detect_pybind11_install()
+  find_package(pybind11 2.6 REQUIRED)
+
+endif()
+
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(test)
 add_subdirectory(tools)
 add_subdirectory(runtime_lib)
+
+if (AIE_ENABLE_BINDINGS_PYTHON)
+  add_subdirectory(python)
+endif()
 
 if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   install(DIRECTORY include/aie

--- a/include/aie-c/Dialects.h
+++ b/include/aie-c/Dialects.h
@@ -1,0 +1,23 @@
+//===- Dialects.h -----------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef AIE_C_DIALECTS_H
+#define AIE_C_DIALECTS_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIE, aie);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AIE_C_DIALECTS_H

--- a/include/aie-c/Dialects.h
+++ b/include/aie-c/Dialects.h
@@ -16,6 +16,13 @@ extern "C" {
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIE, aie);
 
+//===---------------------------------------------------------------------===//
+// ObjectFifoType
+//===---------------------------------------------------------------------===//
+
+MLIR_CAPI_EXPORTED bool aieTypeIsObjectFifoType(MlirType type);
+MLIR_CAPI_EXPORTED MlirType aieObjectFifoTypeGet(MlirType type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/aie-c/Registration.h
+++ b/include/aie-c/Registration.h
@@ -1,0 +1,29 @@
+//===- Registration.h -------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef AIE_C_REGISTRATION_H
+#define AIE_C_REGISTRATION_H
+
+#include "mlir-c/IR.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Registers all AIE dialects with a context.
+ * This is needed before creating IR for these Dialects.
+ */
+void aieRegisterAllDialects(MlirContext context);
+
+/** Registers all AIE passes for symbolic access with the global registry. */
+void aieRegisterAllPasses();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AIE_C_REGISTRATION_H

--- a/include/aie/InitialAllDialect.h
+++ b/include/aie/InitialAllDialect.h
@@ -15,6 +15,7 @@
 #define XILINX_INITALLDIALECTS_H_
 
 #include "aie/Dialect/ADF/ADFDialect.h"
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
 #include "mlir/IR/Dialect.h"
 
@@ -26,8 +27,7 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<
     ADF::ADFDialect,
     aievec::AIEVecDialect,
-    // todo: initial AIE dialect here
-    // AIE::AIEDialect
+    AIE::AIEDialect
   >();
   // clang-format on
 }

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+add_mlir_library(AIECAPI
+Dialects.cpp
+Registration.cpp
+
+DEPENDS
+
+ENABLE_AGGREGATION
+LINK_COMPONENTS
+Core
+
+LINK_LIBS PUBLIC
+AIE
+ADF
+MLIRAIEVec
+#AIEInitAll
+MLIRIR
+MLIRSupport
+)

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -11,3 +11,15 @@
 #include "mlir/CAPI/Registration.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIE, aie, xilinx::AIE::AIEDialect)
+
+//===---------------------------------------------------------------------===//
+// ObjectFifoType
+//===---------------------------------------------------------------------===//
+
+bool aieTypeIsObjectFifoType(MlirType type) {
+  return unwrap(type).isa<xilinx::AIE::AIEObjectFifoType>();
+}
+
+MlirType aieObjectFifoTypeGet(MlirType type) {
+  return wrap(xilinx::AIE::AIEObjectFifoType::get(unwrap(type)));
+}

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -1,0 +1,13 @@
+//===- Dialects.cpp ---------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie-c/Dialects.h"
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "mlir/CAPI/Registration.h"
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIE, aie, xilinx::AIE::AIEDialect)

--- a/lib/CAPI/Registration.cpp
+++ b/lib/CAPI/Registration.cpp
@@ -1,0 +1,21 @@
+//===- Registration.cpp -----------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie-c/Registration.h"
+#include "aie/InitialAllDialect.h"
+
+#include "mlir/CAPI/IR.h"
+// #include "mlir/InitAllPasses.h"
+
+void aieRegisterAllDialects(MlirContext context) {
+  mlir::DialectRegistry registry;
+  xilinx::registerAllDialects(registry);
+}
+
+void aieRegisterAllPasses() {
+  // xilinx::AIE::registerAllPasses();
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,3 +8,4 @@
 
 add_subdirectory(Targets)
 add_subdirectory(Dialect)
+add_subdirectory(CAPI)

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -1,0 +1,44 @@
+//===- AIEMLIRModule.cpp ----------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Bindings/Python/PybindAdaptors.h"
+
+#include "aie-c/Dialects.h"
+#include "aie-c/Registration.h"
+
+namespace py = pybind11;
+using namespace mlir::python::adaptors;
+
+PYBIND11_MODULE(_aieMlir, m) {
+
+  //::aieRegisterAllPasses();
+
+  m.doc() = R"pbdoc(
+    AIE MLIR Python bindings
+    --------------------------
+
+    .. currentmodule:: _aieMlir
+
+    .. autosummary::
+        :toctree: _generate
+  )pbdoc";
+
+  m.def(
+      "register_dialect",
+      [](MlirContext context, bool load) {
+        MlirDialectHandle handle = mlirGetDialectHandle__aie__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (load) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context"), py::arg("load") = true);
+
+  // m.def("_register_all_passes", ::aieRegisterAllPasses);
+
+  m.attr("__version__") = "dev";
+}

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -38,6 +38,16 @@ PYBIND11_MODULE(_aieMlir, m) {
       },
       py::arg("context"), py::arg("load") = true);
 
+  // AIE types bindings
+  mlir_type_subclass(m, "ObjectFifoType", aieTypeIsObjectFifoType)
+      .def_classmethod(
+          "get",
+          [](py::object cls, MlirType type) {
+            return cls(aieObjectFifoTypeGet(type));
+          },
+          "Get an instance of ObjectFifoType with given element type.",
+          py::arg("self"), py::arg("type") = py::none());
+
   // m.def("_register_all_passes", ::aieRegisterAllPasses);
 
   m.attr("__version__") = "dev";

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,92 @@
+# Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(AddMLIRPython)
+
+# The directory at which the Python import tree begins.
+# See documentation for `declare_mlir_python_sources`'s ROOT_DIR
+# argument.
+set(AIE_PYTHON_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/aie")
+
+# The AIE copy of the MLIR bindings is in the `aie.mlir` namespace.
+add_compile_definitions("MLIR_PYTHON_PACKAGE_PREFIX=aie.mlir.")
+
+################################################################################
+# Sources
+################################################################################
+
+declare_mlir_python_sources(AiePythonSources
+  ROOT_DIR "${AIE_PYTHON_ROOT_DIR}"
+  SOURCES
+    dialects/_ods_common.py)
+
+declare_mlir_python_sources(AiePythonExtensions)
+
+declare_mlir_python_sources(AiePythonSources.Dialects
+  ADD_TO_PARENT AiePythonSources
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT AiePythonSources.Dialects
+  ROOT_DIR "${AIE_PYTHON_ROOT_DIR}"
+  TD_FILE dialects/AieBinding.td
+  SOURCES
+    dialects/aie/__init__.py
+    dialects/_AIE_ops_ext.py
+  DIALECT_NAME AIE
+)
+
+################################################################################
+# Extensions
+################################################################################
+
+declare_mlir_python_extension(AiePythonExtensions.MLIR
+  MODULE_NAME _aieMlir
+  ADD_TO_PARENT AiePythonExtensions
+  ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+  SOURCES
+    AIEMLIRModule.cpp
+  EMBED_CAPI_LINK_LIBS
+    AIECAPI
+  PRIVATE_LINK_LIBS
+    LLVMSupport
+)
+
+add_mlir_python_common_capi_library(AieAggregateCAPI
+  INSTALL_COMPONENT AiePythonModules
+  INSTALL_DESTINATION python/aie/mlir/_mlir_libs
+  OUTPUT_DIRECTORY "${AIE_PYTHON_PACKAGES_DIR}/aie/mlir/_mlir_libs"
+  RELATIVE_INSTALL_ROOT "../../../.."
+  DECLARED_SOURCES
+    MLIRPythonSources
+    MLIRPythonExtension.Core
+    MLIRPythonExtension.RegisterEverything
+    MLIRPythonExtension.ExecutionEngine
+    AiePythonSources
+    AiePythonExtensions
+)
+
+add_mlir_python_modules(AieMLIRPythonModules
+  ROOT_PREFIX "${AIE_PYTHON_PACKAGES_DIR}/aie/mlir"
+  INSTALL_PREFIX "python/aie/mlir"
+  DECLARED_SOURCES
+    MLIRPythonSources
+    MLIRPythonExtension.Core
+    MLIRPythonExtension.RegisterEverything
+    MLIRPythonExtension.ExecutionEngine
+    AiePythonExtensions
+  COMMON_CAPI_LINK_LIBS
+    AieAggregateCAPI
+    AIECAPI
+  )
+
+add_mlir_python_modules(AiePythonModules
+  ROOT_PREFIX "${AIE_PYTHON_PACKAGES_DIR}/aie"
+  INSTALL_PREFIX "python/aie"
+  DECLARED_SOURCES
+    AiePythonSources
+  COMMON_CAPI_LINK_LIBS
+    AieAggregateCAPI
+)
+
+#add_subdirectory(test)

--- a/python/aie/dialects/AieBinding.td
+++ b/python/aie/dialects/AieBinding.td
@@ -1,0 +1,15 @@
+//===- AieBinding.td ---------------------------------------*- tablegen -*-===//
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef AIE_BINDING_TD
+#define AIE_BINDING_TD
+
+include "mlir/Bindings/Python/Attributes.td"
+include "aie/Dialect/AIE/IR/AIE.td"
+
+#endif // AIE_BINDING_TD

--- a/python/aie/dialects/_AIE_ops_ext.py
+++ b/python/aie/dialects/_AIE_ops_ext.py
@@ -1,0 +1,9 @@
+# ./python/aie/dialects/_AIE_ops_ext.py -*- Python -*-
+
+# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+try:
+  from ..mlir.ir import *
+except ImportError as e:
+  raise RuntimeError("Error loading imports from extension module") from e

--- a/python/aie/dialects/_ods_common.py
+++ b/python/aie/dialects/_ods_common.py
@@ -1,0 +1,9 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Generated tablegen dialects expect to be able to find some symbols from
+# the mlir.dialects package.
+from ..mlir.dialects._ods_common import (
+    _cext, segmented_accessor, equally_sized_accessor, extend_opview_class,
+    get_default_loc_context, get_op_result_or_value, get_op_results_or_values)

--- a/python/aie/dialects/aie/__init__.py
+++ b/python/aie/dialects/aie/__init__.py
@@ -1,0 +1,7 @@
+# ./python/aie/dialects/aie/__init__.py -*- Python -*-
+
+# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from .._AIE_ops_gen import *
+from ...mlir._mlir_libs._aieMlir import *

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -56,3 +56,16 @@ def memOp():
     bb = Block.create_at_start(m.body)
     with InsertionPoint(bb):
         EndOp()
+
+# CHECK-LABEL: objFifo
+# CHECK: AIE.objectFifo.createObjectFifo(%{{.*}}, {%{{.*}}}, 2) : !AIE.objectFifo<memref<10xf32>>
+@constructAndPrintInModule
+def objFifo():
+    iTy = IntegerType.get_signless(32)
+    two = IntegerAttr.get(iTy, 2)
+    six = IntegerAttr.get(iTy, 6)
+    tile0 = TileOp(IndexType.get(), six, six)
+    tile1 = TileOp(IndexType.get(), two, two)
+    dtype = F32Type.get()
+    memTy = MemRefType.get((10,), dtype)
+    fifo = ObjectFifoCreateOp(ObjectFifoType.get(memTy), tile0, tile1, two)

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: python %s | FileCheck %s
+
+import aie
+from aie.mlir.ir import *
+from aie.dialects.aie import *
+
+def constructAndPrintInModule(f):
+    with Context() as ctx, Location.unknown():
+        aie.dialects.aie.register_dialect(ctx)
+        module = Module.create()
+        print("\nTEST:", f.__name__)
+        with InsertionPoint(module.body):
+            f()
+        print(module)
+
+# CHECK-LABEL: tileOp
+# CHECK: AIE.tile(0, 0)
+@constructAndPrintInModule
+def tileOp():
+    iTy = IntegerType.get_signless(32)
+    row = IntegerAttr.get(iTy, 0)
+    col = IntegerAttr.get(iTy, 0)
+    t = TileOp(IndexType.get(), col, row)
+
+# CHECK-LABEL: coreOp
+# CHECK: %[[VAL_1:.*]] = AIE.tile(1, 1)
+# CHECK: %[[VAL_2:.*]] = AIE.core(%[[VAL_1]]) {
+# CHECK:   AIE.end
+# CHECK: }
+@constructAndPrintInModule
+def coreOp():
+    iTy = IntegerType.get_signless(32)
+    row = IntegerAttr.get(iTy, 1)
+    col = IntegerAttr.get(iTy, 1)
+    t = TileOp(IndexType.get(), col, row)
+    c = CoreOp(IndexType.get(), t)
+    bb = Block.create_at_start(c.body)
+    with InsertionPoint(bb):
+        EndOp()
+
+# CHECK-LABEL: memOp
+# CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
+# CHECK: %[[VAL_2:.*]] = AIE.mem(%[[VAL_1]]) {
+# CHECK:   AIE.end
+# CHECK: }
+@constructAndPrintInModule
+def memOp():
+    iTy = IntegerType.get_signless(32)
+    row = IntegerAttr.get(iTy, 2)
+    col = IntegerAttr.get(iTy, 2)
+    t = TileOp(IndexType.get(), col, row)
+    m = MemOp(IndexType.get(), t)
+    bb = Block.create_at_start(m.body)
+    with InsertionPoint(bb):
+        EndOp()

--- a/utils/build-mlir-aie-cross.sh
+++ b/utils/build-mlir-aie-cross.sh
@@ -53,6 +53,7 @@ cmake -GNinja \
     -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
     -DVitisSysroot=${SYSROOT_DIR} \
     -DCMAKE_BUILD_TYPE=Debug \
+    -DAIE_ENABLE_BINDINGS_PYTHON=ON \
     .. |& tee cmake.log
 
 ninja |& tee ninja.log

--- a/utils/build-mlir-aie.sh
+++ b/utils/build-mlir-aie.sh
@@ -50,6 +50,7 @@ cmake -GNinja \
     -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DAIE_ENABLE_BINDINGS_PYTHON=ON \
     .. |& tee cmake.log
 
 #    -DVitisSysroot=${SYSROOT_DIR} \


### PR DESCRIPTION
`cmake -DAIE_ENABLE_BINDINGS_PYTHON=ON` to get python bindings for AIE dialect. MLIR must be compiled with `MLIR_ENABLE_BINDINGS_PYTHON=ON`