### PR TITLE
Separate unit_tests/04_shared_memory

### DIFF
--- a/test/unit_tests/04_shared_memory_row/aie.mlir
+++ b/test/unit_tests/04_shared_memory_row/aie.mlir
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aiecc.py %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% %S/test.cpp -o test.elf -L%aie_runtime_lib%/test_lib/lib -ltest_lib
+// RUN: %run_on_board ./test.elf
 
 module @test4_row_shared_memory {
   %tile13 = AIE.tile(1, 3)
@@ -42,7 +43,7 @@ module @test4_row_shared_memory {
   %core23 = AIE.core(%tile23) {
     AIE.useLock(%lock13_5, "Acquire", 1) // acquire for read(e.g. input ping)
     AIE.useLock(%lock23_7, "Acquire", 0) // acquire for write
-    %idx1 = arith.constant 3 : index
+    %idx1 = arith.constant 5 : index
     %val1 = memref.load %buf13_1[%idx1] : memref<256xi32>
     %2    = arith.addi %val1, %val1 : i32
     %3 = arith.addi %2, %val1 : i32

--- a/test/unit_tests/04_shared_memory_row/test.cpp
+++ b/test/unit_tests/04_shared_memory_row/test.cpp
@@ -1,0 +1,95 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2020 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "test_library.h"
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
+#include <xaiengine.h>
+
+#define LOCK_TIMEOUT 100
+
+#include "aie_inc.cpp"
+
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
+
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
+
+  mlir_aie_clear_tile_memory(_xaie, 1, 3);
+  mlir_aie_clear_tile_memory(_xaie, 1, 4);
+
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_configure_dmas(_xaie);
+  mlir_aie_initialize_locks(_xaie);
+
+  int errors = 0;
+
+  printf("Acquire input buffer lock first.\n");
+  // Should this part of setup???
+  if (mlir_aie_acquire_input_lock(_xaie, 0, LOCK_TIMEOUT)) {
+    errors++;
+    printf("ERROR: timeout hit!\n");
+  }
+  mlir_aie_write_buffer_a(_xaie, 3, 7);
+
+  mlir_aie_check("Before", mlir_aie_read_buffer_a(_xaie, 3), 7, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_b(_xaie, 5), 0, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_c(_xaie, 5), 0, errors);
+
+  mlir_aie_print_tile_status(_xaie, 1, 3);
+  mlir_aie_print_tile_status(_xaie, 1, 4);
+
+  printf("Starting cores\n");
+  mlir_aie_start_cores(_xaie);
+
+  mlir_aie_check("Before and started", mlir_aie_read_buffer_a(_xaie, 3), 7,
+                 errors);
+  mlir_aie_check("Before and started", mlir_aie_read_buffer_b(_xaie, 5), 0,
+                 errors);
+  mlir_aie_check("Before and started", mlir_aie_read_buffer_c(_xaie, 5), 0,
+                 errors);
+
+  printf("Release input buffer lock.\n");
+  mlir_aie_release_input_lock(_xaie, 1, 0);
+  printf("Waiting to acquire output lock for read ...\n");
+  if (mlir_aie_acquire_output_lock(_xaie, 1, LOCK_TIMEOUT)) {
+    errors++;
+    printf("ERROR: timeout hit!\n");
+  }
+
+  mlir_aie_print_tile_status(_xaie, 1, 3);
+  mlir_aie_print_tile_status(_xaie, 1, 4);
+
+  mlir_aie_check("After", mlir_aie_read_buffer_a(_xaie, 3), 7, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_b(_xaie, 5), 35, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_c(_xaie, 5), 175, errors);
+
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
+
+  printf("test done.\n");
+  return res;
+}


### PR DESCRIPTION
There were two tests in this directory using the same .cpp file, but different mlir files.  Unfortunately, in the current flow, this means that the result products of these tests collide.  As a quick solution, separate these into different directories.

Along the way, fix a latent bug in the 'row' version.