### PR TITLE
Don't build `aie-reset` on windows

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,6 +7,8 @@
 
 add_subdirectory(aiecc)
 add_subdirectory(aie-opt)
-add_subdirectory(aie-reset)
+if(NOT WIN32)
+  add_subdirectory(aie-reset)
+endif()
 add_subdirectory(aie-translate)
 add_subdirectory(chess-clang)


### PR DESCRIPTION
This PR disables building `aie-reset` on windows since it uses `mmap` through `<sys/mman.h>` which is not available as a windows API (as far as I can tell). A longer term solution is required.

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-aie/releases) and [here](https://github.com/makslevental/mlir-aie/actions/runs/6058763625).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
