### PR TITLE
Add Multi-Dimensional Address Generation to Object Fifo

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -838,28 +838,45 @@ def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
     A DMA channel in a Memory Module can process one block descriptor after another by chaining them.
     There are 16 block descriptors per Memory Module. They are shared by four DMA channels.
 
-    On AIE-ML devices, an optional argument can be used to specify an array of 
-    step sizes and wraps to move data in more advanced patterns. Strides and
-    wraps are specified as tuples `<stride, wrap>`, and up to three dimensions
-    can be specified (or up to four dimensions on memtiles). 
+    ## DMA Data Layout Transformations on AIE-ML Devices
 
-    The first element of the array gives the _highest-dimension_ stride and
+    AIE-ML devices can apply data layout transformations at the buffer
+    descriptor level. These transformation are described by strides (also called
+    stepsizes) and wraps (also called lengths) in up to three dimensions (four
+    dimensions on memtiles). Strides and wraps can be supplied to the `dmaBdOp`
+    through an optional argument, an array of tuples `<wrap, stride>`.
+
+    The first element of this array gives the _highest-dimension_ stride and
     wrap, the last element of the array gives the lowest-dimension.
 
-    Example:
+    Strides are always expressed in units of `i32`s; this is an architectural
+    requirement, as data is moved by the DMA at this fundamental size. 
+
+    We can model the access pattern strides and wraps generate by a series of
+    nested loops. In general, a set of strides and wraps like this...
 
     ```
-    AIE.dmaBd(<%buf : memref<128xi32>, 0, 128>, 0, [<16, 8>, <1, 2>, <2, 8>])
+    [<wrap_2, stride_2>, <wrap_1, stride_1>, <wrap_0, stride_0>]
     ```
 
-    This corresponds to alternating between even and odd elements of the 
-    buffer/stream every 8 elements, like so, equivalent to nested loops like so:
+    ...translates to an access pattern that can be epxressed like this:
 
     ```
-    for(int i = 0; i < 8 /* wrap[0] */; i++)
-      for(int j = 0; j < 2 /* wrap[1] */; j++)
-        for(int k = 0; k < 8 /* wrap[2] */; k++)
-          // access/store element at/to index (i * 16 + j * 1 + k * 2)
+    int *buffer;  // i32
+    for(int i = 0; i < wrap_2; i++)
+      for(int j = 0; j < wrap_1; j++)
+        for(int k = 0; k < wrap_0; k++)
+          // access/store element at/to buffer[  i * stride_2 
+          //                                   + j * stride_1 
+          //                                   + k * stride_0]
+    ```
+
+    The following example shows an access pattern that corresponds to 
+    alternating between even and odd elements of the buffer/stream every 8 
+    elements: 
+
+    ```
+    AIE.dmaBd(<%buf : memref<128xi32>, 0, 128>, 0, [<8, 16>, <2, 1>, <8, 2>])
     ```
   }];
 
