### PR TITLE
Use correct macros for C API

### DIFF
--- a/include/aie-c/Registration.h
+++ b/include/aie-c/Registration.h
@@ -17,10 +17,10 @@ extern "C" {
 /** Registers all AIE dialects with a context.
  * This is needed before creating IR for these Dialects.
  */
-void aieRegisterAllDialects(MlirContext context);
+MLIR_CAPI_EXPORTED void aieRegisterAllDialects(MlirContext context);
 
 /** Registers all AIE passes for symbolic access with the global registry. */
-void aieRegisterAllPasses();
+MLIR_CAPI_EXPORTED void aieRegisterAllPasses();
 
 #ifdef __cplusplus
 }

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,21 +1,12 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_mlir_library(AIECAPI
+add_mlir_public_c_api_library(AIECAPI
 Dialects.cpp
 Registration.cpp
-
-DEPENDS
-
-ENABLE_AGGREGATION
-LINK_COMPONENTS
-Core
 
 LINK_LIBS PUBLIC
 AIE
 ADF
 MLIRAIEVec
-#AIEInitAll
-MLIRIR
-MLIRSupport
 )

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-add_mlir_public_c_api_library(AIECAPI
-Dialects.cpp
-Registration.cpp
+add_mlir_public_c_api_library(
+  AIECAPI
+  Dialects.cpp
+  Registration.cpp
 
-LINK_LIBS PUBLIC
-AIE
-ADF
-MLIRAIEVec
-)
+  LINK_LIBS PUBLIC
+  AIE
+  ADF
+  MLIRAIEVec)


### PR DESCRIPTION
This PR uses the correct upstream CMake macros for building the C API (as well as the correct C export macros).

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-aie/releases) and [here](https://github.com/makslevental/mlir-aie/actions/runs/6058763625).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
