### PR TITLE
POC for Buffer Descriptor Analysis

### DIFF
--- a/include/aie/Analysis/BufferDescriptorAnalysis.h
+++ b/include/aie/Analysis/BufferDescriptorAnalysis.h
@@ -1,0 +1,90 @@
+//===- BufferDescriptorAnalysis.h -----------------------------------------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_AIE_ANALYSIS_BUFFERDESCRIPTORANALYSIS_H
+#define MLIR_AIE_ANALYSIS_BUFFERDESCRIPTORANALYSIS_H
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinOps.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
+#include <iostream>
+
+using namespace mlir;
+
+namespace xilinx {
+namespace AIE {
+
+struct BufferDescriptorState {
+public:
+  BufferDescriptorState() = default;
+
+  int64_t getTotalLengthInt() const {
+    int64_t ret = 1;
+    for (auto len : lengthInt) {
+      ret *= len;
+    }
+    return ret;
+  }
+
+  void print(raw_ostream &os) const;
+  void printInt(raw_ostream &os) const;
+
+public:
+  SmallVector<int64_t, 4> lengthInt;
+  Value baseVal;
+  SmallVector<int64_t, 4> stepsInt;
+  SmallVector<int64_t, 4> wrapsInt;
+
+  SmallVector<OpFoldResult> length;
+  OpFoldResult base;
+  SmallVector<OpFoldResult> steps;
+  SmallVector<OpFoldResult> wraps;
+
+  std::optional<int64_t> repetition;
+  std::optional<int64_t> constantStep;
+
+  Value source;
+};
+
+class BufferDescriptorAnalysis {
+public:
+  BufferDescriptorAnalysis() = default;
+
+  static void visitOperand(Value operand, BufferDescriptorState &state);
+
+  static void visitOperandReintCast(memref::ReinterpretCastOp reintCastOp,
+                                    BufferDescriptorState &state);
+
+  static void visitOperandSubView(memref::SubViewOp subViewOp,
+                                  BufferDescriptorState &state);
+
+  static void visitOperandCopy(memref::CopyOp copyOp,
+                               BufferDescriptorState &state);
+
+  static void visitOperandTensorStore(memref::TensorStoreOp tensorStoreOp,
+                                      BufferDescriptorState &state);
+
+  static void visitOperandCast(memref::CastOp castOp,
+                               BufferDescriptorState &state);
+};
+
+} // namespace AIE
+} // namespace xilinx
+
+#endif

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -33,8 +33,6 @@
 #include "aie/Dialect/ADF/ADFDialect.h"
 #include "aie/Dialect/AIE/AIENetlistAnalysis.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 using namespace mlir;
 using namespace mlir::vector;
@@ -549,6 +547,18 @@ SECTIONS
       "aie-mlir-to-shim-solution",
       "Translate AIE design to ShimSolution file for simulation",
       AIETranslateShimSolution, registerDialects);
+  TranslateFromMLIRRegistration registrationLinAlgToADF(
+      "linalg-to-adf", "Translate LinAlg dialect to C++ ADF graph (POC)",
+      [](ModuleOp module, raw_ostream &output) {
+        return TranslateLinalgToADF(module, output);
+      },
+      [](DialectRegistry &registry) {
+        registry.insert<arith::ArithDialect, linalg::LinalgDialect,
+                        bufferization::BufferizationDialect, LLVM::LLVMDialect,
+                        math::MathDialect, memref::MemRefDialect,
+                        func::FuncDialect, tensor::TensorDialect,
+                        cf::ControlFlowDialect, scf::SCFDialect>();
+      });
 }
 } // namespace AIE
 } // namespace xilinx

--- a/lib/Targets/AIETargets.h
+++ b/lib/Targets/AIETargets.h
@@ -6,6 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
@@ -26,5 +32,7 @@ mlir::LogicalResult AIETranslateShimSolution(mlir::ModuleOp module,
                                              llvm::raw_ostream &);
 mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
                                          llvm::raw_ostream &);
+mlir::LogicalResult TranslateLinalgToADF(mlir::ModuleOp module,
+                                         llvm::raw_ostream &output);
 }
 }

