### PR TITLE
Enable use of mlir pass manager in aiecc

### DIFF
--- a/include/aie-c/Dialects.h
+++ b/include/aie-c/Dialects.h
@@ -15,6 +15,8 @@ extern "C" {
 #endif
 
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIE, aie);
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIEVec, aievec);
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIEX, aiex);
 
 //===---------------------------------------------------------------------===//
 // ObjectFifoType

--- a/include/aie/InitialAllDialect.h
+++ b/include/aie/InitialAllDialect.h
@@ -17,6 +17,8 @@
 #include "aie/Dialect/ADF/ADFDialect.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+
 #include "mlir/IR/Dialect.h"
 
 namespace xilinx {
@@ -27,7 +29,8 @@ inline void registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<
     ADF::ADFDialect,
     aievec::AIEVecDialect,
-    AIE::AIEDialect
+    AIE::AIEDialect,
+    AIEX::AIEXDialect
   >();
   // clang-format on
 }

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -8,5 +8,12 @@ add_mlir_public_c_api_library(
 
   LINK_LIBS PUBLIC
   AIE
+  AIEX
   ADF
-  MLIRAIEVec)
+  MLIRAIEVec
+  AIETransforms
+  AIEUtils
+  MLIRAIEVecTransforms
+  MLIRAIEVecUtils
+  AIEXTransforms
+  AIEXUtils)

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -8,9 +8,14 @@
 #include "aie-c/Dialects.h"
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+
 #include "mlir/CAPI/Registration.h"
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIE, aie, xilinx::AIE::AIEDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIEX, aiex, xilinx::AIEX::AIEXDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIEVec, aievec, xilinx::aievec::AIEVecDialect)
 
 //===---------------------------------------------------------------------===//
 // ObjectFifoType

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -15,7 +15,8 @@
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIE, aie, xilinx::AIE::AIEDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIEX, aiex, xilinx::AIEX::AIEXDialect)
-MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIEVec, aievec, xilinx::aievec::AIEVecDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIEVec, aievec,
+                                      xilinx::aievec::AIEVecDialect)
 
 //===---------------------------------------------------------------------===//
 // ObjectFifoType

--- a/lib/CAPI/Registration.cpp
+++ b/lib/CAPI/Registration.cpp
@@ -6,10 +6,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "aie-c/Registration.h"
+
 #include "aie/InitialAllDialect.h"
 
+#include "aie/Dialect/AIEVec/Analysis/Passes.h"
+#include "aie/Dialect/AIEVec/Pipelines/Passes.h"
+#include "aie/Dialect/AIEVec/Transforms/Passes.h"
+
 #include "mlir/CAPI/IR.h"
