### PR TITLE
[aievec] Add lowering for vector.extract_strided_slice

### DIFF
--- a/include/aie/Dialect/AIEVec/Analysis/CMakeLists.txt
+++ b/include/aie/Dialect/AIEVec/Analysis/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 # (c) Copyright 2022 Xilinx Inc.
 
-add_subdirectory(Analysis)
-add_subdirectory(IR)
-add_subdirectory(Transforms)
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name AIEVecAnalysis)
+add_public_tablegen_target(MLIRAIEVecAnalysisPassIncGen)
+
+add_mlir_doc(Passes AIEVecAnalysisPasses ./ -gen-pass-doc)

--- a/include/aie/Dialect/AIEVec/Analysis/Passes.h
+++ b/include/aie/Dialect/AIEVec/Analysis/Passes.h
@@ -1,0 +1,46 @@
+//===- Passes.h - AIE Vector Passes -----------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+// Register all the AIE vectorization passes
+//===----------------------------------------------------------------------===//
+
+#ifndef AIE_DIALECT_AIEVEC_ANALYSIS_PASSES_H
+#define AIE_DIALECT_AIEVEC_ANALYSIS_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassOptions.h"
+#include <limits>
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+namespace mlir {
+namespace func {
+class FuncOp;
+} // namespace func
+} // namespace mlir
+
+namespace xilinx {
+namespace aievec {
+
+#define GEN_PASS_DECL
+#define GEN_PASS_CLASSES
+#include "aie/Dialect/AIEVec/Analysis/Passes.h.inc"
+
+std::unique_ptr<Pass> createAIEVecConvolutionAnalysisPass();
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "aie/Dialect/AIEVec/Analysis/Passes.h.inc"
+
+} // end namespace aievec
+} // end namespace xilinx
+
+#endif // AIE_DIALECT_AIEVEC_ANALYSIS_PASSES_H

--- a/include/aie/Dialect/AIEVec/Analysis/Passes.td
+++ b/include/aie/Dialect/AIEVec/Analysis/Passes.td
@@ -1,0 +1,28 @@
+//=== Passes.td - AIE vector analysis pass definition file -*- tablegen -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+// This file contains definitions for passes within the AIEVec/ directory.
+//===----------------------------------------------------------------------===//
+
+#ifndef AIE_DIALECT_AIEVEC_ANALYSIS_PASSES
+#define AIE_DIALECT_AIEVEC_ANALYSIS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def AIEVecConvAnalysis : Pass<"aievec-convolution-analysis", "mlir::func::FuncOp"> {
+  let summary = "Find MAC chains that can be replaced by convolution ops in "
+                "AIE-ML";
+  let constructor = "xilinx::aievec::createAIEVecConvolutionAnalysisPass()";
+  let options = [
+    Option<"printResult", "print", "bool", /*default=*/"false",
+      "Print the result of the analysis">,
+  ];
+}
+
+#endif // AIE_DIALECT_AIEVEC_ANALYSIS_PASSES