--- a/lib/Targets/BufferDescriptorAnalysis.cpp
+++ b/lib/Targets/BufferDescriptorAnalysis.cpp
@@ -1,0 +1,391 @@
+//===- BufferDescriptorAnalysis.cpp -----------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Analysis/BufferDescriptorAnalysis.h"
+#include "aie/Dialect/ADF/ADFDialect.h"
+#include "aie/Dialect/ADF/ADFOps.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
+#include <iostream>
+
+#define DEBUG_TYPE "buffer-descriptor-analysis"
+
+using namespace mlir;
+
+namespace xilinx {
+namespace AIE {
+
+void BufferDescriptorState::print(raw_ostream &os) const {
+  auto print = [&](StringRef name, SmallVector<OpFoldResult> vec) {
+    os << name << " = [";
+    llvm::interleaveComma(vec, os);
+    os << "]";
+  };
+  os << "BD(";
+  print("length", length);
+  os << ", base = " << base;
+  print(", steps", steps);
+  print(", wraps", wraps);
+  if (repetition)
+    os << ", repetition = " << *repetition;
+  os << ")\n";
+}
+
+void BufferDescriptorState::printInt(raw_ostream &os) const {
+  auto print = [&](StringRef name, SmallVector<int64_t, 4> vec) {
+    os << name << " = [";
+    llvm::interleaveComma(vec, os);
+    os << "]";
+  };
+  os << "BD(";
+  print("length", lengthInt);
+  os << ", totalLength = " << this->getTotalLengthInt();
+  os << ", base = " << base;
+  print(", steps", stepsInt);
+  print(", wraps", wrapsInt);
+  if (repetition)
+    os << ", repetition = " << *repetition;
+  os << ")\n";
+}
+
+void BufferDescriptorAnalysis::visitOperandReintCast(
+    memref::ReinterpretCastOp reintCastOp, BufferDescriptorState &state) {
+  reintCastOp.getOperation()->emitWarning("visitOperandReintCast");
+
+  auto srcVal = reintCastOp.getSource();
+  LLVM_DEBUG(llvm::dbgs() << "reintCastOp source: " << srcVal << "\n");
+  state.source = srcVal;
+
+  auto offsets = reintCastOp.getMixedOffsets();
+  auto sizes = reintCastOp.getMixedSizes();
+  auto strides = reintCastOp.getMixedStrides();
+  auto dstShape =
+      reintCastOp.getResult().getType().cast<ShapedType>().getShape();
+  int64_t rank = dstShape.size();
+
+  assert(rank == (int64_t)sizes.size());
+  assert(rank == (int64_t)strides.size());
+  assert(1 == offsets.size());
+
+  // length
+  for (auto size : sizes) {
+    state.length.push_back(size);
+    auto cstSize = getConstantIntValue(size);
+    if (cstSize) {
+      state.lengthInt.push_back(*cstSize);
+    }
+  }
+
+  // base
+  state.base = offsets[0];
+
+  // steps
+  for (auto stride : llvm::reverse(strides)) {
+    state.steps.push_back(stride);
+    auto cstStride = getConstantIntValue(stride);
+    if (cstStride) {
+      state.stepsInt.push_back(*cstStride);
+    }
+  }
+
+  // wraps
+  for (auto size : llvm::reverse(sizes)) {
+    state.wraps.push_back(size);
+    auto cstSize = getConstantIntValue(size);
+    if (cstSize) {
+      state.wrapsInt.push_back(*cstSize);
+    }
+  }
+
+  // slice analysis from the offset
+  // TODO: need `scalar evolution` to handle more situations when getting the
+  // const step
+  if (auto parentOp = reintCastOp.getOperation()->getParentOp()) {
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+      SetVector<Operation *> bwdSlices;
+      auto isAddI = [](Operation *op) { return isa<arith::AddIOp>(op); };
+      auto offsetVal = offsets[0].dyn_cast<Value>();
+
+      // TODO: the filter option need to support more operations and also has to
+      // check that the operations are within the for loop
+      // TODO: has to verify that the base trace back to the same operators for
+      // analyzing constant step
+      getBackwardSlice(offsetVal, &bwdSlices, isAddI);
+      bwdSlices.insert(offsetVal.getDefiningOp());
+
+      LLVM_DEBUG(llvm::dbgs() << "backwardSlice from current offsetVal = [");
+      LLVM_DEBUG(llvm::interleaveComma(bwdSlices, llvm::dbgs()));
+      LLVM_DEBUG(llvm::dbgs() << "]\n");
+
+      int64_t totalStepPerForLoopIteration = 0;
+      for (auto op : bwdSlices) {
+        if (auto addIOp = dyn_cast<arith::AddIOp>(op)) {
+          LLVM_DEBUG(llvm::dbgs() << "backwardSlice op: " << addIOp << "\n");
+
+          for (auto operand : op->getOperands()) {
+            LLVM_DEBUG(llvm::dbgs()
+                       << "  operand from addIOp: " << operand << "\n");
+            if (bwdSlices.contains(operand.getDefiningOp()))
+              continue;
+
+            arith::ConstantOp constantOp =
+                operand.getDefiningOp<arith::ConstantOp>();
+
+            if (BlockArgument blockArg = dyn_cast<BlockArgument>(operand)) {
+              auto opOperand =
+                  forOp.getOpOperandForRegionIterArg(blockArg).get();
+              LLVM_DEBUG(llvm::dbgs()
+                         << "  is a BlockArgument, the initial operand is: "
+                         << opOperand << "\n");
+              constantOp = opOperand.getDefiningOp<arith::ConstantOp>();
+            }
+            // TODO:: else if, for-loop induction variable
+
+            if (constantOp) {
+              totalStepPerForLoopIteration += constantOp.getValue()
+                                                  .cast<IntegerAttr>()
+                                                  .getValue()
+                                                  .getSExtValue();
+            }
+          }
+        }
+      }
+      LLVM_DEBUG(llvm::dbgs() << "totalStepPerForLoopIteration = "
+                              << totalStepPerForLoopIteration << "\n");
+      state.constantStep = totalStepPerForLoopIteration;
+    }
+  }
+}
+
+void BufferDescriptorAnalysis::visitOperandSubView(
+    memref::SubViewOp subViewOp, BufferDescriptorState &state) {
+  subViewOp.getOperation()->emitWarning("visitOperandSubView");
+
+  auto srcVal = subViewOp.getSource();
+  // TODO: handle the masking size from subview op
+  visitOperand(srcVal, state);
+}
+
+void BufferDescriptorAnalysis::visitOperandCopy(memref::CopyOp copyOp,
+                                                BufferDescriptorState &state) {
+  copyOp.getOperation()->emitWarning("visitOperandCopy");
+
+  auto srcVal = copyOp.getSource();
+  if (BlockArgument blockArg = dyn_cast<BlockArgument>(srcVal)) {
+    LLVM_DEBUG(llvm::dbgs() << "source of memref.copy is block argument\n");
+
+    // get the two BD states from the two reintcast
+    BufferDescriptorState initialState;
+    BufferDescriptorState nextIteState;
+
+    auto parentOp = copyOp.getOperation()->getParentOp();
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+      // get the initial value for the for-loop block argument
+      auto initVal = forOp.getOpOperandForRegionIterArg(blockArg).get();
+      LLVM_DEBUG(llvm::dbgs() << "  initial value is: " << initVal << "\n");
+      visitOperand(initVal, initialState);
+
+      // get the yield value for the for-loop block argument
+      Block::BlockArgListType iterArgs = forOp.getRegionIterArgs();
+      Region &forRegion = forOp.getRegion();
+      Operation *yieldOp = forRegion.getBlocks().front().getTerminator();
+      for (auto pair : llvm::zip(iterArgs, yieldOp->getOperands())) {
+        if (std::get<0>(pair) == blockArg) {
+          auto yieldVal = std::get<1>(pair);
+          LLVM_DEBUG(llvm::dbgs() << "  yield value is: " << yieldVal << "\n");
+          visitOperand(yieldVal, nextIteState);
+          break;
+        }
+      }
+
+      // merge the two BDs and propagate to current state
+      LLVM_DEBUG(initialState.print(llvm::dbgs()));
+      LLVM_DEBUG(initialState.printInt(llvm::dbgs()));
+      LLVM_DEBUG(nextIteState.print(llvm::dbgs()));
+      LLVM_DEBUG(nextIteState.printInt(llvm::dbgs()));
+
+      // verify sizes/ranks and the source pointer
+      assert(initialState.lengthInt.size() == nextIteState.lengthInt.size());
+      assert(initialState.stepsInt.size() == nextIteState.stepsInt.size());
+      assert(initialState.wrapsInt.size() == nextIteState.wrapsInt.size());
+      assert(initialState.length.size() == nextIteState.length.size());
+      assert(initialState.steps.size() == nextIteState.steps.size());
+      assert(initialState.wraps.size() == nextIteState.wraps.size());
+      assert(initialState.source == nextIteState.source);
+
+      // Need deep copy for states and verify that they are compatible
+      // TODO: check repetition?
+      state.base = initialState.base;
+      for (auto [i, s] : llvm::enumerate(initialState.lengthInt)) {
+        if (s == nextIteState.lengthInt[i]) {
+          state.lengthInt.push_back(s);
+        } else {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "lengthInt[" << i << "] are differenet, " << s << " vs "
+                     << nextIteState.lengthInt[i] << "\n");
+        }
+      }
+      for (auto [i, s] : llvm::enumerate(initialState.stepsInt)) {
+        if (s == nextIteState.stepsInt[i]) {
+          state.stepsInt.push_back(s);
+        } else {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "stepsInt[" << i << "] are differenet, " << s << " vs "
+                     << nextIteState.stepsInt[i] << "\n");
+        }
+      }
+      for (auto [i, s] : llvm::enumerate(initialState.wrapsInt)) {
+        if (s == nextIteState.wrapsInt[i]) {
+          state.wrapsInt.push_back(s);
+        } else {
+          LLVM_DEBUG(llvm::dbgs()
+                     << "wrapsInt[" << i << "] are differenet, " << s << " vs "
+                     << nextIteState.wrapsInt[i] << "\n");
+        }
+      }
+      for (auto [i, s] : llvm::enumerate(initialState.length)) {
+        if (s == nextIteState.length[i]) {
+          state.length.push_back(s);
+        } else {
+          LLVM_DEBUG(llvm::dbgs() << "length[" << i << "] are differenet, " << s
+                                  << " vs " << nextIteState.length[i] << "\n");
+        }
+      }
+      for (auto [i, s] : llvm::enumerate(initialState.steps)) {
+        if (s == nextIteState.steps[i]) {
+          state.steps.push_back(s);
+        } else {
+          LLVM_DEBUG(llvm::dbgs() << "steps[" << i << "] are differenet, " << s
+                                  << " vs " << nextIteState.steps[i] << "\n");
+        }
+      }
+      for (auto [i, s] : llvm::enumerate(initialState.wraps)) {
+        if (s == nextIteState.wraps[i]) {
+          state.wraps.push_back(s);
+        } else {
+          LLVM_DEBUG(llvm::dbgs() << "wraps[" << i << "] are differenet, " << s
+                                  << " vs " << nextIteState.wraps[i] << "\n");
+        }
+      }
+
+      // TODO: verify that the `base` can trace back to the same operation
+      if (nextIteState.constantStep) {
+        state.constantStep = *nextIteState.constantStep;
+      }
+    }
+  } else {
+    visitOperand(srcVal, state);
+  }
+
+  // get the loop tripcount if possible
+  int64_t loopTripCount = 1;
+  if (auto parentOp = copyOp.getOperation()->getParentOp()) {
+    if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+      forOp->emitWarning("memref.copy in the scf::ForOp");
+
+      auto inductionVar = forOp.getInductionVar();
+      auto lowerBound = forOp.getLowerBound();
+      auto upperBound = forOp.getUpperBound();
+      auto step = forOp.getStep();
+
+      if (isa<arith::ConstantOp>(lowerBound.getDefiningOp()) &&
+          isa<arith::ConstantOp>(upperBound.getDefiningOp()) &&
+          isa<arith::ConstantOp>(step.getDefiningOp())) {
+        int64_t lowerBoundVal = lowerBound.getDefiningOp<arith::ConstantOp>()
+                                    .getValue()
+                                    .cast<IntegerAttr>()
+                                    .getValue()
+                                    .getSExtValue();
+        int64_t upperBoundVal = upperBound.getDefiningOp<arith::ConstantOp>()
+                                    .getValue()
+                                    .cast<IntegerAttr>()
+                                    .getValue()
+                                    .getSExtValue();
+        int64_t stepVal = step.getDefiningOp<arith::ConstantOp>()
+                              .getValue()
+                              .cast<IntegerAttr>()
+                              .getValue()
+                              .getSExtValue();
+
+        loopTripCount =
+            ((upperBoundVal - lowerBoundVal) + (stepVal - 1)) / stepVal;
+      }
+    }
+  }
+
+  if (loopTripCount > 1 && state.constantStep) {
+    // update the BD state
+    // 1. multiply the loop tripcount to the BD's length
+    // 2. insert the constant step to BD's steps (constant step is analyzed in
+    // visiting reintcast)
+    LLVM_DEBUG(llvm::dbgs() << "loopTripCount = " << loopTripCount
+                 << ", state.constantStep = " << *state.constantStep << "\n");
+    state.lengthInt.push_back(loopTripCount);
+    state.stepsInt.push_back(*state.constantStep);
+
+    // TODO: OpFoldResult version? get rid of OpFoldResult?
+  } else {
+    // pop the last wraps since there is no additional step from for loop
+    if (!state.wraps.empty())
+      state.wraps.pop_back();
+    if (!state.wrapsInt.empty())
+      state.wrapsInt.pop_back();
+  }
+}
+
+void BufferDescriptorAnalysis::visitOperandTensorStore(
+    memref::TensorStoreOp tensorStoreOp, BufferDescriptorState &state) {
+
+  tensorStoreOp.getOperation()->emitWarning("visitOperandTensorStore");
+
+  auto dstVal = tensorStoreOp.getMemref();
+  visitOperand(dstVal, state);
+
+  // pop the last wraps since there is no additional step from for loop
+  if (!state.wraps.empty())
+    state.wraps.pop_back();
+  if (!state.wrapsInt.empty())
+    state.wrapsInt.pop_back();
+}
+
+void BufferDescriptorAnalysis::visitOperandCast(memref::CastOp castOp,
+                                                BufferDescriptorState &state) {
+
+  castOp.getOperation()->emitWarning("visitOperandCast");
+
+  auto srcVal = castOp.getSource();
+  visitOperand(srcVal, state);
+}
+
+void BufferDescriptorAnalysis::visitOperand(Value operand,
+                                            BufferDescriptorState &state) {
+  if (auto op = operand.getDefiningOp<memref::ReinterpretCastOp>()) {
+    visitOperandReintCast(op, state);
+  } else if (auto op = operand.getDefiningOp<memref::SubViewOp>()) {
+    visitOperandSubView(op, state);
+  } else if (auto op = operand.getDefiningOp<memref::CopyOp>()) {
+    visitOperandCopy(op, state);
+  } else if (auto op = operand.getDefiningOp<memref::TensorStoreOp>()) {
+    visitOperandTensorStore(op, state);
+  } else if (auto op = operand.getDefiningOp<memref::CastOp>()) {
+    visitOperandCast(op, state);
+  } else {
+    operand.getDefiningOp()->dump();
+    LLVM_DEBUG(llvm::dbgs()
+        << "encountered addptr operand produced by an unsupported operation\n");
+    // llvm_unreachable("encountered addptr operand produced by an "
+    //                  "unsupported operation");
+  }
+}
+
+} // namespace AIE
+} // namespace xilinx

