### PR TITLE
Initial VCK5000 Functionality

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,5 @@
 	url = https://github.com/Xilinx/cmakeModules.git
 [submodule "runtime_lib/xaiengine/aie-rt"]
 	path = runtime_lib/xaiengine/aie-rt
-	url = https://github.com/stephenneuendorffer/aie-rt.git
+	url = https://github.com/eddierichter-amd/aie-rt.git
+	branch = converged-aie-rt

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	url = https://github.com/Xilinx/cmakeModules.git
 [submodule "runtime_lib/xaiengine/aie-rt"]
 	path = runtime_lib/xaiengine/aie-rt
-	url = https://github.com/eddierichter-amd/aie-rt.git
-	branch = converged-aie-rt
+	url = https://github.com/stephenneuendorffer/aie-rt.git
+	branch = phoenix_v2023.2

--- a/cmake/toolchainFiles/toolchain_x86_64.cmake
+++ b/cmake/toolchainFiles/toolchain_x86_64.cmake
@@ -2,5 +2,3 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-# the default for x86 is to build a PCIe runtime
-set(BUILD_AIR_PCIE ON CACHE BOOL "" FORCE)

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -98,7 +98,9 @@ the tools are largely board and device independent and can be adapted to other e
 
 4. Build the MLIR-AIE tools by calling `utils/build-mlir-aie.sh` for Versal or Ryzen AI 
     with the path to the `llvm/build` directory. The Vitis environment will have to be 
