### PR TITLE
Add option to generate documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,10 +105,14 @@ add_definitions(${LLVM_DEFINITIONS})
 add_custom_target(aie-headers)
 set_target_properties(aie-headers PROPERTIES FOLDER "Misc")
 add_dependencies(aie-headers mlir-headers)
-# Make sure we build the docs
-add_custom_target(docs ALL)
-add_subdirectory(docs)
-add_dependencies(docs mlir-doc)
+
+option(AIE_INCLUDE_DOCS "Generate build targets for the MLIR AIE docs." OFF)
+if (AIE_INCLUDE_DOCS)
+    # Make sure we build the docs
+    add_custom_target(docs ALL)
+    add_subdirectory(docs)
+    add_dependencies(docs mlir-doc)
+endif()
 
 # python install directory
 if (AIE_ENABLE_BINDINGS_PYTHON)


### PR DESCRIPTION
Having an option to enable/disable document generation is needed, generating documentation always produces noisy output that makes working on the code unnecessarily messy. I've opted to not generate documentation by default, and the option can be enabled with `-DAIE_INCLUDE_DOCS=ON`.