### PR TITLE
[aie][aievec][NFC] Prevent disabling tests unnecessarily

### DIFF
--- a/test/aievec/lit.local.cfg
+++ b/test/aievec/lit.local.cfg
@@ -1,0 +1,8 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2022 Xilinx Inc.
+
+config.unsupported = []


### PR DESCRIPTION
Adding a local lit config file to enable this group of tests regardless of whether VITIS is set up or not.