### PR TITLE
Sim restructure

### DIFF
--- a/aie_runtime_lib/AIE/aiesim/Makefile
+++ b/aie_runtime_lib/AIE/aiesim/Makefile
@@ -31,17 +31,14 @@ CC_ENV := (export LD_LIBRARY_PATH=${XILINX_VITIS_AIETOOLS}/lib/lnx64.o:$(LD_LIBR
 CC := "${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/bin/g++" 
 CC_ARGS := -fPIC -fpermissive -c -std=c++17 -D__AIEARCH__=10 -DAIE_OPTION_SCALAR_FLOAT_ON_VECTOR -Wno-deprecated-declarations -DSC_INCLUDE_DYNAMIC_PROCESSES -D__AIESIM__ -D__PS_INIT_AIE__ -DXAIE_DEBUG -Og -flto -D main\(...\)=ps_main\(...\) -I${XILINX_VITIS_AIETOOLS}/include -I${XILINX_VITIS_AIETOOLS}/include/drivers/aiengine -I${XILINX_HLS}/include -I${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/include/c++/8.3.0 -I${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/include/c++/8.3.0/backward -I${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/include/c++/8.3.0/x86_64-pc-linux-gnu -I${XILINX_VITIS_AIETOOLS}/data/osci_systemc/include -I${XILINX_VITIS_AIETOOLS}/tps/boost_1_72_0 -I. -I$(MLIR_AIE_SRC_DIR) -I${XILINX_VITIS_AIETOOLS}/include/xtlm/include -I${XILINX_VITIS_AIETOOLS}/include/common_cpp/common_cpp_v1_0/include -I${MLIR_AIE_INSTALL}/runtime_lib/x86_64/test_lib/include  -I../../ -I../
 
-ps/test_library.o: ${MLIR_AIE_INSTALL}/runtime_lib/x86_64/test_lib/test_library.cpp
-	$(CC_ENV);$(CC) $(CC_ARGS) -o $@ $<
-	
 ps/test.o: $(host)
 	$(CC_ENV);$(CC) $(CC_ARGS) -o $@ $<
 
 ps/genwrapper_for_ps.o: ps/genwrapper_for_ps.cpp
 	$(CC_ENV);$(CC) $(CC_ARGS) -o $@ $<
 
-ps/ps.so: ps/genwrapper_for_ps.o ps/test.o ps/test_library.o $(eval PATH:=$(XILINX_VITIS_AIETOOLS)/tps/lnx64/gcc/bin/:$(PATH))
-	(${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/bin/g++ -o "ps/ps.so" ps/genwrapper_for_ps.o ps/test.o ps/test_library.o -Wl,--as-needed -shared -lxaiengine -lxioutils -ladf_api -lsystemc -lxtlm -flto -L ${XILINX_VITIS_AIETOOLS}/lib/lnx64.o -L${XILINX_VITIS_AIETOOLS}/data/osci_systemc/lib/lnx64)
+ps/ps.so: ps/genwrapper_for_ps.o ps/test.o $(eval PATH:=$(XILINX_VITIS_AIETOOLS)/tps/lnx64/gcc/bin/:$(PATH))
+	(${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/bin/g++ -o "ps/ps.so" ps/genwrapper_for_ps.o ps/test.o -L ${MLIR_AIE_INSTALL}/runtime_lib/x86_64/test_lib/lib -ltest_lib_sim_aie -Wl,--as-needed -shared -lxaiengine -lxioutils -ladf_api -lsystemc -lxtlm -flto -L ${XILINX_VITIS_AIETOOLS}/lib/lnx64.o -L${XILINX_VITIS_AIETOOLS}/data/osci_systemc/lib/lnx64)
 
 link: ps/ps.so
 

--- a/aie_runtime_lib/AIE2/aiesim/Makefile
+++ b/aie_runtime_lib/AIE2/aiesim/Makefile
@@ -31,17 +31,14 @@ CC_ENV := (export LD_LIBRARY_PATH=${XILINX_VITIS_AIETOOLS}/lib/lnx64.o:$(LD_LIBR
 CC := "${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/bin/g++" 
 CC_ARGS := -fPIC -fpermissive -c -std=c++17 -D__AIEARCH__=20 -DAIE_OPTION_SCALAR_FLOAT_ON_VECTOR -DAIE2_FP32_EMULATION_ACCURACY_FAST -Wno-deprecated-declarations -DSC_INCLUDE_DYNAMIC_PROCESSES -D__AIESIM__ -D__PS_INIT_AIE__ -DXAIE_DEBUG -Og -flto -D main\(...\)=ps_main\(...\) -I${XILINX_VITIS_AIETOOLS}/include -I${XILINX_VITIS_AIETOOLS}/include/drivers/aiengine -I${XILINX_HLS}/include -I${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/include/c++/8.3.0 -I${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/include/c++/8.3.0/backward -I${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/include/c++/8.3.0/x86_64-pc-linux-gnu -I${XILINX_VITIS_AIETOOLS}/data/osci_systemc/include -I${XILINX_VITIS_AIETOOLS}/tps/boost_1_72_0 -I. -I$(MLIR_AIE_SRC_DIR) -I${XILINX_VITIS_AIETOOLS}/include/xtlm/include -I${XILINX_VITIS_AIETOOLS}/include/common_cpp/common_cpp_v1_0/include -I${MLIR_AIE_INSTALL}/runtime_lib  -I../../ -I../ 
 
-ps/test_library.o: ${MLIR_AIE_INSTALL}/runtime_lib/test_library.cpp
-	$(CC_ENV);$(CC) $(CC_ARGS) -o $@ $<
-	
 ps/test.o: $(host)
 	$(CC_ENV);$(CC) $(CC_ARGS) -o $@ $<
 
-ps/genwrapper_for_ps.o: ps/genwrapper_for_ps.cpp $(host) ../aie_inc.cpp ${MLIR_AIE_INSTALL}/runtime_lib/test_library.cpp
+ps/genwrapper_for_ps.o: ps/genwrapper_for_ps.cpp 
 	$(CC_ENV);$(CC) $(CC_ARGS) -o $@ $<
 
-ps/ps.so: ps/genwrapper_for_ps.o ps/test.o ps/test_library.o $(eval PATH:=$(XILINX_VITIS_AIETOOLS)/tps/lnx64/gcc/bin/:$(PATH))
-	(${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/bin/g++ -o "ps/ps.so" ps/genwrapper_for_ps.o ps/test.o ps/test_library.o -Wl,--as-needed -shared -lxaiengine -lxioutils -ladf_api -lsystemc -lxtlm -flto -L ${XILINX_VITIS_AIETOOLS}/lib/lnx64.o -L${XILINX_VITIS_AIETOOLS}/data/osci_systemc/lib/lnx64)
+ps/ps.so: ps/genwrapper_for_ps.o ps/test.o $(eval PATH:=$(XILINX_VITIS_AIETOOLS)/tps/lnx64/gcc/bin/:$(PATH))
+	(${XILINX_VITIS_AIETOOLS}/tps/lnx64/gcc/bin/g++ -o "ps/ps.so" ps/genwrapper_for_ps.o ps/test.o -L ${MLIR_AIE_INSTALL}/runtime_lib/x86_64/test_lib/lib -ltest_lib_sim_aie2 -Wl,--as-needed -shared -lxaiengine -lxioutils -ladf_api -lsystemc -lxtlm -flto -L ${XILINX_VITIS_AIETOOLS}/lib/lnx64.o -L${XILINX_VITIS_AIETOOLS}/data/osci_systemc/lib/lnx64)
 
 link: ps/ps.so
 

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -31,9 +31,6 @@ install(TARGETS test_lib
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/include
 )
 
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/test_library.cpp ${CMAKE_CURRENT_SOURCE_DIR}/test_library.h DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib)
-
-
 # create extra libs supporting simulation
 # AIE1 test_lib for aiesimulator
 add_library(test_lib_sim_aie STATIC test_library.cpp)

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -36,7 +36,6 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/test_library.cpp ${CMAKE_CURRENT_SOURC
 
 # create extra libs supporting simulation if target is x86_64
 if(${AIE_RUNTIME_TARGET} STREQUAL "x86_64")
-message(STATUS "NOLF NOLF: sim static libs")
 
 # AIE1 test_lib for aiesimulator
 add_library(test_lib_sim_aie STATIC test_library.cpp)
@@ -52,11 +51,11 @@ install(TARGETS test_lib_sim_aie
     ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/lib
 )
 
-# AIE1 test_lib for aiesimulator
+# AIE2 test_lib for aiesimulator
 add_library(test_lib_sim_aie2 STATIC test_library.cpp)
 #set_target_properties(test_lib_sim_aie2 PROPERTIES PUBLIC_HEADER "test_library.h")
 target_compile_options(test_lib_sim_aie2 PRIVATE -fPIC)
-target_compile_definitions(test_lib_sim_aie2 PRIVATE LIBXAIENGINEV2 __AIESIM__)
+target_compile_definitions(test_lib_sim_aie2 PRIVATE LIBXAIENGINEV2 __AIESIM__ __AIEARCH__=20)
 
 target_include_directories(test_lib_sim_aie2 PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/../../xaiengine/include

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -34,12 +34,9 @@ install(TARGETS test_lib
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/test_library.cpp ${CMAKE_CURRENT_SOURCE_DIR}/test_library.h DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib)
 
 
-# create extra libs supporting simulation if target is x86_64
-if(${AIE_RUNTIME_TARGET} STREQUAL "x86_64")
-
+# create extra libs supporting simulation
 # AIE1 test_lib for aiesimulator
 add_library(test_lib_sim_aie STATIC test_library.cpp)
-#set_target_properties(test_lib_sim_aie PROPERTIES PUBLIC_HEADER "test_library.h")
 target_compile_options(test_lib_sim_aie PRIVATE -fPIC)
 target_compile_definitions(test_lib_sim_aie PRIVATE LIBXAIENGINEV2 __AIESIM__)
 
@@ -53,7 +50,6 @@ install(TARGETS test_lib_sim_aie
 
 # AIE2 test_lib for aiesimulator
 add_library(test_lib_sim_aie2 STATIC test_library.cpp)
-#set_target_properties(test_lib_sim_aie2 PROPERTIES PUBLIC_HEADER "test_library.h")
 target_compile_options(test_lib_sim_aie2 PRIVATE -fPIC)
 target_compile_definitions(test_lib_sim_aie2 PRIVATE LIBXAIENGINEV2 __AIESIM__ __AIEARCH__=20)
 
@@ -64,4 +60,3 @@ target_include_directories(test_lib_sim_aie2 PRIVATE
 install(TARGETS test_lib_sim_aie2 
     ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/lib
 )
-endif()

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -32,3 +32,37 @@ install(TARGETS test_lib
 )
 
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/test_library.cpp ${CMAKE_CURRENT_SOURCE_DIR}/test_library.h DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib)
+
+
+# create extra libs supporting simulation if target is x86_64
+if(${AIE_RUNTIME_TARGET} STREQUAL "x86_64")
+message(STATUS "NOLF NOLF: sim static libs")
+
+# AIE1 test_lib for aiesimulator
+add_library(test_lib_sim_aie STATIC test_library.cpp)
+#set_target_properties(test_lib_sim_aie PROPERTIES PUBLIC_HEADER "test_library.h")
+target_compile_options(test_lib_sim_aie PRIVATE -fPIC)
+target_compile_definitions(test_lib_sim_aie PRIVATE LIBXAIENGINEV2 __AIESIM__)
+
+target_include_directories(test_lib_sim_aie PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}/../../xaiengine/include
+)
+
+install(TARGETS test_lib_sim_aie 
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/lib
+)
+
+# AIE1 test_lib for aiesimulator
+add_library(test_lib_sim_aie2 STATIC test_library.cpp)
+#set_target_properties(test_lib_sim_aie2 PROPERTIES PUBLIC_HEADER "test_library.h")
+target_compile_options(test_lib_sim_aie2 PRIVATE -fPIC)
+target_compile_definitions(test_lib_sim_aie2 PRIVATE LIBXAIENGINEV2 __AIESIM__)
+
+target_include_directories(test_lib_sim_aie2 PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}/../../xaiengine/include
+)
+
+install(TARGETS test_lib_sim_aie2 
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/lib
+)
+endif()

--- a/runtime_lib/xaiengine/CMakeLists.txt
+++ b/runtime_lib/xaiengine/CMakeLists.txt
@@ -8,10 +8,11 @@ cmake_minimum_required(VERSION 3.20.1)
 
 project("xaiengine lib for ${AIE_RUNTIME_TARGET}")
 
-set(xaienginePath ${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src) 
-#set(xaienginePath ${VITIS_AIETOOLS_DIR}/include/drivers/aiengine)
-file(GLOB libheaders ${xaienginePath}/*.h)
-file(GLOB libheadersSub ${xaienginePath}/*/*.h)
+set(xaienginePath ${VITIS_AIETOOLS_DIR}/include/drivers/aiengine)
+#tmp path to header files since we use an older (3_0) version of xaiengine. need to fix when we upgrade to 2023.1
+set(xaienginePathTmp ${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src) 
+file(GLOB libheaders ${xaienginePathTmp}/*.h ${xaienginePath}/xioutils.h)
+file(GLOB libheadersSub ${xaienginePathTmp}/*/*.h)
 
 # copy header files into build area
 foreach(file ${libheaders})


### PR DESCRIPTION
Added 2 x86_64 specific static test_lib targets: test_lib_sim_aie and test_lib_sim_aie2 to support aie and aie2 simulation on x86_64. This should allow us to (finally) remove test_library.cpp from the install.
They are both installed in runtime_lib/x86_64/test_lib/lib for now. Maybe aie_runtime_lib/{AIE,AI2}/aiesim is a better location since they are simulation specific?