### PR TITLE
add `cmake/modulesXilinx` to the cmake module path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ cmake_minimum_required(VERSION 3.21)
 
 set(TOOLCHAINFILES_PATH ${CMAKE_SOURCE_DIR}/cmake/modulesXilinx)
 
+# Allow cmake to find findVitis.cmake, needed for setting variables such as VITIS_AIE_INCLUDE_DIR
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modulesXilinx")
+
 set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runtime libraries for.")
 set(AIE_RUNTIME_TEST_TARGET "x86_64" CACHE STRING "Runtime architecture to test with.")
 


### PR DESCRIPTION
Building and then compiling a tutorial on the current commit does not work when starting from scratch.

Here is how it breaks:

1. First, cmake does not find the `findVitis.cmake` module, because `cmake/modulesXilinx` is not in the cmake module search path. This only raises a warning, not an error -- easily overlooked.
2. Since `findVitis.cmake` is not found, the variable `VITIS_AIE_INCLUDE_PATH` is never defined. Subsequent references produce an empty string.
3. Despite this, building MLIR-AIE successfully completes (in my opinion, there should be an error).
4. Subsequently trying to compile a tutorial (e.g. tutorial 1) gives the error: `Error: Option -d appears as value of another option`, because `xchesscc_wrapper` calls unwrapped xchesscc like this:
    `$UNWRAPPED_XCHESSCC +P 4 -p me -C Release_LLVM -Y clang=$DIR/chess-clang -P $LIBDIR -d -f $@`,
    wherein `$LIBDIR` is defined as `VITIS_AIE_INCLUDE_PATH` or `VITIS_AIE2_INCLUDE_PATH`. Since those are empty strings due to the failure described above, it looks as if option -d is passed as value to option -P.

This pull request fixes this issue by adding the cmake/modulesXilinx path to the cmake module path, by resolving the issue in the first step above.