### PR TITLE
Add Sanity Checks to Build Scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+*.elf
+*.elf.*
+*.exe
+*.map
+*.log
+*.o
+*.vcd
+*.prf
+
 /build*
 /install*
 /sandbox*
@@ -17,3 +26,12 @@ __pycache__
 /platforms/vck190_bare/vivado/vck190_bare_proj
 utils/vitisVariables.config
 runtime_lib/xaiengine/src
+
+/tutorials/**/elf/*
+/tutorials/**/acdc_project/*
+/tutorials/**/aiesimulator_output/*
+/tutorials/**/sim/*
+/tutorials/**/work/*
+/tutorials/**/*.ll
+/tutorials/**/.AIE_SIM_CMD_LINE_OPTIONS
+/tutorials/**/aie.mlir.prj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,15 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-set(TOOLCHAINFILES_PATH ${CMAKE_SOURCE_DIR}/cmake/modulesXilinx)
+project(MLIR_AIE C CXX)
+
+if(NOT EXISTS ${CMAKE_C_COMPILER})
+  message(FATAL_ERROR "Required compiler " ${CMAKE_C_COMPILER} " not found.")
+endif()
+
+if(NOT EXISTS ${CMAKE_CXX_COMPILER})
+  message(FATAL_ERROR "Required compiler " ${CMAKE_CXX_COMPILER} " not found.")
+endif()
 
 set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runtime libraries for.")
 set(AIE_RUNTIME_TEST_TARGET "x86_64" CACHE STRING "Runtime architecture to test with.")

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 ```
-clang 10.0.0+
+clang 12.0.0+
 lld
 cmake 3.20.6
 ninja 1.8.2
@@ -16,12 +16,6 @@ clang/llvm 14+ from source https://github.com/llvm/llvm-project
 Xilinx Vitis can be downloaded and installed from the [Xilinx Downloads](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vitis.html) site.
 
 In order to successfully install Vitis on a fresh bare-bones Ubuntu install, some additional prerequisites are required, [documented here](https://support.xilinx.com/s/article/63794?language=en_US). For Ubuntu 20.04, the installation should succeed if you additionally install the following packages: `libncurses5 libtinfo5 libncurses5-dev libncursesw5-dev ncurses-compat-libs libstdc++6:i386 libgtk2.0-0:i386 dpkg-dev:i386 python3-pip libboost-all-dev` Further note that the above mentioned cmake prerequisite is _not_ satisfied by the package provided by Ubuntu; you will need to obtain a more current version.
-
-NOTE: Using the Vitis recommended `settings64.sh` script to set up your environement can cause tool conflicts. Setup your environment in the following order for aietools and Vitis:
- 
-```
-export PATH=$PATH:<Vitis_install_path>/Vitis/2022.2/aietools/bin:<Vitis_install_path>/Vitis/2022.2/bin
-```
 
 The cmake and python packages prerequisites can be satisfied by sourcing the `utils/setup_python_packages.sh` script. See step 2 of the build instructions. 
 This script requires `virtualenv`.
@@ -44,7 +38,7 @@ the tools are largely board and device independent and can be adapted to other e
 
 1. Clone the mlir-aie repo.
     ```
-    git clone https://github.com/Xilinx/mlir-aie.git
+    git clone --recurse-submodules https://github.com/Xilinx/mlir-aie.git
     cd mlir-aie
     ```
 
@@ -73,10 +67,16 @@ particular revision is expected to work.
     ```
     This will build llvm in llvm/build and install the llvm binaries under llvm/install.
 
-4. Build the mlir-aie tools by calling `utils/build-mlir-aie.sh` with the path to `llvm/build`. The Vitis enviroment will have to be set up for this to succeed. 
+    You will also need to install clang 12, which is the compiler we use for building MLIR-AIE itself. However,
+    you do not need to do this from source. On Ubuntu, you may do this by running:
+    ```
+    sudo apt-get install clang-12
+    ```
+
+4. Build the mlir-aie tools by calling `utils/build-mlir-aie.sh` (optionally with the path to `llvm/build` as its first argument). The Vitis enviroment will have to be set up for this to succeed. 
     ```
     source <Vitis Install Path>/settings64.sh
-    ./utils/build-mlir-aie.sh <llvm dir>/<build dir>
+    ./utils/build-mlir-aie.sh 
     ```
     This will create a `build` and `install` folder in the directory that you cloned MLIR AIE into. 
 

--- a/utils/build-mlir-aie-cross.sh
+++ b/utils/build-mlir-aie-cross.sh
@@ -21,17 +21,21 @@
 #
 ##===----------------------------------------------------------------------===##
 
