### PR TITLE
Introduce ObjectFifoLinkOp to support memory reuse and complex patterns in MemTileDMAs

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1384,9 +1384,9 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
 
     Example:
     ```
-      %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) : !AIE.objectFifo<memref<64xi16>>
-      %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link(%of_t70_t72, %of_t72_t74) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
+      %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) {sym_name = "of0"} : !AIE.objectFifo<memref<64xi16>>
+      %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) {sym_name = "of1"} : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo.link(%of_t70_t72, {%of_t72_t74}) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1411,6 +1411,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
     bool isDistribute() {
       return getFifoOuts().size() > 1;
     }
+    mlir::Optional<Value> getOptionalSharedTile();
   }];
 }
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1373,7 +1373,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", []> {
 }
 
 def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
-  let summary = "Links two objectFifos through an intermediary tile's dma";
+  let summary = "Links two objectFifos through an intermediary tile's DMA";
   let description = [{
     The "aie.objectFifo.link" operation allows to mark two objectFifos as linked. This implies that the two objectFifos form
     one dataflow movement which is split accross multiple objectFifos. Specifically, during the objectFifo lowering there will

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1372,6 +1372,49 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", []> {
   }];
 }
 
+def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
+  let summary = "Links two objectFifos through an intermediary tile's dma";
+  let description = [{
+    The "aie.objectFifo.link" operation allows to mark two objectFifos as linked. This implies that the two objectFifos form
+    one dataflow movement which is split accross multiple objectFifos. Specifically, during the objectFifo lowering there will
+    be less memory elements generated at the link point as the two objectFifos can share.
+
+    The two objectFifos which are linked must have a link point (i.e., a shared AIE tile).
+    In L1, only objectFifos of same size may be linked. In L2, different sized objectFifos can be linked.
+
+    Example:
+    ```
+      %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) : !AIE.objectFifo<memref<64xi16>>
+      %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo.link(%of_t70_t72, %of_t72_t74) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
+    ```
+    This operation links two objectFifos which have tile %t72 as a link point.
+
+    To achieve a broadcast pattern through the link tile, the output objectFifo should have a list of all the consumers tiles.
+    To achieve a distribute pattern from the link tile, there should be multiple output objectFifos in the LinkOp. In this case,
+    parts will be taken out of the input objectFifo's buffers based on the sizes of the output objectFifos, in the order they 
+    were given in the LinkOp.
+  }];
+
+  let arguments = (
+    ins AIE_ObjectFifoType:$fifoIn,
+        Variadic<AIE_ObjectFifoType>:$fifoOuts
+  );
+
+  let assemblyFormat = [{
+    attr-dict `(` $fifoIn `,` `{` $fifoOuts `}` `)` `:` `(` type($fifoIn) `,` type($fifoOuts) `)`
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    bool isDistribute() {
+      return getFifoOuts().size() > 1;
+    }
+  }];
+}
+
+
 def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [TileElement, IsShimNOCTile]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";
   let description = [{

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -436,10 +436,6 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
   MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
   int inputSize = (int)elemType.getShape()[0];
 
-  if (elemType.getShape().size() > 1)
-    return emitError("ObjectFifoLinkOp currently only supports objFifos with "
-                     "1-dimensional memrefs");
-
   for (auto fifoOut : getFifoOuts()) {
     ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
     if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
@@ -456,10 +452,6 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
       AIEObjectFifoType fifo = op.getType().cast<AIEObjectFifoType>();
       MemRefType elemType = fifo.getElementType().cast<MemRefType>();
       outputSize += (int)elemType.getShape()[0];
-
-      if (elemType.getShape().size() > 1)
-        return emitError("ObjectFifoLinkOp currently only supports objFifos "
-                         "with 1-dimensional memrefs");
     }
     if (outputSize != inputSize)
       return emitError("Total size of output objFifos in ObjectFifoLinkOp must "

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -436,15 +436,6 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
     return emitError("ObjectFifoLinkOp must have a link point, i.e., a "
                      "shared tile between objectFifos");
 
-  if (sharedTile) {
-    auto sharedTileOp = (*sharedTile).getDefiningOp<TileOp>();
-    for (auto user : sharedTileOp.getOperation()->getUsers())
-      if (isa<xilinx::AIE::CoreOp>(user))
-        return user->emitOpError(
-            "currently cannot be created on AIE tile used as "
-            "share point for ObjectFifoLinkOp");
-  }
-
   // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn
   // datatype
   ObjectFifoCreateOp fifoIn = getFifoIn().getDefiningOp<ObjectFifoCreateOp>();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -437,15 +437,18 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
   int inputSize = (int)elemType.getShape()[0];
 
   if (elemType.getShape().size() > 1)
-    return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+    return emitError("ObjectFifoLinkOp currently only supports objFifos with "
+                     "1-dimensional memrefs");
 
   for (auto fifoOut : getFifoOuts()) {
     ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
     if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
-      return emitError("ObjectFifoLinkOp must have a link point, i.e., a shared tile between objectFifos");
+      return emitError("ObjectFifoLinkOp must have a link point, i.e., a "
+                       "shared tile between objectFifos");
   }
 
-  // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn datatype
+  // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn
+  // datatype
   if (getFifoOuts().size() > 1) {
     int outputSize = 0;
     for (auto fifoOut : getFifoOuts()) {
@@ -455,15 +458,16 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
       outputSize += (int)elemType.getShape()[0];
 
       if (elemType.getShape().size() > 1)
-        return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+        return emitError("ObjectFifoLinkOp currently only supports objFifos "
+                         "with 1-dimensional memrefs");
     }
     if (outputSize != inputSize)
-      return emitError("Total size of output objFifos in ObjectFifoLinkOp must be equal to size of input objFifo");
+      return emitError("Total size of output objFifos in ObjectFifoLinkOp must "
+                       "be equal to size of input objFifo");
   }
 
   return success();
 }
-
 
 // ObjectFifoRegisterExternalBuffersOp
 LogicalResult xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::verify() {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -434,14 +434,15 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
   auto sharedTile = getOptionalSharedTile();
   if (!sharedTile)
     return emitError("ObjectFifoLinkOp must have a link point, i.e., a "
-                      "shared tile between objectFifos");
+                     "shared tile between objectFifos");
 
   if (sharedTile) {
-  auto sharedTileOp = (*sharedTile).getDefiningOp<TileOp>();
-  for (auto user : sharedTileOp.getOperation()->getUsers())
-    if (isa<xilinx::AIE::CoreOp>(user))
-      return user->emitOpError("currently cannot be created on AIE tile used as "
-                               "share point for ObjectFifoLinkOp");
+    auto sharedTileOp = (*sharedTile).getDefiningOp<TileOp>();
+    for (auto user : sharedTileOp.getOperation()->getUsers())
+      if (isa<xilinx::AIE::CoreOp>(user))
+        return user->emitOpError(
+            "currently cannot be created on AIE tile used as "
+            "share point for ObjectFifoLinkOp");
   }
 
   // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -429,6 +429,42 @@ xilinx::AIE::TileOp xilinx::AIE::ObjectFifoCreateOp::getProducerTileOp() {
   return cast<xilinx::AIE::TileOp>(getProducerTile().getDefiningOp());
 }
 
+// ObjectFifoLinkOp
+LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
+  ObjectFifoCreateOp fifoIn = getFifoIn().getDefiningOp<ObjectFifoCreateOp>();
+  AIEObjectFifoType fifoType = fifoIn.getType().cast<AIEObjectFifoType>();
+  MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
+  int inputSize = (int)elemType.getShape()[0];
+
+  if (elemType.getShape().size() > 1)
+    return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+
+  for (auto fifoOut : getFifoOuts()) {
+    ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
+    if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
+      return emitError("ObjectFifoLinkOp must have a link point, i.e., a shared tile between objectFifos");
+  }
+
+  // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn datatype
+  if (getFifoOuts().size() > 1) {
+    int outputSize = 0;
+    for (auto fifoOut : getFifoOuts()) {
+      auto op = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
+      AIEObjectFifoType fifo = op.getType().cast<AIEObjectFifoType>();
+      MemRefType elemType = fifo.getElementType().cast<MemRefType>();
+      outputSize += (int)elemType.getShape()[0];
+
+      if (elemType.getShape().size() > 1)
+        return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+    }
+    if (outputSize != inputSize)
+      return emitError("Total size of output objFifos in ObjectFifoLinkOp must be equal to size of input objFifo");
+  }
+
+  return success();
+}
+
+
 // ObjectFifoRegisterExternalBuffersOp
 LogicalResult xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::verify() {
   if (!getTileOp().isShimTile())

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -614,13 +614,6 @@ struct AIEObjectFifoStatefulTransformPass
     if (linkOp) {
       if (objFifoLinks.find(*linkOp) != objFifoLinks.end()) {
         target = objFifoLinks[*linkOp];
-        if (target != op) {
-          AIEObjectFifoType targetFifo =
-              target.getType().cast<AIEObjectFifoType>();
-          MemRefType targetElemType =
-              targetFifo.getElementType().cast<MemRefType>();
-          lenOut = getMemrefTypeSize(targetElemType);
-        }
 
         // find offset based on order of this op in distribute list
         if (linkOp->isDistribute()) {
@@ -640,6 +633,14 @@ struct AIEObjectFifoStatefulTransformPass
               else
                 distribOffset += getMemrefTypeSize(elemType);
             }
+          }
+        } else {
+          if (target != op) {
+            AIEObjectFifoType targetFifo = 
+                target.getType().cast<AIEObjectFifoType>();
+            MemRefType targetElemType = 
+                targetFifo.getElementType().cast<MemRefType>();
+            lenOut = getMemrefTypeSize(targetElemType);
           }
         }
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -611,7 +611,7 @@ struct AIEObjectFifoStatefulTransformPass
               if (fifoOut == op.getFifo())
                 break;
               else
-                distribOffset += (int)elemType.getShape()[0];
+                distribOffset += getMemrefTypeSize(elemType);
             }
           }
         }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -315,11 +315,13 @@ struct AIEObjectFifoStatefulTransformPass
         if (linkOp->getFifoIn() != op)
           return;
       } else {
-        AIEObjectFifoType fifoIn = linkOp->getFifoIn().getType().cast<AIEObjectFifoType>();
+        AIEObjectFifoType fifoIn =
+            linkOp->getFifoIn().getType().cast<AIEObjectFifoType>();
         MemRefType elemInType = fifoIn.getElementType().cast<MemRefType>();
         int inSize = getMemrefTypeSize(elemInType);
 
-        AIEObjectFifoType fifoOut = linkOp->getFifoOuts()[0].getType().cast<AIEObjectFifoType>();
+        AIEObjectFifoType fifoOut =
+            linkOp->getFifoOuts()[0].getType().cast<AIEObjectFifoType>();
         MemRefType elemOutType = fifoOut.getElementType().cast<MemRefType>();
         int outSize = getMemrefTypeSize(elemOutType);
 
@@ -613,8 +615,10 @@ struct AIEObjectFifoStatefulTransformPass
       if (objFifoLinks.find(*linkOp) != objFifoLinks.end()) {
         target = objFifoLinks[*linkOp];
         if (target != op) {
-          AIEObjectFifoType targetFifo = target.getType().cast<AIEObjectFifoType>();
-          MemRefType targetElemType = targetFifo.getElementType().cast<MemRefType>();
+          AIEObjectFifoType targetFifo =
+              target.getType().cast<AIEObjectFifoType>();
+          MemRefType targetElemType =
+              targetFifo.getElementType().cast<MemRefType>();
           lenOut = getMemrefTypeSize(targetElemType);
         }
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -636,9 +636,9 @@ struct AIEObjectFifoStatefulTransformPass
           }
         } else {
           if (target != op) {
-            AIEObjectFifoType targetFifo = 
+            AIEObjectFifoType targetFifo =
                 target.getType().cast<AIEObjectFifoType>();
-            MemRefType targetElemType = 
+            MemRefType targetElemType =
                 targetFifo.getElementType().cast<MemRefType>();
             lenOut = getMemrefTypeSize(targetElemType);
           }

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -82,6 +82,7 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK: }
 
 module @link_AIE1 {

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -1,0 +1,101 @@
+//===- link_test_AIE1.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: May 9th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_AIE1 {
+// CHECK:   AIE.device(xcvc1902) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 2)
+// CHECK:     %2 = AIE.tile(2, 4)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %3 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "link1_lock_0"}
+// CHECK:     %4 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %6 = AIE.lock(%1, 0) {init = 0 : i32, sym_name = "link1_cons_lock_0"}
+// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_lock_1"}
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %8 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %9 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %10 = AIE.lock(%2, 0) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
+// CHECK:     %11 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_lock_1"}
+// CHECK:     %12 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     %13 = AIE.shimDMA(%0) {
+// CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%3, Acquire, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%3, Release, 0)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %14 = AIE.mem(%1) {
+// CHECK:       %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%6, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%7, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%6, Acquire, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 0)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%7, Acquire, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 0)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %15 = AIE.mem(%2) {
+// CHECK:       %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%10, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%10, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%11, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%11, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+module @link_AIE1 {
+    AIE.device(xcvc1902) {
+        %tile20 = AIE.tile(2, 0)
+        %tile22 = AIE.tile(2, 2)
+        %tile24 = AIE.tile(2, 4)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile24}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -86,32 +86,17 @@
 // CHECK: }
 
 module @link_AIE1 {
-    AIE.device(xcve2302) {
-        %0 = AIE.tile(0, 0)
-        %1 = AIE.tile(0, 1)
-        %2 = AIE.tile(0, 2)
+    AIE.device(xcvc1902) {
+        %tile20 = AIE.tile(2, 0)
+        %tile22 = AIE.tile(2, 2)
+        %tile24 = AIE.tile(2, 4)
 
-        %objFifo_in0 = AIE.objectFifo.createObjectFifo(%0, {%1}, 2 : i32) {sym_name = "of0"} : !AIE.objectFifo<memref<512xui8>>
-        %objFifo_in1 = AIE.objectFifo.createObjectFifo(%1, {%2}, 2 : i32) {sym_name = "link0"} : !AIE.objectFifo<memref<128xui8>>
-        AIE.objectFifo.link(%objFifo_in0, {%objFifo_in1}) : (!AIE.objectFifo<memref<512xui8>>, !AIE.objectFifo<memref<128xui8>>)
-        
-        %objFifo_out0 = AIE.objectFifo.createObjectFifo(%1, {%0}, 2 : i32) {sym_name = "of1"} : !AIE.objectFifo<memref<512xui8>>
-        %objFifo_out1 = AIE.objectFifo.createObjectFifo(%2, {%1}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<128xui8>>
-        AIE.objectFifo.link(%objFifo_out1, {%objFifo_out0}) : (!AIE.objectFifo<memref<128xui8>>, !AIE.objectFifo<memref<512xui8>>)
-        
-        %21 = AIE.core(%2) {
-            %c0 = arith.constant 0 : index
-            %c1 = arith.constant 1 : index
-            %c4096 = arith.constant 4096 : index
-            scf.for %arg0 = %c0 to %c4096 step %c1 {
-                %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo_in1 : !AIE.objectFifo<memref<128xui8>>, 1) : !AIE.objectFifoSubview<memref<128xui8>>
-                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<128xui8>> -> memref<128xui8>
-                %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo_out1 : !AIE.objectFifo<memref<128xui8>>, 1) : !AIE.objectFifoSubview<memref<128xui8>>
-                %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<128xui8>> -> memref<128xui8>
-                AIE.objectFifo.release<Consume>(%objFifo_in1 : !AIE.objectFifo<memref<128xui8>>, 1)
-                AIE.objectFifo.release<Produce>(%objFifo_out1 : !AIE.objectFifo<memref<128xui8>>, 1)
-            }
-            AIE.end
-        }
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile24}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -83,8 +83,8 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
-// CHECK: }         
+// CHECK:   AIE.shimDMAAllocation("to_memTile", MM2S, 0, 2)
+// CHECK: }
 
 module @link_AIE2 {
     AIE.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -1,0 +1,103 @@
+//===- link_test_AIE2.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: May 9th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_AIE2 {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %3 = AIE.lock(%0, 0) {init = 1 : i32, sym_name = "to_memTile_prod_lock"}
+// CHECK:     %4 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "to_memTile_cons_lock"}
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_0"} : memref<16xi32>
+// CHECK:     %6 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_1"} : memref<16xi32>
+// CHECK:     %7 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "to_memTile_cons_prod_lock"}
+// CHECK:     %8 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "to_memTile_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %9 = AIE.buffer(%2) {sym_name = "from_memTile_cons_buff_0"} : memref<16xi32>
+// CHECK:     %10 = AIE.buffer(%2) {sym_name = "from_memTile_cons_buff_1"} : memref<16xi32>
+// CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "from_memTile_cons_prod_lock"}
+// CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock"}
+// CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     %14 = AIE.shimDMA(%0) {
+// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%4, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%13 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%3, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %15 = AIE.memTileDMA(%1) {
+// CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %18 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %16 = AIE.mem(%2) {
+// CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
+// CHECK: }         
+
+module @link_AIE2 {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -1,4 +1,4 @@
-//===- link_test_AIE2.mlir ------------------------------------------------*- MLIR -*-===//
+//===- link_test_DDR_to_L1.mlir ------------------------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,7 +12,7 @@
 
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
-// CHECK: module @link_AIE2 {
+// CHECK: module @link_DDR_L1 {
 // CHECK:   AIE.device(xcve2302) {
 // CHECK:     %0 = AIE.tile(2, 0)
 // CHECK:     %1 = AIE.tile(2, 1)
@@ -86,7 +86,7 @@
 // CHECK:   AIE.shimDMAAllocation("to_memTile", MM2S, 0, 2)
 // CHECK: }
 
-module @link_AIE2 {
+module @link_DDR_L1 {
     AIE.device(xcve2302) {
         %tile20 = AIE.tile(2, 0)
         %tile21 = AIE.tile(2, 1)

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -1,0 +1,93 @@
+//===- link_test_L1_to_DDR.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: June 30th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_L1_DDR {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     AIE.flow(%2, DMA : 0, %1, DMA : 0)
+// CHECK:     %3 = AIE.buffer(%2) {sym_name = "to_memTile_buff_0"} : memref<16xi32>
+// CHECK:     %4 = AIE.buffer(%2) {sym_name = "to_memTile_buff_1"} : memref<16xi32>
+// CHECK:     %5 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "to_memTile_prod_lock"}
+// CHECK:     %6 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "to_memTile_cons_lock"}
+// CHECK:     %7 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_0"} : memref<16xi32>
+// CHECK:     %8 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_1"} : memref<16xi32>
+// CHECK:     %9 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "to_memTile_cons_prod_lock"}
+// CHECK:     %10 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "to_memTile_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %0, DMA : 0)
+// CHECK:     %11 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "from_memTile_cons_prod_lock"}
+// CHECK:     %12 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock"}
+// CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     %14 = AIE.mem(%2) {
+// CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%3 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%5, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%5, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %15 = AIE.memTileDMA(%1) {
+// CHECK:       %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%10, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%10, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("from_memTile", S2MM, 0, 2)
+// CHECK: }
+
+module @link_L1_DDR {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -65,7 +65,7 @@
 // CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
-// CHECK: // CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
 // CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 0, 48>, 0)
 // CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb4

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -83,11 +83,11 @@ module @link_L1_DDR {
         %tile22 = AIE.tile(2, 2)
 
         %objFifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<48xi32>>
 
-        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<48xi32>>)
 
-        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<48xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo2 : !AIE.objectFifo<memref<48xi32>>, {%ext_buff_in}) : (memref<48xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -22,16 +22,16 @@
 // CHECK:     %4 = AIE.buffer(%2) {sym_name = "to_memTile_buff_1"} : memref<16xi32>
 // CHECK:     %5 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "to_memTile_prod_lock"}
 // CHECK:     %6 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "to_memTile_cons_lock"}
-// CHECK:     %7 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_0"} : memref<16xi32>
-// CHECK:     %8 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_1"} : memref<16xi32>
-// CHECK:     %9 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "to_memTile_cons_prod_lock"}
-// CHECK:     %10 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "to_memTile_cons_cons_lock"}
 // CHECK:     AIE.flow(%1, DMA : 0, %0, DMA : 0)
-// CHECK:     %11 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "from_memTile_cons_prod_lock"}
+// CHECK:     %7 = AIE.buffer(%1) {sym_name = "from_memTile_buff_0"} : memref<48xi32>
+// CHECK:     %8 = AIE.buffer(%1) {sym_name = "from_memTile_buff_1"} : memref<48xi32>
+// CHECK:     %9 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "from_memTile_prod_lock"}
+// CHECK:     %10 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "from_memTile_cons_lock"}
+// CHECK:     %11 = AIE.lock(%0, 0) {init = 1 : i32, sym_name = "from_memTile_cons_prod_lock"}
 // CHECK:     %12 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock"}
-// CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<48xi32>
 // CHECK:     %14 = AIE.mem(%2) {
-// CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
 // CHECK:       AIE.dmaBd(<%3 : memref<16xi32>, 0, 16>, 0)
@@ -46,30 +46,40 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:     %15 = AIE.memTileDMA(%1) {
-// CHECK:       %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 48>, 0)
 // CHECK:       AIE.useLock(%10, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 0, 48>, 0)
 // CHECK:       AIE.useLock(%10, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
-// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:       %18 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
 // CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 48>, 0)
 // CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
-// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK: // CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 0, 48>, 0)
 // CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb4
 // CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %16 = AIE.shimDMA(%0) {
+// CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%13 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -17,102 +17,123 @@
 // CHECK:     %0 = AIE.tile(2, 0)
 // CHECK:     %1 = AIE.tile(2, 1)
 // CHECK:     %2 = AIE.tile(2, 2)
-// CHECK:     %3 = AIE.tile(2, 3)
+// CHECK:     %3 = AIE.tile(3, 3)
 // CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
-// CHECK:     %4 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
-// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
-// CHECK:     %6 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
-// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     %4 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %5 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     %6 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %7 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %8 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %9 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
 // CHECK:     AIE.flow(%1, DMA : 0, %3, DMA : 0)
 // CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
-// CHECK:     %8 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_0"} : memref<16xi32>
-// CHECK:     %9 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %10 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link2_1_cons_prod_lock"}
-// CHECK:     %11 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock"}
-// CHECK:     %12 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_0"} : memref<16xi32>
-// CHECK:     %13 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_1"} : memref<16xi32>
-// CHECK:     %14 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock"}
-// CHECK:     %15 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock"}
-// CHECK:     %16 = AIE.memTileDMA(%1) {
-// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %10 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %11 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %12 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_2"} : memref<16xi32>
+// CHECK:     %13 = AIE.lock(%3, 0) {init = 3 : i32, sym_name = "link2_1_cons_prod_lock"}
+// CHECK:     %14 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock"}
+// CHECK:     %15 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_0"} : memref<16xi32>
+// CHECK:     %16 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_1"} : memref<16xi32>
+// CHECK:     %17 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock"}
+// CHECK:     %18 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock"}
+// CHECK:     AIE.flow(%2, DMA : 0, %3, DMA : 1)
+// CHECK:     %19 = AIE.buffer(%2) {sym_name = "skip_connection_buff_0"} : memref<16xi32>
+// CHECK:     %20 = AIE.buffer(%2) {sym_name = "skip_connection_buff_1"} : memref<16xi32>
+// CHECK:     %21 = AIE.lock(%2, 2) {init = 2 : i32, sym_name = "skip_connection_prod_lock"}
+// CHECK:     %22 = AIE.lock(%2, 3) {init = 0 : i32, sym_name = "skip_connection_cons_lock"}
+// CHECK:     %23 = AIE.buffer(%3) {sym_name = "skip_connection_cons_buff_0"} : memref<16xi32>
+// CHECK:     %24 = AIE.buffer(%3) {sym_name = "skip_connection_cons_buff_1"} : memref<16xi32>
+// CHECK:     %25 = AIE.lock(%3, 2) {init = 2 : i32, sym_name = "skip_connection_cons_prod_lock"}
+// CHECK:     %26 = AIE.lock(%3, 3) {init = 0 : i32, sym_name = "skip_connection_cons_cons_lock"}
+// CHECK:     %27 = AIE.memTileDMA(%1) {
+// CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
-// CHECK:       %20 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb10)
-// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb9
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       %31 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
 // CHECK:       AIE.nextBd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 64, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %28 = AIE.mem(%2) {
+// CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%15 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%16 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %31 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%22, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%19 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%21, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%22, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%20 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%21, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %29 = AIE.mem(%3) {
+// CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%11 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
+// CHECK:       AIE.nextBd ^bb3
+// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb4:  // pred: ^bb0
+// CHECK:       %31 = AIE.dmaStart(S2MM, 1, ^bb5, ^bb7)
+// CHECK:     ^bb5:  // 2 preds: ^bb4, ^bb6
+// CHECK:       AIE.useLock(%25, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%26, Release, 1)
 // CHECK:       AIE.nextBd ^bb6
 // CHECK:     ^bb6:  // pred: ^bb5
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 128, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb7
-// CHECK:     ^bb7:  // pred: ^bb6
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb8
-// CHECK:     ^bb8:  // pred: ^bb7
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb9
-// CHECK:     ^bb9:  // pred: ^bb8
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 128, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb4
-// CHECK:     ^bb10:  // pred: ^bb3
-// CHECK:       AIE.end
-// CHECK:     }
-// CHECK:     %17 = AIE.mem(%2) {
-// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%15, Release, 1)
-// CHECK:       AIE.nextBd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%13 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%15, Release, 1)
-// CHECK:       AIE.nextBd ^bb1
-// CHECK:     ^bb3:  // pred: ^bb0
-// CHECK:       AIE.end
-// CHECK:     }
-// CHECK:     %18 = AIE.mem(%3) {
-// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%11, Release, 1)
-// CHECK:       AIE.nextBd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%11, Release, 1)
-// CHECK:       AIE.nextBd ^bb1
-// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.useLock(%25, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%24 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%26, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb7:  // pred: ^bb4
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
 // CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
-// CHECK: }                
+// CHECK: }               
 
 module @link_broadcast {
     AIE.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -1,0 +1,131 @@
+//===- link_test_broadcast.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: June 28th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_broadcast {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     %3 = AIE.tile(2, 3)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %4 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %6 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %3, DMA : 0)
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %8 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %9 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %10 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link2_1_cons_prod_lock"}
+// CHECK:     %11 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock"}
+// CHECK:     %12 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_0"} : memref<16xi32>
+// CHECK:     %13 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_1"} : memref<16xi32>
+// CHECK:     %14 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock"}
+// CHECK:     %15 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock"}
+// CHECK:     %16 = AIE.memTileDMA(%1) {
+// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %20 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb10)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb9
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 64, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb6
+// CHECK:     ^bb6:  // pred: ^bb5
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 128, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb7:  // pred: ^bb6
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb8
+// CHECK:     ^bb8:  // pred: ^bb7
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb9
+// CHECK:     ^bb9:  // pred: ^bb8
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 128, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb10:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %17 = AIE.mem(%2) {
+// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%15, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%13 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%15, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %18 = AIE.mem(%3) {
+// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%11, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%11, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
+// CHECK: }                
+
+module @link_broadcast {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+        %tile33 = AIE.tile(3, 3)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<48xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22, %tile33}, [2, 2, 3]) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+
+        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile22, {%tile33}, 2 : i32) {sym_name = "skip_connection"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -61,12 +61,12 @@
 // CHECK:       %31 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
 // CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 48>, 0)
 // CHECK:       AIE.useLock(%8, Release, 1)
 // CHECK:       AIE.nextBd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
 // CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 48>, 0)
 // CHECK:       AIE.useLock(%8, Release, 1)
 // CHECK:       AIE.nextBd ^bb4
 // CHECK:     ^bb6:  // pred: ^bb3

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -166,7 +166,6 @@ module @link_distribute {
         %objFifo3 = AIE.objectFifo.createObjectFifo(%tile21, {%tile23}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<20xi32>>
         %objFifo4 = AIE.objectFifo.createObjectFifo(%tile21, {%tile33}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<12xi32>>
 
-
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)
 

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -1,0 +1,162 @@
+//===- link_test_distribute.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: June 28th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_distribute {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     %3 = AIE.tile(2, 3)
+// CHECK:     %4 = AIE.tile(3, 3)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %6 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %7 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %8 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %9 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %10 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
+// CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 2, %3, DMA : 0)
+// CHECK:     %13 = AIE.buffer(%3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
+// CHECK:     %14 = AIE.buffer(%3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
+// CHECK:     %15 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
+// CHECK:     %16 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 1, %4, DMA : 0)
+// CHECK:     %17 = AIE.buffer(%4) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
+// CHECK:     %18 = AIE.buffer(%4) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
+// CHECK:     %19 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
+// CHECK:     %20 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
+// CHECK:     %21 = AIE.memTileDMA(%1) {
+// CHECK:       %25 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %26 = AIE.dmaStart(MM2S, 1, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       %27 = AIE.dmaStart(MM2S, 2, ^bb7, ^bb9)
+// CHECK:     ^bb7:  // 2 preds: ^bb6, ^bb8
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb8
+// CHECK:     ^bb8:  // pred: ^bb7
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb9:  // pred: ^bb6
+// CHECK:       %28 = AIE.dmaStart(S2MM, 0, ^bb10, ^bb12)
+// CHECK:     ^bb10:  // 2 preds: ^bb9, ^bb11
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb11
+// CHECK:     ^bb11:  // pred: ^bb10
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb10
+// CHECK:     ^bb12:  // pred: ^bb9
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %22 = AIE.mem(%2) {
+// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %23 = AIE.mem(%4) {
+// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%17 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%18 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %24 = AIE.mem(%3) {
+// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%13 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%14 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
+// CHECK: }
+               
+module @link_distribute {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+        %tile23 = AIE.tile(2, 3)
+        %tile33 = AIE.tile(3, 3)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<48xi32>>
+
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile21, {%tile23}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<20xi32>>
+        %objFifo4 = AIE.objectFifo.createObjectFifo(%tile21, {%tile33}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<12xi32>>
+
+
+        %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2, %objFifo3, %objFifo4}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -20,117 +20,130 @@
 // CHECK:     %3 = AIE.tile(2, 3)
 // CHECK:     %4 = AIE.tile(3, 3)
 // CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
-// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
-// CHECK:     %6 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
-// CHECK:     %7 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
-// CHECK:     %8 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     %5 = AIE.lock(%0, 0) {init = 1 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %6 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     %7 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %8 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %9 = AIE.lock(%1, 0) {init = 6 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %10 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
 // CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
-// CHECK:     %9 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
-// CHECK:     %10 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
-// CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
-// CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
-// CHECK:     AIE.flow(%1, DMA : 2, %3, DMA : 0)
-// CHECK:     %13 = AIE.buffer(%3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
-// CHECK:     %14 = AIE.buffer(%3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
-// CHECK:     %15 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
-// CHECK:     %16 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
-// CHECK:     AIE.flow(%1, DMA : 1, %4, DMA : 0)
-// CHECK:     %17 = AIE.buffer(%4) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
-// CHECK:     %18 = AIE.buffer(%4) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
-// CHECK:     %19 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
-// CHECK:     %20 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
-// CHECK:     %21 = AIE.memTileDMA(%1) {
-// CHECK:       %25 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     %11 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %12 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %13 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
+// CHECK:     %14 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 1, %3, DMA : 0)
+// CHECK:     %15 = AIE.buffer(%3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
+// CHECK:     %16 = AIE.buffer(%3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
+// CHECK:     %17 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
+// CHECK:     %18 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 2, %4, DMA : 0)
+// CHECK:     %19 = AIE.buffer(%4) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
+// CHECK:     %20 = AIE.buffer(%4) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
+// CHECK:     %21 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
+// CHECK:     %22 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
+// CHECK:     %23 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<48xi32>
+// CHECK:     %24 = AIE.shimDMA(%0) {
+// CHECK:       %29 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%5, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %25 = AIE.memTileDMA(%1) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 3)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%10, Release, 3)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 3)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%10, Release, 3)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
-// CHECK:       %26 = AIE.dmaStart(MM2S, 1, ^bb4, ^bb6)
+// CHECK:       %30 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
 // CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 144, 12>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 144, 12>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb4
 // CHECK:     ^bb6:  // pred: ^bb3
-// CHECK:       %27 = AIE.dmaStart(MM2S, 2, ^bb7, ^bb9)
+// CHECK:       %31 = AIE.dmaStart(MM2S, 1, ^bb7, ^bb9)
 // CHECK:     ^bb7:  // 2 preds: ^bb6, ^bb8
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 20>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb8
 // CHECK:     ^bb8:  // pred: ^bb7
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 64, 20>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb7
 // CHECK:     ^bb9:  // pred: ^bb6
-// CHECK:       %28 = AIE.dmaStart(S2MM, 0, ^bb10, ^bb12)
+// CHECK:       %32 = AIE.dmaStart(MM2S, 2, ^bb10, ^bb12)
 // CHECK:     ^bb10:  // 2 preds: ^bb9, ^bb11
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb11
 // CHECK:     ^bb11:  // pred: ^bb10
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb10
 // CHECK:     ^bb12:  // pred: ^bb9
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     %22 = AIE.mem(%2) {
-// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %26 = AIE.mem(%2) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%11 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     %23 = AIE.mem(%4) {
-// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %27 = AIE.mem(%3) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%17 : memref<12xi32>, 0, 12>, 0)
-// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%15 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%18 : memref<12xi32>, 0, 12>, 0)
-// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%16 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     %24 = AIE.mem(%3) {
-// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %28 = AIE.mem(%4) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%13 : memref<20xi32>, 0, 20>, 0)
-// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.useLock(%21, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%19 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%22, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%14 : memref<20xi32>, 0, 20>, 0)
-// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.useLock(%21, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%20 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%22, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
@@ -138,7 +151,7 @@
 // CHECK:   }
 // CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK: }
-               
+     
 module @link_distribute {
     AIE.device(xcve2302) {
         %tile20 = AIE.tile(2, 0)


### PR DESCRIPTION
This PR introduces a new objectFifo operation, LinkOp, that serves as a hint to the lowering pass in case there is memory reuse between the input and output channels of a DMA. Additionally, this operation can also be used in combination with MemTiles to hint that the MemTileDMA is doing a distribute of the input data on one channel to many output channels, or a broadcast from one input objectFifo to many output objectFifos.

This PR also contains a fix for an error in the objectFifo lowering pass which caused the DMA operations to be generated in a non-deterministic order.