### PR TITLE
Revert "catch up to TOM MLIR (#590)"

### DIFF
--- a/include/aie/AIETokenAnalysis.h
+++ b/include/aie/AIETokenAnalysis.h
@@ -15,11 +15,11 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
-#include "mlir/Interfaces/FunctionImplementation.h"
 #include "llvm/ADT/StringSwitch.h"
 
 #include <map>

--- a/include/aie/Dialect/ADF/ADF.td
+++ b/include/aie/Dialect/ADF/ADF.td
@@ -33,6 +33,7 @@ def ADF_Dialect : Dialect {
   }];
   let cppNamespace = "::xilinx::ADF";
   let useDefaultTypePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/aie/Dialect/AIE/AIENetlistAnalysis.h
+++ b/include/aie/Dialect/AIE/AIENetlistAnalysis.h
@@ -17,11 +17,11 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
-#include "mlir/Interfaces/FunctionImplementation.h"
 #include "llvm/ADT/StringSwitch.h"
 
 #include <map>

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -8,16 +8,22 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef AIE_OPS
-#define AIE_OPS
-
+#ifdef OP_BASE
+#else
 include "mlir/IR/OpBase.td"
+#endif // OP_BASE
+
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
+
+#ifdef AIE_OPS
+#else
+#define AIE_OPS
+#endif
+
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
-
 include "aie/Dialect/AIE/IR/AIEInterfaces.td"
 
 def AIE_Dialect : Dialect {
@@ -35,6 +41,7 @@ switch is referred to as `switchbox` to avoid confusion with the
   }];
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 
@@ -792,7 +799,7 @@ def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
 
 def AIE_DimTupleAttr : AttrDef<AIE_Dialect, "DimTuple", []> {
   let mnemonic = "DimTuple";
-  let summary =
+  let summary = 
     "Tuple encoding the stride and wrap of one dimension in an "
     "AIE2 n-dimensional buffer descriptor";
   let parameters = (ins
@@ -831,10 +838,10 @@ def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
     A DMA channel in a Memory Module can process one block descriptor after another by chaining them.
     There are 16 block descriptors per Memory Module. They are shared by four DMA channels.
 
-    On AIE-ML devices, an optional argument can be used to specify an array of
+    On AIE-ML devices, an optional argument can be used to specify an array of 
     step sizes and wraps to move data in more advanced patterns. Strides and
     wraps are specified as tuples `<stride, wrap>`, and up to three dimensions
-    can be specified (or up to four dimensions on memtiles).
+    can be specified (or up to four dimensions on memtiles). 
 
     The first element of the array gives the _highest-dimension_ stride and
     wrap, the last element of the array gives the lowest-dimension.
@@ -845,7 +852,7 @@ def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
     AIE.dmaBd(<%buf : memref<128xi32>, 0, 128>, 0, [<16, 8>, <1, 2>, <2, 8>])
     ```
 
-    This corresponds to alternating between even and odd elements of the
+    This corresponds to alternating between even and odd elements of the 
     buffer/stream every 8 elements, like so, equivalent to nested loops like so:
 
     ```
@@ -976,8 +983,7 @@ def AIE_MemOp: AIE_Op<"mem", [TileElement, FlowEndPoint, CallableOpInterface, Is
     int maxSizeInBytes() { return 32768; }
     // CallableOpInterface
     Region *getCallableRegion();
-    ArrayRef<Type> getArgumentTypes() { return getOperand().getType(); }
-    ArrayRef<Type> getResultTypes() { return getType(); }
+    ArrayRef<Type> getCallableResults();
     static StringRef getDefaultDialect() { return "AIE"; }
   }];
   let builders = [
@@ -1028,8 +1034,7 @@ def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [TileElement, FlowEndPoint, CallableO
     TileOp getTileOp();
     // CallableOpInterface
     Region *getCallableRegion();
-    ArrayRef<Type> getArgumentTypes() { return getOperand().getType(); }
-    ArrayRef<Type> getResultTypes() { return getType(); }
+    ArrayRef<Type> getCallableResults();
     static StringRef getDefaultDialect() { return "AIE"; }
   }];
   let builders = [
@@ -1358,50 +1363,50 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">
   );
   let results = (outs);
   let assemblyFormat = [{
-    $sym_name `(` $channelDir `,` $channelIndex `,` $col `)` attr-dict
+    $sym_name `(` $channelDir `,` $channelIndex `,` $col `)` attr-dict  
   }];
 }
 
 def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]> {
   let summary = "Create a circular buffer or channel between two tiles";
   let description = [{
-    The `aie.objectFifo` operation creates a circular buffer established between a producer and one or
-    more consumers, which are `aie.tile` operations. The`aie.objectFifo` instantiates the given number of
-    buffers (of given output type) and their locks in the Memory Module of the appropriate tile(s) after
-    lowering, based on tile-adjacency. These elements represent the conceptual depth of the `objectFifo` or,
+    The `aie.objectFifo` operation creates a circular buffer established between a producer and one or 
+    more consumers, which are `aie.tile` operations. The`aie.objectFifo` instantiates the given number of 
+    buffers (of given output type) and their locks in the Memory Module of the appropriate tile(s) after 
+    lowering, based on tile-adjacency. These elements represent the conceptual depth of the `objectFifo` or, 
     more specifically, of its object pool.
 
-    For the producer and for each consumer, a different size (i.e., element number) can be specified as an
-    array of integer values. This will take effect in the case of consumers placed on tiles non-adjacent to
-    the producer. Otherwise, the producer size will be applied. If a single size is specified, it will be
+    For the producer and for each consumer, a different size (i.e., element number) can be specified as an 
+    array of integer values. This will take effect in the case of consumers placed on tiles non-adjacent to 
+    the producer. Otherwise, the producer size will be applied. If a single size is specified, it will be 
     applied to both producer and consumers.
 
-    This operation is then converted by the `AIEObjectFifoStatefulTransformPass` into `aie.buffers` and their associated
+    This operation is then converted by the `AIEObjectFifoStatefulTransformPass` into `aie.buffers` and their associated 
     `aie.locks`. The pass also establishes Flow and DMA operations between the producer and consumer tiles if they are
     not adjacent.
 
     1-to-1 tile example:
     ```
-      AIE.objectFifo @of1 (%tile12, { %tile23 }, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of1 (%tile12, { %tile23 }, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
     ```
     This operation creates an `objectFifo` between `%tile12` and `%tile23` of 4 elements, each a buffer of 16 32-bit integers.
-    Note: If there are no `ObjectFifoAcquireOps` corresponding to this `objectFifo` on the cores of `%tile12` and `%tile23`,
+    Note: If there are no `ObjectFifoAcquireOps` corresponding to this `objectFifo` on the cores of `%tile12` and `%tile23`, 
     then the depths of the object pools on each tile will be 4, as specified. Otherwise, the cores are scanned and the
     highest number of acquired elements (+1 for prefetching) will be used instead, to ensure minimal resource usage.
-
+ 
     1-to-2 tiles broadcast example:
     ```
-      AIE.objectFifo @of2 (%tile12, { %tile13, %tile23 }, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of2 (%tile12, { %tile13, %tile23 }, 4 : i32) : !AIE.objectFifo<memref<16xi32>> 
     ```
-    This operation creates an `objectFifo` between `%tile12` and tiles `%tile13`, `%tile23` of 4 elements, each a buffer of x16
+    This operation creates an `objectFifo` between `%tile12` and tiles `%tile13`, `%tile23` of 4 elements, each a buffer of x16 
     32-bit integers.
 
     1-to-2 tiles broadcast with explicit sizes example:
     ```
-      AIE.objectFifo @of3 (%tile12, { %tile13, %tile23 }, [2, 3, 4]) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of3 (%tile12, { %tile13, %tile23 }, [2, 3, 4]) : !AIE.objectFifo<memref<16xi32>> 
     ```
-    This operation creates an `objectFifo` between `%tile12`, `%tile13` and `%tile23`. The depths of the `objectFifo` object pool
-    at each tile are respectively 2, 3 and 4 for tiles `%tile12`, `%tile13` and `%tile23`. This overrides the depth analysis
+    This operation creates an `objectFifo` between `%tile12`, `%tile13` and `%tile23`. The depths of the `objectFifo` object pool 
+    at each tile are respectively 2, 3 and 4 for tiles `%tile12`, `%tile13` and `%tile23`. This overrides the depth analysis 
     specified in the first example.
   }];
 
@@ -1454,7 +1459,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
 
     To achieve a broadcast pattern through the link tile, the output `objectFifo` should have a list of all the consumers tiles.
     To achieve a distribute pattern from the link tile, there should be multiple output `objectFifos` in the LinkOp. In this case,
-    parts will be taken out of the input `objectFifo`'s buffers based on the sizes of the output `objectFifos`, in the order they
+    parts will be taken out of the input `objectFifo`'s buffers based on the sizes of the output `objectFifos`, in the order they 
     were given in the LinkOp.
     The join pattern is the exact inverse of the distribute one.
   }];
