### PR TITLE
ShimDMA Allocation Info

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1277,8 +1277,36 @@ def AIE_PutCascadeOp: AIE_Op<"putCascade", [HasParent<"CoreOp">]> {
   let assemblyFormat = [{ `(` $cascadeValue `:` type($cascadeValue) `)` attr-dict }];
 }
 
+def AIE_ShimDMAAllocationInfoOp : AIE_Op<"shimDMAAllocationInfo", [HasParent<"ModuleOp">]> {
+  let summary = "Runtime allocation information for a single shim DMA";
+  let description = [{
+    Runtime allocation information for a single shim DMA. It contains attributes for the
+    sym_name of the operation which generated the shim DMA, for the DMAChannelDir and 
+    channel index, and for the column of the shim tile to which the originating operation 
+    was mapped.
 
-
+    Example:
+    ```
+      %tile00 = AIE.tile(0, 0)
+      %tile02 = AIE.tile(0, 2)
+      %connect1 = AIE.objectFifo.createObjectFifo(%tile00, {%tile02}, 2) {sym_name = "of_in_0"} : !AIE.objectFifo<memref<64xi16>>
+    ```
+    could produce the following allocation info (channel direction MM2S, channel index 1, and shim column 0):
+    ```
+      AIE.shimDMAAllocationInfo("of_in_0", MM2S, 1, 0)
+    ```
+  }];
+  let arguments = (
+    ins StrAttr:$sym_name,
+        DMAChannelDir:$channelDir,
+        I64Attr:$channelIndex,
+        I64Attr:$col
+  );
+  let results = (outs);
+  let assemblyFormat = [{
+    `(` $sym_name `,` $channelDir `,` $channelIndex `,` $col `)` attr-dict  
+  }];
+}
 
 def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", []> {
   let summary = "Create a circular buffer or channel between two tiles";

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1280,10 +1280,13 @@ def AIE_PutCascadeOp: AIE_Op<"putCascade", [HasParent<"CoreOp">]> {
 def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"ModuleOp">]> {
   let summary = "Runtime allocation information for a single shim DMA";
   let description = [{
-    Runtime allocation information for a single shim DMA. It contains attributes for the
-    sym_name of an operation which generated the shim DMA, for the DMAChannelDir and 
-    channel index, and for the column of the shim tile to which the originating operation 
-    was mapped.
+    This op exists for cases where shimDMA configuration is performed outside of MLIR-AIE 
+    and hence there is no appropriate dmaStart operation to indicate which channel is being
+    used and on which column the shimDMA is. 
+
+    It contains attributes for the sym_name of an operation which generated the shim DMA, 
+    for the DMAChannelDir and channel index, and for the column of the shim tile to which 
+    the originating operation was mapped.
 
     Example:
     ```

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1277,11 +1277,11 @@ def AIE_PutCascadeOp: AIE_Op<"putCascade", [HasParent<"CoreOp">]> {
   let assemblyFormat = [{ `(` $cascadeValue `:` type($cascadeValue) `)` attr-dict }];
 }
 
-def AIE_ShimDMAAllocationInfoOp : AIE_Op<"shimDMAAllocationInfo", [HasParent<"ModuleOp">]> {
+def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"ModuleOp">]> {
   let summary = "Runtime allocation information for a single shim DMA";
   let description = [{
     Runtime allocation information for a single shim DMA. It contains attributes for the
-    sym_name of the operation which generated the shim DMA, for the DMAChannelDir and 
+    sym_name of an operation which generated the shim DMA, for the DMAChannelDir and 
     channel index, and for the column of the shim tile to which the originating operation 
     was mapped.
 
@@ -1293,7 +1293,7 @@ def AIE_ShimDMAAllocationInfoOp : AIE_Op<"shimDMAAllocationInfo", [HasParent<"Mo
     ```
     could produce the following allocation info (channel direction MM2S, channel index 1, and shim column 0):
     ```
-      AIE.shimDMAAllocationInfo("of_in_0", MM2S, 1, 0)
+      AIE.shimDMAAllocation("of_in_0", MM2S, 1, 0)
     ```
   }];
   let arguments = (

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -497,7 +497,7 @@ struct AIECoreToStandardPass
              AIEOpRemoval<AIE::ShimDMAOp>, AIEOpRemoval<AIE::ShimMuxOp>,
              AIEOpRemoval<AIE::SwitchboxOp>, AIEOpRemoval<AIE::LockOp>,
              AIEOpRemoval<AIE::BufferOp>, AIEOpRemoval<AIE::ExternalBufferOp>,
-             AIEOpRemoval<AIE::ShimDMAAllocationInfoOp>>(m.getContext(), m);
+             AIEOpRemoval<AIE::ShimDMAAllocationOp>>(m.getContext(), m);
 
     if (failed(applyPartialConversion(m, target, std::move(removepatterns))))
       signalPassFailure();

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -496,7 +496,8 @@ struct AIECoreToStandardPass
              AIEOpRemoval<AIE::FlowOp>, AIEOpRemoval<AIE::MemOp>,
              AIEOpRemoval<AIE::ShimDMAOp>, AIEOpRemoval<AIE::ShimMuxOp>,
              AIEOpRemoval<AIE::SwitchboxOp>, AIEOpRemoval<AIE::LockOp>,
-             AIEOpRemoval<AIE::BufferOp>, AIEOpRemoval<AIE::ExternalBufferOp>>(
+             AIEOpRemoval<AIE::BufferOp>, AIEOpRemoval<AIE::ExternalBufferOp>,
+             AIEOpRemoval<AIE::ShimDMAAllocationInfoOp>>(
             m.getContext(), m);
 
     if (failed(applyPartialConversion(m, target, std::move(removepatterns))))

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -497,8 +497,7 @@ struct AIECoreToStandardPass
              AIEOpRemoval<AIE::ShimDMAOp>, AIEOpRemoval<AIE::ShimMuxOp>,
              AIEOpRemoval<AIE::SwitchboxOp>, AIEOpRemoval<AIE::LockOp>,
              AIEOpRemoval<AIE::BufferOp>, AIEOpRemoval<AIE::ExternalBufferOp>,
-             AIEOpRemoval<AIE::ShimDMAAllocationInfoOp>>(
-            m.getContext(), m);
+             AIEOpRemoval<AIE::ShimDMAAllocationInfoOp>>(m.getContext(), m);
 
     if (failed(applyPartialConversion(m, target, std::move(removepatterns))))
       signalPassFailure();

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -956,7 +956,7 @@ struct AIEObjectFifoStatefulTransformPass
                                       StringRef name, int colIndex,
                                       DMAChannelDir channelDir,
                                       int channelIndex) {
-    builder.create<ShimDMAAllocationInfoOp>(
+    builder.create<ShimDMAAllocationOp>(
         builder.getUnknownLoc(), builder.getStringAttr(name.str()),
         DMAChannelDirAttr::get(ctx, channelDir),
         builder.getI64IntegerAttr(channelIndex),

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -956,11 +956,11 @@ struct AIEObjectFifoStatefulTransformPass
                                       StringRef name, int colIndex,
                                       DMAChannelDir channelDir,
                                       int channelIndex) {
-    builder.create<ShimDMAAllocationOp>(
-        builder.getUnknownLoc(), builder.getStringAttr(name.str()),
-        DMAChannelDirAttr::get(ctx, channelDir),
-        builder.getI64IntegerAttr(channelIndex),
-        builder.getI64IntegerAttr(colIndex));
+    builder.create<ShimDMAAllocationOp>(builder.getUnknownLoc(),
+                                        builder.getStringAttr(name.str()),
+                                        DMAChannelDirAttr::get(ctx, channelDir),
+                                        builder.getI64IntegerAttr(channelIndex),
+                                        builder.getI64IntegerAttr(colIndex));
   }
 
   void runOnOperation() override {

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -949,17 +949,18 @@ struct AIEObjectFifoStatefulTransformPass
     return 0;
   }
 
-  /// Function used to generate, from an objectFifo with a shimTile endpoint, a 
-  /// shimDMAAllocationInfoOp containing the channelDir, channelIndex and shimTile col 
-  /// assigned by the objectFifo lowering.
-  void createObjectFifoAllocationInfo(OpBuilder &builder, MLIRContext *ctx, 
-                                      StringRef name, int colIndex, 
-                                      DMAChannelDir channelDir, int channelIndex) {
-    builder.create<ShimDMAAllocationInfoOp>(builder.getUnknownLoc(), 
-                                      builder.getStringAttr(name.str()), 
-                                      DMAChannelDirAttr::get(ctx, channelDir),
-                                      builder.getI64IntegerAttr(channelIndex), 
-                                      builder.getI64IntegerAttr(colIndex));
+  /// Function used to generate, from an objectFifo with a shimTile endpoint, a
+  /// shimDMAAllocationInfoOp containing the channelDir, channelIndex and
+  /// shimTile col assigned by the objectFifo lowering.
+  void createObjectFifoAllocationInfo(OpBuilder &builder, MLIRContext *ctx,
+                                      StringRef name, int colIndex,
+                                      DMAChannelDir channelDir,
+                                      int channelIndex) {
+    builder.create<ShimDMAAllocationInfoOp>(
+        builder.getUnknownLoc(), builder.getStringAttr(name.str()),
+        DMAChannelDirAttr::get(ctx, channelDir),
+        builder.getI64IntegerAttr(channelIndex),
+        builder.getI64IntegerAttr(colIndex));
   }
 
   void runOnOperation() override {
@@ -1058,9 +1059,10 @@ struct AIEObjectFifoStatefulTransformPass
       // generate objectFifo allocation info
       builder.setInsertionPointAfter(device);
       if (producer.getProducerTileOp().isShimTile())
-        createObjectFifoAllocationInfo(builder, ctx, producer.name()->getValue(), 
-                                 producer.getProducerTileOp().colIndex(), 
-                                 producerChan.first, producerChan.second);
+        createObjectFifoAllocationInfo(builder, ctx,
+                                       producer.name()->getValue(),
+                                       producer.getProducerTileOp().colIndex(),
+                                       producerChan.first, producerChan.second);
 
       for (auto consumer : consumers) {
         // create consumer tile DMA
@@ -1071,9 +1073,10 @@ struct AIEObjectFifoStatefulTransformPass
         // generate objectFifo allocation info
         builder.setInsertionPointAfter(device);
         if (consumer.getProducerTileOp().isShimTile())
-          createObjectFifoAllocationInfo(builder, ctx, producer.name()->getValue(), 
-                                 consumer.getProducerTileOp().colIndex(), 
-                                 consumerChan.first, consumerChan.second);
+          createObjectFifoAllocationInfo(
+              builder, ctx, producer.name()->getValue(),
+              consumer.getProducerTileOp().colIndex(), consumerChan.first,
+              consumerChan.second);
 
         // create flow
         builder.setInsertionPointAfter(producer);

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -177,21 +177,23 @@ void registerAIETranslations() {
       },
       registerDialects);
 
-      TranslateFromMLIRRegistration registrationShimDMAToJSON(
+  TranslateFromMLIRRegistration registrationShimDMAToJSON(
       "aie-generate-json", "Transform AIE shim DMA allocation info into JSON",
       [](ModuleOp module, raw_ostream &output) {
         llvm::json::Object moduleJSON;
         for (auto shimDMA_meta : module.getOps<ShimDMAAllocationInfoOp>()) {
           llvm::json::Object shimJSON;
-          ShimDMAAllocationInfoOpAdaptor shimDMAAllocationInfoOpAdaptor(shimDMA_meta);
+          ShimDMAAllocationInfoOpAdaptor shimDMAAllocationInfoOpAdaptor(
+              shimDMA_meta);
           auto channelDir = shimDMAAllocationInfoOpAdaptor.getChannelDirAttr();
           shimJSON["channelDir"] = attrToJSON(channelDir);
-          auto channelIndex = shimDMAAllocationInfoOpAdaptor.getChannelIndexAttr();
+          auto channelIndex =
+              shimDMAAllocationInfoOpAdaptor.getChannelIndexAttr();
           shimJSON["channelIndex"] = attrToJSON(channelIndex);
           auto col = shimDMAAllocationInfoOpAdaptor.getColAttr();
           shimJSON["col"] = attrToJSON(col);
           moduleJSON[shimDMA_meta.getSymName()] =
-                  llvm::json::Value(std::move(shimJSON));
+              llvm::json::Value(std::move(shimJSON));
         }
         llvm::json::Value topv(std::move(moduleJSON));
         std::string ret;

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -181,16 +181,16 @@ void registerAIETranslations() {
       "aie-generate-json", "Transform AIE shim DMA allocation info into JSON",
       [](ModuleOp module, raw_ostream &output) {
         llvm::json::Object moduleJSON;
-        for (auto shimDMA_meta : module.getOps<ShimDMAAllocationInfoOp>()) {
+        for (auto shimDMA_meta : module.getOps<ShimDMAAllocationOp>()) {
           llvm::json::Object shimJSON;
-          ShimDMAAllocationInfoOpAdaptor shimDMAAllocationInfoOpAdaptor(
+          ShimDMAAllocationOpAdaptor shimDMAAllocationOpAdaptor(
               shimDMA_meta);
-          auto channelDir = shimDMAAllocationInfoOpAdaptor.getChannelDirAttr();
+          auto channelDir = shimDMAAllocationOpAdaptor.getChannelDirAttr();
           shimJSON["channelDir"] = attrToJSON(channelDir);
           auto channelIndex =
-              shimDMAAllocationInfoOpAdaptor.getChannelIndexAttr();
+              shimDMAAllocationOpAdaptor.getChannelIndexAttr();
           shimJSON["channelIndex"] = attrToJSON(channelIndex);
-          auto col = shimDMAAllocationInfoOpAdaptor.getColAttr();
+          auto col = shimDMAAllocationOpAdaptor.getColAttr();
           shimJSON["col"] = attrToJSON(col);
           moduleJSON[shimDMA_meta.getSymName()] =
               llvm::json::Value(std::move(shimJSON));

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -183,12 +183,10 @@ void registerAIETranslations() {
         llvm::json::Object moduleJSON;
         for (auto shimDMA_meta : module.getOps<ShimDMAAllocationOp>()) {
           llvm::json::Object shimJSON;
-          ShimDMAAllocationOpAdaptor shimDMAAllocationOpAdaptor(
-              shimDMA_meta);
+          ShimDMAAllocationOpAdaptor shimDMAAllocationOpAdaptor(shimDMA_meta);
           auto channelDir = shimDMAAllocationOpAdaptor.getChannelDirAttr();
           shimJSON["channelDir"] = attrToJSON(channelDir);
-          auto channelIndex =
-              shimDMAAllocationOpAdaptor.getChannelIndexAttr();
+          auto channelIndex = shimDMAAllocationOpAdaptor.getChannelIndexAttr();
           shimJSON["channelIndex"] = attrToJSON(channelIndex);
           auto col = shimDMAAllocationOpAdaptor.getColAttr();
           shimJSON["col"] = attrToJSON(col);

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -13,7 +13,7 @@
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
 // CHECK: module @alloc {
-// CHECK:   AIE.device(ipu) {
+// CHECK:   AIE.device(xcve2302) {
 // CHECK:     %0 = AIE.tile(0, 0)
 // CHECK:     %1 = AIE.tile(0, 2)
 // CHECK:     %2 = AIE.tile(0, 3)

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -1,0 +1,43 @@
+//===- allocation_info_test.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: May 20th 2023
+// 
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @alloc {
+// CHECK:   AIE.device(ipu) {
+// CHECK:     %0 = AIE.tile(0, 0)
+// CHECK:     %1 = AIE.tile(0, 2)
+// CHECK:     %2 = AIE.tile(0, 3)
+// CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
+// CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
+// CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
+// CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
+// CHECK: }
+
+module @alloc {
+    AIE.device(xcve2302) {
+        %tile00 = AIE.tile(0, 0)
+        %tile02 = AIE.tile(0, 2)
+        %tile03 = AIE.tile(0, 3)
+
+        %connect1 = AIE.objectFifo.createObjectFifo(%tile00, {%tile02}, 2) {sym_name = "of_in_0"} : !AIE.objectFifo<memref<64xi16>>
+        %connect2 = AIE.objectFifo.createObjectFifo(%tile02, {%tile00}, 2) {sym_name = "of_out_0"} : !AIE.objectFifo<memref<64xi16>>
+
+        %connect3 = AIE.objectFifo.createObjectFifo(%tile00, {%tile03}, 2) {sym_name = "of_in_1"} : !AIE.objectFifo<memref<64xi16>>
+        %connect4 = AIE.objectFifo.createObjectFifo(%tile03, {%tile00}, 2) {sym_name = "of_out_1"} : !AIE.objectFifo<memref<64xi16>>
+    }
+}

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -22,10 +22,10 @@
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
 // CHECK: }
 
 module @alloc {

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -14,30 +14,30 @@
 
 // CHECK: module @alloc {
 // CHECK:   AIE.device(xcve2302) {
-// CHECK:     %0 = AIE.tile(0, 0)
-// CHECK:     %1 = AIE.tile(0, 2)
-// CHECK:     %2 = AIE.tile(0, 3)
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 2)
+// CHECK:     %2 = AIE.tile(2, 3)
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
-// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 0)
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:   AIE.shimDMAAllocationInfo({{.*}}, {{.*}}, {{.*}}, 2)
 // CHECK: }
 
 module @alloc {
     AIE.device(xcve2302) {
-        %tile00 = AIE.tile(0, 0)
-        %tile02 = AIE.tile(0, 2)
-        %tile03 = AIE.tile(0, 3)
+        %tile20 = AIE.tile(2, 0)
+        %tile22 = AIE.tile(2, 2)
+        %tile23 = AIE.tile(2, 3)
 
-        %connect1 = AIE.objectFifo.createObjectFifo(%tile00, {%tile02}, 2) {sym_name = "of_in_0"} : !AIE.objectFifo<memref<64xi16>>
-        %connect2 = AIE.objectFifo.createObjectFifo(%tile02, {%tile00}, 2) {sym_name = "of_out_0"} : !AIE.objectFifo<memref<64xi16>>
+        %connect1 = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2) {sym_name = "of_in_0"} : !AIE.objectFifo<memref<64xi16>>
+        %connect2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile20}, 2) {sym_name = "of_out_0"} : !AIE.objectFifo<memref<64xi16>>
 
-        %connect3 = AIE.objectFifo.createObjectFifo(%tile00, {%tile03}, 2) {sym_name = "of_in_1"} : !AIE.objectFifo<memref<64xi16>>
-        %connect4 = AIE.objectFifo.createObjectFifo(%tile03, {%tile00}, 2) {sym_name = "of_out_1"} : !AIE.objectFifo<memref<64xi16>>
+        %connect3 = AIE.objectFifo.createObjectFifo(%tile20, {%tile23}, 2) {sym_name = "of_in_1"} : !AIE.objectFifo<memref<64xi16>>
+        %connect4 = AIE.objectFifo.createObjectFifo(%tile23, {%tile20}, 2) {sym_name = "of_out_1"} : !AIE.objectFifo<memref<64xi16>>
     }
 }

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -70,6 +70,7 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
+// CHECK:   AIE.shimDMAAllocationInfo("ext_of", MM2S, 0, 7)
 // CHECK: }
 
 module @register_external_buffers {

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -70,7 +70,7 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocationInfo("ext_of", MM2S, 0, 7)
+// CHECK:   AIE.shimDMAAllocation("ext_of", MM2S, 0, 7)
 // CHECK: }
 
 module @register_external_buffers {

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -70,7 +70,7 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocationInfo("objfifo", MM2S, 0, 7)
+// CHECK:   AIE.shimDMAAllocation("objfifo", MM2S, 0, 7)
 // CHECK: }
 
 module @shimRow_mem {

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -70,6 +70,7 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
+// CHECK:   AIE.shimDMAAllocationInfo("objfifo", MM2S, 0, 7)
 // CHECK: }
 
 module @shimRow_mem {


### PR DESCRIPTION
Currently, higher-level mlir-aie abstractions like the objectFifo, as well as higher-level dialects external to mlir-aie, may do shimDMA allocations as part of their lowering to physical-level mlir-aie. Because of this, there is a need to keep track of which shimDMA and which of its channels were assigned to the original operations, a feature that will be useful in writing and testing designs.

This PR introduces the ShimDMAAllocationOp and through its inputs it makes the connection between the symbolic name of a higher-level op and the channelDir, channelIndex and column of the shimDMA to which it was assigned. This allocation op is removed as part of the AIECoreToStandard.cpp.