### PR TITLE
[aievec] Add support for function declarations in aievec-to-cpp

### DIFF
--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -2166,6 +2166,25 @@ static LogicalResult printOperation(CppEmitter &emitter,
   os << " " << functionOp.getName();
 
   os << "(";
+  if (functionOp.isDeclaration()) {
+    if (failed(interleaveCommaWithError(
+            functionOp.getArgumentTypes(), os, [&](Type type) -> LogicalResult {
+              if (failed(emitter.emitType(functionOp.getLoc(), type)))
+                return failure();
+              // If it is a memref argument, we need to check if it has dynamic
+              // shape. If so, the dimensions have to be printed out
+              MemRefType argType = dyn_cast<MemRefType>(type);
+              if (argType)
+                for (unsigned dim = 0; dim < argType.getRank(); ++dim)
+                  if (argType.isDynamicDim(dim))
+                    os << ", size_t";
+              return success();
+            })))
+      return failure();
+    os << ");\n";
+    return success();
+  }
+
   if (failed(interleaveCommaWithError(
           functionOp.getArguments(), os,
           [&](BlockArgument arg) -> LogicalResult {
@@ -2179,6 +2198,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
             return success();
           })))
     return failure();
+
   os << ") {\n";
   os.indent();
   if (emitter.shouldDeclareVariablesAtTop()) {

--- a/test/Targets/AIEVecToCpp/func-translations.mlir
+++ b/test/Targets/AIEVecToCpp/func-translations.mlir
@@ -1,0 +1,11 @@
+// RUN: aie-translate %s -aievec-to-cpp | FileCheck %s
+
+
+// CHECK: int32_t external_function(v16int32);
+func.func private @external_function(%v : vector<16xi32>) -> i32
+
+// CHECK: void external_function_with_memref(int16_t * restrict);
+func.func private @external_function_with_memref(%m : memref<64xi16>)
+
+// CHECK: void external_function_with_dynamic_memref(int8_t * restrict, size_t);
+func.func private @external_function_with_dynamic_memref(%m : memref<?xi8>)


### PR DESCRIPTION
This change enables declaring and calling external functions from MLIR in our `aievec-to-cpp` translation flow.