### PR TITLE
[AIE][aievec][NFC] Remove unnecessary test conf file after PR#233

### DIFF
--- a/test/aievec/lit.local.cfg
+++ b/test/aievec/lit.local.cfg
@@ -1,8 +1,0 @@
-#
-# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-#
-# (c) Copyright 2022 Xilinx Inc.
-
-config.unsupported = []


### PR DESCRIPTION
PR #233 fixes the issue this configuration file solves, plus the same issue accross all other test suites.