### PR TITLE
Update tutorial Makefiles

### DIFF
--- a/tutorials/tutorial-1/Makefile
+++ b/tutorials/tutorial-1/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: core_1_4.elf
 
@@ -19,8 +20,8 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-1_perf.exe: ./answers/test_perf.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 tutorial-1_q6.exe: ./answers/test_q6.cpp ./answers/aie_q6.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 

--- a/tutorials/tutorial-2/tutorial-2a/Makefile
+++ b/tutorials/tutorial-2/tutorial-2a/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-2a.exe
 
@@ -10,7 +11,7 @@ all: tutorial-2a.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-2a.exe : test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../../runtime_lib ../../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 clean:
 	rm -rf acdc_project *elf core* *log pl_sample_counts foo.vcd *exe aiesimulator_output

--- a/tutorials/tutorial-2/tutorial-2b/Makefile
+++ b/tutorials/tutorial-2/tutorial-2b/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-2b.exe
 
@@ -10,7 +11,7 @@ all: tutorial-2b.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-2b.exe : test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../../runtime_lib ../../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 Work/ps/c_rts/systemC/generated-objects/ps_i96.so: test.cpp aie.mlir
 	make -C Work/ps/c_rts/systemC link

--- a/tutorials/tutorial-2/tutorial-2c/Makefile
+++ b/tutorials/tutorial-2/tutorial-2c/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-2c.exe
 
@@ -10,7 +11,7 @@ all: tutorial-2c.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-2c.exe : test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../../runtime_lib ../../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 Work/ps/c_rts/systemC/generated-objects/ps_i96.so: test.cpp aie.mlir
 	make -C Work/ps/c_rts/systemC link
@@ -26,5 +27,5 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-1_perf.exe: ./answers/test_perf.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 

--- a/tutorials/tutorial-3/Makefile
+++ b/tutorials/tutorial-3/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-3.exe
 
@@ -10,7 +11,7 @@ all: tutorial-3.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-3.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 Work/ps/c_rts/systemC/generated-objects/ps_i96.so: test.cpp aie.mlir
 	make -C Work/ps/c_rts/systemC link
@@ -25,7 +26,7 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-3_perf1.exe: ./answers/test_perf.cpp ./aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 tutorial-3_perf2.exe: ./answers/test_perf.cpp ./answers/aie_perf.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@

--- a/tutorials/tutorial-4/Makefile
+++ b/tutorials/tutorial-4/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-4.exe
 
@@ -10,7 +11,7 @@ all: tutorial-4.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-4.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 view: routes.json
 	../scripts/visualize.py $<

--- a/tutorials/tutorial-5/Makefile
+++ b/tutorials/tutorial-5/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-5.exe
 
@@ -10,7 +11,7 @@ all: tutorial-5.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-5.exe: aie.mlir test.cpp 
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu ./aie.mlir -I../../runtime_lib ../../runtime_lib/test_library.cpp ./test.cpp -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu ./aie.mlir -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./test.cpp -o $@
 
 view: routes.json
 

--- a/tutorials/tutorial-6/Makefile
+++ b/tutorials/tutorial-6/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-6.exe
 
@@ -10,8 +11,7 @@ all: tutorial-6.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-6.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
-
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 clean:
 	rm -rf acdc_project *elf *exe core*

--- a/tutorials/tutorial-7/Makefile
+++ b/tutorials/tutorial-7/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-7.exe
 
@@ -10,7 +11,7 @@ all: tutorial-7.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-7.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 clean:
 	rm -rf acdc_project *elf *exe core*

--- a/tutorials/tutorial-8/Makefile
+++ b/tutorials/tutorial-8/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-8.exe
 
@@ -14,7 +15,7 @@ all: tutorial-8.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-8.exe: test.cpp aie.mlir kernel1.o kernel2.o
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 clean:
 	rm -rf acdc_project *elf core* *log pl_sample_counts foo.vcd *exe aiesimulator_output
@@ -23,4 +24,4 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-8_q3.exe: test.cpp ./answers/aie.mlir
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@

--- a/tutorials/tutorial-9/Makefile
+++ b/tutorials/tutorial-9/Makefile
@@ -3,6 +3,7 @@
 
 # TODO - Change this to env variable?
 SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
+AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-9.exe
 
@@ -23,7 +24,7 @@ kernel_matmul.o: matmul_kernel/kernel.o
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-9.exe: test.cpp aie.mlir kernel.o
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 clean:
 	$(MAKE) -C external_kernel clean
@@ -33,7 +34,7 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-9_perf.exe: ./answers/test_perf.cpp ./aie.mlir kernel.o
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
 
 tutorial-9_matmul_perf.exe: ./answers/test_perf.cpp ./answers/aie_matmul.mlir kernel_matmul.o
-	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I../../runtime_lib ../../runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 --sysroot=${SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@


### PR DESCRIPTION
Use aie-opt installation directory to find runtime_lib installation rather than relative paths for test_library.h/cpp in tutorial Makefiles. 