### PR TITLE
[aievec] Improve alignment offset calculation

### DIFF
--- a/include/aie/Dialect/AIEVec/Analysis/Passes.h
+++ b/include/aie/Dialect/AIEVec/Analysis/Passes.h
@@ -34,7 +34,7 @@ namespace aievec {
 #define GEN_PASS_CLASSES
 #include "aie/Dialect/AIEVec/Analysis/Passes.h.inc"
 
-std::unique_ptr<Pass> createAIEVecConvolutionAnalysisPass();
+std::unique_ptr<mlir::Pass> createAIEVecConvolutionAnalysisPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/aie/Dialect/AIEVec/Utils/Utils.h
+++ b/include/aie/Dialect/AIEVec/Utils/Utils.h
@@ -13,6 +13,7 @@
 
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include <cstdint>
+#include <optional>
 #include <type_traits>
 
 namespace mlir {
@@ -31,10 +32,9 @@ template <
         std::is_same_v<TransferReadLikeOp, mlir::vector::TransferReadOp> ||
         std::is_same_v<TransferReadLikeOp,
                        mlir::vector::TransferReadOp::Adaptor>>>
-int64_t getTransferReadAlignmentOffset(TransferReadLikeOp readOp,
-                                       mlir::VectorType vType,
-                                       int64_t alignment);
-
+std::optional<int64_t> getTransferReadAlignmentOffset(TransferReadLikeOp readOp,
+                                                      mlir::VectorType vType,
+                                                      int64_t alignment);
 }
 
 #endif // AIE_DIALECT_AIEVEC_UTILS_UTILS_H

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -780,7 +780,8 @@ struct LowerVectorTransferReadToAIEUPD
 
     // Misaligned accesses
     auto vType = readOp.getVectorType();
-    if (getTransferReadAlignmentOffset(adaptor, vType, vectorAlignment) != 0)
+    if (getTransferReadAlignmentOffset(adaptor, vType, vectorAlignment)
+            .value_or(0) != 0)
       return failure();
 
     // Invalid vector size.


### PR DESCRIPTION
In order to compute the alignment offset for a given transfer read operation, we impose the following constraints on the indices:

a) are constants, or
b) come from an `affine.apply` on an aligned SSA value, or
c) are an aligned SSA value

This patch tries to loosen the constraints to improve misalignment detection and computation by computing the minimum value a "well-defined" SSA value can have. Now the constraints are that the indices:

a) are constants, or
b) come from an `affine.apply` over an i.v. in an affine.for op, or
c) come from an `affine.apply` over an aligned SSA value that's not an i.v.,
c) are an aligned SSA value

This patch adds correct misalignment calculations for cases where the i.v. starts on an unaligned value (like 1), and can deal with indices computed using affine maps on a multidimensional domain, e.g.:
```
        %index =affine.apply affine_map<(d0, d1) -> (d0 * 512 + d1)>(%i, %j)
```