### PR TITLE
Update runtime_lib/xaiengine cmake to always copy libxaie.

### DIFF
--- a/runtime_lib/CMakeLists.txt
+++ b/runtime_lib/CMakeLists.txt
@@ -40,19 +40,27 @@ foreach(target ${AIE_RUNTIME_TARGETS})
     message(FATAL_ERROR "Toolchain file ${${target}_TOOLCHAIN_FILE} not found! Cannot build target ${target}.")
   endif()
   message("Building AIE runtime for ${target} with TOOLCHAIN=${${target}_TOOLCHAIN_FILE}")
-  
+
   # xaiengine
-  # if no LibXAIE_{target}_DIR specified, build xaiengine_${target} from Vitis
   if (DEFINED LibXAIE_${target}_DIR)
     message("Using xaiengine from LibXAIE_${target}_DIR=${LibXAIE_${target}_DIR}.")
     set(LibXAIE_ROOT ${LibXAIE_${target}_DIR})
-    find_package(LibXAIE)
+    find_package(LibXAIE REQUIRED)
     message(STATUS "FOUND LibXAIE: ${LibXAIE_FOUND}, XILINX_XAIE_LIB_DIR: ${XILINX_XAIE_LIB_DIR}, XILINX_XAIE_INCLUDE_DIR: ${XILINX_XAIE_INCLUDE_DIR}")
+
   elseif (DEFINED VITIS_ROOT)
-      message("LibXAIE_${target}_DIR not specified: Building xaiengine for ${target} from Vitis at ${VITIS_ROOT}.") 
-      set(XILINX_XAIE_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${target}/xaiengine/include) #set path where to pick up libxaiengine from build area
-      set(testLibDependsOnXaiengine xaiengine_${target}-build)
-      ExternalProject_Add(xaiengine_${target}
+  
+    # if no LibXAIE_{target}_DIR specified, build xaiengine_${target} from Vitis
+    message("LibXAIE_${target}_DIR not specified: Building xaiengine for ${target} from Vitis at ${VITIS_ROOT}.") 
+    set(LibXAIE_FOUND TRUE)
+    set(XILINX_XAIE_INCLUDE_DIR ${VITIS_AIETOOLS_DIR}/include/drivers/aiengine)
+    set(XILINX_XAIE_LIBS ${VITIS_ROOT}/aietools/lib/lnx64.o/libxaiengine.so)
+
+  endif()
+
+  if (LibXAIE_FOUND)
+    set(testLibDependsOnXaiengine xaiengine_${target}-build)
+    ExternalProject_Add(xaiengine_${target}
       PREFIX ${CMAKE_CURRENT_BINARY_DIR}/xaiengineTmp/${target}
       SOURCE_DIR ${PROJECT_SOURCE_DIR}/xaiengine
       BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${target}/xaiengine
@@ -63,10 +71,12 @@ foreach(target ${AIE_RUNTIME_TARGETS})
           -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
           -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
           -DAIE_RUNTIME_TARGET=${target}
+          -DAIERT_INCLUDE_DIR=${XILINX_XAIE_INCLUDE_DIR}
+          -DAIERT_LIBS=${XILINX_XAIE_LIBS}
           -DVITIS_ROOT=${VITIS_ROOT}
           -DVITIS_AIETOOLS_DIR=${VITIS_AIETOOLS_DIR}
           -DVitis_VERSION_MAJOR=${Vitis_VERSION_MAJOR}
-		      -DVitis_VERSION_MINOR=${Vitis_VERSION_MINOR}
+          -DVitis_VERSION_MINOR=${Vitis_VERSION_MINOR}
           -DSysroot=${Sysroot}
       BUILD_ALWAYS true
       STEP_TARGETS clean build install test
@@ -76,7 +86,7 @@ foreach(target ${AIE_RUNTIME_TARGETS})
       USES_TERMINAL_INSTALL true
       TEST_BEFORE_INSTALL true
       TEST_EXCLUDE_FROM_MAIN true
-      )
+    )
   else()
     message(STATUS "LibXAIE_${target}_DIR not specified and Vitis not found.  LibXAIE not built.")
   endif()

--- a/runtime_lib/xaiengine/CMakeLists.txt
+++ b/runtime_lib/xaiengine/CMakeLists.txt
@@ -6,18 +6,19 @@
 
 cmake_minimum_required(VERSION 3.20.1)
 
-#tmp path to header files since we use an older (3_0) version of xaiengine. need to fix when we upgrade to 2023.1
-if(${Vitis_VERSION_MAJOR} EQUAL "2022")
-    set(aieRTIncludePath "${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src" CACHE STRING "AIE-RT include path")
-elseif(${Vitis_VERSION_MAJOR} EQUAL "2023")
-    set(aieRTIncludePath "${VITIS_AIETOOLS_DIR}/include/drivers/aiengine" CACHE STRING "AIE-RT include path")
-else()
-    message(FATAL_ERROR "Unsupported Vitis version: ${Vitis_VERSION_MAJOR}")
-endif()
-
 project("xaiengine lib for ${AIE_RUNTIME_TARGET}")
 
 if (${CMAKE_CROSSCOMPILING})
