### PR TITLE
Fix sim folder generation in aiecc.py

### DIFF
--- a/runtime_lib/aiesim/Makefile
+++ b/runtime_lib/aiesim/Makefile
@@ -3,10 +3,10 @@
 
 #
 # From one diretory up, you can invoke the simulator by typing
-# > make -C sim sim
+# > make -C sim
 #
 # If you want to change the host source file, you can redefine host:
-# > make -C sim sim host=../yourhost.cpp
+# > make -C sim host=../yourhost.cpp
 #
 # Note: The host file location is relative to the <sim> folder or can 
 #       be an absolute path
@@ -25,7 +25,7 @@ XILINX_VITIS_AIETOOLS:=${XILINX_VITIS}/aietools
 endif
 .PHONY: all link sim clean
 .NOTPARALLEL:
-all: link
+all: sim
 
 CC_ENV := (export LD_LIBRARY_PATH=${XILINX_VITIS_AIETOOLS}/lib/lnx64.o:$(LD_LIBRARY_PATH))
 CC := "${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/bin/g++" 

--- a/runtime_lib/test_library.h
+++ b/runtime_lib/test_library.h
@@ -15,8 +15,8 @@
 #include <xaiengine.h>
 
 #if defined(__AIESIM__)
-#include <iostream>
 #include "xioutils.h"
+#include <iostream>
 #endif
 
 extern "C" {

--- a/runtime_lib/test_library.h
+++ b/runtime_lib/test_library.h
@@ -15,6 +15,7 @@
 #include <xaiengine.h>
 
 #if defined(__AIESIM__)
+#include <iostream>
 #include "xioutils.h"
 #endif
 


### PR DESCRIPTION
The intermediate file ./acdc_project/input_physical.mlir needs to be created before the sim folder generation can begin. Modified aiecc.py to guarantee this happens.

Also made sim the default make option in the sim folder. So you can run `make -C sim` to simulate