### PR TITLE
Object FIFO lowering fix

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -1055,14 +1055,10 @@ struct AIEObjectFifoStatefulTransformPass
       coreOp.walk([&](ObjectFifoSubviewAccessOp accessOp) {
         ObjectFifoAcquireOp acqOp =
             accessOp.getSubview().getDefiningOp<ObjectFifoAcquireOp>();
-        auto users = accessOp.getOutput().getUsers();
         assert((size_t)accessOp.getIndex() < subviews[acqOp].size() &&
                "Index out of bounds for subview: accessed farther than number "
                "of acquired elements.");
-        for (auto user : users) {
-          user->replaceUsesOfWith(accessOp.getOutput(),
-                                  *subviews[acqOp][accessOp.getIndex()]);
-        }
+        accessOp.getOutput().replaceAllUsesWith(subviews[acqOp][accessOp.getIndex()]->getBuffer());
       });
     }
 


### PR DESCRIPTION
Fixes an error where the result of objectFifo.SubviewAccess ops was not properly replaced with the corresponding AIE buffer ops results.