### PR TITLE
[aie][aievec] Add lowering for splat transfer read

### DIFF
--- a/include/aie/Dialect/AIEVec/Pipelines/Passes.h
+++ b/include/aie/Dialect/AIEVec/Pipelines/Passes.h
@@ -14,4 +14,57 @@
 #ifndef AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H
 #define AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H
 
+#include "aie/Dialect/AIEVec/Transforms/Passes.h"
+#include "mlir/Pass/PassOptions.h"
+
+namespace xilinx {
+namespace aievec {
+
+/// Options for the "convert-vector-to-aievec" pipeline.
+struct ConvertVectorToAIEVecOptions
+    : public PassPipelineOptions<ConvertVectorToAIEVecOptions> {
+  // 'LowerVectorToAIEVec' options
+  // TODO: Review the need for these options.
+  PassOptions::Option<unsigned> shiftParam{
+      *this, "shift",
+      llvm::cl::desc("Shift parameter for rounding and saturation"),
+      llvm::cl::init(0)};
+  PassOptions::Option<unsigned> zeroOffset{
+      *this, "zero-offset",
+      llvm::cl::desc("Zero offset for indicating the location of zeroes in "
+                     "convolution filter (useful for 16x16 scheme)"),
+      llvm::cl::init(0)};
+  PassOptions::Option<unsigned> dupFactor{
+      *this, "dup-actor",
+      llvm::cl::desc("Duplication factor for each value in convolution filter "
+                     "(useful in 8x8 scheme)"),
+      llvm::cl::init(2)};
+  PassOptions::Option<std::string> aieTarget{
+      *this, "aie-target",
+      llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
+                     "determine the vector size and available operations."),
+      llvm::cl::init("aie")};
+
+  LowerVectorToAIEVecOptions getLowerVectorToAIEVecOptions() const {
+    return LowerVectorToAIEVecOptions{shiftParam, zeroOffset, dupFactor,
+                                      aieTarget};
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Building and Registering.
+//===----------------------------------------------------------------------===//
+
+/// Adds the "convert-vector-to-aievec" pipeline to the `OpPassManager`. This
+/// pipeline takes `Vector` code, transforms it to make it compatible with the
+/// selected `AIE` target, and lowers it to `AIEVec` dialect.
+void buildConvertVectorToAIEVec(OpPassManager &pm,
+                                const ConvertVectorToAIEVecOptions &options);
+
+/// Register all pipelines for the AIE Vector dialect.
+void registerAIEVecPipelines();
+
+} // namespace aievec
+} // namespace xilinx
+
 #endif // AIE_DIALECT_AIEVEC_PIPELINES_PASSES_H

--- a/include/aie/Dialect/AIEVec/Transforms/Passes.h
+++ b/include/aie/Dialect/AIEVec/Transforms/Passes.h
@@ -62,9 +62,6 @@ namespace aievec {
 
 std::unique_ptr<Pass> createAIEVectorizePass();
 
-std::unique_ptr<Pass>
-createConvertVectorToAIEVecPass(const ConvertVectorToAIEVecOptions &options);
-
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "aie/Dialect/AIEVec/Transforms/Passes.h.inc"

--- a/include/aie/Dialect/AIEVec/Transforms/Passes.td
+++ b/include/aie/Dialect/AIEVec/Transforms/Passes.td
@@ -37,8 +37,9 @@ def AIEVectorize : Pass<"aie-vectorize", "ModuleOp"> {
   ];
 }
 
-def ConvertVectorToAIEVec : Pass<"convert-vector-to-aievec", "func::FuncOp"> {
-  let summary = "Convert arithmetic and vector operations to AIE vector ops";
+def LowerVectorToAIEVec : Pass<"lower-vector-to-aievec", "func::FuncOp"> {
+  let summary = "Convert standard Vector dialect operations to equivalent AIE "
+                "vector ops";
   let dependentDialects = ["AffineDialect", // NOTE: Do we need this?
                            "xilinx::aievec::AIEVecDialect",
                            "arith::ArithDialect",
@@ -54,7 +55,7 @@ def ConvertVectorToAIEVec : Pass<"convert-vector-to-aievec", "func::FuncOp"> {
     Option<"dupFactor", "dup-factor", "unsigned", /*default=*/"2",
      "Duplication factor for each value in convolution filter "
      "(useful for 8x8 scheme)">,
-    Option<"aieTarget", "aie-target", "std::string", /*default=*/"",
+    Option<"aieTarget", "aie-target", "std::string", /*default=*/"\"aie\"",
      "Select AIE version: \\\"aie\\\" or \\\"aieml\\\". This will determine "
      "the vector size and available operations.">,
   ];

--- a/tools/aie-opt/aie-opt.cpp
+++ b/tools/aie-opt/aie-opt.cpp
@@ -26,6 +26,7 @@
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
+#include "aie/Dialect/AIEVec/Pipelines/Passes.h"
 #include "aie/Dialect/AIEVec/Transforms/Passes.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
@@ -40,6 +41,7 @@ int main(int argc, char **argv) {
   aie::registerAIEPasses();
   xilinx::AIEX::registerAIEXPasses();
   xilinx::aievec::registerAIEVecPasses();
+  xilinx::aievec::registerAIEVecPipelines();
 
   DialectRegistry registry;
   registerAllDialects(registry);


### PR DESCRIPTION
Takes a `vector.transfer_read` using a splat permutation map and replaces it with a regular `vector.transfer_read` followed by a `aievec.broadcast`. The index for the broadcast is extracted from the offset of the inner-most index of the `vector.transfer_read`.