### PR TITLE
Add IPU to TargetModel

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -158,6 +158,7 @@ def AIE2: I32EnumAttrCase<"AIE2", 2>;
 def xcvc1902: I32EnumAttrCase<"xcvc1902", 1>;
 def xcve2302: I32EnumAttrCase<"xcve2302", 2>;
 def xcve2802: I32EnumAttrCase<"xcve2802", 3>;
+def ipu: I32EnumAttrCase<"ipu", 4>;
 
 def LockAction: I32EnumAttr<"LockAction", "lock acquire/release",
   [Acquire, AcquireGreaterEqual, Release]> {
@@ -176,7 +177,7 @@ def AIEArch: I32EnumAttr<"AIEArch", "AIE Architecture",
   let cppNamespace = "xilinx::AIE";
 }
 def AIEDevice: I32EnumAttr<"AIEDevice", "AIE Device",
-  [xcvc1902, xcve2302, xcve2802]> {
+  [xcvc1902, xcve2302, xcve2802, ipu]> {
 
   let cppNamespace = "xilinx::AIE";
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -74,6 +74,7 @@ namespace AIE {
 static xilinx::AIE::VC1902TargetModel VC1902model;
 static xilinx::AIE::VE2302TargetModel VE2302model;
 static xilinx::AIE::VE2802TargetModel VE2802model;
+static xilinx::AIE::IPUTargetModel IPUmodel;
 
 const xilinx::AIE::AIETargetModel &getTargetModel(Operation *op) {
   if (auto t = dyn_cast<xilinx::AIE::AIETarget>(op))
@@ -842,6 +843,8 @@ const xilinx::AIE::AIETargetModel &xilinx::AIE::DeviceOp::getTargetModel() {
     return VE2302model;
   case AIEDevice::xcve2802:
     return VE2802model;
+  case AIEDevice::ipu:
+    return IPUmodel;
   }
   return VC1902model;
 }


### PR DESCRIPTION
Add IPU device to TargetModel.

Maybe there is a better device name than `ipu` to not collide with future IPU variant?
