### PR TITLE
[aievec] Remove muli+addi -> vector.fma pattern

### DIFF
--- a/test/Conversion/VectorToAIEVec/test-mac.mlir
+++ b/test/Conversion/VectorToAIEVec/test-mac.mlir
@@ -1,17 +1,33 @@
 // RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
-// XFAIL: *
 
-// CHECK-LABEL: func @test_fma_to_mac(
+// CHECK-LABEL: func.func @muladd2mac_i32(
 // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
 // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
 // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
-func.func @test_fma_to_mac(%a : vector<8xi32>,
-                           %b : vector<8xi32>,
-                           %c : vector<8xi32>) -> vector<8xi32> {
+func.func @muladd2mac_i32(%a : vector<8xi32>,
+                          %b : vector<8xi32>,
+                          %c : vector<8xi32>) -> vector<8xi32> {
     // CHECK: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
     // CHECK: %[[MAC:.*]] = aievec.mac %[[A]], %[[B]], %[[ACC]] : vector<8xi32>, vector<8xi32>, vector<8xi80>
     // CHECK: %[[RES:.*]] = aievec.srs %[[MAC]] {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
-    %0 = vector.fma %a, %b, %c : vector<8xi32>
+    %0 = arith.muli %a, %b : vector<8xi32>
+    %1 = arith.addi %0, %c : vector<8xi32>
     // CHECK: return %[[RES]] : vector<8xi32>
-    return %0 : vector<8xi32>
+    return %1 : vector<8xi32>
+}
+
+// CHECK-LABEL: func.func @muladd2mac_inv(
+// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
+// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
+// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
+func.func @muladd2mac_inv(%a : vector<8xi32>,
+                          %b : vector<8xi32>,
+                          %c : vector<8xi32>) -> vector<8xi32> {
+    // CHECK: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+    // CHECK: %[[MAC:.*]] = aievec.mac %[[A]], %[[B]], %[[ACC]] : vector<8xi32>, vector<8xi32>, vector<8xi80>
+    // CHECK: %[[RES:.*]] = aievec.srs %[[MAC]] {shift = 0 : i8} : vector<8xi80>, vector<8xi32>
+    %0 = arith.muli %a, %b : vector<8xi32>
+    %1 = arith.addi %c, %0 : vector<8xi32>
+    // CHECK: return %[[RES]] : vector<8xi32>
+    return %1 : vector<8xi32>
 }

--- a/test/Conversion/VectorToAIEVec/test_mac_elem.mlir
+++ b/test/Conversion/VectorToAIEVec/test_mac_elem.mlir
@@ -1,16 +1,33 @@
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" | FileCheck %s
-// XFAIL: *
-
-func.func @test_mac_elem(%a : vector<16xi32>, %b : vector<16xi32>, %c : vector<16xi32>) -> vector<16xi32> {
-    %0 = vector.fma %a, %b, %c : vector<16xi32>
-    return %0 : vector<16xi32>
-}
 
 // CHECK-LABEL: func @test_mac_elem
 // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
 // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
 // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi32>
-//      CHECK: %[[UPS:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
-//      CHECK: %[[ME:.*]] = aievec.mac_elem %[[A]], %[[B]], %[[UPS:.*]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
-//      CHECK: %[[RES:.*]] = aievec.srs %[[ME:.*]] {shift = 0 : i8} : vector<16xi64>, vector<16xi32>
-//      CHECK: return %[[RES:.*]] : vector<16xi32>
+func.func @test_mac_elem(%a : vector<16xi32>,
+                         %b : vector<16xi32>,
+                         %c : vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[UPS:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
+    // CHECK: %[[ME:.*]] = aievec.mac_elem %[[A]], %[[B]], %[[UPS:.*]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
+    // CHECK: %[[RES:.*]] = aievec.srs %[[ME:.*]] {shift = 0 : i8} : vector<16xi64>, vector<16xi32>
+    %0 = arith.muli %a, %b : vector<16xi32>
+    %1 = arith.addi %0, %c : vector<16xi32>
+    // CHECK: return %[[RES:.*]] : vector<16xi32>
+    return %1 : vector<16xi32>
+}
+
+// CHECK-LABEL: func @test_mac_elem_inv
+// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
+// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi32>
+func.func @test_mac_elem_inv(%a : vector<16xi32>,
+                             %b : vector<16xi32>,
+                             %c : vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[UPS:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
+    // CHECK: %[[ME:.*]] = aievec.mac_elem %[[A]], %[[B]], %[[UPS:.*]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
+    // CHECK: %[[RES:.*]] = aievec.srs %[[ME:.*]] {shift = 0 : i8} : vector<16xi64>, vector<16xi32>
+    %0 = arith.muli %a, %b : vector<16xi32>
+    %1 = arith.addi %c, %0 : vector<16xi32>
+    // CHECK: return %[[RES:.*]] : vector<16xi32>
+    return %1 : vector<16xi32>
+}

--- a/test/dialect/AIEVec/transfer-read-splat.mlir
+++ b/test/dialect/AIEVec/transfer-read-splat.mlir
@@ -1,5 +1,4 @@
 // RUN: aie-opt %s -canonicalize-for-aievec -split-input-file | FileCheck %s
-// XFAIL: *
 
 // CHECK-LABEL: func.func @splat(
 // CHECK-SAME: %[[MEM:.*]]: memref<?xi32>,
@@ -14,40 +13,4 @@ func.func @splat(%m : memref<?xi32>, %pos : index) -> vector<8xi32> {
     %v = vector.transfer_read %m[%i], %c0_i32 {permutation_map = affine_map<(d0) -> (0)>} : memref<?xi32>, vector<8xi32>
     // CHECK: return %[[S]] : vector<8xi32>
     return %v : vector<8xi32>
-}
-
-// CHECK-LABEL: func.func @muladd2fma_i32(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
-func.func @muladd2fma_i32(%a : vector<8xi32>, %b : vector<8xi32>, %c : vector<8xi32>) -> vector<8xi32> {
-    // CHECK: %[[R:.*]] = vector.fma %[[A]], %[[B]], %[[C]] : vector<8xi32>
-    %0 = arith.muli %a, %b : vector<8xi32>
-    %1 = arith.addi %0, %c : vector<8xi32>
-    // CHECK: return %[[R]] : vector<8xi32>
-    return %1 : vector<8xi32>
-}
-
-// CHECK-LABEL: func.func @muladd2fma_f32(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xf32>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xf32>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xf32>
-func.func @muladd2fma_f32(%a : vector<8xf32>, %b : vector<8xf32>, %c : vector<8xf32>) -> vector<8xf32> {
-    // CHECK: %[[R:.*]] = vector.fma %[[A]], %[[B]], %[[C]] : vector<8xf32>
-    %0 = arith.mulf %a, %b : vector<8xf32>
-    %1 = arith.addf %0, %c : vector<8xf32>
-    // CHECK: return %[[R]] : vector<8xf32>
-    return %1 : vector<8xf32>
-}
-
-// CHECK-LABEL: func.func @muladd2fma_inv(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
-func.func @muladd2fma_inv(%a : vector<8xi32>, %b : vector<8xi32>, %c : vector<8xi32>) -> vector<8xi32> {
-    // CHECK: %[[R:.*]] = vector.fma %[[A]], %[[B]], %[[C]] : vector<8xi32>
-    %0 = arith.muli %a, %b : vector<8xi32>
-    %1 = arith.addi %c, %0 : vector<8xi32>
-    // CHECK: return %[[R]] : vector<8xi32>
-    return %1 : vector<8xi32>
 }


### PR DESCRIPTION
https://reviews.llvm.org/D141711 upstream disallows `vector.fma` for integral types. In order to work around this, we need to merge the identification of `arith.muli` + `arith.addi` into the patterns that take `vector.fma` and lower it to the equivalent operation in `aievec`.