### PR TITLE
Fix platform and tutorial Makefiles

### DIFF
--- a/platforms/vck190_bare_prod/aie_platform/Makefile
+++ b/platforms/vck190_bare_prod/aie_platform/Makefile
@@ -11,18 +11,9 @@
 #limitations under the License.
 #
 
-#SYSROOT = /proj/xbuilds/2021.1_daily_latest/internal_platforms/sw/versal/xilinx-versal-common-v2021.1/sysroots/aarch64-xilinx-linux/
-#IMAGE = /proj/xbuilds/2021.1_daily_latest/internal_platforms/sw/versal/xilinx-versal-common-v2021.1/Image
-#ROOTFS = /proj/xbuilds/2021.1_daily_latest/internal_platforms/sw/versal/xilinx-versal-common-v2021.1/rootfs.ext4
-#CXX = aarch64-linux-gnu-g++
-
-#SYSROOT = /group/xrlabs2/jackl/proj/acdc/vitis_2021.2_bram_platform_prod/sysroots/cortexa72-cortexa53-xilinx-linux
-#IMAGE = /group/xrlabs2/jackl/proj/acdc/vitis_2021.2_bram_platform_prod/build/petalinux/images/linux/Image
-#ROOTFS = /group/xrlabs2/jackl/proj/acdc/vitis_2021.2_bram_platform_prod/build/petalinux/images/linux/rootfs.ext4
-
-SYSROOT = ../petalinux/build/petalinux/images/linux/sdk/sysroots/cortexa72-cortex53-xilinx-linux
-IMAGE   = ../petalinux/build/petalinux/images/linux/Image
-ROOTFS  = ../petalinux/build/petalinux/images/linux/rootfs.ext4
+SYSROOT ?= ../petalinux/build/petalinux/images/linux/sdk/sysroots/cortexa72-cortexa53-xilinx-linux
+IMAGE    = ../petalinux/build/petalinux/images/linux/Image
+ROOTFS   = ../petalinux/build/petalinux/images/linux/rootfs.ext4
 
 
 #------------------------------------------------------------------------------
@@ -88,9 +79,6 @@ pfm:
 #TARGET   = hw_emu
 TARGET   = hw
 MODE	 = linux
-#PLATFORM = ${PLATFORM_REPO_PATHS}/xilinx_vck190_es1_base_202110_1/xilinx_vck190_es1_base_202110_1.xpfm
-#PLATFORM = /group/xrlabs2/jackl/proj/acdc/vitis_2021.2_bram_platform/platforms/vck190_bare_2021.2/vck190_bare_2021.2.xpfm
-#PLATFORM = /group/xrlabs2/jackl/proj/acdc/vitis_2021.2_bram_platform/platforms/vck190_bare_2021_2/vck190_bare_2021_2.xpfm
 PLATFORM = ./platform_repo/xilinx_vck190_prod_bare/export/xilinx_vck190_prod_bare/xilinx_vck190_prod_bare.xpfm
 
 XCLBIN   = vck190_aie_base_graph_${TARGET}.xclbin
@@ -128,9 +116,6 @@ __check_defined = \
 	$(if $(value $1),, \
 		$(error Undefined $1$(if $2, ($2))))
 
-guard-PLATFORM_REPO_PATHS:
-	$(call check_defined, PLATFORM_REPO_PATHS, Set your where you downloaded xilinx_vck190_es1_base_202110_1)
-
 guard-ROOTFS:
 	$(call check_defined, ROOTFS, Set to: xilinx-versal-common-v2021.1/rootfs.ext4)
 
@@ -150,14 +135,14 @@ all: prep_sd_dir prep_sw_comp pfm prep_sysroot ${XCLBIN} ${HOST_EXE} package
 #run: all run_hw_emu
 sd_card: all
 
