### PR TITLE
fix aiesim install path

### DIFF
--- a/runtime_lib/aiesim/CMakeLists.txt
+++ b/runtime_lib/aiesim/CMakeLists.txt
@@ -21,5 +21,5 @@ foreach(file ${INSTALLS})
     add_dependencies(runtime-libs aie-copy-runtime-libs-${file} )
 endforeach()
 
-install(FILES ${INSTALLS} DESTINATION ${CMAKE_INSTALL_PREFIX}/aiesim)
+install(FILES ${INSTALLS} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/aiesim)
 


### PR DESCRIPTION
install as subfolder of runtime_lib