### PR TITLE
Re-export MLIR target set in CMake

### DIFF
--- a/cmake/modules/AIEConfig.cmake.in
+++ b/cmake/modules/AIEConfig.cmake.in
@@ -25,6 +25,7 @@ set(AIE_LibXAIE_aarch64_DIR "@AIE_CONFIG_LibXAIE_aarch64_DIR@")
 
 # Provide all our library targets to users.
 include("@AIE_CONFIG_EXPORTS_FILE@")
+include("@MLIR_CONFIG_INCLUDE_EXPORTS_FILE@")
 
 if(NOT TARGET aiecc.py)
   add_custom_target(aiecc.py)

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -62,6 +62,7 @@ set(AIE_CONFIG_INCLUDE_DIRS
   "\${AIE_INSTALL_PREFIX}/include"
   )
 set(AIE_CONFIG_EXPORTS_FILE "\${AIE_CMAKE_DIR}/AIETargets.cmake")
+set(MLIR_CONFIG_INCLUDE_EXPORTS_FILE "\${AIE_CMAKE_DIR}/MLIRTargets.cmake")
 set(AIE_CONFIG_LibXAIE_x86_64_DIR)
 if ("x86_64" IN_LIST AIE_RUNTIME_TARGETS)
   set(AIE_CONFIG_LibXAIE_x86_64_DIR "\${AIE_INSTALL_PREFIX}/runtime_lib/x86_64/xaiengine")
@@ -87,6 +88,8 @@ set(AIE_CONFIG_LibXAIE_aarch64_DIR)
 
 # export targets for the install directory
 install(EXPORT AIETargets DESTINATION ${AIE_INSTALL_PACKAGE_DIR}
+        COMPONENT aie-cmake-exports)
+install(EXPORT MLIRTargets DESTINATION ${AIE_INSTALL_PACKAGE_DIR}
         COMPONENT aie-cmake-exports)
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIEConfig.cmake

--- a/cmake/modules/CMakeLists.txt
+++ b/cmake/modules/CMakeLists.txt
@@ -3,12 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2021 Xilinx Inc.
-# (c) Copyright 2023 Advanced Micro Devices Inc.
+# (c) Copyright 2021 Xilinx Inc. (c) Copyright 2023 Advanced Micro Devices Inc.
 
-# Generate a list of CMake library targets so that other CMake projects can
-# link against them. LLVM calls its version of this file LLVMExports.cmake, but
-# the usual CMake convention seems to be ${Project}Targets.cmake.
+# Generate a list of CMake library targets so that other CMake projects can link
+# against them. LLVM calls its version of this file LLVMExports.cmake, but the
+# usual CMake convention seems to be ${Project}Targets.cmake.
 
 set(AIE_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/aie)
 set(aie_cmake_builddir "${CMAKE_BINARY_DIR}/${AIE_INSTALL_PACKAGE_DIR}")
@@ -20,23 +19,21 @@ export(EXPORT AIETargets FILE ${aie_cmake_builddir}/AIETargets.cmake)
 set(AIE_CONFIG_CMAKE_DIR "${aie_cmake_builddir}")
 set(AIE_CONFIG_BINARY_DIR "${PROJECT_BINARY_DIR}")
 set(AIE_CONFIG_TOOLS_BINARY_DIR "${PROJECT_BINARY_DIR}/bin")
-set(AIE_CONFIG_INCLUDE_DIRS
-  "${PROJECT_SOURCE_DIR}/include"
-  "${PROJECT_BINARY_DIR}/include"
-  )
+set(AIE_CONFIG_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include"
+                            "${PROJECT_BINARY_DIR}/include")
 set(AIE_CONFIG_EXPORTS_FILE "\${AIE_CMAKE_DIR}/AIETargets.cmake")
 set(AIE_CONFIG_LibXAIE_x86_64_DIR)
