### PR TITLE
Revert llvm to 35ca6498

### DIFF
--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -164,7 +164,7 @@ class flow_runner:
                             '--expand-strided-metadata',
                             '--lower-affine',
                             '--convert-arith-to-llvm',
-                            '--finalize-memref-to-llvm',
+                            '--convert-memref-to-llvm',
                             '--convert-func-to-llvm=use-bare-ptr-memref-call-conv',
                             '--convert-cf-to-llvm',
                             '--canonicalize', '--cse', file_core, '-o', file_opt_core])
@@ -354,7 +354,7 @@ class flow_runner:
                               '--expand-strided-metadata',
                               '--lower-affine',
                               '--convert-arith-to-llvm',
-                              '--finalize-memref-to-llvm',
+                              '--convert-memref-to-llvm',
                               '--convert-func-to-llvm=use-bare-ptr-memref-call-conv',
                               '--convert-cf-to-llvm',
                               '--canonicalize', '--cse', self.file_with_addresses, '-o', self.file_opt_with_addresses])

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -12,7 +12,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-export commithash=5e111eb275eee3bec1123b4b85606328017e5ee5
+export commithash=35ca64989a75c93ea7e935ef11c3d1883c21cccd
 
 git clone --depth 1 https://github.com/Xilinx/cmakeModules cmakeModules/cmakeModulesXilinx
 export CMAKE_MODULE_PATH=`pwd`/cmakeModules/cmakeModulesXilinx


### PR DESCRIPTION
Workaround for https://github.com/Xilinx/mlir-aie/issues/380

The idea is to hold LLVM/MLIR at this commit until a permanent solution is found.