### PR TITLE
Join pattern with ObjectFifoLinkOp

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1372,13 +1372,8 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", []> {
   }];
 }
 
-<<<<<<< HEAD
 def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> {
-  let summary = "Links two objectFifos through an intermediary tile's dma";
-=======
-def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
   let summary = "Links two objectFifos through an intermediary tile's DMA";
->>>>>>> 4f6b2e55f03e754feffcbf7f639dc22a7cba4319
   let description = [{
     The "aie.objectFifo.link" operation allows to mark two objectFifos as linked. This implies that the two objectFifos form
     one dataflow movement which is split accross multiple objectFifos. Specifically, during the objectFifo lowering there will
@@ -1391,11 +1386,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
     ```
       %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) {sym_name = "of0"} : !AIE.objectFifo<memref<64xi16>>
       %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) {sym_name = "of1"} : !AIE.objectFifo<memref<64xi16>>
-<<<<<<< HEAD
       AIE.objectFifo.link({%of_t70_t72}, {%of_t72_t74}) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
-=======
-      AIE.objectFifo.link(%of_t70_t72, {%of_t72_t74}) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
->>>>>>> 4f6b2e55f03e754feffcbf7f639dc22a7cba4319
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 
@@ -1403,7 +1394,6 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
     To achieve a distribute pattern from the link tile, there should be multiple output objectFifos in the LinkOp. In this case,
     parts will be taken out of the input objectFifo's buffers based on the sizes of the output objectFifos, in the order they 
     were given in the LinkOp.
-<<<<<<< HEAD
     The join pattern is the exact inverse of the distribute one.
   }];
 
@@ -1414,34 +1404,15 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    attr-dict `(` `{` $fifoIns `}` `,` `{` $fifoOuts `}` `)` `:` `(` type($fifoIns) `,` type($fifoOuts) `)`
-=======
-  }];
-
-  let arguments = (
-    ins AIE_ObjectFifoType:$fifoIn,
-        Variadic<AIE_ObjectFifoType>:$fifoOuts
-  );
-
-  let assemblyFormat = [{
-    attr-dict `(` $fifoIn `,` `{` $fifoOuts `}` `)` `:` `(` type($fifoIn) `,` type($fifoOuts) `)`
->>>>>>> 4f6b2e55f03e754feffcbf7f639dc22a7cba4319
+    `(` `{` $fifoIns `}` `,` `{` $fifoOuts `}` `)` attr-dict `:` `(` `{` type($fifoIns) `}` `,` `{` type($fifoOuts) `}` `)`
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-<<<<<<< HEAD
     bool isJoin() {
       return getFifoIns().size() > 1;
     }
-    bool isDistribute() {
-      return getFifoOuts().size() > 1;
-    }
-  }];
-}
-
-=======
     bool isDistribute() {
       return getFifoOuts().size() > 1;
     }
@@ -1449,8 +1420,6 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
   }];
 }
 
-
->>>>>>> 4f6b2e55f03e754feffcbf7f639dc22a7cba4319
 def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [TileElement, IsShimNOCTile]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";
   let description = [{

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1384,9 +1384,9 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
 
     Example:
     ```
-      %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) : !AIE.objectFifo<memref<64xi16>>
-      %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link(%of_t70_t72, %of_t72_t74) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
+      %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) {sym_name = "of0"} : !AIE.objectFifo<memref<64xi16>>
+      %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) {sym_name = "of1"} : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo.link(%of_t70_t72, {%of_t72_t74}) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1386,7 +1386,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> 
     ```
       %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) {sym_name = "of0"} : !AIE.objectFifo<memref<64xi16>>
       %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) {sym_name = "of1"} : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link({%of_t70_t72}, {%of_t72_t74}) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
+      AIE.objectFifo.link({%of_t70_t72}, {%of_t72_t74}) : ({!AIE.objectFifo<memref<64xi16>>}, {!AIE.objectFifo<memref<64xi16>>})
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1372,7 +1372,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", []> {
   }];
 }
 
-def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
+def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> {
   let summary = "Links two objectFifos through an intermediary tile's dma";
   let description = [{
     The "aie.objectFifo.link" operation allows to mark two objectFifos as linked. This implies that the two objectFifos form
@@ -1386,7 +1386,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
     ```
       %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) {sym_name = "of0"} : !AIE.objectFifo<memref<64xi16>>
       %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) {sym_name = "of1"} : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link(%of_t70_t72, {%of_t72_t74}) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
+      AIE.objectFifo.link({%of_t70_t72}, {%of_t72_t74}) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 
@@ -1394,26 +1394,30 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
     To achieve a distribute pattern from the link tile, there should be multiple output objectFifos in the LinkOp. In this case,
     parts will be taken out of the input objectFifo's buffers based on the sizes of the output objectFifos, in the order they 
     were given in the LinkOp.
+    The join pattern is the exact inverse of the distribute one.
   }];
 
   let arguments = (
-    ins AIE_ObjectFifoType:$fifoIn,
+    ins Variadic<AIE_ObjectFifoType>:$fifoIns,
         Variadic<AIE_ObjectFifoType>:$fifoOuts
   );
+  let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    attr-dict `(` $fifoIn `,` `{` $fifoOuts `}` `)` `:` `(` type($fifoIn) `,` type($fifoOuts) `)`
+    attr-dict `(` `{` $fifoIns `}` `,` `{` $fifoOuts `}` `)` `:` `(` type($fifoIns) `,` type($fifoOuts) `)`
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+    bool isJoin() {
+      return getFifoIns().size() > 1;
+    }
     bool isDistribute() {
       return getFifoOuts().size() > 1;
     }
   }];
 }
-
 
 def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [TileElement, IsShimNOCTile]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1372,6 +1372,49 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", []> {
   }];
 }
 