-if ("x86_64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_x86_64_DIR "${PROJECT_BINARY_DIR}/runtime_lib/x86_64/xaiengine")
+if("x86_64" IN_LIST AIE_RUNTIME_TARGETS)
+  set(AIE_CONFIG_LibXAIE_x86_64_DIR
+      "${PROJECT_BINARY_DIR}/runtime_lib/x86_64/xaiengine")
 endif()
 set(AIE_CONFIG_LibXAIE_aarch64_DIR)
-if ("aarch64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_aarch64_DIR "${PROJECT_BINARY_DIR}/runtime_lib/aarch64/xaiengine")
+if("aarch64" IN_LIST AIE_RUNTIME_TARGETS)
+  set(AIE_CONFIG_LibXAIE_aarch64_DIR
+      "${PROJECT_BINARY_DIR}/runtime_lib/aarch64/xaiengine")
 endif()
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/AIEConfig.cmake.in
-  ${aie_cmake_builddir}/AIEConfig.cmake
-  @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AIEConfig.cmake.in
+               ${aie_cmake_builddir}/AIEConfig.cmake @ONLY)
 set(AIE_CONFIG_CMAKE_DIR)
 set(AIE_CONFIG_BINARY_DIR)
 set(AIE_CONFIG_TOOLS_BINARY_DIR)
@@ -44,11 +41,13 @@ set(AIE_CONFIG_INCLUDE_DIRS)
 set(AIE_CONFIG_EXPORTS_FILE)
 
 # Generate AIEConfig.cmake for the install tree.
-set(AIE_CONFIG_CODE "
+set(AIE_CONFIG_CODE
+    "
 # Compute the installation prefix from this file location.
-get_filename_component(AIE_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)")
-# Construct the proper number of get_filename_component(... PATH)
-# calls to compute the installation prefix.
+get_filename_component(AIE_INSTALL_PREFIX \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)"
+)
+# Construct the proper number of get_filename_component(... PATH) calls to
+# compute the installation prefix.
 string(REGEX REPLACE "/" ";" _count "${AIE_INSTALL_PACKAGE_DIR}")
 foreach(p ${_count})
   set(AIE_CONFIG_CODE "${AIE_CONFIG_CODE}
@@ -58,24 +57,22 @@ endforeach(p)
 set(AIE_CONFIG_CMAKE_DIR "\${AIE_INSTALL_PREFIX}/${AIE_INSTALL_PACKAGE_DIR}")
 set(AIE_CONFIG_BINARY_DIR "\${AIE_INSTALL_PREFIX}")
 set(AIE_CONFIG_TOOLS_BINARY_DIR "\${AIE_INSTALL_PREFIX}/bin")
-set(AIE_CONFIG_INCLUDE_DIRS
-  "\${AIE_INSTALL_PREFIX}/include"
-  )
+set(AIE_CONFIG_INCLUDE_DIRS "\${AIE_INSTALL_PREFIX}/include")
 set(AIE_CONFIG_EXPORTS_FILE "\${AIE_CMAKE_DIR}/AIETargets.cmake")
 set(MLIR_CONFIG_INCLUDE_EXPORTS_FILE "\${AIE_CMAKE_DIR}/MLIRTargets.cmake")
 set(AIE_CONFIG_LibXAIE_x86_64_DIR)
-if ("x86_64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_x86_64_DIR "\${AIE_INSTALL_PREFIX}/runtime_lib/x86_64/xaiengine")
+if("x86_64" IN_LIST AIE_RUNTIME_TARGETS)
+  set(AIE_CONFIG_LibXAIE_x86_64_DIR
+      "\${AIE_INSTALL_PREFIX}/runtime_lib/x86_64/xaiengine")
 endif()
 set(AIE_CONFIG_LibXAIE_aarch64_DIR)
-if ("aarch64" IN_LIST AIE_RUNTIME_TARGETS)
-  set(AIE_CONFIG_LibXAIE_aarch64_DIR "\${AIE_INSTALL_PREFIX}/runtime_lib/aarch64/xaiengine")
+if("aarch64" IN_LIST AIE_RUNTIME_TARGETS)
+  set(AIE_CONFIG_LibXAIE_aarch64_DIR
+      "\${AIE_INSTALL_PREFIX}/runtime_lib/aarch64/xaiengine")
 endif()
 
-configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/AIEConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIEConfig.cmake
-  @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/AIEConfig.cmake.in
+               ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIEConfig.cmake @ONLY)
 set(AIE_CONFIG_CODE)
 set(AIE_CONFIG_CMAKE_DIR)
 set(AIE_CONFIG_BINARY_DIR)
@@ -85,13 +82,16 @@ set(AIE_CONFIG_EXPORTS_FILE)
 set(AIE_CONFIG_LibXAIE_x86_64_DIR)
 set(AIE_CONFIG_LibXAIE_aarch64_DIR)
 
-
 # export targets for the install directory
-install(EXPORT AIETargets DESTINATION ${AIE_INSTALL_PACKAGE_DIR}
-        COMPONENT aie-cmake-exports)
-install(EXPORT MLIRTargets DESTINATION ${AIE_INSTALL_PACKAGE_DIR}
-        COMPONENT aie-cmake-exports)
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIEConfig.cmake
+install(
+  EXPORT AIETargets
+  DESTINATION ${AIE_INSTALL_PACKAGE_DIR}
+  COMPONENT aie-cmake-exports)
+install(
+  EXPORT MLIRTargets
+  DESTINATION ${AIE_INSTALL_PACKAGE_DIR}
+  COMPONENT aie-cmake-exports)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/AIEConfig.cmake
   DESTINATION ${AIE_INSTALL_PACKAGE_DIR}
   COMPONENT aie-cmake-exports)


### PR DESCRIPTION
This PR adds a re-export of targets registered with the MLIR library target set (by `add_mlir_library`) so that they can be imported by downstream users.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-aie/releases) and [here](https://github.com/makslevental/mlir-aie/actions/runs/6058763625).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