-    set up for this to succeed.
+    set up for this to succeed. Note that when targetting the VCK5000 platform, please
+    refer to the further instructions below titled `Building on X86 targetting the VCK5000`
+    as there are a few extra steps needed.
 
     ```
     source <Vitis Install Path>/settings64.sh
@@ -107,7 +109,7 @@ the tools are largely board and device independent and can be adapted to other e
 
     This will create a `build` and `install` folder in the directory that you cloned MLIR AIE into. 
 
-    The MLIR AIE tools will be able to generate binaries targetting a combination of AIEngine and ARM/x86 processors.
+    The MLIR AIE tools will be able to generate binaries targetting a combination of AIEngine and ARM/x86 processors. 
 
 5. In order to run all the tools, it is necessary to add some paths into your environment. This can be
 done by sourcing the `utils/env_setup.sh` script with the paths to the install folders for mlir-aie
@@ -115,6 +117,35 @@ and llvm.
     ```
     source utils/env_setup.sh <mlir-aie>/install <llvm dir>/install
     ```
+
+## Building on X86 targetting the VCK5000
+
+In order to build and run on PCIe cards, you first have to build and install the aie-rt library. We chose to install the library in /opt/xaiengine but it is not required for the tools to be installed there. Just ensure that when building mlir-aie and mlir-air, that you point to the directory in which the aie-rt library was installed.
+
+```
+git clone https://github.com/stephenneuendorffer/aie-rt
+cd aie-rt
+git checkout phoenix_v2023.2
+cd driver/src
+make -f Makefile.Linux CFLAGS="-D__AIEAMDAIR__"
+sudo cp -r ../include /opt/aiengine/
+sudo cp libxaiengine.so* /opt/xaiengine/lib/
+export LD_LIBRARY_PATH=/opt/xaiengine/lib:${LD_LIBRARY_PATH}
+```
+
+When targetting the VCK5000 Versal device, you must build and install our experimental ROCm runtime (ROCr) which allows us to communicate with the AIEs. The [ROCm-air-platforms](https://github.com/Xilinx/ROCm-air-platforms) repository contains documentation on how to install ROCr. Run the following script to clone the ROCm-air-platforms repository:
+
+```
+./utils/clone-rocm-air-platforms.sh
+```
+
+Then, set `${ROCM_ROOT}` to the ROCm install from the previous path. Then, run the following command to build the mlir-aie toolchain targetting the VCK5000.
+
+```
+./utils/build-mlir-aie-pcie.sh llvm/build/ build install /opt/xaienginev2 ${ROCM_ROOT}/lib/cmake/hsa-runtime64/ ${ROCM_ROOT}/lib/cmake/hsakmt/
+```
+
+The PCIe AIR runtime requires the use of the [AIR PCIe kernel driver](https://github.com/Xilinx/ROCm-air-platforms/tree/main/driver). The driver directory in the [ROCm-air-platforms](https://github.com/Xilinx/ROCm-air-platforms) repository contains documentation on how to compile and load the AIR PCIe kernel driver.
 
 ### Sysroot
 Since the AIE tools are cross-compiling, in order to actually compile code, we need a 'sysroot' directory,

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -99,7 +99,7 @@ the tools are largely board and device independent and can be adapted to other e
 4. Build the MLIR-AIE tools by calling `utils/build-mlir-aie.sh` for Versal or Ryzen AI 
     with the path to the `llvm/build` directory. The Vitis environment will have to be 
     set up for this to succeed. Note that when targetting the VCK5000 platform, please
-    refer to the further instructions below titled `Building on X86 targetting the VCK5000`
+    refer to the further instructions below titled `Building on X86 targeting the VCK5000`
     as there are a few extra steps needed.
 
     ```

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -350,6 +350,10 @@ struct AIEControl {
     //		macro. In future, the same macro will be expanded to allocate
     //		more memory from the user application for resource management.
     XAie_InstDeclare(_devInst, &configPtr);
+
+    // Setting the backend to CDO
+    configPtr.Backend = XAIE_IO_BACKEND_CDO;
+
     devInst = _devInst;
     // TODO(max): what is the "partition"?
     TRY_XAIE_API_FATAL_ERROR(XAie_SetupPartitionConfig, &devInst,

--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -232,6 +232,14 @@ def parse_args(args=None):
         help="Generate xclbin",
     )
     parser.add_argument(
+        "--link_against_hsa",
+        dest="link_against_hsa",
+        default=False,
+        action="store_const",
+        const=True,
+        help="Link runtime against ROCm runtime HSA interface",
+    )
+    parser.add_argument(
         "--xclbin-name",
         dest="xclbin_name",
         default="final.xclbin",

--- a/python/compiler/aiecc/configure.py.in
+++ b/python/compiler/aiecc/configure.py.in
@@ -16,9 +16,8 @@ aie_disable_compile = not pythonize_bool("@AIECC_COMPILE@")
 aie_unified_compile = True
 host_disable_compile = not pythonize_bool("@AIECC_HOST_COMPILE@")
 host_architecture = os.getenv("LLVM_HOST_TRIPLE", "@LLVM_HOST_TRIPLE@")
-hsa_dir = "@hsa-runtime64_DIR@"
-libxaie_x86_hsa_dir = "@LibXAIE_x86_64-hsa_DIR@"
-peano_install_dir = "@CONFIG_PEANO_INSTALL_DIR@"
+hsa_dir = os.getenv("HSA_RUNTIME_64_DIR", "@hsa-runtime64_DIR@")
+libxaie_x86_hsa_dir = os.getenv("LIBXAIE_X86_HSA_DIR", "@LibXAIE_x86_64-hsa_DIR@")
 
 peano_install_dir = os.getenv("PEANO_INSTALL_DIR", "@PEANO_INSTALL_DIR@")
 aie_dir = os.path.realpath(

--- a/python/compiler/aiecc/configure.py.in
+++ b/python/compiler/aiecc/configure.py.in
@@ -16,6 +16,9 @@ aie_disable_compile = not pythonize_bool("@AIECC_COMPILE@")
 aie_unified_compile = True
 host_disable_compile = not pythonize_bool("@AIECC_HOST_COMPILE@")
 host_architecture = os.getenv("LLVM_HOST_TRIPLE", "@LLVM_HOST_TRIPLE@")
+hsa_dir = "@hsa-runtime64_DIR@"
+libxaie_x86_hsa_dir = "@LibXAIE_x86_64-hsa_DIR@"
+peano_install_dir = "@CONFIG_PEANO_INSTALL_DIR@"
 
 peano_install_dir = os.getenv("PEANO_INSTALL_DIR", "@PEANO_INSTALL_DIR@")
 aie_dir = os.path.realpath(

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -692,7 +692,7 @@ class FlowRunner:
                 hsa_path = os.path.join(aie.compiler.aiecc.configure.hsa_dir)
                 hsa_include_path = os.path.join(hsa_path, "..", "..", "..", "include")
                 hsa_lib_path = os.path.join(hsa_path, "..", "..")
-                hsa_so_path = os.path.join(hsa_lib_path, "libhsa-runtime64.so.1.9.0")
+                hsa_so_path = os.path.join(hsa_lib_path, "libhsa-runtime64.so")
             else:
                 arch_name = opts.host_target.split("-")[0]
 

--- a/runtime_lib/CMakeLists.txt
+++ b/runtime_lib/CMakeLists.txt
@@ -20,6 +20,10 @@ set(AIE_RUNTIME_TEST_TARGET_VAL ${AIR_RUNTIME_TEST_TARGET})
 if(NOT x86_64_TOOLCHAIN_FILE)
   set(x86_64_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/toolchainFiles/toolchain_x86_64.cmake")
 endif()
+# For now, using the same toolchain file for x86_64 and HSA, can seperate if needed
+if(NOT x86_64-hsa_TOOLCHAIN_FILE)
+  set(x86_64-hsa_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/toolchainFiles/toolchain_x86_64.cmake")
+endif()
 if(NOT aarch64_TOOLCHAIN_FILE)
   if(SysrootAarch64)
   set(aarch64_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/toolchainFiles/toolchain_clang_crosscomp_pynq.cmake")
@@ -109,6 +113,8 @@ foreach(target ${AIE_RUNTIME_TARGETS})
           -DVITIS_ROOT=${VITIS_ROOT}
           -DVITIS_AIETOOLS_DIR=${VITIS_AIETOOLS_DIR}
           -DSysroot=${Sysroot}
+          -Dhsa-runtime64_DIR=${hsa-runtime64_DIR}
+          -Dhsakmt_DIR=${hsakmt_DIR}
       DEPENDS ${testLibDependsOnXaiengine}
       BUILD_ALWAYS true
       STEP_TARGETS clean build install test

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(test_lib STATIC test_library.cpp)
 set(TEST_LIB_PUBLIC_HEADERS
     test_library.h
     target.h
+    hsa_ext_air.h
 )
 set_target_properties(test_lib PROPERTIES PUBLIC_HEADER "${TEST_LIB_PUBLIC_HEADERS}")
 target_compile_options(test_lib PRIVATE -fPIC)
@@ -20,8 +21,27 @@ target_include_directories(test_lib PRIVATE
     ${LibXAIE_INC_DIR}
 )
 
+
+if (${AIE_RUNTIME_TARGET} STREQUAL "x86_64-hsa")
+  message("Building x86_64-hsa runtime")
+  add_definitions(-DHSA_RUNTIME)
+endif()
+
+# If we are compiling the x86_64 runtime targetting HSA we need to link against HSA
+if (${AIE_RUNTIME_TARGET} STREQUAL "x86_64-hsa")
+  message("Linking against hsa-runtime64")
+  find_package(hsa-runtime64 REQUIRED)
+  target_link_libraries(test_lib
+    hsa-runtime64::hsa-runtime64
+  )
+  include_directories(
+    ${hsa-runtime64_DIR}/../../../include
+  )
+
+endif()
+
 # copy header and source files into build area
-set(headers target.h test_library.h memory_allocator.h)
+set(headers target.h test_library.h memory_allocator.h hsa_ext_air.h)
 foreach(basefile ${headers})
     set(dest ${CMAKE_CURRENT_BINARY_DIR}/../include/${basefile})
     add_custom_target(aie-copy-runtime-libs-${basefile} ALL DEPENDS ${dest})
@@ -66,10 +86,32 @@ target_include_directories(memory_allocator_ion PRIVATE
 target_compile_options(memory_allocator_ion PRIVATE -fPIC)
 target_compile_definitions(memory_allocator_ion PRIVATE)
 
+message("LibXAIE_INC_DIR is at ${LibXAIE_INC_DIR} for ${AIE_RUNTIME_TARGET}")
+
 install(TARGETS memory_allocator_ion
     ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/lib
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/include
 )
+
+# If we are compiling x86_64 HSA runtime, need to link against HSA
+if (${AIE_RUNTIME_TARGET} STREQUAL "x86_64-hsa")
+  add_library(memory_allocator_hsa STATIC memory_allocator_hsa.cpp)
+  set_target_properties(memory_allocator_hsa PROPERTIES PUBLIC_HEADER "memory_allocator.h")
+  target_compile_options(memory_allocator_hsa PRIVATE -fPIC)
+  target_compile_definitions(memory_allocator_hsa PRIVATE)
+  target_include_directories(memory_allocator_hsa PRIVATE ${LibXAIE_INC_DIR})
+  target_link_libraries(memory_allocator_hsa
+    hsa-runtime64::hsa-runtime64
+  )
+  include_directories(
+    ${hsa-runtime64_DIR}/../../../include
+  )
+ 
+  install(TARGETS memory_allocator_hsa
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/lib
+      PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/test_lib/include
+  )
+endif()
 
 if (VITIS_ROOT)
     add_library(memory_allocator_sim_aie STATIC memory_allocator.cpp)

--- a/runtime_lib/test_lib/hsa_ext_air.h
+++ b/runtime_lib/test_lib/hsa_ext_air.h
@@ -1,0 +1,117 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2023, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef HSA_RUNTIME_EXT_AIR_H_
+#define HSA_RUNTIME_EXT_AIR_H_
+
+#include <stdint.h>
+
+#define AIR_ADDRESS_ABSOLUTE 0x0L
+#define AIR_ADDRESS_ABSOLUTE_RANGE 0x1L
+#define AIR_ADDRESS_HERD_RELATIVE 0x2L
+#define AIR_ADDRESS_HERD_RELATIVE_RANGE 0x3L
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief AIR vendor-specific packet type.
+ */
+typedef enum {
+  AIR_PKT_TYPE_INVALID = 0,
+  AIR_PKT_TYPE_PUT_STREAM = 1,
+  AIR_PKT_TYPE_GET_STREAM = 2,
+  AIR_PKT_TYPE_SDMA_STATUS = 3,
+  AIR_PKT_TYPE_TDMA_STATUS = 4,
+  AIR_PKT_TYPE_CORE_STATUS = 5,
+
+  AIR_PKT_TYPE_DEVICE_INITIALIZE = 0x0010L,
+  AIR_PKT_TYPE_SEGMENT_INITIALIZE = 0x0011L,
+  AIR_PKT_TYPE_HELLO = 0x0012L,
+  AIR_PKT_TYPE_ALLOCATE_HERD_SHIM_DMAS = 0x0013L,
+  AIR_PKT_TYPE_GET_CAPABILITIES = 0x0014L,
+  AIR_PKT_TYPE_GET_INFO = 0x0015L,
+
+  AIR_PKT_TYPE_XAIE_LOCK = 0x0020L,
+
+  AIR_PKT_TYPE_CDMA = 0x030L,
+  AIR_PKT_TYPE_CONFIGURE = 0x031L,
+
+  AIR_PKT_TYPE_POST_RDMA_WQE = 0x040L,
+  AIR_PKT_TYPE_POST_RDMA_RECV = 0x041L,
+
+  AIR_PKT_TYPE_PROG_FIRMWARE = 0x050L,
+  AIR_PKT_TYPE_READ_AIE_REG32 = 0x51L,
+  AIR_PKT_TYPE_WRITE_AIE_REG32 = 0x52L,
+  AIR_PKT_TYPE_AIRBIN = 0x53L,
+  AIR_PKT_TYPE_TRANSLATE = 0x54L,
+
+  AIR_PKT_TYPE_SHIM_DMA_MEMCPY = 0x0100L,
+  AIR_PKT_TYPE_HERD_SHIM_DMA_MEMCPY = 0x0101L,
+  AIR_PKT_TYPE_HERD_SHIM_DMA_1D_STRIDED_MEMCPY = 0x0102L,
+  AIR_PKT_TYPE_ND_MEMCPY = 0x0103L,
+
+} hsa_air_packet_type_t;
+
+/**
+ * @brief AIR agent attributes.
+ */
+typedef enum {
+  AIR_AGENT_INFO_NAME = 0,
+  AIR_AGENT_INFO_VENDOR_NAME = 1,
+  AIR_AGENT_INFO_CONTROLLER_ID = 2,
+  AIR_AGENT_INFO_FIRMWARE_VER = 3,
+  AIR_AGENT_INFO_NUM_REGIONS = 4,
+  AIR_AGENT_INFO_HERD_SIZE = 5,
+  AIR_AGENT_INFO_HERD_ROWS = 6,
+  AIR_AGENT_INFO_HERD_COLS = 7,
+  AIR_AGENT_INFO_TILE_DATA_MEM_SIZE = 8,
+  AIR_AGENT_INFO_TILE_PROG_MEM_SIZE = 9,
+  AIR_AGENT_INFO_L2_MEM_SIZE = 10
+} hsa_air_agent_info_t;
+
+#ifdef __cplusplus
+} // end extern "C" block
+#endif
+
+#endif // header guard

--- a/runtime_lib/test_lib/memory_allocator_hsa.cpp
+++ b/runtime_lib/test_lib/memory_allocator_hsa.cpp
@@ -1,0 +1,106 @@
+//===- memory_allocator_hsa.cpp ---------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+#include "memory_allocator.h"
+#include "test_library.h"
+#include <iostream>
+
+//
+// This memory allocator links against the HSA allocator
+//
+int *mlir_aie_mem_alloc(aie_libxaie_ctx_t *_xaie, ext_mem_model_t &handle,
+                        int size) {
+  int size_bytes = size * sizeof(int);
+  hsa_amd_memory_pool_allocate(_xaie->global_mem_pool, size_bytes, 0,
+                               (void **)&(handle.virtualAddr));
+
+  if (handle.virtualAddr) {
+    handle.size = size_bytes;
+  } else {
+    printf("ExtMemModel: Failed to allocate %d memory.\n", size_bytes);
+  }
+
+  std::cout << "ExtMemModel constructor: virtual address " << std::hex
+            << handle.virtualAddr << ", size " << std::dec << handle.size
+            << std::endl;
+
+  return (int *)handle.virtualAddr;
+}
+
+/*
+  The device memory allocator directly maps device memory over
+  PCIe MMIO. These accesses are uncached and thus don't require
+  explicit synchronization between the host and device
+*/
+void mlir_aie_sync_mem_cpu(ext_mem_model_t &handle) {}
+
+void mlir_aie_sync_mem_dev(ext_mem_model_t &handle) {}
+
+/*
+  The only component that knows the proper translation from
+  VA->PA is the command processor. Sending a request to the
+  command processor to perform the translation.
+*/
+u64 mlir_aie_get_device_address(struct aie_libxaie_ctx_t *_xaie, void *VA) {
+
+  // Checking to make sure that the agent is setup properly
+  if (_xaie == NULL) {
+    printf("[ERROR] %s passed NULL context ptr\n", __func__);
+    return NULL;
+  }
+
+  if (_xaie->agents.size() == 0) {
+    printf("[ERROR] %s passed context has no agents\n", __func__);
+    return NULL;
+  }
+
+  if (_xaie->cmd_queue == NULL) {
+    printf("[ERROR] %s passed context has no queue\n", __func__);
+    return NULL;
+  }
+
+  // Getting pointers to the queue and the agent
+  hsa_queue_t *queue = _xaie->cmd_queue;
+  hsa_agent_t agent = _xaie->agents[0];
+
+  uint64_t wr_idx = hsa_queue_add_write_index_relaxed(queue, 1);
+  uint64_t packet_id = wr_idx % queue->size;
+  hsa_agent_dispatch_packet_t pkt;
+  air_packet_req_translation(&pkt, (uint64_t)VA);
+  hsa_amd_signal_create_on_agent(1, 0, nullptr, &agent, 0,
+                                 &(pkt.completion_signal));
+  reinterpret_cast<hsa_agent_dispatch_packet_t *>(
+      queue->base_address)[packet_id] = pkt;
+
+  // Ringing the doorbell to notify the command processor of the packet
+  hsa_signal_store_screlease(queue->doorbell_signal, wr_idx);
+
+  // wait for packet completion
+  while (hsa_signal_wait_scacquire(pkt.completion_signal,
+                                   HSA_SIGNAL_CONDITION_EQ, 0, 0x80000,
+                                   HSA_WAIT_STATE_ACTIVE) != 0)
+    ;
+
+  // We encode the response in the packet, so need to peek in to get the data
+  hsa_agent_dispatch_packet_t *pkt_peek =
+      &reinterpret_cast<hsa_agent_dispatch_packet_t *>(
+          queue->base_address)[packet_id];
+
+  // Copying the translated address
+  uint64_t PA;
+  PA = (uint64_t)pkt_peek->return_address;
+
+  // Destroying the signal
+  hsa_signal_destroy(pkt.completion_signal);
+
+  return (u64)PA; // The platform will convert the address for us
+}

--- a/runtime_lib/test_lib/target.h
+++ b/runtime_lib/test_lib/target.h
@@ -12,7 +12,13 @@
 #define AIE_TARGET_H
 
 #include <list>
+#include <vector>
 #include <xaiengine.h>
+
+#ifdef HSA_RUNTIME
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+#endif
 
 struct ext_mem_model_t {
   void *virtualAddr;
@@ -27,6 +33,11 @@ struct aie_libxaie_ctx_t {
   XAie_DevInst DevInst;
   // Some device memory allocators need this to keep track of VA->PA mappings
   std::list<ext_mem_model_t> allocations;
+#ifdef HSA_RUNTIME
+  hsa_queue_t *cmd_queue;
+  std::vector<hsa_agent_t> agents;
+  hsa_amd_memory_pool_t global_mem_pool;
+#endif
 };
 
 #endif

--- a/runtime_lib/test_lib/test_library.h
+++ b/runtime_lib/test_lib/test_library.h
@@ -14,6 +14,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef HSA_RUNTIME
+#include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd.h"
+#include "hsa_ext_air.h"
+#endif
+
 extern "C" {
 
 #define mlir_aie_check(s, r, v, errors)                                        \
@@ -109,12 +115,18 @@ private:
  ******************************************************************************
  */
 
+// This is a more elegant solution
+#ifdef HSA_RUNTIME
+hsa_status_t air_packet_req_translation(hsa_agent_dispatch_packet_t *pkt,
+                                        uint64_t va);
+#endif
+
 /// @brief  Initialize libXAIE and allocate a new context object.
 /// @return A pointer to the context
 aie_libxaie_ctx_t *mlir_aie_init_libxaie();
 void mlir_aie_deinit_libxaie(aie_libxaie_ctx_t *);
 
-int mlir_aie_init_device(aie_libxaie_ctx_t *ctx);
+int mlir_aie_init_device(aie_libxaie_ctx_t *ctx, uint32_t device_id = 0);
 
 int mlir_aie_acquire_lock(aie_libxaie_ctx_t *ctx, int col, int row, int lockid,
                           int lockval, int timeout);

--- a/test/unit_tests/aie/09_simple_shim_dma/aie.mlir
+++ b/test/unit_tests/aie/09_simple_shim_dma/aie.mlir
@@ -63,6 +63,9 @@ module @test09_simple_shim_dma {
       aie.end
   }
 
+  %c72 = aie.core(%t72) {
+    aie.end
+  }
 
 
 

--- a/test/unit_tests/aie/21_target_triple/test.cpp
+++ b/test/unit_tests/aie/21_target_triple/test.cpp
@@ -48,12 +48,17 @@ int main(int argc, char *argv[]) {
   mlir_aie_check("After memory writes: ", mlir_aie_read_buffer_a(_xaie, 0), 11,
                  errors);
 
+  int res = 0;
   if (!errors) {
     printf("PASS!\n");
-    return 0;
+    res = 0;
   } else {
     printf("Fail!\n");
-    return -1;
+    res = -1;
   }
+
+  mlir_aie_deinit_libxaie(_xaie);
   printf("test done.\n");
+
+  return res;
 }

--- a/utils/build-mlir-aie-pcie.sh
+++ b/utils/build-mlir-aie-pcie.sh
@@ -52,7 +52,6 @@ CMAKE_CONFIGS="\
     -DLibXAIE_x86_64-hsa_DIR=${LIBXAIE_DIR} \
     -Dhsa-runtime64_DIR=${HSA_DIR} \
     -Dhsakmt_DIR=${HSAKMT_DIR} \
-    -DROCR_DIR=${ROCR_DIR} \
     -DMLIR_DIR=${LLVM_BUILD_DIR}/lib/cmake/mlir \
     -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/modulesXilinx \
     -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
@@ -63,9 +62,8 @@ CMAKE_CONFIGS="\
     -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DLLVM_ENABLE_RTTI=$LLVM_ENABLE_RTTI \
-    -DAIE_RUNTIME_TARGETS=x86_64-hsa;aarch64 \
+    -DAIE_RUNTIME_TARGETS=x86_64-hsa \
     -DAIE_ENABLE_PYTHON_PASSES=OFF \
-    -DAIE_RUNTIME_TEST_TARGET=aarch64
     .. |& tee cmake.log"
 
 if [ -x "$(command -v lld)" ]; then

--- a/utils/build-mlir-aie-pcie.sh
+++ b/utils/build-mlir-aie-pcie.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+##===- utils/build-mlir-aie.sh - Build mlir-aie --*- Script -*-===##
+# 
+# This file licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+##===----------------------------------------------------------------------===##
+#
+# This script builds mlir-aie given <llvm dir>.
+# Assuming they are all in the same subfolder, it would look like:
+#
+# build-mlir-aie.sh <llvm dir> <build dir> <install dir> <mlir-air-dir> <x86-libxaie-dir> <hsa-dir> <hsa-kmt-dir>
+#
+# e.g. build-mlir-aie.sh /scratch/llvm/build
+#
+# <build dir>    - optional, mlir-aie/build dir name, default is 'build'
+# <install dir>  - optional, mlir-aie/install dir name, default is 'install'
+# <x86-libxaie-dir> - optional, path to the x86 libxaie installation, necessary when compiling for VCK5000
+# <HSA-dir> - optional, path to the HSA installation of the ROCm runtime
+# <HSAKMT-dir> - optional, Path to the HSA KMT installation of the ROCm runtime
+#
+##===----------------------------------------------------------------------===##
+
+if [ "$#" -lt 1 ]; then
+    echo "ERROR: Needs at least 1 arguments for <llvm build dir>."
+    exit 1
+fi
+
+BASE_DIR=`realpath $(dirname $0)/..`
+CMAKEMODULES_DIR=$BASE_DIR/cmake
+
+LLVM_BUILD_DIR=`realpath $1`
+echo "LLVM BUILD DIR: $LLVM_BUILD_DIR"
+
+BUILD_DIR=${2:-"build"}
+INSTALL_DIR=${3:-"install"}
+LIBXAIE_DIR=${4:-""}
+HSA_DIR=${5:-""}
+HSAKMT_DIR=${6:-""}
+LLVM_ENABLE_RTTI=${LLVM_ENABLE_RTTI:OFF}
+
+
+mkdir -p $BUILD_DIR
+mkdir -p $INSTALL_DIR
+cd $BUILD_DIR
+set -o pipefail
+set -e
+
+CMAKE_CONFIGS="\
+    -GNinja \
+    -DLLVM_DIR=${LLVM_BUILD_DIR}/lib/cmake/llvm \
+    -DLibXAIE_x86_64-hsa_DIR=${LIBXAIE_DIR} \
+    -Dhsa-runtime64_DIR=${HSA_DIR} \
+    -Dhsakmt_DIR=${HSAKMT_DIR} \
+    -DROCR_DIR=${ROCR_DIR} \
+    -DMLIR_DIR=${LLVM_BUILD_DIR}/lib/cmake/mlir \
+    -DCMAKE_MODULE_PATH=${CMAKEMODULES_DIR}/modulesXilinx \
+    -DCMAKE_INSTALL_PREFIX="../${INSTALL_DIR}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
+    -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
+    -DCMAKE_C_VISIBILITY_PRESET=hidden \
+    -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DLLVM_ENABLE_RTTI=$LLVM_ENABLE_RTTI \
+    -DAIE_RUNTIME_TARGETS=x86_64-hsa;aarch64 \
+    -DAIE_ENABLE_PYTHON_PASSES=OFF \
+    -DAIE_RUNTIME_TEST_TARGET=aarch64
+    .. |& tee cmake.log"
+
+if [ -x "$(command -v lld)" ]; then
+  CMAKE_CONFIGS="${CMAKE_CONFIGS} -DLLVM_USE_LINKER=lld"
+fi
+
+if [ -x "$(command -v ccache)" ]; then
+  CMAKE_CONFIGS="${CMAKE_CONFIGS} -DLLVM_CCACHE_BUILD=ON"
+fi
+
+cmake $CMAKE_CONFIGS .. 2>&1 | tee cmake.log
+ninja 2>&1 | tee ninja.log
+ninja install 2>&1 | tee ninja-install.log

--- a/utils/clone-rocm-air-platforms.sh
+++ b/utils/clone-rocm-air-platforms.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+##===- utils/clone-rocm-air-platforms.sh ---------------------*- Script -*-===##
+#
+# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+##===----------------------------------------------------------------------===##
+#
+# This script checks out the ROCm-air-platforms repository which contains the
+# driver, hardware, and firmware of the AIR ROCm platform.
+#
+##===----------------------------------------------------------------------===##
+
+git clone https://github.com/Xilinx/ROCm-air-platforms

--- a/utils/single_unit_test_compile.sh
+++ b/utils/single_unit_test_compile.sh
@@ -46,9 +46,16 @@ if [ "$runTimeArch" == "aarch64" ]; then
 elif [ "$runTimeArch" == "x86_64" ]; then
     runtimeLibs+=/x86_64
     
-    aiecc.py -v  ./aie.mlir \
-        -fPIC -I${runtimeLibs}/test_lib/include -L${runtimeLibs}/test_lib/lib -ltest_lib \
-        ./test.cpp -o test.elf
+	  aiecc.py -v --host-target=x86_64-amd-linux-gnu  aie.mlir \
+						-I${runtimeLibs}/test_lib/include ${runtimeLibs}/test_lib/src/test_library.cpp \
+						test.cpp -Wl,--no-whole-archive -lstdc++ -ldl -o test.elf
+elif [ "$runTimeArch" == "x86_64-hsa" ]; then
+    runtimeLibs+=/x86_64-hsa
+    
+	  aiecc.py -v --host-target=x86_64-amd-linux-gnu  --link_against_hsa aie.mlir \
+						-I${runtimeLibs}/test_lib/include ${runtimeLibs}/test_lib/src/test_library.cpp \
+						test.cpp -Wl,--no-whole-archive -lstdc++ -ldl -o test.elf
+
 else
     echo "Error: unsupported runtime architecture"
 fi


### PR DESCRIPTION
This is the initial support for mlir-aie on the VCK5000. Couple important notes of this PR:
* We are taking a phased approach where this is only supporting tests which don't require the device memory allocator.  
* We are currently linking against the mlir-air repository when building the x86 runtime. This is only temporary as this runtime functionality will be moved to a platform repository which both mlir-air and mlir-aie will depend on. Linking against AIR was chosen as the temporary path forward as we have all of the CMake infrastructure to link the runtime against an external project, all we will need to do is change where we are pointing. 

After a discussion of the various design decisions, I will update the documentation accordingly.