### PR TITLE
Fix compilation of tutorials using objectFIFO

### DIFF
--- a/tutorials/tutorial-3/objectFifo_ver/aie.mlir
+++ b/tutorials/tutorial-3/objectFifo_ver/aie.mlir
@@ -16,65 +16,66 @@
 // Declare this MLIR module. A wrapper that can contain all 
 // AIE tiles, buffers, and data movement
 module @tutorial_3 {
+    AIE.device(xcvc1902) {
+        // 2 tiles in row 4 (col 1 and col 2)
+        // even rows have local memory to its left
+        %tile14 = AIE.tile(1, 4) 
+        %tile24 = AIE.tile(2, 4)
 
-    // 2 tiles in row 4 (col 1 and col 2)
-    // even rows have local memory to its left
-    %tile14 = AIE.tile(1, 4) 
-    %tile24 = AIE.tile(2, 4)
+        // Declare an object FIFO between the producer tile (1,4) and consumer tile (2,4).
+        // The size of the object FIFO, i.e. its number of elements, is 1.
+        // Objects, i.e. allocated memory elements, have type memref<256xi32>
+        // These tiles share memory between them.
+        AIE.objectFifo @of (%tile14, {%tile24}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
-    // Declare an object FIFO between the producer tile (1,4) and consumer tile (2,4).
-    // The size of the object FIFO, i.e. its number of elements, is 1.
-    // Objects, i.e. allocated memory elements, have type memref<256xi32>
-    // These tiles share memory between them.
-    AIE.objectFifo @of (%tile14, {%tile24}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+        // This lock will be used to gate when our 2nd core is done
+        %lock24_2 = AIE.lock(%tile24, 2) { sym_name = "lock_a24_2" }
 
-    // This lock will be used to gate when our 2nd core is done
-    %lock24_2 = AIE.lock(%tile24, 2) { sym_name = "lock_a24_2" }
+        // Define core algorithm for tile(1,4)
+        // buf[3] = 14
+        %core14 = AIE.core(%tile14) {
+            // Acquire a subview with one object from the object FIFO.
+            // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
+            // This core acquires objects as a Producer: this impacts the acquire value of the lock 
+            // that is generated through the object FIFO lowering.
+            %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            
+            // Access the first, and only, element of the subview.
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-    // Define core algorithm for tile(1,4)
-    // buf[3] = 14
-    %core14 = AIE.core(%tile14) {
-        // Acquire a subview with one object from the object FIFO.
-        // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
-        // This core acquires objects as a Producer: this impacts the acquire value of the lock 
-        // that is generated through the object FIFO lowering.
-        %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        
-        // Access the first, and only, element of the subview.
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+            %val = arith.constant 14 : i32 
+            %idx = arith.constant 3 : index 
+            memref.store %val, %input[%idx] : memref<256xi32>
+            
+            // Release the previously acquired object.
+            // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
+            // This core releases objects as a Producer: this impacts the release value of the lock 
+            // that is generated through the object FIFO lowering.
+            AIE.objectFifo.release @of (Produce, 1)
+            AIE.end
+        }
 
-        %val = arith.constant 14 : i32 
-        %idx = arith.constant 3 : index 
-        memref.store %val, %input[%idx] : memref<256xi32>
-        
-        // Release the previously acquired object.
-        // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
-        // This core releases objects as a Producer: this impacts the release value of the lock 
-        // that is generated through the object FIFO lowering.
-        AIE.objectFifo.release @of (Produce, 1)
-        AIE.end
-    }
+        // Define core algorithm for tile(2,4) which reads value set by tile(1,4)
+        // buf[5] = buf[3] + 100
+        %core24 = AIE.core(%tile24) {
+            // This acquire succeeds when the core is enabled
+            AIE.useLock(%lock24_2, "Acquire", 0)
 
-    // Define core algorithm for tile(2,4) which reads value set by tile(1,4)
-    // buf[5] = buf[3] + 100
-    %core24 = AIE.core(%tile24) {
-        // This acquire succeeds when the core is enabled
-        AIE.useLock(%lock24_2, "Acquire", 0)
+            %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+            %idx1 = arith.constant 3 : index
+            %d1   = memref.load %input[%idx1] : memref<256xi32>
+            %c1   = arith.constant 100 : i32 
+            %d2   = arith.addi %d1, %c1 : i32
+            %idx2 = arith.constant 5 : index
+            memref.store %d2, %input[%idx2] : memref<256xi32> 
 
-        %idx1 = arith.constant 3 : index
-        %d1   = memref.load %input[%idx1] : memref<256xi32>
-        %c1   = arith.constant 100 : i32 
-        %d2   = arith.addi %d1, %c1 : i32
-        %idx2 = arith.constant 5 : index
-        memref.store %d2, %input[%idx2] : memref<256xi32> 
+            AIE.objectFifo.release @of (Consume, 1)
 
-        AIE.objectFifo.release @of (Consume, 1)
-
-        // This release means our 2nd core is done
-        AIE.useLock(%lock24_2, "Release", 1)
-        AIE.end
+            // This release means our 2nd core is done
+            AIE.useLock(%lock24_2, "Release", 1)
+            AIE.end
+        }
     }
 }

--- a/tutorials/tutorial-4/aie.mlir
+++ b/tutorials/tutorial-4/aie.mlir
@@ -18,65 +18,66 @@
 // Declare this MLIR module. A wrapper that can contain all 
 // AIE tiles, buffers, and data movement
 module @tutorial_4 {
-    
-    // 2 tiles in row 4 (col 1 and col 3)
-    // even rows have local memory to its left
-    %tile14 = AIE.tile(1, 4)
-    %tile34 = AIE.tile(3, 4)
+    AIE.device(xcvc1902) {
+        // 2 tiles in row 4 (col 1 and col 3)
+        // even rows have local memory to its left
+        %tile14 = AIE.tile(1, 4)
+        %tile34 = AIE.tile(3, 4)
 
-    // Declare an object FIFO between the producer shim tile (7,0) and consumer tile (3,4).
-    // The size of the object FIFO, i.e. its number of elements, is 1.
-    // Objects, i.e. allocated memory elements, have type memref<256xi32>.
-    // These tiles do not share memory between them.
-    AIE.objectFifo @of (%tile14, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+        // Declare an object FIFO between the producer shim tile (7,0) and consumer tile (3,4).
+        // The size of the object FIFO, i.e. its number of elements, is 1.
+        // Objects, i.e. allocated memory elements, have type memref<256xi32>.
+        // These tiles do not share memory between them.
+        AIE.objectFifo @of (%tile14, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
-    // This lock will be used to gate when our 2nd core is done
-    %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }
+        // This lock will be used to gate when our 2nd core is done
+        %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }
 
-    // Define core algorithm for tile(1,4)
-    // buf[3] = 14
-    %core14 = AIE.core(%tile14) {
-        // Acquire a subview with one object from the object FIFO.
-        // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
-        // This core acquires objects as a Producer: this impacts the acquire value of the lock 
-        // that is generated through the object FIFO lowering.
-        %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        
-        // Access the first, and only, element of the subview.
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+        // Define core algorithm for tile(1,4)
+        // buf[3] = 14
+        %core14 = AIE.core(%tile14) {
+            // Acquire a subview with one object from the object FIFO.
+            // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
+            // This core acquires objects as a Producer: this impacts the acquire value of the lock 
+            // that is generated through the object FIFO lowering.
+            %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            
+            // Access the first, and only, element of the subview.
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-        %val = arith.constant 14 : i32 
-        %idx = arith.constant 3 : index 
-        memref.store %val, %input[%idx] : memref<256xi32> 
-        
-        // Release the previously acquired object.
-        // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
-        // This core releases objects as a Producer: this impacts the release value of the lock 
-        // that is generated through the object FIFO lowering.
-        AIE.objectFifo.release @of (Produce, 1)
-        AIE.end
-    } 
+            %val = arith.constant 14 : i32 
+            %idx = arith.constant 3 : index 
+            memref.store %val, %input[%idx] : memref<256xi32> 
+            
+            // Release the previously acquired object.
+            // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
+            // This core releases objects as a Producer: this impacts the release value of the lock 
+            // that is generated through the object FIFO lowering.
+            AIE.objectFifo.release @of (Produce, 1)
+            AIE.end
+        } 
 
-    // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
-    // buf[5] = buf[3] + 100
-    %core34 = AIE.core(%tile34) {
-        // This acquire succeeds when the core is enabled
-        AIE.useLock(%lock34_8, "Acquire", 0)
+        // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
+        // buf[5] = buf[3] + 100
+        %core34 = AIE.core(%tile34) {
+            // This acquire succeeds when the core is enabled
+            AIE.useLock(%lock34_8, "Acquire", 0)
 
-        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+            %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-        %idx1 = arith.constant 3 : index
-        %d1   = memref.load %input[%idx1] : memref<256xi32>
-        %c1   = arith.constant 100 : i32 
-        %d2   = arith.addi %d1, %c1 : i32
-        %idx2 = arith.constant 5 : index
-        memref.store %d2, %input[%idx2] : memref<256xi32> 
-        
-        AIE.objectFifo.release @of (Consume, 1)
+            %idx1 = arith.constant 3 : index
+            %d1   = memref.load %input[%idx1] : memref<256xi32>
+            %c1   = arith.constant 100 : i32 
+            %d2   = arith.addi %d1, %c1 : i32
+            %idx2 = arith.constant 5 : index
+            memref.store %d2, %input[%idx2] : memref<256xi32> 
+            
+            AIE.objectFifo.release @of (Consume, 1)
 
-        // This release means our 2nd core is done
-        AIE.useLock(%lock34_8, "Release", 1)
-        AIE.end
+            // This release means our 2nd core is done
+            AIE.useLock(%lock34_8, "Release", 1)
+            AIE.end
+        }
     }
 }

--- a/tutorials/tutorial-5/aie.mlir
+++ b/tutorials/tutorial-5/aie.mlir
@@ -18,62 +18,63 @@
 // Declare this MLIR module. A wrapper that can contain all 
 // AIE tiles, buffers, and data movement
 module @tutorial_5 {
-    
-    // 1 tile in row 4 (col 3)
-    // even rows have local memory to its left
-    %tile34 = AIE.tile(3, 4)
+    AIE.device(xcvc1902) {
+        // 1 tile in row 4 (col 3)
+        // even rows have local memory to its left
+        %tile34 = AIE.tile(3, 4)
 
-    // 1 tile in row 0 (col 7)
-    // col 7, row 0 has access to a shimDMA
-    %tile70 = AIE.tile(7, 0)
+        // 1 tile in row 0 (col 7)
+        // col 7, row 0 has access to a shimDMA
+        %tile70 = AIE.tile(7, 0)
 
-    // Declare external buffers, which represent pointers to external memory locations.
-    %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32> 
-    %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<256xi32> 
+        // Declare external buffers, which represent pointers to external memory locations.
+        %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32> 
+        %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<256xi32> 
 
-    // Declare an object FIFO between the producer shim tile (7,0) and consumer tile (3,4).
-    // The size of the object FIFO, i.e. its number of elements, is 1.
-    // Objects, i.e. allocated memory elements, have type memref<256xi32>.
-    // These tiles do not share memory between them.
-    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+        // Declare an object FIFO between the producer shim tile (7,0) and consumer tile (3,4).
+        // The size of the object FIFO, i.e. its number of elements, is 1.
+        // Objects, i.e. allocated memory elements, have type memref<256xi32>.
+        // These tiles do not share memory between them.
+        AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
-    // Declare an object FIFO between the producer tile (3,4) and consumer shim tile (7,0).
-    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+        // Declare an object FIFO between the producer tile (3,4) and consumer shim tile (7,0).
+        AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
-    // Register the external memory pointers to the object FIFOs.
-    AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
-    AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<256xi32>)
+        // Register the external memory pointers to the object FIFOs.
+        AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
+        AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<256xi32>)
 
-    // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
-    // buf[5] = buf[3] + 100
-    %core34 = AIE.core(%tile34) {
-        // Acquire a subview with one object from each object FIFO.
-        // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
-        // This core acquires objects both as a Consumer of one object FIFO and as a Producer of another: 
-        // this impacts the acquire values of the locks that are generated through the object FIFO lowering
-        %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        
-        // Access the first, and only, element of each subview.
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
-        %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+        // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
+        // buf[5] = buf[3] + 100
+        %core34 = AIE.core(%tile34) {
+            // Acquire a subview with one object from each object FIFO.
+            // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
+            // This core acquires objects both as a Consumer of one object FIFO and as a Producer of another: 
+            // this impacts the acquire values of the locks that are generated through the object FIFO lowering
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            
+            // Access the first, and only, element of each subview.
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+            %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-        %idx1 = arith.constant 3 : index
-        %d1   = memref.load %input[%idx1] : memref<256xi32>
-        %c1   = arith.constant 100 : i32 
-        %d2   = arith.addi %d1, %c1 : i32
-        %idx2 = arith.constant 5 : index
-        memref.store %d2, %input[%idx2] : memref<256xi32>
+            %idx1 = arith.constant 3 : index
+            %d1   = memref.load %input[%idx1] : memref<256xi32>
+            %c1   = arith.constant 100 : i32 
+            %d2   = arith.addi %d1, %c1 : i32
+            %idx2 = arith.constant 5 : index
+            memref.store %d2, %input[%idx2] : memref<256xi32>
 
-        memref.store %d1, %output[%idx1] : memref<256xi32> 
-        memref.store %d2, %output[%idx2] : memref<256xi32>  
-        
-        // Release the previously acquired objects.
-        // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
-        // This core releases objects both as a Consumer of one object FIFO and as a Producer of another: 
-        // this impacts the release values of the locks that are generated through the object FIFO lowering.
-        AIE.objectFifo.release @of_in (Consume, 1)
-        AIE.objectFifo.release @of_out (Produce, 1)
-        AIE.end
-    } 
+            memref.store %d1, %output[%idx1] : memref<256xi32> 
+            memref.store %d2, %output[%idx2] : memref<256xi32>  
+            
+            // Release the previously acquired objects.
+            // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
+            // This core releases objects both as a Consumer of one object FIFO and as a Producer of another: 
+            // this impacts the release values of the locks that are generated through the object FIFO lowering.
+            AIE.objectFifo.release @of_in (Consume, 1)
+            AIE.objectFifo.release @of_out (Produce, 1)
+            AIE.end
+        } 
+    }
 }

--- a/tutorials/tutorial-6/aie.mlir
+++ b/tutorials/tutorial-6/aie.mlir
@@ -19,91 +19,92 @@
 // AIE tiles, buffers, and data movement
 module @tutorial_6 {
 
-    // 2 tiles in row 4 (col 1 and col 2)
-    // even rows have local memory to its left
-    %tile14 = AIE.tile(1, 4) 
-    %tile34 = AIE.tile(3, 4)
+    AIE.device(xcvc1902) {
+        // 2 tiles in row 4 (col 1 and col 2)
+        // even rows have local memory to its left
+        %tile14 = AIE.tile(1, 4) 
+        %tile34 = AIE.tile(3, 4)
 
-    // Declare local memory of tile(1,4) and tile (3,4) which are not shared
-    %buf14 = AIE.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
-    %buf34 = AIE.buffer(%tile34) { sym_name = "a34" } : memref<256xi32>
+        // Declare local memory of tile(1,4) and tile (3,4) which are not shared
+        %buf14 = AIE.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
+        %buf34 = AIE.buffer(%tile34) { sym_name = "a34" } : memref<256xi32>
 
-    // Declare local locks for tile(1,4) and tile(3,4) giving new
-    // unique lock ID values 6 and 7
-    %lock14_6 = AIE.lock(%tile14, 6) { sym_name = "lock_a14_6" }
-    %lock34_7 = AIE.lock(%tile34, 7) { sym_name = "lock_a34_7" }
-    %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }
+        // Declare local locks for tile(1,4) and tile(3,4) giving new
+        // unique lock ID values 6 and 7
+        %lock14_6 = AIE.lock(%tile14, 6) { sym_name = "lock_a14_6" }
+        %lock34_7 = AIE.lock(%tile34, 7) { sym_name = "lock_a34_7" }
+        %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }
 
-    // Connect DMA channel 0 on tile(1,4) to DMA channel 1 in tile(3,4)
-    // with automatic shortest distance routing for packets (ID=0xD).
-    // Packet IDs are a 5-bit value.
-    // NOTE: By default, packet header are dropped at destination
-    AIE.packet_flow(0xD) {
-        AIE.packet_source<%tile14, DMA: 0>
-        AIE.packet_dest<%tile34, DMA : 1>
-    }
+        // Connect DMA channel 0 on tile(1,4) to DMA channel 1 in tile(3,4)
+        // with automatic shortest distance routing for packets (ID=0xD).
+        // Packet IDs are a 5-bit value.
+        // NOTE: By default, packet header are dropped at destination
+        AIE.packet_flow(0xD) {
+            AIE.packet_source<%tile14, DMA: 0>
+            AIE.packet_dest<%tile34, DMA : 1>
+        }
 
-    // Define core algorithm for tile(1,4)
-    // buf[3] = 14
-    %core14 = AIE.core(%tile14) {
-        // Locks init value is Release 0, so this will always succeed first
-        AIE.useLock(%lock14_6, "Acquire", 0)
+        // Define core algorithm for tile(1,4)
+        // buf[3] = 14
+        %core14 = AIE.core(%tile14) {
+            // Locks init value is Release 0, so this will always succeed first
+            AIE.useLock(%lock14_6, "Acquire", 0)
 
-		%val = arith.constant 14 : i32 
-		%idx = arith.constant 3 : index 
-		memref.store %val, %buf14[%idx] : memref<256xi32> 
+            %val = arith.constant 14 : i32 
+            %idx = arith.constant 3 : index 
+            memref.store %val, %buf14[%idx] : memref<256xi32> 
 
-        // Release lock to 1 so tile(2,4) can acquire and begin processing
-        AIE.useLock(%lock14_6, "Release", 1)
-        AIE.end
-    }
-
-    %mem14 = AIE.mem(%tile14) {
-        AIE.dmaStart("MM2S", 0, ^bd0, ^end)
-        ^bd0:
-            AIE.useLock(%lock14_6, Acquire, 1)
-            // Insert header for packet routing
-            // 0x4 - packet type, arbitary value
-            // 0xD - packet ID, arbitary value but used for routing
-            AIE.dmaBdPacket(0x4, 0xD) 
-            AIE.dmaBd(<%buf14 : memref<256xi32>, 0, 256>, 0)
-            AIE.useLock(%lock14_6, Release, 0)
-            AIE.nextBd ^end
-        ^end:
+            // Release lock to 1 so tile(2,4) can acquire and begin processing
+            AIE.useLock(%lock14_6, "Release", 1)
             AIE.end
-    }    
+        }
 
- 
-    // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
-    // buf[5] = buf[3] + 100
-    %core34 = AIE.core(%tile34) {
-        AIE.useLock(%lock34_8, "Acquire", 0)
-        // This acquire will stall since locks are initialized to Release, 0
-        AIE.useLock(%lock34_7, "Acquire", 1)
+        %mem14 = AIE.mem(%tile14) {
+            AIE.dmaStart("MM2S", 0, ^bd0, ^end)
+            ^bd0:
+                AIE.useLock(%lock14_6, Acquire, 1)
+                // Insert header for packet routing
+                // 0x4 - packet type, arbitary value
+                // 0xD - packet ID, arbitary value but used for routing
+                AIE.dmaBdPacket(0x4, 0xD) 
+                AIE.dmaBd(<%buf14 : memref<256xi32>, 0, 256>, 0)
+                AIE.useLock(%lock14_6, Release, 0)
+                AIE.nextBd ^end
+            ^end:
+                AIE.end
+        }    
 
-        %idx1 = arith.constant 3 : index
-        %d1   = memref.load %buf34[%idx1] : memref<256xi32>
-        %c1   = arith.constant 100 : i32 
-        %d2   = arith.addi %d1, %c1 : i32
-		%idx2 = arith.constant 5 : index
-		memref.store %d2, %buf34[%idx2] : memref<256xi32> 
+     
+        // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
+        // buf[5] = buf[3] + 100
+        %core34 = AIE.core(%tile34) {
+            AIE.useLock(%lock34_8, "Acquire", 0)
+            // This acquire will stall since locks are initialized to Release, 0
+            AIE.useLock(%lock34_7, "Acquire", 1)
 
-        AIE.useLock(%lock34_7, "Release", 0)
-        AIE.useLock(%lock34_8, "Release", 1)
-        AIE.end
-    }
+            %idx1 = arith.constant 3 : index
+            %d1   = memref.load %buf34[%idx1] : memref<256xi32>
+            %c1   = arith.constant 100 : i32 
+            %d2   = arith.addi %d1, %c1 : i32
+            %idx2 = arith.constant 5 : index
+            memref.store %d2, %buf34[%idx2] : memref<256xi32> 
 
-    // Define local tile memory behavior (i.e. tileDMA)
-    %mem34 = AIE.mem(%tile34) {
-        AIE.dmaStart("S2MM", 1, ^bd0, ^end) 
-        ^bd0:
-            AIE.useLock(%lock34_7, Acquire, 0)
-            // Packets headers are dropped so no need to define packet behavior here
-            AIE.dmaBd(<%buf34 : memref<256xi32>, 0, 256>, 0)
-            AIE.useLock(%lock34_7, Release, 1)
-            AIE.nextBd ^end
-        ^end:
+            AIE.useLock(%lock34_7, "Release", 0)
+            AIE.useLock(%lock34_8, "Release", 1)
             AIE.end
-    }    
+        }
 
+        // Define local tile memory behavior (i.e. tileDMA)
+        %mem34 = AIE.mem(%tile34) {
+            AIE.dmaStart("S2MM", 1, ^bd0, ^end) 
+            ^bd0:
+                AIE.useLock(%lock34_7, Acquire, 0)
+                // Packets headers are dropped so no need to define packet behavior here
+                AIE.dmaBd(<%buf34 : memref<256xi32>, 0, 256>, 0)
+                AIE.useLock(%lock34_7, Release, 1)
+                AIE.nextBd ^end
+            ^end:
+                AIE.end
+        }    
+    }
 }