+
+    #tmp path to header files since we use an older (3_0) version of xaiengine. need to fix when we upgrade to 2023.1
+    if(${Vitis_VERSION_MAJOR} EQUAL "2022")
+        set(aieRTIncludePath "${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src" CACHE STRING "AIE-RT include path")
+    elseif(${Vitis_VERSION_MAJOR} EQUAL "2023")
+        set(aieRTIncludePath "${VITIS_AIETOOLS_DIR}/include/drivers/aiengine" CACHE STRING "AIE-RT include path")
+    else()
+        message(FATAL_ERROR "Unsupported Vitis version: ${Vitis_VERSION_MAJOR}")
+    endif()
+
     message("Building xaiengine for ${AIE_RUNTIME_TARGET} from Vitis at ${VITIS_ROOT}.") 
     file(GLOB libheaders ${aieRTIncludePath}/*.h)
     file(GLOB libheadersSub ${aieRTIncludePath}/*/*.h)
@@ -49,31 +50,30 @@ if (${CMAKE_CROSSCOMPILING})
     add_subdirectory(lib)
 
 else()
-    message("Copying xaiengine for ${AIE_RUNTIME_TARGET} from Vitis at ${VITIS_ROOT}.") 
-    set(xaiengineIncludePath ${VITIS_AIETOOLS_DIR}/include/drivers/aiengine)
-    #tmp path to header files since we use an older (3_0) version of xaiengine. need to fix when we upgrade to 2023.1 and can take this from aie-rt
-    set(xaiengineIncludePathTmp ${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src)
-    file(GLOB libheaders ${aieRTIncludePath}/*.h)
-    file(GLOB libheadersSub ${aieRTIncludePath}/*/*.h)
-    set(xaiengineLibPath ${VITIS_ROOT}/aietools/lib/lnx64.o/libxaiengine.so)
+
+    message("Copying xaiengine for ${AIE_RUNTIME_TARGET} from ${AIERT_LIBS}.") 
+
+    file(GLOB libheaders ${AIERT_INCLUDE_DIR}/*.h)
+    file(GLOB libheadersSub ${AIERT_INCLUDE_DIR}/*/*.h)
 
     # copy header files into build area
     set(dest ${CMAKE_CURRENT_BINARY_DIR}/include)
     add_custom_target(aie-copy-runtime-headers ALL DEPENDS ${dest})
     add_custom_command(OUTPUT ${dest}
-                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${xaiengineIncludePath} ${dest})
+                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${AIERT_INCLUDE_DIR} ${dest})
 
-    # and the libraries
-    set(dest ${CMAKE_CURRENT_BINARY_DIR}/lib/libxaiengine.so)
-    add_custom_target(aie-copy-runtime-libs ALL DEPENDS ${dest})
-    add_custom_command(OUTPUT ${dest}
-                    COMMAND ${CMAKE_COMMAND} -E copy ${xaiengineLibPath} ${dest})
+    # copy library file to build area
+    set(libs
+        ${CMAKE_CURRENT_BINARY_DIR}/lib/libxaiengine.so
+        ${CMAKE_CURRENT_BINARY_DIR}/lib/libxaiengine.so.3)
+    add_custom_target(aie-copy-runtime-libs ALL DEPENDS ${libs})
+    foreach(lib ${libs})
+        add_custom_command(OUTPUT ${lib} COMMAND ${CMAKE_COMMAND} -E copy ${AIERT_LIBS} ${lib})
+    endforeach()
 
+    # install library and headers
     install(FILES ${libheaders} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include)
     install(FILES ${libheadersSub} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include/xaiengine)
-    install(FILES ${xaiengineLibPath}
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/lib)
+    install(FILES ${libs} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/lib)
 
-    # /proj/xbuilds/2023.1_daily_latest/installs/lin64/Vitis/2023.1/aietools/include/drivers/aiengine
-    #     ./aietools/lib/lnx64.o/libxaiengine.so
 endif()

--- a/runtime_lib/xaiengine/lib/CMakeLists.txt
+++ b/runtime_lib/xaiengine/lib/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
-set(XAIE_SOURCE ${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src) 
+set(XAIE_SOURCE ${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src)
 file(GLOB libsources ${XAIE_SOURCE}/*/*.c ${XAIE_SOURCE}/*/*/*.c)
 
 include_directories(


### PR DESCRIPTION
The previous behavior was to copy libxaie into the runtime_lib install area unless the user provided cmake with the libxaie location. This commit changes cmake to always copy libxaie into the install, whether or not it was user provided.

Some pseudo code to try to explain the changes:
```python
# old way
for target in targets: # target is x86_64, aarch64
  if user provided a libxaie for target:
    # do nothing
  else if vitis was found:
    as a cmake subproject:
      if cmake_crosscompiling:
        copy libxaie source and headers from vitis
        cross compile libxaie
        install libxaie under runtime_lib/<target>
      else:
        install libxaie from vitis under runtime_lib/<target>

# new way
for target in targets: # target is x86_64, aarch64
  if user or vitis libxaie exists:
    as a cmake subproject:
      if cmake_crosscompiling:
        copy libxaie source and headers from vitis
        cross compile libxaie
        install libxaie under runtime_lib/<target>
      else:
        install user or vitis libxaie under runtime_lib/<target>
```

Resolves https://github.com/Xilinx/mlir-aie/issues/501 because we always copy libxaie to the hard coded location.