### PR TITLE
Add more add/sub/mul mixed precision tests

### DIFF
--- a/test/Integration/Dialect/TOSA/bf16xbf16_add_elem/bf16xbf16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_add_elem/bf16xbf16_add_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem/bf16xbf16_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem/bf16xbf16_mul_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sel/bf16xbf16_sel.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sel/bf16xbf16_sel.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem/bf16xbf16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem/bf16xbf16_sub_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/bf16xfloat_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/bf16xfloat_add_elem.mlir
@@ -2,16 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
-// RUN: mkdir -p %t
-// RUN: mkdir -p %basename_t
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/floatxbf16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/floatxbf16_add_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xbf16>, %arg1: tensor<1024xf32>) -> (tensor<1024xf32>) {
+    %1 = "tosa.cast" (%arg0) : (tensor<1024xbf16>)  -> (tensor<1024xf32>)
+    %2 = "tosa.add"(%arg1, %1) : (tensor<1024xf32>, tensor<1024xf32>)  -> (tensor<1024xf32>)
+    return %2 : tensor<1024xf32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/bf16xfloat_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/bf16xfloat_sub_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/floatxbf16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/floatxbf16_sub_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xbf16>, %arg1: tensor<1024xf32>) -> (tensor<1024xf32>) {
+    %1 = "tosa.cast" (%arg0) : (tensor<1024xbf16>)  -> (tensor<1024xf32>)
+    %2 = "tosa.sub"(%arg1, %1) : (tensor<1024xf32>, tensor<1024xf32>)  -> (tensor<1024xf32>)
+    return %2 : tensor<1024xf32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/floatxfloat_add_elem/floatxfloat_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_add_elem/floatxfloat_add_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/floatxfloat_sel/floatxfloat_sel.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sel/floatxfloat_sel.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem/floatxfloat_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem/floatxfloat_sub_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi16_add_elem/i16xi16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_add_elem/i16xi16_add_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem/i16xi16_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem/i16xi16_mul_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/dut.cc
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/dut.cc
@@ -1,5 +1,5 @@
 // clang-format off
-void dut(int16_t * restrict v1, int16_t * restrict v2, int16_t * restrict v3) {
+void dut(int16_t * restrict v1, int16_t * restrict v2, int32_t * restrict v3) {
   size_t v4 = 0;
   size_t v5 = 1024;
   size_t v6 = 32;
@@ -10,8 +10,8 @@ void dut(int16_t * restrict v1, int16_t * restrict v2, int16_t * restrict v3) {
     v32int16 v8 = *(v32int16 *)(v1 + v7);
     v32int16 v9 = *(v32int16 *)(v2 + v7);
     v32acc32 v10 = mul_elem_32(v9, v8);
-    v32int16 v11 = srs_to_v32int16(v10, 0);
-    *(v32int16 *)(v3 + v7) = v11;
+    v32int32 v11 = v32int32(v10);
+    *(v32int32 *)(v3 + v7) = v11;
   }
   return;
 }

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/dut.cc
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/dut.cc
@@ -1,0 +1,18 @@
+// clang-format off
+void dut(int16_t * restrict v1, int16_t * restrict v2, int16_t * restrict v3) {
+  size_t v4 = 0;
+  size_t v5 = 1024;
+  size_t v6 = 32;
+  for (size_t v7 = v4; v7 < v5; v7 += v6)
+  chess_prepare_for_pipelining
+  chess_loop_range(32, 32)
+  {
+    v32int16 v8 = *(v32int16 *)(v1 + v7);
+    v32int16 v9 = *(v32int16 *)(v2 + v7);
+    v32acc32 v10 = mul_elem_32(v9, v8);
+    v32int16 v11 = srs_to_v32int16(v10, 0);
+    *(v32int16 *)(v3 + v7) = v11;
+  }
+  return;
+}
+// clang-format on

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/i16xi16_mul_elem_i32.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/i16xi16_mul_elem_i32.mlir
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi16>, %arg1: tensor<1024xi16>) -> (tensor<1024xi32>) {
+    %1 = "tosa.mul"(%arg0,%arg1) {shift = 0 : i32} : (tensor<1024xi16>, tensor<1024xi16>)  -> (tensor<1024xi32>)
+    return %1 : tensor<1024xi32>
+  }
+}

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/testbench.cc
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/testbench.cc
@@ -1,0 +1,58 @@
+#include "../common/testbench.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+void dut(int16_t *restrict in0, int16_t *restrict in1, int32_t *restrict out0);
+void dut_ref(int16_t *in0, int16_t *in1, int32_t *out0);
+
+constexpr unsigned const IN0_SIZE = 1024;
+constexpr unsigned const IN1_SIZE = 1024;
+constexpr unsigned const OUT0_SIZE = 1024;
+
+alignas(32) int16_t g_in0[IN0_SIZE];
+alignas(32) int16_t g_in1[IN1_SIZE];
+alignas(32) int32_t g_out0[OUT0_SIZE];
+alignas(32) int32_t g_out0Ref[OUT0_SIZE];
+
+int main(int argc, char *argv[]) {
+  std::string dataDir(TO_STR(DATA_DIR));
+  srand(10);
+  std::generate(g_in0, g_in0 + IN0_SIZE,
+                [&]() { return random_integer<int16_t>(); });
+  std::generate(g_in1, g_in1 + IN1_SIZE,
+                [&]() { return random_integer<int16_t>(); });
+
+  writeData(g_in0, IN0_SIZE, dataDir + "/in0.txt");
+  writeData(g_in1, IN1_SIZE, dataDir + "/in1.txt");
+
+  chess_memory_fence();
+  auto cyclesBegin = chess_cycle_count();
+  dut(g_in0, g_in1, g_out0);
+  auto cyclesEnd = chess_cycle_count();
+  chess_memory_fence();
+
+  auto cycleCount = (int)(cyclesEnd - cyclesBegin);
+  reportCycleCount(cycleCount, dataDir + "/cycle_count.txt");
+
+  writeData(g_out0, OUT0_SIZE, dataDir + "/out0.txt");
+
+  dut_ref(g_in0, g_in1, g_out0Ref);
+  writeData(g_out0Ref, OUT0_SIZE, dataDir + "/out0_ref.txt");
+
+  bool ok = true;
+  ok &= checkData(g_out0, g_out0Ref, OUT0_SIZE);
+
+  if (ok)
+    printf("TEST PASSED\n");
+  else
+    printf("TEST FAILED\n");
+
+  return ok ? 0 : 1;
+}
+
+void dut_ref(int16_t *in0, int16_t *in1, int32_t *out0) {
+  for (unsigned k = 0; k < OUT0_SIZE; k += 1) {
+    out0[k] = (int32_t)in0[k] * (int32_t)in1[k];
+  }
+}