--- a/tutorials/tutorial-7/aie.mlir
+++ b/tutorials/tutorial-7/aie.mlir
@@ -18,92 +18,94 @@
 // Declare this MLIR module. A wrapper that can contain all 
 // AIE tiles, buffers, and data movement
 module @tutorial_7 {
-    
-    // 2 tiles in row 4 (col 1 and col 3) and 1 in row 5 (col 3)
-    // even rows have local memory to its left
-    // odd rows have local memory to its right
-    %tile14 = AIE.tile(1, 4) 
-    %tile34 = AIE.tile(3, 4)
-    %tile35 = AIE.tile(3, 5)
 
-    // Declare an object FIFO between the producer shim tile (7,0) and consumer tiles (3,4) and (3,5).
-    // As there are multiple consumers, this objectFifo represents a one-to-many broadcast.
-    // The size of the object FIFO, i.e. its number of elements, is 1.
-    // Objects, i.e. allocated memory elements, have type memref<256xi32>.
-    // Each (producer tile / consumer tile) pair does not share memory.
-    AIE.objectFifo @of (%tile14, {%tile34,%tile35}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+    AIE.device(xcvc1902) {
+        // 2 tiles in row 4 (col 1 and col 3) and 1 in row 5 (col 3)
+        // even rows have local memory to its left
+        // odd rows have local memory to its right
+        %tile14 = AIE.tile(1, 4) 
+        %tile34 = AIE.tile(3, 4)
+        %tile35 = AIE.tile(3, 5)
 
-    // These locks will be used to gate when our end cores are done
-    %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }
-    %lock35_8 = AIE.lock(%tile35, 8) { sym_name = "lock_a35_8" }
+        // Declare an object FIFO between the producer shim tile (7,0) and consumer tiles (3,4) and (3,5).
+        // As there are multiple consumers, this objectFifo represents a one-to-many broadcast.
+        // The size of the object FIFO, i.e. its number of elements, is 1.
+        // Objects, i.e. allocated memory elements, have type memref<256xi32>.
+        // Each (producer tile / consumer tile) pair does not share memory.
+        AIE.objectFifo @of (%tile14, {%tile34,%tile35}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
-    // Define core algorithm for tile(1,4)
-    // buf[3] = 14
-    %core14 = AIE.core(%tile14) {
-        // Acquire a subview with one object from the object FIFO.
-        // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
-        // This core acquires objects as a Producer: this impacts the acquire value of the lock 
-        // that is generated through the object FIFO lowering.
-        %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        
-        // Access the first, and only, element of the subview.
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+        // These locks will be used to gate when our end cores are done
+        %lock34_8 = AIE.lock(%tile34, 8) { sym_name = "lock_a34_8" }
+        %lock35_8 = AIE.lock(%tile35, 8) { sym_name = "lock_a35_8" }
 
-        %val = arith.constant 14 : i32 
-        %idx = arith.constant 3 : index 
-        memref.store %val, %input[%idx] : memref<256xi32> 
-        
-        // Release the previously acquired object.
-        // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
-        // This core releases objects as a Producer: this impacts the release value of the lock 
-        // that is generated through the object FIFO lowering.
-        AIE.objectFifo.release @of (Produce, 1)
-        AIE.end
-    } 
+        // Define core algorithm for tile(1,4)
+        // buf[3] = 14
+        %core14 = AIE.core(%tile14) {
+            // Acquire a subview with one object from the object FIFO.
+            // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
+            // This core acquires objects as a Producer: this impacts the acquire value of the lock 
+            // that is generated through the object FIFO lowering.
+            %inputSubview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            
+            // Access the first, and only, element of the subview.
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-    // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
-    // buf[5] = buf[3] + 100
-    %core34 = AIE.core(%tile34) {
-        // This acquire succeeds when the core is enabled
-        AIE.useLock(%lock34_8, "Acquire", 0)
+            %val = arith.constant 14 : i32 
+            %idx = arith.constant 3 : index 
+            memref.store %val, %input[%idx] : memref<256xi32> 
+            
+            // Release the previously acquired object.
+            // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
+            // This core releases objects as a Producer: this impacts the release value of the lock 
+            // that is generated through the object FIFO lowering.
+            AIE.objectFifo.release @of (Produce, 1)
+            AIE.end
+        } 
 
-        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+        // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
+        // buf[5] = buf[3] + 100
+        %core34 = AIE.core(%tile34) {
+            // This acquire succeeds when the core is enabled
+            AIE.useLock(%lock34_8, "Acquire", 0)
 
-        %idx1 = arith.constant 3 : index
-        %d1   = memref.load %input[%idx1] : memref<256xi32>
-        %c1   = arith.constant 100 : i32 
-        %d2   = arith.addi %d1, %c1 : i32
-        %idx2 = arith.constant 5 : index
-        memref.store %d2, %input[%idx2] : memref<256xi32> 
-        
-        AIE.objectFifo.release @of (Consume, 1)
+            %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-        // This release means our 2nd core is done
-        AIE.useLock(%lock34_8, "Release", 1)
-        AIE.end
-    }
+            %idx1 = arith.constant 3 : index
+            %d1   = memref.load %input[%idx1] : memref<256xi32>
+            %c1   = arith.constant 100 : i32 
+            %d2   = arith.addi %d1, %c1 : i32
+            %idx2 = arith.constant 5 : index
+            memref.store %d2, %input[%idx2] : memref<256xi32> 
+            
+            AIE.objectFifo.release @of (Consume, 1)
 
-    // Define core algorithm for tile(3,5) which reads value set by tile(1,4)
-    // buf[5] = buf[3] + 100
-    %core35 = AIE.core(%tile35) {
-        // This acquire succeeds when the core is enabled
-        AIE.useLock(%lock35_8, "Acquire", 0)
+            // This release means our 2nd core is done
+            AIE.useLock(%lock34_8, "Release", 1)
+            AIE.end
+        }
 
-        %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-        %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+        // Define core algorithm for tile(3,5) which reads value set by tile(1,4)
+        // buf[5] = buf[3] + 100
+        %core35 = AIE.core(%tile35) {
+            // This acquire succeeds when the core is enabled
+            AIE.useLock(%lock35_8, "Acquire", 0)
 
-        %idx1 = arith.constant 3 : index
-        %d1   = memref.load %input[%idx1] : memref<256xi32>
-        %c1   = arith.constant 100 : i32 
-        %d2   = arith.addi %d1, %c1 : i32
-        %idx2 = arith.constant 5 : index
-        memref.store %d2, %input[%idx2] : memref<256xi32> 
-        
-        AIE.objectFifo.release @of (Consume, 1)
+            %inputSubview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
-        // This release means our 2nd core is done
-        AIE.useLock(%lock35_8, "Release", 1)
-        AIE.end
+            %idx1 = arith.constant 3 : index
+            %d1   = memref.load %input[%idx1] : memref<256xi32>
+            %c1   = arith.constant 100 : i32 
+            %d2   = arith.addi %d1, %c1 : i32
+            %idx2 = arith.constant 5 : index
+            memref.store %d2, %input[%idx2] : memref<256xi32> 
+            
+            AIE.objectFifo.release @of (Consume, 1)
+
+            // This release means our 2nd core is done
+            AIE.useLock(%lock35_8, "Release", 1)
+            AIE.end
+        }
     }
 }


### PR DESCRIPTION
Tutorials 5 (objectFIFO version), 4, 5, 6 and 7 were missing the AIE.device operation wrapping all the MLIR code within the module. There was an error at the MLIR verification level. This patch adds the operation, making it possible to compile these tutorials. Fixes issue #698 