### PR TITLE
Change default device if AIE-ML compilation is demanded by user

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -45,6 +45,13 @@ def AIECanonicalizeDevice : Pass<"aie-canonicalize-device", "ModuleOp"> {
   }];
 
   let constructor = "xilinx::AIE::createAIECanonicalizeDevicePass()";
+
+  let options = [
+    Option<"aieTarget", "aie-target", "xilinx::AIE::AIEArch", "xilinx::AIE::AIEArch::AIE1",
+           "Target architecture of AIE device (AIE1 or AIE2 aka AIE-ML).",
+           "::llvm::cl::values(clEnumValN(xilinx::AIE::AIEArch::AIE1, \"AIE\", \"First generation AIE.\"),\n"
+           "                   clEnumValN(xilinx::AIE::AIEArch::AIE2, \"AIE2\", \"Second generation AIE-ML.\"))">
+  ];
 }
 
 def AIECoreToStandard : Pass<"aie-standard-lowering", "ModuleOp"> {

--- a/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
@@ -39,10 +39,18 @@ struct AIECanonicalizeDevicePass
     // the new op quite yet.
     OpBuilder builder(moduleOp->getContext());
 
+    // If no device op is present, we assume the VC1902 device by default, or
+    // the VE2802 device if AIE-ML compilation is demanded by the user 
+    // (i.e. flag --aie-target=AIE2 set).
+    AIEDevice defaultDevice = AIEDevice::xcvc1902;
+    if(AIEArch::AIE2 == aieTarget) {
+      defaultDevice = AIEDevice::xcve2802;
+    }
+
     Location location = builder.getUnknownLoc();
     DeviceOp deviceOp = builder.create<DeviceOp>(
         location,
-        AIEDeviceAttr::get(builder.getContext(), AIEDevice::xcvc1902));
+        AIEDeviceAttr::get(builder.getContext(), defaultDevice));
 
     deviceOp.getRegion().takeBody(moduleOp.getBodyRegion());
     new (&moduleOp->getRegion(0)) Region(moduleOp);