-if [ "$#" -lt 2 ]; then
-    echo "ERROR: Needs at least 2 arguments for <sysroot dir>, <llvm build dir>"
+
+if [ "$#" -lt 1 -o ! -d "$1" ]; then
+    echo "ERROR: Needs at least 1 argument for <sysroot dir>"
     exit 1
 fi
 
 BASE_DIR=`realpath $(dirname $0)/..`
+source "${BASE_DIR}/utils/common.sh"
+
 CMAKEMODULES_DIR=$BASE_DIR/cmake
 
 SYSROOT_DIR=$1
 
-LLVM_BUILD_DIR=`realpath $2`
+LLVM_BUILD_DIR=${2:-"${BASE_DIR}/llvm/build"}
+LLVM_BUILD_DIR=$(realpath $LLVM_BUILD_DIR)
 
 BUILD_DIR=${3:-"build-aarch64"}
 INSTALL_DIR=${4:-"install-aarch64"}
@@ -39,14 +43,16 @@ INSTALL_DIR=${4:-"install-aarch64"}
 BUILD_DIR=`realpath ${BUILD_DIR}`
 INSTALL_DIR=`realpath ${INSTALL_DIR}`
 
+sanity_checks $# "$CMAKEMODULES_DIR" "$LLVM_BUILD_DIR"
+
 mkdir -p $BUILD_DIR
 mkdir -p $INSTALL_DIR
 cd $BUILD_DIR
 set -o pipefail
 set -e
 cmake -GNinja \
+    --toolchain "${CMAKEMODULES_DIR}/toolchainFiles/toolchain_clang_crosscomp_pynq.cmake" \
     -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/modulesXilinx \
-    -DCMAKE_TOOLCHAIN_FILE=${CMAKEMODULES_DIR}/toolchainFiles/toolchain_clang_crosscomp_pynq.cmake \
     -DSysroot=${SYSROOT_DIR} \
     -DArch=arm64 \
     -DLLVM_DIR=${LLVM_BUILD_DIR}/lib/cmake/llvm \

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -1,0 +1,39 @@
+##===- utils/common.sh - Common functions for build scripts --*- Script -*-===##
+# 
+# This file licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# 
+##===----------------------------------------------------------------------===##
+
+# sanity_checks()
+# Try to catch potential missing dependencies early to alert the user to it.
+# Argument 1: N args on command line for calling function
+# Argument 2: CMAKEMODULES_DIR
+# Argument 3: LLVM_BUILD_DIR
+sanity_checks() {
+	if [ ! -f "${2}/modulesXilinx/FindVitis.cmake" ]; then
+		echo "cmake/modulesXilinx not found. Make sure you clone all "\
+		     "of the MLIR repository, including submodules, by "\
+		     "running "\
+		     "\`git submodule update --recursive\`."
+		exit 1
+	fi
+
+	if [ ! -d "${3}" ]; then
+		echo "llvm/build directory not found. Make sure you clone and "\
+		     "build LLVM first by running \`./utils/clone-llvm.sh\`, "\
+		     "and \`./utils/build-llvm-local.sh\`, respectively, first."
+		if [ "${1}" -lt 1 ]; then
+			echo "You may also specify a path to a LLVM build as "\
+			     "the first argument to this script."
+		fi
+		exit 1
+	fi
+
+	if [ ! -f "$(which xchesscc)" ]; then
+		echo "xchesscc not found. Make sure you run"\
+		     "\`source <path to Vitis 2022.2>/settings64.sh\` first."
+		exit 1
+	fi
+}


### PR DESCRIPTION
My goal with this is to make the build process just a little more user friendly by catching potential errors early. For this, I would like to suggest the following changes:

1. Check for presence of some of the needed dependencies in `./utils/build-mlir-aie.sh`, namely presence of `xchesscc` (verifying that Vitis has been properly sourced beforehand), presence of the `cmakeModules` submodule, and the `llvm/build` directory (verifying that `./utils/build-llvm-local.sh` has been called beforehand).
2. Remove requirement to add `<llvm build dir>` as an argument to `./utils/build-mlir-aie.sh`. Rationale: most users will simply call `./utils/build-llvm-local.sh` beforehand, which will build LLVM in a standard directory. If no argument is specified, we can try to assume that LLVM was built in that default directory (and abort if it can't be found there, of course).
3. Use same compiler toolchain for main build as for the `runtime_lib` build. **Note: I was not able to check this for the cross-compilation case.** I don't think it should break anything but someone who has a sysroot available might want to check whether the `./utils/build-mlir-aie-cross.sh` script works still.
4. Update `.gitignore`.

I'm happy to hear about any feedback regarding these suggestions.