### PR TITLE
remove requirement absolute paths

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -57,18 +57,18 @@ particular revision is expected to work.
     ```
     This will build llvm in llvm/build and install the llvm binaries under llvm/install.
 
-4. Build the mlir-aie tools by calling utils/build-mlir-aie.sh with __absolute paths__ to the 
-llvm and cmakeModules repos (note that clone-llvm.sh puts the cmakeModules repo under 
+4. Build the mlir-aie tools by calling utils/build-mlir-aie.sh with paths to the 
+llvm/build and cmakeModules repos (note that clone-llvm.sh puts the cmakeModules repo under 
 cmakeModules/cmakeModulesXilinx). 
     ```
-    source utils/build-mlir-aie.sh <llvm dir> <cmakeModules dir>/cmakeModulesXilinx
+    source utils/build-mlir-aie.sh <llvm dir>/<build dir> <cmakeModules dir>/cmakeModulesXilinx
     ```
     This will create a build and install folder under /mlir-aie. 
 
     The MLIR AIE tools will be able to generate binaries targetting a combination of AIEngine and ARM processors.
 
 5. In order to run all the tools, it is necessary to add some paths into your environment. This can be 
-done by calling the utils/env_setup.sh script with the __absolute paths__ to the install folders for mlir-aie
+done by calling the utils/env_setup.sh script with the paths to the install folders for mlir-aie
 and llvm.
     ```
     source utils/env_setup.sh <mlir-aie>/install <llvm dir>/install

--- a/utils/build-mlir-aie.sh
+++ b/utils/build-mlir-aie.sh
@@ -23,8 +23,9 @@ if [ "$#" -lt 2 ]; then
     echo "ERROR: Needs at least 2 arguments for <llvm dir> and <cmakeModules dir>."
     exit 1
 fi
-LLVM_DIR=$1
-CMAKEMODULES_DIR=$2
+
+LLVM_BUILD_DIR=`realpath $1`
+CMAKEMODULES_DIR=`realpath $2`
 
 BUILD_DIR=${3:-"build"}
 INSTALL_DIR=${4:-"install"}
@@ -37,8 +38,8 @@ set -e
 cmake -GNinja \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
-    -DLLVM_DIR=${LLVM_DIR}/build/lib/cmake/llvm \
-    -DMLIR_DIR=${LLVM_DIR}/build/lib/cmake/mlir \
+    -DLLVM_DIR=${LLVM_BUILD_DIR}/lib/cmake/llvm \
+    -DMLIR_DIR=${LLVM_BUILD_DIR}/lib/cmake/mlir \
     -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/ \
     -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
     -DCMAKE_BUILD_TYPE=Release \

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -20,8 +20,8 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-export MLIR_AIE_INSTALL_DIR=$1
-export LLVM_INSTALL_DIR=$2
+export MLIR_AIE_INSTALL_DIR=`realpath $1`
+export LLVM_INSTALL_DIR=`realpath $2`
 
 export PATH=${MLIR_AIE_INSTALL_DIR}/bin:${LLVM_INSTALL_DIR}/bin:${PATH} 
 export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH} 


### PR DESCRIPTION
- avoid requiring absolute paths
- mlir-aie build script takes in build llvm folder in case other name than build was used while building llvm
