### PR TITLE
New objectFifo syntax using symbols

### DIFF
--- a/docs/AIEDesignPatterns.md
+++ b/docs/AIEDesignPatterns.md
@@ -440,7 +440,7 @@ module @objectFIFO  {
     AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 	AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-	AIE.objectFifo.link [@of1] to [@of2]
+	AIE.objectFifo.link [@of1] to [@of2] ()
 }
 ```
 

--- a/docs/AIEDesignPatterns.md
+++ b/docs/AIEDesignPatterns.md
@@ -440,7 +440,7 @@ module @objectFIFO  {
     AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 	AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-	AIE.objectFifo.link [@of1] to [@of2] ()
+	AIE.objectFifo.link [@of1] -> [@of2] ()
 }
 ```
 

--- a/docs/AIEDesignPatterns.md
+++ b/docs/AIEDesignPatterns.md
@@ -347,14 +347,15 @@ XAieTile_LockRelease(&(TileInst[7][2]), 1, 0x1, 0);
 [ObjectFIFO Example](https://github.com/Xilinx/mlir-aie/tree/main/test/objectFifo-stateful-transform/non_adjacency_test_1.aie.mlir)
 
 An objectFIFO can be established between two or more tiles. Broadcast is possible from one producer tile to multiple consumer tiles.
-Unlike a typical FIFO, elements are not pushed to nor popped from the objectFIFO. Instead, a pool of memory elements is allocated to the objectFIFO. 
+Unlike a typical FIFO, elements are not pushed to nor popped from the objectFIFO. Instead, a pool of memory elements is allocated to the objectFIFO by the objectFIFO lowering pass, i.e., AIEObjectFifoStatefulTransform.mlir. 
+
 Processes can then write to and read from these memory elements after acquiring them.
 
-Define two tiles and create an AIE.objectFifo of depth two between them, with the two elements being of type <memref<16xi32>>:
+Define two tiles and create an AIE.objectFifo named @of0 of depth two between them, with the two elements being of type <memref<16xi32>>:
 ```
 %tile12 = AIE.tile(1, 2)
 %tile33 = AIE.tile(3, 3)
-%objFifo = AIE.objectFifo.createObjectFifo(%tile12, {tile33}, 2) : !AIE.objectFifo<memref<16xi32>>
+AIE.objectFifo @of0 (%tile12, {tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 ```
 After subsequent conversion passes, each of the objectFifo elements is instantiated as an AIE.buffer with an AIE.lock.
 
@@ -367,10 +368,10 @@ Operations can be performed on the objectFIFO in the cores: elements can be acqu
 	%height = arith.constant 12 : index
 
 	scf.for %indexInHeight = %c0 to %height step %c1 {
-		%subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+		%subview = AIE.objectFifo.acquire @of0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 		%elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem0) : (memref<16xi32>) -> ()
-		AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+		AIE.objectFifo.release @of0 (Produce, 1)
 	}
 	
 	AIE.end
@@ -382,10 +383,10 @@ Operations can be performed on the objectFIFO in the cores: elements can be acqu
 	%height = arith.constant 12 : index
 
 	scf.for %indexInHeight = %c0 to %height step %c1 { 
-		%subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+		%subview = AIE.objectFifo.acquire @of0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 		%elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem0) : (memref<16xi32>) -> ()
-		AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+		AIE.objectFifo.release @of0 (Consume, 1)
 	}
 	
 	AIE.end
@@ -400,18 +401,46 @@ For correct execution, loops that contain objectFIFO operations must be unrolled
 	%height = arith.constant 12 : index
 
 	scf.for %indexInHeight = %c0 to %height step %c2 {
-		%subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+		%subview0 = AIE.objectFifo.acquire @of0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 		%elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem00) : (memref<16xi32>) -> ()
-		AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+		AIE.objectFifo.release @of0 (Produce, 1)
 
-		%subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+		%subview1 = AIE.objectFifo.acquire @of0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 		%elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem10) : (memref<16xi32>) -> ()
-		AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+		AIE.objectFifo.release @of0 (Produce, 1)
 	}
 	
 	AIE.end
+}
+```
+
+ObjectFIFOs can be established between tiles on the shim row and AIE tiles in order to bring data in from or out to external memory locations. These external memory locations are pointed to using AIE.external_buffer operations and they need to be explicitly registered to an objectFIFO so that it knows where the data has been allocated externally (in this case, the objectFIFO lowering will only allocate memory elements required by AIE tiles):
+```
+module @objectFIFO  {
+    %tile10 = AIE.tile(1, 0)
+    %tile33 = AIE.tile(3, 3)
+
+    AIE.objectFifo @of1 (%tile10, {tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+
+    %ext_buffer_in_0 = AIE.external_buffer {sym_name = "ext_buffer_in_0"}: memref<64xi32>
+    %ext_buffer_in_1 = AIE.external_buffer {sym_name = "ext_buffer_in_1"}: memref<64xi32>
+    AIE.objectFifo.registerExternalBuffers @of1 (%tile10, {%ext_buffer_in_0, %ext_buffer_in_1}) : (memref<64xi32>, memref<64xi32>)
+}
+```
+
+It is possible to copy data from one objectFifo to another. This copy can be done explicitly within the AIE cores, or implicitly using the tile DMAs. The latter case is not as much a copy as it is re-using the same memory buffers when receiving data on an input channel and sending the data out on an output channel. At the objectFIFO abstraction, this is called 'linking' two objectFIFOs. It is most commonly done inside of Mem tiles which have more memory than AIE tiles. 
+```
+module @objectFIFO  {
+    %tile20 = AIE.tile(2, 0)
+    %tile22 = AIE.tile(2, 2)
+    %tile24 = AIE.tile(2, 4)
+
+    AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+	AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+
+	AIE.objectFifo.link [@of1] to [@of2]
 }
 ```
 
@@ -421,7 +450,7 @@ module @objectFIFO  {
     %tile12 = AIE.tile(1, 2)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {tile33}, 2) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of1 (%tile12, {tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
     %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>
@@ -430,7 +459,7 @@ module @objectFIFO  {
         return
     }
 
-    AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %prodAcqPattern : tensor<1xi32>, %prodRelPattern : tensor<1xi32>, @producer_work, %prodLength)
+    AIE.objectFifo.registerProcess @of1 (Produce, %prodAcqPattern : tensor<1xi32>, %prodRelPattern : tensor<1xi32>, @producer_work, %prodLength)
 }
 ```
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1441,7 +1441,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
     ```
       AIE.objectFifo @of1 (%t70, { %t72 }, 2) : !AIE.objectFifo<memref<64xi16>>
       AIE.objectFifo @of2 (%t72, { %t74 }, 2) : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link [@of1] > [@of2] ())
+      AIE.objectFifo.link [@of1] > [@of2] ()
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 
@@ -1459,7 +1459,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    `[` $fifoIns `]` `>` `[` $fifoOuts `]` `(` `)` attr-dict
+    $fifoIns `to` $fifoOuts `(` `)` attr-dict
   }];
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1441,7 +1441,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
     ```
       AIE.objectFifo @of1 (%t70, { %t72 }, 2) : !AIE.objectFifo<memref<64xi16>>
       AIE.objectFifo @of2 (%t72, { %t74 }, 2) : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link [@of1] > [@of2] ()
+      AIE.objectFifo.link [@of1] -> [@of2] ()
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 
@@ -1459,7 +1459,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    $fifoIns `to` $fifoOuts `(` `)` attr-dict
+    $fifoIns `->` $fifoOuts `(` `)` attr-dict
   }];
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1421,21 +1421,14 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
         return dyn_cast<IntegerAttr>(getElemNumber()).getInt();
     }
     TileOp getProducerTileOp();
-    bool hasName() {
-       return name().has_value();
-     }
-    mlir::Optional<StringAttr> name() {
-      if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
-        return {attr};
-      } else {
-        return {};
-      }
-      llvm_unreachable("unreachable");
+    StringAttr name() {
+      auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
+      return attr;
     }
   }];
 }
 
-def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">, AttrSizedOperandSegments]> {
+def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
   let summary = "Links two objectFifos through an intermediary tile's DMA";
   let description = [{
     The "aie.objectFifo.link" operation allows to mark two objectFifos as linked. This implies that the two objectFifos form
@@ -1461,13 +1454,13 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">, Attr
   }];
 
   let arguments = (
-    ins Variadic<FlatSymbolRefAttr>:$fifoIns,
-        Variadic<FlatSymbolRefAttr>:$fifoOuts
+    ins ArrayAttr:$fifoIns,
+        ArrayAttr:$fifoOuts
   );
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    `(` `{` $fifoIns `}` `,` `{` $fifoOuts `}` `)` attr-dict
+    `(` $fifoIns `,` $fifoOuts `)` attr-dict
   }];
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -51,6 +51,17 @@ def ObjectFifoPort: I32EnumAttr<"ObjectFifoPort", "Ports of an object FIFO",
   let cppNamespace = "xilinx::AIE";
 }
 
+def ObjectFifoInterface : OpInterface<"ObjectFifoInterface"> {
+  let description = [{
+    Interface for AIE objectFifo ops.
+  }];
+  let cppNamespace = "xilinx::AIE";
+  let methods = [
+    InterfaceMethod<"description",
+    "StringRef", "getObjFifoName"
+    >,
+  ];
+}
 
 class AIE_Op<string mnemonic, list<Trait> traits = []> :
     Op<AIE_Dialect, mnemonic, traits>;
@@ -1354,13 +1365,14 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">
   }];
 }
 
-def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", [Symbol]> {
+def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [Symbol]> {
   let summary = "Create a circular buffer or channel between two tiles";
   let description = [{
     The `aie.createObjectFifo` operation creates a circular buffer established between a producer and one or 
     more consumers, which are `aie.tile` operations. The aie.createObjectFifo instantiates the given number of 
     buffers (of given output type) and their locks in the Memory Module of the appropriate tile(s) after lowering, 
-    based on tile-adjacency. These elements represent the conceptual depth of the objectFifo.
+    based on tile-adjacency. These elements represent the conceptual depth of the objectFifo or, more specifically,
+    of its object pool.
 
     For the producer and for each consumer, a different size (i.e., element number) can be specified. This will 
     take effect in the case of consumers placed on tiles non-adjacent to the producer. Otherwise, the producer 
@@ -1370,15 +1382,34 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", [Symbol]> {
     locks. The pass also establishes Flow and DMA operations between the producer and consumer tiles if they are
     not adjacent.
 
-    Example:
+    1-to-1 tile example:
     ```
-      %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {tile13, tile23}, 4) : !AIE.objectFifo<memref<16xi32>> 
+      %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
     ```
-    This operation creates an objectFifo between %tile12, %tile13 and %tile23 of 4 elements, each a buffer of 16 32-bit integers.
+    This operation creates an objectFifo between %tile12 and %tile13 of 4 elements, each a buffer of 16 32-bit integers.
+    Note: If there are no ObjectFifoAcquireOps corresponding to this objectFifo on the cores of %tile12 and %tile13, 
+    then the depths of the object pools on each tile will be 4, as specified. Otherwise, the cores are scanned and the
+    highest number of acquired elements (+1 for prefetching) will be used instead, to ensure minimal resource usage.
+ 
+    1-to-2 tiles broadcast example:
+    ```
+      %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13, %tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
+    ```
+    This operation creates an objectFifo between %tile12 and tiles %tile13, %tile23 of 4 elements, each a buffer of x16 
+    32-bit integers.
+
+    1-to-2 tiles broadcast with explicit sizes example:
+    ```
+      %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13, %tile23}, [2, 3, 4]) : !AIE.objectFifo<memref<16xi32>> 
+    ```
+    This operation creates an objectFifo between %tile12, %tile13 and %tile23. The depths of the objectFifo object pool 
+    at each tile are respectively 2, 3 and 4 for tiles %tile12, %tile13 and %tile23. This overrides the depth analysis 
+    specified in the first example.
   }];
 
   let arguments = (
-    ins Index:$producerTile,
+    ins SymbolNameAttr:$sym_name,
+        Index:$producerTile,
         Variadic<Index>:$consumerTiles,
         AIE_ObjectFifo_Depth:$elemNumber
   );
@@ -1386,7 +1417,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo.createObjectFifo", [Symbol]> {
   let results = (outs AIE_ObjectFifoType:$fifo);
 
   let assemblyFormat = [{
-    `(` $producerTile `,` `{` $consumerTiles `}` `,` $elemNumber `)` attr-dict `:` type($fifo)
+    $sym_name `(` $producerTile `,` `{` $consumerTiles `}` `,` $elemNumber `)` attr-dict `:` type($fifo)
   }];
   
   let hasVerifier = 1;
@@ -1461,7 +1492,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> 
   }];
 }
 
-def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [TileElement, IsShimNOCTile]> {
+def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [ObjectFifoInterface, TileElement, IsShimNOCTile]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";
   let description = [{
     The `aie.objectFifo.registerExternalBuffers` operation is used to register one or multiple external buffers 
@@ -1482,21 +1513,18 @@ def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternal
 
   let arguments = (
     ins Index:$tile,
-    AIE_ObjectFifoType:$fifo,
+    FlatSymbolRefAttr:$objFifo_name,
     Variadic<AnyMemRef>:$externalBuffers
   );
 
   let assemblyFormat = [{
-    attr-dict `(` $tile `,` $fifo `:` type($fifo) `,` `{` $externalBuffers `}` `)` `:` `(` type($externalBuffers) `)`
+    attr-dict `(` $objFifo_name `,` $tile `,` `{` $externalBuffers `}` `)` `:` `(` type($externalBuffers) `)`
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     TileOp getTileOp();
-    AIEObjectFifoType getFifoType() {
-      return getFifo().getType().cast<AIEObjectFifoType>();
-    }
   }];
 }
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -51,18 +51,6 @@ def ObjectFifoPort: I32EnumAttr<"ObjectFifoPort", "Ports of an object FIFO",
   let cppNamespace = "xilinx::AIE";
 }
 
-def ObjectFifoInterface : OpInterface<"ObjectFifoInterface"> {
-  let description = [{
-    Interface for AIE objectFifo ops.
-  }];
-  let cppNamespace = "xilinx::AIE";
-  let methods = [
-    InterfaceMethod<"description",
-    "StringRef", "getObjFifoName"
-    >,
-  ];
-}
-
 class AIE_Op<string mnemonic, list<Trait> traits = []> :
     Op<AIE_Dialect, mnemonic, traits>;
 
@@ -1492,7 +1480,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> 
   }];
 }
 
-def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [ObjectFifoInterface, TileElement, IsShimNOCTile]> {
+def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [TileElement, IsShimNOCTile]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";
   let description = [{
     The `aie.objectFifo.registerExternalBuffers` operation is used to register one or multiple external buffers 
@@ -1512,9 +1500,9 @@ def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternal
   }];
 
   let arguments = (
-    ins Index:$tile,
-    FlatSymbolRefAttr:$objFifo_name,
-    Variadic<AnyMemRef>:$externalBuffers
+    ins FlatSymbolRefAttr:$objFifo_name,
+        Index:$tile,
+        Variadic<AnyMemRef>:$externalBuffers
   );
 
   let assemblyFormat = [{
@@ -1525,6 +1513,7 @@ def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternal
 
   let extraClassDeclaration = [{
     TileOp getTileOp();
+    ObjectFifoCreateOp getObjectFifo();
   }];
 }
 
@@ -1552,23 +1541,20 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
 
   let arguments = (
     ins ObjectFifoPort:$port,
-        AIE_ObjectFifoType:$fifo,
+        FlatSymbolRefAttr:$objFifo_name,
         ConfinedAttr<I32Attr, [IntMinValue<0>]>:$size
   );
 
   let results = (outs AIE_ObjectFifoSubviewType:$subview);
 
   let assemblyFormat = [{
-    attr-dict `<` $port `>` `(` $fifo `:` type($fifo) `,` $size `)` `:` type($subview)
+    attr-dict `<` $port `>` `(` $objFifo_name `,` $size `)` `:` type($subview)
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    Value getAIEObjectFifo() { return getFifo(); }
-    AIEObjectFifoType getAIEObjectFifoType() {
-      return getAIEObjectFifo().getType().cast<AIEObjectFifoType>();
-    }
+    ObjectFifoCreateOp getObjectFifo();
     int acqNumber() { return getSize(); }
   }];
 }
@@ -1591,21 +1577,18 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
 
   let arguments = (
     ins ObjectFifoPort:$port,
-        AIE_ObjectFifoType:$fifo,
+        FlatSymbolRefAttr:$objFifo_name,
         ConfinedAttr<I32Attr, [IntMinValue<0>]>:$size
   );
 
   let assemblyFormat = [{
-    attr-dict `<` $port `>` `(` $fifo `:` type($fifo) `,` $size `)` 
+    attr-dict `<` $port `>` `(` $objFifo_name `,` $size `)` 
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    Value getAIEObjectFifo() { return getFifo(); }
-    AIEObjectFifoType getAIEObjectFifoType() {
-      return getAIEObjectFifo().getType().cast<AIEObjectFifoType>();
-    }
+    ObjectFifoCreateOp getObjectFifo();
     int relNumber() { return getSize(); }
   }];
 }
@@ -1672,7 +1655,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
 
   let arguments = (
     ins ObjectFifoPort:$port,
-        AIE_ObjectFifoType:$fifo,
+        FlatSymbolRefAttr:$objFifo_name,
         I32Tensor:$acquirePatternTensor,
         I32Tensor:$releasePatternTensor,
         FlatSymbolRefAttr:$callee,
@@ -1680,12 +1663,13 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict `<` $port `>` `(` $fifo `:` type($fifo) `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
+    attr-dict `<` $port `>` `(` $objFifo_name `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+    ObjectFifoCreateOp getObjectFifo();
     DenseIntElementsAttr getAcquirePattern() { return getAcquirePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
     DenseIntElementsAttr getReleasePattern() { return getReleasePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
     int getProcessLength() { return getLength().getDefiningOp<arith::ConstantOp>().getValue().cast<IntegerAttr>().getInt(); }

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1402,13 +1402,12 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
     ins SymbolNameAttr:$sym_name,
         Index:$producerTile,
         Variadic<Index>:$consumerTiles,
-        AIE_ObjectFifo_Depth:$elemNumber
+        AIE_ObjectFifo_Depth:$elemNumber,
+        TypeAttrOf<AIE_ObjectFifoType>:$elem_type
   );
 
-  let results = (outs AIE_ObjectFifoType:$fifo);
-
   let assemblyFormat = [{
-    $sym_name `(` $producerTile `,` `{` $consumerTiles `}` `,` $elemNumber `)` attr-dict `:` type($fifo)
+    $sym_name `(` $producerTile `,` `{` $consumerTiles `}` `,` $elemNumber `)` attr-dict `:` $elem_type
   }];
   
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1442,7 +1442,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
     ```
       AIE.objectFifo @of1 (%t70, { %t72 }, 2) : !AIE.objectFifo<memref<64xi16>>
       AIE.objectFifo @of2 (%t72, { %t74 }, 2) : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link [@of1] -> [@of2] ())
+      AIE.objectFifo.link [@of1] > [@of2] ())
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 
@@ -1460,7 +1460,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    `[` $fifoIns `]` `-` `>` `[` $fifoOuts `]` `(` `)` attr-dict
+    `[` $fifoIns `]` `>` `[` $fifoOuts `]` `(` `)` attr-dict
   }];
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1337,11 +1337,11 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">
     ```
       %tile00 = AIE.tile(0, 0)
       %tile02 = AIE.tile(0, 2)
-      %connect1 = AIE.objectFifo.createObjectFifo(%tile00, { %tile02 }, 2) {sym_name = "of_in_0"} : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo @of_in_0 (%tile00, { %tile02 }, 2) : !AIE.objectFifo<memref<64xi16>>
     ```
     could produce the following allocation info (channel direction MM2S, channel index 1, and shim column 0):
     ```
-      AIE.shimDMAAllocation("of_in_0", MM2S, 1, 0)
+      AIE.shimDMAAllocation @of_in_0 (MM2S, 1, 0)
     ```
   }];
   let arguments = (
@@ -1352,7 +1352,7 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">
   );
   let results = (outs);
   let assemblyFormat = [{
-    `(` $sym_name `,` $channelDir `,` $channelIndex `,` $col `)` attr-dict  
+    $sym_name `(` $channelDir `,` $channelIndex `,` $col `)` attr-dict  
   }];
 }
 
@@ -1375,7 +1375,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
 
     1-to-1 tile example:
     ```
-      %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
+      AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
     ```
     This operation creates an objectFifo between %tile12 and %tile13 of 4 elements, each a buffer of 16 32-bit integers.
     Note: If there are no ObjectFifoAcquireOps corresponding to this objectFifo on the cores of %tile12 and %tile13, 
@@ -1384,14 +1384,14 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
  
     1-to-2 tiles broadcast example:
     ```
-      %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13, %tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
+      AIE.objectFifo @of2 (%tile12, {%tile13, %tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
     ```
     This operation creates an objectFifo between %tile12 and tiles %tile13, %tile23 of 4 elements, each a buffer of x16 
     32-bit integers.
 
     1-to-2 tiles broadcast with explicit sizes example:
     ```
-      %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13, %tile23}, [2, 3, 4]) : !AIE.objectFifo<memref<16xi32>> 
+      AIE.objectFifo @of3 (%tile12, {%tile13, %tile23}, [2, 3, 4]) : !AIE.objectFifo<memref<16xi32>> 
     ```
     This operation creates an objectFifo between %tile12, %tile13 and %tile23. The depths of the objectFifo object pool 
     at each tile are respectively 2, 3 and 4 for tiles %tile12, %tile13 and %tile23. This overrides the depth analysis 
@@ -1460,7 +1460,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    `(` $fifoIns `,` $fifoOuts `)` attr-dict
+    `[` $fifoIns `]` `-` `>` `[` $fifoOuts `]` `(` `)` attr-dict
   }];
 
   let hasVerifier = 1;
@@ -1504,7 +1504,7 @@ def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternal
   );
 
   let assemblyFormat = [{
-    attr-dict `(` $objFifo_name `,` $tile `,` `{` $externalBuffers `}` `)` `:` `(` type($externalBuffers) `)`
+    attr-dict $objFifo_name `(` $tile `,` `{` $externalBuffers `}` `)` `:` `(` type($externalBuffers) `)`
   }];
 
   let hasVerifier = 1;
@@ -1546,7 +1546,7 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
   let results = (outs AIE_ObjectFifoSubviewType:$subview);
 
   let assemblyFormat = [{
-    attr-dict `<` $port `>` `(` $objFifo_name `,` $size `)` `:` type($subview)
+    attr-dict $objFifo_name `<` $port `>` `(` $size `)` `:` type($subview)
   }];
 
   let hasVerifier = 1;
@@ -1580,7 +1580,7 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict `<` $port `>` `(` $objFifo_name `,` $size `)` 
+    attr-dict $objFifo_name `<` $port `>` `(` $size `)` 
   }];
 
   let hasVerifier = 1;
@@ -1661,7 +1661,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict `<` $port `>` `(` $objFifo_name `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
+    attr-dict $objFifo_name `<` $port `>` `(` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
   }];
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1356,7 +1356,7 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">
   }];
 }
 
-def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [Symbol]> {
+def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]> {
   let summary = "Create a circular buffer or channel between two tiles";
   let description = [{
     The `aie.createObjectFifo` operation creates a circular buffer established between a producer and one or 
@@ -1435,7 +1435,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [Symbol]> {
   }];
 }
 
-def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> {
+def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">, AttrSizedOperandSegments]> {
   let summary = "Links two objectFifos through an intermediary tile's DMA";
   let description = [{
     The "aie.objectFifo.link" operation allows to mark two objectFifos as linked. This implies that the two objectFifos form
@@ -1461,18 +1461,20 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> 
   }];
 
   let arguments = (
-    ins Variadic<AIE_ObjectFifoType>:$fifoIns,
-        Variadic<AIE_ObjectFifoType>:$fifoOuts
+    ins Variadic<FlatSymbolRefAttr>:$fifoIns,
+        Variadic<FlatSymbolRefAttr>:$fifoOuts
   );
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
-    `(` `{` $fifoIns `}` `,` `{` $fifoOuts `}` `)` attr-dict `:` `(` `{` type($fifoIns) `}` `,` `{` type($fifoOuts) `}` `)`
+    `(` `{` $fifoIns `}` `,` `{` $fifoOuts `}` `)` attr-dict
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+    std::vector<ObjectFifoCreateOp> getInputObjectFifos();
+    std::vector<ObjectFifoCreateOp> getOutputObjectFifos();
     bool isJoin() {
       return getFifoIns().size() > 1;
     }
@@ -1483,7 +1485,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [AttrSizedOperandSegments]> 
   }];
 }
 
-def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [TileElement, IsShimNOCTile]> {
+def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [HasParent<"DeviceOp">, TileElement, IsShimNOCTile]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";
   let description = [{
     The `aie.objectFifo.registerExternalBuffers` operation is used to register one or multiple external buffers 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1440,9 +1440,9 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
 
     Example:
     ```
-      %of_t70_t72 = AIE.objectFifo.createObjectFifo(%t70, { %t72 }, 2) {sym_name = "of0"} : !AIE.objectFifo<memref<64xi16>>
-      %of_t72_t74 = AIE.objectFifo.createObjectFifo(%t72, { %t74 }, 2) {sym_name = "of1"} : !AIE.objectFifo<memref<64xi16>>
-      AIE.objectFifo.link({ %of_t70_t72 }, { %of_t72_t74 }) : ({!AIE.objectFifo<memref<64xi16>>}, {!AIE.objectFifo<memref<64xi16>>})
+      AIE.objectFifo @of1 (%t70, { %t72 }, 2) : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo @of2 (%t72, { %t74 }, 2) : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo.link [@of1] -> [@of2] ())
     ```
     This operation links two objectFifos which have tile %t72 as a link point.
 
@@ -1489,10 +1489,10 @@ def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternal
 
     Example:
     ```
-      %of_t70_t73 = AIE.objectFifo.createObjectFifo(%t70, %t73, 2) : !AIE.objectFifo<memref<64xi16>>
+      AIE.objectFifo @of1 (%t70, %t73, 2) : !AIE.objectFifo<memref<64xi16>>
       %buffer_in_0  = AIE.external_buffer : memref<512 x i16>
       %buffer_in_1  = AIE.external_buffer : memref<512 x i16>
-      AIE.objectFifo.registerExternalBuffers(%t70, %of_t70_t73 : !AIE.objectFifo<memref<64xi16>>, {buffer_in_0, buffer_in_1}) : (memref<512 x i16>, memref<512 x i16>)
+      AIE.objectFifo.registerExternalBuffers @of1 (%t70, {buffer_in_0, buffer_in_1}) : (memref<512 x i16>, memref<512 x i16>)
     ```
     This operation registers external buffers %buffer_in_0 and %buffer_in_1 to use in the shimDMA of shimTile %t70.
   }];
@@ -1532,9 +1532,10 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
 
     Example:
     ```
-      %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+      %subview = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
     ```
-    This operation acquires the locks of the next two objects in objFifo from its consumer port and returns a subview of the acquired objects.
+    This operation acquires the locks of the next two objects in the objectFifo named @of1 from its consumer 
+    port and returns a subview of the acquired objects.
   }];
 
   let arguments = (
@@ -1546,7 +1547,7 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
   let results = (outs AIE_ObjectFifoSubviewType:$subview);
 
   let assemblyFormat = [{
-    attr-dict $objFifo_name `<` $port `>` `(` $size `)` `:` type($subview)
+    attr-dict $objFifo_name `(` $port `,` $size `)` `:` type($subview)
   }];
 
   let hasVerifier = 1;
@@ -1568,9 +1569,9 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
 
     Example:
     ```
-      AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+      AIE.objectFifo.release @of1 (Produce, 1)
     ```
-    This operation releases the lock of the next object in objFifo from producer port.
+    This operation releases the lock of the next object in the objectFifo named @of1 from producer port.
   }];
 
   let arguments = (
@@ -1580,7 +1581,7 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict $objFifo_name `<` $port `>` `(` $size `)` 
+    attr-dict $objFifo_name `(` $port `,` $size `)` 
   }];
 
   let hasVerifier = 1;
@@ -1598,10 +1599,10 @@ def AIE_ObjectFifoSubviewAccessOp : AIE_Op<"objectFifo.subview.access", []> {
 
     Example:
     ```
-      %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+      %subview = AIE.objectFifo.acquire @of1 (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
       %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
     ```
-    In this example, elem is the first object of the subview. Note that this may not correspond to the first element of 
+    In this example, %elem is the first object of the subview. Note that this may not correspond to the first element of 
     the objectFifo if other acquire operations took place beforehand.
 
   }];
@@ -1637,15 +1638,16 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
 
     Example:
     ```
+      AIE.objectFifo @of1 (%t72, %t73, 2) : !AIE.objectFifo<memref<16xi32>>
       %length = arith.constant 10 : index
       %acquirePatternProducer = arith.constant dense<[1, 2, 2, 0]> : tensor<4xi32>
       %releasePatternProducer = arith.constant dense<[0, 1, 1, 2]> : tensor<4xi32>
       func @producer_work(%input : !AIE.objectFifoSubview<memref<16xi32>>) -> () { ... }
 
-      AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %acquirePatternProducer : tensor<4xi32>, %releasePatternProducer : tensor<4xi32>, @producer_work, %length)
+      AIE.objectFifo.registerProcess @of1 (Produce, %acquirePatternProducer : tensor<4xi32>, %releasePatternProducer : tensor<4xi32>, @producer_work, %length)
     ```
-    This operation registers function @producer_work and associated patterns to the produce end of %objFifo. 
-    @producer_work will be called with the subviews produced when acquiring elements from %objFifo following the acquire pattern.
+    This operation registers function @producer_work and associated patterns to the produce end of @of1. 
+    @producer_work will be called with the subviews produced when acquiring elements from @of1 following the acquire pattern.
 
     If the input patterns are static (only one element) then the length of the produced for loop will be that of the input %length.
     If the input patterns are cyclo-static then they must be of the same size.
