### PR TITLE
Add valid_xchess_license requirement to tests using xchess

### DIFF
--- a/test/unit_tests/aievec_tests/bf16xbf16_add_elem/bf16xbf16_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/bf16xbf16_add_elem/bf16xbf16_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/bf16xbf16_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/bf16xbf16_mul_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/bf16xbf16_mul_elem_2/bf16xbf16_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/bf16xbf16_mul_elem_2/bf16xbf16_mul_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/bf16xbf16_sub_elem/bf16xbf16_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/bf16xbf16_sub_elem/bf16xbf16_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/floatxfloat_add_elem/floatxfloat_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/floatxfloat_add_elem/floatxfloat_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/floatxfloat_sub_elem/floatxfloat_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/floatxfloat_sub_elem/floatxfloat_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i16xi16_add_elem/i16xi16_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_add_elem/i16xi16_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i16xi16_add_elem_2/i16xi16_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_add_elem_2/i16xi16_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i16xi16_conv2d_1x3_after_polygeist_aie-ml/conv2d_i16_after_polygeist.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_conv2d_1x3_after_polygeist_aie-ml/conv2d_i16_after_polygeist.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" -aieml=true --aie-vectorize="shift=10 zero-offset=4" | aie-translate -aieml=true --aievec-to-cpp -o gen_aie-ml.cc
 // RUN: xchesscc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/testbench.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"

--- a/test/unit_tests/aievec_tests/i16xi16_conv2d_1x3_after_polygeist_aie-ml_2/conv2d_i16_after_polygeist_2.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_conv2d_1x3_after_polygeist_aie-ml_2/conv2d_i16_after_polygeist_2.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" -aieml=true --aie-vectorize="shift=10 zero-offset=4" | aie-translate -aieml=true --aievec-to-cpp -o gen_aie-ml.cc
 // RUN: xchesscc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/testbench.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"

--- a/test/unit_tests/aievec_tests/i16xi16_dynamic_sized_memref/conv2d_uij_i16_unbounded.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_dynamic_sized_memref/conv2d_uij_i16_unbounded.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --aie-vectorize="shift=10 zero-offset=4" | aie-translate --aievec-to-cpp -o gen.cc
 // RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. %S/i16xi16.cc %S/kernel.cc

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o convert_aie-ml.cc
 // RUN: xchesscc %S/kernel.cc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/testbench.cc
 // RUN: xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xme_ca_udm_dbg.stdout

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i16xi16_sub_elem/i16xi16_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_sub_elem/i16xi16_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i16xi16_sub_elem_2/i16xi16_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_sub_elem_2/i16xi16_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i32xi32_add_elem/i32xi32_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_add_elem/i32xi32_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i32xi32_add_elem_2/i32xi32_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_add_elem_2/i32xi32_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i32xi32_sub_elem/i32xi32_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_sub_elem/i32xi32_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i32xi32_sub_elem_2/i32xi32_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_sub_elem_2/i32xi32_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i8xi8_add_elem/i8xi8_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_add_elem/i8xi8_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i8xi8_add_elem_2/i8xi8_add_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_add_elem_2/i8xi8_add_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i8xi8_conv2d_1x3_after_polygeist_aie-ml/conv2d_i8_after_polygeist.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_conv2d_1x3_after_polygeist_aie-ml/conv2d_i8_after_polygeist.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" -aieml=true --aie-vectorize="shift=0 dup-factor=2" | aie-translate -aieml=true --aievec-to-cpp -o gen_aie-ml.cc
 // RUN: xchesscc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/i8xi8.cc %S/kernel.cc
 // RUN: cp -r %S/data . && xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i8xi8_static_sized_memref_init_aie-ml/conv2d_uij_i8_init.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_static_sized_memref_init_aie-ml/conv2d_uij_i8_init.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o convert_aie-ml.cc
 // RUN: xchesscc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/i8xi8.cc %S/convert_kernel.cc
 // RUN: cp -r %S/data . && xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"

--- a/test/unit_tests/aievec_tests/i8xi8_static_sized_memref_unsorted_aie-ml/conv2d_uij_i8_noinit_unsorted.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_static_sized_memref_unsorted_aie-ml/conv2d_uij_i8_noinit_unsorted.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o convert_aie-ml.cc
 // RUN: xchesscc -f -g +s -p me -P %aietools/data/aie_ml/lib/ +w work +o work -I%S -I. %S/i8xi8.cc %S/convert_kernel.cc
 // RUN: cp -r %S/data . && xme_ca_udm_dbg -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"

--- a/test/unit_tests/aievec_tests/i8xi8_sub_elem/i8xi8_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_sub_elem/i8xi8_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data

--- a/test/unit_tests/aievec_tests/i8xi8_sub_elem_2/i8xi8_sub_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_sub_elem_2/i8xi8_sub_elem.mlir
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data


### PR DESCRIPTION
Otherwise these all fail when run on a system without Vitis installed (e.g. vck190)