@@ -1480,7 +1485,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
     bool isDistribute() {
       return getFifoOuts().size() > 1;
     }
-    std::optional<Value> getOptionalSharedTile();
+    mlir::Optional<Value> getOptionalSharedTile();
   }];
 }
 
@@ -1525,14 +1530,14 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
   let summary = "Acquire operation to lock and return objects of an ObjectFifo";
   let description = [{
     The `aie.objectFifo.acquire` operation first acquires the locks of the next given number 
-    of objects in the `objectFifo`. The mode it acquires the locks in is chosen based on the port
+    of objects in the `objectFifo`. The mode it acquires the locks in is chosen based on the port 
     (producer: acquire for write, consumer: acquire for read). Then, it returns a subview of 
     the acquired objects which can be used to access them.
 
-    This operation is then converted by the `AIEObjectFifoStatefulTransformPass` into `aie.useLock` operations on
+    This operation is then converted by the `AIEObjectFifoStatefulTransformPass` into `aie.useLock` operations on 
     the locks of the `objectFifo` objects that will be acquired. Under the hood, the operation only performs
     new acquires if necessary. For example, if two objects have been acquired in the past and none have yet
-    to be released by the same process, then performing another acquire operation on the same `objectFifo`
+    to be released by the same process, then performing another acquire operation on the same `objectFifo` 
     within the same process of size two or less will not result in any new useLock operations (and for size 
     greater than two, only (size - 2) useLock operations will be performed).
 
@@ -1540,7 +1545,7 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
     ```
       %subview = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
     ```
-    This operation acquires the locks of the next two objects in the `objectFifo` named `@of1` from its consumer
+    This operation acquires the locks of the next two objects in the `objectFifo` named `@of1` from its consumer 
     port and returns a subview of the acquired objects.
   }];
 
