### PR TITLE
[chess-clang] Add proper defines for Vitis kernel code

### DIFF
--- a/tools/chess-clang/chess-clang
+++ b/tools/chess-clang/chess-clang
@@ -56,6 +56,9 @@ do
   fi
 done
 
+# aie_api.h spews tons of warnings here.
+ArgsArr+=( "-Wno-deprecated-declarations" )
+
 # Has to be invoked with exec, which means it never returns to this script
 # so this has to be the final invocation.
 exec $CHESSROOT/target/bin/LNa64bin/chess-clang "${ArgsArr[@]}"

--- a/tools/chess-clang/xchesscc_wrapper.in
+++ b/tools/chess-clang/xchesscc_wrapper.in
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2021 Xilinx Inc.
+# (c) Copyright 2022-2023 Advanced Micro Devices, Inc.
 
 TARGET_AIE_LIBDIR="@VITIS_AIE_INCLUDE_DIR@"
 TARGET_AIE2_LIBDIR="@VITIS_AIE2_INCLUDE_DIR@"
@@ -17,6 +18,18 @@ if [ $TARGET != "AIE" -a $TARGET != "AIE2" ]
     echo "xchesscc_wrapper: first argument is expected to be the target architecture (aie or aie2)"
     exit 1
 fi
+if [ $TARGET == "AIE" ]
+  then
+    EXTRA_DEFS="-D__AIE_ARCH__=10 -D__AIEARCH__=10"
+elif [ $TARGET == "AIE2" ]
+  then
+    EXTRA_DEFS="-D__AIE_ARCH__=20 -D__AIEARCH__=20"
+fi
+if [ -z "$AIETOOLS" ]
+  then
+    echo "xchesscc_wrapper needs a valid Vitis installation"
+    exit 1
+fi
 
 TARGETVAR=TARGET_${TARGET}_LIBDIR
 LIBDIR=${!TARGETVAR}
@@ -27,4 +40,4 @@ export UNWRAPPED_XCHESSCC=$AIETOOLS/bin/unwrapped/lnx64.o/xchesscc
 export LD_LIBRARY_PATH=$AIETOOLS/lib/lnx64.o:$AIETOOLS/lnx64/tools/dot/lib:$LD_LIBRARY_PATH
 # Carefully crafted path so that we can inject other scripts into the chess path, namely chess-clang
 export PATH=$DIR:$AIETOOLS/bin/unwrapped/lnx64.o:$AIETOOLS/tps/lnx64/target/bin/LNa64bin
-$UNWRAPPED_XCHESSCC +P 4 -p me -C Release_LLVM -Y clang=$DIR/chess-clang -P $LIBDIR -d -f $@
+$UNWRAPPED_XCHESSCC +P 4 -p me -C Release_LLVM -D__AIENGINE__ $EXTRA_DEFS -Y clang=$DIR/chess-clang -P $LIBDIR -d -f $@


### PR DESCRIPTION
The vitis headers use some defines to switch between synthesizable and functional models.  When feeding code to chess, these always need to be defined.