--- a/lib/Dialect/AIEVec/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEVec/Transforms/CMakeLists.txt
@@ -16,9 +16,11 @@ add_mlir_dialect_library(MLIRAIEVecTransforms
 
   ADDITIONAL_HEADER_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/aie/Dialect/AIEVec/Transforms
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../include/aie/Dialect/AIEVec/Analysis
 
   DEPENDS
   MLIRAIEVecPassIncGen
+  MLIRAIEVecAnalysisPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Dialect/AIEVec/Transforms/ConvertVectorToAIEVec.cpp
+++ b/lib/Dialect/AIEVec/Transforms/ConvertVectorToAIEVec.cpp
@@ -45,6 +45,10 @@ using namespace xilinx::aievec;
 
 #define DEBUG_TYPE "vector-to-aievec-conversion"
 
+//===----------------------------------------------------------------------===//
+// Rewrite patterns
+//===----------------------------------------------------------------------===//
+
 template <typename OpTy>
 struct SetInboundsToReadStoreOpPattern : public RewritePattern {
   SetInboundsToReadStoreOpPattern(MLIRContext *context)
@@ -72,6 +76,10 @@ struct SetInboundsToReadStoreOpPattern : public RewritePattern {
 
 using SetInboundsToReadOp = SetInboundsToReadStoreOpPattern<TransferReadOp>;
 using SetInboundsToWriteOp = SetInboundsToReadStoreOpPattern<TransferWriteOp>;
+
+//===----------------------------------------------------------------------===//
+// Lowering passes
+//===----------------------------------------------------------------------===//
 
 struct RedundantLoadStoreOptimizationPass
     : public PassWrapper<RedundantLoadStoreOptimizationPass,
@@ -111,7 +119,6 @@ void xilinx::aievec::buildConvertVectorToAIEVec(
   // NOTE: This sub-pipeline ingests arbitrary MLIR Vector code.
   buildCanonicalizeVectorForAIEVec(
       pm, options.getCanonicalizeVectorForAIEVecOptions());
-
   // NOTE: At this stage, all the Vector code in the IR can be mapped
   // HOTE: to AIEVec operations.
 
@@ -122,7 +129,6 @@ void xilinx::aievec::buildConvertVectorToAIEVec(
   // NOTE: This sub-pipeline ingests MLIR Vector code that can be mapped to
   // NOTE: AIEVec operations.
   buildLowerVectorToAIEVec(pm, options.getLowerVectorToAIEVecOptions());
-
   // NOTE: At this stage, all vector operations are expressed in AIEVec dialect.
 
   //============================================================================

--- a/test/Conversion/VectorToAIEVec/test-conv-op-i16.mlir
+++ b/test/Conversion/VectorToAIEVec/test-conv-op-i16.mlir
@@ -2,37 +2,40 @@
 
 func.func @conv2d(%arg0: memref<18x288xi16>, %arg1: memref<9xi16>, %arg2: memref<16x256xi16>) {
   %c0 = arith.constant 0 : index
+  %c2_i32 = arith.constant 2 : i32
+  %c4_i32 = arith.constant 4 : i32
   affine.for %arg3 = 0 to 16 {
     affine.for %arg4 = 0 to 256 step 16 {
-      %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<16xi16>
+      %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<32xi16>
+      %sbh = aievec.ext %0 {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+      %sth = aievec.ext %0 {index = 1 : i8} : vector<32xi16>, vector<16xi16>
       %1 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : si32} : memref<9xi16>, vector<16xi16>
       %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<16xi16>, vector<16xi16>
-      %3 = arith.muli %0, %2 : vector<16xi16>
-      %4 = affine.apply affine_map<(d0) -> (d0 + 1)>(%arg4)
-      %5 = aievec.upd %arg0[%arg3, %4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<16xi16>
-      %6 = aievec.broadcast %1 {idx = 1 : i8} : vector<16xi16>, vector<16xi16>
-      %7 = arith.muli %5, %6 : vector<16xi16>
-      %8 = arith.addi %3, %7 : vector<16xi16>
-      %9 = affine.apply affine_map<(d0) -> (d0 + 2)>(%arg4)
-      %10 = aievec.upd %arg0[%arg3, %9] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<16xi16>
-      %11 = aievec.broadcast %1 {idx = 2 : i8} : vector<16xi16>, vector<16xi16>
-      %12 = arith.muli %10, %11 : vector<16xi16>
-      %13 = arith.addi %8, %12 : vector<16xi16>
-      vector.transfer_write %13, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<16x256xi16>
+      %3 = arith.muli %sbh, %2 : vector<16xi16>
+      %4 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+      %5 = aievec.broadcast %1 {idx = 1 : i8} : vector<16xi16>, vector<16xi16>
+      %6 = arith.muli %4, %5 : vector<16xi16>
+      %7 = arith.addi %3, %6 : vector<16xi16>
+      %8 = aievec.shift %sbh, %sth, %c4_i32 {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+      %9 = aievec.broadcast %1 {idx = 2 : i8} : vector<16xi16>, vector<16xi16>
+      %10 = arith.muli %8, %9 : vector<16xi16>
+      %11 = arith.addi %7, %10 : vector<16xi16>
+      vector.transfer_write %11, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<16x256xi16>
     }
   }
   return
 }
 
-// CHECK-LABEL:  func @conv2d
-// CHECK-SAME: %[[A0:[A-Za-z0-9]+]]: memref<18x288xi16>
-// CHECK-SAME: %[[A1:[A-Za-z0-9]+]]: memref<9xi16>
-// CHECK-SAME: %[[A2:[A-Za-z0-9]+]]: memref<16x256xi16>
-//      CHECK:    %[[C0:.*]] = arith.constant 0 : index
-//      CHECK:    %[[T0:.*]] = aievec.upd %[[A1:.*]][%[[C0:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<9xi16>, vector<32xi16>
-//      CHECK:    affine.for %[[A3:.*]] = 0 to 16 {
-//      CHECK:      affine.for %[[A4:.*]] = 0 to 256 step 16 {
-//      CHECK:        %[[T1:.*]] = aievec.upd %[[A0:.*]][%[[A3:.*]], %[[A4:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<32xi16>
-//      CHECK:        %[[T2:.*]] = aievec.mul_conv %[[T1:.*]], %[[T0:.*]] {M = 16 : i32, N = 4 : i32} : vector<32xi16>, vector<32xi16>, vector<16xi64>
-//      CHECK:        %[[T3:.*]] = aievec.srs %[[T2:.*]] {shift = 10 : i8} : vector<16xi64>, vector<16xi16>
-//      CHECK:        vector.transfer_write %[[T3:.*]], %[[A2:.*]][%[[A3:.*]], %[[A4:.*]]] {in_bounds = [true]} : vector<16xi16>, memref<16x256xi16>
+// CHECK-LABEL: func @conv2d
+//  CHECK-SAME: %[[A0:[A-Za-z0-9]+]]: memref<18x288xi16>
+//  CHECK-SAME: %[[A1:[A-Za-z0-9]+]]: memref<9xi16>
+//  CHECK-SAME: %[[A2:[A-Za-z0-9]+]]: memref<16x256xi16>
+//       CHECK:    %[[C0:.*]] = arith.constant 0 : index
+//       CHECK:    %[[T0:.*]] = aievec.upd %[[A1]][%[[C0]]] {index = 0 : i8, offset = 0 : si32} : memref<9xi16>, vector<16xi16>
+//       CHECK:    %[[T1:.*]] = aievec.concat %[[T0]], %[[T0]] : vector<16xi16>, vector<32xi16>
+//       CHECK:    affine.for %[[A3:.*]] = 0 to 16 {
+//       CHECK:      affine.for %[[A4:.*]] = 0 to 256 step 16 {
+//       CHECK:        %[[T2:.*]] = aievec.upd %[[A0]][%[[A3]], %[[A4]]] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi16>, vector<32xi16>
+//       CHECK:        %[[T3:.*]] = aievec.mul_conv %[[T2]], %[[T1]] {M = 16 : i32, N = 4 : i32} : vector<32xi16>, vector<32xi16>, vector<16xi64>
+//       CHECK:        %[[T4:.*]] = aievec.srs %[[T3]] {shift = 10 : i8} : vector<16xi64>, vector<16xi16>
+//       CHECK:        vector.transfer_write %[[T4]], %[[A2]][%[[A3]], %[[A4]]] {in_bounds = [true]} : vector<16xi16>, memref<16x256xi16>

--- a/test/Conversion/VectorToAIEVec/test-conv-op-i8-init.mlir
+++ b/test/Conversion/VectorToAIEVec/test-conv-op-i8-init.mlir
@@ -2,21 +2,23 @@
 
 func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
   %c0 = arith.constant 0 : index
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
   affine.for %arg3 = 0 to 16 {
     affine.for %arg4 = 0 to 256 step 32 {
       %0 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<16x256xi8>, vector<32xi8>
-      %1 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
+      %1 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<64xi8>
+      %sbh = aievec.ext %1 {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+      %sth = aievec.ext %1 {index = 1 : i8} : vector<64xi8>, vector<32xi8>
       %2 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<32xi8>
       %3 = aievec.broadcast %2 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
-      %4 = arith.muli %1, %3 : vector<32xi8>
+      %4 = arith.muli %sbh, %3 : vector<32xi8>
       %5 = arith.addi %0, %4 : vector<32xi8>
-      %6 = affine.apply affine_map<(d0) -> (d0 + 1)>(%arg4)
-      %7 = aievec.upd %arg0[%arg3, %6] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
+      %7 = aievec.shift %sbh, %sth, %c1_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
       %8 = aievec.broadcast %2 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
       %9 = arith.muli %7, %8 : vector<32xi8>
       %10 = arith.addi %5, %9 : vector<32xi8>
-      %11 = affine.apply affine_map<(d0) -> (d0 + 2)>(%arg4)
-      %12 = aievec.upd %arg0[%arg3, %11] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
+      %12 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
       %13 = aievec.broadcast %2 {idx = 4 : i8} : vector<32xi8>, vector<32xi8>
       %14 = arith.muli %12, %13 : vector<32xi8>
       %15 = arith.addi %10, %14 : vector<32xi8>
@@ -26,18 +28,19 @@ func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<
   return
 }
 
-// CHECK-LABEL:  func @conv2d
-// CHECK-SAME: %[[A0:[A-Za-z0-9]+]]: memref<18x288xi8>
-// CHECK-SAME: %[[A1:[A-Za-z0-9]+]]: memref<48xi8>
-// CHECK-SAME: %[[A2:[A-Za-z0-9]+]]: memref<16x256xi8>
-//      CHECK:    %[[C0:.*]] = arith.constant 0 : index
-//      CHECK:    %[[T0:.*]] = aievec.upd %[[A1:.*]][%[[C0:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<64xi8>
-//      CHECK:    %[[T1:.*]] = aievec.shuffle %[[T0:.*]] {mode = 0 : i32} : vector<64xi8>, vector<64xi8>
-//      CHECK:    affine.for %[[A3:.*]] = 0 to 16 {
-//      CHECK:      affine.for %[[A4:.*]] = 0 to 256 step 32 {
-//      CHECK:        %[[T2:.*]] = aievec.upd %[[A2]][%[[A3]], %[[A4]]] {index = 0 : i8, offset = 0 : si32} : memref<16x256xi8>, vector<32xi8>
-//      CHECK:        %[[T3:.*]] = aievec.upd %[[A0]][%[[A3]], %[[A4]]] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<64xi8>
-//      CHECK:        %[[T4:.*]] = aievec.ups %[[T2]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
-//      CHECK:        %[[T5:.*]] = aievec.fma_conv %[[T3]], %[[T1]], %[[T4]] {M = 32 : i32, N = 8 : i32} : vector<64xi8>, vector<64xi8>, vector<32xi32>
-//      CHECK:        %[[T6:.*]] = aievec.srs %[[T5]] {shift = 0 : i8} : vector<32xi32>, vector<32xi8>
-//      CHECK:        vector.transfer_write %[[T6]], %[[A2]][%[[A3]], %[[A4]]] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
+// CHECK-LABEL: func @conv2d
+//  CHECK-SAME: %[[A0:[A-Za-z0-9]+]]: memref<18x288xi8>
+//  CHECK-SAME: %[[A1:[A-Za-z0-9]+]]: memref<48xi8>
+//  CHECK-SAME: %[[A2:[A-Za-z0-9]+]]: memref<16x256xi8>
+//       CHECK:    %[[C0:.*]] = arith.constant 0 : index
+//       CHECK:    %[[T0:.*]] = aievec.upd %[[A1]][%[[C0]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<32xi8>
+//       CHECK:    %[[T1:.*]] = aievec.concat %[[T0]], %[[T0]] : vector<32xi8>, vector<64xi8>
+//       CHECK:    %[[T2:.*]] = aievec.shuffle %[[T1]] {mode = 0 : i32} : vector<64xi8>, vector<64xi8>
+//       CHECK:    affine.for %[[I:.*]] = 0 to 16 {
+//       CHECK:      affine.for %[[J:.*]] = 0 to 256 step 32 {
+//       CHECK:        %[[T3:.*]] = aievec.upd %[[A2]][%[[I]], %[[J]]] {index = 0 : i8, offset = 0 : si32} : memref<16x256xi8>, vector<32xi8>
+//       CHECK:        %[[T4:.*]] = aievec.upd %[[A0]][%[[I]], %[[J]]] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<64xi8>
+//       CHECK:        %[[T5:.*]] = aievec.ups %[[T3]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
+//       CHECK:        %[[T6:.*]] = aievec.fma_conv %[[T4]], %[[T2]], %[[T5]] {M = 32 : i32, N = 8 : i32} : vector<64xi8>, vector<64xi8>, vector<32xi32>
+//       CHECK:        %[[T7:.*]] = aievec.srs %[[T6]] {shift = 0 : i8} : vector<32xi32>, vector<32xi8>
+//       CHECK:        vector.transfer_write %[[T7]], %[[A2]][%[[I]], %[[J]]] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>

--- a/test/Conversion/VectorToAIEVec/test-conv-op-i8.mlir
+++ b/test/Conversion/VectorToAIEVec/test-conv-op-i8.mlir
@@ -2,38 +2,41 @@
 
 func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
   %c0 = arith.constant 0 : index
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
   affine.for %arg3 = 0 to 16 {
     affine.for %arg4 = 0 to 256 step 32 {
-      %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
+      %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<64xi8>
+      %sbh = aievec.ext %0 {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+      %sth = aievec.ext %0 {index = 1 : i8} : vector<64xi8>, vector<32xi8>
       %1 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<32xi8>
       %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
-      %3 = arith.muli %0, %2 : vector<32xi8>
-      %4 = affine.apply affine_map<(d0) -> (d0 + 1)>(%arg4)
-      %5 = aievec.upd %arg0[%arg3, %4] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-      %6 = aievec.broadcast %1 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
-      %7 = arith.muli %5, %6 : vector<32xi8>
-      %8 = arith.addi %3, %7 : vector<32xi8>
-      %9 = affine.apply affine_map<(d0) -> (d0 + 2)>(%arg4)
-      %10 = aievec.upd %arg0[%arg3, %9] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<32xi8>
-      %11 = aievec.broadcast %1 {idx = 4 : i8} : vector<32xi8>, vector<32xi8>
-      %12 = arith.muli %10, %11 : vector<32xi8>
-      %13 = arith.addi %8, %12 : vector<32xi8>
-      vector.transfer_write %13, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
+      %3 = arith.muli %sbh, %2 : vector<32xi8>
+      %4 = aievec.shift %sbh, %sth, %c1_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+      %5 = aievec.broadcast %1 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
+      %6 = arith.muli %4, %5 : vector<32xi8>
+      %7 = arith.addi %3, %6 : vector<32xi8>
+      %8 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+      %9 = aievec.broadcast %1 {idx = 4 : i8} : vector<32xi8>, vector<32xi8>
+      %10 = arith.muli %8, %9 : vector<32xi8>
+      %11 = arith.addi %7, %10 : vector<32xi8>
+      vector.transfer_write %11, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
     }
   }
   return
 }
 
-// CHECK-LABEL:  func @conv2d
-// CHECK-SAME: %[[A0:[A-Za-z0-9]+]]: memref<18x288xi8>
-// CHECK-SAME: %[[A1:[A-Za-z0-9]+]]: memref<48xi8>
-// CHECK-SAME: %[[A2:[A-Za-z0-9]+]]: memref<16x256xi8>
-//      CHECK:    %[[C0:.*]] = arith.constant 0 : index
-//      CHECK:    %[[T0:.*]] = aievec.upd %[[A1:.*]][%[[C0:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<64xi8>
-//      CHECK:    %[[T1:.*]] = aievec.shuffle %[[T0:.*]] {mode = 0 : i32} : vector<64xi8>, vector<64xi8>
-//      CHECK:    affine.for %[[A3:.*]] = 0 to 16 {
-//      CHECK:      affine.for %[[A4:.*]] = 0 to 256 step 32 {
-//      CHECK:        %[[T2:.*]] = aievec.upd %[[A0:.*]][%[[A3:.*]], %[[A4:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<64xi8>
-//      CHECK:        %[[T3:.*]] = aievec.mul_conv %[[T2:.*]], %[[T1:.*]] {M = 32 : i32, N = 8 : i32} : vector<64xi8>, vector<64xi8>, vector<32xi32>
-//      CHECK:        %[[T4:.*]] = aievec.srs %[[T3:.*]] {shift = 0 : i8} : vector<32xi32>, vector<32xi8>
-//      CHECK:        vector.transfer_write %[[T4:.*]], %[[A2:.*]][%[[A3:.*]], %[[A4:.*]]] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
+// CHECK-LABEL: func @conv2d
+//  CHECK-SAME: %[[A0:[A-Za-z0-9]+]]: memref<18x288xi8>
+//  CHECK-SAME: %[[A1:[A-Za-z0-9]+]]: memref<48xi8>
+//  CHECK-SAME: %[[A2:[A-Za-z0-9]+]]: memref<16x256xi8>
+//       CHECK:    %[[C0:.*]] = arith.constant 0 : index
+//       CHECK:    %[[T0:.*]] = aievec.upd %[[A1]][%[[C0]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<32xi8>
+//       CHECK:    %[[T1:.*]] = aievec.concat %[[T0]], %[[T0]] : vector<32xi8>, vector<64xi8>
+//       CHECK:    %[[T2:.*]] = aievec.shuffle %[[T1]] {mode = 0 : i32} : vector<64xi8>, vector<64xi8>
+//       CHECK:    affine.for %[[I:.*]] = 0 to 16 {
+//       CHECK:      affine.for %[[J:.*]] = 0 to 256 step 32 {
+//       CHECK:        %[[T3:.*]] = aievec.upd %[[A0]][%[[I]], %[[J]]] {index = 0 : i8, offset = 0 : si32} : memref<18x288xi8>, vector<64xi8>
+//       CHECK:        %[[T4:.*]] = aievec.mul_conv %[[T3]], %[[T2]] {M = 32 : i32, N = 8 : i32} : vector<64xi8>, vector<64xi8>, vector<32xi32>
+//       CHECK:        %[[T5:.*]] = aievec.srs %[[T4]] {shift = 0 : i8} : vector<32xi32>, vector<32xi8>
+//       CHECK:        vector.transfer_write %[[T5]], %[[A2]][%[[I]], %[[J]]] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>

--- a/test/Conversion/VectorToAIEVec/test-upd.mlir
+++ b/test/Conversion/VectorToAIEVec/test-upd.mlir
@@ -1,49 +1,66 @@
-// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" | FileCheck %s --check-prefix=CHECK-V2
+// RUN: aie-opt %s --convert-vector-to-aievec -split-input-file | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -split-input-file | FileCheck %s --check-prefix=CHECK-V2
 
+// CHECK-V2-LABEL: func @veccopy_i8
 func.func @veccopy_i8(%arg0: memref<256xi8>, %arg1: memref<256xi8>) {
   %c0_i8 = arith.constant 0 : i8
   affine.for %arg2 = 0 to 256 step 16 {
-    // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi8>, vector<16xi8>
+    // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi8>, vector<16xi8>
     %0 = vector.transfer_read %arg0[%arg2], %c0_i8 : memref<256xi8>, vector<16xi8>
-    // CHECK: vector.transfer_write %[[LD]], {{.*}}
+    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}}
     vector.transfer_write %0, %arg1[%arg2] : vector<16xi8>, memref<256xi8>
   }
   return
 }
 
+// -----
+
+// CHECK-LABEL: func @veccopy_i16
+// CHECK-V2-LABEL: func @veccopy_i16
 func.func @veccopy_i16(%arg0: memref<256xi16>, %arg1: memref<256xi16>) {
   %c0_i16 = arith.constant 0 : i16
   affine.for %arg2 = 0 to 256 step 16 {
     // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi16>, vector<16xi16>
+    // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi16>, vector<16xi16>
     %0 = vector.transfer_read %arg0[%arg2], %c0_i16 : memref<256xi16>, vector<16xi16>
     // CHECK: vector.transfer_write %[[LD]], {{.*}}
+    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}}
     vector.transfer_write %0, %arg1[%arg2] : vector<16xi16>, memref<256xi16>
   }
   return
 }
 
+// -----
+
+// CHECK-LABEL: func @veccopy_i32
+// CHECK-V2-LABEL: func @veccopy_i32
 func.func @veccopy_i32(%arg0: memref<256xi32>, %arg1: memref<256xi32>) {
   %c0_i32 = arith.constant 0 : i32
-  affine.for %arg2 = 0 to 256 step 16 {
-    // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi32>, vector<16xi32>
-    %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<16xi32>
+  affine.for %arg2 = 0 to 256 step 8 {
+    // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi32>, vector<8xi32>
+    // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi32>, vector<8xi32>
+    %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<8xi32>
     // CHECK: vector.transfer_write %[[LD]], {{.*}}
-    vector.transfer_write %0, %arg1[%arg2] : vector<16xi32>, memref<256xi32>
+    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}}
+    vector.transfer_write %0, %arg1[%arg2] : vector<8xi32>, memref<256xi32>
   }
   return
 }
 
+// -----
+
+// CHECK-LABEL: func @veccopy_long_i32
+// CHECK-V2-LABEL: func @veccopy_long_i32
 func.func @veccopy_long_i32(%arg0: memref<256xi32>, %arg1: memref<256xi32>) {
   %c0_i32 = arith.constant 0 : i32
-  affine.for %arg2 = 0 to 256 step 32 {
-    // CHECK: %[[LD0:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi32>, vector<32xi32>
-    // CHECK-NEXT: %[[LD1:.*]] = aievec.upd {{.*}}, %[[LD0]] {index = 1 : i8, offset = 512 : si32} : memref<256xi32>, vector<32xi32>
+  affine.for %arg2 = 0 to 256 step 16 {
+    // CHECK: %[[LD0:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi32>, vector<16xi32>
+    // CHECK-NEXT: %[[LD1:.*]] = aievec.upd {{.*}}, %[[LD0]] {index = 1 : i8, offset = 256 : si32} : memref<256xi32>, vector<16xi32>
     // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : si32} : memref<256xi32>, vector<16xi32>
-    %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<32xi32>
+    %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<16xi32>
     // CHECK: vector.transfer_write %[[LD1]], {{.*}}
     // CHECK-V2: vector.transfer_write %[[LD]], {{.*}}
-    vector.transfer_write %0, %arg1[%arg2] : vector<32xi32>, memref<256xi32>
+    vector.transfer_write %0, %arg1[%arg2] : vector<16xi32>, memref<256xi32>
   }
   return
 }

--- a/test/Conversion/VectorToAIEVec/unaligned-load-aieml.mlir
+++ b/test/Conversion/VectorToAIEVec/unaligned-load-aieml.mlir
@@ -1,0 +1,25 @@
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -split-input-file | FileCheck %s --check-prefix=CHECK
+func.func @unaligned_read(%a: memref<48xi8>) -> (vector<32xi8>, vector<32xi8>) {
+   %c0_i8 = arith.constant 0 : i8
+   %c16 = arith.constant 16 : index
+   %c34 = arith.constant 34 : index
+   %0 = vector.transfer_read %a[%c16], %c0_i8 : memref<48xi8>, vector<32xi8>
+   %1 = vector.transfer_read %a[%c34], %c0_i8 : memref<48xi8>, vector<32xi8>
+   return %0, %1 : vector<32xi8>, vector<32xi8>
+}
+
+// CHECK-LABEL: func @unaligned_read
+//       CHECK:    %[[C2i32:.*]] = arith.constant 2 : i32
+//       CHECK:    %[[C32:.*]] = arith.constant 32 : index
+//       CHECK:    %[[C16i32:.*]] = arith.constant 16 : i32
+//       CHECK:    %[[C0:.*]] = arith.constant 0 : index
+//       CHECK:    %[[T0:.*]] = aievec.upd {{.*}}[%[[C0:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<64xi8>
+//       CHECK:    %[[T0E0:.*]] = aievec.ext %[[T0]] {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+//       CHECK:    %[[T0E1:.*]] = aievec.ext %[[T0]] {index = 1 : i8} : vector<64xi8>, vector<32xi8>
+//       CHECK:    %[[R0:.*]] = aievec.shift %[[T0E0]], %[[T0E1]], %[[C16i32]] {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+//       CHECK:    %[[T1:.*]] = aievec.upd {{.*}}[%[[C32:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<64xi8>
+//       CHECK:    %[[T1E0:.*]] = aievec.ext %[[T1]] {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+//       CHECK:    %[[T1E1:.*]] = aievec.ext %[[T1]] {index = 1 : i8} : vector<64xi8>, vector<32xi8>
+//       CHECK:    %[[R1:.*]] = aievec.shift %[[T1E0]], %[[T1E1]], %[[C2i32]] {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+//       CHECK:    return %[[R0:.*]], %[[R1:.*]] : vector<32xi8>, vector<32xi8>
+

--- a/test/Conversion/VectorToAIEVec/unaligned-load.mlir
+++ b/test/Conversion/VectorToAIEVec/unaligned-load.mlir
@@ -1,20 +1,70 @@
-// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
-func.func @unaligned_read(%a: memref<48xi8>) -> (vector<32xi8>, vector<32xi8>) {
-   %c0_i8 = arith.constant 0 : i8
-   %c16 = arith.constant 16 : index
-   %c34 = arith.constant 34 : index
-   %0 = vector.transfer_read %a[%c16], %c0_i8 : memref<48xi8>, vector<32xi8>
-   %1 = vector.transfer_read %a[%c34], %c0_i8 : memref<48xi8>, vector<32xi8>
-   return %0, %1 : vector<32xi8>, vector<32xi8>
-}
+// RUN: aie-opt %s --convert-vector-to-aievec -split-input-file | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aieml" -split-input-file | FileCheck %s --check-prefix=CHECK-V2
 
 // CHECK-LABEL: func @unaligned_read
-// CHECK      :    %[[C64:.*]] = arith.constant 64 : index
-// CHECK      :    %[[C32:.*]] = arith.constant 32 : index
-// CHECK      :    %[[C0:.*]] = arith.constant 0 : index
-// CHECK      :    %[[T0:.*]] = aievec.upd {{.*}}[%[[C0:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<32xi8>
-// CHECK      :    %[[T1:.*]] = aievec.upd {{.*}}[%[[C32:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<32xi8>
-// CHECK      :    %[[T2:.*]] = aievec.shift %[[T0:.*]], %[[T1:.*]] {shift = 16 : i32} : vector<32xi8>, vector<32xi8>
-// CHECK      :    %[[T3:.*]] = aievec.upd {{.*}}[%[[C64:.*]]] {index = 0 : i8, offset = 0 : si32} : memref<48xi8>, vector<32xi8>
-// CHECK      :    %[[T4:.*]] = aievec.shift %[[T1:.*]], %[[T3:.*]] {shift = 2 : i32} : vector<32xi8>, vector<32xi8>
-// CHECK      :    return %[[T2:.*]], %[[T4:.*]] : vector<32xi8>, vector<32xi8>
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[V0B:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : si32} : memref<64xi32>, vector<16xi32>
+// CHECK: %[[V0T:.*]] = aievec.upd %{{.*}}[%[[C0]]], %[[V0B]] {index = 1 : i8, offset = 256 : si32} : memref<64xi32>, vector<16xi32>
+// CHECK: %[[V0ROT:.*]] = aievec.select %[[V0T]] {select = "0", xoffsets = "0x76543210", xsquare = "0x3210", xstart = "3",
+// CHECK-SAME:                                                  yoffsets = "0", ysquare = "0", ystart = "0"}
+// CHECK-SAME:                                   : vector<16xi32>, vector<16xi32>
+// CHECK: %[[V0:.*]] = aievec.ext %[[V0ROT]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
+// CHECK: %[[V1ROT:.*]] = aievec.select %[[V0T]] {select = "0", xoffsets = "0x76543210", xsquare = "0x3210", xstart = "6",
+// CHECK-SAME:                                                  yoffsets = "0", ysquare = "0", ystart = "0"}
+// CHECK-SAME:                                   : vector<16xi32>, vector<16xi32>
+// CHECK: %[[V1:.*]] = aievec.ext %[[V1ROT]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
+// CHECK: return %[[V0]], %[[V1]] : vector<8xi32>, vector<8xi32>
+
+// CHECK-V2-LABEL: func @unaligned_read
+// CHECK-V2: %[[C24i32:.*]] = arith.constant 24 : i32
+// CHECK-V2: %[[C12i32:.*]] = arith.constant 12 : i32
+// CHECK-V2: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-V2: %[[LV:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : si32} : memref<64xi32>, vector<16xi32>
+// CHECK-V2: %[[LV0:.*]] = aievec.ext %[[LV]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
+// CHECK-V2: %[[LV1:.*]] = aievec.ext %[[LV]] {index = 1 : i8} : vector<16xi32>, vector<8xi32>
+// CHECK-V2: %[[R0:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C12i32]] {isAcc = false} : vector<8xi32>, vector<8xi32>, i32, vector<8xi32>
+// CHECK-V2: %[[R1:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C24i32]] {isAcc = false} : vector<8xi32>, vector<8xi32>, i32, vector<8xi32>
+// CHECK-V2: return %[[R0]], %[[R1]] : vector<8xi32>, vector<8xi32>
+func.func @unaligned_read(%m: memref<64xi32>) -> (vector<8xi32>, vector<8xi32>) {
+   %c0_i32 = arith.constant 0 : i32
+   %c3 = arith.constant 3 : index
+   %c6 = arith.constant 6 : index
+   %0 = vector.transfer_read %m[%c3], %c0_i32 : memref<64xi32>, vector<8xi32>
+   %1 = vector.transfer_read %m[%c6], %c0_i32 : memref<64xi32>, vector<8xi32>
+   return %0, %1 : vector<8xi32>, vector<8xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @unaligned_read
+// CHECK: %[[C0:.*]] = arith.constant 0 : index
+// CHECK: %[[V0B:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : si32} : memref<64xi16>, vector<32xi16>
+// CHECK: %[[V0T:.*]] = aievec.upd %{{.*}}[%[[C0]]], %[[V0B]] {index = 1 : i8, offset = 256 : si32} : memref<64xi16>, vector<32xi16>
+// CHECK: %[[V0ROT:.*]] = aievec.select %[[V0T]] {select = "0x11111111", xoffsets = "0x06040200", xoffsets_hi = "0x0e0c0a08", xsquare = "0x2103", xstart = "4",
+// CHECK-SAME:                                                           yoffsets = "0x0503010f", yoffsets_hi = "0x0d0b0907", ysquare = "0x2103", ystart = "2"}
+// CHECK-SAME:                                   : vector<32xi16>, vector<32xi16>
+// CHECK: %[[V0:.*]] = aievec.ext %[[V0ROT]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+// CHECK: %[[V1ROT:.*]] = aievec.select %[[V0T]] {select = "0", xoffsets = "0x06040200", xoffsets_hi = "0x0e0c0a08", xsquare = "0x3210", xstart = "6",
+// CHECK-SAME:                                                  yoffsets = "0", yoffsets_hi = "0", ysquare = "0", ystart = "0"}
+// CHECK-SAME:                                   : vector<32xi16>, vector<32xi16>
+// CHECK: %[[V1:.*]] = aievec.ext %[[V1ROT]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+// CHECK: return %[[V0]], %[[V1]] : vector<16xi16>, vector<16xi16>
+
+// CHECK-V2-LABEL: func @unaligned_read
+// CHECK-V2: %[[C12i32:.*]] = arith.constant 12 : i32
+// CHECK-V2: %[[C6i32:.*]] = arith.constant 6 : i32
+// CHECK-V2: %[[C0:.*]] = arith.constant 0 : index
+// CHECK-V2: %[[LV:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : si32} : memref<64xi16>, vector<32xi16>
+// CHECK-V2: %[[LV0:.*]] = aievec.ext %[[LV]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+// CHECK-V2: %[[LV1:.*]] = aievec.ext %[[LV]] {index = 1 : i8} : vector<32xi16>, vector<16xi16>
+// CHECK-V2: %[[R0:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C6i32]] {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+// CHECK-V2: %[[R1:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C12i32]] {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+// CHECK-V2: return %[[R0]], %[[R1]] : vector<16xi16>, vector<16xi16>
+func.func @unaligned_read(%m: memref<64xi16>) -> (vector<16xi16>, vector<16xi16>) {
+   %c0_i16 = arith.constant 0 : i16
+   %c3 = arith.constant 3 : index
+   %c6 = arith.constant 6 : index
+   %0 = vector.transfer_read %m[%c3], %c0_i16 : memref<64xi16>, vector<16xi16>
+   %1 = vector.transfer_read %m[%c6], %c0_i16 : memref<64xi16>, vector<16xi16>
+   return %0, %1 : vector<16xi16>, vector<16xi16>
+}

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/helplib.cc
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/helplib.cc
@@ -1,0 +1,48 @@
+#include "aie_api/aie.hpp"
+#include "aie_api/utils.hpp"
+#include <cstdint>
+#include <cstdio>
+
+template <typename T> const char *tid() { return "@"; }
+
+template <> const char *tid<int8_t>() { return "i"; }
+template <> const char *tid<int16_t>() { return "i"; }
+template <> const char *tid<int32_t>() { return "i"; }
+
+template <int nlanes, typename elemtype, typename vtype> void printv(vtype v) {
+  printf("vector<%dx%s%u>[ ", nlanes, tid<elemtype>(), 8 * sizeof(elemtype));
+  aie::print(aie::vector<elemtype, nlanes>(v));
+  printf("]\n");
+}
+
+void printv16xi32(v16int32 v) { printv<16, int32_t>(v); }
+
+void printv8xi32(v8int32 v) { printv<8, int32_t>(v); }
+
+void printv32xi16(v32int16 v) { printv<32, int16_t>(v); }
+
+void printv16xi16(v16int16 v) { printv<16, int16_t>(v); }
+
+void printv32xi8(v32int8 v) { printv<32, int8_t>(v); }
+
+alignas(32) int32_t buff_i32[64];
+alignas(32) int16_t buff_i16[64];
+alignas(32) int8_t buff_i8[64];
+
+int32_t *loadA64xi32() {
+  for (int i = 0; i < 64; ++i)
+    buff_i32[i] = i;
+  return buff_i32;
+}
+
+int16_t *loadA64xi16() {
+  for (int i = 0; i < 64; ++i)
+    buff_i16[i] = i;
+  return buff_i16;
+}
+
+int8_t *loadA64xi8() {
+  for (int i = 0; i < 64; ++i)
+    buff_i8[i] = i;
+  return buff_i8;
+}

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/kernel.mlir
@@ -1,0 +1,81 @@
+// REQUIRES: valid_xchess_license
+// RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml" | aie-translate -aieml=true -aievec-to-cpp -o kernel.tmp.cc
+// RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
+
+func.func private @printv32xi16(%v : vector<32xi16>)
+func.func private @loadA64xi16() -> memref<64xi16>
+
+#map6 = affine_map<(d0) -> (d0 + 6)>
+#map7 = affine_map<(d0) -> (d0 + 7)>
+#map8 = affine_map<(d0) -> (d0 + 8)>
+#map9 = affine_map<(d0) -> (d0 + 9)>
+#map10 = affine_map<(d0) -> (d0 + 10)>
+
+func.func @entry() -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %c0_i16 = arith.constant 0 : i16
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c6 = arith.constant 6 : index
+  %c7 = arith.constant 7 : index
+  %c8 = arith.constant 8 : index
+  %c9 = arith.constant 9 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  %c12 = arith.constant 12 : index
+  %c13 = arith.constant 13 : index
+  %c14 = arith.constant 14 : index
+  %c15 = arith.constant 15 : index
+
+  %buffi16 = func.call @loadA64xi16() : () -> (memref<64xi16>)
+  %v16 = vector.transfer_read %buffi16[%c0], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%v16) : (vector<32xi16>) -> ()
+
+  %1 = vector.transfer_read %buffi16[%c1], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%1) : (vector<32xi16>) -> ()
+  %2 = vector.transfer_read %buffi16[%c2], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%2) : (vector<32xi16>) -> ()
+  %3 = vector.transfer_read %buffi16[%c3], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%3) : (vector<32xi16>) -> ()
+  %4 = vector.transfer_read %buffi16[%c4], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%4) : (vector<32xi16>) -> ()
+  %5 = vector.transfer_read %buffi16[%c5], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%5) : (vector<32xi16>) -> ()
+
+  %i6 = affine.apply #map6(%c0)
+  %6 = vector.transfer_read %buffi16[%i6], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%6) : (vector<32xi16>) -> ()
+  %i7 = affine.apply #map7(%c0)
+  %7 = vector.transfer_read %buffi16[%i7], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%7) : (vector<32xi16>) -> ()
+  %i8 = affine.apply #map8(%c0)
+  %8 = vector.transfer_read %buffi16[%i8], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%8) : (vector<32xi16>) -> ()
+  %i9 = affine.apply #map9(%c0)
+  %9 = vector.transfer_read %buffi16[%i9], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%9) : (vector<32xi16>) -> ()
+  %i10 = affine.apply #map10(%c0)
+  %10 = vector.transfer_read %buffi16[%i10], %c0_i16 : memref<64xi16>, vector<32xi16>
+  func.call @printv32xi16(%10) : (vector<32xi16>) -> ()
+
+  return %c0_i32 : i32
+}
+
+// CHECK-LABEL: vector<32xi16>[ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 ]
+// CHECK-LABEL: vector<32xi16>[ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 ]
+// CHECK-LABEL: vector<32xi16>[ 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 ]
+// CHECK-LABEL: vector<32xi16>[ 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 ]
+// CHECK-LABEL: vector<32xi16>[ 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 ]
+// CHECK-LABEL: vector<32xi16>[ 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 ]
+// CHECK-LABEL: vector<32xi16>[ 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 ]
+// CHECK-LABEL: vector<32xi16>[ 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 ]
+// CHECK-LABEL: vector<32xi16>[ 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 ]
+// CHECK-LABEL: vector<32xi16>[ 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 ]
+// CHECK-LABEL: vector<32xi16>[ 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 ]
+// CHECK-LABEL: SUCCESS

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/main.cc
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/main.cc
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+int entry(void);
+
+int main(void) {
+  int r = entry();
+  if (r)
+    printf("ERROR: %d", r);
+  printf("SUCCESS");
+  return r;
+}

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/helplib.cc
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/helplib.cc
@@ -1,0 +1,48 @@
+#include "aie_api/aie.hpp"
+#include "aie_api/utils.hpp"
+#include <cstdint>
+#include <cstdio>
+
+template <typename T> const char *tid() { return "@"; }
+
+template <> const char *tid<int8_t>() { return "i"; }
+template <> const char *tid<int16_t>() { return "i"; }
+template <> const char *tid<int32_t>() { return "i"; }
+
+template <int nlanes, typename elemtype, typename vtype> void printv(vtype v) {
+  printf("vector<%dx%s%u>[ ", nlanes, tid<elemtype>(), 8 * sizeof(elemtype));
+  aie::print(aie::vector<elemtype, nlanes>(v));
+  printf("]\n");
+}
+
+void printv16xi32(v16int32 v) { printv<16, int32_t>(v); }
+
+void printv8xi32(v8int32 v) { printv<8, int32_t>(v); }
+
+void printv32xi16(v32int16 v) { printv<32, int16_t>(v); }
+
+void printv16xi16(v16int16 v) { printv<16, int16_t>(v); }
+
+void printv32xi8(v32int8 v) { printv<32, int8_t>(v); }
+
+alignas(32) int32_t buff_i32[64];
+alignas(32) int16_t buff_i16[64];
+alignas(32) int8_t buff_i8[64];
+
+int32_t *loadA64xi32() {
+  for (int i = 0; i < 64; ++i)
+    buff_i32[i] = i;
+  return buff_i32;
+}
+
+int16_t *loadA64xi16() {
+  for (int i = 0; i < 64; ++i)
+    buff_i16[i] = i;
+  return buff_i16;
+}
+
+int8_t *loadA64xi8() {
+  for (int i = 0; i < 64; ++i)
+    buff_i8[i] = i;
+  return buff_i8;
+}

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/kernel.mlir
@@ -1,0 +1,35 @@
+// REQUIRES: valid_xchess_license
+// RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml" | aie-translate -aieml=true -aievec-to-cpp -o kernel.tmp.cc
+// RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
+
+func.func private @printv16xi32(%v : vector<16xi32>)
+func.func private @loadA64xi32() -> memref<64xi32>
+
+#map6 = affine_map<(d0) -> (d0 + 6)>
+
+func.func @entry() -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %c5 = arith.constant 5 : index
+
+  %buffi32 = func.call @loadA64xi32() : () -> (memref<64xi32>)
+
+  %v0 = vector.transfer_read %buffi32[%c0], %c0_i32 : memref<64xi32>, vector<16xi32>
+  func.call @printv16xi32(%v0) : (vector<16xi32>) -> ()
+
+  %v5 = vector.transfer_read %buffi32[%c5], %c0_i32 : memref<64xi32>, vector<16xi32>
+  func.call @printv16xi32(%v5) : (vector<16xi32>) -> ()
+
+  %idx6 = affine.apply #map6(%c0)
+  %v6 = vector.transfer_read %buffi32[%idx6], %c0_i32 : memref<64xi32>, vector<16xi32>
+  func.call @printv16xi32(%v6) : (vector<16xi32>) -> ()
+
+  return %c0_i32 : i32
+}
+
+// CHECK-LABEL: vector<16xi32>[ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 ]
+// CHECK-LABEL: vector<16xi32>[ 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 ]
+// CHECK-LABEL: vector<16xi32>[ 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 ]
+// CHECK-LABEL: SUCCESS

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/main.cc
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/main.cc
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+int entry(void);
+
+int main(void) {
+  int r = entry();
+  if (r)
+    printf("ERROR: %d", r);
+  printf("SUCCESS");
+  return r;
+}

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/helplib.cc
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/helplib.cc
@@ -1,0 +1,50 @@
+#include "aie_api/aie.hpp"
+#include "aie_api/utils.hpp"
+#include <cstdint>
+#include <cstdio>
+
+template <typename T> const char *tid() { return "@"; }
+
+template <> const char *tid<int8_t>() { return "i"; }
+template <> const char *tid<int16_t>() { return "i"; }
+template <> const char *tid<int32_t>() { return "i"; }
+
+template <int nlanes, typename elemtype, typename vtype> void printv(vtype v) {
+  printf("vector<%dx%s%u>[ ", nlanes, tid<elemtype>(), 8 * sizeof(elemtype));
+  aie::print(aie::vector<elemtype, nlanes>(v));
+  printf("]\n");
+}
+
+void printv16xi32(v16int32 v) { printv<16, int32_t>(v); }
+
+void printv8xi32(v8int32 v) { printv<8, int32_t>(v); }
+
+void printv32xi16(v32int16 v) { printv<32, int16_t>(v); }
+
+void printv16xi16(v16int16 v) { printv<16, int16_t>(v); }
+
+void printv32xi8(v32int8 v) { printv<32, int8_t>(v); }
+
+void printv64xi8(v64int8 v) { printv<64, int8_t>(v); }
+
+alignas(32) int32_t buff_i32[64];
+alignas(32) int16_t buff_i16[64];
+alignas(32) int8_t buff_i8[128];
+
+int32_t *loadA64xi32() {
+  for (int i = 0; i < 64; ++i)
+    buff_i32[i] = i;
+  return buff_i32;
+}
+
+int16_t *loadA64xi16() {
+  for (int i = 0; i < 64; ++i)
+    buff_i16[i] = i;
+  return buff_i16;
+}
+
+int8_t *loadA128xi8() {
+  for (int i = 0; i < 128; ++i)
+    buff_i8[i] = i;
+  return buff_i8;
+}

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/kernel.mlir
@@ -1,0 +1,81 @@
+// REQUIRES: valid_xchess_license
+// RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml" | aie-translate -aieml=true -aievec-to-cpp -o kernel.tmp.cc
+// RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
+
+func.func private @printv64xi8(%v : vector<64xi8>)
+func.func private @loadA128xi8() -> memref<128xi8>
+
+#map6 = affine_map<(d0) -> (d0 + 6)>
+#map7 = affine_map<(d0) -> (d0 + 7)>
+#map8 = affine_map<(d0) -> (d0 + 8)>
+#map9 = affine_map<(d0) -> (d0 + 9)>
+#map10 = affine_map<(d0) -> (d0 + 10)>
+
+func.func @entry() -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %c0_i8 = arith.constant 0 : i8
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c6 = arith.constant 6 : index
+  %c7 = arith.constant 7 : index
+  %c8 = arith.constant 8 : index
+  %c9 = arith.constant 9 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  %c12 = arith.constant 12 : index
+  %c13 = arith.constant 13 : index
+  %c14 = arith.constant 14 : index
+  %c15 = arith.constant 15 : index
+
+  %buffi8 = func.call @loadA128xi8() : () -> (memref<128xi8>)
+  %v16 = vector.transfer_read %buffi8[%c0], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%v16) : (vector<64xi8>) -> ()
+
+  %1 = vector.transfer_read %buffi8[%c1], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%1) : (vector<64xi8>) -> ()
+  %2 = vector.transfer_read %buffi8[%c2], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%2) : (vector<64xi8>) -> ()
+  %3 = vector.transfer_read %buffi8[%c3], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%3) : (vector<64xi8>) -> ()
+  %4 = vector.transfer_read %buffi8[%c4], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%4) : (vector<64xi8>) -> ()
+  %5 = vector.transfer_read %buffi8[%c5], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%5) : (vector<64xi8>) -> ()
+
+  %i6 = affine.apply #map6(%c0)
+  %6 = vector.transfer_read %buffi8[%i6], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%6) : (vector<64xi8>) -> ()
+  %i7 = affine.apply #map7(%c0)
+  %7 = vector.transfer_read %buffi8[%i7], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%7) : (vector<64xi8>) -> ()
+  %i8 = affine.apply #map8(%c0)
+  %8 = vector.transfer_read %buffi8[%i8], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%8) : (vector<64xi8>) -> ()
+  %i9 = affine.apply #map9(%c0)
+  %9 = vector.transfer_read %buffi8[%i9], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%9) : (vector<64xi8>) -> ()
+  %i10 = affine.apply #map10(%c0)
+  %10 = vector.transfer_read %buffi8[%i10], %c0_i8 : memref<128xi8>, vector<64xi8>
+  func.call @printv64xi8(%10) : (vector<64xi8>) -> ()
+
+  return %c0_i32 : i32
+}
+
+// CHECK-LABEL: vector<64xi8>[ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 ]
+// CHECK-LABEL: vector<64xi8>[ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 ]
+// CHECK-LABEL: vector<64xi8>[ 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 ]
+// CHECK-LABEL: vector<64xi8>[ 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 ]
+// CHECK-LABEL: vector<64xi8>[ 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 ]
+// CHECK-LABEL: vector<64xi8>[ 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 ]
+// CHECK-LABEL: vector<64xi8>[ 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 ]
+// CHECK-LABEL: vector<64xi8>[ 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 ]
+// CHECK-LABEL: vector<64xi8>[ 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 ]
+// CHECK-LABEL: vector<64xi8>[ 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 ]
+// CHECK-LABEL: vector<64xi8>[ 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 ]
+// CHECK-LABEL: SUCCESS

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/main.cc
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/main.cc
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+int entry(void);
+
+int main(void) {
+  int r = entry();
+  if (r)
+    printf("ERROR: %d", r);
+  printf("SUCCESS");
+  return r;
+}

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/helplib.cc
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/helplib.cc
@@ -1,0 +1,48 @@
+#include "aie_api/aie.hpp"
+#include "aie_api/utils.hpp"
+#include <cstdint>
+#include <cstdio>
+
+template <typename T> const char *tid() { return "@"; }
+
+template <> const char *tid<int8_t>() { return "i"; }
+template <> const char *tid<int16_t>() { return "i"; }
+template <> const char *tid<int32_t>() { return "i"; }
+
+template <int nlanes, typename elemtype, typename vtype> void printv(vtype v) {
+  printf("vector<%dx%s%u>[ ", nlanes, tid<elemtype>(), 8 * sizeof(elemtype));
+  aie::print(aie::vector<elemtype, nlanes>(v));
+  printf("]\n");
+}
+
+void printv16xi32(v16int32 v) { printv<16, int32_t>(v); }
+
+void printv8xi32(v8int32 v) { printv<8, int32_t>(v); }
+
+void printv32xi16(v32int16 v) { printv<32, int16_t>(v); }
+
+void printv16xi16(v16int16 v) { printv<16, int16_t>(v); }
+
+void printv32xi8(v32int8 v) { printv<32, int8_t>(v); }
+
+alignas(32) int32_t buff_i32[64];
+alignas(32) int16_t buff_i16[64];
+alignas(32) int8_t buff_i8[64];
+
+int32_t *loadA64xi32() {
+  for (int i = 0; i < 64; ++i)
+    buff_i32[i] = i;
+  return buff_i32;
+}
+
+int16_t *loadA64xi16() {
+  for (int i = 0; i < 64; ++i)
+    buff_i16[i] = i;
+  return buff_i16;
+}
+
+int8_t *loadA64xi8() {
+  for (int i = 0; i < 64; ++i)
+    buff_i8[i] = i;
+  return buff_i8;
+}

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/kernel.mlir
@@ -1,0 +1,81 @@
+// REQUIRES: valid_xchess_license
+// RUN: aie-opt %s -convert-vector-to-aievec | aie-translate -aievec-to-cpp -o kernel.tmp.cc
+// RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xca_udm_dbg -qf -T -P %aietools/data/versal_prod/lib -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
+
+func.func private @printv16xi16(%v : vector<16xi16>)
+func.func private @loadA64xi16() -> memref<64xi16>
+
+#map6 = affine_map<(d0) -> (d0 + 6)>
+#map7 = affine_map<(d0) -> (d0 + 7)>
+#map8 = affine_map<(d0) -> (d0 + 8)>
+#map9 = affine_map<(d0) -> (d0 + 9)>
+#map10 = affine_map<(d0) -> (d0 + 10)>
+
+func.func @entry() -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %c0_i16 = arith.constant 0 : i16
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %c5 = arith.constant 5 : index
+  %c6 = arith.constant 6 : index
+  %c7 = arith.constant 7 : index
+  %c8 = arith.constant 8 : index
+  %c9 = arith.constant 9 : index
+  %c10 = arith.constant 10 : index
+  %c11 = arith.constant 11 : index
+  %c12 = arith.constant 12 : index
+  %c13 = arith.constant 13 : index
+  %c14 = arith.constant 14 : index
+  %c15 = arith.constant 15 : index
+
+  %buffi16 = func.call @loadA64xi16() : () -> (memref<64xi16>)
+  %v16 = vector.transfer_read %buffi16[%c0], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%v16) : (vector<16xi16>) -> ()
+
+  %1 = vector.transfer_read %buffi16[%c1], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%1) : (vector<16xi16>) -> ()
+  %2 = vector.transfer_read %buffi16[%c2], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%2) : (vector<16xi16>) -> ()
+  %3 = vector.transfer_read %buffi16[%c3], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%3) : (vector<16xi16>) -> ()
+  %4 = vector.transfer_read %buffi16[%c4], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%4) : (vector<16xi16>) -> ()
+  %5 = vector.transfer_read %buffi16[%c5], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%5) : (vector<16xi16>) -> ()
+
+  %i6 = affine.apply #map6(%c0)
+  %6 = vector.transfer_read %buffi16[%i6], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%6) : (vector<16xi16>) -> ()
+  %i7 = affine.apply #map7(%c0)
+  %7 = vector.transfer_read %buffi16[%i7], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%7) : (vector<16xi16>) -> ()
+  %i8 = affine.apply #map8(%c0)
+  %8 = vector.transfer_read %buffi16[%i8], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%8) : (vector<16xi16>) -> ()
+  %i9 = affine.apply #map9(%c0)
+  %9 = vector.transfer_read %buffi16[%i9], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%9) : (vector<16xi16>) -> ()
+  %i10 = affine.apply #map10(%c0)
+  %10 = vector.transfer_read %buffi16[%i10], %c0_i16 : memref<64xi16>, vector<16xi16>
+  func.call @printv16xi16(%10) : (vector<16xi16>) -> ()
+
+  return %c0_i32 : i32
+}
+
+// CHECK-LABEL: vector<16xi16>[ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 ]
+// CHECK-LABEL: vector<16xi16>[ 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 ]
+// CHECK-LABEL: vector<16xi16>[ 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 ]
+// CHECK-LABEL: vector<16xi16>[ 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 ]
+// CHECK-LABEL: vector<16xi16>[ 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 ]
+// CHECK-LABEL: vector<16xi16>[ 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 ]
+// CHECK-LABEL: vector<16xi16>[ 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 ]
+// CHECK-LABEL: vector<16xi16>[ 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 ]
+// CHECK-LABEL: vector<16xi16>[ 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 ]
+// CHECK-LABEL: vector<16xi16>[ 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 ]
+// CHECK-LABEL: vector<16xi16>[ 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 ]
+// CHECK-LABEL: SUCCESS

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/main.cc
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/main.cc
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+int entry(void);
+
+int main(void) {
+  int r = entry();
+  if (r)
+    printf("ERROR: %d", r);
+  printf("SUCCESS");
+  return r;
+}

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/helplib.cc
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/helplib.cc
@@ -1,0 +1,48 @@
+#include "aie_api/aie.hpp"
+#include "aie_api/utils.hpp"
+#include <cstdint>
+#include <cstdio>
+
+template <typename T> const char *tid() { return "@"; }
+
+template <> const char *tid<int8_t>() { return "i"; }
+template <> const char *tid<int16_t>() { return "i"; }
+template <> const char *tid<int32_t>() { return "i"; }
+
+template <int nlanes, typename elemtype, typename vtype> void printv(vtype v) {
+  printf("vector<%dx%s%u>[ ", nlanes, tid<elemtype>(), 8 * sizeof(elemtype));
+  aie::print(aie::vector<elemtype, nlanes>(v));
+  printf("]\n");
+}
+
+void printv16xi32(v16int32 v) { printv<16, int32_t>(v); }
+
+void printv8xi32(v8int32 v) { printv<8, int32_t>(v); }
+
+void printv32xi16(v32int16 v) { printv<32, int16_t>(v); }
+
+void printv16xi16(v16int16 v) { printv<16, int16_t>(v); }
+
+void printv32xi8(v32int8 v) { printv<32, int8_t>(v); }
+
+alignas(32) int32_t buff_i32[64];
+alignas(32) int16_t buff_i16[64];
+alignas(32) int8_t buff_i8[64];
+
+int32_t *loadA64xi32() {
+  for (int i = 0; i < 64; ++i)
+    buff_i32[i] = i;
+  return buff_i32;
+}
+
+int16_t *loadA64xi16() {
+  for (int i = 0; i < 64; ++i)
+    buff_i16[i] = i;
+  return buff_i16;
+}
+
+int8_t *loadA64xi8() {
+  for (int i = 0; i < 64; ++i)
+    buff_i8[i] = i;
+  return buff_i8;
+}

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/kernel.mlir
@@ -1,0 +1,35 @@
+// REQUIRES: valid_xchess_license
+// RUN: aie-opt %s -convert-vector-to-aievec | aie-translate -aievec-to-cpp -o kernel.tmp.cc
+// RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xca_udm_dbg -qf -T -P %aietools/data/versal_prod/lib -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
+
+func.func private @printv8xi32(%v : vector<8xi32>)
+func.func private @loadA64xi32() -> memref<64xi32>
+
+#map6 = affine_map<(d0) -> (d0 + 6)>
+
+func.func @entry() -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %c0 = arith.constant 0 : index
+  %c5 = arith.constant 5 : index
+
+  %buffi32 = func.call @loadA64xi32() : () -> (memref<64xi32>)
+
+  %v0 = vector.transfer_read %buffi32[%c0], %c0_i32 : memref<64xi32>, vector<8xi32>
+  func.call @printv8xi32(%v0) : (vector<8xi32>) -> ()
+
+  %v5 = vector.transfer_read %buffi32[%c5], %c0_i32 : memref<64xi32>, vector<8xi32>
+  func.call @printv8xi32(%v5) : (vector<8xi32>) -> ()
+
+  %idx6 = affine.apply #map6(%c0)
+  %v6 = vector.transfer_read %buffi32[%idx6], %c0_i32 : memref<64xi32>, vector<8xi32>
+  func.call @printv8xi32(%v6) : (vector<8xi32>) -> ()
+
+  return %c0_i32 : i32
+}
+
+// CHECK-LABEL: vector<8xi32>[ 0 1 2 3 4 5 6 7 ]
+// CHECK-LABEL: vector<8xi32>[ 5 6 7 8 9 10 11 12 ]
+// CHECK-LABEL: vector<8xi32>[ 6 7 8 9 10 11 12 13 ]
+// CHECK-LABEL: SUCCESS

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/main.cc
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/main.cc
@@ -1,0 +1,11 @@
+#include <cstdio>
+
+int entry(void);
+
+int main(void) {
+  int r = entry();
+  if (r)
+    printf("ERROR: %d", r);
+  printf("SUCCESS");
+  return r;
+}

--- a/tools/aie-opt/aie-opt.cpp
+++ b/tools/aie-opt/aie-opt.cpp
@@ -25,6 +25,7 @@
 #include "aie/Dialect/ADF/ADFDialect.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h"
+#include "aie/Dialect/AIEVec/Analysis/Passes.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
 #include "aie/Dialect/AIEVec/Pipelines/Passes.h"
 #include "aie/Dialect/AIEVec/Transforms/Passes.h"
@@ -40,6 +41,7 @@ int main(int argc, char **argv) {
   xilinx::registerConversionPasses();
   aie::registerAIEPasses();
   xilinx::AIEX::registerAIEXPasses();
+  xilinx::aievec::registerAIEVecAnalysisPasses();
   xilinx::aievec::registerAIEVecPasses();
   xilinx::aievec::registerAIEVecPipelines();
 


### PR DESCRIPTION
This patch adds the lowering for `vector.extract_strided_slice` as a canonical solution to unaligned loads. This process breaks convolution detection and optimization for AIE-ML, and this patch addresses those as well.