### PR TITLE
Use upstream CMake macros to find python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,10 @@ if(AIE_INCLUDE_DOCS)
   add_dependencies(docs mlir-doc)
 endif()
 
+# setup python
+include(MLIRDetectPythonEnv)
+mlir_configure_python_dev_packages()
+
 # python install directory
 if(NOT AIE_PYTHON_PACKAGES_DIR)
   set(AIE_PYTHON_PACKAGES_DIR "${CMAKE_CURRENT_BINARY_DIR}/python")
@@ -156,10 +160,6 @@ endif()
 if(NOT AIE_PYTHON_INSTALL_DIR)
   set(AIE_PYTHON_INSTALL_DIR "python")
 endif()
-
-# setup python
-include(MLIRDetectPythonEnv)
-mlir_configure_python_dev_packages()
 
 add_subdirectory(include)
 add_subdirectory(lib)
@@ -173,7 +173,7 @@ add_subdirectory(tools)
 
 if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   install(
-    DIRECTORY include/aie
+    DIRECTORY include/aie include/aie-c
     DESTINATION include
     COMPONENT aie-headers
     FILES_MATCHING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ set(AIE_TOOLS_BINARY_DIR ${AIE_BINARY_DIR}/bin)
 find_package(Vitis 2022.2 COMPONENTS AIE AIE2)
 configure_file(./utils/vitisVariables.config.in
                ${CMAKE_BINARY_DIR}/utils/vitisVariables.config @ONLY)
-find_package(Python3 COMPONENTS Interpreter)
 
 # Set up default Vitis Sysroot as sysroot when testing on aarch64
 list(FIND AIE_RUNTIME_TARGETS "aarch64" indexAarch64)
@@ -159,13 +158,8 @@ if(NOT AIE_PYTHON_INSTALL_DIR)
 endif()
 
 # setup python
-find_package(
-  Python3
-  COMPONENTS Interpreter Development
-  REQUIRED)
 include(MLIRDetectPythonEnv)
-mlir_detect_pybind11_install()
-find_package(pybind11 2.6 REQUIRED)
+mlir_configure_python_dev_packages()
 
 add_subdirectory(include)
 add_subdirectory(lib)


### PR DESCRIPTION
This PR uses the upstream CMake macros (which are more robust in various CI environment) to find python and pybind.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-aie/releases) and [here](https://github.com/makslevental/mlir-aie/actions/runs/6058763625).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
