### PR TITLE
Disable `-Wno-unknown-warning-option` on windows

### DIFF
--- a/lib/Dialect/AIE/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIE/Transforms/CMakeLists.txt
@@ -6,7 +6,9 @@
 # (c) Copyright 2021 Xilinx Inc.
 
 
-add_compile_options(-Wno-unknown-warning-option)
+if(NOT WIN32)
+  add_compile_options(-Wno-unknown-warning-option)
+endif()
 add_mlir_dialect_library(AIETransforms
   AIEAssignBuffers.cpp
   AIEAssignLockIDs.cpp

--- a/lib/Dialect/AIE/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIE/Transforms/CMakeLists.txt
@@ -5,11 +5,12 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
-
 if(NOT WIN32)
   add_compile_options(-Wno-unknown-warning-option)
 endif()
-add_mlir_dialect_library(AIETransforms
+
+add_mlir_dialect_library(
+  AIETransforms
   AIEAssignBuffers.cpp
   AIEAssignLockIDs.cpp
   AIEFindFlows.cpp
@@ -37,5 +38,4 @@ add_mlir_dialect_library(AIETransforms
   MLIRIR
   MLIRPass
   MLIRSupport
-  MLIRTransformUtils
-  )
+  MLIRTransformUtils)


### PR DESCRIPTION
This PR disables `-Wno-unknown-warning-option` on windows as this flag is unrecognized by MSVC (and halts build).

This PR is part of a series of fixes/patches/refactorings that enable distribution as a python wheel. See [here](https://github.com/makslevental/mlir-aie/releases) and [here](https://github.com/makslevental/mlir-aie/actions/runs/6058763625).
This PR consists of two commits - the first commit is the substantive change and the second is a reformat of all touched files. The substantive commit can be selected (in the `Files changed` tab) like this:

<img width="400" alt="image" src="https://github.com/Xilinx/mlir-air/assets/5657668/9c8b7792-5dce-4450-b477-7262cb1d7db0">