@@ -1661,7 +1663,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict $objFifo_name `<` $port `>` `(` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
+    attr-dict $objFifo_name `(` $port `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
   }];
 
   let hasVerifier = 1;

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -449,7 +449,8 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
 
   if (isJoin()) {
     ObjectFifoCreateOp fifoOut = getOutputObjectFifos()[0];
-    AIEObjectFifoType fifoType = fifoOut.getElemType().cast<AIEObjectFifoType>();
+    AIEObjectFifoType fifoType =
+        fifoOut.getElemType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
     int outputSize = (int)elemType.getShape()[0];
 
@@ -496,7 +497,7 @@ std::optional<Value> xilinx::AIE::ObjectFifoLinkOp::getOptionalSharedTile() {
       if (fifoIn.getConsumerTiles()[0] != fifoOut.getProducerTile())
         return {};
     return {fifoIn.getConsumerTiles()[0]};
-    
+
   } else {
     auto fifoIn = getInputObjectFifos()[0];
     auto fifoOut = getOutputObjectFifos()[0];
@@ -551,7 +552,7 @@ xilinx::AIE::TileOp
 xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
-xilinx::AIE::ObjectFifoCreateOp 
+xilinx::AIE::ObjectFifoCreateOp
 xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::getObjectFifo() {
   Operation *parent = getOperation();
   while ((parent = parent->getParentOp())) {
@@ -563,7 +564,7 @@ xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::getObjectFifo() {
   }
   return ObjectFifoCreateOp();
 }
-// xilinx::AIE::ObjectFifoCreateOp 
+// xilinx::AIE::ObjectFifoCreateOp
 // xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::getObjectFifo() {
 //   Operation *parent = getOperation();
 //   while ((parent = parent->getParentOp())) {
@@ -608,7 +609,7 @@ LogicalResult xilinx::AIE::ObjectFifoAcquireOp::verify() {
 
   return success();
 }
-xilinx::AIE::ObjectFifoCreateOp 
+xilinx::AIE::ObjectFifoCreateOp
 xilinx::AIE::ObjectFifoAcquireOp::getObjectFifo() {
   Operation *parent = getOperation();
   while ((parent = parent->getParentOp())) {
@@ -653,7 +654,7 @@ LogicalResult xilinx::AIE::ObjectFifoReleaseOp::verify() {
 
   return success();
 }
-xilinx::AIE::ObjectFifoCreateOp 
+xilinx::AIE::ObjectFifoCreateOp
 xilinx::AIE::ObjectFifoReleaseOp::getObjectFifo() {
   Operation *parent = getOperation();
   while ((parent = parent->getParentOp())) {
@@ -665,7 +666,8 @@ xilinx::AIE::ObjectFifoReleaseOp::getObjectFifo() {
   }
   return ObjectFifoCreateOp();
 }
-// xilinx::AIE::ObjectFifoCreateOp xilinx::AIE::ObjectFifoReleaseOp::getObjectFifo() {
+// xilinx::AIE::ObjectFifoCreateOp
+// xilinx::AIE::ObjectFifoReleaseOp::getObjectFifo() {
 //   Operation *parent = getOperation();
 //   while ((parent = parent->getParentOp())) {
 //     if (auto device = dyn_cast<DeviceOp>(parent)) {
@@ -709,7 +711,7 @@ LogicalResult xilinx::AIE::ObjectFifoRegisterProcessOp::verify() {
 
   return success();
 }
-xilinx::AIE::ObjectFifoCreateOp 
+xilinx::AIE::ObjectFifoCreateOp
 xilinx::AIE::ObjectFifoRegisterProcessOp::getObjectFifo() {
   Operation *parent = getOperation();
   while ((parent = parent->getParentOp())) {
@@ -721,7 +723,7 @@ xilinx::AIE::ObjectFifoRegisterProcessOp::getObjectFifo() {
   }
   return ObjectFifoCreateOp();
 }
-// xilinx::AIE::ObjectFifoCreateOp 
+// xilinx::AIE::ObjectFifoCreateOp
 // xilinx::AIE::ObjectFifoRegisterProcessOp::getObjectFifo() {
 //   Operation *parent = getOperation();
 //   while ((parent = parent->getParentOp())) {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -517,6 +517,18 @@ std::optional<Value> xilinx::AIE::ObjectFifoLinkOp::getOptionalSharedTile() {
   }
   return {};
 }
+std::vector<xilinx::AIE::ObjectFifoCreateOp>
+xilinx::AIE::ObjectFifoLinkOp::getInputObjectFifos() {
+  Operation *parent = getOperation();
+  while ((parent = parent->getParentOp())) {
+    if (auto device = dyn_cast<DeviceOp>(parent)) {
+      for (auto objFifo : device.getOps<ObjectFifoCreateOp>())
+        if (objFifo.name() == getObjFifoName())
+          return objFifo;
+    }
+  }
+  return ObjectFifoCreateOp();
+}
 
 // ObjectFifoRegisterExternalBuffersOp
 LogicalResult xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::verify() {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -522,6 +522,18 @@ xilinx::AIE::TileOp
 xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
+xilinx::AIE::ObjectFifoCreateOp 
+xilinx::AIE::ObjectFifoRegisterExternalBuffersOp::getObjectFifo() {
+  Operation *parent = getOperation();
+  while ((parent = parent->getParentOp())) {
+    if (auto device = dyn_cast<DeviceOp>(parent)) {
+      for (auto objFifo : device.getOps<ObjectFifoCreateOp>())
+        if (objFifo.name() == getObjFifoName())
+          return objFifo;
+    }
+  }
+  return ObjectFifoCreateOp();
+}
 
 // ObjectFifoAcquireOp
 LogicalResult xilinx::AIE::ObjectFifoAcquireOp::verify() {
@@ -533,7 +545,7 @@ LogicalResult xilinx::AIE::ObjectFifoAcquireOp::verify() {
     return emitOpError("must be called from inside a CoreOp");
 
   auto coreTile = parent.getTile();
-  auto objFifo = getAIEObjectFifo().getDefiningOp<ObjectFifoCreateOp>();
+  auto objFifo = getObjectFifo();
   if (getPort() == ObjectFifoPort::Produce) {
     if (coreTile != objFifo.getProducerTile())
       return parent.emitOpError(
@@ -555,6 +567,17 @@ LogicalResult xilinx::AIE::ObjectFifoAcquireOp::verify() {
 
   return success();
 }
+xilinx::AIE::ObjectFifoCreateOp xilinx::AIE::ObjectFifoAcquireOp::getObjectFifo() {
+  Operation *parent = getOperation();
+  while ((parent = parent->getParentOp())) {
+    if (auto device = dyn_cast<DeviceOp>(parent)) {
+      for (auto objFifo : device.getOps<ObjectFifoCreateOp>())
+        if (objFifo.name() == getObjFifoName())
+          return objFifo;
+    }
+  }
+  return ObjectFifoCreateOp();
+}
 
 // ObjectFifoReleaseOp
 LogicalResult xilinx::AIE::ObjectFifoReleaseOp::verify() {
@@ -566,7 +589,7 @@ LogicalResult xilinx::AIE::ObjectFifoReleaseOp::verify() {
     return emitOpError("must be called from inside a CoreOp");
 
   auto coreTile = parent.getTile();
-  auto objFifo = getAIEObjectFifo().getDefiningOp<ObjectFifoCreateOp>();
+  auto objFifo = getObjectFifo();
   if (getPort() == ObjectFifoPort::Produce) {
     if (coreTile != objFifo.getProducerTile())
       return parent.emitOpError(
@@ -587,6 +610,17 @@ LogicalResult xilinx::AIE::ObjectFifoReleaseOp::verify() {
   }
 
   return success();
+}
+xilinx::AIE::ObjectFifoCreateOp xilinx::AIE::ObjectFifoReleaseOp::getObjectFifo() {
+  Operation *parent = getOperation();
+  while ((parent = parent->getParentOp())) {
+    if (auto device = dyn_cast<DeviceOp>(parent)) {
+      for (auto objFifo : device.getOps<ObjectFifoCreateOp>())
+        if (objFifo.name() == getObjFifoName())
+          return objFifo;
+    }
+  }
+  return ObjectFifoCreateOp();
 }
 
 // ObjectFifoSubviewAccessOp
@@ -620,6 +654,18 @@ LogicalResult xilinx::AIE::ObjectFifoRegisterProcessOp::verify() {
   }
 
   return success();
+}
+xilinx::AIE::ObjectFifoCreateOp 
+xilinx::AIE::ObjectFifoRegisterProcessOp::getObjectFifo() {
+  Operation *parent = getOperation();
+  while ((parent = parent->getParentOp())) {
+    if (auto device = dyn_cast<DeviceOp>(parent)) {
+      for (auto objFifo : device.getOps<ObjectFifoCreateOp>())
+        if (objFifo.name() == getObjFifoName())
+          return objFifo;
+    }
+  }
+  return ObjectFifoCreateOp();
 }
 
 const xilinx::AIE::AIETargetModel &xilinx::AIE::DeviceOp::getTargetModel() {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -449,13 +449,13 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
 
   if (isJoin()) {
     ObjectFifoCreateOp fifoOut = getOutputObjectFifos()[0];
-    AIEObjectFifoType fifoType = fifoOut.getType().cast<AIEObjectFifoType>();
+    AIEObjectFifoType fifoType = fifoOut.getElemType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
     int outputSize = (int)elemType.getShape()[0];
 
     int inputSize = 0;
     for (auto fifoIn : getInputObjectFifos()) {
-      AIEObjectFifoType fifo = fifoIn.getType().cast<AIEObjectFifoType>();
+      AIEObjectFifoType fifo = fifoIn.getElemType().cast<AIEObjectFifoType>();
       MemRefType elemType = fifo.getElementType().cast<MemRefType>();
       inputSize += (int)elemType.getShape()[0];
     }
@@ -465,13 +465,13 @@ LogicalResult xilinx::AIE::ObjectFifoLinkOp::verify() {
 
   } else if (isDistribute()) {
     ObjectFifoCreateOp fifoIn = getInputObjectFifos()[0];
-    AIEObjectFifoType fifoType = fifoIn.getType().cast<AIEObjectFifoType>();
+    AIEObjectFifoType fifoType = fifoIn.getElemType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifoType.getElementType().cast<MemRefType>();
     int inputSize = (int)elemType.getShape()[0];
 
     int outputSize = 0;
     for (auto fifoOut : getOutputObjectFifos()) {
-      AIEObjectFifoType fifo = fifoOut.getType().cast<AIEObjectFifoType>();
+      AIEObjectFifoType fifo = fifoOut.getElemType().cast<AIEObjectFifoType>();
       MemRefType elemType = fifo.getElementType().cast<MemRefType>();
       outputSize += (int)elemType.getShape()[0];
     }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -134,7 +134,7 @@ struct AIEObjectFifoRegisterProcessPass
       builder.setInsertionPointToEnd(device.getBody());
       ObjectFifoCreateOp objFifo = registerOp.getObjectFifo();
       auto elementType =
-          objFifo.getType().dyn_cast<AIEObjectFifoType>().getElementType();
+          objFifo.getElemType().dyn_cast<AIEObjectFifoType>().getElementType();
 
       if (consumersPerFifo.find(objFifo) == consumersPerFifo.end()) {
         std::queue<Value> consumers;

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -114,7 +114,7 @@ struct AIEObjectFifoRegisterProcessPass
     // releases
     if (relNumber.getInt() > 0) {
       auto relOp = builder.create<ObjectFifoReleaseOp>(
-          builder.getUnknownLoc(), regOp.getPortAttr(), 
+          builder.getUnknownLoc(), regOp.getPortAttr(),
           SymbolRefAttr::get(ctx, regOp.getObjFifoName()), relNumber);
       builder.setInsertionPointAfter(relOp);
     }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -75,6 +75,7 @@ struct AIEObjectFifoRegisterProcessPass
   void createPattern(OpBuilder &builder, DeviceOp &device,
                      ObjectFifoRegisterProcessOp regOp, mlir::Type elementType,
                      IntegerAttr acqNumber, IntegerAttr relNumber, int length) {
+    auto ctx = device->getContext();
     // create for loop
     mlir::scf::ForOp forLoop;
     if (length > 1) {
@@ -88,7 +89,7 @@ struct AIEObjectFifoRegisterProcessPass
       auto acqType = AIEObjectFifoSubviewType::get(elementType);
       auto acqOp = builder.create<ObjectFifoAcquireOp>(
           builder.getUnknownLoc(), acqType, regOp.getPortAttr(),
-          regOp.getFifo(), acqNumber);
+          SymbolRefAttr::get(ctx, regOp.getObjFifoName()), acqNumber);
 
       // subview accesses
       ObjectFifoSubviewAccessOp acc;
@@ -113,8 +114,8 @@ struct AIEObjectFifoRegisterProcessPass
     // releases
     if (relNumber.getInt() > 0) {
       auto relOp = builder.create<ObjectFifoReleaseOp>(
-          builder.getUnknownLoc(), regOp.getPortAttr(), regOp.getFifo(),
-          relNumber);
+          builder.getUnknownLoc(), regOp.getPortAttr(), 
+          SymbolRefAttr::get(ctx, regOp.getObjFifoName()), relNumber);
       builder.setInsertionPointAfter(relOp);
     }
 
@@ -131,8 +132,7 @@ struct AIEObjectFifoRegisterProcessPass
     //===----------------------------------------------------------------------===//
     for (auto registerOp : device.getOps<ObjectFifoRegisterProcessOp>()) {
       builder.setInsertionPointToEnd(device.getBody());
-      ObjectFifoCreateOp objFifo =
-          registerOp.getFifo().getDefiningOp<ObjectFifoCreateOp>();
+      ObjectFifoCreateOp objFifo = registerOp.getObjectFifo();
       auto elementType =
           objFifo.getType().dyn_cast<AIEObjectFifoType>().getElementType();
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -238,8 +238,8 @@ struct AIEObjectFifoStatefulTransformPass
                                       Attribute depth) {
     auto ofName = builder.getStringAttr(name);
     ObjectFifoCreateOp fifo = builder.create<ObjectFifoCreateOp>(
-        builder.getUnknownLoc(), datatype, ofName, prodTile, consTile, 
-        depth);
+        builder.getUnknownLoc(), ofName, prodTile, consTile, depth,
+        datatype);
     return fifo;
   }
 
@@ -301,7 +301,7 @@ struct AIEObjectFifoStatefulTransformPass
 
     std::vector<BufferOp> buffers;
     std::vector<LockOp> locks;
-    AIEObjectFifoType fifo = op.getType().cast<AIEObjectFifoType>();
+    AIEObjectFifoType fifo = op.getElemType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifo.getElementType().cast<MemRefType>();
     int numElem = op.size();
     int of_elem_index = 0; // used to give objectFifo elements a symbolic name
@@ -327,12 +327,12 @@ struct AIEObjectFifoStatefulTransformPass
           return;
       } else {
         AIEObjectFifoType fifoInType =
-            linkOp->getInputObjectFifos()[0].getType().cast<AIEObjectFifoType>();
+            linkOp->getInputObjectFifos()[0].getElemType().cast<AIEObjectFifoType>();
         MemRefType elemInType = fifoInType.getElementType().cast<MemRefType>();
         int inSize = getMemrefTypeSize(elemInType);
 
         AIEObjectFifoType fifoOutType =
-            linkOp->getOutputObjectFifos()[0].getType().cast<AIEObjectFifoType>();
+            linkOp->getOutputObjectFifos()[0].getElemType().cast<AIEObjectFifoType>();
         MemRefType elemOutType =
             fifoOutType.getElementType().cast<MemRefType>();
         int outSize = getMemrefTypeSize(elemOutType);
@@ -464,7 +464,7 @@ struct AIEObjectFifoStatefulTransformPass
     int relNum = 1;
     int offset = 0;
 
-    AIEObjectFifoType fifo = op.getType().cast<AIEObjectFifoType>();
+    AIEObjectFifoType fifo = op.getElemType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifo.getElementType().cast<MemRefType>();
     int len = getMemrefTypeSize(elemType);
 
@@ -611,7 +611,7 @@ struct AIEObjectFifoStatefulTransformPass
       return;
 
     int offset = 0;
-    AIEObjectFifoType fifo = op.getType().cast<AIEObjectFifoType>();
+    AIEObjectFifoType fifo = op.getElemType().cast<AIEObjectFifoType>();
     MemRefType elemType = fifo.getElementType().cast<MemRefType>();
     int lenOut = getMemrefTypeSize(elemType);
     int bytes = elemType.getElementTypeBitWidth() / 8;
@@ -638,7 +638,7 @@ struct AIEObjectFifoStatefulTransformPass
           } else {
             for (auto fifoIn : linkOp->getInputObjectFifos()) {
               AIEObjectFifoType fifoType =
-                  fifoIn.getType().cast<AIEObjectFifoType>();
+                  fifoIn.getElemType().cast<AIEObjectFifoType>();
               MemRefType elemType =
                   fifoType.getElementType().cast<MemRefType>();
               if (fifoIn.name() == op.name())
@@ -656,7 +656,7 @@ struct AIEObjectFifoStatefulTransformPass
           } else {
             for (auto fifoOut : linkOp->getOutputObjectFifos()) {
               AIEObjectFifoType fifoType =
-                  fifoOut.getType().cast<AIEObjectFifoType>();
+                  fifoOut.getElemType().cast<AIEObjectFifoType>();
               MemRefType elemType =
                   fifoType.getElementType().cast<MemRefType>();
               if (fifoOut.name() == op.name())
@@ -668,7 +668,7 @@ struct AIEObjectFifoStatefulTransformPass
         } else {
           if (target != op) {
             AIEObjectFifoType targetFifo =
-                target.getType().cast<AIEObjectFifoType>();
+                target.getElemType().cast<AIEObjectFifoType>();
             MemRefType targetElemType =
                 targetFifo.getElementType().cast<MemRefType>();
             lenOut = getMemrefTypeSize(targetElemType);
@@ -1156,7 +1156,7 @@ struct AIEObjectFifoStatefulTransformPass
 
         builder.setInsertionPointAfter(createOp);
         AIEObjectFifoType datatype =
-            createOp.getType().cast<AIEObjectFifoType>();
+            createOp.getElemType().cast<AIEObjectFifoType>();
         auto consumerObjFifoSize =
             builder.getIntegerAttr(builder.getI32Type(), consumerDepth);
         // rename and replace split objectFifo
@@ -1468,7 +1468,7 @@ struct AIEObjectFifoStatefulTransformPass
       createOp->setAttr(mlir::SymbolTable::getSymbolAttrName(),
                         builder.getStringAttr("__erase_" + sym_name));
       auto memrefType = cast<MemRefType>(
-          cast<AIEObjectFifoType>(createOp.getType()).getElementType());
+          cast<AIEObjectFifoType>(createOp.getElemType()).getElementType());
       builder.create<memref::GlobalOp>(builder.getUnknownLoc(), sym_name,
                                        builder.getStringAttr("public"), 
                                        memrefType, nullptr, false, nullptr);

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -233,13 +233,11 @@ struct AIEObjectFifoStatefulTransformPass
 
   ObjectFifoCreateOp createObjectFifo(OpBuilder &builder,
                                       AIEObjectFifoType datatype,
-                                      std::string name,
-                                      Value prodTile, Value consTile,
-                                      Attribute depth) {
+                                      std::string name, Value prodTile,
+                                      Value consTile, Attribute depth) {
     auto ofName = builder.getStringAttr(name);
     ObjectFifoCreateOp fifo = builder.create<ObjectFifoCreateOp>(
-        builder.getUnknownLoc(), ofName, prodTile, consTile, depth,
-        datatype);
+        builder.getUnknownLoc(), ofName, prodTile, consTile, depth, datatype);
     return fifo;
   }
 
@@ -326,13 +324,15 @@ struct AIEObjectFifoStatefulTransformPass
         if (op.name() != fifoIn.name())
           return;
       } else {
-        AIEObjectFifoType fifoInType =
-            linkOp->getInputObjectFifos()[0].getElemType().cast<AIEObjectFifoType>();
+        AIEObjectFifoType fifoInType = linkOp->getInputObjectFifos()[0]
+                                           .getElemType()
+                                           .cast<AIEObjectFifoType>();
         MemRefType elemInType = fifoInType.getElementType().cast<MemRefType>();
         int inSize = getMemrefTypeSize(elemInType);
 
-        AIEObjectFifoType fifoOutType =
-            linkOp->getOutputObjectFifos()[0].getElemType().cast<AIEObjectFifoType>();
+        AIEObjectFifoType fifoOutType = linkOp->getOutputObjectFifos()[0]
+                                            .getElemType()
+                                            .cast<AIEObjectFifoType>();
         MemRefType elemOutType =
             fifoOutType.getElementType().cast<MemRefType>();
         int outSize = getMemrefTypeSize(elemOutType);
@@ -1041,13 +1041,12 @@ struct AIEObjectFifoStatefulTransformPass
   }
 
   /// Function used to replace uses of split objectFifos.
-  void replaceSplitFifo(ObjectFifoCreateOp originalOp, 
-                        ObjectFifoCreateOp newOp, 
+  void replaceSplitFifo(ObjectFifoCreateOp originalOp, ObjectFifoCreateOp newOp,
                         TileOp tile) {
-    auto original = originalOp->getAttrOfType<StringAttr>(
-        SymbolTable::getSymbolAttrName());
-    auto newSymbol = newOp->getAttrOfType<StringAttr>(
-        SymbolTable::getSymbolAttrName());
+    auto original =
+        originalOp->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
+    auto newSymbol =
+        newOp->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
     for (auto user : tile->getUsers())
       if (auto coreOp = dyn_cast<CoreOp>(user))
         mlir::SymbolTable::replaceAllSymbolUses(original, newSymbol, user);
@@ -1163,14 +1162,14 @@ struct AIEObjectFifoStatefulTransformPass
         std::string consumerFifoName;
         if (createOp.getConsumerTiles().size() > 1) {
           consumerFifoName = createOp.name().str() + "_" +
-                                std::to_string(consumerIndex) + "_cons";
+                             std::to_string(consumerIndex) + "_cons";
           consumerIndex++;
         } else {
           consumerFifoName = createOp.name().str() + "_cons";
         }
-        ObjectFifoCreateOp consumerFifo = createObjectFifo(
-            builder, datatype, consumerFifoName, consumerTile, consumerTile, 
-            consumerObjFifoSize);
+        ObjectFifoCreateOp consumerFifo =
+            createObjectFifo(builder, datatype, consumerFifoName, consumerTile,
+                             consumerTile, consumerObjFifoSize);
         replaceSplitFifo(createOp, consumerFifo, consumerTileOp);
 
         // identify external buffers that were registered to
@@ -1187,8 +1186,8 @@ struct AIEObjectFifoStatefulTransformPass
           for (auto fifoIn : linkOp->getInputObjectFifos())
             if (fifoIn.name() == createOp.name())
               if (consumerTile == *(linkOp->getOptionalSharedTile()))
-                mlir::SymbolTable::replaceAllSymbolUses(createOp.name(), 
-                                                        consumerFifo.name(), 
+                mlir::SymbolTable::replaceAllSymbolUses(createOp.name(),
+                                                        consumerFifo.name(),
                                                         linkOp->getOperation());
       }
 
@@ -1470,7 +1469,7 @@ struct AIEObjectFifoStatefulTransformPass
       auto memrefType = cast<MemRefType>(
           cast<AIEObjectFifoType>(createOp.getElemType()).getElementType());
       builder.create<memref::GlobalOp>(builder.getUnknownLoc(), sym_name,
-                                       builder.getStringAttr("public"), 
+                                       builder.getStringAttr("public"),
                                        memrefType, nullptr, false, nullptr);
     }
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -1049,8 +1049,9 @@ struct AIEObjectFifoStatefulTransformPass
         newOp->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
     for (auto user : tile->getUsers())
       if (auto coreOp = dyn_cast<CoreOp>(user)) {
-        auto res = mlir::SymbolTable::replaceAllSymbolUses(original, newSymbol, user);
-        if (res.failed()) 
+        auto res =
+            mlir::SymbolTable::replaceAllSymbolUses(original, newSymbol, user);
+        if (res.failed())
           llvm_unreachable("unreachable");
       }
   }
@@ -1189,10 +1190,10 @@ struct AIEObjectFifoStatefulTransformPass
           for (auto fifoIn : linkOp->getInputObjectFifos())
             if (fifoIn.name() == createOp.name())
               if (consumerTile == *(linkOp->getOptionalSharedTile())) {
-                auto res = mlir::SymbolTable::replaceAllSymbolUses(createOp.name(),
-                                                        consumerFifo.name(),
-                                                        linkOp->getOperation());
-                if (res.failed()) 
+                auto res = mlir::SymbolTable::replaceAllSymbolUses(
+                    createOp.name(), consumerFifo.name(),
+                    linkOp->getOperation());
+                if (res.failed())
                   llvm_unreachable("unreachable");
               }
       }

--- a/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
+++ b/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
@@ -65,85 +65,85 @@ module @MM_2x2 {
   func.func private @extern_kernel(%A: memref<1024xi32>, %B: memref<1024xi32>, %acc: memref<1024xi32>, %C: memref<1024xi32>) -> ()
 
   %core63 = AIE.core(%t63) { 
-    %LHS0Subview = AIE.objectFifo.acquire @of_LHS0 <Consume>(Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %LHS0Subview = AIE.objectFifo.acquire @of_LHS0 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %LHS0 = AIE.objectFifo.subview.access %LHS0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %RHS0Subview = AIE.objectFifo.acquire<Consume>(%of_RHS0 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %RHS0Subview = AIE.objectFifo.acquire @of_RHS0 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %RHS0 = AIE.objectFifo.subview.access %RHS0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %ACC0Subview = AIE.objectFifo.acquire<Produce>(%of_ACC0 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %ACC0Subview = AIE.objectFifo.acquire @of_acc0 (Produce, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %ACC0 = AIE.objectFifo.subview.access %ACC0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
     func.call @extern_kernel(%LHS0, %RHS0, %buf63, %ACC0) : (memref<1024xi32>, memref<1024xi32>, memref<1024xi32>, memref<1024xi32>) -> ()
     
-    AIE.objectFifo.release @of_LHS0 <Consume>(Consume, 1)
-    AIE.objectFifo.release<Consume>(%of_RHS0 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Produce>(%of_ACC0 : !AIE.objectFifo<memref<1024xi32>>, 1)
+    AIE.objectFifo.release @of_LHS0 (Consume, 1)
+    AIE.objectFifo.release @of_RHS0 (Consume, 1)
+    AIE.objectFifo.release @of_acc0 (Produce, 1)
 
     AIE.end
   } { link_with="kernel.o" }
 
   %core64 = AIE.core(%t64) { 
-    %LHS1Subview = AIE.objectFifo.acquire<Consume>(%of_LHS1 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %LHS1Subview = AIE.objectFifo.acquire @of_LHS1 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %LHS1 = AIE.objectFifo.subview.access %LHS1Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %RHS1Subview = AIE.objectFifo.acquire<Consume>(%of_RHS1 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %RHS1Subview = AIE.objectFifo.acquire @of_RHS1 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %RHS1 = AIE.objectFifo.subview.access %RHS1Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %ACC0Subview = AIE.objectFifo.acquire<Consume>(%of_ACC0 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %ACC0Subview = AIE.objectFifo.acquire @of_acc0 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %ACC0 = AIE.objectFifo.subview.access %ACC0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %Out0Subview = AIE.objectFifo.acquire<Produce>(%of_Out0 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %Out0Subview = AIE.objectFifo.acquire @of_out0 (Produce, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %Out0 = AIE.objectFifo.subview.access %Out0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
     func.call @extern_kernel(%LHS1, %RHS1, %ACC0, %Out0) : (memref<1024xi32>, memref<1024xi32>, memref<1024xi32>, memref<1024xi32>) -> ()
     
-    AIE.objectFifo.release<Consume>(%of_LHS1 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Consume>(%of_RHS1 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Consume>(%of_ACC0 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Produce>(%of_Out0 : !AIE.objectFifo<memref<1024xi32>>, 1)
+    AIE.objectFifo.release @of_LHS1 (Consume, 1)
+    AIE.objectFifo.release @of_RHS1 (Consume, 1)
+    AIE.objectFifo.release @of_acc0 (Consume, 1)
+    AIE.objectFifo.release @of_out0 (Produce, 1)
 
     AIE.end
   } { link_with="kernel.o" }
 
   %core73 = AIE.core(%t73) { 
-    %LHS0Subview = AIE.objectFifo.acquire @of_LHS0 <Consume>(Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %LHS0Subview = AIE.objectFifo.acquire @of_LHS0 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %LHS0 = AIE.objectFifo.subview.access %LHS0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %RHS2Subview = AIE.objectFifo.acquire<Consume>(%of_RHS2 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %RHS2Subview = AIE.objectFifo.acquire @of_RHS2 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %RHS2 = AIE.objectFifo.subview.access %RHS2Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %ACC1Subview = AIE.objectFifo.acquire<Produce>(%of_ACC1 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %ACC1Subview = AIE.objectFifo.acquire @of_acc1 (Produce, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %ACC1 = AIE.objectFifo.subview.access %ACC1Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
     func.call @extern_kernel(%LHS0, %RHS2, %buf73, %ACC1) : (memref<1024xi32>, memref<1024xi32>, memref<1024xi32>, memref<1024xi32>) -> ()
     
-    AIE.objectFifo.release @of_LHS0 <Consume>(Consume, 1)
-    AIE.objectFifo.release<Consume>(%of_RHS2 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Produce>(%of_ACC1 : !AIE.objectFifo<memref<1024xi32>>, 1)
+    AIE.objectFifo.release @of_LHS0 (Consume, 1)
+    AIE.objectFifo.release @of_RHS2 (Consume, 1)
+    AIE.objectFifo.release @of_acc1 (Produce, 1)
 
     AIE.end
   } { link_with="kernel.o" }
 
   %core74 = AIE.core(%t74) { 
-    %LHS1Subview = AIE.objectFifo.acquire<Consume>(%of_LHS1 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %LHS1Subview = AIE.objectFifo.acquire @of_LHS1 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %LHS1 = AIE.objectFifo.subview.access %LHS1Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %RHS3Subview = AIE.objectFifo.acquire<Consume>(%of_RHS3 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %RHS3Subview = AIE.objectFifo.acquire @of_RHS3 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %RHS3 = AIE.objectFifo.subview.access %RHS3Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %ACC1Subview = AIE.objectFifo.acquire<Consume>(%of_ACC1 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %ACC1Subview = AIE.objectFifo.acquire @of_acc1 (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %ACC1 = AIE.objectFifo.subview.access %ACC1Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
-    %Out1Subview = AIE.objectFifo.acquire<Produce>(%of_Out1 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %Out1Subview = AIE.objectFifo.acquire @of_out1 (Produce, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %Out1 = AIE.objectFifo.subview.access %Out1Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
     func.call @extern_kernel(%LHS1, %RHS3, %ACC1, %Out1) : (memref<1024xi32>, memref<1024xi32>, memref<1024xi32>, memref<1024xi32>) -> ()
     
-    AIE.objectFifo.release<Consume>(%of_LHS1 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Consume>(%of_RHS3 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Consume>(%of_ACC1 : !AIE.objectFifo<memref<1024xi32>>, 1)
-    AIE.objectFifo.release<Produce>(%of_Out1 : !AIE.objectFifo<memref<1024xi32>>, 1)
+    AIE.objectFifo.release @of_LHS1 (Consume, 1)
+    AIE.objectFifo.release @of_RHS3 (Consume, 1)
+    AIE.objectFifo.release @of_acc1 (Consume, 1)
+    AIE.objectFifo.release @of_out1 (Produce, 1)
 
     AIE.end
   } { link_with="kernel.o" }

--- a/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
+++ b/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
@@ -26,18 +26,18 @@ module @MM_2x2 {
 
   %t100 = AIE.tile(10, 0)
 
-  %of_LHS0 = AIE.objectFifo.createObjectFifo(%t60, {%t63, %t73}, 1 : i32) {sym_name = "of_LHS0"} : !AIE.objectFifo<memref<1024xi32>>
-  %of_LHS1 = AIE.objectFifo.createObjectFifo(%t60, {%t64, %t74}, 1 : i32) {sym_name = "of_LHS1"} : !AIE.objectFifo<memref<1024xi32>>
-  %of_RHS0 = AIE.objectFifo.createObjectFifo(%t70, {%t63}, 1 : i32) {sym_name = "of_RHS0"} : !AIE.objectFifo<memref<1024xi32>>
-  %of_RHS1 = AIE.objectFifo.createObjectFifo(%t70, {%t64}, 1 : i32) {sym_name = "of_RHS1"} : !AIE.objectFifo<memref<1024xi32>>
-  %of_RHS2 = AIE.objectFifo.createObjectFifo(%t100, {%t73}, 1 : i32) {sym_name = "of_RHS2"} : !AIE.objectFifo<memref<1024xi32>>
-  %of_RHS3 = AIE.objectFifo.createObjectFifo(%t100, {%t74}, 1 : i32) {sym_name = "of_RHS3"} : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_LHS0 (%t60, {%t63, %t73}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_LHS1 (%t60, {%t64, %t74}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_RHS0 (%t70, {%t63}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_RHS1 (%t70, {%t64}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_RHS2 (%t100, {%t73}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_RHS3 (%t100, {%t74}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
 
-  %of_Out0 = AIE.objectFifo.createObjectFifo(%t64, {%t60}, 1 : i32) {sym_name = "of_out0"} : !AIE.objectFifo<memref<1024xi32>>
-  %of_Out1 = AIE.objectFifo.createObjectFifo(%t74, {%t60}, 1 : i32) {sym_name = "of_out1"} : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_out0 (%t64, {%t60}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_out1 (%t74, {%t60}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
 
-  %of_ACC0 = AIE.objectFifo.createObjectFifo(%t63, {%t64}, 1 : i32) {sym_name = "of_acc0"} : !AIE.objectFifo<memref<1024xi32>>
-  %of_ACC1 = AIE.objectFifo.createObjectFifo(%t73, {%t74}, 1 : i32) {sym_name = "of_acc1"} : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_acc0 (%t63, {%t64}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+  AIE.objectFifo @of_acc1 (%t73, {%t74}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
 
   %buffer0 = AIE.external_buffer {sym_name = "LHS_tile0"} : memref<1024 x i32>     //LHS_tile0
   %buffer1 = AIE.external_buffer {sym_name = "LHS_tile1"} : memref<1024 x i32>     //LHS_tile1

--- a/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
+++ b/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
@@ -65,7 +65,7 @@ module @MM_2x2 {
   func.func private @extern_kernel(%A: memref<1024xi32>, %B: memref<1024xi32>, %acc: memref<1024xi32>, %C: memref<1024xi32>) -> ()
 
   %core63 = AIE.core(%t63) { 
-    %LHS0Subview = AIE.objectFifo.acquire<Consume>(%of_LHS0 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %LHS0Subview = AIE.objectFifo.acquire @of_LHS0 <Consume>(Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %LHS0 = AIE.objectFifo.subview.access %LHS0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
     %RHS0Subview = AIE.objectFifo.acquire<Consume>(%of_RHS0 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
@@ -76,7 +76,7 @@ module @MM_2x2 {
 
     func.call @extern_kernel(%LHS0, %RHS0, %buf63, %ACC0) : (memref<1024xi32>, memref<1024xi32>, memref<1024xi32>, memref<1024xi32>) -> ()
     
-    AIE.objectFifo.release<Consume>(%of_LHS0 : !AIE.objectFifo<memref<1024xi32>>, 1)
+    AIE.objectFifo.release @of_LHS0 <Consume>(Consume, 1)
     AIE.objectFifo.release<Consume>(%of_RHS0 : !AIE.objectFifo<memref<1024xi32>>, 1)
     AIE.objectFifo.release<Produce>(%of_ACC0 : !AIE.objectFifo<memref<1024xi32>>, 1)
 
@@ -107,7 +107,7 @@ module @MM_2x2 {
   } { link_with="kernel.o" }
 
   %core73 = AIE.core(%t73) { 
-    %LHS0Subview = AIE.objectFifo.acquire<Consume>(%of_LHS0 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+    %LHS0Subview = AIE.objectFifo.acquire @of_LHS0 <Consume>(Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
     %LHS0 = AIE.objectFifo.subview.access %LHS0Subview[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
     %RHS2Subview = AIE.objectFifo.acquire<Consume>(%of_RHS2 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
@@ -118,7 +118,7 @@ module @MM_2x2 {
 
     func.call @extern_kernel(%LHS0, %RHS2, %buf73, %ACC1) : (memref<1024xi32>, memref<1024xi32>, memref<1024xi32>, memref<1024xi32>) -> ()
     
-    AIE.objectFifo.release<Consume>(%of_LHS0 : !AIE.objectFifo<memref<1024xi32>>, 1)
+    AIE.objectFifo.release @of_LHS0 <Consume>(Consume, 1)
     AIE.objectFifo.release<Consume>(%of_RHS2 : !AIE.objectFifo<memref<1024xi32>>, 1)
     AIE.objectFifo.release<Produce>(%of_ACC1 : !AIE.objectFifo<memref<1024xi32>>, 1)
 

--- a/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
+++ b/reference_designs/MM_2x2/objectFifo_circuit_switched_version/aie.mlir
@@ -48,16 +48,16 @@ module @MM_2x2 {
   %buffer6 = AIE.external_buffer {sym_name = "Out_tile0"} : memref<1024 x i32>     //Out_tile0
   %buffer7 = AIE.external_buffer {sym_name = "Out_tile1"} : memref<1024 x i32>     //Out_tile1
 
-  AIE.objectFifo.registerExternalBuffers(%t60, %of_LHS0 : !AIE.objectFifo<memref<1024xi32>>, {%buffer0}) : (memref<1024xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t60, %of_LHS1 : !AIE.objectFifo<memref<1024xi32>>, {%buffer1}) : (memref<1024xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t60, %of_Out0 : !AIE.objectFifo<memref<1024xi32>>, {%buffer6}) : (memref<1024xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t60, %of_Out1 : !AIE.objectFifo<memref<1024xi32>>, {%buffer7}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_LHS0 (%t60, {%buffer0}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_LHS1 (%t60, {%buffer1}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_out0 (%t60, {%buffer6}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_out1 (%t60, {%buffer7}) : (memref<1024xi32>)
 
-  AIE.objectFifo.registerExternalBuffers(%t70, %of_RHS0 : !AIE.objectFifo<memref<1024xi32>>, {%buffer2}) : (memref<1024xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %of_RHS1 : !AIE.objectFifo<memref<1024xi32>>, {%buffer3}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_RHS0 (%t70, {%buffer2}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_RHS1 (%t70, {%buffer3}) : (memref<1024xi32>)
 
-  AIE.objectFifo.registerExternalBuffers(%t100, %of_RHS2 : !AIE.objectFifo<memref<1024xi32>>, {%buffer4}) : (memref<1024xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t100, %of_RHS3 : !AIE.objectFifo<memref<1024xi32>>, {%buffer5}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_RHS2 (%t100, {%buffer4}) : (memref<1024xi32>)
+  AIE.objectFifo.registerExternalBuffers @of_RHS3 (%t100, {%buffer5}) : (memref<1024xi32>)
 
   %buf63 = AIE.buffer(%t63) {sym_name = "buf63"} : memref<1024xi32>  //Accumulator0
   %buf73 = AIE.buffer(%t73) {sym_name = "buf73"} : memref<1024xi32>  //Accumulator1

--- a/reference_designs/autocorrelation/objectFifo_version/aie.mlir
+++ b/reference_designs/autocorrelation/objectFifo_version/aie.mlir
@@ -27,15 +27,15 @@ module @autocorrelation {
     %inputExt = AIE.external_buffer {sym_name = "input"} : memref<1024 x i32>
     %outputExt = AIE.external_buffer {sym_name = "output"} : memref<1024 x i32>
 
-    %objFifoIn = AIE.objectFifo.createObjectFifo(%tile7_0, {%tile0_1, %tile0_2, %tile0_3, %tile0_4}, 1 : i32) {sym_name = "of_in"} : !AIE.objectFifo<memref<1024xi32>>
-    %objFifoOut = AIE.objectFifo.createObjectFifo(%tile0_1, {%tile7_0}, 1 : i32) {sym_name = "of_out"} : !AIE.objectFifo<memref<1024xi32>>
+    AIE.objectFifo @of_in (%tile7_0, {%tile0_1, %tile0_2, %tile0_3, %tile0_4}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+    AIE.objectFifo @of_out (%tile0_1, {%tile7_0}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
 
     AIE.objectFifo.registerExternalBuffers(%tile7_0, %objFifoIn : !AIE.objectFifo<memref<1024xi32>>, {%inputExt}) : (memref<1024xi32>)
     AIE.objectFifo.registerExternalBuffers(%tile7_0, %objFifoOut : !AIE.objectFifo<memref<1024xi32>>, {%outputExt}) : (memref<1024xi32>)
 
-    %objFifo_04_03 = AIE.objectFifo.createObjectFifo(%tile0_4, {%tile0_3}, 1 : i32) {sym_name = "of_04_03"} : !AIE.objectFifo<memref<1024xi32>>
-    %objFifo_03_02 = AIE.objectFifo.createObjectFifo(%tile0_3, {%tile0_2}, 1 : i32) {sym_name = "of_03_02"} : !AIE.objectFifo<memref<1024xi32>>
-    %objFifo_02_01 = AIE.objectFifo.createObjectFifo(%tile0_2, {%tile0_1}, 1 : i32) {sym_name = "of_02_01"} : !AIE.objectFifo<memref<1024xi32>>
+    AIE.objectFifo @of_04_03 (%tile0_4, {%tile0_3}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+    AIE.objectFifo @of_03_02 (%tile0_3, {%tile0_2}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
+    AIE.objectFifo @of_02_01 (%tile0_2, {%tile0_1}, 1 : i32) : !AIE.objectFifo<memref<1024xi32>>
 
     func.func @autocorrelate(%bufin: memref<1024xi32>, %bufout:memref<1024xi32>, %offset:index, %blocksize:index) -> () {
         %c0 = arith.constant 0 : index

--- a/reference_designs/autocorrelation/objectFifo_version/aie.mlir
+++ b/reference_designs/autocorrelation/objectFifo_version/aie.mlir
@@ -58,8 +58,8 @@ module @autocorrelation {
     }
 
     AIE.core(%tile0_1) {
-        %subviewIn = AIE.objectFifo.acquire<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
-        %subviewOut = AIE.objectFifo.acquire<Produce>(%objFifoOut : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+        %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+        %subviewOut = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
         
         %input = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
         %output = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
@@ -68,10 +68,10 @@ module @autocorrelation {
 
         func.call @autocorrelate(%input, %output, %offset, %blocksize) : (memref<1024xi32>, memref<1024xi32>, index, index) -> ()
 
-        AIE.objectFifo.release<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1)
+        AIE.objectFifo.release @of_in (Consume, 1)
 
         // Append the prior results, block of 16.
-        %subviewIn2 = AIE.objectFifo.acquire<Consume>(%objFifo_02_01 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+        %subviewIn2 = AIE.objectFifo.acquire @of_in (%objFifo_02_01 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
         %input2 = AIE.objectFifo.subview.access %subviewIn2[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 
         %1 = memref.subview %input2[0][64][1] : memref<1024xi32> to memref<64xi32>
@@ -80,13 +80,13 @@ module @autocorrelation {
         
         AIE.objectFifo.release<Consume>(%objFifo_02_01 : !AIE.objectFifo<memref<1024xi32>>, 1)
 
-        AIE.objectFifo.release<Produce>(%objFifoOut : !AIE.objectFifo<memref<1024xi32>>, 1)
+        AIE.objectFifo.release @of_out (Produce, 1)
         
         AIE.end
     }
 
     AIE.core(%tile0_2) {
-        %subviewIn = AIE.objectFifo.acquire<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+        %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
         %subviewOut = AIE.objectFifo.acquire<Produce>(%objFifo_02_01 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
         
         %input = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
@@ -96,7 +96,7 @@ module @autocorrelation {
 
         func.call @autocorrelate(%input, %output, %offset, %blocksize) : (memref<1024xi32>, memref<1024xi32>, index, index) -> ()
 
-        AIE.objectFifo.release<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1)
+        AIE.objectFifo.release @of_in (Consume, 1)
 
         // Append the prior results, block of 16.
         %subviewIn3 = AIE.objectFifo.acquire<Consume>(%objFifo_03_02 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
@@ -114,7 +114,7 @@ module @autocorrelation {
     }
 
     AIE.core(%tile0_3) {
-        %subviewIn = AIE.objectFifo.acquire<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+        %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
         %subviewOut = AIE.objectFifo.acquire<Produce>(%objFifo_03_02 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
         
         %input = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
@@ -124,7 +124,7 @@ module @autocorrelation {
 
         func.call @autocorrelate(%input, %output, %offset, %blocksize) : (memref<1024xi32>, memref<1024xi32>, index, index) -> ()
 
-        AIE.objectFifo.release<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1)
+        AIE.objectFifo.release @of_in (Consume, 1)
 
         // Append the prior results, block of 16.
         %subviewIn4 = AIE.objectFifo.acquire<Consume>(%objFifo_04_03 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
@@ -142,7 +142,7 @@ module @autocorrelation {
     }
 
     AIE.core(%tile0_4) {
-        %subviewIn = AIE.objectFifo.acquire<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+        %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
         %subviewOut = AIE.objectFifo.acquire<Produce>(%objFifo_04_03 : !AIE.objectFifo<memref<1024xi32>>, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
 
         %input = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
@@ -153,7 +153,7 @@ module @autocorrelation {
         func.call @autocorrelate(%input, %output, %offset, %blocksize) : (memref<1024xi32>, memref<1024xi32>, index, index) -> ()
 
         AIE.objectFifo.release<Produce>(%objFifo_04_03 : !AIE.objectFifo<memref<1024xi32>>, 1)
-        AIE.objectFifo.release<Consume>(%objFifoIn : !AIE.objectFifo<memref<1024xi32>>, 1)
+        AIE.objectFifo.release @of_in (Consume, 1)
         
         AIE.end
     }

--- a/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie.mlir
@@ -32,28 +32,25 @@ module @hdiff_multi_AIE{
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 5) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xi32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 4 ) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Produce, 4) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
       func.call @hdiff_lap(%row0,%row1,%row2,%row3,%row4,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>,  memref<256xi32>,  memref<256xi32>,  memref<256xi32>) -> ()
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Produce, 4)
+      AIE.objectFifo.release @obj_in (Consume, 1)
 
     }
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_lap.o" }
@@ -65,28 +62,27 @@ func.func private @hdiff_flux(%AF: memref<256xi32>,%BF: memref<256xi32>, %CF:  m
     %ub = arith.constant 2: index
     %step = arith.constant 1 : index
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 5) : !AIE.objectFifoSubview<memref<256xi32>>
-      
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xi32>>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 4) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Consume, 4) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview_flux = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_flux = AIE.objectFifo.acquire @obj_out_flux (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_flux = AIE.objectFifo.subview.access %obj_out_subview_flux[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
       func.call @hdiff_flux(%row1,%row2,%row3,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4, %obj_out_flux ) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>,  memref<256xi32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 4)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xi32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Consume, 4)
+      AIE.objectFifo.release @obj_out_flux (Produce, 1)
+      AIE.objectFifo.release @obj_in (Consume, 1)
     }
     AIE.useLock(%lock72_14, "Acquire", 0) // stop the timer
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_flux.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie.mlir
@@ -12,9 +12,10 @@ module @hdiff_multi_AIE{
   %lock71_14 = AIE.lock(%t71, 14) { sym_name = "lock71_14" }
   %lock72_14 = AIE.lock(%t72, 14) { sym_name = "lock72_14" }
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71,%t72}, 6 : i32) {sym_name = "obj_in" }: !AIE.objectFifo<memref<256xi32>>
-  %obj_fifo_out_lap = AIE.objectFifo.createObjectFifo(%t71, {%t72}, 4 : i32) {sym_name = "obj_out_lap" } : !AIE.objectFifo<memref<256xi32>>
-  %obj_fifo_out_flux = AIE.objectFifo.createObjectFifo(%t72, {%t70}, 2 : i32) {sym_name = "obj_out_flux" } : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_in (%t70, {%t71,%t72}, 6 : i32) : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_out_lap (%t71, {%t72}, 4 : i32) : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_out_flux (%t72, {%t70}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
+  
    // DDR buffer
   %ext_buffer_in0  = AIE.external_buffer  {sym_name = "ddr_test_buffer_in0"}: memref<1536 x i32>
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x i32>

--- a/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie.mlir
@@ -21,8 +21,8 @@ module @hdiff_multi_AIE{
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x i32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_in0}) : (memref<1536xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out_flux : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_out}) : (memref<512xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out_flux (%t70, {%ext_buffer_out}) : (memref<512xi32>)
 
   func.func private @hdiff_lap(%AL: memref<256xi32>,%BL: memref<256xi32>, %CL:  memref<256xi32>, %DL: memref<256xi32>, %EL:  memref<256xi32>,  %OLL1: memref<256xi32>,  %OLL2: memref<256xi32>,  %OLL3: memref<256xi32>,  %OLL4: memref<256xi32>) -> ()
   

--- a/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -33,7 +33,7 @@ module @hdiff_multi_AIE{
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume 5) : !AIE.objectFifoSubview<memref<256xf32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
@@ -41,21 +41,18 @@ module @hdiff_multi_AIE{
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
 
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 4 ) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Produce, 4 ) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
       func.call @hdiff_lap_fp32(%row0,%row1,%row2,%row3,%row4,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>,  memref<256xf32>,  memref<256xf32>,  memref<256xf32>) -> ()
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Produce, 4)
+      AIE.objectFifo.release @obj_in (Consume 1)
 
     }
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume 4)
 
     AIE.end
   } { link_with="hdiff_lap_fp32.o" }
@@ -68,29 +65,29 @@ func.func private @hdiff_flux_fp32(%AF: memref<256xf32>,%BF: memref<256xf32>, %C
     %ub = arith.constant 2: index
     %step = arith.constant 1 : index
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume 5) : !AIE.objectFifoSubview<memref<256xf32>>
       
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 4) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Consume, 4) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
-      %obj_out_subview_flux = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xf32>>, 1) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview_flux = AIE.objectFifo.acquire @obj_out_flux (Produce, 1) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out_flux = AIE.objectFifo.subview.access %obj_out_subview_flux[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
 
       func.call @hdiff_flux_fp32(%row1,%row2,%row3,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4, %obj_out_flux ) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>,  memref<256xf32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 4)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Consume, 4)
+      AIE.objectFifo.release @obj_out_flux (Produce, 1)
+      AIE.objectFifo.release @obj_in (Consume 1)
     }
     AIE.useLock(%lock72_14, "Acquire", 0) // stop the timer
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume 4)
 
     AIE.end
   } { link_with="hdiff_flux_fp32.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -13,9 +13,9 @@ module @hdiff_multi_AIE{
   %lock71_14 = AIE.lock(%t71, 14) { sym_name = "lock71_14" }
   %lock72_14 = AIE.lock(%t72, 14) { sym_name = "lock72_14" }
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71,%t72}, 6 : i32) {sym_name = "" }: !AIE.objectFifo<memref<256xf32>>
-  %obj_fifo_out_lap = AIE.objectFifo.createObjectFifo(%t71, {%t72}, 4 : i32){sym_name = "obj_out_lap" } : !AIE.objectFifo<memref<256xf32>>
-  %obj_fifo_out_flux = AIE.objectFifo.createObjectFifo(%t72, {%t70}, 2 : i32){sym_name = "obj_out_flux" } : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_in (%t70, {%t71,%t72}, 6 : i32) : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_out_lap (%t71, {%t72}, 4 : i32) : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_out_flux (%t72, {%t70}, 2 : i32) : !AIE.objectFifo<memref<256xf32>>
    // DDR buffer
   %ext_buffer_in0  = AIE.external_buffer  {sym_name = "ddr_test_buffer_in0"}: memref<1536 x f32>
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x f32>

--- a/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -21,8 +21,8 @@ module @hdiff_multi_AIE{
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x f32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_in0}) : (memref<1536xf32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out_flux : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_out}) : (memref<512xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out_flux (%t70, {%ext_buffer_out}) : (memref<512xf32>)
 
   func.func private @hdiff_lap_fp32(%AL: memref<256xf32>,%BL: memref<256xf32>, %CL:  memref<256xf32>, %DL: memref<256xf32>, %EL:  memref<256xf32>,  %OLL1: memref<256xf32>,  %OLL2: memref<256xf32>,  %OLL3: memref<256xf32>,  %OLL4: memref<256xf32>) -> ()
   

--- a/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_dual_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -33,7 +33,7 @@ module @hdiff_multi_AIE{
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xf32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
@@ -49,10 +49,10 @@ module @hdiff_multi_AIE{
 
       func.call @hdiff_lap_fp32(%row0,%row1,%row2,%row3,%row4,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>,  memref<256xf32>,  memref<256xf32>,  memref<256xf32>) -> ()
       AIE.objectFifo.release @obj_out_lap (Produce, 4)
-      AIE.objectFifo.release @obj_in (Consume 1)
+      AIE.objectFifo.release @obj_in (Consume, 1)
 
     }
-    AIE.objectFifo.release @obj_in (Consume 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_lap_fp32.o" }
@@ -65,7 +65,7 @@ func.func private @hdiff_flux_fp32(%AF: memref<256xf32>,%BF: memref<256xf32>, %C
     %ub = arith.constant 2: index
     %step = arith.constant 1 : index
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xf32>>
       
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
@@ -84,10 +84,10 @@ func.func private @hdiff_flux_fp32(%AF: memref<256xf32>,%BF: memref<256xf32>, %C
       func.call @hdiff_flux_fp32(%row1,%row2,%row3,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4, %obj_out_flux ) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>,  memref<256xf32>) -> ()
       AIE.objectFifo.release @obj_out_lap (Consume, 4)
       AIE.objectFifo.release @obj_out_flux (Produce, 1)
-      AIE.objectFifo.release @obj_in (Consume 1)
+      AIE.objectFifo.release @obj_in (Consume, 1)
     }
     AIE.useLock(%lock72_14, "Acquire", 0) // stop the timer
-    AIE.objectFifo.release @obj_in (Consume 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_flux_fp32.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie.mlir
@@ -10,8 +10,8 @@ module @hdiff_single_AIE {
   
   %lock71_14 = AIE.lock(%t71, 14) {sym_name = "lock71_14"}
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71}, 5 : i32) {sym_name = "obj_in" }: !AIE.objectFifo<memref<256xi32>>
-  %obj_fifo_out = AIE.objectFifo.createObjectFifo(%t71, {%t70}, 1 : i32) {sym_name = "obj_out" } : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_in (%t70, {%t71}, 5 : i32) : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_out (%t71, {%t70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
    // DDR buffer
   %ext_buffer_in0 = AIE.external_buffer {sym_name = "ddr_test_buffer_in0"}: memref<1536 x i32>

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie.mlir
@@ -29,22 +29,22 @@ module @hdiff_single_AIE {
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 5) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xi32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview = AIE.objectFifo.acquire<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview = AIE.objectFifo.acquire @obj_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out = AIE.objectFifo.subview.access %obj_out_subview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
     
       func.call @vec_hdiff(%row0,%row1,%row2,%row3,%row4,%obj_out) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xi32>>, 1)
+      AIE.objectFifo.release @obj_in (Consume, 1)
+      AIE.objectFifo.release @obj_out (Produce, 1)
     }
     AIE.useLock(%lock71_14, "Release", 0) // stop the timer
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie.mlir
@@ -18,8 +18,8 @@ module @hdiff_single_AIE {
   %ext_buffer_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<512 x i32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_in0}) : (memref<1536xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_out}) : (memref<512xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out (%t70, {%ext_buffer_out}) : (memref<512xi32>)
 
   func.func private @vec_hdiff(%A: memref<256xi32>,%B: memref<256xi32>, %C:  memref<256xi32>, %D: memref<256xi32>, %E:  memref<256xi32>,  %O: memref<256xi32>) -> ()
 

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
@@ -19,8 +19,8 @@ module @hdiff_single_AIE_fp32{
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x f32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_in0}) : (memref<1536xf32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_out}) : (memref<512xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out (%t70, {%ext_buffer_out}) : (memref<512xf32>)
 
   func.func private @vec_hdiff_fp32(%A: memref<256xf32>,%B: memref<256xf32>, %C:  memref<256xf32>, %D: memref<256xf32>, %E:  memref<256xf32>,  %O: memref<256xf32>) -> ()
 

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
@@ -31,7 +31,7 @@ module @hdiff_single_AIE_fp32{
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xf32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
@@ -43,11 +43,11 @@ module @hdiff_single_AIE_fp32{
     
     
       func.call @vec_hdiff_fp32(%row0,%row1,%row2,%row3,%row4,%obj_out) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>) -> ()
-      AIE.objectFifo.release @obj_in (Consume 1)
+      AIE.objectFifo.release @obj_in (Consume, 1)
       AIE.objectFifo.release @obj_out (Produce, 1)
     }
     AIE.useLock(%lock71_14, "Release", 0) // stop the timer
-    AIE.objectFifo.release @obj_in (Consume 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_fp32.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
@@ -11,8 +11,8 @@ module @hdiff_single_AIE_fp32{
   
   %lock71_14 = AIE.lock(%t71, 14) { sym_name = "lock71_14" }
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71}, 5 : i32) {sym_name = "obj_in" }: !AIE.objectFifo<memref<256xf32>>
-  %obj_fifo_out = AIE.objectFifo.createObjectFifo(%t71, {%t70}, 1 : i32){sym_name = "obj_out" } : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_in (%t70, {%t71}, 5 : i32) : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_out (%t71, {%t70}, 1 : i32) : !AIE.objectFifo<memref<256xf32>>
 
    // DDR buffer
   %ext_buffer_in0  = AIE.external_buffer  {sym_name = "ddr_test_buffer_in0"}: memref<1536 x f32>

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO/aie_fp32.mlir
@@ -31,23 +31,23 @@ module @hdiff_single_AIE_fp32{
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume 5) : !AIE.objectFifoSubview<memref<256xf32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
-      %obj_out_subview = AIE.objectFifo.acquire<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xf32>>, 1) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview = AIE.objectFifo.acquire @obj_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out = AIE.objectFifo.subview.access %obj_out_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
     
     
       func.call @vec_hdiff_fp32(%row0,%row1,%row2,%row3,%row4,%obj_out) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xf32>>, 1)
+      AIE.objectFifo.release @obj_in (Consume 1)
+      AIE.objectFifo.release @obj_out (Produce, 1)
     }
     AIE.useLock(%lock71_14, "Release", 0) // stop the timer
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume 4)
 
     AIE.end
   } { link_with="hdiff_fp32.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie.mlir
@@ -10,8 +10,8 @@ module @hdiff_single_AIE {
   
   %lock71_14 = AIE.lock(%t71, 14) { sym_name = "lock71_14" }
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71}, 6 : i32) {sym_name = "obj_in"}: !AIE.objectFifo<memref<256xi32>>
-  %obj_fifo_out = AIE.objectFifo.createObjectFifo(%t71, {%t70}, 2 : i32) {sym_name = "obj_out"} : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_in (%t70, {%t71}, 6 : i32) : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_out (%t71, {%t70}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
 
    // DDR buffer
   %ext_buffer_in0 = AIE.external_buffer {sym_name = "ddr_test_buffer_in0"}: memref<1536 x i32>

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie.mlir
@@ -18,8 +18,8 @@ module @hdiff_single_AIE {
   %ext_buffer_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<512 x i32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_in0}) : (memref<1536xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_out}) : (memref<512xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out (%t70, {%ext_buffer_out}) : (memref<512xi32>)
 
   func.func private @vec_hdiff(%A: memref<256xi32>, %B: memref<256xi32>, %C:  memref<256xi32>, %D: memref<256xi32>, %E:  memref<256xi32>,  %O: memref<256xi32>) -> ()
 

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie.mlir
@@ -29,22 +29,22 @@ module @hdiff_single_AIE {
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 5) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xi32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview = AIE.objectFifo.acquire<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview = AIE.objectFifo.acquire @obj_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out = AIE.objectFifo.subview.access %obj_out_subview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
     
       func.call @vec_hdiff(%row0,%row1,%row2,%row3,%row4,%obj_out) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xi32>>, 1)
+      AIE.objectFifo.release @obj_in (Consume, 1)
+      AIE.objectFifo.release @obj_out (Produce, 1)
     }
     AIE.useLock(%lock71_14, "Release", 0) // stop the timer
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -19,8 +19,8 @@ module @hdiff_single_AIE_fp32{
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x f32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_in0}) : (memref<1536xf32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_out}) : (memref<512xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out (%t70, {%ext_buffer_out}) : (memref<512xf32>)
 
   func.func private @vec_hdiff_fp32(%A: memref<256xf32>,%B: memref<256xf32>, %C:  memref<256xf32>, %D: memref<256xf32>, %E:  memref<256xf32>,  %O: memref<256xf32>) -> ()
 

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -11,8 +11,8 @@ module @hdiff_single_AIE_fp32{
   
   %lock71_14 = AIE.lock(%t71, 14) { sym_name = "lock71_14" }
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71}, 6 : i32) {sym_name = "obj_in" }: !AIE.objectFifo<memref<256xf32>>
-  %obj_fifo_out = AIE.objectFifo.createObjectFifo(%t71, {%t70}, 2 : i32){sym_name = "obj_out" } : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_in (%t70, {%t71}, 6 : i32) : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_out (%t71, {%t70}, 2 : i32) : !AIE.objectFifo<memref<256xf32>>
 
    // DDR buffer
   %ext_buffer_in0  = AIE.external_buffer  {sym_name = "ddr_test_buffer_in0"}: memref<1536 x f32>

--- a/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_single_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -31,23 +31,23 @@ module @hdiff_single_AIE_fp32{
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xf32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
-      %obj_out_subview = AIE.objectFifo.acquire<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xf32>>, 1) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview = AIE.objectFifo.acquire @obj_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out = AIE.objectFifo.subview.access %obj_out_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
     
     
       func.call @vec_hdiff_fp32(%row0,%row1,%row2,%row3,%row4,%obj_out) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out : !AIE.objectFifo<memref<256xf32>>, 1)
+      AIE.objectFifo.release @obj_in (Consume, 1)
+      AIE.objectFifo.release @obj_out (Produce, 1)
     }
     AIE.useLock(%lock71_14, "Release", 0) // stop the timer
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_fp32.o" }

--- a/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
@@ -13,10 +13,10 @@ module @hdiff_tri_AIE {
   %lock71_14 = AIE.lock(%t71, 14) {sym_name = "lock71_14"}
   %lock73_14 = AIE.lock(%t73, 14) {sym_name = "lock73_14"}
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71, %t72}, 6 : i32) {sym_name = "obj_in"} : !AIE.objectFifo<memref<256xi32>>
-  %obj_fifo_out_lap = AIE.objectFifo.createObjectFifo(%t71, {%t72}, 5 : i32) {sym_name = "obj_out_lap"} : !AIE.objectFifo<memref<256xi32>>
-  %obj_fifo_out_flux_inter1 = AIE.objectFifo.createObjectFifo(%t72, {%t73}, 6 : i32) {sym_name = "obj_out_flux_inter1"} : !AIE.objectFifo<memref<512xi32>>
-  %obj_fifo_out_flux = AIE.objectFifo.createObjectFifo(%t73, {%t70}, 2 : i32) {sym_name = "obj_out_flux"} : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_in (%t70, {%t71, %t72}, 6 : i32) : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_out_lap (%t71, {%t72}, 5 : i32)  : !AIE.objectFifo<memref<256xi32>>
+  AIE.objectFifo @obj_out_flux_inter1 (%t72, {%t73}, 6 : i32) : !AIE.objectFifo<memref<512xi32>>
+  AIE.objectFifo @obj_out_flux (%t73, {%t70}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
    
   // DDR buffer
   %ext_buffer_in0  = AIE.external_buffer {sym_name = "ddr_test_buffer_in0"} : memref<1536 x i32>

--- a/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
@@ -23,8 +23,8 @@ module @hdiff_tri_AIE {
   %ext_buffer_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"} : memref<512 x i32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_in0}) : (memref<1536xi32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out_flux : !AIE.objectFifo<memref<256xi32>>, {%ext_buffer_out}) : (memref<512xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xi32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out_flux (%t70, {%ext_buffer_out}) : (memref<512xi32>)
 
   func.func private @hdiff_lap(%AL: memref<256xi32>,%BL: memref<256xi32>, %CL:  memref<256xi32>, %DL: memref<256xi32>, %EL:  memref<256xi32>,  %OLL1: memref<256xi32>,  %OLL2: memref<256xi32>,  %OLL3: memref<256xi32>,  %OLL4: memref<256xi32>) -> ()
   func.func private @hdiff_flux1(%AF: memref<256xi32>,%BF: memref<256xi32>, %CF:  memref<256xi32>,   %OLF1: memref<256xi32>,  %OLF2: memref<256xi32>,  %OLF3: memref<256xi32>,  %OLF4: memref<256xi32>,  %OFI1: memref<512xi32>,  %OFI2: memref<512xi32>,  %OFI3: memref<512xi32>,  %OFI4: memref<512xi32>,  %OFI5: memref<512xi32>) -> ()

--- a/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
@@ -36,24 +36,24 @@ module @hdiff_tri_AIE {
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 5) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xi32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 4 ) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Produce 4 ) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
       func.call @hdiff_lap(%row0,%row1,%row2,%row3,%row4,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>,  memref<256xi32>,  memref<256xi32>,  memref<256xi32>) -> ()
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 4)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Produce 4)
+      AIE.objectFifo.release @obj_in (Consume, 1)
     }
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_lap.o" }
@@ -63,19 +63,19 @@ module @hdiff_tri_AIE {
     %ub = arith.constant 2: index
     %step = arith.constant 1 : index
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 5) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xi32>>
 
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 4) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Consume 4) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview_flux1 = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xi32>>, 5) : !AIE.objectFifoSubview<memref<512xi32>>
+      %obj_out_subview_flux1 = AIE.objectFifo.acquire @obj_out_flux_inter1 (Produce, 5) : !AIE.objectFifoSubview<memref<512xi32>>
       %obj_out_flux_inter1 = AIE.objectFifo.subview.access %obj_out_subview_flux1[0] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
 
       %obj_out_flux_inter2 = AIE.objectFifo.subview.access %obj_out_subview_flux1[1] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
@@ -84,11 +84,11 @@ module @hdiff_tri_AIE {
       %obj_out_flux_inter5 = AIE.objectFifo.subview.access %obj_out_subview_flux1[4] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
 
       func.call @hdiff_flux1(%row1,%row2,%row3,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4, %obj_out_flux_inter1 , %obj_out_flux_inter2, %obj_out_flux_inter3, %obj_out_flux_inter4, %obj_out_flux_inter5) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>,  memref<512xi32>,  memref<512xi32>,  memref<512xi32>,  memref<512xi32>,  memref<512xi32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xi32>>, 4)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xi32>>, 5)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Consume 4)
+      AIE.objectFifo.release @obj_out_flux_inter1 (Produce, 5)
+      AIE.objectFifo.release @obj_in (Consume, 1)
     }
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xi32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_flux1.o" }
@@ -99,7 +99,7 @@ module @hdiff_tri_AIE {
     %step = arith.constant 1 : index
     scf.for %iv = %lb to %ub step %step {  
 
-      %obj_out_subview_flux_inter1 = AIE.objectFifo.acquire<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xi32>>, 5) : !AIE.objectFifoSubview<memref<512xi32>>
+      %obj_out_subview_flux_inter1 = AIE.objectFifo.acquire @obj_out_flux_inter1 (Consume, 5) : !AIE.objectFifoSubview<memref<512xi32>>
       %obj_flux_inter_element1 = AIE.objectFifo.subview.access %obj_out_subview_flux_inter1[0] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
 
       %obj_flux_inter_element2 = AIE.objectFifo.subview.access %obj_out_subview_flux_inter1[1] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
@@ -107,12 +107,12 @@ module @hdiff_tri_AIE {
       %obj_flux_inter_element4 = AIE.objectFifo.subview.access %obj_out_subview_flux_inter1[3] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
       %obj_flux_inter_element5 = AIE.objectFifo.subview.access %obj_out_subview_flux_inter1[4] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
 
-      %obj_out_subview_flux = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_flux = AIE.objectFifo.acquire @obj_out_flux (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_flux_element = AIE.objectFifo.subview.access %obj_out_subview_flux[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
       func.call @hdiff_flux2(%obj_flux_inter_element1, %obj_flux_inter_element2,%obj_flux_inter_element3, %obj_flux_inter_element4, %obj_flux_inter_element5,  %obj_out_flux_element ) : ( memref<512xi32>,  memref<512xi32>, memref<512xi32>, memref<512xi32>, memref<512xi32>, memref<256xi32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xi32>>, 5)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xi32>>, 1)
+      AIE.objectFifo.release @obj_out_flux_inter1 (Consume, 5)
+      AIE.objectFifo.release @obj_out_flux (Produce, 1)
     }
     AIE.useLock(%lock73_14, "Acquire", 0) // stop the timer
 

--- a/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie.mlir
@@ -43,14 +43,14 @@ module @hdiff_tri_AIE {
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Produce 4 ) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Produce, 4 ) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
       func.call @hdiff_lap(%row0,%row1,%row2,%row3,%row4,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>,  memref<256xi32>,  memref<256xi32>,  memref<256xi32>) -> ()
-      AIE.objectFifo.release @obj_out_lap (Produce 4)
+      AIE.objectFifo.release @obj_out_lap (Produce, 4)
       AIE.objectFifo.release @obj_in (Consume, 1)
     }
     AIE.objectFifo.release @obj_in (Consume, 4)
@@ -69,7 +69,7 @@ module @hdiff_tri_AIE {
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Consume 4) : !AIE.objectFifoSubview<memref<256xi32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Consume, 4) : !AIE.objectFifoSubview<memref<256xi32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
@@ -84,7 +84,7 @@ module @hdiff_tri_AIE {
       %obj_out_flux_inter5 = AIE.objectFifo.subview.access %obj_out_subview_flux1[4] : !AIE.objectFifoSubview<memref<512xi32>> -> memref<512xi32>
 
       func.call @hdiff_flux1(%row1,%row2,%row3,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4, %obj_out_flux_inter1 , %obj_out_flux_inter2, %obj_out_flux_inter3, %obj_out_flux_inter4, %obj_out_flux_inter5) : (memref<256xi32>,memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>, memref<256xi32>,  memref<256xi32>,  memref<512xi32>,  memref<512xi32>,  memref<512xi32>,  memref<512xi32>,  memref<512xi32>) -> ()
-      AIE.objectFifo.release @obj_out_lap (Consume 4)
+      AIE.objectFifo.release @obj_out_lap (Consume, 4)
       AIE.objectFifo.release @obj_out_flux_inter1 (Produce, 5)
       AIE.objectFifo.release @obj_in (Consume, 1)
     }

--- a/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -13,11 +13,11 @@ module @hdiff_tri_AIE{
   %lock71_14 = AIE.lock(%t71, 14) { sym_name = "lock71_14" }
   %lock73_14 = AIE.lock(%t73, 14) { sym_name = "lock73_14" }
 
-  %obj_fifo_in = AIE.objectFifo.createObjectFifo(%t70, {%t71,%t72}, 6 : i32) {sym_name = "" }: !AIE.objectFifo<memref<256xf32>>
-  %obj_fifo_out_lap = AIE.objectFifo.createObjectFifo(%t71, {%t72}, 5 : i32){sym_name = "obj_out_lap" } : !AIE.objectFifo<memref<256xf32>>
-  %obj_fifo_out_flux_inter1 = AIE.objectFifo.createObjectFifo(%t72, {%t73}, 6 : i32){sym_name = "obj_out_flux_inter1" } : !AIE.objectFifo<memref<512xf32>>
+  AIE.objectFifo @obj_in (%t70, {%t71,%t72}, 6 : i32) : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_out_lap (%t71, {%t72}, 5 : i32) : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_out_flux_inter1 (%t72, {%t73}, 6 : i32) : !AIE.objectFifo<memref<512xf32>>
  
-  %obj_fifo_out_flux = AIE.objectFifo.createObjectFifo(%t73, {%t70}, 2 : i32){sym_name = "obj_out_flux" } : !AIE.objectFifo<memref<256xf32>>
+  AIE.objectFifo @obj_out_flux (%t73, {%t70}, 2 : i32) : !AIE.objectFifo<memref<256xf32>>
    // DDR buffer
   %ext_buffer_in0  = AIE.external_buffer  {sym_name = "ddr_test_buffer_in0"}: memref<1536 x f32>
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x f32>

--- a/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -23,8 +23,8 @@ module @hdiff_tri_AIE{
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x f32>
       
   // Register the external memory pointers to the object FIFOs.
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_in0}) : (memref<1536xf32>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %obj_fifo_out_flux : !AIE.objectFifo<memref<256xf32>>, {%ext_buffer_out}) : (memref<512xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_in (%t70, {%ext_buffer_in0}) : (memref<1536xf32>)
+  AIE.objectFifo.registerExternalBuffers @obj_out_flux (%t70, {%ext_buffer_out}) : (memref<512xf32>)
 
 
   func.func private @hdiff_lap_fp32(%AL: memref<256xf32>,%BL: memref<256xf32>, %CL:  memref<256xf32>, %DL: memref<256xf32>, %EL:  memref<256xf32>,  %OLL1: memref<256xf32>,  %OLL2: memref<256xf32>,  %OLL3: memref<256xf32>,  %OLL4: memref<256xf32>) -> ()

--- a/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie_fp32.mlir
+++ b/reference_designs/horizontal_diffusion/HDIFF_tri_AIE_objectFIFO_ping_pong/aie_fp32.mlir
@@ -16,8 +16,8 @@ module @hdiff_tri_AIE{
   AIE.objectFifo @obj_in (%t70, {%t71,%t72}, 6 : i32) : !AIE.objectFifo<memref<256xf32>>
   AIE.objectFifo @obj_out_lap (%t71, {%t72}, 5 : i32) : !AIE.objectFifo<memref<256xf32>>
   AIE.objectFifo @obj_out_flux_inter1 (%t72, {%t73}, 6 : i32) : !AIE.objectFifo<memref<512xf32>>
- 
   AIE.objectFifo @obj_out_flux (%t73, {%t70}, 2 : i32) : !AIE.objectFifo<memref<256xf32>>
+
    // DDR buffer
   %ext_buffer_in0  = AIE.external_buffer  {sym_name = "ddr_test_buffer_in0"}: memref<1536 x f32>
   %ext_buffer_out = AIE.external_buffer  {sym_name = "ddr_test_buffer_out"}: memref<512 x f32>
@@ -38,7 +38,7 @@ module @hdiff_tri_AIE{
     %step = arith.constant 1 : index
     AIE.useLock(%lock71_14, "Acquire", 0) // start the timer
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xf32>>
       %row0 = AIE.objectFifo.subview.access %obj_in_subview[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
@@ -46,21 +46,18 @@ module @hdiff_tri_AIE{
       %row4 = AIE.objectFifo.subview.access %obj_in_subview[4] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
 
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 4 ) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Produce, 4 ) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
       func.call @hdiff_lap_fp32(%row0,%row1,%row2,%row3,%row4,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>,  memref<256xf32>,  memref<256xf32>,  memref<256xf32>) -> ()
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Produce, 4)
+      AIE.objectFifo.release @obj_in (Consume, 1)
 
     }
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_lap_fp32.o" }
@@ -71,19 +68,19 @@ module @hdiff_tri_AIE{
     %ub = arith.constant 2: index
     %step = arith.constant 1 : index
     scf.for %iv = %lb to %ub step %step {  
-      %obj_in_subview = AIE.objectFifo.acquire<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 5) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_in_subview = AIE.objectFifo.acquire @obj_in (Consume, 5) : !AIE.objectFifoSubview<memref<256xf32>>
  
       %row1 = AIE.objectFifo.subview.access %obj_in_subview[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row2 = AIE.objectFifo.subview.access %obj_in_subview[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %row3 = AIE.objectFifo.subview.access %obj_in_subview[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
  
-      %obj_out_subview_lap = AIE.objectFifo.acquire<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 4) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview_lap = AIE.objectFifo.acquire @obj_out_lap (Consume, 4) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out_lap1 = AIE.objectFifo.subview.access %obj_out_subview_lap[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap2 = AIE.objectFifo.subview.access %obj_out_subview_lap[1] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap3 = AIE.objectFifo.subview.access %obj_out_subview_lap[2] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
       %obj_out_lap4 = AIE.objectFifo.subview.access %obj_out_subview_lap[3] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
-      %obj_out_subview_flux1 = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 5) : !AIE.objectFifoSubview<memref<512xf32>>
+      %obj_out_subview_flux1 = AIE.objectFifo.acquire @obj_out_flux_inter1 (Produce, 5) : !AIE.objectFifoSubview<memref<512xf32>>
       %obj_out_flux_inter1 = AIE.objectFifo.subview.access %obj_out_subview_flux1[0] : !AIE.objectFifoSubview<memref<512xf32>> -> memref<512xf32>
 
       
@@ -93,15 +90,11 @@ module @hdiff_tri_AIE{
       %obj_out_flux_inter5 = AIE.objectFifo.subview.access %obj_out_subview_flux1[4] : !AIE.objectFifoSubview<memref<512xf32>> -> memref<512xf32>
 
       func.call @hdiff_flux1_fp32(%row1,%row2,%row3,%obj_out_lap1,%obj_out_lap2,%obj_out_lap3,%obj_out_lap4, %obj_out_flux_inter1 , %obj_out_flux_inter2, %obj_out_flux_inter3, %obj_out_flux_inter4, %obj_out_flux_inter5) : (memref<256xf32>,memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>, memref<256xf32>,  memref<256xf32>,  memref<512xf32>,  memref<512xf32>,  memref<512xf32>,  memref<512xf32>,  memref<512xf32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_lap : !AIE.objectFifo<memref<256xf32>>, 4)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 1)
+      AIE.objectFifo.release @obj_out_lap (Consume, 4)
+      AIE.objectFifo.release @obj_out_flux_inter1 (Produce, 5)
+      AIE.objectFifo.release @obj_in (Consume, 1)
     }
-    AIE.objectFifo.release<Consume>(%obj_fifo_in : !AIE.objectFifo<memref<256xf32>>, 4)
+    AIE.objectFifo.release @obj_in (Consume, 4)
 
     AIE.end
   } { link_with="hdiff_flux1_fp32.o" }
@@ -112,7 +105,7 @@ module @hdiff_tri_AIE{
     %step = arith.constant 1 : index
     scf.for %iv = %lb to %ub step %step {  
 
-      %obj_out_subview_flux_inter1 = AIE.objectFifo.acquire<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 5) : !AIE.objectFifoSubview<memref<512xf32>>
+      %obj_out_subview_flux_inter1 = AIE.objectFifo.acquire @obj_out_flux_inter1 (Consume, 5) : !AIE.objectFifoSubview<memref<512xf32>>
       %obj_flux_inter_element1 = AIE.objectFifo.subview.access %obj_out_subview_flux_inter1[0] : !AIE.objectFifoSubview<memref<512xf32>> -> memref<512xf32>
 
       
@@ -121,17 +114,13 @@ module @hdiff_tri_AIE{
       %obj_flux_inter_element4 = AIE.objectFifo.subview.access %obj_out_subview_flux_inter1[3] : !AIE.objectFifoSubview<memref<512xf32>> -> memref<512xf32>
       %obj_flux_inter_element5 = AIE.objectFifo.subview.access %obj_out_subview_flux_inter1[4] : !AIE.objectFifoSubview<memref<512xf32>> -> memref<512xf32>
 
-      %obj_out_subview_flux = AIE.objectFifo.acquire<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xf32>>, 1) : !AIE.objectFifoSubview<memref<256xf32>>
+      %obj_out_subview_flux = AIE.objectFifo.acquire @obj_out_flux (Produce, 1) : !AIE.objectFifoSubview<memref<256xf32>>
       %obj_out_flux_element = AIE.objectFifo.subview.access %obj_out_subview_flux[0] : !AIE.objectFifoSubview<memref<256xf32>> -> memref<256xf32>
 
 
       func.call @hdiff_flux2_fp32(%obj_flux_inter_element1, %obj_flux_inter_element2,%obj_flux_inter_element3, %obj_flux_inter_element4, %obj_flux_inter_element5,  %obj_out_flux_element ) : ( memref<512xf32>,  memref<512xf32>, memref<512xf32>, memref<512xf32>, memref<512xf32>, memref<256xf32>) -> ()
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Consume>(%obj_fifo_out_flux_inter1 : !AIE.objectFifo<memref<512xf32>>, 1)
-      AIE.objectFifo.release<Produce>(%obj_fifo_out_flux : !AIE.objectFifo<memref<256xf32>>, 1)
+      AIE.objectFifo.release @obj_out_flux_inter1 (Consume, 5)
+      AIE.objectFifo.release @obj_out_flux (Produce, 1)
     }
     AIE.useLock(%lock73_14, "Acquire", 0) // stop the timer
 

--- a/reference_designs/idct/objectFifo_circuit_switched_version/aie.mlir
+++ b/reference_designs/idct/objectFifo_circuit_switched_version/aie.mlir
@@ -22,10 +22,10 @@ module @idct {
   %t71 = AIE.tile(7, 1)
   %t70 = AIE.tile(7, 0)
 
-  %of_t70_t73 = AIE.objectFifo.createObjectFifo(%t70, {%t73}, 2 : i32) {sym_name = "of_in"} : !AIE.objectFifo<memref<64xi16>>
-  %of_t73_t74 = AIE.objectFifo.createObjectFifo(%t73, {%t74}, 2 : i32) {sym_name = "of_dequant_horizontal"} : !AIE.objectFifo<memref<64xi16>>
-  %of_t74_t75 = AIE.objectFifo.createObjectFifo(%t74, {%t75}, 2 : i32) {sym_name = "of_horizontal_vertical"} : !AIE.objectFifo<memref<64xi16>>
-  %of_t75_t70 = AIE.objectFifo.createObjectFifo(%t75, {%t70}, 2 : i32) {sym_name = "of_out"} : !AIE.objectFifo<memref<64xi16>>
+  AIE.objectFifo @of_in (%t70, {%t73}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+  AIE.objectFifo @of_dequant_horizontal (%t73, {%t74}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+  AIE.objectFifo @of_horizontal_vertical (%t74, {%t75}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+  AIE.objectFifo @of_out (%t75, {%t70}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
 
   // DDR buffer
   %buffer_in  = AIE.external_buffer { sym_name = "buffer_in" }  : memref<512xi16>

--- a/reference_designs/idct/objectFifo_circuit_switched_version/aie.mlir
+++ b/reference_designs/idct/objectFifo_circuit_switched_version/aie.mlir
@@ -31,8 +31,8 @@ module @idct {
   %buffer_in  = AIE.external_buffer { sym_name = "buffer_in" }  : memref<512xi16>
   %buffer_out = AIE.external_buffer { sym_name = "buffer_out" }  : memref<512xi16>
 
-  AIE.objectFifo.registerExternalBuffers(%t70, %of_t70_t73 : !AIE.objectFifo<memref<64xi16>>, {%buffer_in}) : (memref<512xi16>)
-  AIE.objectFifo.registerExternalBuffers(%t70, %of_t75_t70 : !AIE.objectFifo<memref<64xi16>>, {%buffer_out}) : (memref<512xi16>)
+  AIE.objectFifo.registerExternalBuffers @of_in (%t70, {%buffer_in}) : (memref<512xi16>)
+  AIE.objectFifo.registerExternalBuffers @of_out (%t70, {%buffer_out}) : (memref<512xi16>)
 
   func.func private @dequant_8x8(%A: memref<64xi16>, %B: memref<64xi16>) -> ()
   func.func private @idct_8x8_mmult_h(%A: memref<64xi16>, %B: memref<64xi16>) -> ()

--- a/reference_designs/idct/objectFifo_circuit_switched_version/aie.mlir
+++ b/reference_designs/idct/objectFifo_circuit_switched_version/aie.mlir
@@ -51,15 +51,15 @@ module @idct {
     %c64 = arith.constant 64 : index
 
     scf.for %iv = %lb to %ub step %step {
-      %inputSubview = AIE.objectFifo.acquire<Consume>(%of_t70_t73 : !AIE.objectFifo<memref<64xi16>>, 1) : !AIE.objectFifoSubview<memref<64xi16>>
+      %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<64xi16>>
       %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<64xi16>> -> memref<64xi16>
-      %outputSubview = AIE.objectFifo.acquire<Produce>(%of_t73_t74 : !AIE.objectFifo<memref<64xi16>>, 1) : !AIE.objectFifoSubview<memref<64xi16>>
+      %outputSubview = AIE.objectFifo.acquire @of_dequant_horizontal (Produce, 1) : !AIE.objectFifoSubview<memref<64xi16>>
       %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<64xi16>> -> memref<64xi16>
 
       func.call @dequant_8x8(%input, %output) : (memref<64xi16>, memref<64xi16>) -> ()
       
-      AIE.objectFifo.release<Consume>(%of_t70_t73 : !AIE.objectFifo<memref<64xi16>>, 1)
-      AIE.objectFifo.release<Produce>(%of_t73_t74 : !AIE.objectFifo<memref<64xi16>>, 1)
+      AIE.objectFifo.release @of_in (Consume, 1)
+      AIE.objectFifo.release @of_dequant_horizontal (Produce, 1)
     }
 
     AIE.end
@@ -77,15 +77,15 @@ module @idct {
     %c64 = arith.constant 64 : index
 
     scf.for %iv = %lb to %ub step %step {
-      %inputSubview = AIE.objectFifo.acquire<Consume>(%of_t73_t74 : !AIE.objectFifo<memref<64xi16>>, 1) : !AIE.objectFifoSubview<memref<64xi16>>
+      %inputSubview = AIE.objectFifo.acquire @of_dequant_horizontal (Consume, 1) : !AIE.objectFifoSubview<memref<64xi16>>
       %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<64xi16>> -> memref<64xi16>
-      %outputSubview = AIE.objectFifo.acquire<Produce>(%of_t74_t75 : !AIE.objectFifo<memref<64xi16>>, 1) : !AIE.objectFifoSubview<memref<64xi16>>
+      %outputSubview = AIE.objectFifo.acquire @of_horizontal_vertical (Produce, 1) : !AIE.objectFifoSubview<memref<64xi16>>
       %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<64xi16>> -> memref<64xi16>
 
       func.call @idct_8x8_mmult_h(%input, %output) : (memref<64xi16>, memref<64xi16>) -> ()
       
-      AIE.objectFifo.release<Consume>(%of_t73_t74 : !AIE.objectFifo<memref<64xi16>>, 1)
-      AIE.objectFifo.release<Produce>(%of_t74_t75 : !AIE.objectFifo<memref<64xi16>>, 1)  
+      AIE.objectFifo.release @of_dequant_horizontal (Consume, 1)
+      AIE.objectFifo.release @of_horizontal_vertical (Produce, 1)  
     }
 
     AIE.end
@@ -103,15 +103,15 @@ module @idct {
     %c64 = arith.constant 64 : index
 
     scf.for %iv = %lb to %ub step %step {
-      %inputSubview = AIE.objectFifo.acquire<Consume>(%of_t74_t75 : !AIE.objectFifo<memref<64xi16>>, 1) : !AIE.objectFifoSubview<memref<64xi16>>
+      %inputSubview = AIE.objectFifo.acquire @of_horizontal_vertical <Consume>(Consume, 1) : !AIE.objectFifoSubview<memref<64xi16>>
       %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<64xi16>> -> memref<64xi16>
-      %outputSubview = AIE.objectFifo.acquire<Produce>(%of_t75_t70 : !AIE.objectFifo<memref<64xi16>>, 1) : !AIE.objectFifoSubview<memref<64xi16>>
+      %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<64xi16>>
       %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<64xi16>> -> memref<64xi16>
 
       func.call @idct_8x8_mmult_v(%input, %output) : (memref<64xi16>, memref<64xi16>) -> ()
       
-      AIE.objectFifo.release<Consume>(%of_t74_t75 : !AIE.objectFifo<memref<64xi16>>, 1)
-      AIE.objectFifo.release<Produce>(%of_t75_t70 : !AIE.objectFifo<memref<64xi16>>, 1)   
+      AIE.objectFifo.release @of_horizontal_vertical <Consume>(Consume, 1)
+      AIE.objectFifo.release @of_out (Produce, 1)   
     }
 
     AIE.end

--- a/test/Targets/AIEGenerateJSON/shim_alloc.mlir
+++ b/test/Targets/AIEGenerateJSON/shim_alloc.mlir
@@ -37,9 +37,9 @@
 
 module @alloc {
   AIE.device(xcve2302) {
-    AIE.shimDMAAllocation(@of_out_1, S2MM, 1, 2)
-    AIE.shimDMAAllocation(@of_in_1, MM2S, 1, 2)
-    AIE.shimDMAAllocation(@of_out_0, S2MM, 0, 2)
-    AIE.shimDMAAllocation(@of_in_0, MM2S, 0, 2)
+    AIE.shimDMAAllocation @of_out_1(S2MM, 1, 2)
+    AIE.shimDMAAllocation @of_in_1(MM2S, 1, 2)
+    AIE.shimDMAAllocation @of_out_0(S2MM, 0, 2)
+    AIE.shimDMAAllocation @of_in_0(MM2S, 0, 2)
   }
 }

--- a/test/objectFifo-register-process/base_test_1.aie.mlir
+++ b/test/objectFifo-register-process/base_test_1.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK: module @registerPatterns  {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo(%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<1> : tensor<1xi32>
 // CHECK:    %cst_0 = arith.constant dense<1> : tensor<1xi32>
 // CHECK:    %c10 = arith.constant 10 : index
@@ -27,10 +27,10 @@
 // CHECK:      %c10_1 = arith.constant 10 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c10_1 step %c1 {
-// CHECK:        %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %3 = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:        %4 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
-// CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:        AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:      }
 // CHECK:      AIE.end
 // CHECK:    }
@@ -50,6 +50,6 @@ module @registerPatterns  {
             return
         }
 
-        AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %acquirePattern : tensor<1xi32>, %releasePattern : tensor<1xi32>, @producer_work, %length) 
+        AIE.objectFifo.registerProcess @objfifo (Produce, %acquirePattern : tensor<1xi32>, %releasePattern : tensor<1xi32>, @producer_work, %length) 
     }
 }

--- a/test/objectFifo-register-process/base_test_1.aie.mlir
+++ b/test/objectFifo-register-process/base_test_1.aie.mlir
@@ -28,7 +28,7 @@
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c10_1 step %c1 {
 // CHECK:        %3 = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:        %4 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
 // CHECK:        AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:      }

--- a/test/objectFifo-register-process/base_test_1.aie.mlir
+++ b/test/objectFifo-register-process/base_test_1.aie.mlir
@@ -15,20 +15,20 @@
 // CHECK: module @registerPatterns  {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<1> : tensor<1xi32>
 // CHECK:    %cst_0 = arith.constant dense<1> : tensor<1xi32>
 // CHECK:    %c10 = arith.constant 10 : index
 // CHECK:    func.func @producer_work() {
 // CHECK:      return
 // CHECK:    }
-// CHECK:    %3 = AIE.core(%0)  {
+// CHECK:    %2 = AIE.core(%0)  {
 // CHECK:      %c0 = arith.constant 0 : index
 // CHECK:      %c10_1 = arith.constant 10 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c10_1 step %c1 {
-// CHECK:        %4 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:        %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %4 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
 // CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
 // CHECK:      }
@@ -41,7 +41,7 @@ module @registerPatterns  {
     %tile12 = AIE.tile(1, 2)
     %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
     %releasePattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_1.aie.mlir
+++ b/test/objectFifo-register-process/base_test_1.aie.mlir
@@ -37,19 +37,19 @@
 // CHECK:  }
 
 module @registerPatterns  {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
-    %releasePattern = arith.constant dense<[1]> : tensor<1xi32>
-    %length = arith.constant 10 : index
-    func.func @producer_work() -> () { 
-        return
+        %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
+        %releasePattern = arith.constant dense<[1]> : tensor<1xi32>
+        %length = arith.constant 10 : index
+        func.func @producer_work() -> () { 
+            return
+        }
+
+        AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %acquirePattern : tensor<1xi32>, %releasePattern : tensor<1xi32>, @producer_work, %length) 
     }
-
-    AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %acquirePattern : tensor<1xi32>, %releasePattern : tensor<1xi32>, @producer_work, %length) 
- }
 }

--- a/test/objectFifo-register-process/base_test_2.aie.mlir
+++ b/test/objectFifo-register-process/base_test_2.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK: module @registerPatterns {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo(%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<[2, 3, 3, 2]> : tensor<4xi32>
 // CHECK:    %cst_0 = arith.constant dense<[0, 1, 1, 2]> : tensor<4xi32>
 // CHECK:    %c10 = arith.constant 10 : index
@@ -23,7 +23,7 @@
 // CHECK:      return
 // CHECK:    }
 // CHECK:    %2 = AIE.core(%0) {
-// CHECK:      %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %3 = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:      %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      %5 = AIE.objectFifo.subview.access %3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
@@ -31,36 +31,36 @@
 // CHECK:      %c2 = arith.constant 2 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c2 step %c1 {
-// CHECK:        %9 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %9 = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:        %10 = AIE.objectFifo.subview.access %9[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        %11 = AIE.objectFifo.subview.access %9[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        %12 = AIE.objectFifo.subview.access %9[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
-// CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:        AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:      }
-// CHECK:      %6 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %6 = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:      %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      %8 = AIE.objectFifo.subview.access %6[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
-// CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2)
+// CHECK:      AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:      AIE.end
 // CHECK:    }
 // CHECK:  }
 
 module @registerPatterns  {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %acquirePattern = arith.constant dense<[2,3,3,2]> : tensor<4xi32>
-    %releasePattern = arith.constant dense<[0,1,1,2]> : tensor<4xi32>
-    %length = arith.constant 10 : index
-    func.func @producer_work() -> () { 
-        return
+        %acquirePattern = arith.constant dense<[2,3,3,2]> : tensor<4xi32>
+        %releasePattern = arith.constant dense<[0,1,1,2]> : tensor<4xi32>
+        %length = arith.constant 10 : index
+        func.func @producer_work() -> () { 
+            return
+        }
+
+        AIE.objectFifo.registerProcess @objfifo (Produce, %acquirePattern : tensor<4xi32>, %releasePattern : tensor<4xi32>, @producer_work, %length) 
     }
-
-    AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %acquirePattern : tensor<4xi32>, %releasePattern : tensor<4xi32>, @producer_work, %length) 
- }
 }

--- a/test/objectFifo-register-process/base_test_2.aie.mlir
+++ b/test/objectFifo-register-process/base_test_2.aie.mlir
@@ -15,32 +15,32 @@
 // CHECK: module @registerPatterns {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<[2, 3, 3, 2]> : tensor<4xi32>
 // CHECK:    %cst_0 = arith.constant dense<[0, 1, 1, 2]> : tensor<4xi32>
 // CHECK:    %c10 = arith.constant 10 : index
 // CHECK:    func.func @producer_work() {
 // CHECK:      return
 // CHECK:    }
-// CHECK:    %3 = AIE.core(%0) {
-// CHECK:      %4 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:      %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:      %6 = AIE.objectFifo.subview.access %4[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:    %2 = AIE.core(%0) {
+// CHECK:      %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %5 = AIE.objectFifo.subview.access %3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
 // CHECK:      %c0 = arith.constant 0 : index
 // CHECK:      %c2 = arith.constant 2 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c2 step %c1 {
-// CHECK:        %10 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:        %11 = AIE.objectFifo.subview.access %10[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:        %12 = AIE.objectFifo.subview.access %10[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:        %13 = AIE.objectFifo.subview.access %10[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %9 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %10 = AIE.objectFifo.subview.access %9[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %11 = AIE.objectFifo.subview.access %9[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %12 = AIE.objectFifo.subview.access %9[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
 // CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
 // CHECK:      }
-// CHECK:      %7 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:      %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:      %9 = AIE.objectFifo.subview.access %7[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %6 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %8 = AIE.objectFifo.subview.access %6[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
 // CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2)
 // CHECK:      AIE.end
@@ -52,7 +52,7 @@ module @registerPatterns  {
     %tile12 = AIE.tile(1, 2)
     %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %acquirePattern = arith.constant dense<[2,3,3,2]> : tensor<4xi32>
     %releasePattern = arith.constant dense<[0,1,1,2]> : tensor<4xi32>

--- a/test/objectFifo-register-process/base_test_3.aie.mlir
+++ b/test/objectFifo-register-process/base_test_3.aie.mlir
@@ -40,10 +40,10 @@
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Produce 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @producer_work() : () -> ()
-// CHECK:       AIE.objectFifo.release @objfifo(Produce 1)
+// CHECK:       AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }
@@ -52,10 +52,10 @@
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Consume 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @consumer_work1() : () -> ()
-// CHECK:       AIE.objectFifo.release @objfifo(Consume 1)
+// CHECK:       AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }
@@ -64,10 +64,10 @@
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Consume 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @consumer_work2() : () -> ()
-// CHECK:       AIE.objectFifo.release @objfifo(Consume 1)
+// CHECK:       AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }

--- a/test/objectFifo-register-process/base_test_3.aie.mlir
+++ b/test/objectFifo-register-process/base_test_3.aie.mlir
@@ -16,7 +16,7 @@
 // CHECK:   %0 = AIE.tile(1, 2)
 // CHECK:   %1 = AIE.tile(1, 3)
 // CHECK:   %2 = AIE.tile(3, 3)
-// CHECK:   %3 = AIE.objectFifo.createObjectFifo(%0, {%2, %1}, 2 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+// CHECK:   AIE.objectFifo @objfifo (%0, {%2, %1}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:   %cst = arith.constant dense<1> : tensor<1xi32>
 // CHECK:   %cst_0 = arith.constant dense<1> : tensor<1xi32>
 // CHECK:   %c10 = arith.constant 10 : index
@@ -35,37 +35,37 @@
 // CHECK:   func.func @consumer_work2() {
 // CHECK:     return
 // CHECK:   }
-// CHECK:   %4 = AIE.core(%0) {
+// CHECK:   %3 = AIE.core(%0) {
 // CHECK:     %c0 = arith.constant 0 : index
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %7 = AIE.objectFifo.acquire<Produce> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:       %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:       %6 = AIE.objectFifo.acquire<Produce> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @producer_work() : () -> ()
 // CHECK:       AIE.objectFifo.release<Produce> (%3 : !AIE.objectFifo<memref<16xi32>>, 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }
-// CHECK:   %5 = AIE.core(%2) {
+// CHECK:   %4 = AIE.core(%2) {
 // CHECK:     %c0 = arith.constant 0 : index
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %7 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:       %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:       %6 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @consumer_work1() : () -> ()
 // CHECK:       AIE.objectFifo.release<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }
-// CHECK:   %6 = AIE.core(%1) {
+// CHECK:   %5 = AIE.core(%1) {
 // CHECK:     %c0 = arith.constant 0 : index
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %7 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:       %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:       %6 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @consumer_work2() : () -> ()
 // CHECK:       AIE.objectFifo.release<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1)
 // CHECK:     }
@@ -80,7 +80,7 @@ module @registerPatterns  {
     %tile13 = AIE.tile(1, 3)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33, %tile13}, 2 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
     %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_3.aie.mlir
+++ b/test/objectFifo-register-process/base_test_3.aie.mlir
@@ -16,7 +16,7 @@
 // CHECK:   %0 = AIE.tile(1, 2)
 // CHECK:   %1 = AIE.tile(1, 3)
 // CHECK:   %2 = AIE.tile(3, 3)
-// CHECK:   AIE.objectFifo @objfifo (%0, {%2, %1}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:   AIE.objectFifo @objfifo(%0, {%2, %1}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:   %cst = arith.constant dense<1> : tensor<1xi32>
 // CHECK:   %cst_0 = arith.constant dense<1> : tensor<1xi32>
 // CHECK:   %c10 = arith.constant 10 : index
@@ -40,10 +40,10 @@
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %6 = AIE.objectFifo.acquire<Produce> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Produce 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @producer_work() : () -> ()
-// CHECK:       AIE.objectFifo.release<Produce> (%3 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:       AIE.objectFifo.release @objfifo(Produce 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }
@@ -52,10 +52,10 @@
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %6 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Consume 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @consumer_work1() : () -> ()
-// CHECK:       AIE.objectFifo.release<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:       AIE.objectFifo.release @objfifo(Consume 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }
@@ -64,10 +64,10 @@
 // CHECK:     %c10_7 = arith.constant 10 : index
 // CHECK:     %c1 = arith.constant 1 : index
 // CHECK:     scf.for %arg0 = %c0 to %c10_7 step %c1 {
-// CHECK:       %6 = AIE.objectFifo.acquire<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:       %6 = AIE.objectFifo.acquire @objfifo(Consume 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:       %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:       func.call @consumer_work2() : () -> ()
-// CHECK:       AIE.objectFifo.release<Consume> (%3 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:       AIE.objectFifo.release @objfifo(Consume 1)
 // CHECK:     }
 // CHECK:     AIE.end
 // CHECK:   }
@@ -75,36 +75,36 @@
 
 
 module @registerPatterns  {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
+        %tile33 = AIE.tile(3, 3)
 
-    AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
-    %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>
-    %prodLength = arith.constant 10 : index
-    func.func @producer_work() -> () {
-        return
+        %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
+        %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>
+        %prodLength = arith.constant 10 : index
+        func.func @producer_work() -> () {
+            return
+        }
+
+        %consAcqPattern1 = arith.constant dense<[1]> : tensor<1xi32>
+        %consRelPattern1 = arith.constant dense<[1]> : tensor<1xi32>
+        %consLength1 = arith.constant 10 : index
+        func.func @consumer_work1() -> () {
+            return
+        }
+
+        %consAcqPattern2 = arith.constant dense<[1]> : tensor<1xi32>
+        %consRelPattern2 = arith.constant dense<[1]> : tensor<1xi32>
+        %consLength2 = arith.constant 10 : index
+        func.func @consumer_work2() -> () {
+            return
+        }
+
+        AIE.objectFifo.registerProcess @objfifo (Produce, %prodAcqPattern : tensor<1xi32>, %prodRelPattern : tensor<1xi32>, @producer_work, %prodLength) 
+        AIE.objectFifo.registerProcess @objfifo (Consume, %consAcqPattern1 : tensor<1xi32>, %consRelPattern1 : tensor<1xi32>, @consumer_work1, %consLength1) 
+        AIE.objectFifo.registerProcess @objfifo (Consume, %consAcqPattern2 : tensor<1xi32>, %consRelPattern2 : tensor<1xi32>, @consumer_work2, %consLength2) 
     }
-
-    %consAcqPattern1 = arith.constant dense<[1]> : tensor<1xi32>
-    %consRelPattern1 = arith.constant dense<[1]> : tensor<1xi32>
-    %consLength1 = arith.constant 10 : index
-    func.func @consumer_work1() -> () {
-        return
-    }
-
-    %consAcqPattern2 = arith.constant dense<[1]> : tensor<1xi32>
-    %consRelPattern2 = arith.constant dense<[1]> : tensor<1xi32>
-    %consLength2 = arith.constant 10 : index
-    func.func @consumer_work2() -> () {
-        return
-    }
-
-    AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %prodAcqPattern : tensor<1xi32>, %prodRelPattern : tensor<1xi32>, @producer_work, %prodLength) 
-    AIE.objectFifo.registerProcess<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %consAcqPattern1 : tensor<1xi32>, %consRelPattern1 : tensor<1xi32>, @consumer_work1, %consLength1) 
-    AIE.objectFifo.registerProcess<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %consAcqPattern2 : tensor<1xi32>, %consRelPattern2 : tensor<1xi32>, @consumer_work2, %consLength2) 
- }
 }

--- a/test/objectFifo-register-process/base_test_4.aie.mlir
+++ b/test/objectFifo-register-process/base_test_4.aie.mlir
@@ -15,33 +15,33 @@
 // CHECK: module @registerPatterns {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<[2, 3, 3, 3, 0]> : tensor<5xi32>
 // CHECK:    %cst_0 = arith.constant dense<[0, 1, 1, 2, 1]> : tensor<5xi32>
 // CHECK:    %c10 = arith.constant 10 : index
 // CHECK:    func.func @producer_work() {
 // CHECK:      return
 // CHECK:    }
-// CHECK:    %3 = AIE.core(%0) {
-// CHECK:      %4 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:      %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:      %6 = AIE.objectFifo.subview.access %4[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:    %2 = AIE.core(%0) {
+// CHECK:      %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %5 = AIE.objectFifo.subview.access %3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
 // CHECK:      %c0 = arith.constant 0 : index
 // CHECK:      %c2 = arith.constant 2 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c2 step %c1 {
-// CHECK:        %11 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:        %12 = AIE.objectFifo.subview.access %11[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:        %13 = AIE.objectFifo.subview.access %11[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:        %14 = AIE.objectFifo.subview.access %11[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %10 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %11 = AIE.objectFifo.subview.access %10[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %12 = AIE.objectFifo.subview.access %10[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %13 = AIE.objectFifo.subview.access %10[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
 // CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
 // CHECK:      }
-// CHECK:      %7 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:      %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:      %9 = AIE.objectFifo.subview.access %7[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:      %10 = AIE.objectFifo.subview.access %7[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %6 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %8 = AIE.objectFifo.subview.access %6[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %9 = AIE.objectFifo.subview.access %6[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
 // CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2)
 // CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
@@ -54,7 +54,7 @@ module @registerPatterns  {
     %tile12 = AIE.tile(1, 2)
     %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %acquirePattern = arith.constant dense<[2,3,3,3,0]> : tensor<5xi32>
     %releasePattern = arith.constant dense<[0,1,1,2,1]> : tensor<5xi32>

--- a/test/objectFifo-register-process/base_test_4.aie.mlir
+++ b/test/objectFifo-register-process/base_test_4.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK: module @registerPatterns {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo(%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<[2, 3, 3, 3, 0]> : tensor<5xi32>
 // CHECK:    %cst_0 = arith.constant dense<[0, 1, 1, 2, 1]> : tensor<5xi32>
 // CHECK:    %c10 = arith.constant 10 : index
@@ -23,7 +23,7 @@
 // CHECK:      return
 // CHECK:    }
 // CHECK:    %2 = AIE.core(%0) {
-// CHECK:      %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %3 = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:      %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      %5 = AIE.objectFifo.subview.access %3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
@@ -31,38 +31,38 @@
 // CHECK:      %c2 = arith.constant 2 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c2 step %c1 {
-// CHECK:        %10 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %10 = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:        %11 = AIE.objectFifo.subview.access %10[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        %12 = AIE.objectFifo.subview.access %10[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        %13 = AIE.objectFifo.subview.access %10[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
-// CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:        AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:      }
-// CHECK:      %6 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %6 = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:      %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      %8 = AIE.objectFifo.subview.access %6[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      %9 = AIE.objectFifo.subview.access %6[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
-// CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2)
-// CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:      AIE.objectFifo.release @objfifo(Produce, 2)
+// CHECK:      AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:      AIE.end
 // CHECK:    }
 // CHECK:  }
 
 module @registerPatterns  {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %acquirePattern = arith.constant dense<[2,3,3,3,0]> : tensor<5xi32>
-    %releasePattern = arith.constant dense<[0,1,1,2,1]> : tensor<5xi32>
-    %length = arith.constant 10 : index
-    func.func @producer_work() -> () { 
-        return
+        %acquirePattern = arith.constant dense<[2,3,3,3,0]> : tensor<5xi32>
+        %releasePattern = arith.constant dense<[0,1,1,2,1]> : tensor<5xi32>
+        %length = arith.constant 10 : index
+        func.func @producer_work() -> () { 
+            return
+        }
+
+        AIE.objectFifo.registerProcess @objfifo (Produce, %acquirePattern : tensor<5xi32>, %releasePattern : tensor<5xi32>, @producer_work, %length) 
     }
-
-    AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %acquirePattern : tensor<5xi32>, %releasePattern : tensor<5xi32>, @producer_work, %length) 
- }
 }

--- a/test/objectFifo-register-process/base_test_5.aie.mlir
+++ b/test/objectFifo-register-process/base_test_5.aie.mlir
@@ -15,28 +15,28 @@
 // CHECK: module @registerPatterns {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    %2 = AIE.objectFifo.createObjectFifo(%0, {%1}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<1> : tensor<1xi32>
 // CHECK:    %cst_0 = arith.constant dense<[0, 1, 1, 1, 2]> : tensor<5xi32>
 // CHECK:    %c5 = arith.constant 5 : index
 // CHECK:    func.func @producer_work() {
 // CHECK:      return
 // CHECK:    }
-// CHECK:    %3 = AIE.core(%0) {
-// CHECK:      %4 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:      %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:    %2 = AIE.core(%0) {
+// CHECK:      %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
 // CHECK:      %c0 = arith.constant 0 : index
 // CHECK:      %c3 = arith.constant 3 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c3 step %c1 {
-// CHECK:        %8 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:        %9 = AIE.objectFifo.subview.access %8[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:        %7 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
 // CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
 // CHECK:      }
-// CHECK:      %6 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:      %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:      %5 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
 // CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2)
 // CHECK:      AIE.end
@@ -48,7 +48,7 @@ module @registerPatterns  {
     %tile12 = AIE.tile(1, 2)
     %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
     %releasePattern = arith.constant dense<[0,1,1,1,2]> : tensor<5xi32>

--- a/test/objectFifo-register-process/base_test_5.aie.mlir
+++ b/test/objectFifo-register-process/base_test_5.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK: module @registerPatterns {
 // CHECK:    %0 = AIE.tile(1, 2)
 // CHECK:    %1 = AIE.tile(1, 3)
-// CHECK:    AIE.objectFifo @objfifo (%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:    AIE.objectFifo @objfifo(%0, {%1}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:    %cst = arith.constant dense<1> : tensor<1xi32>
 // CHECK:    %cst_0 = arith.constant dense<[0, 1, 1, 1, 2]> : tensor<5xi32>
 // CHECK:    %c5 = arith.constant 5 : index
@@ -23,40 +23,40 @@
 // CHECK:      return
 // CHECK:    }
 // CHECK:    %2 = AIE.core(%0) {
-// CHECK:      %3 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %3 = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:      %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
 // CHECK:      %c0 = arith.constant 0 : index
 // CHECK:      %c3 = arith.constant 3 : index
 // CHECK:      %c1 = arith.constant 1 : index
 // CHECK:      scf.for %arg0 = %c0 to %c3 step %c1 {
-// CHECK:        %7 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:        %7 = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:        %8 = AIE.objectFifo.subview.access %7[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:        func.call @producer_work() : () -> ()
-// CHECK:        AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1)
+// CHECK:        AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:      }
-// CHECK:      %5 = AIE.objectFifo.acquire<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:      %5 = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
 // CHECK:      %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:      func.call @producer_work() : () -> ()
-// CHECK:      AIE.objectFifo.release<Produce> (%2 : !AIE.objectFifo<memref<16xi32>>, 2)
+// CHECK:      AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:      AIE.end
 // CHECK:    }
 // CHECK:  }
 
 module @registerPatterns  {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
-    %releasePattern = arith.constant dense<[0,1,1,1,2]> : tensor<5xi32>
-    %length = arith.constant 5 : index
-    func.func @producer_work() -> () { 
-        return
+        %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
+        %releasePattern = arith.constant dense<[0,1,1,1,2]> : tensor<5xi32>
+        %length = arith.constant 5 : index
+        func.func @producer_work() -> () { 
+            return
+        }
+
+        AIE.objectFifo.registerProcess @objfifo (Produce, %acquirePattern : tensor<1xi32>, %releasePattern : tensor<5xi32>, @producer_work, %length) 
     }
-
-    AIE.objectFifo.registerProcess<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, %acquirePattern : tensor<1xi32>, %releasePattern : tensor<5xi32>, @producer_work, %length) 
- }
 }

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
@@ -93,7 +93,7 @@ module @aie2_cyclostatic_dma {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        %fifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile83}, 4 : i32) {sym_name = "fifo"} : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile83}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
@@ -103,28 +103,28 @@ module @aie2_cyclostatic_dma {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             AIE.end
         }
@@ -138,32 +138,30 @@ module @aie2_cyclostatic_dma {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf83[%i0] : memref<4xi32>
-            AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 2) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
             %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf83[%i1] : memref<4xi32>
             memref.store %v77, %buf83[%i2] : memref<4xi32>
-            AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 2)
+            AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf83[%i3] : memref<4xi32>
-            AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Consume, 1)
 
             AIE.end
         }
-
-
     }
 }

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
@@ -61,28 +61,28 @@ module @aie2_cyclostatic_l1 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
-            AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Produce, 1)
 
             AIE.end
         }
@@ -96,31 +96,30 @@ module @aie2_cyclostatic_l1 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf23[%i0] : memref<4xi32>
-            AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 2) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
             %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf23[%i1] : memref<4xi32>
             memref.store %v77, %buf23[%i2] : memref<4xi32>
-            AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 2)
+            AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf23[%i3] : memref<4xi32>
-            AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+            AIE.objectFifo.release @fifo (Consume, 1)
 
             AIE.end
         }
-
     }
 }

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
@@ -51,7 +51,7 @@ module @aie2_cyclostatic_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        %fifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile23}, 4 : i32) {sym_name = "fifo"} : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -279,8 +279,8 @@ module @aie2_cyclostatic_l2 {
 
         // ObjectFifo that can hold 4 memref<1xi32>s, populated by tile22 and
         // consumed by tile23
-        %fifo0 = AIE.objectFifo.createObjectFifo(%tile22, {%memtile}, 4 : i32) {sym_name = "fifo0"} : !AIE.objectFifo<memref<1xi32>>
-        %fifo1 = AIE.objectFifo.createObjectFifo(%memtile, {%tile83}, [4, 4]) {sym_name = "fifo1"} : !AIE.objectFifo<memref<1xi32>>
+        AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : !AIE.objectFifo<memref<1xi32>>
+        AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : !AIE.objectFifo<memref<1xi32>>
         AIE.objectFifo.link({%fifo0}, {%fifo1}) : ({!AIE.objectFifo<memref<1xi32>>}, {!AIE.objectFifo<memref<1xi32>>})
 
         // Producer core

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -281,7 +281,7 @@ module @aie2_cyclostatic_l2 {
         // consumed by tile23
         AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : !AIE.objectFifo<memref<1xi32>>
         AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : !AIE.objectFifo<memref<1xi32>>
-        AIE.objectFifo.link({%fifo0}, {%fifo1}) : ({!AIE.objectFifo<memref<1xi32>>}, {!AIE.objectFifo<memref<1xi32>>})
+        AIE.objectFifo.link [@fifo0] to [@fifo1] ()
 
         // Producer core
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -281,7 +281,7 @@ module @aie2_cyclostatic_l2 {
         // consumed by tile23
         AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : !AIE.objectFifo<memref<1xi32>>
         AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : !AIE.objectFifo<memref<1xi32>>
-        AIE.objectFifo.link [@fifo0] to [@fifo1] ()
+        AIE.objectFifo.link [@fifo0] -> [@fifo1] ()
 
         // Producer core
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -292,28 +292,28 @@ module @aie2_cyclostatic_l2 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c55, %subview0_obj[%i0] : memref<1xi32>
-            AIE.objectFifo.release<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1)
+            AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
             %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c66, %subview1_obj[%i0] : memref<1xi32>
-            AIE.objectFifo.release<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1)
+            AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c77, %subview2_obj[%i0] : memref<1xi32>
-            AIE.objectFifo.release<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1)
+            AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview3 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
             %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c88, %subview3_obj[%i0] : memref<1xi32>
-            AIE.objectFifo.release<Produce>(%fifo0 : !AIE.objectFifo<memref<1xi32>>, 1)
+            AIE.objectFifo.release @fifo0 (Produce, 1)
 
             AIE.end
         }
@@ -327,28 +327,28 @@ module @aie2_cyclostatic_l2 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire<Consume>(%fifo1 : !AIE.objectFifo<memref<1xi32>>, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview0 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             %v55 = memref.load %subview0_obj[%i0] : memref<1xi32>
             memref.store %v55, %buf83[%i0] : memref<1xi32>
-            AIE.objectFifo.release<Consume>(%fifo1 : !AIE.objectFifo<memref<1xi32>>, 1)
+            AIE.objectFifo.release @fifo1 (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire<Consume>(%fifo1 : !AIE.objectFifo<memref<1xi32>>, 2) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview1 = AIE.objectFifo.acquire @fifo1 (Consume, 2) : !AIE.objectFifoSubview<memref<1xi32>>
             %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             %v66 = memref.load %subview1_obj0[%i0] : memref<1xi32>
             %v77 = memref.load %subview1_obj1[%i0] : memref<1xi32>
             memref.store %v66, %buf83[%i1] : memref<1xi32>
             memref.store %v77, %buf83[%i2] : memref<1xi32>
-            AIE.objectFifo.release<Consume>(%fifo1 : !AIE.objectFifo<memref<1xi32>>, 2)
+            AIE.objectFifo.release @fifo1 (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire<Consume>(%fifo1 : !AIE.objectFifo<memref<1xi32>>, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview2 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             %v88 = memref.load %subview2_obj[%i0] : memref<1xi32>
             memref.store %v88, %buf83[%i3] : memref<1xi32>
-            AIE.objectFifo.release<Consume>(%fifo1 : !AIE.objectFifo<memref<1xi32>>, 1)
+            AIE.objectFifo.release @fifo1 (Consume, 1)
 
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
@@ -133,10 +133,10 @@ module @AIE2_delayed_release {
             %i4 = arith.constant 4 : index
             scf.for %it = %i0 to %i4 step %i1 {
                 // Produce one 1 element (acquire producer lock) ...
-                %subview = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
                 %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 memref.store %c99, %subview_obj[] : memref<i32>
-                AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+                AIE.objectFifo.release @fifo (Produce, 1)
                 // ... done producing (release consumer lock)
             }
             AIE.end
@@ -150,31 +150,31 @@ module @AIE2_delayed_release {
             %i3 = arith.constant 3 : index
 
             // Begin consuming 2 elements (acquire consumer lock with value 2)
-            %subview0 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 2) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v0 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v0, %buf23[%i0] : memref<4xi32>
 
             // For the next step, we only need one element (this could be a subroutine that acquires 1, not knowing that we already acquired 2)
-            %subview1 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v1 = memref.load %subview1_obj[] : memref<i32>
             memref.store %v1, %buf23[%i1] : memref<4xi32>
 
             // Actually, give us the two from before and one more for three objects total (consumer lock should increase by one)
-            %subview2 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 3) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : !AIE.objectFifoSubview<memref<i32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v2 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v2, %buf23[%i2] : memref<4xi32>
 
             // Now let's just work on one element (consumer lock should not change value)
-            %subview3 = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
             %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v3 = memref.load %subview3_obj[] : memref<i32>
             memref.store %v3, %buf23[%i3] : memref<4xi32>
 
             // Done, let's release everything we hold (we hold 3 objects from our max acquire)
-            AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 3)
+            AIE.objectFifo.release @fifo (Consume, 3)
 
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
@@ -123,7 +123,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        %fifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile23}, 4 : i32) {sym_name = "fifo"} : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
@@ -25,7 +25,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        %fifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile23}, 4 : i32) {sym_name = "fifo"} : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
@@ -177,7 +177,7 @@ module @aie2_dynamic_locks {
             %c1 = arith.constant 1 : i64
 
             // Acquire one element.
-            %subview0  = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i64>>, 1) : !AIE.objectFifoSubview<memref<i64>>
+            %subview0  = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
 
             scf.for %idx = %i_c0 to %i_c3 step %i_c1 {
                 // Acquire one element (again). In the first iteration of the
@@ -186,14 +186,13 @@ module @aie2_dynamic_locks {
                 // just above the loop. In the second iteration, that object
                 // has been released, and now a lock acquire 1 would be 
                 // required.
-                %subview = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i64>>, 1) : !AIE.objectFifoSubview<memref<i64>>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
                 %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i64>> -> memref<i64>
                 memref.store %c1, %elem[] : memref<i64>
-                AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i64>>, 1)
+                AIE.objectFifo.release @fifo (Produce, 1)
             }
 
             AIE.end
         }
-
     }
 }

--- a/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
@@ -165,7 +165,7 @@ module @aie2_dynamic_locks {
     AIE.device(xcve2302) {
         %tile22 = AIE.tile(2, 2)  // producer tile
         %tile43 = AIE.tile(4, 3)  // consumer tile
-        %fifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile43}, 1 : i32) {sym_name = "fifo"} : !AIE.objectFifo<memref<i64>>
+        AIE.objectFifo @fifo (%tile22, {%tile43}, 1 : i32) : !AIE.objectFifo<memref<i64>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
@@ -73,10 +73,10 @@ module @aie2_static_l1 {
             scf.for %idx = %i_c0 to %i_c16 step %i_c1 {
                 %val0 = memref.load %srcbuf22[] : memref<i32>
                 // Produce 1 elements, so acquire 1 element
-                %subview = AIE.objectFifo.acquire<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1) : !AIE.objectFifoSubview<memref<i32>>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
                 %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 memref.store %val0, %elem[] : memref<i32>
-                AIE.objectFifo.release<Produce>(%fifo : !AIE.objectFifo<memref<i32>>, 1)
+                AIE.objectFifo.release @fifo (Produce, 1)
                 // Increment
                 %val1 = arith.addi %c1, %val0 : i32
                 memref.store %val1, %srcbuf22[] : memref<i32>
@@ -89,7 +89,7 @@ module @aie2_static_l1 {
         %core23 = AIE.core(%tile23) {
             scf.for %idx = %i_c0 to %i_c16 step %i_c2 {
                 // Consume _two_ elements at once (cyclo static)
-                %subview = AIE.objectFifo.acquire<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 2) : !AIE.objectFifoSubview<memref<i32>>
+                %subview = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
                 %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 %val0 = memref.load %elem0[] : memref<i32>
@@ -97,7 +97,7 @@ module @aie2_static_l1 {
                 // Pass through to destination buffer
                 func.call @store2(%val0, %val1, %idx, %dstbuf23) : (i32, i32, index, memref<16xi32>) -> ()
                 // Release consumed objects
-                AIE.objectFifo.release<Consume>(%fifo : !AIE.objectFifo<memref<i32>>, 2)
+                AIE.objectFifo.release @fifo (Consume, 2)
             }
 
             AIE.end
@@ -112,6 +112,5 @@ module @aie2_static_l1 {
                 memref.store %val1, %buf[%idx1] : memref<16xi32>
                 return
         }
-
     }
 }

--- a/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
@@ -60,7 +60,7 @@ module @aie2_static_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        %fifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile23}, 4 : i32) {sym_name = "fifo"} : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -21,10 +21,10 @@
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
-// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
-// CHECK:     AIE.shimDMAAllocation({{.*}}, {{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
 // CHECK:   }
 // CHECK: }
 

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -34,10 +34,10 @@ module @alloc {
         %tile22 = AIE.tile(2, 2)
         %tile23 = AIE.tile(2, 3)
 
-        %connect1 = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "of_in_0"} : !AIE.objectFifo<memref<64xi16>>
-        %connect2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile20}, 2 : i32) {sym_name = "of_out_0"} : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_in_0 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_out_0 (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
 
-        %connect3 = AIE.objectFifo.createObjectFifo(%tile20, {%tile23}, 2 : i32) {sym_name = "of_in_1"} : !AIE.objectFifo<memref<64xi16>>
-        %connect4 = AIE.objectFifo.createObjectFifo(%tile23, {%tile20}, 2 : i32) {sym_name = "of_out_1"} : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_in_1 (%tile20, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_out_1 (%tile23, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
     }
 }

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -21,10 +21,10 @@
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
 // CHECK:     AIE.flow({{.*}}, DMA : {{.*}}, {{.*}}, DMA : {{.*}})
-// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
-// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
-// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
-// CHECK:     AIE.shimDMAAllocation {{.*}} ({{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}}({{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}}({{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}}({{.*}}, {{.*}}, 2)
+// CHECK:     AIE.shimDMAAllocation {{.*}}({{.*}}, {{.*}}, 2)
 // CHECK:   }
 // CHECK: }
 

--- a/test/objectFifo-stateful-transform/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE1.mlir
@@ -75,10 +75,14 @@ module @elementGenerationAIE1 {
     %tile33 = AIE.tile(3, 3)
 
     // In the shared memory case, the number of elements does not change.
-    %objFifo0 = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "of0"} : !AIE.objectFifo<memref<16xi32>>
+
+    //%objFifo0 = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "of0"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
     // the processes running on each core (here nothing is specified so it cannot be derived).
-    %objFifo1 = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "of1"} : !AIE.objectFifo<memref<16xi32>>
+
+    // %objFifo1 = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "of1"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE1.mlir
@@ -69,20 +69,16 @@
 // CHECK: }
 
 module @elementGenerationAIE1 {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
-    %tile33 = AIE.tile(3, 3)
+   AIE.device(xcvc1902) {
+      %tile12 = AIE.tile(1, 2)
+      %tile13 = AIE.tile(1, 3)
+      %tile33 = AIE.tile(3, 3)
 
-    // In the shared memory case, the number of elements does not change.
+      // In the shared memory case, the number of elements does not change.
+      AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    //%objFifo0 = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "of0"} : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-
-    // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
-    // the processes running on each core (here nothing is specified so it cannot be derived).
-
-    // %objFifo1 = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "of1"} : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
- }
+      // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
+      // the processes running on each core (here nothing is specified so it cannot be derived).
+      AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+   }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE2.mlir
@@ -73,10 +73,10 @@ module @elementGenerationAIE2 {
     %tile33 = AIE.tile(3, 3)
 
     // In the shared memory case, the number of elements does not change.
-    %objFifo0 = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "of0"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
     // the processes running on each core (here nothing is specified so it cannot be derived).
-    %objFifo1 = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "of1"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/broadcast_error_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_error_test.mlir
@@ -22,6 +22,6 @@ module @broadcast_error {
         %tile32 = AIE.tile(3, 2)
         %tile33 = AIE.tile(3, 3)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3]) {sym_name = "broadcast_of"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3]) : !AIE.objectFifo<memref<16xi32>>
     }
 }

--- a/test/objectFifo-stateful-transform/broadcast_error_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_error_test.mlir
@@ -12,7 +12,7 @@
 
 // RUN: not aie-opt --aie-objectFifo-stateful-transform %s |& FileCheck %s
 
-// CHECK:   error: 'AIE.objectFifo.createObjectFifo' op does not have enough depths specified for producer and for each consumer.
+// CHECK:   error: 'AIE.objectFifo' op does not have enough depths specified for producer and for each consumer.
 
 module @broadcast_error {
     AIE.device(xcvc1902) {

--- a/test/objectFifo-stateful-transform/broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_test.mlir
@@ -271,7 +271,7 @@ module @broadcast {
     %tile32 = AIE.tile(3, 2)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3, 4, 3]) {sym_name = "broadcast_of"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3, 4, 3]) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return

--- a/test/objectFifo-stateful-transform/broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_test.mlir
@@ -283,10 +283,10 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @broadcast_of (Produce, 1)
         }
         
         AIE.end
@@ -298,10 +298,10 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @broadcast_of (Consume, 1)
         }
         
         AIE.end
@@ -313,12 +313,12 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
+            AIE.objectFifo.release @broadcast_of (Consume, 2)
         }
         
         AIE.end
@@ -330,14 +330,14 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 { 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             func.call @some_work(%elem2) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @broadcast_of (Consume, 1)
         }
         
         AIE.end
@@ -349,12 +349,12 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 { 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @broadcast_of (Consume, 1)
         }
         
         AIE.end

--- a/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
+++ b/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
@@ -97,7 +97,7 @@ module @cyclostatic {
         %tile12 = AIE.tile(1, 2)
         %tile23 = AIE.tile(2, 2)
 
-        %fifo0 = AIE.objectFifo.createObjectFifo(%tile12, {%tile23}, 4 : i32) {sym_name = "fifo0"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @fifo0 (%tile12, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %core12 = AIE.core(%tile12) {
             %v11 = arith.constant 11 : i32

--- a/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
+++ b/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
@@ -106,10 +106,10 @@ module @cyclostatic {
             %c9 = arith.constant 9 : index
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire<Produce>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
                 %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 memref.store %v11, %subview1_obj[%c0] : memref<16xi32>
-                AIE.objectFifo.release<Produce>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 1)
+                AIE.objectFifo.release @fifo0 (Produce, 1)
             }
 
             AIE.end
@@ -120,28 +120,28 @@ module @cyclostatic {
             %c1 = arith.constant 1 : index
             %c9 = arith.constant 9 : index
 
-            %subview0 = AIE.objectFifo.acquire<Consume>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %v0 = memref.load %subview0_obj[%c0] : memref<16xi32>
-            AIE.objectFifo.release<Consume>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @fifo0 (Consume, 1)
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire<Consume>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
                 %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 %subview1_obj2 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 %v1 = memref.load %subview1_obj[%c0] : memref<16xi32>
                 %v2 = memref.load %subview1_obj1[%c0] : memref<16xi32>
                 %v3 = memref.load %subview1_obj2[%c0] : memref<16xi32>
-                AIE.objectFifo.release<Consume>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 1)
+                AIE.objectFifo.release @fifo0 (Consume, 1)
             }
 
-            %subview2 = AIE.objectFifo.acquire<Consume>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %subview2_obj1 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %v4 = memref.load %subview2_obj[%c0] : memref<16xi32>
             %v5 = memref.load %subview2_obj1[%c0] : memref<16xi32>
-            AIE.objectFifo.release<Consume>(%fifo0 : !AIE.objectFifo<memref<16xi32>>, 2)
+            AIE.objectFifo.release @fifo0 (Consume, 2)
 
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -94,7 +94,7 @@ module @link_AIE1 {
         AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link [@of1] to [@of2] ()
+        AIE.objectFifo.link [@of1] -> [@of2] ()
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers @of1 (%tile20, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -91,12 +91,12 @@ module @link_AIE1 {
         %tile22 = AIE.tile(2, 2)
         %tile24 = AIE.tile(2, 4)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<16xi32>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile24}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo.create @link1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo.create @link2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
+        AIE.objectFifo.link({@link1}, {@link2})
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+        AIE.objectFifo.registerExternalBuffers(@link1, %tile20, {%ext_buff_in}) : (memref<16xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -18,18 +18,18 @@
 // CHECK:     %1 = AIE.tile(2, 2)
 // CHECK:     %2 = AIE.tile(2, 4)
 // CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
-// CHECK:     %3 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "link1_lock_0"}
-// CHECK:     %4 = AIE.buffer(%1) {sym_name = "link1_cons_buff_0"} : memref<16xi32>
-// CHECK:     %5 = AIE.buffer(%1) {sym_name = "link1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %6 = AIE.lock(%1, 0) {init = 0 : i32, sym_name = "link1_cons_lock_0"}
-// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "link1_cons_lock_1"}
+// CHECK:     %3 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "of1_lock_0"}
+// CHECK:     %4 = AIE.buffer(%1) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %5 = AIE.buffer(%1) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %6 = AIE.lock(%1, 0) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %7 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "of1_cons_lock_1"}
 // CHECK:     AIE.flow(%1, DMA : 0, %2, DMA : 0)
-// CHECK:     %8 = AIE.buffer(%2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
-// CHECK:     %9 = AIE.buffer(%2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
-// CHECK:     %10 = AIE.lock(%2, 0) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
-// CHECK:     %11 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "link2_cons_lock_1"}
+// CHECK:     %8 = AIE.buffer(%2) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %9 = AIE.buffer(%2) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %10 = AIE.lock(%2, 0) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK:     %11 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
 // CHECK:     %12 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
-// CHECK:     AIE.shimDMAAllocation(@link1, MM2S, 0, 2)
+// CHECK:     AIE.shimDMAAllocation(@of1, MM2S, 0, 2)
 // CHECK:     %13 = AIE.shimDMA(%0) {
 // CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -90,13 +90,13 @@ module @link_AIE1 {
         %tile20 = AIE.tile(2, 0)
         %tile22 = AIE.tile(2, 2)
         %tile24 = AIE.tile(2, 4)
-
+        
         AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link([@of1], [@of2])
+        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
 
-        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
-        AIE.objectFifo.registerExternalBuffers(@of1, %tile20, {%ext_buff_in}) : (memref<16xi32>)
+        %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32> 
+        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -94,9 +94,9 @@ module @link_AIE1 {
         AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
+        AIE.objectFifo.link [@of1] to [@of2] ()
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32> 
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+        AIE.objectFifo.registerExternalBuffers @of1 (%tile20, {%ext_buff_in}) : (memref<16xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -29,7 +29,7 @@
 // CHECK:     %10 = AIE.lock(%2, 0) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
 // CHECK:     %11 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
 // CHECK:     %12 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
-// CHECK:     AIE.shimDMAAllocation(@of1, MM2S, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @of1(MM2S, 0, 2)
 // CHECK:     %13 = AIE.shimDMA(%0) {
 // CHECK:       %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -91,12 +91,12 @@ module @link_AIE1 {
         %tile22 = AIE.tile(2, 2)
         %tile24 = AIE.tile(2, 4)
 
-        AIE.objectFifo.create @link1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo.create @link2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({@link1}, {@link2})
+        AIE.objectFifo.link([@of1], [@of2])
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
-        AIE.objectFifo.registerExternalBuffers(@link1, %tile20, {%ext_buff_in}) : (memref<16xi32>)
+        AIE.objectFifo.registerExternalBuffers(@of1, %tile20, {%ext_buff_in}) : (memref<16xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -54,7 +54,7 @@
 // CHECK:       memref.store %c11_i32, %15[%c0] : memref<3000xi32>
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     AIE.shimDMAAllocation(@mem_in, MM2S, 0, 0)
+// CHECK:     AIE.shimDMAAllocation @mem_in(MM2S, 0, 0)
 // CHECK:     %26 = AIE.core(%3) {
 // CHECK:       %c11_i32 = arith.constant 11 : i32
 // CHECK:       %c0 = arith.constant 0 : index
@@ -191,7 +191,7 @@ module @link_AIE2 {
 
         AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : !AIE.objectFifo<memref<3000xi32>>
         AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : !AIE.objectFifo<memref<3000xi32>>
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<3000xi32>>}, {!AIE.objectFifo<memref<3000xi32>>})
+        AIE.objectFifo.link [@mem_in] to [@mem_out] ()
 
         %core02 = AIE.core(%tile02) {
             %v11 = arith.constant 11 : i32

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -197,7 +197,7 @@ module @link_AIE2 {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<3000xi32>>, 1) : !AIE.objectFifoSubview<memref<3000xi32>>
+            %subview = AIE.objectFifo.acquire @mem_in (Consume, 1) : !AIE.objectFifoSubview<memref<3000xi32>>
             %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end
@@ -207,7 +207,7 @@ module @link_AIE2 {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<3000xi32>>, 3) : !AIE.objectFifoSubview<memref<3000xi32>>
+            %subview = AIE.objectFifo.acquire @mem_out (Consume, 3) : !AIE.objectFifoSubview<memref<3000xi32>>
             %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -18,12 +18,10 @@
 // CHECK:     %1 = AIE.tile(0, 1)
 // CHECK:     %2 = AIE.tile(0, 2)
 // CHECK:     %3 = AIE.tile(0, 3)
-// CHECK:     memref.global "public" @mem_in : memref<3000xi32>
 // CHECK:     AIE.flow(%0, DMA : 0, %1, DMA : 0)
 // CHECK:     AIE.flow(%0, DMA : 0, %2, DMA : 0)
 // CHECK:     %4 = AIE.lock(%0, 0) {init = 0 : i32, sym_name = "mem_in_prod_lock"}
 // CHECK:     %5 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "mem_in_cons_lock"}
-// CHECK:     memref.global "public" @mem_in_1_cons : memref<3000xi32>
 // CHECK:     %6 = AIE.buffer(%1) {sym_name = "mem_in_1_cons_buff_0"} : memref<3000xi32>
 // CHECK:     %7 = AIE.buffer(%1) {sym_name = "mem_in_1_cons_buff_1"} : memref<3000xi32>
 // CHECK:     %8 = AIE.buffer(%1) {sym_name = "mem_in_1_cons_buff_2"} : memref<3000xi32>
@@ -33,14 +31,11 @@
 // CHECK:     %12 = AIE.buffer(%1) {sym_name = "mem_in_1_cons_buff_6"} : memref<3000xi32>
 // CHECK:     %13 = AIE.lock(%1, 0) {init = 7 : i32, sym_name = "mem_in_1_cons_prod_lock"}
 // CHECK:     %14 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "mem_in_1_cons_cons_lock"}
-// CHECK:     memref.global "public" @mem_in_0_cons : memref<3000xi32>
 // CHECK:     %15 = AIE.buffer(%2) {sym_name = "mem_in_0_cons_buff_0"} : memref<3000xi32>
 // CHECK:     %16 = AIE.buffer(%2) {sym_name = "mem_in_0_cons_buff_1"} : memref<3000xi32>
 // CHECK:     %17 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "mem_in_0_cons_prod_lock"}
 // CHECK:     %18 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "mem_in_0_cons_cons_lock"}
-// CHECK:     memref.global "public" @mem_out : memref<3000xi32>
 // CHECK:     AIE.flow(%1, DMA : 0, %3, DMA : 0)
-// CHECK:     memref.global "public" @mem_out_cons : memref<3000xi32>
 // CHECK:     %19 = AIE.buffer(%3) {sym_name = "mem_out_cons_buff_0"} : memref<3000xi32>
 // CHECK:     %20 = AIE.buffer(%3) {sym_name = "mem_out_cons_buff_1"} : memref<3000xi32>
 // CHECK:     %21 = AIE.buffer(%3) {sym_name = "mem_out_cons_buff_2"} : memref<3000xi32>

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -186,7 +186,7 @@ module @link_AIE2 {
 
         AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : !AIE.objectFifo<memref<3000xi32>>
         AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : !AIE.objectFifo<memref<3000xi32>>
-        AIE.objectFifo.link [@mem_in] to [@mem_out] ()
+        AIE.objectFifo.link [@mem_in] -> [@mem_out] ()
 
         %core02 = AIE.core(%tile02) {
             %v11 = arith.constant 11 : i32

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -189,8 +189,8 @@ module @link_AIE2 {
         %tile02 = AIE.tile(0, 2)
         %tile03 = AIE.tile(0, 3)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile00, {%tile02, %tile01}, [2,2,7]) {sym_name = "mem_in"} : !AIE.objectFifo<memref<3000xi32>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile01, {%tile03}, 7 : i32) {sym_name = "mem_out"} : !AIE.objectFifo<memref<3000xi32>>
+        AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : !AIE.objectFifo<memref<3000xi32>>
+        AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : !AIE.objectFifo<memref<3000xi32>>
         AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<3000xi32>>}, {!AIE.objectFifo<memref<3000xi32>>})
 
         %core02 = AIE.core(%tile02) {

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -92,8 +92,8 @@ module @link_DDR_L1 {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
 

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -30,7 +30,7 @@
 // CHECK:     %11 = AIE.lock(%2, 0) {init = 2 : i32, sym_name = "from_memTile_cons_prod_lock"}
 // CHECK:     %12 = AIE.lock(%2, 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock"}
 // CHECK:     %13 = AIE.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
-// CHECK:     AIE.shimDMAAllocation(@to_memTile, MM2S, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @to_memTile(MM2S, 0, 2)
 // CHECK:     %14 = AIE.shimDMA(%0) {
 // CHECK:       %17 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -95,7 +95,7 @@ module @link_DDR_L1 {
         AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
+        AIE.objectFifo.link [@to_memTile] to [@from_memTile] ()
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers @to_memTile (%tile20, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -95,7 +95,7 @@ module @link_DDR_L1 {
         AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link [@to_memTile] to [@from_memTile] ()
+        AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
         AIE.objectFifo.registerExternalBuffers @to_memTile (%tile20, {%ext_buff_in}) : (memref<16xi32>)

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -98,6 +98,6 @@ module @link_DDR_L1 {
         AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<16xi32> 
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buff_in}) : (memref<16xi32>)
+        AIE.objectFifo.registerExternalBuffers @to_memTile (%tile20, {%ext_buff_in}) : (memref<16xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -95,7 +95,7 @@ module @link_L1_DDR {
         AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
 
-        AIE.objectFifo.link [@to_memTile] to [@from_memTile] ()
+        AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<48xi32> 
         AIE.objectFifo.registerExternalBuffers @from_memTile (%tile20, {%ext_buff_in}) : (memref<48xi32>)

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -92,8 +92,8 @@ module @link_L1_DDR {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "to_memTile"} : !AIE.objectFifo<memref<16xi32>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "from_memTile"} : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
 
         AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<48xi32>>})
 

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -72,7 +72,7 @@
 // CHECK:     ^bb6:  // pred: ^bb3
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     AIE.shimDMAAllocation(@from_memTile, S2MM, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @from_memTile(S2MM, 0, 2)
 // CHECK:     %16 = AIE.shimDMA(%0) {
 // CHECK:       %17 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -95,7 +95,7 @@ module @link_L1_DDR {
         AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<48xi32>>})
+        AIE.objectFifo.link [@to_memTile] to [@from_memTile] ()
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<48xi32> 
         AIE.objectFifo.registerExternalBuffers @from_memTile (%tile20, {%ext_buff_in}) : (memref<48xi32>)

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -98,6 +98,6 @@ module @link_L1_DDR {
         AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<16xi32>>}, {!AIE.objectFifo<memref<48xi32>>})
 
         %ext_buff_in = AIE.external_buffer {sym_name = "ext_buff_in"}: memref<48xi32> 
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo2 : !AIE.objectFifo<memref<48xi32>>, {%ext_buff_in}) : (memref<48xi32>)
+        AIE.objectFifo.registerExternalBuffers @from_memTile (%tile20, {%ext_buff_in}) : (memref<48xi32>)
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -142,10 +142,10 @@ module @link_broadcast {
         %tile22 = AIE.tile(2, 2)
         %tile33 = AIE.tile(3, 3)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<48xi32>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22, %tile33}, [2, 2, 3]) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @link2 (%tile21, {%tile22, %tile33}, [2, 2, 3]) : !AIE.objectFifo<memref<16xi32>>
 
-        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile22, {%tile33}, 2 : i32) {sym_name = "skip_connection"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<48xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
     }

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -45,7 +45,7 @@
 // CHECK:     %24 = AIE.buffer(%3) {sym_name = "skip_connection_cons_buff_1"} : memref<16xi32>
 // CHECK:     %25 = AIE.lock(%3, 2) {init = 2 : i32, sym_name = "skip_connection_cons_prod_lock"}
 // CHECK:     %26 = AIE.lock(%3, 3) {init = 0 : i32, sym_name = "skip_connection_cons_cons_lock"}
-// CHECK:     AIE.shimDMAAllocation(@link1, MM2S, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @link1(MM2S, 0, 2)
 // CHECK:     %27 = AIE.memTileDMA(%1) {
 // CHECK:       %30 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
@@ -147,6 +147,6 @@ module @link_broadcast {
 
         AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2}) : ({!AIE.objectFifo<memref<48xi32>>}, {!AIE.objectFifo<memref<16xi32>>})
+        AIE.objectFifo.link [@link1] to [@link2] ()
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -147,6 +147,6 @@ module @link_broadcast {
 
         AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo.link [@link1] to [@link2] ()
+        AIE.objectFifo.link [@link1] -> [@link2] ()
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -42,7 +42,7 @@
 // CHECK:     %21 = AIE.lock(%4, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
 // CHECK:     %22 = AIE.lock(%4, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
 // CHECK:     %23 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<48xi32>
-// CHECK:     AIE.shimDMAAllocation(@link1, MM2S, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @link1(MM2S, 0, 2)
 // CHECK:     %24 = AIE.shimDMA(%0) {
 // CHECK:       %29 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -168,6 +168,6 @@ module @link_distribute {
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers @link1 (%tile20, {%ext_buffer_in}) : (memref<48xi32>)
 
-        AIE.objectFifo.link({%objFifo}, {%objFifo2, %objFifo3, %objFifo4}) : ({!AIE.objectFifo<memref<48xi32>>}, {!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>})
+        AIE.objectFifo.link [@link1] to [@link2, @link3, @link4] ()
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -160,11 +160,11 @@ module @link_distribute {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile20, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
 
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile21, {%tile22}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<16xi32>>
-        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile21, {%tile23}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<20xi32>>
-        %objFifo4 = AIE.objectFifo.createObjectFifo(%tile21, {%tile33}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<12xi32>>
+        AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<20xi32>>
+        AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<12xi32>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -168,6 +168,6 @@ module @link_distribute {
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers @link1 (%tile20, {%ext_buffer_in}) : (memref<48xi32>)
 
-        AIE.objectFifo.link [@link1] to [@link2, @link3, @link4] ()
+        AIE.objectFifo.link [@link1] -> [@link2, @link3, @link4] ()
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -161,13 +161,12 @@ module @link_distribute {
         %tile33 = AIE.tile(3, 3)
 
         AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
-
         AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
         AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<20xi32>>
         AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<12xi32>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo : !AIE.objectFifo<memref<48xi32>>, {%ext_buffer_in}) : (memref<48xi32>)
+        AIE.objectFifo.registerExternalBuffers @link1 (%tile20, {%ext_buffer_in}) : (memref<48xi32>)
 
         AIE.objectFifo.link({%objFifo}, {%objFifo2, %objFifo3, %objFifo4}) : ({!AIE.objectFifo<memref<48xi32>>}, {!AIE.objectFifo<memref<16xi32>>, !AIE.objectFifo<memref<20xi32>>, !AIE.objectFifo<memref<12xi32>>})
     }

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -203,6 +203,6 @@ module @link_join {
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
         AIE.objectFifo.registerExternalBuffers @link5 (%tile20, {%ext_buffer_in}) : (memref<512xi8>)
 
-        AIE.objectFifo.link [@link1, @link2, @link3, @link4] to [@link5] ()
+        AIE.objectFifo.link [@link1, @link2, @link3, @link4] -> [@link5] ()
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -171,7 +171,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     AIE.shimDMAAllocation(@link5, S2MM, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @link5(S2MM, 0, 2)
 // CHECK:     %34 = AIE.shimDMA(%0) {
 // CHECK:       %35 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -203,6 +203,6 @@ module @link_join {
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
         AIE.objectFifo.registerExternalBuffers @link5 (%tile20, {%ext_buffer_in}) : (memref<512xi8>)
 
-        AIE.objectFifo.link({%objFifo1, %objFifo2, %objFifo3, %objFifo4}, {%objFifoOut}) : ({!AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>}, {!AIE.objectFifo<memref<512xi8>>})
+        AIE.objectFifo.link [@link1, @link2, @link3, @link4] to [@link5] ()
     }
 }

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -198,11 +198,10 @@ module @link_join {
         AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
         AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
         AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-
-        %objFifoOut = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "link5"} : !AIE.objectFifo<memref<512xi8>>
+        AIE.objectFifo @link5 (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<512xi8>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
-        AIE.objectFifo.registerExternalBuffers(%tile20, %objFifoOut : !AIE.objectFifo<memref<512xi8>>, {%ext_buffer_in}) : (memref<512xi8>)
+        AIE.objectFifo.registerExternalBuffers @link5 (%tile20, {%ext_buffer_in}) : (memref<512xi8>)
 
         AIE.objectFifo.link({%objFifo1, %objFifo2, %objFifo3, %objFifo4}, {%objFifoOut}) : ({!AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>, !AIE.objectFifo<memref<128xi8>>}, {!AIE.objectFifo<memref<512xi8>>})
     }

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -194,10 +194,10 @@ module @link_join {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        %objFifo1 = AIE.objectFifo.createObjectFifo(%tile12, {%tile21}, 2 : i32) {sym_name = "link1"} : !AIE.objectFifo<memref<128xi8>>
-        %objFifo2 = AIE.objectFifo.createObjectFifo(%tile22, {%tile21}, 2 : i32) {sym_name = "link2"} : !AIE.objectFifo<memref<128xi8>>
-        %objFifo3 = AIE.objectFifo.createObjectFifo(%tile23, {%tile21}, 2 : i32) {sym_name = "link3"} : !AIE.objectFifo<memref<128xi8>>
-        %objFifo4 = AIE.objectFifo.createObjectFifo(%tile33, {%tile21}, 2 : i32) {sym_name = "link4"} : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link1 (%tile12, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
 
         %objFifoOut = AIE.objectFifo.createObjectFifo(%tile21, {%tile20}, 2 : i32) {sym_name = "link5"} : !AIE.objectFifo<memref<512xi8>>
 

--- a/test/objectFifo-stateful-transform/loop_test.aie.mlir
+++ b/test/objectFifo-stateful-transform/loop_test.aie.mlir
@@ -87,43 +87,43 @@
 // CHECK: }
 
 module @loop  {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %c2 = arith.constant 2 : index
-        %c4 = arith.constant 4 : index
-        %c21 = arith.constant 21 : index
-
-        %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
-        AIE.objectFifo.release @loop_of (Produce, 1)
-
-        scf.for %indexInHeight = %c1 to %c21 step %c2 { 
-            %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
-            AIE.objectFifo.release @loop_of (Produce, 1)
+        func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
+            return
         }
 
-        scf.for %indexInHeight = %c1 to %c4 step %c1 { 
-            %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %c2 = arith.constant 2 : index
+            %c4 = arith.constant 4 : index
+            %c21 = arith.constant 21 : index
+
+            %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
             AIE.objectFifo.release @loop_of (Produce, 1)
+
+            scf.for %indexInHeight = %c1 to %c21 step %c2 { 
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
+                AIE.objectFifo.release @loop_of (Produce, 1)
+            }
+
+            scf.for %indexInHeight = %c1 to %c4 step %c1 { 
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
+                AIE.objectFifo.release @loop_of (Produce, 1)
+            }
+            
+            AIE.end
         }
-        
-        AIE.end
     }
- }
 }

--- a/test/objectFifo-stateful-transform/loop_test.aie.mlir
+++ b/test/objectFifo-stateful-transform/loop_test.aie.mlir
@@ -91,7 +91,7 @@ module @loop  {
     %tile12 = AIE.tile(1, 2)
     %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "loop_of"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
         return

--- a/test/objectFifo-stateful-transform/loop_test.aie.mlir
+++ b/test/objectFifo-stateful-transform/loop_test.aie.mlir
@@ -104,23 +104,23 @@ module @loop  {
         %c4 = arith.constant 4 : index
         %c21 = arith.constant 21 : index
 
-        %subviewTop0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+        %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
         %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
         func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+        AIE.objectFifo.release @loop_of (Produce, 1)
 
         scf.for %indexInHeight = %c1 to %c21 step %c2 { 
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @loop_of (Produce, 1)
         }
 
         scf.for %indexInHeight = %c1 to %c4 step %c1 { 
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @loop_of (Produce, 1)
         }
         
         AIE.end

--- a/test/objectFifo-stateful-transform/memTile_test.mlir
+++ b/test/objectFifo-stateful-transform/memTile_test.mlir
@@ -60,10 +60,10 @@
 // CHECK: }
 
 module @memTile {
- AIE.device(xcve2302) {
-    %tile11 = AIE.tile(2, 1)
-    %tile12 = AIE.tile(2, 2)
+   AIE.device(xcve2302) {
+      %tile11 = AIE.tile(2, 1)
+      %tile12 = AIE.tile(2, 2)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile11, {%tile12}, 2 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<16xi32>>
- }
+      AIE.objectFifo @of (%tile11, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+   }
 }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
@@ -96,7 +96,7 @@ module @non_adjacency {
     %tile12 = AIE.tile(1, 2)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
@@ -92,44 +92,44 @@
 // CHECK: }
 
 module @non_adjacency {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile33 = AIE.tile(3, 3)
 
-    AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%lineOut : memref<16xi32>) -> () {
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
-
-        scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+        func.func @some_work(%lineOut : memref<16xi32>) -> () {
+            return
         }
-        
-        AIE.end
-    }
 
-    %core33 = AIE.core(%tile33) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
 
-        scf.for %indexInHeight = %c0 to %height step %c1 { 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            scf.for %indexInHeight = %c0 to %height step %c1 {
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Produce, 1)
+            }
+            
+            AIE.end
         }
-        
-        AIE.end
+
+        %core33 = AIE.core(%tile33) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
+
+            scf.for %indexInHeight = %c0 to %height step %c1 { 
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Consume, 1)
+            }
+            
+            AIE.end
+        }
     }
- }
 }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
@@ -118,7 +118,7 @@ module @non_adjacency {
     %tile12 = AIE.tile(1, 2)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
@@ -114,46 +114,46 @@
 // CHECK: }
 
 module @non_adjacency {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile33 = AIE.tile(3, 3)
 
-    AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%lineOut : memref<16xi32>) -> () {
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
-
-        scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+        func.func @some_work(%lineOut : memref<16xi32>) -> () {
+            return
         }
-        
-        AIE.end
-    }
 
-    %core33 = AIE.core(%tile33) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
 
-        scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            scf.for %indexInHeight = %c0 to %height step %c1 {
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Produce, 1)
+            }
+            
+            AIE.end
         }
-        
-        AIE.end
+
+        %core33 = AIE.core(%tile33) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
+
+            scf.for %indexInHeight = %c0 to %height step %c1 {
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Consume, 1)
+            }
+            
+            AIE.end
+        }
     }
- }
 }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
@@ -93,44 +93,44 @@
 // CHECK: }
 
 module @non_adjacency_AIE2 {
- AIE.device(xcve2302) {
-    %tile12 = AIE.tile(1, 2)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcve2302) {
+        %tile12 = AIE.tile(1, 2)
+        %tile33 = AIE.tile(3, 3)
 
-    AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%lineOut : memref<16xi32>) -> () {
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
-
-        scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+        func.func @some_work(%lineOut : memref<16xi32>) -> () {
+            return
         }
-        
-        AIE.end
-    }
 
-    %core33 = AIE.core(%tile33) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
 
-        scf.for %indexInHeight = %c0 to %height step %c1 { 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            scf.for %indexInHeight = %c0 to %height step %c1 {
+                %subview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release @of (Produce, 1)
+            }
+            
+            AIE.end
         }
-        
-        AIE.end
+
+        %core33 = AIE.core(%tile33) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
+
+            scf.for %indexInHeight = %c0 to %height step %c1 { 
+                %subview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release @of (Consume, 1)
+            }
+            
+            AIE.end
+        }
     }
- }
 }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
@@ -97,7 +97,7 @@ module @non_adjacency_AIE2 {
     %tile12 = AIE.tile(1, 2)
     %tile33 = AIE.tile(3, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -83,7 +83,7 @@ module @register_external_buffers {
     AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %ext_buffer_in = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-    AIE.objectFifo.registerExternalBuffers(%tile70, %ext_of: !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
+    AIE.objectFifo.registerExternalBuffers @ext_of (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
 
     func.func @some_work(%a : memref<16xi32>, %b : memref<16xi32>) -> () {
         return

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -17,9 +17,7 @@
 // CHECK:   AIE.device(xcvc1902) {
 // CHECK:     %0 = AIE.tile(7, 1)
 // CHECK:     %1 = AIE.tile(7, 0)
-// CHECK:     memref.global "public" @ext_of : memref<16xi32>
 // CHECK:     AIE.flow(%1, DMA : 0, %0, DMA : 0)
-// CHECK:     memref.global "public" @ext_of_cons : memref<16xi32>
 // CHECK:     %2 = AIE.lock(%1, 0) {init = 0 : i32, sym_name = "ext_of_lock_0"}
 // CHECK:     %3 = AIE.buffer(%0) {sym_name = "ext_of_cons_buff_0"} : memref<16xi32>
 // CHECK:     %4 = AIE.buffer(%0) {sym_name = "ext_of_cons_buff_1"} : memref<16xi32>

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -28,7 +28,7 @@
 // CHECK:     %7 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "ext_of_cons_lock_1"}
 // CHECK:     %8 = AIE.lock(%0, 2) {init = 0 : i32, sym_name = "ext_of_cons_lock_2"}
 // CHECK:     %9 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>
-// CHECK:     AIE.shimDMAAllocation(@ext_of, MM2S, 0, 7)
+// CHECK:     AIE.shimDMAAllocation @ext_of(MM2S, 0, 7)
 // CHECK:     func.func @some_work(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
 // CHECK:       return
 // CHECK:     }

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -95,10 +95,10 @@ module @register_external_buffers {
         %height = arith.constant 12 : index
 
         %subview = AIE.objectFifo.acquire<Consume>(@ext_of, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        // %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        // %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        // func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
-        // AIE.objectFifo.release<Consume>(@ext_of, 1)
+        %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
+        AIE.objectFifo.release<Consume>(@ext_of, 1)
         
         AIE.end
     }

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -26,7 +26,6 @@
 // CHECK:     %7 = AIE.lock(%0, 1) {init = 0 : i32, sym_name = "ext_of_cons_lock_1"}
 // CHECK:     %8 = AIE.lock(%0, 2) {init = 0 : i32, sym_name = "ext_of_cons_lock_2"}
 // CHECK:     %9 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>
-// CHECK:     AIE.shimDMAAllocation @ext_of(MM2S, 0, 7)
 // CHECK:     func.func @some_work(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
 // CHECK:       return
 // CHECK:     }
@@ -40,6 +39,7 @@
 // CHECK:       AIE.useLock(%6, Release, 0)
 // CHECK:       AIE.end
 // CHECK:     }
+// CHECK:     AIE.shimDMAAllocation @ext_of(MM2S, 0, 7)
 // CHECK:     %11 = AIE.shimDMA(%1) {
 // CHECK:       %13 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -83,7 +83,7 @@ module @register_external_buffers {
     AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %ext_buffer_in = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-    AIE.objectFifo.registerExternalBuffers(@ext_of, %tile70, {%ext_buffer_in}) : (memref<64xi32>)
+    AIE.objectFifo.registerExternalBuffers(%tile70, %ext_of: !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
 
     func.func @some_work(%a : memref<16xi32>, %b : memref<16xi32>) -> () {
         return
@@ -94,11 +94,11 @@ module @register_external_buffers {
         %c1 = arith.constant 1 : index
         %height = arith.constant 12 : index
 
-        %subview = AIE.objectFifo.acquire<Consume>(@ext_of, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+        %subview = AIE.objectFifo.acquire<Consume>(%ext_of: !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
         %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
         %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
         func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(@ext_of, 1)
+        AIE.objectFifo.release<Consume>(%ext_of: !AIE.objectFifo<memref<16xi32>>, 1)
         
         AIE.end
     }

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -83,24 +83,24 @@ module @register_external_buffers {
     AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %ext_buffer_in = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-    AIE.objectFifo.registerExternalBuffers(@objFifo, %tile70, {%ext_buffer_in}) : (memref<64xi32>)
+    AIE.objectFifo.registerExternalBuffers(@ext_of, %tile70, {%ext_buffer_in}) : (memref<64xi32>)
 
     func.func @some_work(%a : memref<16xi32>, %b : memref<16xi32>) -> () {
         return
     }
 
-    // %core71 = AIE.core(%tile71) {
-    //     %c0 = arith.constant 0 : index
-    //     %c1 = arith.constant 1 : index
-    //     %height = arith.constant 12 : index
+    %core71 = AIE.core(%tile71) {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %height = arith.constant 12 : index
 
-    //     %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-    //     %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-    //     %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-    //     func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
-    //     AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+        %subview = AIE.objectFifo.acquire<Consume>(@ext_of, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+        %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
+        AIE.objectFifo.release<Consume>(@ext_of, 1)
         
-    //     AIE.end
-    // }
+        AIE.end
+    }
  }
 }

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -94,11 +94,11 @@ module @register_external_buffers {
         %c1 = arith.constant 1 : index
         %height = arith.constant 12 : index
 
-        %subview = AIE.objectFifo.acquire<Consume>(%ext_of: !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+        %subview = AIE.objectFifo.acquire @ext_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
         %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
         %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
         func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%ext_of: !AIE.objectFifo<memref<16xi32>>, 1)
+        AIE.objectFifo.release @ext_of (Consume, 1)
         
         AIE.end
     }

--- a/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
+++ b/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
@@ -45,7 +45,7 @@ module @same_core {
     AIE.device(xcve2302) {
         %tile12 = AIE.tile(1, 2)
 
-        %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile12}, 3 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return

--- a/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
+++ b/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
@@ -53,27 +53,27 @@ module @same_core {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @of (Produce, 1)
 
-            %subview1 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @of (Consume, 1)
 
-            %subview2 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview2 = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @of (Produce, 1)
 
-            %subview3 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview3 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem30) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @of (Consume, 1)
 
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -81,7 +81,7 @@ module @shimRow_mem {
         AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-        AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
+        AIE.objectFifo.registerExternalBuffers @objfifo (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
 
         func.func @some_work(%a : memref<16xi32>, %b : memref<16xi32>) -> () {
             return

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -74,31 +74,31 @@
 // CHECK: }
 
 module @shimRow_mem {
- AIE.device(xcvc1902) {
-    %tile71 = AIE.tile(7, 1)
-    %tile70 = AIE.tile(7, 0)
+    AIE.device(xcvc1902) {
+        %tile71 = AIE.tile(7, 1)
+        %tile70 = AIE.tile(7, 0)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile70, {%tile71}, 3 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-    AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
+        %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
+        AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
 
-    func.func @some_work(%a : memref<16xi32>, %b : memref<16xi32>) -> () {
-        return
+        func.func @some_work(%a : memref<16xi32>, %b : memref<16xi32>) -> () {
+            return
+        }
+
+        %core71 = AIE.core(%tile71) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
+
+            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
+            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            
+            AIE.end
+        }
     }
-
-    %core71 = AIE.core(%tile71) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
-
-        %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        
-        AIE.end
-    }
- }
 }

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -92,11 +92,11 @@ module @shimRow_mem {
             %c1 = arith.constant 1 : index
             %height = arith.constant 12 : index
 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @objfifo (Consume, 1)
             
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -39,7 +39,7 @@
 // CHECK:       AIE.useLock(%6, Release, 0)
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     AIE.shimDMAAllocation(@objfifo, MM2S, 0, 7)
+// CHECK:     AIE.shimDMAAllocation @objfifo(MM2S, 0, 7)
 // CHECK:     %11 = AIE.shimDMA(%1) {
 // CHECK:       %13 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -91,7 +91,7 @@ module @shim_AIE2 {
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
       %ext_buffer_out  = AIE.external_buffer {sym_name = "ext_buffer_out"}: memref<64xi32>
-      AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_in : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
-      AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_out : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_out}) : (memref<64xi32>)
+      AIE.objectFifo.registerExternalBuffers @of_in (%tile20, {%ext_buffer_in}) : (memref<64xi32>)
+      AIE.objectFifo.registerExternalBuffers @of_out (%tile20, {%ext_buffer_out}) : (memref<64xi32>)
    }
 }

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -32,7 +32,7 @@
 // CHECK:     %13 = AIE.lock(%1, 3) {init = 0 : i32, sym_name = "of_out_cons_cons_lock"}
 // CHECK:     %14 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>
 // CHECK:     %15 = AIE.external_buffer {sym_name = "ext_buffer_out"} : memref<64xi32>
-// CHECK:     AIE.shimDMAAllocation(@of_in, MM2S, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @of_in(MM2S, 0, 2)
 // CHECK:     %16 = AIE.shimDMA(%1) {
 // CHECK:       %18 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
@@ -50,7 +50,7 @@
 // CHECK:     ^bb4:  // pred: ^bb2
 // CHECK:       AIE.end
 // CHECK:     }
-// CHECK:     AIE.shimDMAAllocation(@of_out, S2MM, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @of_out(S2MM, 0, 2)
 // CHECK:     %17 = AIE.mem(%0) {
 // CHECK:       %18 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -82,16 +82,16 @@
 // CHECK: }
 
 module @shim_AIE2 {
- AIE.device(xcve2302) {
-    %tile22 = AIE.tile(2, 2)
-    %tile20 = AIE.tile(2, 0)
+   AIE.device(xcve2302) {
+      %tile22 = AIE.tile(2, 2)
+      %tile20 = AIE.tile(2, 0)
 
-    %objFifo_in = AIE.objectFifo.createObjectFifo(%tile20, {%tile22}, 2 : i32) {sym_name = "of_in"} : !AIE.objectFifo<memref<16xi32>>
-    %objFifo_out = AIE.objectFifo.createObjectFifo(%tile22, {%tile20}, 2 : i32) {sym_name = "of_out"} : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_in (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_out (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-    %ext_buffer_out  = AIE.external_buffer {sym_name = "ext_buffer_out"}: memref<64xi32>
-    AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_in : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
-    AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_out : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_out}) : (memref<64xi32>)
- }
+      %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
+      %ext_buffer_out  = AIE.external_buffer {sym_name = "ext_buffer_out"}: memref<64xi32>
+      AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_in : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
+      AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_out : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_out}) : (memref<64xi32>)
+   }
 }

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -96,15 +96,15 @@
 // CHECK: }
 
 module @shim_broadcast {
- AIE.device(xcve2302) {
-    %tile20 = AIE.tile(2, 0)
-    %tile22 = AIE.tile(2, 2)
-    %tile23 = AIE.tile(2, 3)
-    %tile33 = AIE.tile(3, 3)
+   AIE.device(xcve2302) {
+      %tile20 = AIE.tile(2, 0)
+      %tile22 = AIE.tile(2, 2)
+      %tile23 = AIE.tile(2, 3)
+      %tile33 = AIE.tile(3, 3)
 
-    %objFifo_in = AIE.objectFifo.createObjectFifo(%tile20, {%tile22, %tile23, %tile33}, 2 : i32) {sym_name = "of_in"} : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-    AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_in : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
- }
+      %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
+      AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_in : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
+   }
 }

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -105,6 +105,6 @@ module @shim_broadcast {
       AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
-      AIE.objectFifo.registerExternalBuffers(%tile20, %objFifo_in : !AIE.objectFifo<memref<16xi32>>, {%ext_buffer_in}) : (memref<64xi32>)
+      AIE.objectFifo.registerExternalBuffers @of_in (%tile20, {%ext_buffer_in}) : (memref<64xi32>)
    }
 }

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -36,7 +36,7 @@
 // CHECK:     %16 = AIE.lock(%1, 0) {init = 2 : i32, sym_name = "of_in_0_cons_prod_lock"}
 // CHECK:     %17 = AIE.lock(%1, 1) {init = 0 : i32, sym_name = "of_in_0_cons_cons_lock"}
 // CHECK:     %18 = AIE.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>
-// CHECK:     AIE.shimDMAAllocation(@of_in, MM2S, 0, 2)
+// CHECK:     AIE.shimDMAAllocation @of_in(MM2S, 0, 2)
 // CHECK:     %19 = AIE.shimDMA(%0) {
 // CHECK:       %23 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1

--- a/test/objectFifo-stateful-transform/subview_test_1.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_1.mlir
@@ -49,51 +49,51 @@
 // CHECK: }
 
 module @singleFifo {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%line_in:memref<16xi32>) -> () {
-        return
+        func.func @some_work(%line_in:memref<16xi32>) -> () {
+            return
+        }
+
+        %core12 = AIE.core(%tile12) {
+            // this acquires 2 elements
+            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem00) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem01) : (memref<16xi32>) -> ()
+
+            // this should only acquire one new element, previous two are still acquired
+            %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem10) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem11) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem12) : (memref<16xi32>) -> ()
+
+            // one new acquire should take place
+            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            %subview2 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem21 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem20) : (memref<16xi32>) -> () 
+            func.call @some_work(%elem21) : (memref<16xi32>) -> ()
+
+            // no new acquires should take place, elem30 should be third element of objFifo (with index 2)
+            %subview3 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem31 = AIE.objectFifo.subview.access %subview3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            //%elem32 = AIE.subview.access %subview3[2] : !AIE.subview<memref<16xi32>> -> memref<16xi32> // expected to fail if this line is uncommented
+            func.call @some_work(%elem30) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem31) : (memref<16xi32>) -> ()
+
+            AIE.end
+        }
     }
-
-    %core12 = AIE.core(%tile12) {
-        // this acquires 2 elements
-        %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem00) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem01) : (memref<16xi32>) -> ()
-
-        // this should only acquire one new element, previous two are still acquired
-        %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem10) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem11) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem12) : (memref<16xi32>) -> ()
-
-        // one new acquire should take place
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        %subview2 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem21 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem20) : (memref<16xi32>) -> () 
-        func.call @some_work(%elem21) : (memref<16xi32>) -> ()
-
-        // no new acquires should take place, elem30 should be third element of objFifo (with index 2)
-        %subview3 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem31 = AIE.objectFifo.subview.access %subview3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        //%elem32 = AIE.subview.access %subview3[2] : !AIE.subview<memref<16xi32>> -> memref<16xi32> // expected to fail if this line is uncommented
-        func.call @some_work(%elem30) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem31) : (memref<16xi32>) -> ()
-
-        AIE.end
-    }
- }
 }

--- a/test/objectFifo-stateful-transform/subview_test_1.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_1.mlir
@@ -61,14 +61,14 @@ module @singleFifo {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
             // this should only acquire one new element, previous two are still acquired
-            %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview1 = AIE.objectFifo.acquire @objfifo (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
@@ -77,16 +77,16 @@ module @singleFifo {
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
 
             // one new acquire should take place
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-            %subview2 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            AIE.objectFifo.release @objfifo (Produce, 1)
+            AIE.objectFifo.release @objfifo (Produce, 1)
+            %subview2 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem21 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> () 
             func.call @some_work(%elem21) : (memref<16xi32>) -> ()
 
             // no new acquires should take place, elem30 should be third element of objFifo (with index 2)
-            %subview3 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview3 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem31 = AIE.objectFifo.subview.access %subview3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             //%elem32 = AIE.subview.access %subview3[2] : !AIE.subview<memref<16xi32>> -> memref<16xi32> // expected to fail if this line is uncommented

--- a/test/objectFifo-stateful-transform/subview_test_2.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_2.mlir
@@ -79,70 +79,70 @@
 // CHECK: }
 
 module @multiFifo {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<16xi32>>
-    %objFifo2 = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 3 : i32) {sym_name = "of2"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile12, {%tile13}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%line_in:memref<16xi32>) -> () {
-        return
+        func.func @some_work(%line_in:memref<16xi32>) -> () {
+            return
+        }
+
+        %core12 = AIE.core(%tile12) {
+            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem00) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem01) : (memref<16xi32>) -> ()
+
+            %subview02 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem002) : (memref<16xi32>) -> ()
+
+            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem10) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem11) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem12) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3)
+            
+            AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
+            %subview12 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem102) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem112) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
+            
+            AIE.end
+        }
+
+        %core13 = AIE.core(%tile13) {
+            %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem00) : (memref<16xi32>) -> ()
+
+            %subview02 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem002) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem012) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2)
+
+            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            %subview1 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem10) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem11) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
+
+            AIE.end
+        }
     }
-
-    %core12 = AIE.core(%tile12) {
-        %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem00) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem01) : (memref<16xi32>) -> ()
-
-        %subview02 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem002) : (memref<16xi32>) -> ()
-
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem10) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem11) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem12) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3)
-        
-        AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
-        %subview12 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem102) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem112) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
-        
-        AIE.end
-    }
-
-    %core13 = AIE.core(%tile13) {
-        %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem00) : (memref<16xi32>) -> ()
-
-        %subview02 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem002) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem012) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2)
-
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        %subview1 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem10) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem11) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
-
-        AIE.end
-    }
- }
 }

--- a/test/objectFifo-stateful-transform/subview_test_2.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_2.mlir
@@ -91,56 +91,56 @@ module @multiFifo {
         }
 
         %core12 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-            %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            AIE.objectFifo.release @of (Produce, 1)
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3)
+            AIE.objectFifo.release @of (Produce, 3)
             
-            AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
-            %subview12 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            AIE.objectFifo.release @of2 (Produce, 1)
+            %subview12 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @of2 (Produce, 1)
             
             AIE.end
         }
 
         %core13 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2)
+            AIE.objectFifo.release @of2 (Consume, 2)
 
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-            %subview1 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            AIE.objectFifo.release @of (Consume, 1)
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
+            AIE.objectFifo.release @of (Consume, 2)
 
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/subview_test_3.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_3.mlir
@@ -79,70 +79,70 @@
 // CHECK: }
 
 module @multiCoreMixedFifo {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<16xi32>>
-    %objFifo2 = AIE.objectFifo.createObjectFifo(%tile13, {%tile12}, 3 : i32) {sym_name = "of2"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile13, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%line_in:memref<16xi32>) -> () {
-        return
+        func.func @some_work(%line_in:memref<16xi32>) -> () {
+            return
+        }
+
+        %core11 = AIE.core(%tile12) {
+            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem00) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem01) : (memref<16xi32>) -> ()
+
+            %subview02 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem002) : (memref<16xi32>) -> ()
+
+            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem10) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem11) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem12) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3)
+            
+            AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
+            %subview12 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem102) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem112) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
+            
+            AIE.end
+        }
+
+        %core12 = AIE.core(%tile13) {
+            %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem00) : (memref<16xi32>) -> ()
+
+            %subview02 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem002) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem012) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2)
+
+            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            %subview1 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @some_work(%elem10) : (memref<16xi32>) -> ()
+            func.call @some_work(%elem11) : (memref<16xi32>) -> ()
+            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
+
+            AIE.end
+        }
     }
-
-    %core11 = AIE.core(%tile12) {
-        %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem00) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem01) : (memref<16xi32>) -> ()
-
-        %subview02 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem002) : (memref<16xi32>) -> ()
-
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem10) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem11) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem12) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3)
-        
-        AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
-        %subview12 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem102) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem112) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
-        
-        AIE.end
-    }
-
-    %core12 = AIE.core(%tile13) {
-        %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem00) : (memref<16xi32>) -> ()
-
-        %subview02 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem002) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem012) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2)
-
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        %subview1 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @some_work(%elem10) : (memref<16xi32>) -> ()
-        func.call @some_work(%elem11) : (memref<16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
-
-        AIE.end
-    }
- }
 }

--- a/test/objectFifo-stateful-transform/subview_test_3.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_3.mlir
@@ -91,56 +91,56 @@ module @multiCoreMixedFifo {
         }
 
         %core11 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-            %subview1 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            AIE.objectFifo.release @of (Produce, 1)
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 3)
+            AIE.objectFifo.release @of (Produce, 3)
             
-            AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
-            %subview12 = AIE.objectFifo.acquire<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            AIE.objectFifo.release @of2 (Consume, 1)
+            %subview12 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.objectFifo.release @of2 (Consume, 1)
             
             AIE.end
         }
 
         %core12 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo2 : !AIE.objectFifo<memref<16xi32>>, 2)
+            AIE.objectFifo.release @of2 (Produce, 2)
 
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-            %subview1 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            AIE.objectFifo.release @of (Consume, 1)
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
+            AIE.objectFifo.release @of (Consume, 2)
 
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/tileDMA_test.mlir
@@ -103,59 +103,59 @@
 // CHECK: }
 
 module @tileDMA_channels {
- AIE.device(xcvc1902) {
-    %tile12 = AIE.tile(1, 2)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile33 = AIE.tile(3, 3)
 
-    %buff0 = AIE.buffer(%tile12) : memref<16xi32>
-    %lock0 = AIE.lock(%tile12, 0)
-    %buff1 = AIE.buffer(%tile12) : memref<16xi32>
-    %lock1 = AIE.lock(%tile12, 1)
-    %buff2 = AIE.buffer(%tile12) : memref<16xi32>
-    %lock2 = AIE.lock(%tile12, 2)
+        %buff0 = AIE.buffer(%tile12) : memref<16xi32>
+        %lock0 = AIE.lock(%tile12, 0)
+        %buff1 = AIE.buffer(%tile12) : memref<16xi32>
+        %lock1 = AIE.lock(%tile12, 1)
+        %buff2 = AIE.buffer(%tile12) : memref<16xi32>
+        %lock2 = AIE.lock(%tile12, 2)
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @some_work(%lineOut : memref<16xi32>) -> () {
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 12 : index
-
-        scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+        func.func @some_work(%lineOut : memref<16xi32>) -> () {
+            return
         }
-        
-        AIE.end
-    }
 
-    %mem12 = AIE.mem(%tile12) {
-        %dma1 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
-    ^bb1:
-        AIE.useLock(%lock0, Acquire, 1)
-        AIE.dmaBd(<%buff0 : memref<16xi32>, 0, 16>, 0)
-        AIE.useLock(%lock0, Release, 0)
-        AIE.nextBd ^bb2
-    ^bb2:
-        AIE.useLock(%lock1, Acquire, 1)
-        AIE.dmaBd(<%buff1 : memref<16xi32>, 0, 16>, 0)
-        AIE.useLock(%lock1, Release, 0)
-        AIE.nextBd ^bb1
-    ^bb3:
-        %dma2 = AIE.dmaStart(S2MM, 0, ^bb4, ^bb5)
-    ^bb4:
-        AIE.useLock(%lock2, Acquire, 0)
-        AIE.dmaBd(<%buff2 : memref<16xi32>, 0, 16>, 0)
-        AIE.useLock(%lock2, Release, 1)
-        AIE.nextBd ^bb4
-    ^bb5:
-        AIE.end
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 12 : index
+
+            scf.for %indexInHeight = %c0 to %height step %c1 {
+                %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            }
+            
+            AIE.end
+        }
+
+        %mem12 = AIE.mem(%tile12) {
+            %dma1 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+        ^bb1:
+            AIE.useLock(%lock0, Acquire, 1)
+            AIE.dmaBd(<%buff0 : memref<16xi32>, 0, 16>, 0)
+            AIE.useLock(%lock0, Release, 0)
+            AIE.nextBd ^bb2
+        ^bb2:
+            AIE.useLock(%lock1, Acquire, 1)
+            AIE.dmaBd(<%buff1 : memref<16xi32>, 0, 16>, 0)
+            AIE.useLock(%lock1, Release, 0)
+            AIE.nextBd ^bb1
+        ^bb3:
+            %dma2 = AIE.dmaStart(S2MM, 0, ^bb4, ^bb5)
+        ^bb4:
+            AIE.useLock(%lock2, Acquire, 0)
+            AIE.dmaBd(<%buff2 : memref<16xi32>, 0, 16>, 0)
+            AIE.useLock(%lock2, Release, 1)
+            AIE.nextBd ^bb4
+        ^bb5:
+            AIE.end
+        }
     }
- }
 }

--- a/test/objectFifo-stateful-transform/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/tileDMA_test.mlir
@@ -126,10 +126,10 @@ module @tileDMA_channels {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
                 %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
-                AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+                AIE.objectFifo.release @objfifo (Produce, 1)
             }
             
             AIE.end

--- a/test/objectFifo_tests/broadcast/aie.mlir
+++ b/test/objectFifo_tests/broadcast/aie.mlir
@@ -32,7 +32,7 @@ module @broadcast {
     %buff_out_33 = AIE.buffer(%tile33) { sym_name = "out33" } :  memref<4x16xi32>
     %lock_out_33 = AIE.lock(%tile33, 0) { sym_name = "lock_out33" }
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile13, {%tile12, %tile14, %tile33}, 7 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
         %c0 = arith.constant 0 : index

--- a/test/objectFifo_tests/broadcast/aie.mlir
+++ b/test/objectFifo_tests/broadcast/aie.mlir
@@ -20,138 +20,140 @@
 // adjusted based on the maximum acquire value of the producer.
 
 module @broadcast {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
-    %tile14 = AIE.tile(1, 4)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
+        %tile14 = AIE.tile(1, 4)
+        %tile33 = AIE.tile(3, 3)
 
-    %buff_out_12 = AIE.buffer(%tile12) { sym_name = "out12" } :  memref<4x16xi32>
-    %lock_out_12 = AIE.lock(%tile12, 0) { sym_name = "lock_out12" }
-    %buff_out_14 = AIE.buffer(%tile14) { sym_name = "out14" } :  memref<4x16xi32>
-    %lock_out_14 = AIE.lock(%tile14, 0) { sym_name = "lock_out14" }
-    %buff_out_33 = AIE.buffer(%tile33) { sym_name = "out33" } :  memref<4x16xi32>
-    %lock_out_33 = AIE.lock(%tile33, 0) { sym_name = "lock_out33" }
+        %buff_out_12 = AIE.buffer(%tile12) { sym_name = "out12" } :  memref<4x16xi32>
+        %lock_out_12 = AIE.lock(%tile12, 0) { sym_name = "lock_out12" }
+        %buff_out_14 = AIE.buffer(%tile14) { sym_name = "out14" } :  memref<4x16xi32>
+        %lock_out_14 = AIE.lock(%tile14, 0) { sym_name = "lock_out14" }
+        %buff_out_33 = AIE.buffer(%tile33) { sym_name = "out33" } :  memref<4x16xi32>
+        %lock_out_33 = AIE.lock(%tile33, 0) { sym_name = "lock_out33" }
 
-    AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-        
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value = arith.index_cast %indexInLine : index to i32
-            memref.store %value, %lineOut[%indexInLine] : memref<16xi32>
-        }
-        return
-    }
-
-    %core13 = AIE.core(%tile13) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 4 : index
-        
-        scf.for %indexInLine = %c0 to %height step %c1 {
-            %subview0 = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @generateLineScalar(%elem0) : (memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        }
-        
-        AIE.end
-    }
-
-    func.func @storeLineScalar(%lineIn : memref<16xi32>, %row : index, %bufferOut : memref<4x16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value = memref.load %lineIn[%indexInLine] : memref<16xi32>
-            memref.store %value, %bufferOut[%row,%indexInLine] : memref<4x16xi32>
-        }
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 4 : index
-
-        AIE.useLock(%lock_out_12, "Acquire", 0)
-
-        scf.for %indexInLine = %c0 to %height step %c1 {
-            %subview0 = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_12) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        }
-
-        AIE.useLock(%lock_out_12, "Release", 1)
-        
-        AIE.end
-    }
-
-    %core14 = AIE.core(%tile14) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %c2 = arith.constant 2 : index
-        %height = arith.constant 4 : index
-
-        AIE.useLock(%lock_out_14, "Acquire", 0)
-        
-        scf.for %indexInLine = %c0 to %height step %c2 {
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
-            %indexPlusOne = arith.addi %indexInLine, %c1 : index
-            func.call @storeLineScalar(%elem1, %indexPlusOne, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2)
-        }
+        func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
             
-        AIE.useLock(%lock_out_14, "Release", 1)
-        
-        AIE.end
-    }
-
-    func.func @addAndStore(%lineIn0 : memref<16xi32>, %lineIn1 : memref<16xi32>, %row : index, %bufferOut : memref<4x16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
-            %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
-            %sum = arith.addi %value0, %value1 : i32
-            memref.store %sum, %bufferOut[%row,%indexInLine] : memref<4x16xi32>
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value = arith.index_cast %indexInLine : index to i32
+                memref.store %value, %lineOut[%indexInLine] : memref<16xi32>
+            }
+            return
         }
-        return
-    }
 
-    %core33 = AIE.core(%tile33) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %c3 = arith.constant 3 : index
-        %height = arith.constant 3 : index
+        %core13 = AIE.core(%tile13) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 4 : index
+            
+            scf.for %indexInLine = %c0 to %height step %c1 {
+                %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @generateLineScalar(%elem0) : (memref<16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Produce, 1)
+            }
+            
+            AIE.end
+        }
 
-        AIE.useLock(%lock_out_33, "Acquire", 0)
+        func.func @storeLineScalar(%lineIn : memref<16xi32>, %row : index, %bufferOut : memref<4x16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
 
-        scf.for %indexInLine = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value = memref.load %lineIn[%indexInLine] : memref<16xi32>
+                memref.store %value, %bufferOut[%row,%indexInLine] : memref<4x16xi32>
+            }
+            return
+        }
+
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 4 : index
+
+            AIE.useLock(%lock_out_12, "Acquire", 0)
+
+            scf.for %indexInLine = %c0 to %height step %c1 {
+                %subview0 = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_12) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Consume, 1)
+            }
+
+            AIE.useLock(%lock_out_12, "Release", 1)
+            
+            AIE.end
+        }
+
+        %core14 = AIE.core(%tile14) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %c2 = arith.constant 2 : index
+            %height = arith.constant 4 : index
+
+            AIE.useLock(%lock_out_14, "Acquire", 0)
+            
+            scf.for %indexInLine = %c0 to %height step %c2 {
+                %subview = AIE.objectFifo.acquire  @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
+                %indexPlusOne = arith.addi %indexInLine, %c1 : index
+                func.call @storeLineScalar(%elem1, %indexPlusOne, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Consume, 2)
+            }
+                
+            AIE.useLock(%lock_out_14, "Release", 1)
+            
+            AIE.end
+        }
+
+        func.func @addAndStore(%lineIn0 : memref<16xi32>, %lineIn1 : memref<16xi32>, %row : index, %bufferOut : memref<4x16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
+                %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
+                %sum = arith.addi %value0, %value1 : i32
+                memref.store %sum, %bufferOut[%row,%indexInLine] : memref<4x16xi32>
+            }
+            return
+        }
+
+        %core33 = AIE.core(%tile33) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %c3 = arith.constant 3 : index
+            %height = arith.constant 3 : index
+
+            AIE.useLock(%lock_out_33, "Acquire", 0)
+
+            scf.for %indexInLine = %c0 to %height step %c1 {
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @addAndStore(%elem0, %elem1, %indexInLine, %buff_out_33) : (memref<16xi32>, memref<16xi32>, index, memref<4x16xi32>) -> ()
+                AIE.objectFifo.release @objfifo (Consume, 1)
+            }
+
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
             %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @addAndStore(%elem0, %elem1, %indexInLine, %buff_out_33) : (memref<16xi32>, memref<16xi32>, index, memref<4x16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+            func.call @storeLineScalar(%elem0, %c3, %buff_out_33) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
+            AIE.objectFifo.release @objfifo (Consume, 1)
+
+            AIE.useLock(%lock_out_33, "Release", 1)
+            
+            AIE.end
         }
-
-        %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @storeLineScalar(%elem0, %c3, %buff_out_33) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-
-        AIE.useLock(%lock_out_33, "Release", 1)
-        
-        AIE.end
     }
 }

--- a/test/objectFifo_tests/ping_pong/aie.mlir
+++ b/test/objectFifo_tests/ping_pong/aie.mlir
@@ -19,85 +19,87 @@
 // that a flow and dma operations are established between the memory modules.
 
 module @ping_pong {
-    %tile12 = AIE.tile(1, 2)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile33 = AIE.tile(3, 3)
 
-    %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
-    %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
+        %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
+        %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-    AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    // Fills the given memref with the same input index value.
-    func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-        
-        %value = arith.index_cast %valueIndex : index to i32
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %i = arith.index_cast %indexInLine : index to i32
-            %sum = arith.addi %value, %i : i32
-            memref.store %sum, %lineOut[%indexInLine] : memref<16xi32>
-        }
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 10 : index
-
-        scf.for %indexInHeight = %c0 to %height step %c1 { 
-            // acquire next element for produce
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            // call generator function
-            func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
-
-            // release next element for consume
-            AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
-        }
-        
-        AIE.end
-    }
-
-    // Stores the given memref in the bufferOut at the given row index.
-    func.func @storeLineScalar(%lineIn : memref<16xi32>, %row : index, %bufferOut : memref<10x16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value = memref.load %lineIn[%indexInLine] : memref<16xi32>
-            memref.store %value, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
-        }
-        return
-    }
-
-    %core33 = AIE.core(%tile33) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 10 : index
-
-        // acquire output buffer
-        AIE.useLock(%lock_out, "Acquire", 0) // acquire for produce
-
-        scf.for %indexInHeight = %c0 to %height step %c1 { 
-            // acquire next element for consume
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            // call consumer function
-            func.call @storeLineScalar(%elem0, %indexInHeight, %buff_out) : (memref<16xi32>, index, memref<10x16xi32>) -> ()
-
-            // release next element for produce
-            AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)
+        // Fills the given memref with the same input index value.
+        func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+            
+            %value = arith.index_cast %valueIndex : index to i32
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %i = arith.index_cast %indexInLine : index to i32
+                %sum = arith.addi %value, %i : i32
+                memref.store %sum, %lineOut[%indexInLine] : memref<16xi32>
+            }
+            return
         }
 
-        // release output buffer
-        AIE.useLock(%lock_out, "Release", 1) // release for consume
-        
-        AIE.end
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 10 : index
+
+            scf.for %indexInHeight = %c0 to %height step %c1 { 
+                // acquire next element for produce
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                // call generator function
+                func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
+
+                // release next element for consume
+                AIE.objectFifo.release @objfifo (Produce, 1)
+            }
+            
+            AIE.end
+        }
+
+        // Stores the given memref in the bufferOut at the given row index.
+        func.func @storeLineScalar(%lineIn : memref<16xi32>, %row : index, %bufferOut : memref<10x16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value = memref.load %lineIn[%indexInLine] : memref<16xi32>
+                memref.store %value, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
+            }
+            return
+        }
+
+        %core33 = AIE.core(%tile33) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 10 : index
+
+            // acquire output buffer
+            AIE.useLock(%lock_out, "Acquire", 0) // acquire for produce
+
+            scf.for %indexInHeight = %c0 to %height step %c1 { 
+                // acquire next element for consume
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                // call consumer function
+                func.call @storeLineScalar(%elem0, %indexInHeight, %buff_out) : (memref<16xi32>, index, memref<10x16xi32>) -> ()
+
+                // release next element for produce
+                AIE.objectFifo.release @objfifo (Consume, 1)
+            }
+
+            // release output buffer
+            AIE.useLock(%lock_out, "Release", 1) // release for consume
+            
+            AIE.end
+        }
     }
 }

--- a/test/objectFifo_tests/ping_pong/aie.mlir
+++ b/test/objectFifo_tests/ping_pong/aie.mlir
@@ -25,7 +25,7 @@ module @ping_pong {
     %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
     %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "objfifo"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     // Fills the given memref with the same input index value.
     func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {

--- a/test/objectFifo_tests/tileDMA_channels/aie.mlir
+++ b/test/objectFifo_tests/tileDMA_channels/aie.mlir
@@ -20,125 +20,127 @@
 // final output. 
 
 module @dmaChannels {
-    %tile12 = AIE.tile(1, 2)
-    %tile33 = AIE.tile(3, 3)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile33 = AIE.tile(3, 3)
 
-    %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
-    %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
+        %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
+        %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-    AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    func.func @copy(%lineIn : memref<16xi32>, %lineOut : memref<16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-        
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value = memref.load %lineIn[%indexInLine] : memref<16xi32>
-            memref.store %value, %lineOut[%indexInLine] : memref<16xi32>
-        }
-        return
-    }
-
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 10 : index
-
-        scf.for %indexInHeight = %c0 to %height step %c1 { 
-            %subviewIn0 = AIE.objectFifo.acquire<Consume>(%objFifoIn0 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            %subviewIn1 = AIE.objectFifo.acquire<Consume>(%objFifoIn1 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            %subviewOut0 = AIE.objectFifo.acquire<Produce>(%objFifoOut0 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            %subviewOut1 = AIE.objectFifo.acquire<Produce>(%objFifoOut1 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            func.call @copy(%elemIn0, %elemOut0) : (memref<16xi32>, memref<16xi32>) -> ()
-            func.call @copy(%elemIn1, %elemOut1) : (memref<16xi32>, memref<16xi32>) -> ()
-
-            AIE.objectFifo.release<Consume>(%objFifoIn0 : !AIE.objectFifo<memref<16xi32>>, 1)
-            AIE.objectFifo.release<Consume>(%objFifoIn1 : !AIE.objectFifo<memref<16xi32>>, 1)
-            AIE.objectFifo.release<Produce>(%objFifoOut0 : !AIE.objectFifo<memref<16xi32>>, 1)
-            AIE.objectFifo.release<Produce>(%objFifoOut1 : !AIE.objectFifo<memref<16xi32>>, 1)
-        }
-        
-        AIE.end
-    }
-
-    // Fills the given memref.
-    func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-        
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %i = arith.index_cast %indexInLine : index to i32
-            memref.store %i, %lineOut[%indexInLine] : memref<16xi32>
-        }
-        return
-    }
-
-    // Stores sum of two input memrefs in the bufferOut at the given row index.
-    func.func @addAndStore(%lineIn0 : memref<16xi32>, %lineIn1 : memref<16xi32>, %row : index, %bufferOut : memref<10x16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
-            %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
-            %sum = arith.addi %value0, %value1 : i32
-            memref.store %sum, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
-        }
-        return
-    }
-
-    %core33 = AIE.core(%tile33) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 10 : index
-
-        // acquire output buffer
-        AIE.useLock(%lock_out, "Acquire", 0) // acquire for produce
-
-        scf.for %indexInHeight = %c0 to %height step %c1 { 
-            %subviewOut0 = AIE.objectFifo.acquire<Produce>(%objFifoIn0 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            %subviewOut1 = AIE.objectFifo.acquire<Produce>(%objFifoIn1 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            func.call @generateLineScalar(%elemOut0) : (memref<16xi32>) -> ()
-            func.call @generateLineScalar(%elemOut1) : (memref<16xi32>) -> ()
-
-            AIE.objectFifo.release<Produce>(%objFifoIn0 : !AIE.objectFifo<memref<16xi32>>, 1)
-            AIE.objectFifo.release<Produce>(%objFifoIn1 : !AIE.objectFifo<memref<16xi32>>, 1)
-
-
-            %subviewIn0 = AIE.objectFifo.acquire<Consume>(%objFifoOut0 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            %subviewIn1 = AIE.objectFifo.acquire<Consume>(%objFifoOut1 : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            func.call @addAndStore(%elemIn0, %elemIn1, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
-
-            AIE.objectFifo.release<Consume>(%objFifoOut0 : !AIE.objectFifo<memref<16xi32>>, 1)
-            AIE.objectFifo.release<Consume>(%objFifoOut1 : !AIE.objectFifo<memref<16xi32>>, 1)
+        func.func @copy(%lineIn : memref<16xi32>, %lineOut : memref<16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+            
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value = memref.load %lineIn[%indexInLine] : memref<16xi32>
+                memref.store %value, %lineOut[%indexInLine] : memref<16xi32>
+            }
+            return
         }
 
-        // release output buffer
-        AIE.useLock(%lock_out, "Release", 1) // release for consume
-        
-        AIE.end
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 10 : index
+
+            scf.for %indexInHeight = %c0 to %height step %c1 { 
+                %subviewIn0 = AIE.objectFifo.acquire @of_in0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                %subviewIn1 = AIE.objectFifo.acquire @of_in1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                %subviewOut0 = AIE.objectFifo.acquire @of_out0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                %subviewOut1 = AIE.objectFifo.acquire @of_out1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                func.call @copy(%elemIn0, %elemOut0) : (memref<16xi32>, memref<16xi32>) -> ()
+                func.call @copy(%elemIn1, %elemOut1) : (memref<16xi32>, memref<16xi32>) -> ()
+
+                AIE.objectFifo.release @of_in0 (Consume, 1)
+                AIE.objectFifo.release @of_in1 (Consume, 1)
+                AIE.objectFifo.release @of_out0 (Produce, 1)
+                AIE.objectFifo.release @of_out1 (Produce, 1)
+            }
+            
+            AIE.end
+        }
+
+        // Fills the given memref.
+        func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+            
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %i = arith.index_cast %indexInLine : index to i32
+                memref.store %i, %lineOut[%indexInLine] : memref<16xi32>
+            }
+            return
+        }
+
+        // Stores sum of two input memrefs in the bufferOut at the given row index.
+        func.func @addAndStore(%lineIn0 : memref<16xi32>, %lineIn1 : memref<16xi32>, %row : index, %bufferOut : memref<10x16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
+                %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
+                %sum = arith.addi %value0, %value1 : i32
+                memref.store %sum, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
+            }
+            return
+        }
+
+        %core33 = AIE.core(%tile33) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 10 : index
+
+            // acquire output buffer
+            AIE.useLock(%lock_out, "Acquire", 0) // acquire for produce
+
+            scf.for %indexInHeight = %c0 to %height step %c1 { 
+                %subviewOut0 = AIE.objectFifo.acquire @of_in0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                %subviewOut1 = AIE.objectFifo.acquire @of_in1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                func.call @generateLineScalar(%elemOut0) : (memref<16xi32>) -> ()
+                func.call @generateLineScalar(%elemOut1) : (memref<16xi32>) -> ()
+
+                AIE.objectFifo.release @of_in0 (Produce, 1)
+                AIE.objectFifo.release @of_in1 (Produce, 1)
+
+
+                %subviewIn0 = AIE.objectFifo.acquire @of_out0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                %subviewIn1 = AIE.objectFifo.acquire @of_out1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+                func.call @addAndStore(%elemIn0, %elemIn1, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
+
+                AIE.objectFifo.release @of_out0 (Consume, 1)
+                AIE.objectFifo.release @of_out1 (Consume, 1)
+            }
+
+            // release output buffer
+            AIE.useLock(%lock_out, "Release", 1) // release for consume
+            
+            AIE.end
+        }
     }
 }

--- a/test/objectFifo_tests/tileDMA_channels/aie.mlir
+++ b/test/objectFifo_tests/tileDMA_channels/aie.mlir
@@ -26,11 +26,11 @@ module @dmaChannels {
     %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
     %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-    %objFifoIn0 = AIE.objectFifo.createObjectFifo(%tile33, {%tile12}, 2 : i32) {sym_name = "of_in0"} : !AIE.objectFifo<memref<16xi32>>
-    %objFifoIn1 = AIE.objectFifo.createObjectFifo(%tile33, {%tile12}, 2 : i32) {sym_name = "of_in1"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    %objFifoOut0 = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "of_out0"} : !AIE.objectFifo<memref<16xi32>>
-    %objFifoOut1 = AIE.objectFifo.createObjectFifo(%tile12, {%tile33}, 2 : i32) {sym_name = "of_out1"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @copy(%lineIn : memref<16xi32>, %lineOut : memref<16xi32>) -> () {
         %c0 = arith.constant 0 : index

--- a/test/objectFifo_tests/twoFilter2D/aie.mlir
+++ b/test/objectFifo_tests/twoFilter2D/aie.mlir
@@ -26,8 +26,8 @@ module @twoFilter2D  {
     %buff_out = AIE.buffer(%tile14) { sym_name = "out" } :  memref<10x16xi32>
     %lock_out = AIE.lock(%tile14, 0) { sym_name = "lock_out" }
 
-    %objFifoOne = AIE.objectFifo.createObjectFifo(%tile12, {%tile13}, 4 : i32) {sym_name = "of1"} : !AIE.objectFifo<memref<16xi32>>
-    %objFifoTwo = AIE.objectFifo.createObjectFifo(%tile13, {%tile14}, 4 : i32) {sym_name = "of2"} : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     // Kernel Functions
     func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {

--- a/test/objectFifo_tests/twoFilter2D/aie.mlir
+++ b/test/objectFifo_tests/twoFilter2D/aie.mlir
@@ -19,194 +19,196 @@
 // At the top and bottom borders only two lines are acquired, instead of three.
 
 module @twoFilter2D  {
-    %tile12 = AIE.tile(1, 2)
-    %tile13 = AIE.tile(1, 3)
-    %tile14 = AIE.tile(1, 4)
+    AIE.device(xcvc1902) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
+        %tile14 = AIE.tile(1, 4)
 
-    %buff_out = AIE.buffer(%tile14) { sym_name = "out" } :  memref<10x16xi32>
-    %lock_out = AIE.lock(%tile14, 0) { sym_name = "lock_out" }
+        %buff_out = AIE.buffer(%tile14) { sym_name = "out" } :  memref<10x16xi32>
+        %lock_out = AIE.lock(%tile14, 0) { sym_name = "lock_out" }
 
-    AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-    // Kernel Functions
-    func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
+        // Kernel Functions
+        func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
 
-        %value = arith.index_cast %valueIndex : index to i32
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %i = arith.index_cast %indexInLine : index to i32
-            %sum = arith.addi %value, %i : i32
-            memref.store %sum, %lineOut[%indexInLine] : memref<16xi32>
+            %value = arith.index_cast %valueIndex : index to i32
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %i = arith.index_cast %indexInLine : index to i32
+                %sum = arith.addi %value, %i : i32
+                memref.store %sum, %lineOut[%indexInLine] : memref<16xi32>
+            }
+            return
         }
-        return
-    }
 
-    func.func @firstFilterTwoLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %bufferOut:memref<16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
+        func.func @firstFilterTwoLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %bufferOut:memref<16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
 
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
-            %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
-            %sum = arith.addi %value0, %value1 : i32
-            memref.store %sum, %bufferOut[%indexInLine] : memref<16xi32>
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
+                %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
+                %sum = arith.addi %value0, %value1 : i32
+                memref.store %sum, %bufferOut[%indexInLine] : memref<16xi32>
+            }
+            return
         }
-        return
-    }
 
-    func.func @firstFilterThreeLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %lineIn2:memref<16xi32>, %bufferOut:memref<16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
+        func.func @firstFilterThreeLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %lineIn2:memref<16xi32>, %bufferOut:memref<16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
 
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
-            %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
-            %value2 = memref.load %lineIn2[%indexInLine] : memref<16xi32>
-            %tmpSum = arith.addi %value0, %value1 : i32
-            %sum = arith.addi %tmpSum, %value2 : i32
-            memref.store %sum, %bufferOut[%indexInLine] : memref<16xi32>
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
+                %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
+                %value2 = memref.load %lineIn2[%indexInLine] : memref<16xi32>
+                %tmpSum = arith.addi %value0, %value1 : i32
+                %sum = arith.addi %tmpSum, %value2 : i32
+                memref.store %sum, %bufferOut[%indexInLine] : memref<16xi32>
+            }
+            return
         }
-        return
-    }
 
-    func.func @secondFilterTwoLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %row:index, %bufferOut:memref<10x16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
+        func.func @secondFilterTwoLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %row:index, %bufferOut:memref<10x16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
 
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
-            %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
-            %sum = arith.addi %value0, %value1 : i32
-            memref.store %sum, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
+                %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
+                %sum = arith.addi %value0, %value1 : i32
+                memref.store %sum, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
+            }
+            return
         }
-        return
-    }
 
-    func.func @secondFilterThreeLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %lineIn2:memref<16xi32>, %row:index, %bufferOut:memref<10x16xi32>) -> () {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
+        func.func @secondFilterThreeLines(%lineIn0:memref<16xi32>, %lineIn1:memref<16xi32>, %lineIn2:memref<16xi32>, %row:index, %bufferOut:memref<10x16xi32>) -> () {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
 
-        scf.for %indexInLine = %c0 to %lineWidth step %c1 {
-            %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
-            %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
-            %value2 = memref.load %lineIn2[%indexInLine] : memref<16xi32>
-            %tmpSum = arith.addi %value0, %value1 : i32
-            %sum = arith.addi %tmpSum, %value2 : i32
-            memref.store %sum, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
-        }
-        return
-    }
-    
-    // Producer of objFifoOne
-    %core12 = AIE.core(%tile12) {
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %height = arith.constant 10 : index
-
-        scf.for %indexInHeight = %c0 to %height step %c1 { 
-            %subview = AIE.objectFifo.acquire<Produce>(%objFifoOne : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
-            AIE.objectFifo.release<Produce>(%objFifoOne : !AIE.objectFifo<memref<16xi32>>, 1)
+            scf.for %indexInLine = %c0 to %lineWidth step %c1 {
+                %value0 = memref.load %lineIn0[%indexInLine] : memref<16xi32>
+                %value1 = memref.load %lineIn1[%indexInLine] : memref<16xi32>
+                %value2 = memref.load %lineIn2[%indexInLine] : memref<16xi32>
+                %tmpSum = arith.addi %value0, %value1 : i32
+                %sum = arith.addi %tmpSum, %value2 : i32
+                memref.store %sum, %bufferOut[%row,%indexInLine] : memref<10x16xi32>
+            }
+            return
         }
         
-        AIE.end
-    }
+        // Producer of @of1
+        %core12 = AIE.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %height = arith.constant 10 : index
 
-    // Consumer of objFifoOne; Producer of objFifoTwo
-    %core13 = AIE.core(%tile13) {
-        %zero = arith.constant 0 : i32
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-        %height = arith.constant 9 : index
-
-        // Top Border
-        %subviewOneTop = AIE.objectFifo.acquire<Consume>(%objFifoOne : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-        %subviewTwoTop = AIE.objectFifo.acquire<Produce>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-        func.call @firstFilterTwoLines(%elemOneTop0, %elemOneTop1, %elemTwoTop0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
-
-        AIE.objectFifo.release<Produce>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 1)
-
-        // Middle 
-        scf.for %indexInHeight = %c1 to %height step %c1 { 
-            %subviewOne = AIE.objectFifo.acquire<Consume>(%objFifoOne : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-
-            %subviewTwo = AIE.objectFifo.acquire<Produce>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            scf.for %indexInHeight = %c0 to %height step %c1 { 
+                %subview = AIE.objectFifo.acquire @of1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
+                AIE.objectFifo.release @of1 (Produce, 1)
+            }
             
-            func.call @firstFilterThreeLines(%elemOne0, %elemOne1, %elemOne2, %elemTwo0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
-
-            AIE.objectFifo.release<Consume>(%objFifoOne : !AIE.objectFifo<memref<16xi32>>, 1)
-            AIE.objectFifo.release<Produce>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 1)
+            AIE.end
         }
 
-        // Bottom Border
-        %subviewOneBottom = AIE.objectFifo.acquire<Consume>(%objFifoOne : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        // Consumer of objFifoOne; Producer of @of2
+        %core13 = AIE.core(%tile13) {
+            %zero = arith.constant 0 : i32
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+            %height = arith.constant 9 : index
 
-        %subviewTwoBottom = AIE.objectFifo.acquire<Produce>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        
-        func.call @firstFilterTwoLines(%elemOneBottom0, %elemOneBottom1, %elemTwoBottom0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
+            // Top Border
+            %subviewOneTop = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-        AIE.objectFifo.release<Consume>(%objFifoOne : !AIE.objectFifo<memref<16xi32>>, 2)
-        AIE.objectFifo.release<Produce>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 1)
-        
-        AIE.end
-    }
+            %subviewTwoTop = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-    // Consumer of objFifoTwo
-    %core14 = AIE.core(%tile14) {
-        %zero = arith.constant 0 : i32
-        %c0 = arith.constant 0 : index
-        %c1 = arith.constant 1 : index
-        %lineWidth = arith.constant 16 : index
-        %height = arith.constant 9 : index
+            func.call @firstFilterTwoLines(%elemOneTop0, %elemOneTop1, %elemTwoTop0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
-        AIE.useLock(%lock_out, "Acquire", 0) // acquire output buffer for produce
+            AIE.objectFifo.release @of2 (Produce, 1)
 
-        // Top Border
-        %subviewTop = AIE.objectFifo.acquire<Consume>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @secondFilterTwoLines(%elemTop0, %elemTop1, %c0, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
+            // Middle 
+            scf.for %indexInHeight = %c1 to %height step %c1 { 
+                %subviewOne = AIE.objectFifo.acquire @of1 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-        // Middle
-        scf.for %indexInHeight = %c1 to %height step %c1 { 
-            %subview = AIE.objectFifo.acquire<Consume>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            func.call @secondFilterThreeLines(%elem0, %elem1, %elem2, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
-            AIE.objectFifo.release<Consume>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 1)
+                %subviewTwo = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                
+                func.call @firstFilterThreeLines(%elemOne0, %elemOne1, %elemOne2, %elemTwo0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
+
+                AIE.objectFifo.release @of1 (Consume, 1)
+                AIE.objectFifo.release @of2 (Produce, 1)
+            }
+
+            // Bottom Border
+            %subviewOneBottom = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+
+            %subviewTwoBottom = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            
+            func.call @firstFilterTwoLines(%elemOneBottom0, %elemOneBottom1, %elemTwoBottom0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
+
+            AIE.objectFifo.release @of1 (Consume, 2)
+            AIE.objectFifo.release @of2 (Produce, 1)
+            
+            AIE.end
         }
 
-        // Bottom Border
-        %subviewBottom = AIE.objectFifo.acquire<Consume>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        func.call @secondFilterTwoLines(%elemBottom0, %elemBottom1, %height, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
-        AIE.objectFifo.release<Consume>(%objFifoTwo : !AIE.objectFifo<memref<16xi32>>, 2)
+        // Consumer of objFifoTwo
+        %core14 = AIE.core(%tile14) {
+            %zero = arith.constant 0 : i32
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %lineWidth = arith.constant 16 : index
+            %height = arith.constant 9 : index
 
-        AIE.useLock(%lock_out, "Release", 1) // release output buffer for consume
-        
-        AIE.end
+            AIE.useLock(%lock_out, "Acquire", 0) // acquire output buffer for produce
+
+            // Top Border
+            %subviewTop = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @secondFilterTwoLines(%elemTop0, %elemTop1, %c0, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
+
+            // Middle
+            scf.for %indexInHeight = %c1 to %height step %c1 { 
+                %subview = AIE.objectFifo.acquire @of2 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                func.call @secondFilterThreeLines(%elem0, %elem1, %elem2, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
+                AIE.objectFifo.release @of2 (Consume, 1)
+            }
+
+            // Bottom Border
+            %subviewBottom = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            func.call @secondFilterTwoLines(%elemBottom0, %elemBottom1, %height, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
+            AIE.objectFifo.release @of2 (Consume, 2)
+
+            AIE.useLock(%lock_out, "Release", 1) // release output buffer for consume
+            
+            AIE.end
+        }
     }
 }

--- a/test/unit_tests/24_host_loop/aie.mlir
+++ b/test/unit_tests/24_host_loop/aie.mlir
@@ -28,11 +28,11 @@ module @host_loop {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32> 
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<256xi32> 
 
-    %objFifo_in = AIE.objectFifo.createObjectFifo(%tile70, {%tile34}, 1) {sym_name = "of_in"} : !AIE.objectFifo<memref<256xi32>>
-    %objFifo_out = AIE.objectFifo.createObjectFifo(%tile34, {%tile70}, 1) {sym_name = "of_out"} : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1) : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1) : !AIE.objectFifo<memref<256xi32>>
 
-    AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo_in : !AIE.objectFifo<memref<256xi32>>, {%ext_buf70_in}) : (memref<256xi32>)
-    AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo_out : !AIE.objectFifo<memref<256xi32>>, {%ext_buf70_out}) : (memref<256xi32>)
+    AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
+    AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<256xi32>)
  
     %core34 = AIE.core(%tile34) {
         %c0 = arith.constant 0 : index
@@ -47,8 +47,8 @@ module @host_loop {
             ^bb0(%arg2: i32):
             %next = func.call @payload(%arg2) : (i32) -> i32
 
-            %inputSubview = AIE.objectFifo.acquire<Consume>(%objFifo_in : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-            %outputSubview = AIE.objectFifo.acquire<Produce>(%objFifo_out : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
             
             %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
             %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
@@ -58,8 +58,8 @@ module @host_loop {
                 memref.store %d1, %output[%indexInHeight] : memref<256xi32> 
             }
             
-            AIE.objectFifo.release<Consume>(%objFifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
-            AIE.objectFifo.release<Produce>(%objFifo_out : !AIE.objectFifo<memref<256xi32>>, 1)
+            AIE.objectFifo.release @of_in (Consume, 1)
+            AIE.objectFifo.release @of_out (Produce, 1)
             
             scf.yield %next : i32
         }

--- a/test/unit_tests/25_host_multirate/aie.mlir
+++ b/test/unit_tests/25_host_multirate/aie.mlir
@@ -30,11 +30,11 @@ module @host_multirate {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32> 
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<64xi32> 
 
-    %objFifo_in = AIE.objectFifo.createObjectFifo(%tile70, {%tile34}, 1) {sym_name = "of_in"}  : !AIE.objectFifo<memref<64xi32>>
-    %objFifo_out = AIE.objectFifo.createObjectFifo(%tile34, {%tile70}, 1) {sym_name = "of_out"}  : !AIE.objectFifo<memref<64xi32>>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1) : !AIE.objectFifo<memref<64xi32>>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1) : !AIE.objectFifo<memref<64xi32>>
 
-    AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo_in : !AIE.objectFifo<memref<64xi32>>, {%ext_buf70_in}) : (memref<256xi32>)
-    AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo_out : !AIE.objectFifo<memref<64xi32>>, {%ext_buf70_out}) : (memref<64xi32>)
+    AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
+    AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<64xi32>)
  
     %core34 = AIE.core(%tile34) {
         %c0 = arith.constant 0 : index
@@ -51,8 +51,8 @@ module @host_multirate {
 
             AIE.useLock(%hostLock, Acquire, 1)
 
-            %inputSubview = AIE.objectFifo.acquire<Consume>(%objFifo_in : !AIE.objectFifo<memref<64xi32>>, 1) : !AIE.objectFifoSubview<memref<64xi32>>
-            %outputSubview = AIE.objectFifo.acquire<Produce>(%objFifo_out : !AIE.objectFifo<memref<64xi32>>, 1) : !AIE.objectFifoSubview<memref<64xi32>>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<64xi32>>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<64xi32>>
             
             %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
             %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
@@ -62,8 +62,8 @@ module @host_multirate {
                 memref.store %d1, %output[%indexInHeight] : memref<64xi32> 
             }
             
-            AIE.objectFifo.release<Consume>(%objFifo_in : !AIE.objectFifo<memref<64xi32>>, 1)
-            AIE.objectFifo.release<Produce>(%objFifo_out : !AIE.objectFifo<memref<64xi32>>, 1)
+            AIE.objectFifo.release @of_in (Consume, 1)
+            AIE.objectFifo.release @of_out (Produce, 1)
 
             AIE.useLock(%hostLock, Release, 0)
             

--- a/test/unit_tests/28_multidepth_objectFifos/multi_depth/aie.mlir
+++ b/test/unit_tests/28_multidepth_objectFifos/multi_depth/aie.mlir
@@ -22,12 +22,12 @@ module @multi_depth {
         %lock_out = AIE.lock(%tile25, 1) {sym_name = "lock_out"}
         %buff_out = AIE.buffer(%tile25) {sym_name = "buff_out"} : memref<4x32xi32>
 
-        %of_in = AIE.objectFifo.createObjectFifo(%tile20, {%tile23, %tile25}, [2, 2, 3]) {sym_name = "of_in"} : !AIE.objectFifo<memref<32xi32>>
-        %of_inter = AIE.objectFifo.createObjectFifo(%tile23, {%tile25}, 2 : i32) {sym_name = "of_inter"} : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, [2, 2, 3]) : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
 
         %ext_buffer_in_0  = AIE.external_buffer {sym_name = "ext_buffer_in_0"} : memref<32xi32>
         %ext_buffer_in_1  = AIE.external_buffer {sym_name = "ext_buffer_in_1"} : memref<32xi32>
-        AIE.objectFifo.registerExternalBuffers(%tile20, %of_in : !AIE.objectFifo<memref<32xi32>>, {%ext_buffer_in_0, %ext_buffer_in_1}) : (memref<32xi32>, memref<32xi32>)
+        AIE.objectFifo.registerExternalBuffers @of_in (%tile20, {%ext_buffer_in_0, %ext_buffer_in_1}) : (memref<32xi32>, memref<32xi32>)
 
         func.func @add_one(%elemIn : memref<32xi32>, %elemOut : memref<32xi32>) -> () {
             %c0 = arith.constant 0 : index
@@ -63,16 +63,16 @@ module @multi_depth {
             %iter_max = arith.constant 4 : index
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn = AIE.objectFifo.acquire<Consume>(%of_in : !AIE.objectFifo<memref<32xi32>>, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
                 %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
-                %subviewOut = AIE.objectFifo.acquire<Produce>(%of_inter : !AIE.objectFifo<memref<32xi32>>, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : !AIE.objectFifoSubview<memref<32xi32>>
                 %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
                 func.call @add_one(%elemIn, %elemOut) : (memref<32xi32>, memref<32xi32>) -> ()
                 
-                AIE.objectFifo.release<Consume>(%of_in : !AIE.objectFifo<memref<32xi32>>, 1)
-                AIE.objectFifo.release<Produce>(%of_inter : !AIE.objectFifo<memref<32xi32>>, 1)
+                AIE.objectFifo.release @of_in (Consume, 1)
+                AIE.objectFifo.release @of_inter (Produce, 1)
             }
                 
             AIE.end
@@ -89,16 +89,16 @@ module @multi_depth {
             AIE.useLock(%lock_out, Acquire, 0)
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn_21 = AIE.objectFifo.acquire<Consume>(%of_in : !AIE.objectFifo<memref<32xi32>>, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
                 %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
-                %subviewIn_22 = AIE.objectFifo.acquire<Consume>(%of_inter : !AIE.objectFifo<memref<32xi32>>, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
                 %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
                 func.call @add_store(%elemIn_21, %elemIn_22, %buff_out, %iter) : (memref<32xi32>, memref<32xi32>, memref<4x32xi32>, index) -> ()
                 
-                AIE.objectFifo.release<Consume>(%of_in : !AIE.objectFifo<memref<32xi32>>, 1)
-                AIE.objectFifo.release<Consume>(%of_inter : !AIE.objectFifo<memref<32xi32>>, 1)
+                AIE.objectFifo.release @of_in (Consume, 1)
+                AIE.objectFifo.release @of_inter (Consume, 1)
             }
 
             AIE.useLock(%lock_out, Release, 1)

--- a/tutorials/tutorial-3/objectFifo_ver/README.md
+++ b/tutorials/tutorial-3/objectFifo_ver/README.md
@@ -24,7 +24,7 @@ The objectFifo describes both the data allocation and its movement. An objectFif
 
 To achieve deadlock-free communication, actors must acquire and release objects from the objectFifo. In this example, there is only one object to acquire. The operation, 
 ```
