### PR TITLE
Add support for event instruction

### DIFF
--- a/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
+++ b/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
@@ -25,3 +25,9 @@ extern "C" void llvm___aie___lock___acquire___reg(unsigned id, unsigned val) {
 extern "C" void llvm___aie___lock___release___reg(unsigned id, unsigned val) {
   release(id, val);
 }
+extern "C" void llvm___aie___event0() {
+  event0();
+}
+extern "C" void llvm___aie___event1() {
+  event1();
+}

--- a/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
+++ b/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
@@ -25,9 +25,5 @@ extern "C" void llvm___aie___lock___acquire___reg(unsigned id, unsigned val) {
 extern "C" void llvm___aie___lock___release___reg(unsigned id, unsigned val) {
   release(id, val);
 }
-extern "C" void llvm___aie___event0() {
-  event0();
-}
-extern "C" void llvm___aie___event1() {
-  event1();
-}
+extern "C" void llvm___aie___event0() { event0(); }
+extern "C" void llvm___aie___event1() { event1(); }

--- a/aie_runtime_lib/AIE2/chess_intrinsic_wrapper.cpp
+++ b/aie_runtime_lib/AIE2/chess_intrinsic_wrapper.cpp
@@ -25,3 +25,9 @@ extern "C" void llvm___aie___lock___acquire___reg(unsigned id, unsigned val) {
 extern "C" void llvm___aie___lock___release___reg(unsigned id, unsigned val) {
   release(id, val);
 }
+extern "C" void llvm___aie___event0() {
+  event0();
+}
+extern "C" void llvm___aie___event1() {
+  event1();
+}

--- a/aie_runtime_lib/AIE2/chess_intrinsic_wrapper.cpp
+++ b/aie_runtime_lib/AIE2/chess_intrinsic_wrapper.cpp
@@ -25,9 +25,5 @@ extern "C" void llvm___aie___lock___acquire___reg(unsigned id, unsigned val) {
 extern "C" void llvm___aie___lock___release___reg(unsigned id, unsigned val) {
   release(id, val);
 }
-extern "C" void llvm___aie___event0() {
-  event0();
-}
-extern "C" void llvm___aie___event1() {
-  event1();
-}
+extern "C" void llvm___aie___event0() { event0(); }
+extern "C" void llvm___aie___event1() { event1(); }

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -1263,6 +1263,17 @@ def AIE_ExternalBufferOp: AIE_Op<"external_buffer", []>, Results<(outs AnyMemRef
   }];
 }
 
+def AIE_EventOp: AIE_Op<"event", []> {
+  let summary = "Event instruction";
+  let description = [{
+    Event instruction.
+  }];
+  let arguments = (ins ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<1>]>:$val);
+  let results = (outs);
+  let assemblyFormat = [{
+    `(` $val `)` attr-dict
+  }];
+}
 
 def AIE_GetStreamOp: AIE_Op<"getStream", [HasParent<"CoreOp">]>,
                  Results<(outs AnyTypeOf<[F32, I32, I<128>]>)> {

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -348,8 +348,8 @@ struct AIEEventOpToStdLowering : public OpConversionPattern<EventOp> {
     auto eventFunc = module.lookupSymbol<func::FuncOp>(funcName);
     if (!eventFunc)
       return module.emitOpError("Could not find the intrinsic function!");
-    auto eventCall = rewriter.create<func::CallOp>(rewriter.getUnknownLoc(),
-                                                   eventFunc, ValueRange({}));
+    rewriter.create<func::CallOp>(rewriter.getUnknownLoc(), eventFunc,
+                                  ValueRange({}));
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -338,7 +338,7 @@ struct AIEEventOpToStdLowering : public OpConversionPattern<EventOp> {
   ModuleOp &module;
 
   AIEEventOpToStdLowering(MLIRContext *context, ModuleOp &m,
-                             PatternBenefit benefit = 1)
+                          PatternBenefit benefit = 1)
       : OpConversionPattern<EventOp>(context, benefit), module(m) {}
 
   LogicalResult
@@ -349,7 +349,7 @@ struct AIEEventOpToStdLowering : public OpConversionPattern<EventOp> {
     if (!eventFunc)
       return module.emitOpError("Could not find the intrinsic function!");
     auto eventCall = rewriter.create<func::CallOp>(rewriter.getUnknownLoc(),
-                                                    eventFunc, ValueRange({}));
+                                                   eventFunc, ValueRange({}));
     rewriter.eraseOp(op);
     return success();
   }
@@ -413,16 +413,14 @@ struct AIECoreToStandardPass
 
     // llvm.func @llvm.aie.event0() -> ()
     builder
-        .create<func::FuncOp>(
-            builder.getUnknownLoc(), "llvm.aie.event0",
-            FunctionType::get(builder.getContext(), {}, {}))
+        .create<func::FuncOp>(builder.getUnknownLoc(), "llvm.aie.event0",
+                              FunctionType::get(builder.getContext(), {}, {}))
         .setPrivate();
 
     // llvm.func @llvm.aie.event1() -> ()
     builder
-        .create<func::FuncOp>(
-            builder.getUnknownLoc(), "llvm.aie.event1",
-            FunctionType::get(builder.getContext(), {}, {}))
+        .create<func::FuncOp>(builder.getUnknownLoc(), "llvm.aie.event1",
+                              FunctionType::get(builder.getContext(), {}, {}))
         .setPrivate();
 
     // llvm.func @llvm.aie.put.ms(%channel: !llvm.i1, %stream_val: !llvm.i32) ->
@@ -514,8 +512,7 @@ struct AIECoreToStandardPass
     patterns.add<AIEPutStreamToStdLowering, AIEGetStreamToStdLowering,
                  AIEPutCascadeToStdLowering, AIEGetCascadeToStdLowering,
                  AIEDebugOpToStdLowering, AIEUseLockToStdLowering,
-                 AIEEventOpToStdLowering>(
-        m.getContext(), m);
+                 AIEEventOpToStdLowering>(m.getContext(), m);
 
     patterns.add<AIEBufferToStandard>(m.getContext(), m, mapper);
     patterns.add<AIECoreToStandardFunc>(m.getContext(), m, mapper,

--- a/test/lower-to-standard/lower_event.mlir
+++ b/test/lower-to-standard/lower_event.mlir
@@ -1,0 +1,24 @@
+//===- lower_event.mlir ----------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-standard-lowering %s | FileCheck %s
+
+// CHECK: call @llvm.aie.event0()
+// CHECK: call @llvm.aie.event1()
+module @test {
+ AIE.device(xcvc1902) {
+  %tile11 = AIE.tile(1, 1)
+  %core11 = AIE.core(%tile11) {
+    AIE.event(0)
+    AIE.event(1)
+    AIE.end
+  }
+ }
+}


### PR DESCRIPTION
Add `AIE.event(N)` operation. `N` can be 0 or 1. This lowers to AIE core's event instruction.