### PR TITLE
[aiecc] The default target architecture is also the host architecture.

### DIFF
--- a/tools/aiecc/aiecc/cl_arguments.py
+++ b/tools/aiecc/aiecc/cl_arguments.py
@@ -82,7 +82,7 @@ def parse_args():
             help='Disable compiling of AIE code')
     parser.add_argument('--host-target',
             dest="host_target",
-            default="x86_64-unknown-linux-gnu",
+            default=host_architecture,
             help='Target architecture of the host program')
     parser.add_argument('--aie-target',
             dest="aie_target",

--- a/tools/aiecc/aiecc/configure.py.in
+++ b/tools/aiecc/aiecc/configure.py.in
@@ -12,3 +12,4 @@ aie_disable_compile = @CONFIG_DISABLE_COMPILE@
 aie_unified_compile = True
 host_disable_compile = @CONFIG_DISABLE_HOST_COMPILE@
 peano_install_dir = "@CONFIG_PEANO_INSTALL_DIR@"
+host_architecture = "@LLVM_HOST_TRIPLE@"


### PR DESCRIPTION
Previously we defaulted to x86 as the host architecture, but this is clearly wrong if we're compiling on ARM.