### PR TITLE
Allow multiple AIE.device per module

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -546,11 +546,6 @@ const xilinx::AIE::AIETargetModel &xilinx::AIE::DeviceOp::getTargetModel() {
 }
 
 LogicalResult xilinx::AIE::DeviceOp::verify() {
-  auto top = cast<mlir::ModuleOp>((*this)->getParentOp());
-  auto ops = top.getOps<DeviceOp>();
-  int num_devices = std::distance(ops.begin(), ops.end());
-  if (num_devices > 1)
-    return emitOpError("expected at most one device operation");
   return success();
 }
 


### PR DESCRIPTION
There is a use case in mlir-air to have multiple independent `AIE.device` in the same module when lowering multiple air segments. In the current design each air segment is mapped to its own `AIE.device`, and all segments + host code are in the same module.