@@ -1359,8 +1376,8 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">
 def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]> {
   let summary = "Create a circular buffer or channel between two tiles";
   let description = [{
-    The `aie.createObjectFifo` operation creates a circular buffer established between a producer and one or 
-    more consumers, which are `aie.tile` operations. The aie.createObjectFifo instantiates the given number of 
+    The `aie.objectFifo` operation creates a circular buffer established between a producer and one or 
+    more consumers, which are `aie.tile` operations. The `aie.objectFifo` instantiates the given number of 
     buffers (of given output type) and their locks in the Memory Module of the appropriate tile(s) after lowering, 
     based on tile-adjacency. These elements represent the conceptual depth of the objectFifo or, more specifically,
     of its object pool.
@@ -1396,6 +1413,34 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
     This operation creates an objectFifo between %tile12, %tile13 and %tile23. The depths of the objectFifo object pool 
     at each tile are respectively 2, 3 and 4 for tiles %tile12, %tile13 and %tile23. This overrides the depth analysis 
     specified in the first example.
+
+    ## Data Layout Transformations on AIE-ML devices
+    
+    On AIE-ML devices, objectFifos can also apply data layout transformations by
+    using the DMAs n-dimensional address generation scheme. Two transformations
+    can be applied for an objectFifo: one on the producer side, given by a
+    `toStream` attribute, and one transformation on the consumer side, given by
+    a `fromStream` attribute. See the `DMABDOp` documentation for a description
+    of strides and wraps.
+
+    Note that using data layout transformations will cause the DMA be used even
+    between adjacent tiles whose objectFifos would otherwise use shared memory.
+
+    Further note that data layout transforms always apply at a granularity of 
+    `i32`s, irrespective of the used `memref` data type. This is an 
+    architectural requirement. Hence, a stride of 4 always expresses 4 `i32`s, 
+    i.e. 16 bytes.
+
+    The following example shows an objectFifo which transposes a 16x16 matrix of 
+    `i32`s on the producer side using strides and wraps. No transformation is
+    applied on the consumer side (in this case the `fromStream` attribute may
+    also be left off):
+
+    ```
+      AIE.objectFifo @of4 (%tile12, {%tile13}, 2 : i32,
+                           toStream [<16, 1>, <16, 16>, <1, 1>],
+                           fromStream []) : !AIE.objectFifo<memref<256xi32>>
+    ```
   }];
 
   let arguments = (

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -811,6 +811,8 @@ def AIE_DimTupleAttr : AttrDef<AIE_Dialect, "DimTuple", []> {
 
 def AIE_DimTupleArrayAttr : ArrayOfAttr<AIE_Dialect, "DimTupleArray", "DimTupleArray", "::xilinx::AIE::DimTupleAttr">;
 
+def AIE_DimTupleArrayArrayAttr : ArrayOfAttr<AIE_Dialect, "DimTupleArrayArray", "DimTupleArrayArray", "::xilinx::AIE::DimTupleArrayAttr">;
+
 def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
   let summary = "Declare a dma block descriptor op";
   let description = [{
@@ -1421,7 +1423,10 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
     can be applied for an objectFifo: one on the producer side, given by a
     `toStream` attribute, and one transformation on the consumer side, given by
     a `fromStream` attribute. See the `DMABDOp` documentation for a description
-    of strides and wraps.
+    of strides and wraps. The `toStream` and `fromStream` optional attributes
+    are given directly following the producer or consumer tile declaration. 
+    Different transformations can be specified for each consumer. See example
+    below.
 
     Note that using data layout transformations will cause the DMA be used even
     between adjacent tiles whose objectFifos would otherwise use shared memory.
@@ -1433,13 +1438,16 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
 
     The following example shows an objectFifo which transposes a 16x16 matrix of 
     `i32`s on the producer side using strides and wraps. No transformation is
-    applied on the consumer side (in this case the `fromStream` attribute may
-    also be left off):
+    applied on the consumer side of %tile13 (in this case the `fromStream` 
+    attribute may also be left off), and a transformation on %tile23 first gives
+    all even indices from the stream, followed by all odd indices:
 
     ```
-      AIE.objectFifo @of4 (%tile12, {%tile13}, 2 : i32,
-                           toStream [<16, 1>, <16, 16>, <1, 1>],
-                           fromStream []) : !AIE.objectFifo<memref<256xi32>>
+      AIE.objectFifo @of4 (%tile12 toStream [<16, 1>, <16, 16>, <1,1>], 
+                           {%tile13 fromStream [],
+                            %tile23 fromStream [<2, 1>, <128, 2>]}, 
+                           2 : i32
+                          ) : !AIE.objectFifo<memref<256xi32>>
     ```
   }];
 
@@ -1449,14 +1457,19 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
         Variadic<Index>:$consumerTiles,
         AIE_ObjectFifo_Depth:$elemNumber,
         TypeAttrOf<AIE_ObjectFifoType>:$elem_type,
-        OptionalAttr<AIE_DimTupleArrayAttr>:$dimensionsToStream,
-        OptionalAttr<AIE_DimTupleArrayAttr>:$dimensionsFromStream
+        AIE_DimTupleArrayAttr:$dimensionsToStream,
+        AIE_DimTupleArrayArrayAttr:$dimensionsFromStreamPerConsumer
   );
 
   let assemblyFormat = [{
-    $sym_name `(` $producerTile `,` `{` $consumerTiles `}` `,` $elemNumber 
-      (`,` `toStream` $dimensionsToStream^)?
-      (`,` `fromStream` $dimensionsFromStream^)?
+    $sym_name 
+    `(` 
+        custom<ObjectFifoProducerTile>($producerTile, $dimensionsToStream) `,` 
+        `{` 
+          custom<ObjectFifoConsumerTiles>($consumerTiles, $dimensionsFromStreamPerConsumer) 
+        `}` 
+        `,` 
+        $elemNumber 
     `)` attr-dict `:` $elem_type
   }];
   

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -806,7 +806,7 @@ def AIE_DimTupleAttr : AttrDef<AIE_Dialect, "DimTuple", []> {
     "uint32_t" : $stepsize,
     "uint16_t" : $wrap
   );
-  let assemblyFormat = "`<` $stepsize `,` $wrap `>`";
+  let assemblyFormat = "`<` $wrap `,` $stepsize `>`";
 }
 
 def AIE_DimTupleArrayAttr : ArrayOfAttr<AIE_Dialect, "DimTupleArray", "DimTupleArray", "::xilinx::AIE::DimTupleAttr">;

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1403,11 +1403,16 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
         Index:$producerTile,
         Variadic<Index>:$consumerTiles,
         AIE_ObjectFifo_Depth:$elemNumber,
-        TypeAttrOf<AIE_ObjectFifoType>:$elem_type
+        TypeAttrOf<AIE_ObjectFifoType>:$elem_type,
+        OptionalAttr<AIE_DimTupleArrayAttr>:$dimensionsToStream,
+        OptionalAttr<AIE_DimTupleArrayAttr>:$dimensionsFromStream
   );
 
   let assemblyFormat = [{
-    $sym_name `(` $producerTile `,` `{` $consumerTiles `}` `,` $elemNumber `)` attr-dict `:` $elem_type
+    $sym_name `(` $producerTile `,` `{` $consumerTiles `}` `,` $elemNumber 
+      (`,` `toStream` $dimensionsToStream^)?
+      (`,` `fromStream` $dimensionsFromStream^)?
+    `)` attr-dict `:` $elem_type
   }];
   
   let hasVerifier = 1;
@@ -1425,6 +1430,17 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
       return attr;
     }
   }];
