### PR TITLE
Fix TOSA integration test regressions

### DIFF
--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i16xi32_add_elem_v32/i16xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_add_elem_v32/i16xi32_add_elem.mlir
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
-// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i32xi16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i32xi16_sub_elem.mlir
@@ -12,9 +12,11 @@
 
 module {
   func.func @dut(%arg0: tensor<1024xi16>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
-    %0 = "tosa.cast"(%arg0) : (tensor<1024xi16>) -> tensor<1024xi32>
-    %2 = "tosa.sub"(%arg1, %0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
-    return %2 : tensor<1024xi32>
+    %0 = "tosa.const"() {value = dense<0> : tensor<1024xi32>} : () -> tensor<1024xi32>
+    %1 = "tosa.cast"(%arg0) : (tensor<1024xi16>) -> tensor<1024xi32>
+    %2 = "tosa.sub"(%arg1, %1) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    %3 = "tosa.sub"(%0, %2) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %3 : tensor<1024xi32>
   }
 }
 

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v32/i16xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v32/i16xi32_sub_elem.mlir
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
-// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v16.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v32.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i16xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i16xi8_sub_elem.mlir
@@ -15,7 +15,9 @@ module {
     %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
     %1 = "tosa.cast"(%arg1) : (tensor<1024xi16>) -> tensor<1024xi32>
     %2 = "tosa.sub"(%1,%0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
-    return %2 : tensor<1024xi32>
+    %3 = "tosa.const"() {value = dense<0> : tensor<1024xi32>} : () -> tensor<1024xi32>
+    %4 = "tosa.sub"(%3, %2) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %4 : tensor<1024xi32>
   }
 }
 

--- a/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i32xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i32xi8_sub_elem.mlir
@@ -12,9 +12,11 @@
 
 module {
   func.func @dut(%arg0: tensor<1024xi8>, %arg1: tensor<1024xi32>) -> (tensor<1024xi32>) {
-    %0 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
-    %2 = "tosa.sub"(%arg1, %0) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
-    return %2 : tensor<1024xi32>
+    %0 = "tosa.const"() {value = dense<0> : tensor<1024xi32>} : () -> tensor<1024xi32>
+    %1 = "tosa.cast"(%arg0) : (tensor<1024xi8>) -> tensor<1024xi32>
+    %2 = "tosa.sub"(%arg1, %1) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    %3 = "tosa.sub"(%0, %2) : (tensor<1024xi32>, tensor<1024xi32>)  -> (tensor<1024xi32>)
+    return %3 : tensor<1024xi32>
   }
 }
 

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_1d.mlir
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
+// Need the later LLVM version from `catch up to TOM MLIR #590`
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir


### PR DESCRIPTION
Changes:
- Fix i32xi16, i32xi8, i16xi8 sub_elem TOSA tests
- Remove XFAIL for i16xi32_add/sub_elem_v32
- Add XFAIL for 2d_broadcast_1d TOSA tests. These fails can be resolved when bumping LLVM version to a newer one.

Regression result from `test/Integration/Dialect/TOSA`:
```
Testing Time: 1067.50s
  Passed           : 108
  Expectedly Failed:  15
```

Found other regressions from `test/unit_tests/aievec_tests`:
```
Failed Tests (3):
  AIE :: unit_tests/aievec_tests/bf16_erf_v16/bf16_erf.mlir
  AIE :: unit_tests/aievec_tests/bf16_erf_v32/bf16_erf.mlir
  AIE :: unit_tests/aievec_tests/bf16_tanh/bf16_tanh.mlir

Testing Time: 830.86s
  Passed           : 93
  Expectedly Failed:  1
  Failed           :  3
```

