### PR TITLE
allow aiesim.sh script to run independent of working directory

### DIFF
--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -377,9 +377,20 @@ class flow_runner:
                                 '-o', os.path.join(sim_dir, 'flows_physical.json')])
 
       sim_script = os.path.join(self.tmpdirname, 'aiesim.sh')
+      sim_script_template = \
+"""
+#!/bin/sh
+prj_name=$(basename $(dirname $(realpath $0)))
+root=$(dirname $(dirname $(realpath $0)))
+vcd_filename=foo
+if [ -n "$1" ]; then
+  vcd_filename=$1
+fi
+cd $root
+aiesimulator --pkg-dir=${prj_name}/sim --dump-vcd ${vcd_filename}
+"""
       with open(sim_script, "wt") as sim_script_file:
-        sim_script_file.write("#!/bin/sh\n")
-        sim_script_file.write("aiesimulator --pkg-dir=" + sim_dir + " --dump-vcd foo\n")
+        sim_script_file.write(sim_script_template)
       stats = os.stat(sim_script)
       os.chmod(sim_script, stats.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 


### PR DESCRIPTION
When running `aiecc.py` with the `--aiesim` flag, a shell script named `aiesim.sh` that invokes the `aiesimulator` is generated.

This pull request adjusts the generated `aiesim.sh` script, so that it can be called from any working directory and still function. Just something to make working with it a little easier if you compile, e.g., into a separate build folder and don't want to enter that folder before running the simulation.

Previously, this script could only be called from the parent directory of the `...prj` directory where `aiesim.sh` resides.

I also added a parameter to be able to define the file name of the generated VCD file. If nothing is supplied, the same name as before, `foo` is used.