### PR TITLE
Update chess_intrinsic_wrapper.cpp

### DIFF
--- a/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
+++ b/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
@@ -25,5 +25,3 @@ extern "C" void llvm___aie___lock___acquire___reg(unsigned id, unsigned val) {
 extern "C" void llvm___aie___lock___release___reg(unsigned id, unsigned val) {
   release(id, val);
 }
-extern "C" void llvm___aie___event0() { event0(); }
-extern "C" void llvm___aie___event1() { event1(); }


### PR DESCRIPTION
Remove event intrinsic declarations from AIEv1 wrapper

These were added in https://github.com/Xilinx/mlir-aie/pull/591 but seem to be causing compiler crashes when targeting AIE1, so removing for now.