@@ -1568,7 +1573,7 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
   let summary = "Release operation for object locks in an ObjectFifo";
   let description = [{
     The `aie.objectFifo.release` operation releases the locks of the given number of objects 
-    in the `objectFifo`. The mode it releases the locks in is chosen based on the `port`
+    in the `objectFifo`. The mode it releases the locks in is chosen based on the `port` 
     (producer: release for read, consumer: release for write). 
 
     This operation is then converted by the `AIEObjectFifoStatefulTransformPass` into `aie.useLock` operations.
@@ -1587,7 +1592,7 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict $objFifo_name `(` $port `,` $size `)`
+    attr-dict $objFifo_name `(` $port `,` $size `)` 
   }];
 
   let hasVerifier = 1;
@@ -1608,7 +1613,7 @@ def AIE_ObjectFifoSubviewAccessOp : AIE_Op<"objectFifo.subview.access", []> {
       %subview = AIE.objectFifo.acquire @of1 (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
       %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
     ```
-    In this example, %elem is the first object of the subview. Note that this may not correspond to the first element of
+    In this example, %elem is the first object of the subview. Note that this may not correspond to the first element of 
     the `objectFifo` if other acquire operations took place beforehand.
 
   }];
@@ -1635,9 +1640,9 @@ def AIE_ObjectFifoSubviewAccessOp : AIE_Op<"objectFifo.subview.access", []> {
 def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
   let summary = "Operation that produces the acquire/release patterns for a process registered to an objectFifo";
   let description = [{
-    The `aie.registerProcess` operation allows the user to register a function to an `objectFifo` along with its
+    The `aie.registerProcess` operation allows the user to register a function to an `objectFifo` along with its 
     acquire and release patterns. These patterns will be used to generate a sequence of acquires and releases
-    on the `objectFifo` elements. This generated sequence is often in the form of a for loop, however, in the case
+    on the `objectFifo` elements. This generated sequence is often in the form of a for loop, however, in the case 
     of cyclo-static patterns only the repetition of same number accesses and releases will generate a for loop. 
     This may result in multiple for loops of different sizes being generated. If there is no repetition, then no 
     loops will be generated.
@@ -1652,7 +1657,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
 
       AIE.objectFifo.registerProcess @of1 (Produce, %acquirePatternProducer : tensor<4xi32>, %releasePatternProducer : tensor<4xi32>, @producer_work, %length)
     ```
-    This operation registers function @producer_work and associated patterns to the produce end of @of1.
+    This operation registers function @producer_work and associated patterns to the produce end of @of1. 
     @producer_work will be called with the subviews produced when acquiring elements from @of1 following the acquire pattern.
 
     If the input patterns are static (only one element) then the length of the produced for loop will be that of the input %length.
@@ -1669,7 +1674,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict $objFifo_name `(` $port `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)`
+    attr-dict $objFifo_name `(` $port `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)` 
   }];
 
   let hasVerifier = 1;
@@ -1681,5 +1686,3 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
     int getProcessLength() { return getLength().getDefiningOp<arith::ConstantOp>().getValue().cast<IntegerAttr>().getInt(); }
   }];
 }
-
-#endif // AIE_OPS

--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -8,11 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#ifndef AIE_INTERFACES
-#define AIE_INTERFACES
-
+#ifdef OP_BASE
+#else
 include "mlir/IR/OpBase.td"
+#endif // OP_BASE
+
 include "mlir/IR/EnumAttr.td"
 
 // Op is a DMA-like operation with BD contraints
@@ -180,5 +180,3 @@ def AIEDevice: I32EnumAttr<"AIEDevice", "AIE Device",
 
   let cppNamespace = "xilinx::AIE";
 }
-
-#endif // AIE_INTERFACES

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -12,6 +12,7 @@
 #define MLIR_AIE_DEVICEMODEL_H
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallSet.h"
 
 #include "aie/Dialect/AIE/IR/AIEEnums.h"
@@ -65,16 +66,16 @@ public:
 
   /// Return the tile ID of the memory to the west of the given tile, if it
   /// exists.
-  virtual std::optional<TileID> getMemWest(TileID src) const = 0;
+  virtual llvm::Optional<TileID> getMemWest(TileID src) const = 0;
   /// Return the tile ID of the memory to the east of the given tile, if it
   /// exists.
-  virtual std::optional<TileID> getMemEast(TileID src) const = 0;
+  virtual llvm::Optional<TileID> getMemEast(TileID src) const = 0;
   /// Return the tile ID of the memory to the north of the given tile, if it
   /// exists.
-  virtual std::optional<TileID> getMemNorth(TileID src) const = 0;
+  virtual llvm::Optional<TileID> getMemNorth(TileID src) const = 0;
   /// Return the tile ID of the memory to the south of the given tile, if it
   /// exists.
