### PR TITLE
Make cmake export libxaie path to air

### DIFF
--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -27,11 +27,11 @@ set(AIE_CONFIG_INCLUDE_DIRS
 set(AIE_CONFIG_EXPORTS_FILE "\${AIE_CMAKE_DIR}/AIETargets.cmake")
 set(AIE_CONFIG_LibXAIE_x86_64_DIR)
 if ("x86_64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_x86_64_DIR "${PROJECT_BINARY_DIR}/runtime_lib/x86_64/xaiengine")
+  set(AIE_CONFIG_LibXAIE_x86_64_DIR "${LibXAIE_x86_64_DIR}")
 endif()
 set(AIE_CONFIG_LibXAIE_aarch64_DIR)
 if ("aarch64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_aarch64_DIR "${PROJECT_BINARY_DIR}/runtime_lib/aarch64/xaiengine")
+  set(AIE_CONFIG_LibXAIE_aarch64_DIR "${LibXAIE_aarch64_DIR}")
 endif()
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/AIEConfig.cmake.in
@@ -62,14 +62,6 @@ set(AIE_CONFIG_INCLUDE_DIRS
   "\${AIE_INSTALL_PREFIX}/include"
   )
 set(AIE_CONFIG_EXPORTS_FILE "\${AIE_CMAKE_DIR}/AIETargets.cmake")
-set(AIE_CONFIG_LibXAIE_x86_64_DIR)
-if ("x86_64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_x86_64_DIR "\${AIE_INSTALL_PREFIX}/runtime_lib/x86_64/xaiengine")
-endif()
-set(AIE_CONFIG_LibXAIE_aarch64_DIR)
-if ("aarch64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_aarch64_DIR "\${AIE_INSTALL_PREFIX}/runtime_lib/aarch64/xaiengine")
-endif()
 
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/AIEConfig.cmake.in

--- a/runtime_lib/CMakeLists.txt
+++ b/runtime_lib/CMakeLists.txt
@@ -110,4 +110,9 @@ foreach(target ${AIE_RUNTIME_TARGETS})
       TEST_EXCLUDE_FROM_MAIN true
     )
   endif()
+
+  # Export newly built libxaie
+  if (NOT DEFINED LibXAIE_${target}_DIR)
+    set(LibXAIE_${target}_DIR ${CMAKE_CURRENT_BINARY_DIR}/${target}/xaiengine PARENT_SCOPE)
+  endif()
 endforeach()


### PR DESCRIPTION
- Support both scenarios below:
-- (i) libxaie is user defined
-- (ii) libxaie is built from vitis