### PR TITLE
Update linker script generation with stack size control

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -331,7 +331,8 @@ def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint, TileElement
 
 def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint, TileElement]>, Results<(outs Index)> {
   let arguments = (
-    ins Index:$tile
+    ins Index:$tile,
+    DefaultValuedAttr<I32Attr, "0x400">:$stackSize
   );
   let summary = "Declare a core module";
   let description = [{
@@ -340,6 +341,11 @@ def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint, TileElement]>, Results<(outs Index
     typically be outlined into the LLVM dialect, eventually resulting in a binary file
     for each core.  The name of this file can be be specified using the 'elf_file'
     attribute.
+
+    This op has an optional 'stackSize' attribute, to control the amount of memory (in bytes)
+    reserved for the stack.  The default value is 1024.  The stack (and other data allocations)
+    are always stored in the local core memory, to avoid conflicts with static data allocations
+    in other cores.
 
     Examples:
     ```
@@ -355,7 +361,7 @@ def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint, TileElement]>, Results<(outs Index
     %tile = AIE.tile(3, 3)
     AIE.core(%tile) {
       AIE.end
-    } { elf_file = "core_33.elf" }
+    } { stackSize = 2048 : i32, elf_file = "core_33.elf" }
     ```
   }];
   let regions = (region AnyRegion:$body);

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -310,6 +310,16 @@ struct AIECoreToStandardFunc : public OpConversionPattern<CoreOp> {
   }
 };
 
+// Move all the ops with OpTy inside device, to just before the device.
+template <typename OpTy> void outlineOps(AIE::DeviceOp device) {
+  SmallVector<OpTy, 16> ops;
+  for (const auto &op : device.getOps<OpTy>())
+    ops.push_back(op);
+
+  for (const auto &op : ops)
+    op->moveBefore(device);
+}
+
 struct AIECoreToStandardPass
     : public AIECoreToStandardBase<AIECoreToStandardPass> {
   void runOnOperation() override {
@@ -462,13 +472,10 @@ struct AIECoreToStandardPass
     if (failed(applyPartialConversion(m, target, std::move(patterns))))
       signalPassFailure();
 
-    // Move all the func.func ops from the device to the module
-    SmallVector<func::FuncOp, 16> funcs;
-    for (const auto &op : device.getOps<func::FuncOp>())
-      funcs.push_back(op);
-
-    for (const auto &op : funcs)
-      op->moveBefore(device);
+    // Move all the func.func ops and memref.globals from the device to the
+    // module
+    outlineOps<memref::GlobalOp>(device);
+    outlineOps<func::FuncOp>(device);
 
     RewritePatternSet removepatterns(&getContext());
     removepatterns

--- a/test/assign-buffer-addresses/error.mlir
+++ b/test/assign-buffer-addresses/error.mlir
@@ -23,5 +23,11 @@ module @test {
   %b2 = AIE.buffer(%0) { sym_name = "c" } : memref<16xi16>
   %3 = AIE.tile(4, 4)
   %4 = AIE.buffer(%3) : memref<500xi32>
+  AIE.core(%0) {
+    AIE.end
+  }
+  AIE.core(%3) {
+    AIE.end
+  }
  }
 }

--- a/test/assign-buffer-addresses/simple.mlir
+++ b/test/assign-buffer-addresses/simple.mlir
@@ -22,5 +22,11 @@ module @test {
   %b2 = AIE.buffer(%0) { sym_name = "c" } : memref<16xi16>
   %3 = AIE.tile(4, 4)
   %4 = AIE.buffer(%3) : memref<500xi32>
+  AIE.core(%0) {
+    AIE.end
+  }
+  AIE.core(%3) {
+    AIE.end
+  }
  }
 }