+def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", []> {
+  let summary = "Links two objectFifos through an intermediary tile's dma";
+  let description = [{
+    The "aie.objectFifo.link" operation allows to mark two objectFifos as linked. This implies that the two objectFifos form
+    one dataflow movement which is split accross multiple objectFifos. Specifically, during the objectFifo lowering there will
+    be less memory elements generated at the link point as the two objectFifos can share.
+
+    The two objectFifos which are linked must have a link point (i.e., a shared AIE tile).
+    In L1, only objectFifos of same size may be linked. In L2, different sized objectFifos can be linked.
+
+    Example:
+    ```
+      %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, {%t72}, 2) : !AIE.objectFifo<memref<64xi16>>
+      %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, {%t74}, 2) : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo.link(%of_t70_t72, %of_t72_t74) : (!AIE.objectFifo<memref<64xi16>>, !AIE.objectFifo<memref<64xi16>>)
+    ```
+    This operation links two objectFifos which have tile %t72 as a link point.
+
+    To achieve a broadcast pattern through the link tile, the output objectFifo should have a list of all the consumers tiles.
+    To achieve a distribute pattern from the link tile, there should be multiple output objectFifos in the LinkOp. In this case,
+    parts will be taken out of the input objectFifo's buffers based on the sizes of the output objectFifos, in the order they 
+    were given in the LinkOp.
+  }];
+
+  let arguments = (
+    ins AIE_ObjectFifoType:$fifoIn,
+        Variadic<AIE_ObjectFifoType>:$fifoOuts
+  );
+
+  let assemblyFormat = [{
+    attr-dict `(` $fifoIn `,` `{` $fifoOuts `}` `)` `:` `(` type($fifoIn) `,` type($fifoOuts) `)`
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    bool isDistribute() {
+      return getFifoOuts().size() > 1;
+    }
+  }];
+}
+
+
 def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [TileElement, IsShimNOCTile]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";
   let description = [{

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -437,15 +437,18 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
   int inputSize = (int)elemType.getShape()[0];
 
   if (elemType.getShape().size() > 1)
-    return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+    return emitError("ObjectFifoLinkOp currently only supports objFifos with "
+                     "1-dimensional memrefs");
 
   for (auto fifoOut : getFifoOuts()) {
     ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
     if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
-      return emitError("ObjectFifoLinkOp must have a link point, i.e., a shared tile between objectFifos");
+      return emitError("ObjectFifoLinkOp must have a link point, i.e., a "
+                       "shared tile between objectFifos");
   }
 
-  // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn datatype
+  // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn
+  // datatype
   if (getFifoOuts().size() > 1) {
     int outputSize = 0;
     for (auto fifoOut : getFifoOuts()) {
@@ -455,15 +458,16 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
       outputSize += (int)elemType.getShape()[0];
 
       if (elemType.getShape().size() > 1)
-        return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+        return emitError("ObjectFifoLinkOp currently only supports objFifos "
+                         "with 1-dimensional memrefs");
     }
     if (outputSize != inputSize)
-      return emitError("Total size of output objFifos in ObjectFifoLinkOp must be equal to size of input objFifo");
+      return emitError("Total size of output objFifos in ObjectFifoLinkOp must "
+                       "be equal to size of input objFifo");
   }
 
   return success();
 }
-
 
 // ObjectFifoRegisterExternalBuffersOp
 LogicalResult xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::verify() {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -432,15 +432,17 @@ xilinx::AIE::TileOp xilinx::AIE::ObjectFifoCreateOp::getProducerTileOp() {
 // ObjectFifoLinkOp
 LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
   if (isJoin() && isDistribute())
-    return emitError("ObjectFifoLinkOp does not support 'join' and 'distribute' at the same time");
-  
+    return emitError("ObjectFifoLinkOp does not support 'join' and "
+                     "'distribute' at the same time");
+
   auto sharedTile = getOptionalSharedTile();
   if (!sharedTile)
     return emitError("ObjectFifoLinkOp must have a link point, i.e., a "
                      "shared tile between objectFifos");
 
   if (isJoin()) {
-    ObjectFifoCreateOp fifoOut = getFifoOuts()[0].getDefiningOp<ObjectFifoCreateOp>();
+    ObjectFifoCreateOp fifoOut =
+        getFifoOuts()[0].getDefiningOp<ObjectFifoCreateOp>();
     AIEObjectFifoType fifoType = fifoOut.getType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
     int outputSize = (int)elemType.getShape()[0];
@@ -457,7 +459,8 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
                        "be equal to size of output objFifo");
 
   } else if (isDistribute()) {
-    ObjectFifoCreateOp fifoIn = getFifoIns()[0].getDefiningOp<ObjectFifoCreateOp>();
+    ObjectFifoCreateOp fifoIn =
+        getFifoIns()[0].getDefiningOp<ObjectFifoCreateOp>();
     AIEObjectFifoType fifoType = fifoIn.getType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
     int inputSize = (int)elemType.getShape()[0];
@@ -488,7 +491,8 @@ std::optional<Value> xilinx::AIE::ObjectFifoLinkOp::getOptionalSharedTile() {
   } else {
     auto fifoIn = getFifoIns()[0].getDefiningOp<ObjectFifoCreateOp>();
     for (auto fifoOut : getFifoOuts()) {
-      ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
+      ObjectFifoCreateOp fifoOutOp =
+          fifoOut.getDefiningOp<ObjectFifoCreateOp>();
       if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
         return {};
     }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -431,9 +431,13 @@ xilinx::AIE::TileOp xilinx::AIE::ObjectFifoCreateOp::getProducerTileOp() {
 
 // ObjectFifoLinkOp
 LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
-<<<<<<< HEAD
   if (isJoin() && isDistribute())
     return emitError("ObjectFifoLinkOp does not support 'join' and 'distribute' at the same time");
+  
+  auto sharedTile = getOptionalSharedTile();
+  if (!sharedTile)
+    return emitError("ObjectFifoLinkOp must have a link point, i.e., a "
+                     "shared tile between objectFifos");
 
   if (isJoin()) {
     ObjectFifoCreateOp fifoOut = getFifoOuts()[0].getDefiningOp<ObjectFifoCreateOp>();
@@ -441,70 +445,23 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
     MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
     int outputSize = (int)elemType.getShape()[0];
 
-    if (elemType.getShape().size() > 1)
-      return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
-
     int inputSize = 0;
     for (auto fifoIn : getFifoIns()) {
-      ObjectFifoCreateOp fifoInOp = fifoIn.getDefiningOp<ObjectFifoCreateOp>();
-      AIEObjectFifoType fifoType = fifoInOp.getType().cast<AIEObjectFifoType>();
-      MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
+      auto op = fifoIn.getDefiningOp<ObjectFifoCreateOp>();
+      AIEObjectFifoType fifo = op.getType().cast<AIEObjectFifoType>();
+      MemRefType elemType = fifo.getElementType().cast<MemRefType>();
       inputSize += (int)elemType.getShape()[0];
-
-      if (fifoOut.getConsumerTiles()[0] != fifoInOp.getProducerTile())
-        return emitError("ObjectFifoLinkOp must have a link point, i.e., a shared tile between objectFifos");
     }
-    // if size of fifoIns > 1, check that the sum of their datatypes = fifoOut datatype
     if (inputSize != outputSize)
-      return emitError("Total size of input objFifos in ObjectFifoLinkOp must be equal to size of output objFifo");
+      return emitError("Total size of input objFifos in ObjectFifoLinkOp must "
+                       "be equal to size of output objFifo");
+
   } else if (isDistribute()) {
     ObjectFifoCreateOp fifoIn = getFifoIns()[0].getDefiningOp<ObjectFifoCreateOp>();
     AIEObjectFifoType fifoType = fifoIn.getType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
     int inputSize = (int)elemType.getShape()[0];
 
-    if (elemType.getShape().size() > 1)
-      return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
-    
-    int outputSize = 0;
-    for (auto fifoOut : getFifoOuts()) {
-      ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
-      AIEObjectFifoType fifoType = fifoOutOp.getType().cast<AIEObjectFifoType>();
-      MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
-      outputSize += (int)elemType.getShape()[0];
-
-      if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
-        return emitError("ObjectFifoLinkOp must have a link point, i.e., a shared tile between objectFifos");
-    }
-    // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn datatype
-    if (outputSize != inputSize)
-      return emitError("Total size of output objFifos in ObjectFifoLinkOp must be equal to size of input objFifo");
-  } else {
-    ObjectFifoCreateOp fifoIn = getFifoIns()[0].getDefiningOp<ObjectFifoCreateOp>();
-    AIEObjectFifoType fifoInType = fifoIn.getType().cast<AIEObjectFifoType>();
-    MemRefType elemInType = fifoInType.getElementType().cast<MemRefType>();
-
-    ObjectFifoCreateOp fifoOut = getFifoOuts()[0].getDefiningOp<ObjectFifoCreateOp>();
-    AIEObjectFifoType fifoOutType = fifoOut.getType().cast<AIEObjectFifoType>();
-    MemRefType elemOutType = fifoOutType.getElementType().cast<MemRefType>();
-
-    if ((elemInType.getShape().size() > 1) || (elemOutType.getShape().size() > 1))
-      return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
-    if (fifoIn.getConsumerTiles()[0] != fifoOut.getProducerTile())
-        return emitError("ObjectFifoLinkOp must have a link point, i.e., a shared tile between objectFifos");
-=======
-  auto sharedTile = getOptionalSharedTile();
-  if (!sharedTile)
-    return emitError("ObjectFifoLinkOp must have a link point, i.e., a "
-                     "shared tile between objectFifos");
-
-  // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn
-  // datatype
-  ObjectFifoCreateOp fifoIn = getFifoIn().getDefiningOp<ObjectFifoCreateOp>();
-  AIEObjectFifoType fifoType = fifoIn.getType().cast<AIEObjectFifoType>();
-  MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
-  int inputSize = (int)elemType.getShape()[0];
-  if (getFifoOuts().size() > 1) {
     int outputSize = 0;
     for (auto fifoOut : getFifoOuts()) {
       auto op = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
@@ -515,23 +472,30 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
     if (outputSize != inputSize)
       return emitError("Total size of output objFifos in ObjectFifoLinkOp must "
                        "be equal to size of input objFifo");
->>>>>>> 4f6b2e55f03e754feffcbf7f639dc22a7cba4319
   }
 
   return success();
 }
-<<<<<<< HEAD
-=======
 std::optional<Value> xilinx::AIE::ObjectFifoLinkOp::getOptionalSharedTile() {
-  ObjectFifoCreateOp fifoIn = getFifoIn().getDefiningOp<ObjectFifoCreateOp>();
-  for (auto fifoOut : getFifoOuts()) {
-    ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
-    if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
-      return {};
+  if (isJoin()) {
+    auto fifoOut = getFifoOuts()[0].getDefiningOp<ObjectFifoCreateOp>();
+    for (auto fifoIn : getFifoIns()) {
+      ObjectFifoCreateOp fifoInOp = fifoIn.getDefiningOp<ObjectFifoCreateOp>();
+      if (fifoOut.getProducerTile() != fifoInOp.getConsumerTiles()[0])
+        return {};
+    }
+    return {fifoOut.getProducerTile()};
+  } else {
+    auto fifoIn = getFifoIns()[0].getDefiningOp<ObjectFifoCreateOp>();
+    for (auto fifoOut : getFifoOuts()) {
+      ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
+      if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
+        return {};
+    }
+    return {fifoIn.getConsumerTiles()[0]};
   }
-  return {fifoIn.getConsumerTiles()[0]};
+  return {};
 }
->>>>>>> 4f6b2e55f03e754feffcbf7f639dc22a7cba4319
 
 // ObjectFifoRegisterExternalBuffersOp
 LogicalResult xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::verify() {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -429,6 +429,42 @@ xilinx::AIE::TileOp xilinx::AIE::ObjectFifoCreateOp::getProducerTileOp() {
   return cast<xilinx::AIE::TileOp>(getProducerTile().getDefiningOp());
 }
 
+// ObjectFifoLinkOp
+LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
+  ObjectFifoCreateOp fifoIn = getFifoIn().getDefiningOp<ObjectFifoCreateOp>();
+  AIEObjectFifoType fifoType = fifoIn.getType().cast<AIEObjectFifoType>();
+  MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
+  int inputSize = (int)elemType.getShape()[0];
+
+  if (elemType.getShape().size() > 1)
+    return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+
+  for (auto fifoOut : getFifoOuts()) {
+    ObjectFifoCreateOp fifoOutOp = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
+    if (fifoIn.getConsumerTiles()[0] != fifoOutOp.getProducerTile())
+      return emitError("ObjectFifoLinkOp must have a link point, i.e., a shared tile between objectFifos");
+  }
+
+  // if size of fifoOuts > 1, check that the sum of their datatypes = fifoIn datatype
+  if (getFifoOuts().size() > 1) {
+    int outputSize = 0;
+    for (auto fifoOut : getFifoOuts()) {
+      auto op = fifoOut.getDefiningOp<ObjectFifoCreateOp>();
+      AIEObjectFifoType fifo = op.getType().cast<AIEObjectFifoType>();
+      MemRefType elemType = fifo.getElementType().cast<MemRefType>();
+      outputSize += (int)elemType.getShape()[0];
+
+      if (elemType.getShape().size() > 1)
+        return emitError("ObjectFifoLinkOp currently only supports objFifos with 1-dimensional memrefs");
+    }
+    if (outputSize != inputSize)
+      return emitError("Total size of output objFifos in ObjectFifoLinkOp must be equal to size of input objFifo");
+  }
+
+  return success();
+}
+
+
 // ObjectFifoRegisterExternalBuffersOp
 LogicalResult xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::verify() {
   if (!getTileOp().isShimTile())

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -307,7 +307,8 @@ struct AIEObjectFifoStatefulTransformPass
     bool linked = false;
     auto linkOp = getOptionalLinkOp(op);
     if (linkOp) {
-      auto fifoOut = linkOp->getFifoOuts()[0].getDefiningOp<ObjectFifoCreateOp>();
+      auto fifoOut =
+          linkOp->getFifoOuts()[0].getDefiningOp<ObjectFifoCreateOp>();
       auto fifoIn = linkOp->getFifoIns()[0].getDefiningOp<ObjectFifoCreateOp>();
       linked = true;
       if (objFifoLinks.find(*linkOp) != objFifoLinks.end())
@@ -328,7 +329,8 @@ struct AIEObjectFifoStatefulTransformPass
 
         AIEObjectFifoType fifoOutType =
             linkOp->getFifoOuts()[0].getType().cast<AIEObjectFifoType>();
-        MemRefType elemOutType = fifoOutType.getElementType().cast<MemRefType>();
+        MemRefType elemOutType =
+            fifoOutType.getElementType().cast<MemRefType>();
         int outSize = getMemrefTypeSize(elemOutType);
 
         if (inSize >= outSize) {
@@ -631,11 +633,13 @@ struct AIEObjectFifoStatefulTransformPass
           } else {
             for (auto fifoIn : linkOp->getFifoIns()) {
               auto createOp = fifoIn.getDefiningOp<ObjectFifoCreateOp>();
-              AIEObjectFifoType fifoType = createOp.getType().cast<AIEObjectFifoType>();
-              MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
-              if (fifoIn == op.getFifo()) 
+              AIEObjectFifoType fifoType =
+                  createOp.getType().cast<AIEObjectFifoType>();
+              MemRefType elemType =
+                  fifoType.getElementType().cast<MemRefType>();
+              if (fifoIn == op.getFifo())
                 break;
-              else 
+              else
                 extraOffset += (int)elemType.getShape()[0];
             }
           }
@@ -654,7 +658,7 @@ struct AIEObjectFifoStatefulTransformPass
                   fifoType.getElementType().cast<MemRefType>();
               if (fifoOut == op.getFifo())
                 break;
-              else 
+              else
                 extraOffset += (int)elemType.getShape()[0];
             }
           }
@@ -1192,7 +1196,7 @@ struct AIEObjectFifoStatefulTransformPass
         if (linkOp)
           for (auto fifoIn : linkOp->getFifoIns()) {
             if (fifoIn == createOp.getFifo())
-              linkOp->getOperation()->replaceUsesOfWith(createOp.getFifo(), 
+              linkOp->getOperation()->replaceUsesOfWith(createOp.getFifo(),
                                                         consumerFifo.getFifo());
           }
       }

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -82,6 +82,7 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK: }
 
 module @link_AIE1 {

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -1,0 +1,101 @@
+//===- link_test_AIE1.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: May 9th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_AIE1 {
+// CHECK:   AIE.device(xcvc1902) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 2)
+// CHECK:     %2 = AIE.tile(2, 4)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %3 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "link1_lock_0"}
+// CHECK:     %4 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %6 = AIE.lock(%1, 0) {init = 0 : i32, sym_name = "link1_cons_lock_0"}
+// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_lock_1"}
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %8 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %9 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %10 = AIE.lock(%2, 0) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
+// CHECK:     %11 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_lock_1"}
+// CHECK:     %12 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     %13 = AIE.shimDMA(%0) {
+// CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%3, Acquire, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%3, Release, 0)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %14 = AIE.mem(%1) {
+// CHECK:       %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%6, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%7, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%6, Acquire, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 0)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%7, Acquire, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 0)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %15 = AIE.mem(%2) {
+// CHECK:       %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%10, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%10, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%11, Acquire, 0)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%11, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+module @link_AIE1 {
+    AIE.device(xcvc1902) {
+        %tile20 = AIE.tile(2, 0)
+        %tile22 = AIE.tile(2, 2)
+        %tile24 = AIE.tile(2, 4)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile24}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -94,7 +94,7 @@ module @link_AIE1 {
         %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<16xi32>>
         %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile24}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -94,7 +94,7 @@ module @link_AIE1 {
         %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<16xi32>>
         %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile24}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -83,8 +83,8 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
-// CHECK: }         
+// CHECK:   AIE.shimDMAAllocation("to_memTile", MM2S, 0, 2)
+// CHECK: }
 
 module @link_AIE2 {
     AIE.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -1,0 +1,103 @@
+//===- link_test_AIE2.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: May 9th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_AIE2 {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %3 = AIE.lock(%0, 0) {init = 1 : i32, sym_name = "to_memTile_prod_lock"}
+// CHECK:     %4 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "to_memTile_cons_lock"}
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_0"} : memref<16xi32>
+// CHECK:     %6 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_1"} : memref<16xi32>
+// CHECK:     %7 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "to_memTile_cons_prod_lock"}
+// CHECK:     %8 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "to_memTile_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %9 = AIE.buffer(%2) {sym_name = "from_memTile_cons_buff_0"} : memref<16xi32>
+// CHECK:     %10 = AIE.buffer(%2) {sym_name = "from_memTile_cons_buff_1"} : memref<16xi32>
+// CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "from_memTile_cons_prod_lock"}
+// CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock"}
+// CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     %14 = AIE.shimDMA(%0) {
+// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%4, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%13 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%3, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %15 = AIE.memTileDMA(%1) {
+// CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %18 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %16 = AIE.mem(%2) {
+// CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
+// CHECK: }         
+
+module @link_AIE2 {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -95,7 +95,7 @@ module @link_DDR_L1 {
         %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
         %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -95,7 +95,7 @@ module @link_DDR_L1 {
         %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
         %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -1,4 +1,4 @@
-//===- link_test_AIE2.mlir ------------------------------------------------*- MLIR -*-===//
+//===- link_test_DDR_to_L1.mlir ------------------------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,7 +12,7 @@
 
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
-// CHECK: module @link_AIE2 {
+// CHECK: module @link_DDR_L1 {
 // CHECK:   AIE.device(xcve2302) {
 // CHECK:     %0 = AIE.tile(2, 0)
 // CHECK:     %1 = AIE.tile(2, 1)
@@ -86,7 +86,7 @@
 // CHECK:   AIE.shimDMAAllocation("to_memTile", MM2S, 0, 2)
 // CHECK: }
 
-module @link_AIE2 {
+module @link_DDR_L1 {
     AIE.device(xcve2302) {
         %tile20 = AIE.tile(2, 0)
         %tile21 = AIE.tile(2, 1)

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -1,0 +1,93 @@
+//===- link_test_L1_to_DDR.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: June 30th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_L1_DDR {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     AIE.flow(%2, DMA : 0, %1, DMA : 0)
+// CHECK:     %3 = AIE.buffer(%2) {sym_name = "to_memTile_buff_0"} : memref<16xi32>
+// CHECK:     %4 = AIE.buffer(%2) {sym_name = "to_memTile_buff_1"} : memref<16xi32>
+// CHECK:     %5 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "to_memTile_prod_lock"}
+// CHECK:     %6 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "to_memTile_cons_lock"}
+// CHECK:     %7 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_0"} : memref<16xi32>
+// CHECK:     %8 = AIE.buffer(%1) {sym_name = "to_memTile_cons_buff_1"} : memref<16xi32>
+// CHECK:     %9 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "to_memTile_cons_prod_lock"}
+// CHECK:     %10 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "to_memTile_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %0, DMA : 0)
+// CHECK:     %11 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "from_memTile_cons_prod_lock"}
+// CHECK:     %12 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock"}
+// CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     %14 = AIE.mem(%2) {
+// CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%3 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%5, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%5, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %15 = AIE.memTileDMA(%1) {
+// CHECK:       %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%10, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%10, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("from_memTile", S2MM, 0, 2)
+// CHECK: }
+
+module @link_L1_DDR {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -85,7 +85,7 @@ module @link_L1_DDR {
         %objFifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
         %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<16xi32>>,)
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -95,7 +95,7 @@ module @link_L1_DDR {
         %objFifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
         %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<48xi32>>
 
-        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<48xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<48xi32>>})
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<48xi32> 
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo2 : !AIE.objectFifo<memref<48xi32>>, {%ext_buff_in}) : (memref<48xi32>)

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -17,102 +17,123 @@
 // CHECK:     %0 = AIE.tile(2, 0)
 // CHECK:     %1 = AIE.tile(2, 1)
 // CHECK:     %2 = AIE.tile(2, 2)
-// CHECK:     %3 = AIE.tile(2, 3)
+// CHECK:     %3 = AIE.tile(3, 3)
 // CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
-// CHECK:     %4 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
-// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
-// CHECK:     %6 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
-// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     %4 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %5 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     %6 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %7 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %8 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %9 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
 // CHECK:     AIE.flow(%1, DMA : 0, %3, DMA : 0)
 // CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
-// CHECK:     %8 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_0"} : memref<16xi32>
-// CHECK:     %9 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %10 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link2_1_cons_prod_lock"}
-// CHECK:     %11 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock"}
-// CHECK:     %12 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_0"} : memref<16xi32>
-// CHECK:     %13 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_1"} : memref<16xi32>
-// CHECK:     %14 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock"}
-// CHECK:     %15 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock"}
-// CHECK:     %16 = AIE.memTileDMA(%1) {
-// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %10 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %11 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %12 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_2"} : memref<16xi32>
+// CHECK:     %13 = AIE.lock(%3, 0) {init = 3 : i32, sym_name = "link2_1_cons_prod_lock"}
+// CHECK:     %14 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock"}
+// CHECK:     %15 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_0"} : memref<16xi32>
+// CHECK:     %16 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_1"} : memref<16xi32>
+// CHECK:     %17 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock"}
+// CHECK:     %18 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock"}
+// CHECK:     AIE.flow(%2, DMA : 0, %3, DMA : 1)
+// CHECK:     %19 = AIE.buffer(%2) {sym_name = "skip_connection_buff_0"} : memref<16xi32>
+// CHECK:     %20 = AIE.buffer(%2) {sym_name = "skip_connection_buff_1"} : memref<16xi32>
+// CHECK:     %21 = AIE.lock(%2, 2) {init = 2 : i32, sym_name = "skip_connection_prod_lock"}
+// CHECK:     %22 = AIE.lock(%2, 3) {init = 0 : i32, sym_name = "skip_connection_cons_lock"}
+// CHECK:     %23 = AIE.buffer(%3) {sym_name = "skip_connection_cons_buff_0"} : memref<16xi32>
+// CHECK:     %24 = AIE.buffer(%3) {sym_name = "skip_connection_cons_buff_1"} : memref<16xi32>
+// CHECK:     %25 = AIE.lock(%3, 2) {init = 2 : i32, sym_name = "skip_connection_cons_prod_lock"}
+// CHECK:     %26 = AIE.lock(%3, 3) {init = 0 : i32, sym_name = "skip_connection_cons_cons_lock"}
+// CHECK:     %27 = AIE.memTileDMA(%1) {
+// CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
-// CHECK:       %20 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb10)
-// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb9
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       %31 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
 // CHECK:       AIE.nextBd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 64, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %28 = AIE.mem(%2) {
+// CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%15 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%16 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %31 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%22, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%19 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%21, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%22, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%20 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%21, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %29 = AIE.mem(%3) {
+// CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%11 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
+// CHECK:       AIE.nextBd ^bb3
+// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb4:  // pred: ^bb0
+// CHECK:       %31 = AIE.dmaStart(S2MM, 1, ^bb5, ^bb7)
+// CHECK:     ^bb5:  // 2 preds: ^bb4, ^bb6
+// CHECK:       AIE.useLock(%25, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%26, Release, 1)
 // CHECK:       AIE.nextBd ^bb6
 // CHECK:     ^bb6:  // pred: ^bb5
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 128, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb7
-// CHECK:     ^bb7:  // pred: ^bb6
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb8
-// CHECK:     ^bb8:  // pred: ^bb7
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb9
-// CHECK:     ^bb9:  // pred: ^bb8
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 128, 16>, 0)
-// CHECK:       AIE.useLock(%6, Release, 1)
-// CHECK:       AIE.nextBd ^bb4
-// CHECK:     ^bb10:  // pred: ^bb3
-// CHECK:       AIE.end
-// CHECK:     }
-// CHECK:     %17 = AIE.mem(%2) {
-// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%15, Release, 1)
-// CHECK:       AIE.nextBd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%13 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%15, Release, 1)
-// CHECK:       AIE.nextBd ^bb1
-// CHECK:     ^bb3:  // pred: ^bb0
-// CHECK:       AIE.end
-// CHECK:     }
-// CHECK:     %18 = AIE.mem(%3) {
-// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%11, Release, 1)
-// CHECK:       AIE.nextBd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%11, Release, 1)
-// CHECK:       AIE.nextBd ^bb1
-// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.useLock(%25, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%24 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%26, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb7:  // pred: ^bb4
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
 // CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
-// CHECK: }                
+// CHECK: }               
 
 module @link_broadcast {
     AIE.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -147,6 +147,6 @@ module @link_broadcast {
 
         %objFifo3 = AIE.objectFifo.createObjectFifo(%tile22, {%tile33}, 2 : i32) {sym_name = "skip_connection"} : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<48xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -1,0 +1,131 @@
+//===- link_test_broadcast.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: June 28th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_broadcast {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     %3 = AIE.tile(2, 3)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %4 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %6 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %3, DMA : 0)
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %8 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %9 = AIE.buffer(%3) {sym_name = "link2_1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %10 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link2_1_cons_prod_lock"}
+// CHECK:     %11 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock"}
+// CHECK:     %12 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_0"} : memref<16xi32>
+// CHECK:     %13 = AIE.buffer(%2) {sym_name = "link2_0_cons_buff_1"} : memref<16xi32>
+// CHECK:     %14 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock"}
+// CHECK:     %15 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock"}
+// CHECK:     %16 = AIE.memTileDMA(%1) {
+// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %20 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb10)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb9
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 64, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb6
+// CHECK:     ^bb6:  // pred: ^bb5
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%4 : memref<48xi32>, 128, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb7:  // pred: ^bb6
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb8
+// CHECK:     ^bb8:  // pred: ^bb7
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb9
+// CHECK:     ^bb9:  // pred: ^bb8
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 128, 16>, 0)
+// CHECK:       AIE.useLock(%6, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb10:  // pred: ^bb3
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %17 = AIE.mem(%2) {
+// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%15, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%14, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%13 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%15, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %18 = AIE.mem(%3) {
+// CHECK:       %19 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%11, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%11, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
+// CHECK: }                
+
+module @link_broadcast {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+        %tile33 = AIE.tile(3, 3)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<48xi32>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22, %tile33}, [2, 2, 3]) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+
+        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile22, {%tile33}, 2 : i32) {sym_name = "skip_connection"} : !AIE.objectFifo<memref<16xi32>>
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -147,6 +147,6 @@ module @link_broadcast {
 
         %objFifo3 = AIE.objectFifo.createObjectFifo(%tile22, {%tile33}, 2 : i32) {sym_name = "skip_connection"} : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link(%objFifo, {%objFifo2}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -166,7 +166,6 @@ module @link_distribute {
         %objFifo3 = AIE.objectFifo.createObjectFifo(%tile21, {%tile23}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<20xi32>>
         %objFifo4 = AIE.objectFifo.createObjectFifo(%tile21, {%tile33}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<12xi32>>
 
-
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)
 

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -1,0 +1,162 @@
+//===- link_test_distribute.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: June 28th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_distribute {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(2, 2)
+// CHECK:     %3 = AIE.tile(2, 3)
+// CHECK:     %4 = AIE.tile(3, 3)
+// CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %6 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %7 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %8 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
+// CHECK:     %9 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %10 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
+// CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 2, %3, DMA : 0)
+// CHECK:     %13 = AIE.buffer(%3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
+// CHECK:     %14 = AIE.buffer(%3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
+// CHECK:     %15 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
+// CHECK:     %16 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 1, %4, DMA : 0)
+// CHECK:     %17 = AIE.buffer(%4) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
+// CHECK:     %18 = AIE.buffer(%4) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
+// CHECK:     %19 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
+// CHECK:     %20 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
+// CHECK:     %21 = AIE.memTileDMA(%1) {
+// CHECK:       %25 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %26 = AIE.dmaStart(MM2S, 1, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       %27 = AIE.dmaStart(MM2S, 2, ^bb7, ^bb9)
+// CHECK:     ^bb7:  // 2 preds: ^bb6, ^bb8
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb8
+// CHECK:     ^bb8:  // pred: ^bb7
+// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb9:  // pred: ^bb6
+// CHECK:       %28 = AIE.dmaStart(S2MM, 0, ^bb10, ^bb12)
+// CHECK:     ^bb10:  // 2 preds: ^bb9, ^bb11
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb11
+// CHECK:     ^bb11:  // pred: ^bb10
+// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb10
+// CHECK:     ^bb12:  // pred: ^bb9
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %22 = AIE.mem(%2) {
+// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %23 = AIE.mem(%4) {
+// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%17 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%18 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %24 = AIE.mem(%3) {
+// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%13 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%14 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
+// CHECK: }
+               
+module @link_distribute {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+        %tile23 = AIE.tile(2, 3)
+        %tile33 = AIE.tile(3, 3)
+
+        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<48xi32>>
+
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile21, {%tile23}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<20xi32>>
+        %objFifo4 = AIE.objectFifo.createObjectFifo(%tile21, {%tile33}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<12xi32>>
+
+
+        %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)
+
+        AIE.objectFifo.link(%objFifo, {%objFifo2, %objFifo3, %objFifo4}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>)
+    }
+}

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -20,117 +20,130 @@
 // CHECK:     %3 = AIE.tile(2, 3)
 // CHECK:     %4 = AIE.tile(3, 3)
 // CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
-// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
-// CHECK:     %6 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
-// CHECK:     %7 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
-// CHECK:     %8 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     %5 = AIE.lock(%0, 0) {init = 1 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %6 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     %7 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %8 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %9 = AIE.lock(%1, 0) {init = 6 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %10 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
 // CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
-// CHECK:     %9 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
-// CHECK:     %10 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
-// CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
-// CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
-// CHECK:     AIE.flow(%1, DMA : 2, %3, DMA : 0)
-// CHECK:     %13 = AIE.buffer(%3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
-// CHECK:     %14 = AIE.buffer(%3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
-// CHECK:     %15 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
-// CHECK:     %16 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
-// CHECK:     AIE.flow(%1, DMA : 1, %4, DMA : 0)
-// CHECK:     %17 = AIE.buffer(%4) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
-// CHECK:     %18 = AIE.buffer(%4) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
-// CHECK:     %19 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
-// CHECK:     %20 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
-// CHECK:     %21 = AIE.memTileDMA(%1) {
-// CHECK:       %25 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     %11 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %12 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %13 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
+// CHECK:     %14 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 1, %3, DMA : 0)
+// CHECK:     %15 = AIE.buffer(%3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
+// CHECK:     %16 = AIE.buffer(%3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
+// CHECK:     %17 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
+// CHECK:     %18 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 2, %4, DMA : 0)
+// CHECK:     %19 = AIE.buffer(%4) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
+// CHECK:     %20 = AIE.buffer(%4) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
+// CHECK:     %21 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
+// CHECK:     %22 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
+// CHECK:     %23 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<48xi32>
+// CHECK:     %24 = AIE.shimDMA(%0) {
+// CHECK:       %29 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%6, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%5, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %25 = AIE.memTileDMA(%1) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 3)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%10, Release, 3)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 3)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 0, 48>, 0)
+// CHECK:       AIE.useLock(%10, Release, 3)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
-// CHECK:       %26 = AIE.dmaStart(MM2S, 1, ^bb4, ^bb6)
+// CHECK:       %30 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb6)
 // CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 144, 12>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 144, 12>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb4
 // CHECK:     ^bb6:  // pred: ^bb3
-// CHECK:       %27 = AIE.dmaStart(MM2S, 2, ^bb7, ^bb9)
+// CHECK:       %31 = AIE.dmaStart(MM2S, 1, ^bb7, ^bb9)
 // CHECK:     ^bb7:  // 2 preds: ^bb6, ^bb8
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 64, 20>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb8
 // CHECK:     ^bb8:  // pred: ^bb7
-// CHECK:       AIE.useLock(%8, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 64, 20>, 0)
-// CHECK:       AIE.useLock(%7, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 64, 20>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb7
 // CHECK:     ^bb9:  // pred: ^bb6
-// CHECK:       %28 = AIE.dmaStart(S2MM, 0, ^bb10, ^bb12)
+// CHECK:       %32 = AIE.dmaStart(MM2S, 2, ^bb10, ^bb12)
 // CHECK:     ^bb10:  // 2 preds: ^bb9, ^bb11
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%5 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb11
 // CHECK:     ^bb11:  // pred: ^bb10
-// CHECK:       AIE.useLock(%7, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%6 : memref<48xi32>, 0, 48>, 0)
-// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.useLock(%10, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%8 : memref<48xi32>, 144, 12>, 0)
+// CHECK:       AIE.useLock(%9, Release, 1)
 // CHECK:       AIE.nextBd ^bb10
 // CHECK:     ^bb12:  // pred: ^bb9
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     %22 = AIE.mem(%2) {
-// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %26 = AIE.mem(%2) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%9 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%11 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%11, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%10 : memref<16xi32>, 0, 16>, 0)
-// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%12 : memref<16xi32>, 0, 16>, 0)
+// CHECK:       AIE.useLock(%14, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     %23 = AIE.mem(%4) {
-// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %27 = AIE.mem(%3) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%17 : memref<12xi32>, 0, 12>, 0)
-// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%15 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%19, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%18 : memref<12xi32>, 0, 12>, 0)
-// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%16 : memref<20xi32>, 0, 20>, 0)
+// CHECK:       AIE.useLock(%18, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     %24 = AIE.mem(%3) {
-// CHECK:       %25 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     %28 = AIE.mem(%4) {
+// CHECK:       %29 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
-// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%13 : memref<20xi32>, 0, 20>, 0)
-// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.useLock(%21, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%19 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%22, Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       AIE.useLock(%15, AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%14 : memref<20xi32>, 0, 20>, 0)
-// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.useLock(%21, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%20 : memref<12xi32>, 0, 12>, 0)
+// CHECK:       AIE.useLock(%22, Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
@@ -138,7 +151,7 @@
 // CHECK:   }
 // CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK: }
-               
+     
 module @link_distribute {
     AIE.device(xcve2302) {
         %tile20 = AIE.tile(2, 0)

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -169,6 +169,6 @@ module @link_distribute {
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2, %objFifo3, %objFifo4}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2, %objFifo3, %objFifo4}) : ({!AIE.objectFifo<memref<48xi32>>}, {!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>})
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -169,6 +169,6 @@ module @link_distribute {
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)
 
-        AIE.objectFifo.link(%objFifo, {%objFifo2, %objFifo3, %objFifo4}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>)
+        AIE.objectFifo.link({%objFifo}, {%objFifo2, %objFifo3, %objFifo4}) : (!AIE.objectFifo<memref<48xi32>>, !AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -13,6 +13,177 @@
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
 // CHECK: module @link_join {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %0 = AIE.tile(2, 0)
+// CHECK:     %1 = AIE.tile(2, 1)
+// CHECK:     %2 = AIE.tile(1, 2)
+// CHECK:     %3 = AIE.tile(2, 2)
+// CHECK:     %4 = AIE.tile(2, 3)
+// CHECK:     %5 = AIE.tile(3, 3)
+// CHECK:     AIE.flow(%2, DMA : 0, %1, DMA : 0)
+// CHECK:     %6 = AIE.buffer(%2) {sym_name = "link1_buff_0"} : memref<128xi8>
+// CHECK:     %7 = AIE.buffer(%2) {sym_name = "link1_buff_1"} : memref<128xi8>
+// CHECK:     %8 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %9 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     AIE.flow(%3, DMA : 0, %1, DMA : 1)
+// CHECK:     %10 = AIE.buffer(%3) {sym_name = "link2_buff_0"} : memref<128xi8>
+// CHECK:     %11 = AIE.buffer(%3) {sym_name = "link2_buff_1"} : memref<128xi8>
+// CHECK:     %12 = AIE.lock(%3, 0) {init = 2 : i32, sym_name = "link2_prod_lock"}
+// CHECK:     %13 = AIE.lock(%3, 1) {init = 0 : i32, sym_name = "link2_cons_lock"}
+// CHECK:     AIE.flow(%4, DMA : 0, %1, DMA : 2)
+// CHECK:     %14 = AIE.buffer(%4) {sym_name = "link3_buff_0"} : memref<128xi8>
+// CHECK:     %15 = AIE.buffer(%4) {sym_name = "link3_buff_1"} : memref<128xi8>
+// CHECK:     %16 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link3_prod_lock"}
+// CHECK:     %17 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link3_cons_lock"}
+// CHECK:     AIE.flow(%5, DMA : 0, %1, DMA : 3)
+// CHECK:     %18 = AIE.buffer(%5) {sym_name = "link4_buff_0"} : memref<128xi8>
+// CHECK:     %19 = AIE.buffer(%5) {sym_name = "link4_buff_1"} : memref<128xi8>
+// CHECK:     %20 = AIE.lock(%5, 0) {init = 2 : i32, sym_name = "link4_prod_lock"}
+// CHECK:     %21 = AIE.lock(%5, 1) {init = 0 : i32, sym_name = "link4_cons_lock"}
+// CHECK:     AIE.flow(%1, DMA : 0, %0, DMA : 0)
+// CHECK:     %22 = AIE.buffer(%1) {sym_name = "link5_buff_0"} : memref<512xi8>
+// CHECK:     %23 = AIE.buffer(%1) {sym_name = "link5_buff_1"} : memref<512xi8>
+// CHECK:     %24 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "link5_prod_lock"}
+// CHECK:     %25 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link5_cons_lock"}
+// CHECK:     %26 = AIE.lock(%0, 0) {init = 1 : i32, sym_name = "link5_cons_prod_lock"}
+// CHECK:     %27 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "link5_cons_cons_lock"}
+// CHECK:     %28 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<512xi8>
+// CHECK:     %29 = AIE.mem(%2) {
+// CHECK:       %35 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%6 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%9, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%7 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%8, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %30 = AIE.memTileDMA(%1) {
+// CHECK:       %35 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%22 : memref<512xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<512xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       %36 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb6)
+// CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%22 : memref<512xi8>, 128, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb5
+// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<512xi8>, 128, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb6:  // pred: ^bb3
+// CHECK:       %37 = AIE.dmaStart(S2MM, 2, ^bb7, ^bb9)
+// CHECK:     ^bb7:  // 2 preds: ^bb6, ^bb8
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%22 : memref<512xi8>, 256, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb8
+// CHECK:     ^bb8:  // pred: ^bb7
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<512xi8>, 256, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb9:  // pred: ^bb6
+// CHECK:       %38 = AIE.dmaStart(S2MM, 3, ^bb10, ^bb12)
+// CHECK:     ^bb10:  // 2 preds: ^bb9, ^bb11
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%22 : memref<512xi8>, 384, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb11
+// CHECK:     ^bb11:  // pred: ^bb10
+// CHECK:       AIE.useLock(%24, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%23 : memref<512xi8>, 384, 128>, 0)
+// CHECK:       AIE.useLock(%25, Release, 1)
+// CHECK:       AIE.nextBd ^bb10
+// CHECK:     ^bb12:  // pred: ^bb9
+// CHECK:       %39 = AIE.dmaStart(MM2S, 0, ^bb13, ^bb15)
+// CHECK:     ^bb13:  // 2 preds: ^bb12, ^bb14
+// CHECK:       AIE.useLock(%25, AcquireGreaterEqual, 4)
+// CHECK:       AIE.dmaBd(<%22 : memref<512xi8>, 0, 512>, 0)
+// CHECK:       AIE.useLock(%24, Release, 4)
+// CHECK:       AIE.nextBd ^bb14
+// CHECK:     ^bb14:  // pred: ^bb13
+// CHECK:       AIE.useLock(%25, AcquireGreaterEqual, 4)
+// CHECK:       AIE.dmaBd(<%23 : memref<512xi8>, 0, 512>, 0)
+// CHECK:       AIE.useLock(%24, Release, 4)
+// CHECK:       AIE.nextBd ^bb13
+// CHECK:     ^bb15:  // pred: ^bb12
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %31 = AIE.mem(%3) {
+// CHECK:       %35 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%10 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%13, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%11 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%12, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %32 = AIE.mem(%4) {
+// CHECK:       %35 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%14 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%17, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%15 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%16, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %33 = AIE.mem(%5) {
+// CHECK:       %35 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%21, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%18 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%21, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%19 : memref<128xi8>, 0, 128>, 0)
+// CHECK:       AIE.useLock(%20, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %34 = AIE.shimDMA(%0) {
+// CHECK:       %35 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
+// CHECK:       AIE.useLock(%26, AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%28 : memref<512xi8>, 0, 512>, 0)
+// CHECK:       AIE.useLock(%27, Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK:   AIE.shimDMAAllocation("link5", S2MM, 0, 2)
+// CHECK: }
      
 module @link_join {
     AIE.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -18,20 +18,21 @@ module @link_join {
     AIE.device(xcve2302) {
         %tile20 = AIE.tile(2, 0)
         %tile21 = AIE.tile(2, 1)
+        %tile12 = AIE.tile(1, 2)
         %tile22 = AIE.tile(2, 2)
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        %objFifo1 = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<128xi8>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile23, {%tile21}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<128xi8>>
-        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile33, {%tile21}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<128xi8>>
-        %objFifo4 = AIE.objectFifo.createObjectFifo(%tile33, {%tile21}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<128xi8>>
+        %objFifo1 = AIE.objectFifo.createObjectFifo(%tile12, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<128xi8>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<128xi8>>
+        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile23, {%tile21}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<128xi8>>
+        %objFifo4 = AIE.objectFifo.createObjectFifo(%tile33, {%tile21}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<128xi8>>
 
-        %objFifoOut = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<512xi8>>
+        %objFifoOut = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "link5"} : !AIE.objectFifo<memref<512xi8>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<512xi8>>, {%ext_buffer_in}) : (memref<512xi8>)
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifoOut : !AIE.objectFifo<memref<512xi8>>, {%ext_buffer_in}) : (memref<512xi8>)
 
-        AIE.objectFifo.link({%objFifo1, %objFifo2, %objFifo3, %objFifo4}, {%objFifoOut}) : (!AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<512xi8>>)
+        AIE.objectFifo.link({%objFifo1, %objFifo2, %objFifo3, %objFifo4}, {%objFifoOut}) : ({!AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>}, {!AIE.objectFifo<memref<512xi8>>})
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -1,0 +1,37 @@
+//===- link_test_join.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: June 30th 2023
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @link_join {
+     
+module @link_join {
+    AIE.device(xcve2302) {
+        %tile20 = AIE.tile(2, 0)
+        %tile21 = AIE.tile(2, 1)
+        %tile22 = AIE.tile(2, 2)
+        %tile23 = AIE.tile(2, 3)
+        %tile33 = AIE.tile(3, 3)
+
+        %objFifo1 = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<128xi8>>
+        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile23, {%tile21}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<128xi8>>
+        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile33, {%tile21}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<128xi8>>
+        %objFifo4 = AIE.objectFifo.createObjectFifo(%tile33, {%tile21}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<128xi8>>
+
+        %objFifoOut = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<512xi8>>
+
+        %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<512xi8>>, {%ext_buffer_in}) : (memref<512xi8>)
+
+        AIE.objectFifo.link({%objFifo1, %objFifo2, %objFifo3, %objFifo4}, {%objFifoOut}) : (!AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<512xi8>>)
+    }
+}


### PR DESCRIPTION
This PR extends the ObjectFifoLinkOp with a list of input objectFifos that can be joined together from multiple input channels inside a sharedTile and output on a single outgoing channel.