### PR TITLE
Fix TableGen file to avoid {% Liquid templating language

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1375,7 +1375,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
 
     1-to-1 tile example:
     ```
-      AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
+      AIE.objectFifo @of1 (%tile12, { %tile13 }, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
     ```
     This operation creates an objectFifo between %tile12 and %tile13 of 4 elements, each a buffer of 16 32-bit integers.
     Note: If there are no ObjectFifoAcquireOps corresponding to this objectFifo on the cores of %tile12 and %tile13, 
@@ -1384,14 +1384,14 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
  
     1-to-2 tiles broadcast example:
     ```
-      AIE.objectFifo @of2 (%tile12, {%tile13, %tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
+      AIE.objectFifo @of2 (%tile12, { %tile13, %tile23 }, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
     ```
     This operation creates an objectFifo between %tile12 and tiles %tile13, %tile23 of 4 elements, each a buffer of x16 
     32-bit integers.
 
     1-to-2 tiles broadcast with explicit sizes example:
     ```
-      AIE.objectFifo @of3 (%tile12, {%tile13, %tile23}, [2, 3, 4]) : !AIE.objectFifo<memref<16xi32>> 
+      AIE.objectFifo @of3 (%tile12, { %tile13, %tile23 }, [2, 3, 4]) : !AIE.objectFifo<memref<16xi32>> 
     ```
     This operation creates an objectFifo between %tile12, %tile13 and %tile23. The depths of the objectFifo object pool 
     at each tile are respectively 2, 3 and 4 for tiles %tile12, %tile13 and %tile23. This overrides the depth analysis 


### PR DESCRIPTION
Probably I need to update the CI to compile the documentation without installing it just to check we do not break the documentation.
The problem now is that the breakage is post-commit, when the `main` branch is updated.