### PR TITLE
Remove redundant clone of Xilinx/cmakeModules.git in the CI

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -44,11 +44,6 @@ jobs:
           key: ${{ runner.os }}-clangreleaseasserts-${{ steps.get-submodule-hash.outputs.hash }}
           max-size: 1G
 
-      - name: Get cmakeModules
-        id: clone-cmakeModules
-        run: git clone --depth 1 https://github.com/Xilinx/cmakeModules.git
-        shell: bash
-
       - name: Get LLVM
         id: clone-llvm
         run: utils/clone-llvm.sh

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -64,9 +64,9 @@ jobs:
             -DAIE_LINKER=NONE \
             -DHOST_COMPILER=NONE \
             -DLLVM_ENABLE_ASSERTIONS=ON \
-            -DCMAKE_MODULE_PATH=`pwd`/../cmakeModules \
-            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
-            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DCMAKE_MODULE_PATH=`pwd`/../cmake/modulesXilinx \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm \
             -DCMAKE_LINKER=lld \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \
@@ -90,9 +90,9 @@ jobs:
             -DAIE_LINKER=NONE \
             -DHOST_COMPILER=NONE \
             -DLLVM_ENABLE_ASSERTIONS=OFF \
-            -DCMAKE_MODULE_PATH=../cmakeModules \
-            -DMLIR_DIR=../llvm/install/lib/cmake/mlir/ \
-            -DLLVM_DIR=../llvm/install/lib/cmake/llvm/ \
+            -DCMAKE_MODULE_PATH=`pwd`/../cmake/modulesXilinx \
+            -DMLIR_DIR=../llvm/install/lib/cmake/mlir \
+            -DLLVM_DIR=../llvm/install/lib/cmake/llvm \
             -DCMAKE_LINKER=lld \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \


### PR DESCRIPTION
This is now a submodule in cmake/modulesXilinx.
But first, this PR is to check that this is really the case and does not break the CI.