--- a/tools/aiecc/aiecc/cl_arguments.py
+++ b/tools/aiecc/aiecc/cl_arguments.py
@@ -87,6 +87,7 @@ def parse_args():
     parser.add_argument('--aie-target',
             dest="aie_target",
             default="AIE",
+            choices=["AIE", "AIE2"],
             help='Target architecture of the AIE program')
     parser.add_argument('--compile-host',
             dest="compile_host",

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -336,7 +336,7 @@ class flow_runner:
         self.file_with_addresses = os.path.join(self.tmpdirname, 'input_with_addresses.mlir')
         await self.do_call(progress.task, ['aie-opt',
                                           '--lower-affine',
-                                          '--aie-canonicalize-device',
+                                          '--aie-canonicalize-device=aie-target={}'.format(opts.aie_target.upper()),
                                           '--aie-assign-lock-ids',
                                           '--aie-register-objectFifos',
                                           '--aie-objectFifo-stateful-transform',

--- a/tutorials/makefile-common
+++ b/tutorials/makefile-common
@@ -4,6 +4,10 @@
 # running make, the following should work to find the AIE install directory.
 AIE_INSTALL ?= $(shell realpath $(dir $(shell which aie-opt))/../runtime_lib/aarch64)
 
+# To run tutorials on new AIE-ML architecture, set this to AIE2
+# in an environment variable, e.g. AIE_TARGET=AIE2 make
+AIE_TARGET ?= AIE
+
 # VITIS related variables
 VITIS_ROOT ?= $(shell realpath $(dir $(shell which vitis))/../)
 VITIS_AIETOOLS_DIR ?= ${VITIS_ROOT}/aietools
@@ -23,7 +27,7 @@ LIBCXX_VERSION ?= 11.2.0
 
 # The following flags are passed to both AI core and host compilation for
 # aiecc.py invocations.
-AIECC_FLAGS += --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu
+AIECC_FLAGS += --sysroot=${MLIR_AIE_SYSROOT} --host-target=aarch64-linux-gnu --aie-target=${AIE_TARGET}
 
 CHESSCC_FLAGS = -f -p me -P ${VITIS_AIE_INCLUDE_DIR} -I ${VITIS_AIETOOLS_DIR}/include
 CHESS_FLAGS = -P ${VITIS_AIE_INCLUDE_DIR}

--- a/tutorials/tutorial-1/README.md
+++ b/tutorials/tutorial-1/README.md
@@ -126,6 +126,13 @@ We will be introducing more components and the ways these components are customi
     ```
     > make
     ```
+   
+   Alternatively, to compile the first tutorial for the AIE-ML architecture, run:
+   ```
+   > AIE_TARGET=AIE2 make
+   ```
+
+   Note that not all tutorials have been ported to AIE-ML yet.
 
 ### <ins>MLIR-AIE Transformations</ins>
 Under the hood, `make` calls `aiecc.py` which itself calls a number of utilities that are built as part of the `mlir-aie` project (`aie-translate`, `aie-opt`). More details on these utilities can be found in [tutorial-10](../tutorial-10). These utilities are built as part of the `mlir-aie` to perform IR transformations and lowerings. In this example, since we are already describing our design at a low physical level, we will perform the final transformation and produce an AI Engine program (core_1_4.elf).

--- a/tutorials/tutorial-2/tutorial-2b/README.md
+++ b/tutorials/tutorial-2/tutorial-2b/README.md
@@ -24,7 +24,7 @@ module @module_name {
 
 This operation specifies which particular device is being targetted by the design. This information is necessary as different AIE devices have different hardware architectures which influence some of the lower level mappings and library calls when running designs, both in simulation and on hardware.
 
-This operation can be added explicitly, as can be seen in the MLIR source code (`aie.mlir`). Alternatively, `aiecc.py` also adds a defaut device target as part of its build flow in case no other target was specified in the code. The different device targets are described in [AIETargetModel.h](../../../include/aie/Dialect/AIE/IR/AIETargetModel.h) with the default target being the `VC1902TargetModel`.
+This operation can be added explicitly, as can be seen in the MLIR source code (`aie.mlir`). Alternatively, `aiecc.py` also adds a defaut device target as part of its build flow in case no other target was specified in the code. The different device targets are described in [AIETargetModel.h](../../../include/aie/Dialect/AIE/IR/AIETargetModel.h) with the default target being the `VC1902TargetModel`. If you are targeting the newer AIE-ML architecture, the default target is `VE2802TargetModel`.
 
 # <ins>Tutorial 2b - Simulation</ins>
 

--- a/tutorials/tutorial-2/tutorial-2b/aie.mlir
+++ b/tutorials/tutorial-2/tutorial-2b/aie.mlir
@@ -22,6 +22,8 @@ module @tutorial_2b {
     
     // Declare the target device
     AIE.device(xcvc1902) {
+    // For AIE-ML, use an AIE-ML device, for example:
+    // AIE.device(xcve2802) {
         // Declare tile object of the AIE class located at position col 1, row 4
         %tile14 = AIE.tile(1, 4)
 


### PR DESCRIPTION
Currently, if no `AIE.device` op is present in MLIR, the "Canonicalize Device" pass automatically adds a **default device** `AIE.device(xcvc1902)`. **This default device is an AIE1 device.**

However, if the user wants to compile AIE-ML (AIE2) code, this device will not work for simulation, since it is a first generation AIE device. The user can currently request AIE-ML compilation if `aiecc.py` is called with `--aie-target=AIE2`.

**Thus, if the user explicitly asks for `--aie-target=AIE2`, I suggest using a more appropriate default device that supports AIE-ML.**

This pull request ...

1. ... adds an option `--aie-target` to the `AIECanonicalizeDevice` pass, which takes AIE (AIE) or AIE2 as values.
2. ... makes `aiecc.py` pass the `--aie-target` option it receives on to the `AIECanonicalizeDevice` pass.
3. ... changes the default device added in the `AIECanonicalizeDevice` to the `VE2802` instead of `VC1902` if the target architecture passed in is `AIE2`.
4. ... updates tutorial documentation to reflect this.

This pull request does not change any behavior if ...
- the target is not explicitly specified (AIE is assumed) or AIE compilation is specified
- an explicit AIE.device op is present in the user's MLIR