-// #include "mlir/InitAllPasses.h"
 
 void aieRegisterAllDialects(MlirContext context) {
   mlir::DialectRegistry registry;
@@ -17,5 +21,9 @@ void aieRegisterAllDialects(MlirContext context) {
 }
 
 void aieRegisterAllPasses() {
-  // xilinx::AIE::registerAllPasses();
+  xilinx::AIE::registerAIEPasses();
+  xilinx::AIEX::registerAIEXPasses();
+  xilinx::aievec::registerAIEVecAnalysisPasses();
+  xilinx::aievec::registerAIEVecPasses();
+  xilinx::aievec::registerAIEVecPipelines();
 }

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -15,7 +15,7 @@ using namespace mlir::python::adaptors;
 
 PYBIND11_MODULE(_aieMlir, m) {
 
-  //::aieRegisterAllPasses();
+  ::aieRegisterAllPasses();
 
   m.doc() = R"pbdoc(
     AIE MLIR Python bindings
@@ -30,10 +30,16 @@ PYBIND11_MODULE(_aieMlir, m) {
   m.def(
       "register_dialect",
       [](MlirContext context, bool load) {
-        MlirDialectHandle handle = mlirGetDialectHandle__aie__();
-        mlirDialectHandleRegisterDialect(handle, context);
+        MlirDialectHandle aie_handle = mlirGetDialectHandle__aie__();
+        mlirDialectHandleRegisterDialect(aie_handle, context);
+        MlirDialectHandle aiex_handle = mlirGetDialectHandle__aiex__();
+        mlirDialectHandleRegisterDialect(aiex_handle, context);
+        MlirDialectHandle aievec_handle = mlirGetDialectHandle__aievec__();
+        mlirDialectHandleRegisterDialect(aievec_handle, context);
         if (load) {
-          mlirDialectHandleLoadDialect(handle, context);
+          mlirDialectHandleLoadDialect(aie_handle, context);
+          mlirDialectHandleLoadDialect(aiex_handle, context);
+          mlirDialectHandleLoadDialect(aievec_handle, context);
         }
       },
       py::arg("context"), py::arg("load") = true);
@@ -47,8 +53,6 @@ PYBIND11_MODULE(_aieMlir, m) {
           },
           "Get an instance of ObjectFifoType with given element type.",
           py::arg("self"), py::arg("type") = py::none());
-
-  // m.def("_register_all_passes", ::aieRegisterAllPasses);
 
   m.attr("__version__") = "dev";
 }

--- a/test/dialect/AIE/badbuffer-ve2802.mlir
+++ b/test/dialect/AIE/badbuffer-ve2802.mlir
@@ -10,7 +10,7 @@
 
 // RUN: not aiecc.py %s |& FileCheck %s
 // Row 2 is a memtile, not a coretile.
-// CHECK: error: 'AIE.buffer' op in Column 1 and Row 2 is accessed from an unreachable tile in Column 1 and Row 3
+// CHECK: error{{.*}}'AIE.buffer' op in Column 1 and Row 2 is accessed from an unreachable tile in Column 1 and Row 3
 
 module @test {
  AIE.device(xcve2802) {

--- a/test/dialect/AIE/badbuffer.mlir
+++ b/test/dialect/AIE/badbuffer.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.buffer' op in Column 1 and Row 1 is accessed from an unreachable tile in Column 4 and Row 4
+// CHECK: error{{.*}}'AIE.buffer' op in Column 1 and Row 1 is accessed from an unreachable tile in Column 4 and Row 4
 
 module @test {
   %t1 = AIE.tile(1, 1)

--- a/test/dialect/AIE/badconnect.mlir
+++ b/test/dialect/AIE/badconnect.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.connect' op source index cannot be less than zero
+// CHECK: error{{.*}} 'AIE.connect' op source index cannot be less than zero
 
 module {
   %20 = AIE.tile(2, 0)

--- a/test/dialect/AIE/badcore.mlir
+++ b/test/dialect/AIE/badcore.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.core' op failed to verify that op exists in a core tile
+// CHECK: error{{.*}}'AIE.core' op failed to verify that op exists in a core tile
 
 module @test {
   %t1 = AIE.tile(4, 0)

--- a/test/dialect/AIE/badcore2.mlir
+++ b/test/dialect/AIE/badcore2.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.core' op failed to verify that op exists in a core tile
+// CHECK: error{{.*}}'AIE.core' op failed to verify that op exists in a core tile
 
 module @test {
   AIE.device(xcve2802) {

--- a/test/dialect/AIE/badlock-vc1902.mlir
+++ b/test/dialect/AIE/badlock-vc1902.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.lock' op lock assigned invalid id (maximum is 15)
+// CHECK: error{{.*}}'AIE.lock' op lock assigned invalid id (maximum is 15)
 module @test {
   %t1 = AIE.tile(1, 1)
   %lock = AIE.lock(%t1, 16) { sym_name = "lock1" }

--- a/test/dialect/AIE/badlock-ve2802.mlir
+++ b/test/dialect/AIE/badlock-ve2802.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.lock' op lock assigned invalid id (maximum is 63)
+// CHECK: error{{.*}}'AIE.lock' op lock assigned invalid id (maximum is 63)
 module @test {
   AIE.device(xcve2802) {
     %t1 = AIE.tile(1, 1)

--- a/test/dialect/AIE/badlockdma.mlir
+++ b/test/dialect/AIE/badlockdma.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.lock' op in Column 4 and Row 4 is accessed from an unreachable tile in Column 1 and Row 1
+// CHECK: error{{.*}}'AIE.lock' op in Column 4 and Row 4 is accessed from an unreachable tile in Column 1 and Row 1
 module @test {
   %t1 = AIE.tile(1, 1)
   %t2 = AIE.tile(4, 4)

--- a/test/dialect/AIE/badlockfunc.mlir
+++ b/test/dialect/AIE/badlockfunc.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.lock' op is accessed outside of a tile
+// CHECK: error{{.*}}'AIE.lock' op is accessed outside of a tile
 module @test {
   %t1 = AIE.tile(1, 1)
   %t2 = AIE.tile(4, 4)

--- a/test/dialect/AIE/badmemtiledma_channel4buffer.mlir
+++ b/test/dialect/AIE/badmemtiledma_channel4buffer.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt --canonicalize %s |& FileCheck %s
-// CHECK:  error: 'AIE.dmaBd' op is reachable from DMA channel 4 and attempts to access a non-local buffer
+// CHECK:  error{{.*}}'AIE.dmaBd' op is reachable from DMA channel 4 and attempts to access a non-local buffer
 // CHECK: note: channel
 // CHECK:     AIE.dmaStart("MM2S", 4, ^bd1, ^dma1)
 // CHECK: note: buffer

--- a/test/dialect/AIE/badmemtiledma_channel4lock.mlir
+++ b/test/dialect/AIE/badmemtiledma_channel4lock.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt --canonicalize %s |& FileCheck %s
-// CHECK: error: 'AIE.useLock' op is reachable from DMA channel 4 and attempts to access a non-local lock
+// CHECK: error{{.*}}'AIE.useLock' op is reachable from DMA channel 4 and attempts to access a non-local lock
 // CHECK: note: channel
 // CHECK:     AIE.dmaStart("MM2S", 4, ^bd0, ^dma1)
 // CHECK: note: lock

--- a/test/dialect/AIE/badmemtiledma_neighboraccess.mlir
+++ b/test/dialect/AIE/badmemtiledma_neighboraccess.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.buffer' op in Column 3 and Row 1 is accessed from an unreachable tile in Column 1 and Row 1
+// CHECK: error{{.*}}'AIE.buffer' op in Column 3 and Row 1 is accessed from an unreachable tile in Column 1 and Row 1
 
 // memtiles can only access neighboring memtiles
 

--- a/test/dialect/AIE/badswitchbox_memtile_nofifo-ve2802.mlir
+++ b/test/dialect/AIE/badswitchbox_memtile_nofifo-ve2802.mlir
@@ -10,7 +10,7 @@
 
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.connect' op source bundle FIFO not supported
+// CHECK: error{{.*}}'AIE.connect' op source bundle FIFO not supported
 
 module {
   AIE.device(xcve2802) {

--- a/test/dialect/AIE/badswitchbox_shimtile_nodma-ve2802.mlir
+++ b/test/dialect/AIE/badswitchbox_shimtile_nodma-ve2802.mlir
@@ -10,7 +10,7 @@
 
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.connect' op source bundle DMA not supported
+// CHECK: error{{.*}}'AIE.connect' op source bundle DMA not supported
 
 module {
   AIE.device(xcve2802) {

--- a/test/dialect/AIE/badtile-ve2802.mlir
+++ b/test/dialect/AIE/badtile-ve2802.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.tile' op column index (50) must be less than the number of columns in the device (38)
+// CHECK: error{{.*}}'AIE.tile' op column index (50) must be less than the number of columns in the device (38)
 
 module @test {
  AIE.device(xcve2802) {

--- a/test/dialect/AIE/badtile.mlir
+++ b/test/dialect/AIE/badtile.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.tile' op attribute 'col' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 0
+// CHECK: error{{.*}}'AIE.tile' op attribute 'col' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 0
 
 module @test {
   %t1 = AIE.tile(-1, -1)

--- a/test/dialect/AIE/badtile2.mlir
+++ b/test/dialect/AIE/badtile2.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.tile' op column index (50) must be less than the number of columns in the device (50)
+// CHECK: error{{.*}}'AIE.tile' op column index (50) must be less than the number of columns in the device (50)
 
 module @test {
   %t1 = AIE.tile(50, 50)

--- a/test/dialect/AIE/badtiledma.mlir
+++ b/test/dialect/AIE/badtiledma.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.useLock' op used in a DMA block that have multiple locks.
+// CHECK: error{{.*}}'AIE.useLock' op used in a DMA block that have multiple locks.
 
 module @test {
     %t63 = AIE.tile(6, 3)

--- a/test/dialect/AIE/badtiledma2.mlir
+++ b/test/dialect/AIE/badtiledma2.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.dmaBd' op can only access a buffer in the same tile.
+// CHECK: error{{.*}}'AIE.dmaBd' op can only access a buffer in the same tile.
 
 module @test {
     %t63 = AIE.tile(6, 3)

--- a/test/dialect/AIE/badtiledma3.mlir
+++ b/test/dialect/AIE/badtiledma3.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aiecc.py %s |& FileCheck %s
-// CHECK: error: 'AIE.useLock' op can only access a lock in the same tile
+// CHECK: error{{.*}}'AIE.useLock' op can only access a lock in the same tile
 
 module @test {
     %t63 = AIE.tile(6, 3)

--- a/test/dialect/AIE/nd-dma-oob.mlir
+++ b/test/dialect/AIE/nd-dma-oob.mlir
@@ -25,7 +25,7 @@ module @tutorial_2b {
         %mem14 = AIE.mem(%tile14) {
           %srcDma = AIE.dmaStart("MM2S", 0, ^bd0, ^end)
           ^bd0:
-            // The following should generate an out-of-bounds error: the second
+            // The following should generate an out-of-bounds error{{.*}}the second
             // repetition of accessing array %buf14 with stride of 128 will
             // attempt an access at index 128, which is OOB for a 128xi32 
             // memref.

--- a/test/dialect/AIE/nd-dma-oob.mlir
+++ b/test/dialect/AIE/nd-dma-oob.mlir
@@ -25,7 +25,7 @@ module @tutorial_2b {
         %mem14 = AIE.mem(%tile14) {
           %srcDma = AIE.dmaStart("MM2S", 0, ^bd0, ^end)
           ^bd0:
-            // The following should generate an out-of-bounds error{{.*}}the second
+            // The following should generate an out-of-bounds error: the second
             // repetition of accessing array %buf14 with stride of 128 will
             // attempt an access at index 128, which is OOB for a 128xi32 
             // memref.


### PR DESCRIPTION
* add aievec and aiex to CAPI
* ensure passes are registered
* convert the first `aie-opt` in `aiecc` to use `PassManager` directly