--- a/test/Integration/Dialect/TOSA/i16xi16_sel/i16xi16_sel.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sel/i16xi16_sel.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem/i16xi16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem/i16xi16_sub_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i16xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i16xi32_add_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i32xi16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i32xi16_add_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi16>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.add"(%arg1, %0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i16xi32_add_elem_v32/i16xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_add_elem_v32/i16xi32_add_elem.mlir
@@ -3,14 +3,12 @@
 
 // XFAIL: *
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine --debug-only=lower-vector-to-aievec -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp --debug-only=aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i32xi16_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i32xi16_mul_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi16>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.mul"(%arg1, %0) {shift = 0 : i32} : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i16xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i16xi32_sub_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i32xi16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i32xi16_sub_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi16>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.sub"(%arg1, %0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v32/i16xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v32/i16xi32_sub_elem.mlir
@@ -3,14 +3,12 @@
 
 // XFAIL: *
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i32xi32_add_elem/i32xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_add_elem/i32xi32_add_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem/i32xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem/i32xi32_mul_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i32xi32_sel/i32xi32_sel.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sel/i32xi32_sel.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem/i32xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem/i32xi32_sub_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi16_add_elem/i16xi8_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_add_elem/i16xi8_add_elem.mlir
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi16>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %1 = "tosa.cast"(%arg1) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.add"(%1,%0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi16_add_elem/i8xi16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_add_elem/i8xi16_add_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/i8xi16_mul_elem_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/i8xi16_mul_elem_v16.mlir
@@ -3,14 +3,12 @@
 
 // XFAIL: *
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all >& aie-opt.stdout
-// RUN: aie-translate aievec_new.mlir -aieml=true --aievec-to-cpp -o dut.cc >& aie-translate.stdout
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut_new.cc >& xchesscc.stdout
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i16xi8_mul_elem_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i16xi8_mul_elem_v32.mlir
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi16>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %1 = "tosa.cast"(%arg1) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.mul"(%1,%0) {shift = 0 : i32} : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i16xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i16xi8_sub_elem.mlir
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi16>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %1 = "tosa.cast"(%arg1) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.sub"(%1,%0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i8xi16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i8xi16_sub_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi32_add_elem/i32xi8_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_add_elem/i32xi8_add_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %2 = "tosa.add"(%arg1, %0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi32_add_elem/i8xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_add_elem/i8xi32_add_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i32xi8_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i32xi8_mul_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %2 = "tosa.mul"(%arg1, %0) {shift = 0 : i32} : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir --mlir-print-ir-after-all
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i32xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i32xi8_sub_elem.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
+    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %2 = "tosa.sub"(%arg1, %0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %2 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i8xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i8xi32_sub_elem.mlir
@@ -2,14 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
-// RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi8_add_elem/i8xi8_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_add_elem/i8xi8_add_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=64" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem/i8xi8_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem/i8xi8_mul_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/dut.cc
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/dut.cc
@@ -1,3 +1,4 @@
+// clang-format off
 void dut(int8_t * restrict v1, int8_t * restrict v2, int32_t * restrict v3) {
   int8_t v4 = 0;
   v64int8 v5 = broadcast_to_v64int8(v4);
@@ -19,5 +20,4 @@ void dut(int8_t * restrict v1, int8_t * restrict v2, int32_t * restrict v3) {
   }
   return;
 }
-
-
+// clang-format on

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/dut.cc
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/dut.cc
@@ -1,0 +1,23 @@
+void dut(int8_t * restrict v1, int8_t * restrict v2, int32_t * restrict v3) {
+  int8_t v4 = 0;
+  v64int8 v5 = broadcast_to_v64int8(v4);
+  v32int8 v6 = extract_v32int8(v5, 0);
+  size_t v7 = 0;
+  size_t v8 = 1024;
+  size_t v9 = 32;
+  for (size_t v10 = v7; v10 < v8; v10 += v9)
+  chess_prepare_for_pipelining
+  chess_loop_range(32, 32)
+  {
+    v32int8 v11 = *(v32int8 *)(v1 + v10);
+    v32int8 v12 = *(v32int8 *)(v2 + v10);
+    v64int8 v13 = concat(v11, v6);
+    v64int8 v14 = concat(v12, v6);
+    v32acc32 v15 = mul_elem_32_2(v14, v13);
+    v32int32 v16 = v32int32(v15);
+    *(v32int32 *)(v3 + v10) = v16;
+  }
+  return;
+}
+
+

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/i8xi8_mul_elem_i32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/i8xi8_mul_elem_i32.mlir
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+
+// REQUIRES: valid_xchess_license
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% -o %t/linalg.mlir
+// RUN: aie-opt %t/linalg.mlir %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc >& xchesscc_wrapper.stdout
+// RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
+// CHECK: TEST PASSED
+
+module {
+  func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi8>) -> (tensor<1024xi32>) {
+    %1 = "tosa.mul"(%arg0,%arg1) {shift = 0 : i32} : (tensor<1024xi8>, tensor<1024xi8>)  -> (tensor<1024xi32>)
+    return %1 : tensor<1024xi32>
+  }
+}
+

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/testbench.cc
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/testbench.cc
@@ -1,0 +1,58 @@
+#include "../common/testbench.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+void dut(int8_t *restrict in0, int8_t *restrict in1, int32_t *restrict out0);
+void dut_ref(int8_t *in0, int8_t *in1, int32_t *out0);
+
+constexpr unsigned const IN0_SIZE = 1024;
+constexpr unsigned const IN1_SIZE = 1024;
+constexpr unsigned const OUT0_SIZE = 1024;
+
+alignas(32) int8_t g_in0[IN0_SIZE];
+alignas(32) int8_t g_in1[IN1_SIZE];
+alignas(32) int32_t g_out0[OUT0_SIZE];
+alignas(32) int32_t g_out0Ref[OUT0_SIZE];
+
+int main(int argc, char *argv[]) {
+  std::string dataDir(TO_STR(DATA_DIR));
+  srand(10);
+  std::generate(g_in0, g_in0 + IN0_SIZE,
+                [&]() { return random_integer<int8_t>(); });
+  std::generate(g_in1, g_in1 + IN1_SIZE,
+                [&]() { return random_integer<int8_t>(); });
+
+  writeData(g_in0, IN0_SIZE, dataDir + "/in0.txt");
+  writeData(g_in1, IN1_SIZE, dataDir + "/in1.txt");
+
+  chess_memory_fence();
+  auto cyclesBegin = chess_cycle_count();
+  dut(g_in0, g_in1, g_out0);
+  auto cyclesEnd = chess_cycle_count();
+  chess_memory_fence();
+
+  auto cycleCount = (int)(cyclesEnd - cyclesBegin);
+  reportCycleCount(cycleCount, dataDir + "/cycle_count.txt");
+
+  writeData(g_out0, OUT0_SIZE, dataDir + "/out0.txt");
+
+  dut_ref(g_in0, g_in1, g_out0Ref);
+  writeData(g_out0Ref, OUT0_SIZE, dataDir + "/out0_ref.txt");
+
+  bool ok = true;
+  ok &= checkData(g_out0, g_out0Ref, OUT0_SIZE);
+
+  if (ok)
+    printf("TEST PASSED\n");
+  else
+    printf("TEST FAILED\n");
+
+  return ok ? 0 : 1;
+}
+
+void dut_ref(int8_t *in0, int8_t *in1, int32_t *out0) {
+  for (unsigned k = 0; k < OUT0_SIZE; k += 1) {
+    out0[k] = (int32_t)in0[k] * (int32_t)in1[k];
+  }
+}

--- a/test/Integration/Dialect/TOSA/i8xi8_sel/i8xi8_sel.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sel/i8xi8_sel.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=64" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem/i8xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem/i8xi8_sub_elem.mlir
@@ -2,13 +2,12 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
-// RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=64" -o affine.mlir 
-// RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
-// RUN: mkdir -p data
+// RUN: mkdir -p %t/data
+// RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
+// RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
-// RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
+// RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
 
 module {

--- a/test/Integration/lit.local.cfg
+++ b/test/Integration/lit.local.cfg
@@ -7,3 +7,11 @@
 
 if config.aie_include_integration_tests != 'ON':
     config.unsupported = True
+
+tosa_to_linalg = '--pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor))"'
+linalg_to_affine = '--linalg-fuse-elementwise-ops --linalg-fold-unit-extent-dims --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map unknown-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops'
+
+config.substitutions.append(('%tosa-to-linalg%', tosa_to_linalg))
+config.substitutions.append(('%linalg-to-vector-v64%', linalg_to_affine+' --affine-super-vectorize="virtual-vector-size=64"'))
+config.substitutions.append(('%linalg-to-vector-v32%', linalg_to_affine+' --affine-super-vectorize="virtual-vector-size=32"'))
+config.substitutions.append(('%linalg-to-vector-v16%', linalg_to_affine+' --affine-super-vectorize="virtual-vector-size=16"'))


### PR DESCRIPTION
- Refactor the tosa-to-vector pipelines script in each test to a central place at `test/Integration/lit.local.cfg` for better maintainability. Also, make sure each .mlir test is running in a unique workdir for placing multiple .mlir test in a single directory.
- For add/sub/mul mixed precision tests, we add tests with swapped inputs
- Per the TOSA spec at https://www.mlplatform.org/tosa/tosa_spec.html#_mul, we add test coverage for i16xi16_mul_elem_i32, and i8xi8_mul_elem_i32. Our refactored mul_elem lowering pattern works on these two cases directly, and the acctype for the i8/i16 mac intrinsics we used is i32.  