### PR TITLE
[tests] Remove unused configuration options

### DIFF
--- a/reference_designs/lit.site.cfg.py.in
+++ b/reference_designs/lit.site.cfg.py.in
@@ -49,7 +49,6 @@ config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.libxaie_dir = "@XILINX_XAIE_LIBS@"
 config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"

--- a/test/Integration/lit.local.cfg
+++ b/test/Integration/lit.local.cfg
@@ -5,8 +5,5 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
-if not config.libxaie_dir:
-    config.unsupported = True
-
 if config.aie_include_integration_tests != 'ON':
     config.unsupported = True

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -49,7 +49,6 @@ config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.libxaie_dir = "@XILINX_XAIE_LIBS@"
 config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"

--- a/tutorials/lit.site.cfg.py.in
+++ b/tutorials/lit.site.cfg.py.in
@@ -49,7 +49,6 @@ config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.libxaie_dir = "@XILINX_XAIE_LIBS@"
 config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"


### PR DESCRIPTION
The configuration option XILINX_XAIE_LIBS is not being used anywhere, and it's preventing integration tests from running. It looks like some references were left in our test configuration when the option was originally removed.