### PR TITLE
Pipeclean AIE2 peano flow

### DIFF
--- a/test/aiecc/simple.mlir
+++ b/test/aiecc/simple.mlir
@@ -15,14 +15,16 @@
 // RUN: aiecc.py --no-unified --compile --no-link --no-xchesscc -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
 // RUN: aiecc.py --no-unified --no-compile --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%aie_runtime_lib% %aie_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
 
+// Note that llc determines the architecture from the llvm IR.
+
 // XCHESSCC-NOT: {{^llc}}
 // XCHESSCC: xchesscc_wrapper aie
 // XCHESSCC-NOT: {{^llc}}
-// PEANO-NOT: xchesscc_wrapper aie
+// PEANO-NOT: xchesscc_wrapper
 // PEANO: {{^llc}}
 // PEANO-SAME: --march=aie
-// PEANO-NOT: xchesscc_wrapper aie
-// NOCOMPILE-NOT: xchesscc_wrapper aie
+// PEANO-NOT: xchesscc_wrapper
+// NOCOMPILE-NOT: xchesscc_wrapper
 // NOCOMPILE-NOT: {{^llc}}
 
 module {

--- a/tools/aiecc/aiecc/main.py
+++ b/tools/aiecc/aiecc/main.py
@@ -223,7 +223,7 @@ class flow_runner:
         if(not opts.unified):
           file_core_llvmir_stripped = self.tmpcorefile(core, "stripped.ll")
           await self.do_call(task, ['opt', '--passes=default<O2>,strip', '-S', file_core_llvmir, '-o', file_core_llvmir_stripped])
-          await self.do_call(task, ['llc', file_core_llvmir_stripped, '-O2', '--march=aie', '--function-sections', '--filetype=obj', '-o', file_core_obj])
+          await self.do_call(task, ['llc', file_core_llvmir_stripped, '-O2', '--march=%s' % self.aie_target.lower(), '--function-sections', '--filetype=obj', '-o', file_core_obj])
         else:
           file_core_obj = self.file_obj
         if(opts.link and opts.xbridge):
@@ -458,7 +458,7 @@ aiesimulator --pkg-dir=${prj_name}/sim --dump-vcd ${vcd_filename}
             self.file_llvmir_opt= os.path.join(self.tmpdirname, 'input.opt.ll')
             await self.do_call(progress_bar.task, ['opt', '--opaque-pointers=0', '--passes=default<O2>', '-inline-threshold=10', '-S', self.file_llvmir, '-o', self.file_llvmir_opt])
 
-            await self.do_call(progress_bar.task, ['llc', self.file_llvmir_opt, '-O2', '--march=aie', '--function-sections', '--filetype=obj', '-o', self.file_obj])
+            await self.do_call(progress_bar.task, ['llc', self.file_llvmir_opt, '-O2', '--march=%s' % self.aie_target.lower(), '--function-sections', '--filetype=obj', '-o', self.file_obj])
 
         progress_bar.update(progress_bar.task,advance=0,visible=False)
         progress_bar.task_completed = progress_bar.add_task("[green] AIE Compilation:", total=len(cores)+1, command="%d Workers" % nworkers)


### PR DESCRIPTION
Peano for AIE2 has matured quite a bit, but we haven't been actively using it for AIE2/phoenix.  This patch enables some simple designs to go through the flow:
1) aiecc.py now assumes the target architecture is set in the LLVMIR generated from MLIR, rather than hardcoding --march=aie

2) We generate the correct target architecture in LLVMIR based on the DeviceOp in MLIR.

3) We lower lock operations to AIE2 lock intrinsics based on the DeviceOp as well.