-AIE.objectFifo.acquire<port>(objectFifo, numberElem) : subviewType
+AIE.objectFifo.acquire @name (port, numberElem) : subviewType
 ```
 returns a subview of the objectFifo containing the specified number of elements. Individual elements can then be accessed in an array-like fashion with the operation: 
 ```
@@ -32,7 +32,7 @@ AIE.objectFifo.subview.access(subview, index) : elemDatatype
 ```
 When an object is no longer required for computation, the actor which acquired it should release it with the operation:
 ```
-AIE.objectFifo.release<port>(objectFifo, numberElem)
+AIE.objectFifo.release @name (port, numberElem)
 ``` 
 such that other actors may acquire it in the future. The acquire and release operations both take an additional port attribute which can be either "Produce" or "Consume". The use of this attribute will be further described in the `Object FIFO Lowering` section.
 
@@ -40,8 +40,8 @@ such that other actors may acquire it in the future. The acquire and release ope
 
 The objects of an objectFifo each lower into a lock and buffer pair. As such, the `AIE.objectFifo.acquire` and `AIE.objectFifo.release` operations are lowered into `useLock` operations. Both these operations take a port attribute which can be either "Produce" or "Consume". This attribute is used to determine the lock values to give to the `useLock` operations in order to achieve the desired synchronisation. For example:
 ```
-AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
-AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+AIE.objectFifo.acquire @objFifo (Produce, 1)
+AIE.objectFifo.acquire @objFifo (Consume, 1)
 ```
 are each lowered into,
 ```

--- a/tutorials/tutorial-3/objectFifo_ver/README.md
+++ b/tutorials/tutorial-3/objectFifo_ver/README.md
@@ -16,7 +16,7 @@ This abstraction consists of several `AIE.objectFifo` operations which are gradu
 
 Firstly, an objectFifo is created between tiles (1,4) and (2,4) with the operation:
 ```
-AIE.objectFifo.createObjectFifo(producerTile, {list of consumerTiles}, depth) : elemDatatype`
+AIE.objectFifo @name (producerTile, {list of consumerTiles}, depth) : elemDatatype`
 ```
 The objectFifo describes both the data allocation and its movement. An objectFifo has a depth, or size, which represents a number of pre-allocated objects of the specified datatype that can be synchronously accessed by actors, which we separate into consumers and producers. In this tutorial, tile (1,4) is the producer tile and tile (2,4) is the consumer tile and the objectFifo established between them has one object of type `memref<256xi32>`. This is shown in the diagram below.
 

--- a/tutorials/tutorial-3/objectFifo_ver/aie.mlir
+++ b/tutorials/tutorial-3/objectFifo_ver/aie.mlir
@@ -38,7 +38,7 @@ module @tutorial_3 {
         // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
         // This core acquires objects as a Producer: this impacts the acquire value of the lock 
         // that is generated through the object FIFO lowering.
-        %inputSubview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         
         // Access the first, and only, element of the subview.
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
@@ -51,7 +51,7 @@ module @tutorial_3 {
         // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
         // This core releases objects as a Producer: this impacts the release value of the lock 
         // that is generated through the object FIFO lowering.
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of (Produce, 1)
         AIE.end
     }
 
@@ -61,7 +61,7 @@ module @tutorial_3 {
         // This acquire succeeds when the core is enabled
         AIE.useLock(%lock24_2, "Acquire", 0)
 
-        %inputSubview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
         %idx1 = arith.constant 3 : index
@@ -71,7 +71,7 @@ module @tutorial_3 {
         %idx2 = arith.constant 5 : index
         memref.store %d2, %input[%idx2] : memref<256xi32> 
 
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of (Consume, 1)
 
         // This release means our 2nd core is done
         AIE.useLock(%lock24_2, "Release", 1)

--- a/tutorials/tutorial-3/objectFifo_ver/aie.mlir
+++ b/tutorials/tutorial-3/objectFifo_ver/aie.mlir
@@ -26,7 +26,7 @@ module @tutorial_3 {
     // The size of the object FIFO, i.e. its number of elements, is 1.
     // Objects, i.e. allocated memory elements, have type memref<256xi32>
     // These tiles share memory between them.
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile14, {%tile24}, 1 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of (%tile14, {%tile24}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     // This lock will be used to gate when our 2nd core is done
     %lock24_2 = AIE.lock(%tile24, 2) { sym_name = "lock_a24_2" }

--- a/tutorials/tutorial-4/aie.mlir
+++ b/tutorials/tutorial-4/aie.mlir
@@ -28,7 +28,7 @@ module @tutorial_4 {
     // The size of the object FIFO, i.e. its number of elements, is 1.
     // Objects, i.e. allocated memory elements, have type memref<256xi32>.
     // These tiles do not share memory between them.
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile14, {%tile34}, 1 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of (%tile14, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     // This lock will be used to gate when our 2nd core is done
     %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }

--- a/tutorials/tutorial-4/aie.mlir
+++ b/tutorials/tutorial-4/aie.mlir
@@ -40,7 +40,7 @@ module @tutorial_4 {
         // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
         // This core acquires objects as a Producer: this impacts the acquire value of the lock 
         // that is generated through the object FIFO lowering.
-        %inputSubview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         
         // Access the first, and only, element of the subview.
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
@@ -53,7 +53,7 @@ module @tutorial_4 {
         // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
         // This core releases objects as a Producer: this impacts the release value of the lock 
         // that is generated through the object FIFO lowering.
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of (Produce, 1)
         AIE.end
     } 
 
@@ -63,7 +63,7 @@ module @tutorial_4 {
         // This acquire succeeds when the core is enabled
         AIE.useLock(%lock34_8, "Acquire", 0)
 
-        %inputSubview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
         %idx1 = arith.constant 3 : index
@@ -73,7 +73,7 @@ module @tutorial_4 {
         %idx2 = arith.constant 5 : index
         memref.store %d2, %input[%idx2] : memref<256xi32> 
         
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of (Consume, 1)
 
         // This release means our 2nd core is done
         AIE.useLock(%lock34_8, "Release", 1)

--- a/tutorials/tutorial-5/README.md
+++ b/tutorials/tutorial-5/README.md
@@ -36,7 +36,7 @@ While the shim DMA itself is not present in the design, the `AIE.external_buffer
 
 As for now, the `objectFifo` lowering only instantiates memory elements in L1, i.e., in local memory. In order to make the objectFifo aware of external memory regions that are part of its data movement, the external buffers are registered to the objectFifo with the operation:
 ```
-AIE.objectFifo.registerExternalBuffers(shimTile, objectFifo, {list of external buffers to register}) : (list of external buffer datatypes)
+AIE.objectFifo.registerExternalBuffers @name (shimTile, {list of external buffers to register}) : (list of external buffer datatypes)
 ``` 
 
 ## <ins>Tutorial 5 Lab </ins>

--- a/tutorials/tutorial-5/aie.mlir
+++ b/tutorials/tutorial-5/aie.mlir
@@ -41,8 +41,8 @@ module @tutorial_5 {
     AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     // Register the external memory pointers to the object FIFOs.
-    AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo_in : !AIE.objectFifo<memref<256xi32>>, {%ext_buf70_in}) : (memref<256xi32>)
-    AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo_out : !AIE.objectFifo<memref<256xi32>>, {%ext_buf70_out}) : (memref<256xi32>)
+    AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
+    AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<256xi32>)
 
     // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
     // buf[5] = buf[3] + 100

--- a/tutorials/tutorial-5/aie.mlir
+++ b/tutorials/tutorial-5/aie.mlir
@@ -51,8 +51,8 @@ module @tutorial_5 {
         // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
         // This core acquires objects both as a Consumer of one object FIFO and as a Producer of another: 
         // this impacts the acquire values of the locks that are generated through the object FIFO lowering
-        %inputSubview = AIE.objectFifo.acquire<Consume>(%objFifo_in : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        %outputSubview = AIE.objectFifo.acquire<Produce>(%objFifo_out : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         
         // Access the first, and only, element of each subview.
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
@@ -72,8 +72,8 @@ module @tutorial_5 {
         // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
         // This core releases objects both as a Consumer of one object FIFO and as a Producer of another: 
         // this impacts the release values of the locks that are generated through the object FIFO lowering.
-        AIE.objectFifo.release<Consume>(%objFifo_in : !AIE.objectFifo<memref<256xi32>>, 1)
-        AIE.objectFifo.release<Produce>(%objFifo_out : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of_in (Consume, 1)
+        AIE.objectFifo.release @of_out (Produce, 1)
         AIE.end
     } 
 }

--- a/tutorials/tutorial-5/aie.mlir
+++ b/tutorials/tutorial-5/aie.mlir
@@ -35,10 +35,10 @@ module @tutorial_5 {
     // The size of the object FIFO, i.e. its number of elements, is 1.
     // Objects, i.e. allocated memory elements, have type memref<256xi32>.
     // These tiles do not share memory between them.
-    %objFifo_in = AIE.objectFifo.createObjectFifo(%tile70, {%tile34}, 1 : i32) {sym_name = "of_in"} : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     // Declare an object FIFO between the producer tile (3,4) and consumer shim tile (7,0).
-    %objFifo_out = AIE.objectFifo.createObjectFifo(%tile34, {%tile70}, 1 : i32) {sym_name = "of_out"} : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     // Register the external memory pointers to the object FIFOs.
     AIE.objectFifo.registerExternalBuffers(%tile70, %objFifo_in : !AIE.objectFifo<memref<256xi32>>, {%ext_buf70_in}) : (memref<256xi32>)

--- a/tutorials/tutorial-7/aie.mlir
+++ b/tutorials/tutorial-7/aie.mlir
@@ -44,7 +44,7 @@ module @tutorial_7 {
         // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
         // This core acquires objects as a Producer: this impacts the acquire value of the lock 
         // that is generated through the object FIFO lowering.
-        %inputSubview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         
         // Access the first, and only, element of the subview.
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
@@ -57,7 +57,7 @@ module @tutorial_7 {
         // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
         // This core releases objects as a Producer: this impacts the release value of the lock 
         // that is generated through the object FIFO lowering.
-        AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of (Produce, 1)
         AIE.end
     } 
 
@@ -67,7 +67,7 @@ module @tutorial_7 {
         // This acquire succeeds when the core is enabled
         AIE.useLock(%lock34_8, "Acquire", 0)
 
-        %inputSubview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
         %idx1 = arith.constant 3 : index
@@ -77,7 +77,7 @@ module @tutorial_7 {
         %idx2 = arith.constant 5 : index
         memref.store %d2, %input[%idx2] : memref<256xi32> 
         
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of (Consume, 1)
 
         // This release means our 2nd core is done
         AIE.useLock(%lock34_8, "Release", 1)
@@ -90,7 +90,7 @@ module @tutorial_7 {
         // This acquire succeeds when the core is enabled
         AIE.useLock(%lock35_8, "Acquire", 0)
 
-        %inputSubview = AIE.objectFifo.acquire<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
         %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
         %idx1 = arith.constant 3 : index
@@ -100,7 +100,7 @@ module @tutorial_7 {
         %idx2 = arith.constant 5 : index
         memref.store %d2, %input[%idx2] : memref<256xi32> 
         
-        AIE.objectFifo.release<Consume>(%objFifo : !AIE.objectFifo<memref<256xi32>>, 1)
+        AIE.objectFifo.release @of (Consume, 1)
 
         // This release means our 2nd core is done
         AIE.useLock(%lock35_8, "Release", 1)

--- a/tutorials/tutorial-7/aie.mlir
+++ b/tutorials/tutorial-7/aie.mlir
@@ -31,7 +31,7 @@ module @tutorial_7 {
     // The size of the object FIFO, i.e. its number of elements, is 1.
     // Objects, i.e. allocated memory elements, have type memref<256xi32>.
     // Each (producer tile / consumer tile) pair does not share memory.
-    %objFifo = AIE.objectFifo.createObjectFifo(%tile14, {%tile34,%tile35}, 1 : i32) {sym_name = "of"} : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of (%tile14, {%tile34,%tile35}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     // These locks will be used to gate when our end cores are done
     %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }


### PR DESCRIPTION
This PR introduces a cleaner syntax for objectFifo operations that leverage the objectFifo symbolic name instead of an SSA return value. As a result, the CreateObjectFifoOp no longer returns an SSA value. Below is a comparison of the old versus the new syntax:

```AIE.shimDMAAllocation("of_in_0", MM2S, 1, 0)```
becomes
```AIE.shimDMAAllocation @of_in_0(MM2S, 1, 0)```

```%objFifo = AIE.objectFifo.createObjectFifo(%tile12, {tile33}, 2 : i32) {sym_name = "of0"} : !AIE.objectFifo<memref<16xi32>>```
becomes
```AIE.objectFifo @of0 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>```

```AIE.objectFifo.link({ %of1 }, { %of2 }) : ({!AIE.objectFifo<memref<64xi16>>}, {!AIE.objectFifo<memref<64xi16>>})```
becomes
```AIE.objectFifo.link [@of1] -> [@of2] ()```

```AIE.objectFifo.registerExternalBuffers(%t70, %of1 : !AIE.objectFifo<memref<64xi16>>, {buffer_in_0, buffer_in_1}) : (memref<512 x i16>, memref<512 x i16>)```
becomes
```AIE.objectFifo.registerExternalBuffers @of1(%t70, {buffer_in_0, buffer_in_1}) : (memref<512 x i16>, memref<512 x i16>)```

```%subview = AIE.objectFifo.acquire<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1) : !AIE.objectFifoSubview<memref<16xi32>>```
becomes
```%subview = AIE.objectFifo.acquire @of0(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>```

```AIE.objectFifo.release<Produce>(%objFifo : !AIE.objectFifo<memref<16xi32>>, 1)```
becomes
```AIE.objectFifo.release @of0(Produce, 1)```