### PR TITLE
Refactor conversion of aievec.mul_elem to support combined precision

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -88,8 +88,8 @@ extractMACOperandsFromAddOperands(Value addLhs, Value addRhs) {
 }
 
 // Convert a input value to a target vector type. This function can insert
-// multiple aievec ops depends on the combination of input and output vector
-// type.
+// multiple aievec ops depending on the combination of input and output vector
+// types.
 static std::optional<Value>
 convertValueToTargetTypeAieML(ConversionPatternRewriter &rewriter, Location loc,
                               Value inputVal, VectorType tgtType) {
@@ -607,11 +607,11 @@ struct ConvertMulFToAIEVecMulElemOpPattern
     // Decide the accType for aievec.mul_elem based on mulOp's lhs & rhs
     auto lval = adaptor.getLhs();
     auto rval = adaptor.getRhs();
-    if (lval.getDefiningOp() && isa<arith::ExtFOp>(lval.getDefiningOp())) {
-      lval = lval.getDefiningOp()->getOperand(0);
+    if (auto lvalExtOp = lval.getDefiningOp<arith::ExtFOp>()) {
+      lval = lvalExtOp->getOperand(0);
     }
-    if (rval.getDefiningOp() && isa<arith::ExtFOp>(rval.getDefiningOp())) {
-      rval = rval.getDefiningOp()->getOperand(0);
+    if (auto rvalExtOp = rval.getDefiningOp<arith::ExtFOp>()) {
+      rval = rvalExtOp->getOperand(0);
     }
     VectorType lSrcType = cast<VectorType>(lval.getType());
     VectorType rSrcType = cast<VectorType>(rval.getType());
@@ -704,11 +704,11 @@ struct ConvertMulIToAIEVecMulElemOpPattern
     // Decide the accType for aievec.mul_elem based on mulOp's lhs & rhs
     auto lval = adaptor.getLhs();
     auto rval = adaptor.getRhs();
-    if (lval.getDefiningOp() && isa<arith::ExtSIOp>(lval.getDefiningOp())) {
-      lval = lval.getDefiningOp()->getOperand(0);
+    if (auto lvalExtOp = lval.getDefiningOp<arith::ExtSIOp>()) {
+      lval = lvalExtOp->getOperand(0);
     }
-    if (rval.getDefiningOp() && isa<arith::ExtSIOp>(rval.getDefiningOp())) {
-      rval = rval.getDefiningOp()->getOperand(0);
+    if (auto rvalExtOp = rval.getDefiningOp<arith::ExtSIOp>()) {
+      rval = rvalExtOp->getOperand(0);
     }
     VectorType lSrcType = cast<VectorType>(lval.getType());
     VectorType rSrcType = cast<VectorType>(rval.getType());

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -607,11 +607,11 @@ struct ConvertMulFToAIEVecMulElemOpPattern
     // Decide the accType for aievec.mul_elem based on mulOp's lhs & rhs
     auto lval = adaptor.getLhs();
     auto rval = adaptor.getRhs();
-    if (auto lhsExt = dyn_cast<arith::ExtFOp>(lval.getDefiningOp())) {
-      lval = lhsExt->getOperand(0);
+    if (lval.getDefiningOp() && isa<arith::ExtFOp>(lval.getDefiningOp())) {
+      lval = lval.getDefiningOp()->getOperand(0);
     }
-    if (auto rhsExt = dyn_cast<arith::ExtFOp>(rval.getDefiningOp())) {
-      rval = rhsExt->getOperand(0);
+    if (rval.getDefiningOp() && isa<arith::ExtFOp>(rval.getDefiningOp())) {
+      rval = rval.getDefiningOp()->getOperand(0);
     }
     VectorType lSrcType = cast<VectorType>(lval.getType());
     VectorType rSrcType = cast<VectorType>(rval.getType());
@@ -704,11 +704,11 @@ struct ConvertMulIToAIEVecMulElemOpPattern
     // Decide the accType for aievec.mul_elem based on mulOp's lhs & rhs
     auto lval = adaptor.getLhs();
     auto rval = adaptor.getRhs();
-    if (auto lhsExt = dyn_cast<arith::ExtSIOp>(lval.getDefiningOp())) {
-      lval = lhsExt->getOperand(0);
+    if (lval.getDefiningOp() && isa<arith::ExtSIOp>(lval.getDefiningOp())) {
+      lval = lval.getDefiningOp()->getOperand(0);
     }
-    if (auto rhsExt = dyn_cast<arith::ExtSIOp>(rval.getDefiningOp())) {
-      rval = rhsExt->getOperand(0);
+    if (rval.getDefiningOp() && isa<arith::ExtSIOp>(rval.getDefiningOp())) {
+      rval = rval.getDefiningOp()->getOperand(0);
     }
     VectorType lSrcType = cast<VectorType>(lval.getType());
     VectorType rSrcType = cast<VectorType>(rval.getType());

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -1566,7 +1566,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
   if (isa<FloatType>(resElemType) || (resBitWidth * resLaneSize == 1024))
     isAcc = true;
 
-  if (failed(emitter.emitAssignPrefix(*sub_elemOp, isAcc)))
+  if (failed(emitter.emitAssignPrefix(*sub_elemOp, /*isAcc=*/isAcc)))
     return failure();
 
   os << "sub(";

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -1499,7 +1499,16 @@ static LogicalResult printOperation(CppEmitter &emitter,
   raw_indented_ostream &os = emitter.ostream();
 
   // Generate the initialization for the result
-  if (failed(emitter.emitAssignPrefix(*add_elemOp, true)))
+  // FIXME: move the logic to the op creation and add isAcc to the op attribute
+  bool isAcc = false;
+  VectorType resType = cast<VectorType>(add_elemOp.getResult().getType());
+  auto resElemType = resType.getElementType();
+  unsigned resBitWidth = resElemType.getIntOrFloatBitWidth();
+  unsigned resLaneSize = getVectorLaneSize(resType);
+  if (isa<FloatType>(resElemType) || (resBitWidth * resLaneSize == 1024))
+    isAcc = true;
+
+  if (failed(emitter.emitAssignPrefix(*add_elemOp, /*isAcc=*/isAcc)))
     return failure();
 
   os << "add(";
@@ -1527,7 +1536,16 @@ static LogicalResult printOperation(CppEmitter &emitter,
   raw_indented_ostream &os = emitter.ostream();
 
   // Generate the initialization for the result
-  if (failed(emitter.emitAssignPrefix(*sub_elemOp, true)))
+  // FIXME: move the logic to the op creation and add isAcc to the op attribute
+  bool isAcc = false;
+  VectorType resType = cast<VectorType>(sub_elemOp.getResult().getType());
+  auto resElemType = resType.getElementType();
+  unsigned resBitWidth = resElemType.getIntOrFloatBitWidth();
+  unsigned resLaneSize = getVectorLaneSize(resType);
+  if (isa<FloatType>(resElemType) || (resBitWidth * resLaneSize == 1024))
+    isAcc = true;
+
+  if (failed(emitter.emitAssignPrefix(*sub_elemOp, isAcc)))
     return failure();
 
   os << "sub(";

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -679,6 +679,27 @@ static LogicalResult printOperation(CppEmitter &emitter,
   return success();
 }
 
+// Generate the unpack intrinsic for AIE-ML
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    aievec::UnpackOp unpackOp) {
+
+  // The source should have already been emitted
+  Value source = unpackOp.getSource();
+  if (!emitter.hasValueInScope(source))
+    return failure();
+
+  // Generate the initialization for the vector
+  if (failed(emitter.emitAssignPrefix(*unpackOp, /*isAcc=*/false)))
+    return failure();
+
+  raw_indented_ostream &os = emitter.ostream();
+
+  os << "unpack(";
+  os << emitter.getOrCreateName(source);
+  os << ")";
+  return success();
+}
+
 // Generate the srs intrinsic
 static LogicalResult printOperation(CppEmitter &emitter, aievec::SRSOp srsOp) {
   Value source = srsOp.getSource();
@@ -2928,7 +2949,7 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
                 aievec::BroadcastScalarOp, aievec::MulConvOp, aievec::FMAConvOp,
                 aievec::ShiftOp, aievec::ShuffleOp, aievec::CastOp,
                 aievec::MinOp, aievec::MaxOp, aievec::CmpOp, aievec::SelOp,
-                aievec::ExtElemOp>(
+                aievec::ExtElemOp, aievec::UnpackOp>(
               [&](auto op) { return printOperation(*this, op); })
           .Default([&](Operation *) {
             return op.emitOpError("unable to find printer for op");

--- a/test/Conversion/VectorToAIEVec/test_mul_elem.mlir
+++ b/test/Conversion/VectorToAIEVec/test_mul_elem.mlir
@@ -97,3 +97,44 @@ func.func @test_mul_elem_bf16_float(%a : vector<16xbf16>,
   %3 = arith.mulf %1, %2 : vector<16xf32>
   return %3 : vector<16xf32>
 }
+
+// CHECK-LABEL: func @test_i8_i16_mul_elem
+// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi8>
+// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi16>
+func.func @test_i8_i16_mul_elem(%a : vector<32xi8>, %b : vector<32xi16>) -> vector<32xi32> {
+  // CHECK: %[[UNPACK:.*]] = aievec.unpack %arg0 : vector<32xi8>, vector<32xi16>
+  // CHECK: %[[ME:.*]] = aievec.mul_elem %arg1, %[[UNPACK:.*]] : vector<32xi16>, vector<32xi16>, vector<32xi32>
+  // CHECK: %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+  %1 = arith.extsi %b : vector<32xi16> to vector<32xi32>
+  %2 = arith.extsi %a : vector<32xi8> to vector<32xi32>
+  %3 = arith.muli %1, %2 : vector<32xi32>
+  return %3 : vector<32xi32>
+}
+
+// CHECK-LABEL: func @test_i8_i32_mul_elem
+// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi8>
+// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+func.func @test_i8_i32_mul_elem(%a : vector<16xi8>, %b : vector<16xi32>) -> vector<16xi32> {
+  // CHECK: %[[CC:.*]] = aievec.concat %arg0, %arg0 : vector<16xi8>, vector<32xi8>
+  // CHECK: %[[UPS:.*]] = aievec.ups %[[CC]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
+  // CHECK: %[[CAST:.*]] = aievec.cast %[[UPS]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+  // CHECK: %[[EXT:.*]] = aievec.ext %[[CAST]] {index = 0 : i8} : vector<32xi32>, vector<16xi32>
+  // CHECK: %[[ME:.*]] = aievec.mul_elem %[[EXT]], %arg1 : vector<16xi32>, vector<16xi32>, vector<16xi64>
+  // CHECK: %[[SRS:.*]] = aievec.srs %[[ME]] {shift = 0 : i8} : vector<16xi64>, vector<16xi32>
+  %1 = arith.extsi %a : vector<16xi8> to vector<16xi32>
+  %2 = arith.muli %1, %b : vector<16xi32>
+  return %2 : vector<16xi32>
+}
+
+// CHECK-LABEL: func @test_i16_i32_mul_elem
+// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi16>
+// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+func.func @test_i16_i32_mul_elem(%a : vector<16xi16>, %b : vector<16xi32>) -> vector<16xi32> {
+  // CHECK: %[[UPS:.*]] = aievec.ups %arg0 {shift = 0 : i8} : vector<16xi16>, vector<16xi32>
+  // CHECK: %[[CAST:.*]] = aievec.cast %[[UPS]] {isResAcc = false} : vector<16xi32>, vector<16xi32>
+  // CHECK: %[[ME:.*]] = aievec.mul_elem %[[CAST]], %arg1 : vector<16xi32>, vector<16xi32>, vector<16xi64>
+  // CHECK: %[[SRS:.*]] = aievec.srs %[[ME]] {shift = 0 : i8} : vector<16xi64>, vector<16xi32>
+  %1 = arith.extsi %a : vector<16xi16> to vector<16xi32>
+  %2 = arith.muli %1, %b : vector<16xi32>
+  return %2 : vector<16xi32>
+}

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/defines.h
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/defines.h
@@ -1,0 +1,4 @@
+#pragma once
+constexpr unsigned const IN0_SIZE = 1024;
+constexpr unsigned const IN1_SIZE = 1024;
+constexpr unsigned const OUT0_SIZE = 1024;

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/dut.cc
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/dut.cc
@@ -1,0 +1,20 @@
+// clang-format off
+void dut(int16_t * restrict v1, int32_t * restrict v2, int32_t * restrict v3) {
+  size_t v4 = 0;
+  size_t v5 = 1024;
+  size_t v6 = 16;
+  for (size_t v7 = v4; v7 < v5; v7 += v6)
+  chess_prepare_for_pipelining
+  chess_loop_range(64, 64)
+  {
+    v16int16 v8 = *(v16int16 *)(v1 + v7);
+    v16int32 v9 = *(v16int32 *)(v2 + v7);
+    v16acc32 v10 = ups_to_v16acc32(v8, 0);
+    v16int32 v11 = v16int32(v10);
+    v16acc64 v12 = mul_elem_16_2(v9, broadcast_zero_s32(), v11, undef_v16int32());
+    v16int32 v13 = srs_to_v16int32(v12, 0);
+    *(v16int32 *)(v3 + v7) = v13;
+  }
+  return;
+}
+// clang-format on

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
-// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
 // RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine --debug-only=lower-vector-to-aievec -o aievec.mlir >& aie-opt.stdout
-// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp --debug-only=aievec-to-cpp -o dut.cc >& aie-translate.stdout
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc >& xchesscc.stdout
+// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine --debug-only=lower-vector-to-aievec -o aievec.mlir
+// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp --debug-only=aievec-to-cpp -o dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// XFAIL: *
+// REQUIRES: valid_xchess_license
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
+// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
+// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine --debug-only=lower-vector-to-aievec -o aievec.mlir >& aie-opt.stdout
+// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp --debug-only=aievec-to-cpp -o dut.cc >& aie-translate.stdout
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc >& xchesscc.stdout
+// RUN: mkdir -p data
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi16>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.mul"(%0,%arg1) {shift = 0 : i32} : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/testbench.cc
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/testbench.cc
@@ -1,0 +1,57 @@
+#include "../common/testbench.h"
+#include "defines.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+void dut(int16_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
+void dut_ref(int16_t *in0, int32_t *in1, int32_t *out0);
+
+alignas(32) int16_t g_in0[IN0_SIZE];
+alignas(32) int32_t g_in1[IN1_SIZE];
+alignas(32) int32_t g_out0[OUT0_SIZE];
+alignas(32) int32_t g_out0Ref[OUT0_SIZE];
+
+int main(int argc, char *argv[]) {
+  // XXX Figure out how to use argv with xme_ca_udm_dbg -A
+  std::string dataDir(TO_STR(DATA_DIR));
+  srand(10);
+  std::generate(g_in0, g_in0 + IN0_SIZE,
+                [&]() { return random_integer<int16_t>(); });
+  std::generate(g_in1, g_in1 + IN1_SIZE,
+                [&]() { return random_integer<int32_t>(); });
+
+  writeData(g_in0, IN0_SIZE, dataDir + "/in0.txt");
+  writeData(g_in1, IN1_SIZE, dataDir + "/in1.txt");
+
+  chess_memory_fence();
+  auto cyclesBegin = chess_cycle_count();
+  dut(g_in0, g_in1, g_out0);
+  auto cyclesEnd = chess_cycle_count();
+  chess_memory_fence();
+
+  auto cycleCount = (int)(cyclesEnd - cyclesBegin);
+  reportCycleCount(cycleCount, dataDir + "/cycle_count.txt");
+
+  writeData(g_out0, OUT0_SIZE, dataDir + "/out0.txt");
+
+  dut_ref(g_in0, g_in1, g_out0Ref);
+  writeData(g_out0Ref, OUT0_SIZE, dataDir + "/out0_ref.txt");
+
+  bool ok = true;
+  ok &= checkData(g_out0, g_out0Ref, OUT0_SIZE);
+
+  if (ok)
+    printf("TEST PASSED\n");
+  else
+    printf("TEST FAILED\n");
+
+  return ok ? 0 : 1;
+}
+
+// in0, in1, out0 are in C4 layout.
+void dut_ref(int16_t *in0, int32_t *in1, int32_t *out0) {
+  for (unsigned k = 0; k < OUT0_SIZE; k += 1) {
+    out0[k] = in0[k] * in1[k];
+  }
+}

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/defines.h
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/defines.h
@@ -1,0 +1,4 @@
+#pragma once
+constexpr unsigned const IN0_SIZE = 1024;
+constexpr unsigned const IN1_SIZE = 1024;
+constexpr unsigned const OUT0_SIZE = 1024;

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/i8xi16_mul_elem_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/i8xi16_mul_elem_v16.mlir
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// XFAIL: *
+// REQUIRES: valid_xchess_license
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
+// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
+// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all >& aie-opt.stdout
+// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp -o dut.cc >& aie-translate.stdout
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut_new.cc >& xchesscc.stdout
+// RUN: mkdir -p data
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi16>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %1 = "tosa.cast"(%arg1) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.mul"(%0,%1) {shift = 0 : i32} : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/testbench.cc
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/testbench.cc
@@ -1,0 +1,57 @@
+#include "../common/testbench.h"
+#include "defines.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+void dut(int8_t *restrict in0, int16_t *restrict in1, int32_t *restrict out0);
+void dut_ref(int8_t *in0, int16_t *in1, int32_t *out0);
+
+alignas(32) int8_t g_in0[IN0_SIZE];
+alignas(32) int16_t g_in1[IN1_SIZE];
+alignas(32) int32_t g_out0[OUT0_SIZE];
+alignas(32) int32_t g_out0Ref[OUT0_SIZE];
+
+int main(int argc, char *argv[]) {
+  // XXX Figure out how to use argv with xme_ca_udm_dbg -A
+  std::string dataDir(TO_STR(DATA_DIR));
+  srand(10);
+  std::generate(g_in0, g_in0 + IN0_SIZE,
+                [&]() { return random_integer<int8_t>(); });
+  std::generate(g_in1, g_in1 + IN1_SIZE,
+                [&]() { return random_integer<int16_t>(); });
+
+  writeData(g_in0, IN0_SIZE, dataDir + "/in0.txt");
+  writeData(g_in1, IN1_SIZE, dataDir + "/in1.txt");
+
+  chess_memory_fence();
+  auto cyclesBegin = chess_cycle_count();
+  dut(g_in0, g_in1, g_out0);
+  auto cyclesEnd = chess_cycle_count();
+  chess_memory_fence();
+
+  auto cycleCount = (int)(cyclesEnd - cyclesBegin);
+  reportCycleCount(cycleCount, dataDir + "/cycle_count.txt");
+
+  writeData(g_out0, OUT0_SIZE, dataDir + "/out0.txt");
+
+  dut_ref(g_in0, g_in1, g_out0Ref);
+  writeData(g_out0Ref, OUT0_SIZE, dataDir + "/out0_ref.txt");
+
+  bool ok = true;
+  ok &= checkData(g_out0, g_out0Ref, OUT0_SIZE);
+
+  if (ok)
+    printf("TEST PASSED\n");
+  else
+    printf("TEST FAILED\n");
+
+  return ok ? 0 : 1;
+}
+
+// in0, in1, out0 are in C4 layout.
+void dut_ref(int8_t *in0, int16_t *in1, int32_t *out0) {
+  for (unsigned k = 0; k < OUT0_SIZE; k += 1) {
+    out0[k] = in0[k] * in1[k];
+  }
+}

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/defines.h
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/defines.h
@@ -1,0 +1,4 @@
+#pragma once
+constexpr unsigned const IN0_SIZE = 1024;
+constexpr unsigned const IN1_SIZE = 1024;
+constexpr unsigned const OUT0_SIZE = 1024;

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/dut.cc
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/dut.cc
@@ -1,0 +1,19 @@
+// clang-format off
+void dut(int8_t * restrict v1, int16_t * restrict v2, int32_t * restrict v3) {
+  size_t v4 = 0;
+  size_t v5 = 1024;
+  size_t v6 = 32;
+  for (size_t v7 = v4; v7 < v5; v7 += v6)
+  chess_prepare_for_pipelining
+  chess_loop_range(32, 32)
+  {
+    v32int8 v8 = *(v32int8 *)(v1 + v7);
+    v32int16 v9 = *(v32int16 *)(v2 + v7);
+    v32int16 v10 = unpack(v8);
+    v32acc32 v11 = mul_elem_32(v9, v10);
+    v32int32 v12 = v32int32(v11);
+    *(v32int32 *)(v3 + v7) = v12;
+  }
+  return;
+}
+// clang-format on

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// XFAIL: *
+// REQUIRES: valid_xchess_license
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
+// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
+// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all >& aie-opt.stdout
+// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp -o dut.cc >& aie-translate.stdout
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut_new.cc >& xchesscc.stdout
+// RUN: mkdir -p data
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi16>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %1 = "tosa.cast"(%arg1) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.mul"(%0,%1) {shift = 0 : i32} : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
-// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all >& aie-opt.stdout
-// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp -o dut.cc >& aie-translate.stdout
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut_new.cc >& xchesscc.stdout
+// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32"
+// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all
+// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/testbench.cc
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/testbench.cc
@@ -1,0 +1,57 @@
+#include "../common/testbench.h"
+#include "defines.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+void dut(int8_t *restrict in0, int16_t *restrict in1, int32_t *restrict out0);
+void dut_ref(int8_t *in0, int16_t *in1, int32_t *out0);
+
+alignas(32) int8_t g_in0[IN0_SIZE];
+alignas(32) int16_t g_in1[IN1_SIZE];
+alignas(32) int32_t g_out0[OUT0_SIZE];
+alignas(32) int32_t g_out0Ref[OUT0_SIZE];
+
+int main(int argc, char *argv[]) {
+  // XXX Figure out how to use argv with xme_ca_udm_dbg -A
+  std::string dataDir(TO_STR(DATA_DIR));
+  srand(10);
+  std::generate(g_in0, g_in0 + IN0_SIZE,
+                [&]() { return random_integer<int8_t>(); });
+  std::generate(g_in1, g_in1 + IN1_SIZE,
+                [&]() { return random_integer<int16_t>(); });
+
+  writeData(g_in0, IN0_SIZE, dataDir + "/in0.txt");
+  writeData(g_in1, IN1_SIZE, dataDir + "/in1.txt");
+
+  chess_memory_fence();
+  auto cyclesBegin = chess_cycle_count();
+  dut(g_in0, g_in1, g_out0);
+  auto cyclesEnd = chess_cycle_count();
+  chess_memory_fence();
+
+  auto cycleCount = (int)(cyclesEnd - cyclesBegin);
+  reportCycleCount(cycleCount, dataDir + "/cycle_count.txt");
+
+  writeData(g_out0, OUT0_SIZE, dataDir + "/out0.txt");
+
+  dut_ref(g_in0, g_in1, g_out0Ref);
+  writeData(g_out0Ref, OUT0_SIZE, dataDir + "/out0_ref.txt");
+
+  bool ok = true;
+  ok &= checkData(g_out0, g_out0Ref, OUT0_SIZE);
+
+  if (ok)
+    printf("TEST PASSED\n");
+  else
+    printf("TEST FAILED\n");
+
+  return ok ? 0 : 1;
+}
+
+// in0, in1, out0 are in C4 layout.
+void dut_ref(int8_t *in0, int16_t *in1, int32_t *out0) {
+  for (unsigned k = 0; k < OUT0_SIZE; k += 1) {
+    out0[k] = in0[k] * in1[k];
+  }
+}

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/defines.h
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/defines.h
@@ -1,0 +1,4 @@
+#pragma once
+constexpr unsigned const IN0_SIZE = 1024;
+constexpr unsigned const IN1_SIZE = 1024;
+constexpr unsigned const OUT0_SIZE = 1024;

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/dut.cc
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/dut.cc
@@ -1,0 +1,22 @@
+// clang-format off
+void dut(int8_t * restrict v1, int32_t * restrict v2, int32_t * restrict v3) {
+  size_t v4 = 0;
+  size_t v5 = 1024;
+  size_t v6 = 16;
+  for (size_t v7 = v4; v7 < v5; v7 += v6)
+  chess_prepare_for_pipelining
+  chess_loop_range(64, 64)
+  {
+    v16int8 v8 = *(v16int8 *)(v1 + v7);
+    v16int32 v9 = *(v16int32 *)(v2 + v7);
+    v32int8 v10 = concat(v8, v8);
+    v32acc32 v11 = ups_to_v32acc32(v10, 0);
+    v32int32 v12 = v32int32(v11);
+    v16int32 v13 = extract_v16int32(v12, 0);
+    v16acc64 v14 = mul_elem_16_2(v9, broadcast_zero_s32(), v13, undef_v16int32());
+    v16int32 v15 = srs_to_v16int32(v14, 0);
+    *(v16int32 *)(v3 + v7) = v15;
+  }
+  return;
+}
+// clang-format on

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// XFAIL: *
+// REQUIRES: valid_xchess_license
+// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
+// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
+// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all >& aie-opt.stdout
+// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp -o dut.cc >& aie-translate.stdout
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc >& xchesscc.stdout
+// RUN: mkdir -p data
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %2 = "tosa.mul"(%0,%arg1) {shift = 0 : i32} : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
-// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
 // RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all >& aie-opt.stdout
-// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp -o dut.cc >& aie-translate.stdout
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc >& xchesscc.stdout
+// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all
+// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/testbench.cc
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/testbench.cc
@@ -1,0 +1,57 @@
+#include "../common/testbench.h"
+#include "defines.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+void dut(int8_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
+void dut_ref(int8_t *in0, int32_t *in1, int32_t *out0);
+
+alignas(32) int8_t g_in0[IN0_SIZE];
+alignas(32) int32_t g_in1[IN1_SIZE];
+alignas(32) int32_t g_out0[OUT0_SIZE];
+alignas(32) int32_t g_out0Ref[OUT0_SIZE];
+
+int main(int argc, char *argv[]) {
+  // XXX Figure out how to use argv with xme_ca_udm_dbg -A
+  std::string dataDir(TO_STR(DATA_DIR));
+  srand(10);
+  std::generate(g_in0, g_in0 + IN0_SIZE,
+                [&]() { return random_integer<int8_t>(); });
+  std::generate(g_in1, g_in1 + IN1_SIZE,
+                [&]() { return random_integer<int32_t>(); });
+
+  writeData(g_in0, IN0_SIZE, dataDir + "/in0.txt");
+  writeData(g_in1, IN1_SIZE, dataDir + "/in1.txt");
+
+  chess_memory_fence();
+  auto cyclesBegin = chess_cycle_count();
+  dut(g_in0, g_in1, g_out0);
+  auto cyclesEnd = chess_cycle_count();
+  chess_memory_fence();
+
+  auto cycleCount = (int)(cyclesEnd - cyclesBegin);
+  reportCycleCount(cycleCount, dataDir + "/cycle_count.txt");
+
+  writeData(g_out0, OUT0_SIZE, dataDir + "/out0.txt");
+
+  dut_ref(g_in0, g_in1, g_out0Ref);
+  writeData(g_out0Ref, OUT0_SIZE, dataDir + "/out0_ref.txt");
+
+  bool ok = true;
+  ok &= checkData(g_out0, g_out0Ref, OUT0_SIZE);
+
+  if (ok)
+    printf("TEST PASSED\n");
+  else
+    printf("TEST FAILED\n");
+
+  return ok ? 0 : 1;
+}
+
+// in0, in1, out0 are in C4 layout.
+void dut_ref(int8_t *in0, int32_t *in1, int32_t *out0) {
+  for (unsigned k = 0; k < OUT0_SIZE; k += 1) {
+    out0[k] = in0[k] * in1[k];
+  }
+}

--- a/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/dut.cc
+++ b/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/dut.cc
@@ -1,19 +1,23 @@
-void dut(bfloat16 *restrict v1, bfloat16 *restrict v2, bfloat16 *restrict v3) {
-  size_t v4 = 16;
-  size_t v5 = 1024;
-  size_t v6 = 0;
-  bfloat16 v7 = 0.0e+00;
-  v32bfloat16 v8 = broadcast_to_v32bfloat16(v7);
-  v16bfloat16 v9 = extract_v16bfloat16(v8, 0);
-  for (size_t v10 = v6; v10 < v5; v10 += v4)
-    chess_prepare_for_pipelining chess_loop_range(64, 64) {
-      v16bfloat16 v11 = *(v16bfloat16 *)(v1 + v10);
-      v16bfloat16 v12 = *(v16bfloat16 *)(v2 + v10);
-      v32bfloat16 v13 = concat(v11, v9);
-      v32bfloat16 v14 = concat(v12, v9);
-      v16accfloat v15 = mul_elem_16_2(v14, v13);
-      v16bfloat16 v16 = to_v16bfloat16(v15);
-      *(v16bfloat16 *)(v3 + v10) = v16;
-    }
+// clang-format off
+void dut(bfloat16 * restrict v1, bfloat16 * restrict v2, bfloat16 * restrict v3) {
+  bfloat16 v4 = 0.0e+00;
+  v32bfloat16 v5 = broadcast_to_v32bfloat16(v4);
+  v16bfloat16 v6 = extract_v16bfloat16(v5, 0);
+  size_t v7 = 0;
+  size_t v8 = 1024;
+  size_t v9 = 16;
+  for (size_t v10 = v7; v10 < v8; v10 += v9)
+  chess_prepare_for_pipelining
+  chess_loop_range(64, 64)
+  {
+    v16bfloat16 v11 = *(v16bfloat16 *)(v1 + v10);
+    v16bfloat16 v12 = *(v16bfloat16 *)(v2 + v10);
+    v32bfloat16 v13 = concat(v11, v6);
+    v32bfloat16 v14 = concat(v12, v6);
+    v16accfloat v15 = mul_elem_16_2(v14, v13);
+    v16bfloat16 v16 = to_v16bfloat16(v15);
+    *(v16bfloat16 *)(v3 + v10) = v16;
+  }
   return;
 }
+// clang-format on

--- a/test/unit_tests/aievec_tests/bf16xbf16_mul_elem_2/dut.cc
+++ b/test/unit_tests/aievec_tests/bf16xbf16_mul_elem_2/dut.cc
@@ -1,4 +1,5 @@
-void dut(bfloat16 *restrict v1, bfloat16 *restrict v2, float *restrict v3) {
+// clang-format off
+void dut(bfloat16 * restrict v1, bfloat16 * restrict v2, float * restrict v3) {
   bfloat16 v4 = 0.0e+00;
   v32bfloat16 v5 = broadcast_to_v32bfloat16(v4);
   v16bfloat16 v6 = extract_v16bfloat16(v5, 0);
@@ -6,14 +7,17 @@ void dut(bfloat16 *restrict v1, bfloat16 *restrict v2, float *restrict v3) {
   size_t v8 = 1024;
   size_t v9 = 16;
   for (size_t v10 = v7; v10 < v8; v10 += v9)
-    chess_prepare_for_pipelining chess_loop_range(64, 64) {
-      v16bfloat16 v11 = *(v16bfloat16 *)(v1 + v10);
-      v16bfloat16 v12 = *(v16bfloat16 *)(v2 + v10);
-      v32bfloat16 v13 = concat(v11, v6);
-      v32bfloat16 v14 = concat(v12, v6);
-      v16accfloat v15 = mul_elem_16_2(v14, v13);
-      v16float v16 = v16float(v15);
-      *(v16float *)(v3 + v10) = v16;
-    }
+  chess_prepare_for_pipelining
+  chess_loop_range(64, 64)
+  {
+    v16bfloat16 v11 = *(v16bfloat16 *)(v1 + v10);
+    v16bfloat16 v12 = *(v16bfloat16 *)(v2 + v10);
+    v32bfloat16 v13 = concat(v11, v6);
+    v32bfloat16 v14 = concat(v12, v6);
+    v16accfloat v15 = mul_elem_16_2(v14, v13);
+    v16float v16 = v16float(v15);
+    *(v16float *)(v3 + v10) = v16;
+  }
   return;
 }
+// clang-format on


### PR DESCRIPTION
 - Refactor AIE-ML acc datatype emission
 - Refactor arith.muli/mulf to aievec.mul_elem conversion pattern to make it extensible and clean
   - Reorganize the existing case-by-case patterns and decouple the pattern that requires two inputs to be the same type
   - Make it a cleaner pattern considering lhs/rhs/out datatype
   - Verified that all the dut.cc are identical before/after the refactor
 - Add `convertValueToTargetTypeAieML()` which can be helpful for handling the vector lane mismatch issue later on. 
 - Add CPP emission for `aievec.unpack` op
 - Add VectorToAIEVec lit tests to cover the lowering patterns
 - Add new combined precision tosa tests for element-wise multiply:
   - i8xi16_mul_elem_v32 (out=i32, lane=32) (cycle count=144, PM=272), PASS
   - i8xi16_mul_elem_v16 (out=i32, lane=16) (cycle count=792, PM=368), XFAIL
     - No intent to work on this at the moment, but keep a record there 
   - i16xi32_mul_elem (out=i32, lane=16) (cycle count=408, PM=384), PASS
   - i8xi32_mul_elem (out=i32, lane=16) (cycle count=728, PM=368), PASS
 - Pass the following regression tests:
   - test/Conversion/VectorToAIEVec
   - test/Integration/Dialect
   - test/unit_tests/aievec_tests
 - New regression failures (due to the bufferization pass in new LLVM version):
```
AIE :: Integration/Dialect/TOSA/bf16xbf16_sub_elem_2d_broadcast_1d/bf16xbf16_sub_elem_2d_broadcast_1d.mlir
AIE :: Integration/Dialect/TOSA/bf16xbf16_sub_elem_2d_broadcast_1d_reshape/bf16xbf16_sub_elem_2d_broadcast_1d_reshape.mlir
AIE :: Integration/Dialect/TOSA/i16xi16_sub_elem_2d_broadcast_1d_unit_dim/i16xi16_sub_elem_2d_broadcast_1d_unit_dim.mlir
AIE :: Integration/Dialect/TOSA/i16xi16_sub_elem_2d_broadcast_scalar/i16xi16_sub_elem_2d_broadcast_1d_unit_dim.mlir
```