-aie: guard-PLATFORM_REPO_PATHS ${LIBADF}
+aie: ${LIBADF}
 ${LIBADF}: aie/*
 	${AIE_CMPL_CMD}
 
 aiesim: ${LIBADF}
 	${AIE_SIM_CMD}
 
-xclbin: guard-PLATFORM_REPO_PATHS ${XCLBIN}
+xclbin: ${XCLBIN}
 
 
 ${XCLBIN}: ${LIBADF} ${VPP_SPEC} 
@@ -167,7 +152,7 @@ host: guard-CXX guard-SDKTARGETSYSROOT ${HOST_EXE}
 ${HOST_EXE}: ${GRAPH} ./Work/ps/c_rts/aie_control_xrt.cpp
 	$(MAKE) -C sw/
 
-package: guard-ROOTFS guard-IMAGE guard-PLATFORM_REPO_PATHS package_${TARGET}
+package: guard-ROOTFS guard-IMAGE package_${TARGET}
 package_${TARGET}: ${LIBADF} ${XCLBIN} ${HOST_EXE} 
 	${VCC} -p -t ${TARGET} -f ${PLATFORM} \
 		--package.rootfs ${ROOTFS} \

--- a/platforms/vck190_bare_prod/aie_platform/sw/Makefile
+++ b/platforms/vck190_bare_prod/aie_platform/sw/Makefile
@@ -11,8 +11,8 @@
 #limitations under the License.
 #
 CXX = aarch64-linux-gnu-g++
-#SDKTARGETSYSROOT = /proj/xbuilds/2020.1_daily_latest/internal_platforms/sw/versal/xilinx-versal-common-v2020.1/sysroots/aarch64-xilinx-linux/
-SDKTARGETSYSROOT = /group/xrlabs2/jackl/proj/acdc/vitis_2021.2_bram_platform/sysroots/cortexa72-cortexa53-xilinx-linux
+LIBCXX_VERSION ?= 10.2.0
+SDKTARGETSYSROOT ?= ../../petalinux/build/petalinux/images/linux/sdk/sysroots/cortexa72-cortexa53-xilinx-linux
 
 HOST_EXE     = ../host.exe
 HOST_INC   = -I../ -I../aie
@@ -22,8 +22,7 @@ AIE_CTRL_CPP = ../Work/ps/c_rts/aie_control_xrt.cpp
 #AIE_CTRL_CPP = ../Work/ps/c_rts/aie_control.cpp
 GRAPH_CPP = ../aie/graph.cpp
 
-CXXFLAGS += -std=c++14 -I$(XILINX_VIVADO)/include/ -I${SDKTARGETSYSROOT}/usr/include/xrt/ -O0 -g -Wall -c -fmessage-length=0 --sysroot=${SDKTARGETSYSROOT} -I${XILINX_VITIS}/aietools/include ${HOST_INC}
-#CXXFLAGS += -std=c++14 -I$(XILINX_VIVADO)/include/ -I${SDKTARGETSYSROOT}/usr/include/xrt/ -O0 -g -Wall -c -fmessage-length=0 --sysroot=${SDKTARGETSYSROOT} -I${XILINX_VITIS}/cardano/include ${HOST_INC}
+CXXFLAGS += -std=c++14 -I$(XILINX_VIVADO)/include/ -I${SDKTARGETSYSROOT}/usr/include/xrt/ -O0 -g -Wall -c -fmessage-length=0 --sysroot=${SDKTARGETSYSROOT} -I${XILINX_VITIS}/aietools/include ${HOST_INC} -I${SDKTARGETSYSROOT}/usr/include/c++/${LIBCXX_VERSION}/ -I${SDKTARGETSYSROOT}/usr/include/c++/${LIBCXX_VERSION}/aarch64-xilinx-linux/
 
 LDFLAGS += -ladf_api_xrt -lgcc -lc -lxrt_coreutil -lxilinxopencl -lpthread -lrt -ldl -lcrypt -lstdc++ -L${SDKTARGETSYSROOT}/usr/lib/ --sysroot=${SDKTARGETSYSROOT} -L$(XILINX_VITIS)/aietools/lib/aarch64.o
 #LDFLAGS += -lcardano_api_xrt -lgcc -lc -lxrt_coreutil -lxilinxopencl -lpthread -lrt -ldl -lcrypt -lstdc++ -L${SDKTARGETSYSROOT}/usr/lib/ --sysroot=${SDKTARGETSYSROOT} -L$(XILINX_VITIS)/cardano/lib/aarch64.o

--- a/tutorials/makefile-common
+++ b/tutorials/makefile-common
@@ -1,0 +1,25 @@
+# Contains common definitions used across the Makefiles of all tutorials.
+
+# MLIR-AIE install directory. If you have sourced utils/env_setup.sh before
+# running make, the following should work to find the AIE install directory.
+AIE_INSTALL ?= $(dir $(shell which aie-opt))/..
+
+# An aarch64 sysroot is required for cross-compiling the host code. The default
+# values of these variables assume that you have built a sysroot by running
+# make in platforms/vck190_bare_prod, but you can use other aarch64 sysroots by
+MLIR_AIE_SYSROOT ?= ${AIE_INSTALL}/../platforms/vck190_bare_prod/aie_platform/sw_comp/sysroots/cortexa72-cortexa53-xilinx-linux
+
+# The libstdc++ version that is installed in the sysroot given above. This is
+# used for include and library paths. If you built the sysroot with Vitis
+# 2021.2 and PetaLinux 2021.2, libstdc++ 10.2.0 will be installed. 
+LIBCXX_VERSION ?= 10.2.0
+
+# The following flags are passed to both AI core and host compilation for
+# aiecc.py invocations.
+AIECC_FLAGS += --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu
+
+# The following additional flags are only applied for host code. We add the
+# necessary search paths for the sysroot so clang++ can find the aarch64
+# includes and libraries.
+AIECC_HOST_FLAGS += -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp -I${MLIR_AIE_SYSROOT}/usr/include -I${MLIR_AIE_SYSROOT}/usr/include/c++/${LIBCXX_VERSION} -I${MLIR_AIE_SYSROOT}/usr/include/c++/${LIBCXX_VERSION}/aarch64-xilinx-linux -L${MLIR_AIE_SYSROOT}/usr/lib/aarch64-xilinx-linux/${LIBCXX_VERSION} -B${MLIR_AIE_SYSROOT}/usr/lib/aarch64-xilinx-linux/${LIBCXX_VERSION}
+

--- a/tutorials/tutorial-1/Makefile
+++ b/tutorials/tutorial-1/Makefile
@@ -1,11 +1,6 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: core_1_4.elf
 	@mkdir -p elf
@@ -23,10 +18,8 @@ clean:
 
 #------------------------------------------------------------------------------
 # Additional make targets for tutorial exercises
+# Note: AIECC_HOST_FLAGS is defined in the included tutorials/makefile-common.
 #------------------------------------------------------------------------------
-tutorial-1_perf.exe: ./answers/test_perf.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
-
-tutorial-1_q6.exe: ./answers/test_q6.cpp ./answers/aie_q6.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+tutorial: ./test.cpp aie.mlir
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 

--- a/tutorials/tutorial-2/tutorial-2a/Makefile
+++ b/tutorials/tutorial-2/tutorial-2a/Makefile
@@ -1,11 +1,6 @@
+include ../../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-2a.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-2a.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-2a.exe : test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 ${AIECC_FLAGS} $(word 2,$^) ${AIECC_HOST_FLAGS} ./$< -o $@
 
 clean:
 	rm -rf acdc_project *elf core* *log pl_sample_counts foo.vcd *exe aiesimulator_output sim .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-2/tutorial-2b/Makefile
+++ b/tutorials/tutorial-2/tutorial-2b/Makefile
@@ -1,11 +1,6 @@
+include ../../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-2b.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-2b.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-2b.exe : test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project *elf core* *log pl_sample_counts foo.vcd *exe aiesimulator_output sim .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-3/Makefile
+++ b/tutorials/tutorial-3/Makefile
@@ -1,11 +1,6 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-3.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-3.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-3.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS
@@ -25,7 +20,7 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-3_perf1.exe: ./answers/test_perf.cpp ./aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 tutorial-3_perf2.exe: ./answers/test_perf.cpp ./answers/aie_perf.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@

--- a/tutorials/tutorial-3/objectFifo_ver/Makefile
+++ b/tutorials/tutorial-3/objectFifo_ver/Makefile
@@ -1,11 +1,6 @@
+include ../../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-3.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-3.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-3.exe: test.cpp aie.mlir 
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-4/Makefile
+++ b/tutorials/tutorial-4/Makefile
@@ -1,11 +1,6 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-4.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-4.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-4.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-4/flow/Makefile
+++ b/tutorials/tutorial-4/flow/Makefile
@@ -1,11 +1,6 @@
+include ../../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-4.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-4.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-4.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-4/switchbox/Makefile
+++ b/tutorials/tutorial-4/switchbox/Makefile
@@ -1,11 +1,6 @@
+include ../../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-4.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-4.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-4.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 pathfinder:
 	aie-opt --aie-create-pathfinder-flows ./path/pathfinder_input.mlir > ./path/pathfinder_output.mlir

--- a/tutorials/tutorial-5/Makefile
+++ b/tutorials/tutorial-5/Makefile
@@ -1,11 +1,6 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-5.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-5.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-5.exe: aie.mlir test.cpp 
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu ./aie.mlir -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./test.cpp -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) ./aie.mlir $(AIECC_HOST_FLAGS) ./test.cpp -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-5/flow/Makefile
+++ b/tutorials/tutorial-5/flow/Makefile
@@ -1,11 +1,6 @@
+include ../../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-5.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-5.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-5.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-6/Makefile
+++ b/tutorials/tutorial-6/Makefile
@@ -1,11 +1,6 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-6.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-6.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-6.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-7/Makefile
+++ b/tutorials/tutorial-7/Makefile
@@ -1,11 +1,6 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-7.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-7.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-7.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-7/flow/Makefile
+++ b/tutorials/tutorial-7/flow/Makefile
@@ -1,3 +1,4 @@
+include ../../makefile-common
 
 .PHONY: all clean
 
@@ -16,7 +17,7 @@ all: tutorial-7.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-7.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-7/switchbox/Makefile
+++ b/tutorials/tutorial-7/switchbox/Makefile
@@ -1,11 +1,6 @@
+include ../../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-7.exe
 	@mkdir -p elf
@@ -16,7 +11,7 @@ all: tutorial-7.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-7.exe: test.cpp aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts .AIE_SIM_CMD_LINE_OPTIONS

--- a/tutorials/tutorial-8/Makefile
+++ b/tutorials/tutorial-8/Makefile
@@ -1,11 +1,6 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 ifeq (${AIETOOLS_ROOT},)
 AIETOOLS_ROOT = $(dir $(shell which xchesscc))/..
@@ -24,7 +19,7 @@ all: tutorial-8.exe
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-8.exe: test.cpp aie.mlir kernel1.o kernel2.o
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	rm -rf acdc_project sim aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts *.o .AIE_SIM_CMD_LINE_OPTIONS
@@ -33,4 +28,4 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-8_q3.exe: test.cpp ./answers/aie.mlir
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@

--- a/tutorials/tutorial-9/Makefile
+++ b/tutorials/tutorial-9/Makefile
@@ -1,19 +1,11 @@
+include ../makefile-common
 
 .PHONY: all clean
-
-# TODO - Change this to env variable?
-ifeq ($(MLIR_AIE_SYSROOT),)
-MLIR_AIE_SYSROOT = /group/xrlabs/platforms/vck190-pynq-v2.7/sysroot
-endif
-AIE_INSTALL = $(dir $(shell which aie-opt))/..
 
 all: tutorial-9.exe
 	@mkdir -p elf
 	@mv *.elf* ./elf
 	@cp ./elf/*.elf ./elf/*.elf.map .
-
-#external_kernel/work/Release_LLVM/test.prx/kernel.o: external_kernel/kernel.cc
-#	$(MAKE) -C external_kernel build
 
 external_kernel/kernel.o: external_kernel/kernel.cc
 	$(MAKE) -C external_kernel mlir
@@ -28,7 +20,7 @@ kernel_matmul.o: matmul_kernel/kernel.o
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
 tutorial-9.exe: test.cpp aie.mlir kernel.o
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:
 	$(MAKE) -C external_kernel clean
@@ -38,7 +30,7 @@ clean:
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
 tutorial-9_perf.exe: ./answers/test_perf.cpp ./aie.mlir kernel.o
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 tutorial-9_matmul_perf.exe: ./answers/test_perf.cpp ./answers/aie_matmul.mlir kernel_matmul.o
-	aiecc.py -j4 --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu $(word 2,$^) -I$(AIE_INSTALL)/runtime_lib $(AIE_INSTALL)/runtime_lib/test_library.cpp ./$< -o $@
+	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -17,7 +17,7 @@
 
 if [ "$#" -ne 2 ]; then
     echo "ERROR: Needs 2 arguments for <mlir-aie install dir> and <llvm install dir>"
-    exit 1
+    return 1
 fi
 
 export MLIR_AIE_INSTALL_DIR=`realpath $1`


### PR DESCRIPTION
Executive summary: These changes should allow an outside user that strictly follows the "Getting Started" instructions in the documentation to eventually build and simulate the tutorials in the `tutorials` folder. For this, some hard-coded paths, typos, and missing search paths had to be fixed in several Makefiles. I have tested and suceeded at building all tutorials except 2c (because I don't have the physical hardware available) on a fairly bare-bones Ubuntu 20.04.

Note: This changes the _MLIR_AIE_SYSROOT_ in the tutorial Makefiles. Previously, this path was set to `/group/xrlabs/platforms/vck190-pynq-v2.7/sysroot` -- I assume this is a Xilinx-internal path, that most outside users that are getting started with the tutorials would not have. If you would like to build the tutorials using this previous value for the sysroot path, it is still possible, but you will now have to call make as `MLIR_AIE_SYSROOT=/group/xrlabs/platforms/vck190-pynq-v2.7/sysroot make`, not just `make`.

I think this change is justified, since it will make it easier for most users who follow the instructions in the documentation, by using the sysroot installed by following the instructions in `Platform.md`. (That sysroot will be installed in a subdirectory of `/platforms/vck190_bare_prod` when calling `make` from there.)

------

More details (to elaborate a little in the changes of the commits):

Building the sysroot in `platforms/vck190_bare_prod` and any of the tutorials in `tutorials` did not succeed for me on a fresh Ubuntu 20.04 install. 

The following were the issues stopped me from building the platform, specifically `make aie_platform_build` in `platforms/vck190_bare_prod` was broken:

1. A typo (missing letter A) for the sysroot path
2. A guard for an undefined variable that is not actually used anywhere (PLATFORM_REPO_PATHS, seems to be a remnant of previous versions of this file)
3. A hard-coded path to a user employee (`/group/xrlabs2/jackl ...`) that will not be present on users systems
4. At least on my system, clang++ was not able to find the necessary C++ includes and libraries without some help, so I added some `-I` and `-L` flags; these should be unproblematic on a system where the files are located elsewhere, but can be found by clang, since those flags just append to the search path.

With these issues fixed, I was able to move on to compiling the tutorials and simulating them on my machine. Again, for cross-compilation, my version of clang++ did not find the includes and libraries, so I added some flags for the appropriate search paths. These search paths are set up such that a PetaLinux sysroot version 2021.1, which includes libstdc++ 10.2.0, should work.

I also took the liberty of reorganizing the makefiles so they would be a little easier to read by moving redundant/repeated definitions into a separate new file, `tutorials/makefile-common`.

Finally, I also took the liberty of a miniscule change in `utils/env_setup.sh`. Since this script will mostly be `source`d, calling `exit` in there will quit an user's terminal if they accidentally run the script without arguments, before they can read the error message. I think a `return` is more appropriate -- it quits the script, shows the user the error message, but allows the user to re-try in the same terminal.

----

I'm very happy about any feedback. Please feel free to disregard this if I clearly misunderstood something. This is simply the only way I could get things to run, from an outsider perspective.