--- a/test/generate-mmap/allocation_error.mlir
+++ b/test/generate-mmap/allocation_error.mlir
@@ -1,0 +1,44 @@
+//===- allocation_error.mlir -----------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aiecc.py --xchesscc --xbridge %s |& FileCheck %s --check-prefix=CHESS
+// RUN: not aiecc.py --no-xchesscc --no-xbridge %s |& FileCheck %s --check-prefix=PEANO
+
+// CHESS: Error: could not find free space for SpaceSymbol x in memory DMb
+// PEANO: ld.lld: error: section '.bss' will not fit in region 'data': overflowed by 4 bytes
+
+// REQUIRES: chess
+// REQUIRES: peano
+// If we use all of the local memory, then linking the AIE executable should fail.
+
+module @example0 {
+ AIE.device(xcvc1902) {
+  memref.global @x : memref<4xi8> = uninitialized
+  func.func @test (%i: index, %v: i8) -> i8 {
+      %x = memref.get_global @x : memref<4xi8>
+      memref.store %v, %x[%i] : memref<4xi8>
+      %r = memref.load %x[%i] : memref<4xi8>
+      func.return %r : i8
+  }
+
+  %t33 = AIE.tile(3, 3)
+
+  // Use all the local memory for buffers, combined with the 1024 byte stack size.
+  %buf33 = AIE.buffer(%t33) : memref<31744xi8>
+
+  %c33 = AIE.core(%t33) {
+    %idx1 = arith.constant 3 : index
+    %val1 = arith.constant 7 : i8
+    memref.store %val1, %buf33[%idx1] : memref<31744xi8>
+    func.call @test(%idx1, %val1) : (index, i8) -> i8
+    AIE.end
+  }
+ }
+}

--- a/test/generate-mmap/test_mmap0.mlir
+++ b/test/generate-mmap/test_mmap0.mlir
@@ -43,16 +43,25 @@
 // BCF44-NEXT: _reserved DMb      0x00000 0x20000 //Don't put data in code memory
 // BCF44-NEXT: _symbol z 0x20000 0x20
 // BCF44-NEXT: _extern z
+// BCF44-NEXT: _reserved DMb 0x20000 0x20
+// BCF44-NEXT: _reserved DMb 0x20000 0x8000
 // BCF44-NEXT: _symbol a 0x28000 0x10
 // BCF44-NEXT: _extern a
+// BCF44-NEXT: _reserved DMb 0x28000 0x10
 // BCF44-NEXT: _symbol b 0x28010 0x40
 // BCF44-NEXT: _extern b
+// BCF44-NEXT: _reserved DMb 0x28010 0x40
 // BCF44-NEXT: _symbol c 0x28050 0x400
 // BCF44-NEXT: _extern c
+// BCF44-NEXT: _reserved DMb 0x28050 0x400
 // BCF44-NEXT: _symbol t 0x30000 0x20
 // BCF44-NEXT: _extern t
+// BCF44-NEXT: _reserved DMb 0x30000 0x20
+// BCF44-NEXT: _reserved DMb 0x30000 0x8000
 // BCF44-NEXT: _symbol y 0x38000 0x20
 // BCF44-NEXT: _extern y
+// BCF44-NEXT: _reserved DMb 0x38000 0x20
+// BCF44-NEXT: _reserved DMb 0x38000 0x8000
 // BCF44-NEXT: _stack    DM_stack 0x28000  0x400 //stack for core
 // BCF44-NEXT: _reserved DMb 0x40000 0xc0000 // And everything else the core can't see
 
@@ -61,7 +70,7 @@
 // LD44: MEMORY
 // LD44-NEXT: {
 // LD44-NEXT:    program (RX) : ORIGIN = 0, LENGTH = 0x0020000
-// LD44-NEXT:    data (!RX) : ORIGIN = 0x20000, LENGTH = 0x0020000
+// LD44-NEXT:    data (!RX) : ORIGIN = 0x28450, LENGTH = 0x7BB0
 // LD44-NEXT: }
 // LD44-NEXT: ENTRY(_main_init)
 // LD44-NEXT: SECTIONS
@@ -122,6 +131,9 @@ module @test_mmap0 {
   %buf43_0 = AIE.buffer(%t43) { sym_name = "z", address = 0x0 } : memref<8xi32>
   %buf45_0 = AIE.buffer(%t45) { sym_name = "t", address = 0x0 } : memref<8xi32>
 
+  AIE.core(%t44) {
+    AIE.end
+  }
  }
 }
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -103,6 +103,7 @@ if(config.enable_chess_tests):
 
     if result != None:
         print("Chess found: " + result)
+        config.available_features.add('chess')
         config.available_features.add('valid_xchess_license')
         lm_license_file = os.getenv('LM_LICENSE_FILE')
         if(lm_license_file != None):


### PR DESCRIPTION
CoreOp now supports a 'stackSize' attribute, enabling the control of the stack allocation.

Along the way, fix a bug where memory areas were not properly being reserved (either with gnu linker scripts or bcf files).  This allowed static allocations to potentially overlap with allocated communication buffers.  Note that in order to keep static allocations independent on different cores, we allow them only to be mapped into the local memory of a core.

Fixes #209