### PR TITLE
add "memory_allocator.h" target to cmake

### DIFF
--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -46,6 +46,7 @@ install(FILES test_library.cpp DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/$
 set(xaienginePath ${VITIS_AIETOOLS_DIR}/include/drivers/aiengine)
 # Memory Allocator
 add_library(memory_allocator_ion STATIC memory_allocator_ion.cpp)
+set_target_properties(memory_allocator_ion PROPERTIES PUBLIC_HEADER "memory_allocator.h")
 find_program(UNAME_EXEC uname)
 execute_process(COMMAND ${UNAME_EXEC} -r OUTPUT_VARIABLE KERNEL_RELEASE OUTPUT_STRIP_TRAILING_WHITESPACE)
 find_path(LINUX_HEADERS_PATH NAMES "linux/dma-buf.h" PATHS "/usr/src/kernels/${KERNEL_RELEASE}/include" REQUIRED)
@@ -55,6 +56,7 @@ target_compile_definitions(memory_allocator_ion PRIVATE)
 
 install(TARGETS memory_allocator_ion
     ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/lib
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/include
 )
 
 if (VITIS_ROOT)


### PR DESCRIPTION
The "libmemory_allocator" library is successfully compiled and installed in the MLIR AIE install directory, but  the corresponding header is not added to the install 'include' directory.

This commit fixes that, thus allowing to use data movement via external buffers into the shim tiles from the host.