### PR TITLE
Fix the failure  of tanh test case and set tosa.erf test cases to xfail

### DIFF
--- a/test/unit_tests/aievec_tests/bf16_erf_v16/bf16_erf.mlir
+++ b/test/unit_tests/aievec_tests/bf16_erf_v16/bf16_erf.mlir
@@ -1,3 +1,4 @@
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
 // RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 

--- a/test/unit_tests/aievec_tests/bf16_erf_v32/bf16_erf.mlir
+++ b/test/unit_tests/aievec_tests/bf16_erf_v32/bf16_erf.mlir
@@ -1,3 +1,4 @@
+// XFAIL: *
 // REQUIRES: valid_xchess_license
 // RUN: mlir-opt %s --pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg))" -o linalg.mlir
 // RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=32" -o affine.mlir 

--- a/test/unit_tests/aievec_tests/bf16_tanh/bf16_tanh.mlir
+++ b/test/unit_tests/aievec_tests/bf16_tanh/bf16_tanh.mlir
@@ -3,7 +3,7 @@
 // RUN: mlir-opt linalg.mlir --linalg-fuse-elementwise-ops --eliminate-empty-tensors --empty-tensor-to-alloc-tensor --one-shot-bufferize="allow-return-allocs allow-unknown-ops bufferize-function-boundaries function-boundary-type-conversion=identity-layout-map" --drop-equivalent-buffer-results --buffer-results-to-out-params --buffer-deallocation --canonicalize --cse --convert-linalg-to-affine-loops --affine-super-vectorize="virtual-vector-size=16" -o affine.mlir 
 // RUN: aie-opt affine.mlir --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o aievec.mlir
 // RUN: aie-translate aievec.mlir -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 %aie_runtime_lib%/AIE2/tanh.cpp -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 %aie_runtime_lib%/AIE2/lut_based_ops.cpp -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s


### PR DESCRIPTION
set tosa.erf test cases to xfail until the community changeset will be pulled down.

[MLIR][TOSA] add tosa erf operator
This commit adds tosa erf operator and its lowering
to math lib functions.

Reviewed By: eric-k256, jpienaar

Differential Revision: https://reviews.llvm.org/D150357