+
+  let builders = [
+    OpBuilder<(ins "StringAttr":$sym_name, "Value":$producerTile, "ValueRange":$consumerTiles, "Attribute":$elemNumber, "Type":$elem_type), [{
+      printf("Non additional attribute builder called.\n");
+      odsState.addOperands(producerTile);
+      odsState.addOperands(consumerTiles);
+      odsState.addAttribute(getSymNameAttrName(odsState.name), sym_name);
+      odsState.addAttribute(getElemNumberAttrName(odsState.name), elemNumber);
+      odsState.addAttribute(getElemTypeAttrName(odsState.name), ::mlir::TypeAttr::get(elem_type));
+      }]>
+  ];
 }
 
 def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {

--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -168,6 +168,22 @@ struct AIEDevDesc {
 
 const xilinx::AIE::AIETargetModel &getTargetModel(Operation *op);
 
+::mlir::ParseResult
+parseObjectFifoProducerTile(::mlir::OpAsmParser &parser,
+                            ::mlir::OpAsmParser::UnresolvedOperand &operand,
+                            DimTupleArrayAttr &dimensions);
+void printObjectFifoProducerTile(::mlir::OpAsmPrinter &_odsPrinter,
+                                 Operation *op, Value tile,
+                                 Attribute dimensions);
+
+::mlir::ParseResult parseObjectFifoConsumerTiles(
+    ::mlir::OpAsmParser &parser,
+    SmallVectorImpl<::mlir::OpAsmParser::UnresolvedOperand> &tiles,
+    DimTupleArrayArrayAttr &dimensions);
+void printObjectFifoConsumerTiles(::mlir::OpAsmPrinter &_odsPrinter,
+                                  Operation *op, OperandRange tiles,
+                                  Attribute dimensions);
+
 } // namespace AIE
 } // namespace xilinx
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -465,9 +465,9 @@ parseObjectFifoProducerTile(::mlir::OpAsmParser &parser,
 
 void printObjectFifoProducerTile(::mlir::OpAsmPrinter &_odsPrinter,
                                  Operation *op, Value operand,
-                                 Attribute dimensions) {
+                                 DimTupleArrayAttr dimensions) {
   _odsPrinter << operand;
-  if (dimensions) {
+  if (dimensions && dimensions.size() > 0) {
     _odsPrinter << " toStream ";
     _odsPrinter.printStrippedAttrOrType(dimensions);
   }
@@ -510,13 +510,16 @@ void printObjectFifoProducerTile(::mlir::OpAsmPrinter &_odsPrinter,
 
 void printObjectFifoConsumerTiles(::mlir::OpAsmPrinter &_odsPrinter,
                                   Operation *op, OperandRange tiles,
-                                  Attribute dimensions) {
+                                  DimTupleArrayArrayAttr dimsPerTileAttr) {
+  int tileIdx = 0;
   for (auto tile : tiles) {
     _odsPrinter << tile;
-    if (dimensions) {
+    if (dimsPerTileAttr && dimsPerTileAttr.size() == tiles.size()
+        && dimsPerTileAttr[tileIdx] && dimsPerTileAttr[tileIdx].size() > 0) {
       _odsPrinter << " fromStream ";
-      _odsPrinter.printStrippedAttrOrType(dimensions);
+      _odsPrinter.printStrippedAttrOrType(dimsPerTileAttr[tileIdx]);
     }
+    tileIdx++;
   }
 }
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1308,6 +1308,12 @@ LogicalResult xilinx::AIE::DMABDOp::verify() {
                << "Step size " << std::to_string(dim.getStepsize() * 4) << " "
                << "bytes exceeds memref size " << std::to_string(memref_size);
       }
+      if (dim.getWrap() >= (1UL << 9) + 1) {
+        return emitOpError() << "Wrap may not exceed 1023.";
+      }
+      if (dim.getStepsize() >= (1UL << 19)) {
+        return emitOpError() << "Stepsize may not exceed " << (1 << 20);
+      }
     }
     if (memref_size <= 4 * max_idx) {
       return emitOpError() << "Specified stepsize(s) and wrap(s) result in out "

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -485,7 +485,7 @@ void printObjectFifoProducerTile(::mlir::OpAsmPrinter &_odsPrinter,
     if (parser.parseOperand(tiles.emplace_back(), true)) {
       return ::mlir::failure();
     }
-    // By default, create empty dimensions array for each customer; this way,
+    // By default, create empty dimensions array for each consumer; this way,
     // we can be certain to have as many entries in the dimensions array as
     // there are customer
     DimTupleArrayAttr dimAttr = DimTupleArrayAttr::get(parser.getContext(), {});
@@ -511,13 +511,16 @@ void printObjectFifoProducerTile(::mlir::OpAsmPrinter &_odsPrinter,
 void printObjectFifoConsumerTiles(::mlir::OpAsmPrinter &_odsPrinter,
                                   Operation *op, OperandRange tiles,
                                   DimTupleArrayArrayAttr dimsPerTileAttr) {
-  int tileIdx = 0;
+  size_t tileIdx = 0;
   for (auto tile : tiles) {
     _odsPrinter << tile;
-    if (dimsPerTileAttr && dimsPerTileAttr.size() == tiles.size()
-        && dimsPerTileAttr[tileIdx] && dimsPerTileAttr[tileIdx].size() > 0) {
+    if (dimsPerTileAttr && dimsPerTileAttr.size() == tiles.size() &&
+        dimsPerTileAttr[tileIdx] && dimsPerTileAttr[tileIdx].size() > 0) {
       _odsPrinter << " fromStream ";
       _odsPrinter.printStrippedAttrOrType(dimsPerTileAttr[tileIdx]);
+    }
+    if (tileIdx < dimsPerTileAttr.size() - 1) {
+      _odsPrinter << ", ";
     }
     tileIdx++;
   }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -426,8 +426,12 @@ struct AIEObjectFifoStatefulTransformPass
                 DimTupleArrayAttr dims) {
     builder.create<UseLockOp>(builder.getUnknownLoc(), acqLock, acqMode,
                               acqLockAction);
-    builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len, 0,
-                            dims);
+    if (dims && dims.getValue().size() > 0) {
+      builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len, 0,
+                              dims);
+    } else {
+      builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len, 0);
+    }
     builder.create<UseLockOp>(builder.getUnknownLoc(), relLock, relMode,
                               LockAction::Release);
     builder.create<NextBDOp>(builder.getUnknownLoc(), succ);

--- a/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
@@ -44,7 +44,7 @@ module @aie_module  {
       %dstDma = AIE.dmaStart(MM2S, 0, ^bd3, ^end)
     ^bd0:
       AIE.useLock(%l01_0, "AcquireGreaterEqual", 1)
-      AIE.dmaBd(<%buf01_0 : memref<16xi32>, 0, 128>, 0, [<1, 2>, <2, 3>, <4, 2>, <1, 1>])
+      AIE.dmaBd(<%buf01_0 : memref<16xi32>, 0, 128>, 0, [<2, 1>, <3, 2>, <2, 4>, <1, 1>])
       AIE.useLock(%l01_1, "Release", 1)
       AIE.nextBd ^bd0
     ^bd1:

--- a/test/dialect/AIE/nd-dma-oob.mlir
+++ b/test/dialect/AIE/nd-dma-oob.mlir
@@ -30,7 +30,7 @@ module @tutorial_2b {
             // attempt an access at index 128, which is OOB for a 128xi32 
             // memref.
             // expected-error@+1 {{Specified stepsize(s) and wrap(s) result in out of bounds access}}
-            AIE.dmaBd(<%buf14 : memref<128xi32>, 0, 128>, 0, [<128, 2>])
+            AIE.dmaBd(<%buf14 : memref<128xi32>, 0, 128>, 0, [<2, 128>])
             AIE.nextBd ^end
           ^end: 
             AIE.end

--- a/test/dialect/AIE/nd-dma-wrong-rank.mlir
+++ b/test/dialect/AIE/nd-dma-wrong-rank.mlir
@@ -28,7 +28,7 @@ module @tutorial_2b {
             // Currently, we only allow multi-dimensional stride/wrap definitons
             // on BDs referring to a memref of rank 1.
             // expected-error@+1 {{Specifying transfer step sizes and wraps is only supported for }}
-            AIE.dmaBd(<%buf14 : memref<3x2x64xi32>, 0, 128>, 0, [<2, 8>])
+            AIE.dmaBd(<%buf14 : memref<3x2x64xi32>, 0, 128>, 0, [<8, 2>])
             AIE.nextBd ^end
           ^end: 
             AIE.end

--- a/test/dialect/AIE/nd-dma-wrong-type.mlir
+++ b/test/dialect/AIE/nd-dma-wrong-type.mlir
@@ -30,7 +30,7 @@ module @tutorial_2b {
             // the hardware does.
             // Cast to an i32 memref type if needed.
             //expected-error@+1 {{Specifying transfer step sizes and wraps is only supported for }}
-            AIE.dmaBd(<%buf14 : memref<128xi8>, 0, 128>, 0, [<2, 8>])
+            AIE.dmaBd(<%buf14 : memref<128xi8>, 0, 128>, 0, [<8, 2>])
             AIE.nextBd ^end
           ^end: 
             AIE.end

--- a/test/objectFifo-register-process/nd_dma_test_aie2.mlir
+++ b/test/objectFifo-register-process/nd_dma_test_aie2.mlir
@@ -1,0 +1,57 @@
+//===- base_test_1.aie.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+//
+// Date: February 9th 2022
+// 
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-register-objectFifos %s | FileCheck %s
+
+// CHECK: module @registerPatterns {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %[[tile_1_2:.*]] = AIE.tile(1, 2)
+// CHECK:     %[[tile_1_3:.*]] = AIE.tile(1, 3)
+// CHECK:     AIE.objectFifo @objfifo(%[[tile_1_2]] toStream [<1, 2>], {%[[tile_1_3]] fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:     %cst = arith.constant dense<1> : tensor<1xi32>
+// CHECK:     %cst_0 = arith.constant dense<1> : tensor<1xi32>
+// CHECK:     %c10 = arith.constant 10 : index
+// CHECK:     func.func @producer_work() {
+// CHECK:       return
+// CHECK:     }
+// CHECK:     %2 = AIE.core(%[[tile_1_2]]) {
+// CHECK:       %c0 = arith.constant 0 : index
+// CHECK:       %c10_1 = arith.constant 10 : index
+// CHECK:       %c1 = arith.constant 1 : index
+// CHECK:       scf.for %arg0 = %c0 to %c10_1 step %c1 {
+// CHECK:         %3 = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:         %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:         func.call @producer_work() : () -> ()
+// CHECK:         AIE.objectFifo.release @objfifo(Produce, 1)
+// CHECK:       }
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+module @registerPatterns  {
+    AIE.device(xcve2302) {
+        %tile12 = AIE.tile(1, 2)
+        %tile13 = AIE.tile(1, 3)
+
+        AIE.objectFifo @objfifo (%tile12 toStream [<1, 2>], {%tile13 fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+
+        %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
+        %releasePattern = arith.constant dense<[1]> : tensor<1xi32>
+        %length = arith.constant 10 : index
+        func.func @producer_work() -> () { 
+            return
+        }
+
+        AIE.objectFifo.registerProcess @objfifo (Produce, %acquirePattern : tensor<1xi32>, %releasePattern : tensor<1xi32>, @producer_work, %length) 
+    }
+}

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -48,34 +48,34 @@
 // CHECK:       %26 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb5)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%[[of0_buff_0]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.dmaBd(<%[[of0_buff_0]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
 // CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
 // CHECK:       AIE.nextBd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%[[of0_buff_1]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.dmaBd(<%[[of0_buff_1]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
 // CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
 // CHECK:       AIE.nextBd ^bb3
 // CHECK:     ^bb3:  // pred: ^bb2
 // CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%[[of0_buff_2]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.dmaBd(<%[[of0_buff_2]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
 // CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
 // CHECK:       AIE.nextBd ^bb4
 // CHECK:     ^bb4:  // pred: ^bb3
 // CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%[[of0_buff_3]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.dmaBd(<%[[of0_buff_3]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
 // CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
 // CHECK:       AIE.nextBd ^bb1
 // CHECK:     ^bb5:  // pred: ^bb0
 // CHECK:       %27 = AIE.dmaStart(MM2S, 1, ^bb6, ^bb8)
 // CHECK:     ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:       AIE.useLock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%[[of1_buff_0]] : memref<256xi32>, 0, 256>, 0, [<2, 128>])
+// CHECK:       AIE.dmaBd(<%[[of1_buff_0]] : memref<256xi32>, 0, 256>, 0, [<128, 2>])
 // CHECK:       AIE.useLock(%[[of1_prod_lock]], Release, 1)
 // CHECK:       AIE.nextBd ^bb7
 // CHECK:     ^bb7:  // pred: ^bb6
 // CHECK:       AIE.useLock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dmaBd(<%[[of1_buff_1]] : memref<256xi32>, 0, 256>, 0, [<2, 128>])
+// CHECK:       AIE.dmaBd(<%[[of1_buff_1]] : memref<256xi32>, 0, 256>, 0, [<128, 2>])
 // CHECK:       AIE.useLock(%[[of1_prod_lock]], Release, 1)
 // CHECK:       AIE.nextBd ^bb6
 // CHECK:     ^bb8:  // pred: ^bb5
@@ -134,10 +134,10 @@ module @ndDMAObjFifoAIE2 {
     // this case between two adjacent tiles, we need to use DMAs if a data
     // layout transformation with toStream and fromStream was specified.
     AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32,
-                         toStream [<1, 16>, <16, 16>, <1, 1>], // transpose
+                         toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          fromStream [<1, 1>]) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32,
-                         toStream [<2, 128>]) : !AIE.objectFifo<memref<256xi32>>
+                         toStream [<128, 2>]) : !AIE.objectFifo<memref<256xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -133,11 +133,11 @@ module @ndDMAObjFifoAIE2 {
     // Even if an objectFifo could be implemented in shared memory, as with 
     // this case between two adjacent tiles, we need to use DMAs if a data
     // layout transformation with toStream and fromStream was specified.
-    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32,
-                         toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
-                         fromStream [<1, 1>]) : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
+                         {%tile13 fromStream [<1, 1>]}, 
+                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
 
-    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32,
-                         toStream [<128, 2>]) : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33}, 
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -1,0 +1,143 @@
+//===- base_test_AIE2.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Xilinx Inc.
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: May 9th 2023
+// 
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @ndDMAObjFifoAIE2 {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     memref.global "public" @of1_cons : memref<256xi32>
+// CHECK:     memref.global "public" @of1 : memref<256xi32>
+// CHECK:     memref.global "public" @of0_cons : memref<256xi32>
+// CHECK:     memref.global "public" @of0 : memref<256xi32>
+// CHECK:     %[[tile_1_2:.*]] = AIE.tile(1, 2)
+// CHECK:     %[[tile_1_3:.*]] = AIE.tile(1, 3)
+// CHECK:     %[[tile_3_3:.*]] = AIE.tile(3, 3)
+// CHECK:     AIE.flow(%[[tile_1_2]], DMA : 0, %[[tile_1_3]], DMA : 0)
+// CHECK:     %[[of0_buff_0:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_0"} : memref<256xi32>
+// CHECK:     %[[of0_buff_1:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_1"} : memref<256xi32>
+// CHECK:     %[[of0_buff_2:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_2"} : memref<256xi32>
+// CHECK:     %[[of0_buff_3:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_3"} : memref<256xi32>
+// CHECK:     %[[of0_prod_lock:.*]] = AIE.lock(%[[tile_1_2]], 0) {init = 4 : i32, sym_name = "of0_prod_lock"}
+// CHECK:     %[[of0_cons_lock:.*]] = AIE.lock(%[[tile_1_2]], 1) {init = 0 : i32, sym_name = "of0_cons_lock"}
+// CHECK:     %[[of0_cons_buff_0:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_0"} : memref<256xi32>
+// CHECK:     %[[of0_cons_buff_1:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_1"} : memref<256xi32>
+// CHECK:     %[[of0_cons_buff_2:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_2"} : memref<256xi32>
+// CHECK:     %[[of0_cons_buff_3:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_3"} : memref<256xi32>
+// CHECK:     %[[of0_cons_prod_lock:.*]] = AIE.lock(%[[tile_1_3]], 0) {init = 4 : i32, sym_name = "of0_cons_prod_lock"}
+// CHECK:     %[[of0_cons_cons_lock:.*]] = AIE.lock(%[[tile_1_3]], 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock"}
+// CHECK:     AIE.flow(%[[tile_1_2]], DMA : 1, %[[tile_3_3]], DMA : 0)
+// CHECK:     %[[of1_buff_0:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_0"} : memref<256xi32>
+// CHECK:     %[[of1_buff_1:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_1"} : memref<256xi32>
+// CHECK:     %[[of1_prod_lock:.*]] = AIE.lock(%[[tile_1_2]], 2) {init = 2 : i32, sym_name = "of1_prod_lock"}
+// CHECK:     %[[of1_cons_lock:.*]] = AIE.lock(%[[tile_1_2]], 3) {init = 0 : i32, sym_name = "of1_cons_lock"}
+// CHECK:     %[[of1_cons_buff_0:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_0"} : memref<256xi32>
+// CHECK:     %[[of1_cons_buff_1:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_1"} : memref<256xi32>
+// CHECK:     %[[of1_cons_prod_lock:.*]] = AIE.lock(%[[tile_3_3]], 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
+// CHECK:     %[[of1_cons_cons_lock:.*]] = AIE.lock(%[[tile_3_3]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
+// CHECK:     %23 = AIE.mem(%[[tile_1_2]]) {
+// CHECK:       %26 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb5)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_0]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_1]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb3
+// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_2]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb4:  // pred: ^bb3
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_3]] : memref<256xi32>, 0, 256>, 0, [<1, 16>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb5:  // pred: ^bb0
+// CHECK:       %27 = AIE.dmaStart(MM2S, 1, ^bb6, ^bb8)
+// CHECK:     ^bb6:  // 2 preds: ^bb5, ^bb7
+// CHECK:       AIE.useLock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_buff_0]] : memref<256xi32>, 0, 256>, 0, [<2, 128>])
+// CHECK:       AIE.useLock(%[[of1_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb7:  // pred: ^bb6
+// CHECK:       AIE.useLock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_buff_1]] : memref<256xi32>, 0, 256>, 0, [<2, 128>])
+// CHECK:       AIE.useLock(%[[of1_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb6
+// CHECK:     ^bb8:  // pred: ^bb5
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %24 = AIE.mem(%[[tile_1_3]]) {
+// CHECK:       %26 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb5)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
+// CHECK:       AIE.useLock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_cons_buff_0]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_cons_buff_1]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb3
+// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       AIE.useLock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_cons_buff_2]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb4:  // pred: ^bb3
+// CHECK:       AIE.useLock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_cons_buff_3]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb5:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %25 = AIE.mem(%[[tile_3_3]]) {
+// CHECK:       %26 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256>, 0)
+// CHECK:       AIE.useLock(%[[of1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256>, 0)
+// CHECK:       AIE.useLock(%[[of1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+module @ndDMAObjFifoAIE2 {
+ AIE.device(xcve2302) {
+    %tile12 = AIE.tile(1, 2)
+    %tile13 = AIE.tile(1, 3)
+    %tile33 = AIE.tile(3, 3)
+
+    // Even if an objectFifo could be implemented in shared memory, as with 
+    // this case between two adjacent tiles, we need to use DMAs if a data
+    // layout transformation with toStream and fromStream was specified.
+    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32,
+                         toStream [<1, 16>, <16, 16>, <1, 1>], // transpose
+                         fromStream [<1, 1>]) : !AIE.objectFifo<memref<256xi32>>
+
+    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32,
+                         toStream [<2, 128>]) : !AIE.objectFifo<memref<256xi32>>
+ }
+}

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -198,7 +198,7 @@ module @ndDMAObjFifoAIE2 {
     %tile22 = AIE.tile(2, 2)
     %tile23 = AIE.tile(2, 3)
 
-    AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>], // transpose
+    AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          {%tile13 fromStream [<1, 1>],
                           %tile33 fromStream [<3, 4>]}, 
                          4 : i32) : !AIE.objectFifo<memref<256xi32>>

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -198,10 +198,7 @@ module @ndDMAObjFifoAIE2 {
     %tile22 = AIE.tile(2, 2)
     %tile23 = AIE.tile(2, 3)
 
-    // Even if an objectFifo could be implemented in shared memory, as with 
-    // this case between two adjacent tiles, we need to use DMAs if a data
-    // layout transformation with toStream and fromStream was specified.
-    AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
+    AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>], // transpose
                          {%tile13 fromStream [<1, 1>],
                           %tile33 fromStream [<3, 4>]}, 
                          4 : i32) : !AIE.objectFifo<memref<256xi32>>

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -1,0 +1,215 @@
+//===- base_test_AIE2.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Xilinx Inc.
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+// Date: May 9th 2023
+// 
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK: module @ndDMAObjFifoAIE2 {
+// CHECK:   AIE.device(xcve2302) {
+// CHECK:     %[[tile_1_2:.*]] = AIE.tile(1, 2)
+// CHECK:     %[[tile_1_3:.*]] = AIE.tile(1, 3)
+// CHECK:     %[[tile_3_3:.*]] = AIE.tile(3, 3)
+// CHECK:     %[[tile_2_2:.*]] = AIE.tile(2, 2)
+// CHECK:     %[[tile_2_3:.*]] = AIE.tile(2, 3)
+// CHECK:     AIE.flow(%[[tile_1_2]], DMA : 0, %[[tile_3_3]], DMA : 0)
+// CHECK:     AIE.flow(%[[tile_1_2]], DMA : 0, %[[tile_1_3]], DMA : 0)
+// CHECK:     %[[of0_buff_0:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_0"} : memref<256xi32>
+// CHECK:     %[[of0_buff_1:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_1"} : memref<256xi32>
+// CHECK:     %[[of0_buff_2:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_2"} : memref<256xi32>
+// CHECK:     %[[of0_buff_3:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_3"} : memref<256xi32>
+// CHECK:     %[[of0_prod_lock:.*]] = AIE.lock(%[[tile_1_2]], 0) {init = 4 : i32, sym_name = "of0_prod_lock"}
+// CHECK:     %[[of0_cons_lock:.*]] = AIE.lock(%[[tile_1_2]], 1) {init = 0 : i32, sym_name = "of0_cons_lock"}
+// CHECK:     %[[of0_1_cons_buff_0:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_0"} : memref<256xi32>
+// CHECK:     %[[of0_1_cons_buff_1:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_1"} : memref<256xi32>
+// CHECK:     %[[of0_1_cons_buff_2:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_2"} : memref<256xi32>
+// CHECK:     %[[of0_1_cons_buff_3:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_3"} : memref<256xi32>
+// CHECK:     %[[of0_1_cons_prod_lock:.*]] = AIE.lock(%[[tile_3_3]], 0) {init = 4 : i32, sym_name = "of0_1_cons_prod_lock"}
+// CHECK:     %[[of0_1_cons_cons_lock:.*]] = AIE.lock(%[[tile_3_3]], 1) {init = 0 : i32, sym_name = "of0_1_cons_cons_lock"}
+// CHECK:     %[[of0_0_cons_buff_0:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_0"} : memref<256xi32>
+// CHECK:     %[[of0_0_cons_buff_1:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_1"} : memref<256xi32>
+// CHECK:     %[[of0_0_cons_buff_2:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_2"} : memref<256xi32>
+// CHECK:     %[[of0_0_cons_buff_3:.*]] = AIE.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_3"} : memref<256xi32>
+// CHECK:     %[[of0_0_cons_prod_lock:.*]] = AIE.lock(%[[tile_1_3]], 0) {init = 4 : i32, sym_name = "of0_0_cons_prod_lock"}
+// CHECK:     %[[of0_0_cons_cons_lock:.*]] = AIE.lock(%[[tile_1_3]], 1) {init = 0 : i32, sym_name = "of0_0_cons_cons_lock"}
+// CHECK:     AIE.flow(%[[tile_1_2]], DMA : 1, %[[tile_3_3]], DMA : 1)
+// CHECK:     %[[of1_buff_0:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_0"} : memref<256xi32>
+// CHECK:     %[[of1_buff_1:.*]] = AIE.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_1"} : memref<256xi32>
+// CHECK:     %[[of1_prod_lock:.*]] = AIE.lock(%[[tile_1_2]], 2) {init = 2 : i32, sym_name = "of1_prod_lock"}
+// CHECK:     %[[of1_cons_lock:.*]] = AIE.lock(%[[tile_1_2]], 3) {init = 0 : i32, sym_name = "of1_cons_lock"}
+// CHECK:     %[[of1_cons_buff_0:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_0"} : memref<256xi32>
+// CHECK:     %[[of1_cons_buff_1:.*]] = AIE.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_1"} : memref<256xi32>
+// CHECK:     %[[of1_cons_prod_lock:.*]] = AIE.lock(%[[tile_3_3]], 2) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
+// CHECK:     %[[of1_cons_cons_lock:.*]] = AIE.lock(%[[tile_3_3]], 3) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
+// CHECK:     AIE.flow(%[[tile_2_2]], DMA : 0, %[[tile_2_3]], DMA : 0)
+// CHECK:     %[[of3_buff_0:.*]] = AIE.buffer(%[[tile_2_2]]) {sym_name = "of3_buff_0"} : memref<256xi32>
+// CHECK:     %[[of3_buff_1:.*]] = AIE.buffer(%[[tile_2_2]]) {sym_name = "of3_buff_1"} : memref<256xi32>
+// CHECK:     %[[of3_prod_lock:.*]] = AIE.lock(%[[tile_2_2]], 0) {init = 2 : i32, sym_name = "of3_prod_lock"}
+// CHECK:     %[[of3_cons_lock:.*]] = AIE.lock(%[[tile_2_2]], 1) {init = 0 : i32, sym_name = "of3_cons_lock"}
+// CHECK:     %[[of3_cons_buff_0:.*]] = AIE.buffer(%[[tile_2_3]]) {sym_name = "of3_cons_buff_0"} : memref<256xi32>
+// CHECK:     %[[of3_cons_buff_1:.*]] = AIE.buffer(%[[tile_2_3]]) {sym_name = "of3_cons_buff_1"} : memref<256xi32>
+// CHECK:     %[[of3_cons_prod_lock:.*]] = AIE.lock(%[[tile_2_3]], 0) {init = 2 : i32, sym_name = "of3_cons_prod_lock"}
+// CHECK:     %[[of3_cons_cons_lock:.*]] = AIE.lock(%[[tile_2_3]], 1) {init = 0 : i32, sym_name = "of3_cons_cons_lock"}
+// CHECK:     %39 = AIE.mem(%[[tile_1_2]]) {
+// CHECK:       %44 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb5)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_0]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_1]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb3
+// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_2]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb4:  // pred: ^bb3
+// CHECK:       AIE.useLock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_buff_3]] : memref<256xi32>, 0, 256>, 0, [<16, 1>, <16, 16>, <1, 1>])
+// CHECK:       AIE.useLock(%[[of0_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb5:  // pred: ^bb0
+// CHECK:       %45 = AIE.dmaStart(MM2S, 1, ^bb6, ^bb8)
+// CHECK:     ^bb6:  // 2 preds: ^bb5, ^bb7
+// CHECK:       AIE.useLock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_buff_0]] : memref<256xi32>, 0, 256>, 0, [<128, 2>])
+// CHECK:       AIE.useLock(%[[of1_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb7:  // pred: ^bb6
+// CHECK:       AIE.useLock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_buff_1]] : memref<256xi32>, 0, 256>, 0, [<128, 2>])
+// CHECK:       AIE.useLock(%[[of1_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb6
+// CHECK:     ^bb8:  // pred: ^bb5
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %40 = AIE.mem(%[[tile_1_3]]) {
+// CHECK:       %44 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb5)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
+// CHECK:       AIE.useLock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_0_cons_buff_0]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_0_cons_buff_1]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb3
+// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       AIE.useLock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_0_cons_buff_2]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb4:  // pred: ^bb3
+// CHECK:       AIE.useLock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_0_cons_buff_3]] : memref<256xi32>, 0, 256>, 0, [<1, 1>])
+// CHECK:       AIE.useLock(%[[of0_0_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb5:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %41 = AIE.mem(%[[tile_3_3]]) {
+// CHECK:       %44 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb5)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
+// CHECK:       AIE.useLock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_1_cons_buff_0]] : memref<256xi32>, 0, 256>, 0, [<3, 4>])
+// CHECK:       AIE.useLock(%[[of0_1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_1_cons_buff_1]] : memref<256xi32>, 0, 256>, 0, [<3, 4>])
+// CHECK:       AIE.useLock(%[[of0_1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb3
+// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       AIE.useLock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_1_cons_buff_2]] : memref<256xi32>, 0, 256>, 0, [<3, 4>])
+// CHECK:       AIE.useLock(%[[of0_1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb4
+// CHECK:     ^bb4:  // pred: ^bb3
+// CHECK:       AIE.useLock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of0_1_cons_buff_3]] : memref<256xi32>, 0, 256>, 0, [<3, 4>])
+// CHECK:       AIE.useLock(%[[of0_1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb5:  // pred: ^bb0
+// CHECK:       %45 = AIE.dmaStart(S2MM, 1, ^bb6, ^bb8)
+// CHECK:     ^bb6:  // 2 preds: ^bb5, ^bb7
+// CHECK:       AIE.useLock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256>, 0)
+// CHECK:       AIE.useLock(%[[of1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb7
+// CHECK:     ^bb7:  // pred: ^bb6
+// CHECK:       AIE.useLock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256>, 0)
+// CHECK:       AIE.useLock(%[[of1_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb6
+// CHECK:     ^bb8:  // pred: ^bb5
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %42 = AIE.mem(%[[tile_2_2]]) {
+// CHECK:       %44 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%[[of3_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of3_buff_0]] : memref<256xi32>, 0, 256>, 0)
+// CHECK:       AIE.useLock(%[[of3_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of3_cons_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of3_buff_1]] : memref<256xi32>, 0, 256>, 0)
+// CHECK:       AIE.useLock(%[[of3_prod_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:     %43 = AIE.mem(%[[tile_2_3]]) {
+// CHECK:       %44 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
+// CHECK:       AIE.useLock(%[[of3_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of3_cons_buff_0]] : memref<256xi32>, 0, 256>, 0, [<9, 9>])
+// CHECK:       AIE.useLock(%[[of3_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb2
+// CHECK:     ^bb2:  // pred: ^bb1
+// CHECK:       AIE.useLock(%[[of3_cons_prod_lock]], AcquireGreaterEqual, 1)
+// CHECK:       AIE.dmaBd(<%[[of3_cons_buff_1]] : memref<256xi32>, 0, 256>, 0, [<9, 9>])
+// CHECK:       AIE.useLock(%[[of3_cons_cons_lock]], Release, 1)
+// CHECK:       AIE.nextBd ^bb1
+// CHECK:     ^bb3:  // pred: ^bb0
+// CHECK:       AIE.end
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+module @ndDMAObjFifoAIE2 {
+ AIE.device(xcve2302) {
+    %tile12 = AIE.tile(1, 2)
+    %tile13 = AIE.tile(1, 3)
+    %tile33 = AIE.tile(3, 3)
+    %tile22 = AIE.tile(2, 2)
+    %tile23 = AIE.tile(2, 3)
+
+    // Even if an objectFifo could be implemented in shared memory, as with 
+    // this case between two adjacent tiles, we need to use DMAs if a data
+    // layout transformation with toStream and fromStream was specified.
+    AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
+                         {%tile13 fromStream [<1, 1>],
+                          %tile33 fromStream [<3, 4>]}, 
+                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
+
+    AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33}, 
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+
+    AIE.objectFifo @of3 (%tile22, {%tile23 fromStream [<9, 9>]}, 
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+ }
+}

--- a/test/unit_tests/29_aie2_nd_dma_even_odd/aie.mlir
+++ b/test/unit_tests/29_aie2_nd_dma_even_odd/aie.mlir
@@ -83,9 +83,9 @@ module @tutorial_2b {
           ^bd0:
             AIE.useLock(%lock14_done, "AcquireGreaterEqual", 1)
                                                              ////////// new //////////
-            AIE.dmaBd(<%buf14 : memref<128xi32>, 0, 128>, 0, [<16, 8>, <1, 2>, <2, 8>])
-                                                            // s, w    s, w    s,  w
-                                                            // dim 0,  dim 1,  dim 2
+            AIE.dmaBd(<%buf14 : memref<128xi32>, 0, 128>, 0, [<8, 16>, <2, 1>, <8, 2>])
+                                                            // w, s    w, s    w,  s
+                                                            // dim 2,  dim 1,  dim 0
             AIE.useLock(%lock14_sent, "Release", 1)
             AIE.nextBd ^end
           ^end: 

--- a/test/unit_tests/30_aie2_nd_dma_transpose_repeat/aie.mlir
+++ b/test/unit_tests/30_aie2_nd_dma_transpose_repeat/aie.mlir
@@ -62,9 +62,9 @@ module @tutorial_2b {
           ^bd0:
             AIE.useLock(%lock14_done, "AcquireGreaterEqual", 1)
                                                              ////////// new //////////
-            AIE.dmaBd(<%buf14 : memref<128xi32>, 0, 128>, 0, [<1, 2>, <1, 8>, <8, 8>])
-                                                            // s, w    s, w    s,  w
-                                                            // dim 0,  dim 1,  dim 2
+            AIE.dmaBd(<%buf14 : memref<128xi32>, 0, 128>, 0, [<2, 1>, <8, 1>, <8, 8>])
+                                                            // w, s    w, s    w,  s
+                                                            // dim 2,  dim 1,  dim 0
             AIE.useLock(%lock14_sent, "Release", 1)
             AIE.nextBd ^end
           ^end: 


### PR DESCRIPTION
I recently added support for the n-dimensional data layout transformations (strides/wraps) of AIE2 to the `dmaBdOp`, #547. This PR adds the same functionality at the objectFifo level.

You can specify two data layout transformations; `toStream` and `fromStream`. `toStream` is applied at the producer side; data in the buffer referenced by the objectFifo is put in the stream by following the strides and wraps given. `fromStream` is the analog on the consumer side; what comes in from the stream is written into the memory addresses obtained by applying the given strides wraps.

Since these data layout transformations require a DMA to perform them, if either `toStream` or `fromStream` is used, a DMA connection between tiles is forced, even if they are adjacent and have shared memory. (This required some light refactoring of the objectFifo code.)

To be more consistent with the `AIEX.dma_nd_memcpy` operation, which first lists lengths and then strides, I also refactored the strides and wraps tuples in both `dmaBdOp` and `objectFifo` (this PR) to now be in order `<wrap, stepsize>` (== synonymously `<length, stride>`).