### PR TITLE
Make shimDMAAllocation have DeviceOp as parent

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1279,7 +1279,7 @@ def AIE_PutCascadeOp: AIE_Op<"putCascade", [HasParent<"CoreOp">]> {
   let assemblyFormat = [{ `(` $cascadeValue `:` type($cascadeValue) `)` attr-dict }];
 }
 
-def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"ModuleOp">]> {
+def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">]> {
   let summary = "Runtime allocation information for a single shim DMA";
   let description = [{
     This op exists for cases where shimDMA configuration is performed outside of MLIR-AIE 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -1108,7 +1108,7 @@ struct AIEObjectFifoStatefulTransformPass
   }
 
   /// Function used to generate, from an objectFifo with a shimTile endpoint, a
-  /// shimDMAAllocationInfoOp containing the channelDir, channelIndex and
+  /// shimDMAAllocationOp containing the channelDir, channelIndex and
   /// shimTile col assigned by the objectFifo lowering.
   void createObjectFifoAllocationInfo(OpBuilder &builder, MLIRContext *ctx,
                                       StringRef name, int colIndex,
@@ -1240,7 +1240,7 @@ struct AIEObjectFifoStatefulTransformPass
       createDMA(device, builder, producer, producerChan.first,
                 producerChan.second, 0);
       // generate objectFifo allocation info
-      builder.setInsertionPointAfter(device);
+      builder.setInsertionPoint(&device.getBody()->back());
       if (producer.getProducerTileOp().isShimTile())
         createObjectFifoAllocationInfo(builder, ctx,
                                        producer.name()->getValue(),
@@ -1254,7 +1254,7 @@ struct AIEObjectFifoStatefulTransformPass
         createDMA(device, builder, consumer, consumerChan.first,
                   consumerChan.second, 1);
         // generate objectFifo allocation info
-        builder.setInsertionPointAfter(device);
+        builder.setInsertionPoint(&device.getBody()->back());
         if (consumer.getProducerTileOp().isShimTile())
           createObjectFifoAllocationInfo(
               builder, ctx, producer.name()->getValue(),

--- a/test/Targets/AIEGenerateJSON/shim_alloc.mlir
+++ b/test/Targets/AIEGenerateJSON/shim_alloc.mlir
@@ -36,8 +36,10 @@
 // CHECK: }
 
 module @alloc {
-  AIE.shimDMAAllocation("of_out_1", S2MM, 1, 2)
-  AIE.shimDMAAllocation("of_in_1", MM2S, 1, 2)
-  AIE.shimDMAAllocation("of_out_0", S2MM, 0, 2)
-  AIE.shimDMAAllocation("of_in_0", MM2S, 0, 2)
+  AIE.device(xcve2302) {
+    AIE.shimDMAAllocation("of_out_1", S2MM, 1, 2)
+    AIE.shimDMAAllocation("of_in_1", MM2S, 1, 2)
+    AIE.shimDMAAllocation("of_out_0", S2MM, 0, 2)
+    AIE.shimDMAAllocation("of_in_0", MM2S, 0, 2)
+  }
 }

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -21,11 +21,11 @@
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
+// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:   AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
 // CHECK: }
 
 module @alloc {

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -29,6 +29,7 @@
 // CHECK:     %10 = AIE.lock(%2, 0) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
 // CHECK:     %11 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_lock_1"}
 // CHECK:     %12 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK:     %13 = AIE.shimDMA(%0) {
 // CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -82,7 +83,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK: }
 
 module @link_AIE1 {

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -30,6 +30,7 @@
 // CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "from_memTile_cons_prod_lock"}
 // CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock"}
 // CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
+// CHECK:     AIE.shimDMAAllocation("to_memTile", MM2S, 0, 2)
 // CHECK:     %14 = AIE.shimDMA(%0) {
 // CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -83,7 +84,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("to_memTile", MM2S, 0, 2)
 // CHECK: }
 
 module @link_DDR_L1 {

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -72,6 +72,7 @@
 // CHECK:     ^bb6:  // pred: ^bb3
 // CHECK:       AIE.end
 // CHECK:     }
+// CHECK:     AIE.shimDMAAllocation("from_memTile", S2MM, 0, 2)
 // CHECK:     %16 = AIE.shimDMA(%0) {
 // CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -83,7 +84,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("from_memTile", S2MM, 0, 2)
 // CHECK: }
 
 module @link_L1_DDR {

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -45,6 +45,7 @@
 // CHECK:     %24 = AIE.buffer(%3) {sym_name = "skip_connection_cons_buff_1"} : memref<16xi32>
 // CHECK:     %25 = AIE.lock(%3, 2) {init = 2 : i32, sym_name = "skip_connection_cons_prod_lock"}
 // CHECK:     %26 = AIE.lock(%3, 3) {init = 0 : i32, sym_name = "skip_connection_cons_cons_lock"}
+// CHECK:     AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK:     %27 = AIE.memTileDMA(%1) {
 // CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
@@ -132,7 +133,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK: }               
 
 module @link_broadcast {

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -42,6 +42,7 @@
 // CHECK:     %21 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
 // CHECK:     %22 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
 // CHECK:     %23 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<48xi32>
+// CHECK:     AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK:     %24 = AIE.shimDMA(%0) {
 // CHECK:       %29 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -149,7 +150,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("link1", MM2S, 0, 2)
 // CHECK: }
      
 module @link_distribute {

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -171,6 +171,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
 // CHECK:     }
+// CHECK:     AIE.shimDMAAllocation("link5", S2MM, 0, 2)
 // CHECK:     %34 = AIE.shimDMA(%0) {
 // CHECK:       %35 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -182,7 +183,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("link5", S2MM, 0, 2)
 // CHECK: }
      
 module @link_join {

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -39,6 +39,7 @@
 // CHECK:       AIE.useLock(%6, Release, 0)
 // CHECK:       AIE.end
 // CHECK:     }
+// CHECK:     AIE.shimDMAAllocation("ext_of", MM2S, 0, 7)
 // CHECK:     %11 = AIE.shimDMA(%1) {
 // CHECK:       %13 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -70,7 +71,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("ext_of", MM2S, 0, 7)
 // CHECK: }
 
 module @register_external_buffers {

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -39,6 +39,7 @@
 // CHECK:       AIE.useLock(%6, Release, 0)
 // CHECK:       AIE.end
 // CHECK:     }
+// CHECK:     AIE.shimDMAAllocation("objfifo", MM2S, 0, 7)
 // CHECK:     %11 = AIE.shimDMA(%1) {
 // CHECK:       %13 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -70,7 +71,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("objfifo", MM2S, 0, 7)
 // CHECK: }
 
 module @shimRow_mem {

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -32,6 +32,7 @@
 // CHECK:     %13 = AIE.lock(%1, 3) {init = 0 : i32, sym_name = "of_out_cons_cons_lock"}
 // CHECK:     %14 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>
 // CHECK:     %15 = AIE.external_buffer {sym_name = "ext_buffer_out"} : memref<64xi32>
+// CHECK:     AIE.shimDMAAllocation("of_in", MM2S, 0, 2)
 // CHECK:     %16 = AIE.shimDMA(%1) {
 // CHECK:       %18 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -49,6 +50,7 @@
 // CHECK:     ^bb4:  // pred: ^bb2
 // CHECK:       AIE.end
 // CHECK:     }
+// CHECK:     AIE.shimDMAAllocation("of_out", S2MM, 0, 2)
 // CHECK:     %17 = AIE.mem(%0) {
 // CHECK:       %18 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
@@ -77,8 +79,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("of_out", S2MM, 0, 2)
-// CHECK:   AIE.shimDMAAllocation("of_in", MM2S, 0, 2)
 // CHECK: }
 
 module @shim_AIE2 {

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -36,6 +36,7 @@
 // CHECK:     %16 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "of_in_0_cons_prod_lock"}
 // CHECK:     %17 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "of_in_0_cons_cons_lock"}
 // CHECK:     %18 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>
+// CHECK:     AIE.shimDMAAllocation("of_in", MM2S, 0, 2)
 // CHECK:     %19 = AIE.shimDMA(%0) {
 // CHECK:       %23 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -92,7 +93,6 @@
 // CHECK:       AIE.end
 // CHECK:     }
 // CHECK:   }
-// CHECK:   AIE.shimDMAAllocation("of_in", MM2S, 0, 2)
 // CHECK: }
 
 module @shim_broadcast {


### PR DESCRIPTION
The allocation information should be inside the `AIE.device` op it refers to, so `AIE.device` should be the required parent, not `module`.