--- a/lib/Targets/BufferDescriptorAnalysis.cpp
+++ b/lib/Targets/BufferDescriptorAnalysis.cpp
@@ -327,8 +327,9 @@ void BufferDescriptorAnalysis::visitOperandCopy(memref::CopyOp copyOp,
     // 1. multiply the loop tripcount to the BD's length
     // 2. insert the constant step to BD's steps (constant step is analyzed in
     // visiting reintcast)
-    LLVM_DEBUG(llvm::dbgs() << "loopTripCount = " << loopTripCount
-                 << ", state.constantStep = " << *state.constantStep << "\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "loopTripCount = " << loopTripCount
+               << ", state.constantStep = " << *state.constantStep << "\n");
     state.lengthInt.push_back(loopTripCount);
     state.stepsInt.push_back(*state.constantStep);
 
@@ -380,7 +381,8 @@ void BufferDescriptorAnalysis::visitOperand(Value operand,
     visitOperandCast(op, state);
   } else {
     operand.getDefiningOp()->dump();
-    LLVM_DEBUG(llvm::dbgs()
+    LLVM_DEBUG(
+        llvm::dbgs()
         << "encountered addptr operand produced by an unsupported operation\n");
     // llvm_unreachable("encountered addptr operand produced by an "
     //                  "unsupported operation");

--- a/lib/Targets/BufferDescriptorAnalysis.cpp
+++ b/lib/Targets/BufferDescriptorAnalysis.cpp
@@ -292,7 +292,7 @@ void BufferDescriptorAnalysis::visitOperandCopy(memref::CopyOp copyOp,
     if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
       forOp->emitWarning("memref.copy in the scf::ForOp");
 
-      auto inductionVar = forOp.getInductionVar();
+      // auto inductionVar = forOp.getInductionVar();
       auto lowerBound = forOp.getLowerBound();
       auto upperBound = forOp.getUpperBound();
       auto step = forOp.getStep();

--- a/lib/Targets/CMakeLists.txt
+++ b/lib/Targets/CMakeLists.txt
@@ -13,6 +13,8 @@ add_mlir_library(AIETargets
   AIETargetSimulationFiles.cpp
   ADFGenerateCppGraph.cpp
   AIEFlowsToJSON.cpp
+  TranslateLinalgToADF.cpp
+  BufferDescriptorAnalysis.cpp
   ADDITIONAL_HEADER_DIRS
   ${AIE_BINARY_DIR}/include
 

--- a/lib/Targets/TranslateLinalgToADF.cpp
+++ b/lib/Targets/TranslateLinalgToADF.cpp
@@ -1,0 +1,51 @@
+//===- TranslateLinalgToADF.cpp ---------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AIETargets.h"
+#include "aie/Analysis/BufferDescriptorAnalysis.h"
+#include "aie/Dialect/ADF/ADFDialect.h"
+#include "aie/Dialect/ADF/ADFOps.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/FileSystem.h"
+#include <iostream>
+
+using namespace mlir;
+using namespace xilinx;
+
+namespace xilinx {
+namespace AIE {
+
+mlir::LogicalResult TranslateLinalgToADF(ModuleOp module, raw_ostream &output) {
+  module.walk([&](func::FuncOp funcOp) {
+    funcOp.walk([&](Operation *op) {
+      if (auto copyOp = dyn_cast<memref::CopyOp>(op)) {
+        BufferDescriptorState bd;
+        BufferDescriptorAnalysis::visitOperandCopy(copyOp, bd);
+        bd.print(llvm::errs());
+        bd.printInt(llvm::errs());
+      } else if (auto tensorStoreOp = dyn_cast<memref::TensorStoreOp>(op)) {
+        BufferDescriptorState bd;
+        BufferDescriptorAnalysis::visitOperandTensorStore(tensorStoreOp, bd);
+        bd.print(llvm::errs());
+        bd.printInt(llvm::errs());
+      }
+    });
+  });
+
+  return mlir::success();
+}
+
+} // namespace AIE
+} // namespace xilinx


### PR DESCRIPTION
This draft shows an implementation of an analysis for generating Buffer Descriptors.
- Problem formulation:
    - Input: 
      - LinAlg IR converted from Triton IR by `--triton-to-linalg` conversion pass
      - Make dynamic strides/sizes from function argument to constant strides/sizes in arith.constant (task 3.2.1., this is done manually at the moment)
    - Output:
      - Buffer descriptor with constant length/steps/wraps, and dynamic base (base pointer address, a function of program_id)
- Proposed method in high-level:
    - Analysis is done by visiting all the `memref.copy/memref.tensor_store` in the function and recursively call visitor functions for operands until reaching `memref.reinterpretcast`. 
    - Buffer descriptor is propagated from `memref.reinterpretcast` to `memref.copy/memref.tensor_store` by recursion of visitor functions.
- Able to handle tasks 3.2.2. and 3.2.3. for triton tutorials:
    - add vector, softmax, and layernorm
    - matmul (works for various group sizes)
    - fused attention (only works for full attention that comes with constant for-loop tripcount. The original tutorial example is masked attention where the tripcount is dynamic to the program_id)
- Known limitation:
    - Memory block size masking/padding is skipped
    - Multiple load of a tensor in a single for loop iteration isn't supported
    - For-loop has to have constant tripcount to infer the BD for task 3.2.3.
    - Haven't looked into the case of nested for-loop