-  virtual std::optional<TileID> getMemSouth(TileID src) const = 0;
+  virtual llvm::Optional<TileID> getMemSouth(TileID src) const = 0;
 
   /// Return true if src is the internal memory of dst
   bool isInternal(int srcCol, int srcRow, int dstCol, int dstRow) const {
@@ -165,10 +166,10 @@ public:
 
   AIEArch getTargetArch() const override;
 
-  std::optional<TileID> getMemWest(TileID src) const override;
-  std::optional<TileID> getMemEast(TileID src) const override;
-  std::optional<TileID> getMemNorth(TileID src) const override;
-  std::optional<TileID> getMemSouth(TileID src) const override;
+  llvm::Optional<TileID> getMemWest(TileID src) const override;
+  llvm::Optional<TileID> getMemEast(TileID src) const override;
+  llvm::Optional<TileID> getMemNorth(TileID src) const override;
+  llvm::Optional<TileID> getMemSouth(TileID src) const override;
 
   bool isMemWest(int srcCol, int srcRow, int dstCol, int dstRow) const override;
   bool isMemEast(int srcCol, int srcRow, int dstCol, int dstRow) const override;
@@ -215,10 +216,10 @@ public:
 
   AIEArch getTargetArch() const override;
 
-  std::optional<TileID> getMemWest(TileID src) const override;
-  std::optional<TileID> getMemEast(TileID src) const override;
-  std::optional<TileID> getMemNorth(TileID src) const override;
-  std::optional<TileID> getMemSouth(TileID src) const override;
+  llvm::Optional<TileID> getMemWest(TileID src) const override;
+  llvm::Optional<TileID> getMemEast(TileID src) const override;
+  llvm::Optional<TileID> getMemNorth(TileID src) const override;
+  llvm::Optional<TileID> getMemSouth(TileID src) const override;
 
   bool isMemWest(int srcCol, int srcRow, int dstCol, int dstRow) const override;
   bool isMemEast(int srcCol, int srcRow, int dstCol, int dstRow) const override;

--- a/include/aie/Dialect/AIE/Transforms/AIEFindFlows.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEFindFlows.td
@@ -11,9 +11,9 @@
 #ifndef AIE_FIND_FLOWS
 #define AIE_FIND_FLOWS
 
-include "mlir/IR/PatternBase.td"
-include "aie/Dialect/AIE/IR/AIE.td"
+include "AIE.td"
 
-def : Pat<(AIE_WireOp (AIE_CoreOp:$core $x, $y), $port, (AIE_SwitchboxOp:$switch $x, $y), $b), (AIE_FlowOp $core, $port)>;
+def : Pat<(aie_WireOp (aie_CoreOp:$core $x, $y), $port, (aie_SwitchboxOp:$switch $x, $y), $b),
+					(aie_FlowOp $core, $port)>;
 
 #endif // AIE_FIND_FLOWS

--- a/include/aie/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.td
+++ b/include/aie/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.td
@@ -19,11 +19,9 @@ def toDefaultAddressSpace : NativeCodeCall<"TypeAttr::get(memRefToDefaultAddress
 def hasNonDefaultAddressSpace : Constraint<
     CPred<"$0.getValue().cast<MemRefType>().getMemorySpace() != 0">,
     "has non-default address space">;
-def : Pat<
-        /*pattern*/ (MemRef_GlobalOp $sym_name, $sym_visibility, $type, $initial_value, $constant, $attrs),
-        /*result*/ (MemRef_GlobalOp $sym_name, $sym_visibility, (toDefaultAddressSpace $type), $initial_value, $constant, $attrs),
-        /*preds*/ [(hasNonDefaultAddressSpace $type)],
-        /*supplemental_results*/ [],
-        /*benefitAdded*/ (addBenefit 20)>;
+def : Pat<(MemRef_GlobalOp $sym_name, $sym_visibility, $type, $initial_value, $constant, $attrs),
+        (MemRef_GlobalOp $sym_name, $sym_visibility, (toDefaultAddressSpace $type), $initial_value, $constant, $attrs),
+        [(hasNonDefaultAddressSpace $type)],
+        (addBenefit 20)>;
 
 #endif // AIE_NORMALIZE_ADDRESS_SPACES

--- a/include/aie/Dialect/AIEVec/AIEVecUtils.h
+++ b/include/aie/Dialect/AIEVec/AIEVecUtils.h
@@ -43,7 +43,7 @@ inline VectorType createVectorType(unsigned lanes, Type elementType) {
 
 // Return the size (in bits) of the underlying element type of the vector
 inline int32_t getElementSizeInBits(VectorType type) {
-  return type.cast<ShapedType>().getElementTypeBitWidth();
+  return type.cast<ShapedType>().getSizeInBits() / type.getNumElements();
 }
 
 // Return the number of lanes along the vectorized dimension for the vector
@@ -142,15 +142,16 @@ inline AffineExpr flattenedStridedExpr(ArrayRef<int64_t> sizes,
 
 // Construct a linearized affine expression for the upd op.
 inline AffineExpr constructLinearizedAffineExprForUPDOp(aievec::UPDOp updOp) {
+  SmallVector<Value, 4> indices(updOp.getIndices().begin(),
+                                updOp.getIndices().end());
   MemRefType memRefType = updOp.getSource().getType().cast<MemRefType>();
   MLIRContext *context = memRefType.getContext();
 
   SmallVector<AffineExpr, 8> exprVec;
-  llvm::SmallDenseMap<Value, AffineExpr, 8> indexToExprDimMap;
-  for (auto idxAndValue : llvm::enumerate(updOp.getIndices())) {
+  DenseMap<Value, AffineExpr> indexToExprDimMap;
+  for (auto idxAndValue : llvm::enumerate(indices)) {
     auto value = idxAndValue.value();
-    if (affine::AffineApplyOp apOf =
-            value.getDefiningOp<affine::AffineApplyOp>()) {
+    if (AffineApplyOp apOf = value.getDefiningOp<AffineApplyOp>()) {
       AffineMap map = apOf.getAffineMap();
       // Cannot create linearized affineExpr for complicated index.
       if (map.getNumResults() != 1) {

--- a/include/aie/Dialect/AIEVec/IR/AIEVecDialect.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecDialect.td
@@ -22,6 +22,7 @@ def AIEVec_Dialect : Dialect {
   let extraClassDeclaration = [{
     void registerTypes();
   }];
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 #endif // AIEVEC_DIALECT

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.h
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.h
@@ -13,10 +13,8 @@
 #ifndef AIE_DIALECT_AIEVEC_IR_AIEVECOPS_H
 #define AIE_DIALECT_AIEVEC_IR_AIEVECOPS_H
 
-#include "mlir/Bytecode/BytecodeOpInterface.h"
-#include "mlir/Interfaces/SideEffectInterfaces.h"
-
 #include "AIEVecDialect.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES
 #include "aie/Dialect/AIEVec/IR/AIEVecOps.h.inc"

--- a/include/aie/Dialect/AIEVec/Transforms/Passes.h
+++ b/include/aie/Dialect/AIEVec/Transforms/Passes.h
@@ -19,9 +19,7 @@
 
 namespace mlir {
 
-namespace affine {
 class AffineDialect;
-}
 
 namespace func {
 class FuncDialect;
@@ -58,13 +56,11 @@ class FuncOp;
 namespace xilinx {
 namespace aievec {
 
-using mlir::affine::AffineDialect;
-
 #define GEN_PASS_DECL
 #define GEN_PASS_CLASSES
 #include "aie/Dialect/AIEVec/Transforms/Passes.h.inc"
 
-std::unique_ptr<mlir::Pass> createAIEVectorizePass();
+std::unique_ptr<Pass> createAIEVectorizePass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/aie/Dialect/AIEX/AIETokenAnalysis.h
+++ b/include/aie/Dialect/AIEX/AIETokenAnalysis.h
@@ -16,11 +16,11 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/IR/FunctionImplementation.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/TypeSupport.h"
 #include "mlir/IR/Types.h"
-#include "mlir/Interfaces/FunctionImplementation.h"
 #include "llvm/ADT/StringSwitch.h"
 
 #include <map>

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -36,6 +36,7 @@ to the more mature AIE dialect.
 
   }];
   let useDefaultTypePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -12,7 +12,7 @@
 #define AIE_CONVERSION_PASSDETAIL_H_
 
 #include "mlir/IR/BuiltinOps.h"
-#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"
 
 namespace xilinx {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1057,6 +1057,9 @@ int xilinx::AIE::MemOp::rowIndex() { return getTileOp().rowIndex(); }
 /// function.
 Region *xilinx::AIE::MemOp::getCallableRegion() { return &(getBody()); }
 
+/// Returns the results types that the callable region produces when executed.
+ArrayRef<Type> xilinx::AIE::MemOp::getCallableResults() { return getType(); }
+
 // MemTileDMAOp
 LogicalResult xilinx::AIE::MemTileDMAOp::verify() {
   assert(getOperation()->getNumRegions() == 1 &&
@@ -1216,6 +1219,11 @@ int xilinx::AIE::MemTileDMAOp::rowIndex() { return getTileOp().rowIndex(); }
 /// return nullptr in the case of an external callable object, e.g. an external
 /// function.
 Region *xilinx::AIE::MemTileDMAOp::getCallableRegion() { return &(getBody()); }
+
+/// Returns the results types that the callable region produces when executed.
+ArrayRef<Type> xilinx::AIE::MemTileDMAOp::getCallableResults() {
+  return getType();
+}
 
 // SwitchboxOp
 xilinx::AIE::TileOp xilinx::AIE::SwitchboxOp::getTileOp() {

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -26,9 +26,9 @@ AIETargetModel::~AIETargetModel() {}
 AIEArch AIE1TargetModel::getTargetArch() const { return AIEArch::AIE1; }
 
 // Return the tile ID of the memory to the west of the given tile, if it exists.
-std::optional<TileID> AIE1TargetModel::getMemWest(TileID src) const {
+Optional<TileID> AIE1TargetModel::getMemWest(TileID src) const {
   bool isEvenRow = ((src.second % 2) == 0);
-  std::optional<TileID> ret;
+  Optional<TileID> ret;
   if (isEvenRow)
     ret = src;
   else
@@ -38,9 +38,9 @@ std::optional<TileID> AIE1TargetModel::getMemWest(TileID src) const {
   return ret;
 }
 // Return the tile ID of the memory to the west of the given tile, if it exists.
-std::optional<TileID> AIE1TargetModel::getMemEast(TileID src) const {
+Optional<TileID> AIE1TargetModel::getMemEast(TileID src) const {
   bool isEvenRow = ((src.second % 2) == 0);
-  std::optional<TileID> ret;
+  Optional<TileID> ret;
   if (isEvenRow)
     ret = std::make_pair(src.first + 1, src.second);
   else
@@ -50,14 +50,14 @@ std::optional<TileID> AIE1TargetModel::getMemEast(TileID src) const {
   return ret;
 }
 // Return the tile ID of the memory to the west of the given tile, if it exists.
-std::optional<TileID> AIE1TargetModel::getMemNorth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second + 1);
+Optional<TileID> AIE1TargetModel::getMemNorth(TileID src) const {
+  Optional<TileID> ret = std::make_pair(src.first, src.second + 1);
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
 }
-std::optional<TileID> AIE1TargetModel::getMemSouth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second - 1);
+Optional<TileID> AIE1TargetModel::getMemSouth(TileID src) const {
+  Optional<TileID> ret = std::make_pair(src.first, src.second - 1);
   // The first row doesn't have a tile memory south
   if (!isValidTile(*ret) || ret->second == 0)
     ret.reset();
@@ -259,28 +259,28 @@ AIE1TargetModel::getNumSourceShimMuxConnections(int col, int row,
 AIEArch AIE2TargetModel::getTargetArch() const { return AIEArch::AIE2; }
 
 // Return the tile ID of the memory to the west of the given tile, if it exists.
-std::optional<TileID> AIE2TargetModel::getMemWest(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first - 1, src.second);
+Optional<TileID> AIE2TargetModel::getMemWest(TileID src) const {
+  Optional<TileID> ret = std::make_pair(src.first - 1, src.second);
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
 }
 // Return the tile ID of the memory to the west of the given tile, if it exists.
-std::optional<TileID> AIE2TargetModel::getMemEast(TileID src) const {
-  std::optional<TileID> ret = src;
+Optional<TileID> AIE2TargetModel::getMemEast(TileID src) const {
+  Optional<TileID> ret = src;
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
 }
 // Return the tile ID of the memory to the west of the given tile, if it exists.
-std::optional<TileID> AIE2TargetModel::getMemNorth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second + 1);
+Optional<TileID> AIE2TargetModel::getMemNorth(TileID src) const {
+  Optional<TileID> ret = std::make_pair(src.first, src.second + 1);
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
 }
-std::optional<TileID> AIE2TargetModel::getMemSouth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second - 1);
+Optional<TileID> AIE2TargetModel::getMemSouth(TileID src) const {
+  Optional<TileID> ret = std::make_pair(src.first, src.second - 1);
   // The first row doesn't have a tile memory south
   // Memtiles don't have memory adjacency to neighboring core tiles.
   if (!isValidTile(*ret) || ret->second == 0 ||

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -33,7 +33,7 @@ public:
   ConnectivityAnalysis(DeviceOp &d) : device(d) {}
 
 private:
-  std::optional<PortConnection>
+  llvm::Optional<PortConnection>
   getConnectionThroughWire(Operation *op, Port masterPort) const {
     LLVM_DEBUG(llvm::dbgs()
                << "Wire:" << *op << " " << stringifyWireBundle(masterPort.first)

--- a/lib/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.cpp
+++ b/lib/Dialect/AIE/Transforms/AIENormalizeAddressSpaces.cpp
@@ -41,7 +41,7 @@ struct AIENormalizeAddressSpacesPass
     DeviceOp device = getOperation();
 
     TypeConverter converter;
-    converter.addConversion([&](Type type) -> std::optional<Type> {
+    converter.addConversion([&](Type type) -> Optional<Type> {
       return memRefToDefaultAddressSpace(type);
     });
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -59,11 +59,14 @@ struct AIEObjectFifoRegisterProcessPass
 
   mlir::scf::ForOp createForLoop(OpBuilder &builder, int length) {
     arith::ConstantOp lowerBound = builder.create<arith::ConstantOp>(
-        builder.getUnknownLoc(), builder.getIndexAttr(0));
+        builder.getUnknownLoc(), builder.getIndexAttr(0),
+        builder.getIndexType());
     arith::ConstantOp upperBound = builder.create<arith::ConstantOp>(
-        builder.getUnknownLoc(), builder.getIndexAttr(length));
+        builder.getUnknownLoc(), builder.getIndexAttr(length),
+        builder.getIndexType());
     arith::ConstantOp step = builder.create<arith::ConstantOp>(
-        builder.getUnknownLoc(), builder.getIndexAttr(1));
+        builder.getUnknownLoc(), builder.getIndexAttr(1),
+        builder.getIndexType());
     mlir::scf::ForOp forLoop = builder.create<mlir::scf::ForOp>(
         builder.getUnknownLoc(), lowerBound, upperBound, step);
     return forLoop;

--- a/lib/Dialect/AIE/Transforms/AIEVectorOpt.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEVectorOpt.cpp
@@ -10,7 +10,6 @@
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
-#include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
 #include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/IRMapping.h"
@@ -35,8 +34,7 @@ struct AIEVectorOptPass : public AIEVectorOptBase<AIEVectorOptPass> {
     func::FuncOp f = getOperation();
 
     // Initial store->load forwarding
-    IRRewriter rewriter(&getContext());
-    vector::transferOpflowOpt(rewriter, f);
+    vector::transferOpflowOpt(f);
 
     ConversionTarget target(getContext());
     target.addLegalDialect<memref::MemRefDialect>();

--- a/lib/Dialect/AIE/Utils/AIENetlistAnalysis.cpp
+++ b/lib/Dialect/AIE/Utils/AIENetlistAnalysis.cpp
@@ -249,7 +249,7 @@ xilinx::AIE::NetlistAnalysis::getMemUsageInBytes(Operation *tileOp) const {
   uint64_t memUsage = 0;
   for (auto buf : buffers[tileOp]) {
     auto t = buf.getType().cast<ShapedType>();
-    memUsage += t.getElementTypeBitWidth();
+    memUsage += t.getSizeInBits();
   }
   return memUsage / 8;
 }

--- a/lib/Dialect/AIEVec/Transforms/ConvertVectorToAIEVec.cpp
+++ b/lib/Dialect/AIEVec/Transforms/ConvertVectorToAIEVec.cpp
@@ -82,19 +82,18 @@ using SetInboundsToWriteOp = SetInboundsToReadStoreOpPattern<TransferWriteOp>;
 //===----------------------------------------------------------------------===//
 
 struct RedundantLoadStoreOptimizationPass
-    : public PassWrapper<RedundantLoadStoreOptimizationPass, OperationPass<>> {
-
+    : public PassWrapper<RedundantLoadStoreOptimizationPass,
+                         OperationPass<func::FuncOp>> {
   void runOnOperation() override {
-    auto op = getOperation();
+    func::FuncOp funcOp = getOperation();
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
 
     patterns.add<SetInboundsToReadOp, SetInboundsToWriteOp>(
         patterns.getContext());
 
-    (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
-    IRRewriter rewriter(&getContext());
-    vector::transferOpflowOpt(rewriter, op);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+    transferOpflowOpt(funcOp);
   }
 };
 

--- a/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
+++ b/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
@@ -241,10 +241,8 @@ struct LongestConvMACChainAnalysis {
         return isa<aievec::BroadcastOp>(op) || isa<aievec::ExtOp>(op) ||
                isa<aievec::ConcatOp>(op);
       };
-      BackwardSliceOptions backwardSliceOptions;
-      backwardSliceOptions.filter = opFilter;
 
-      getBackwardSlice(mulOpOperand, &opBwdSlices, backwardSliceOptions);
+      getBackwardSlice(mulOpOperand, &opBwdSlices, opFilter);
       opBwdSlices.insert(mulOpOperand);
 
       LLVM_DEBUG(llvm::dbgs() << "opBwdSlices = [\n");

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -429,7 +429,7 @@ struct UPDOpEffectiveAccessSizeAnalysis {
   UPDOpEffectiveAccessSizeAnalysis(aievec::UPDOp updOp) {
     auto vecType = cast<VectorType>(updOp.getResult().getType());
     unsigned sizeInBits =
-        cast<ShapedType>(vecType).getElementTypeBitWidth() - updOp.getOffset();
+        cast<ShapedType>(vecType).getSizeInBits() - updOp.getOffset();
     for (Operation *user : updOp->getUsers()) {
       auto userUpdOp = dyn_cast<xilinx::aievec::UPDOp>(user);
       if (userUpdOp)
@@ -463,7 +463,7 @@ struct FoldVectorExtractAndBroadcastToAIEBroadcast
 
     auto src = extOp.getVector();
     auto pos = extOp.getPosition();
-    int64_t posVal = pos[0];
+    int64_t posVal = cast<IntegerAttr>(pos[0]).getInt();
     VectorType srcVecType = cast<VectorType>(src.getType());
     VectorType resultType = cast<VectorType>(bcastOp.getResult().getType());
     if (srcVecType != resultType) {
@@ -837,7 +837,7 @@ struct FoldBroadcastToFMAOp : public OpConversionPattern<aievec::FMAOp> {
             .getResult();
     // XXX: We assume a 1D vector
     auto pos = extOp.getPosition();
-    int64_t zstart = pos[0];
+    int64_t zstart = cast<IntegerAttr>(pos[0]).getInt();
     auto fmaOpAttr = buildFMAOpSplatAttrForElemTy(fmaOp, zstart);
     rewriter.replaceOpWithNewOp<aievec::FMAOp>(
         fmaOp, TypeRange({fmaOp.getResult().getType()}),
@@ -1656,7 +1656,7 @@ struct LowerVectorExtractStridedSliceOpAIEv1Pattern
   LogicalResult
   matchAndRewrite(vector::ExtractStridedSliceOp extractOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto vType = extractOp.getSourceVectorType();
+    auto vType = extractOp.getVectorType();
     if (vType.getRank() != 1)
       return failure();
 

--- a/lib/Dialect/AIEVec/Utils/Utils.cpp
+++ b/lib/Dialect/AIEVec/Utils/Utils.cpp
@@ -29,7 +29,7 @@ static std::optional<int64_t> getLowerBoundValue(Value idx) {
   if (auto blkArg = dyn_cast<BlockArgument>(idx)) {
     auto parentOp = blkArg.getOwner()->getParentOp();
     return TypeSwitch<Operation *, std::optional<int64_t>>(parentOp)
-        .Case<affine::AffineForOp>([&blkArg](affine::AffineForOp forOp) {
+        .Case<AffineForOp>([&blkArg](AffineForOp forOp) {
           if (forOp.getInductionVar() == blkArg &&
               forOp.hasConstantLowerBound())
             return std::optional<int64_t>(forOp.getConstantLowerBound());
@@ -46,7 +46,7 @@ static std::optional<int64_t> getLowerBoundValue(Value idx) {
         return std::optional<int64_t>(
             cast<IntegerAttr>(constantOp.getValue()).getInt());
       })
-      .Case<affine::AffineApplyOp>([](auto applyOp) {
+      .Case<AffineApplyOp>([](auto applyOp) {
         if (applyOp.getAffineMap().getNumResults() == 1) {
           SmallVector<int64_t, 4> srcIndices;
           for (auto index : applyOp.getMapOperands()) {

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -49,7 +49,7 @@ const char xaie_c_file_header[] = R"code(
 
 // The following is a wrapper for the common "if(call() != 0) return 1" pattern.
 // Use this only in functions that return int. If the call this wrapper is used
-// on does not succeed, the expanded code will exit out of the function
+// on does not succeed, the expanded code will exit out of the function 
 // containing this macro with an error code.
 #define __mlir_aie_try(x) do { \
   AieRC ret = (x); \
@@ -896,7 +896,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
     int row = coord.second;
     auto loc = tileLocStr(col, row);
 
-    auto bufferAccessor = [&](std::optional<TileID> tile, BufferOp buf) {
+    auto bufferAccessor = [&](Optional<TileID> tile, BufferOp buf) {
       // int32_t mlir_aie_read_buffer_a13(int index) {
       // void mlir_aie_write_buffer_a13(int index, int32_t value) {
       std::string bufName(buf.name().getValue());

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -158,7 +158,7 @@ void registerAIETranslations() {
           output << "// Tile(" << srcCol << ", " << srcRow << ")\n";
           output << "// Memory map: name base_address num_bytes\n";
 
-          auto doBuffer = [&](std::optional<TileID> tile, int offset) {
+          auto doBuffer = [&](Optional<TileID> tile, int offset) {
             if (tiles.count(*tile))
               for (auto buf : buffers[tiles[*tile]])
                 writeBufferMap(output, buf, offset, NL);
@@ -307,7 +307,7 @@ SECTIONS
      *(.rodata*)
   } > data
 )THESCRIPT";
-            auto doBuffer = [&](std::optional<TileID> tile, int offset,
+            auto doBuffer = [&](Optional<TileID> tile, int offset,
                                 std::string dir) {
               if (tile) {
                 if (tiles.count(*tile))
@@ -420,7 +420,7 @@ SECTIONS
                    << " //Don't put data in code memory\n";
 
             auto srcCoord = std::make_pair(tile.colIndex(), tile.rowIndex());
-            auto doBuffer = [&](std::optional<TileID> tile, int offset,
+            auto doBuffer = [&](Optional<TileID> tile, int offset,
                                 std::string dir) {
               if (tile) {
                 if (tiles.count(*tile))

--- a/python/aie/compiler/aiecc/main.py
+++ b/python/aie/compiler/aiecc/main.py
@@ -37,7 +37,7 @@ aie_opt_passes = ['--aie-normalize-address-spaces',
                   '--lower-affine',
                   '--convert-math-to-llvm',
                   '--convert-arith-to-llvm',
-                  '--finalize-memref-to-llvm',
+                  '--convert-memref-to-llvm',
                   '--convert-func-to-llvm=use-bare-ptr-memref-call-conv',
                   '--convert-cf-to-llvm',
                   '--canonicalize',
@@ -96,7 +96,7 @@ class flow_runner:
       with Context() as ctx, Location.unknown():
         aiedialect.register_dialect(ctx)
         module = Module.parse(mlir_module_str)
-        PassManager.parse(pass_pipeline).run(module.operation)
+        PassManager.parse(pass_pipeline).run(module)
         mlir_module_str = str(module)
         if outputfile:
           with open(outputfile, 'w') as g:

--- a/python/aie/dialects/AieBinding.td
+++ b/python/aie/dialects/AieBinding.td
@@ -9,6 +9,7 @@
 #ifndef AIE_BINDING_TD
 #define AIE_BINDING_TD
 
+include "mlir/Bindings/Python/Attributes.td"
 include "aie/Dialect/AIE/IR/AIE.td"
 
 #endif // AIE_BINDING_TD

--- a/test/Conversion/AIEVecToLLVM/test-upd_large.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-upd_large.mlir
@@ -1,5 +1,4 @@
 // RUN: aie-opt %s --convert-aievec-to-llvm | FileCheck %s
-// XFAIL: *
 // Test loads and updates to a vector register
 module {
   func.func @test(%arg0: memref<4x32x64xi16>) {

--- a/test/Conversion/AIEVecToLLVM/test-upd_small.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-upd_small.mlir
@@ -1,5 +1,4 @@
 // RUN: aie-opt %s --convert-aievec-to-llvm | FileCheck %s
-// XFAIL: *
 // Test a direct load to vector register that does not actually need an update
 module {
   func.func @test(%arg0: memref<4x32x64xi16>) {

--- a/test/aievec/test_linalg_conv2d.mlir
+++ b/test/aievec/test_linalg_conv2d.mlir
@@ -178,8 +178,8 @@ func.func @conv_2d(%arg0: memref<10x3x256x256xf32>, %arg1: memref<10x3x3x3xf32>,
   return
 }
 
-//CHECK-NEXT: %c1 = arith.constant 1 : index
 //CHECK-NEXT: %c2 = arith.constant 2 : index
+//CHECK-NEXT: %c1 = arith.constant 1 : index
 //CHECK-NEXT: %c0 = arith.constant 0 : index
 //CHECK-NEXT: %c0_0 = arith.constant 0 : index
 //CHECK-NEXT: %c10 = arith.constant 10 : index

--- a/tools/aie-opt/aie-opt.cpp
+++ b/tools/aie-opt/aie-opt.cpp
@@ -55,6 +55,7 @@ int main(int argc, char **argv) {
   registry.insert<xilinx::ADF::ADFDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
 
-  return failed(
-      MlirOptMain(argc, argv, "MLIR modular optimizer driver\n", registry));
+  return failed(MlirOptMain(argc, argv, "MLIR modular optimizer driver\n",
+                            registry,
+                            /*preloadDialectsInContext=*/false));
 }

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -15,7 +15,7 @@
 # The LLVM commit to use.
 # TODO: create a branch or a tag instead, to avoid fetching main and
 # this commit later.
-commithash=11c3b979e6512b00a5bd9c3e0d4ed986cf500630
+commithash=35ca64989a75c93ea7e935ef11c3d1883c21cccd
 
 here=$PWD
 


### PR DESCRIPTION
Summary: 47ff7d38a89372c02e22515e61a696f2a3e93013 broke main because of `--opaque-pointers`. I was aware that it was broken but I committed anyway (over)confident in the notion that I had a patch for LLVM that would restore `--opaque-pointers`. Well, as can be surmised from my thrashing [here](https://github.com/Xilinx/mlir-aie/pull/647), turns out I in fact did not have such a patch. Thus, this commit reverts.

As soon as we can land https://github.com/Xilinx/mlir-aie/pull/634, I will revert this revert.

cc @linay-xsj 