### PR TITLE
use structs instead of pairs

### DIFF
--- a/include/aie/Dialect/AIE/AIENetlistAnalysis.h
+++ b/include/aie/Dialect/AIE/AIENetlistAnalysis.h
@@ -28,8 +28,7 @@
 
 using namespace mlir;
 
-namespace xilinx {
-namespace AIE {
+namespace xilinx::AIE {
 
 class NetlistAnalysis {
   DeviceOp &device;
@@ -58,14 +57,9 @@ public:
       : device(d), tiles(tiles), cores(cores), mems(mems), locks(locks),
         buffers(buffers), switchboxes(switchboxes) {}
 
-  //  void runAnalysis();
-
   void collectTiles(DenseMap<TileID, Operation *> &tiles);
   void collectCores(DenseMap<Operation *, CoreOp> &cores);
-  void collectMems(DenseMap<Operation *, MemOp> &mems);
-  void collectLocks(DenseMap<std::pair<Operation *, int>, LockOp> &locks);
   void collectBuffers(DenseMap<Operation *, SmallVector<BufferOp, 4>> &buffers);
-  void collectSwitchboxes(DenseMap<Operation *, SwitchboxOp> &switchboxes);
 
   auto getBufferUsers() const { return bufferUsers; }
 
@@ -73,36 +67,15 @@ public:
 
   auto getDMAs() const { return dmas; }
 
-  auto getDMAConnections() const { return dmaConnections; }
-
-  auto getLockPairs() const { return lockPairs; }
-
-  auto getLockChains() const { return lockChains; }
-
-  auto getBufAcqLocks() const { return bufAcqLocks; }
-
-  auto getDma2ConnectsMap() const { return dma2ConnectsMap; }
-
-  TileID getCoord(Operation *Op) const;
-  bool isLegalAffinity(Operation *src, Operation *user) const;
-  bool validateCoreOrMemRegion(Operation *CoreOrMemOp);
-  void collectBufferUsage();
   void collectDMAUsage();
-  uint64_t getMemUsageInBytes(Operation *tileOp) const;
   uint64_t getBufferBaseAddress(Operation *bufOp) const;
 
   SmallVector<Operation *, 4> getNextConnectOps(ConnectOp currentConnect) const;
   SmallVector<Operation *, 4> findDestConnectOps(ConnectOp source,
                                                  WireBundle destBundle) const;
-  SmallVector<Operation *, 4> findRoutes(Operation *sourceConnectOp,
-                                         Operation *destConnectOp) const;
   void dmaAnalysis();
-  void lockAnalysis();
-
-  void print(raw_ostream &os);
 };
 
-} // namespace AIE
-} // namespace xilinx
+} // namespace xilinx::AIE
 
 #endif

--- a/include/aie/Dialect/AIE/AIENetlistAnalysis.h
+++ b/include/aie/Dialect/AIE/AIENetlistAnalysis.h
@@ -33,7 +33,7 @@ namespace AIE {
 
 class NetlistAnalysis {
   DeviceOp &device;
-  DenseMap<std::pair<int, int>, Operation *> &tiles;
+  DenseMap<TileID, Operation *> &tiles;
   DenseMap<Operation *, CoreOp> &cores;
   DenseMap<Operation *, MemOp> &mems;
   DenseMap<std::pair<Operation *, int>, LockOp> &locks;
@@ -49,8 +49,7 @@ class NetlistAnalysis {
   DenseMap<Operation *, SmallVector<Operation *, 4>> bufAcqLocks;
 
 public:
-  NetlistAnalysis(DeviceOp &d,
-                  DenseMap<std::pair<int, int>, Operation *> &tiles,
+  NetlistAnalysis(DeviceOp &d, DenseMap<TileID, Operation *> &tiles,
                   DenseMap<Operation *, CoreOp> &cores,
                   DenseMap<Operation *, MemOp> &mems,
                   DenseMap<std::pair<Operation *, int>, LockOp> &locks,
@@ -59,9 +58,9 @@ public:
       : device(d), tiles(tiles), cores(cores), mems(mems), locks(locks),
         buffers(buffers), switchboxes(switchboxes) {}
 
-  void runAnalysis();
+  //  void runAnalysis();
 
-  void collectTiles(DenseMap<std::pair<int, int>, Operation *> &tiles);
+  void collectTiles(DenseMap<TileID, Operation *> &tiles);
   void collectCores(DenseMap<Operation *, CoreOp> &cores);
   void collectMems(DenseMap<Operation *, MemOp> &mems);
   void collectLocks(DenseMap<std::pair<Operation *, int>, LockOp> &locks);
@@ -84,7 +83,7 @@ public:
 
   auto getDma2ConnectsMap() const { return dma2ConnectsMap; }
 
-  std::pair<int, int> getCoord(Operation *Op) const;
+  TileID getCoord(Operation *Op) const;
   bool isLegalAffinity(Operation *src, Operation *user) const;
   bool validateCoreOrMemRegion(Operation *CoreOrMemOp);
   void collectBufferUsage();

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -130,10 +130,10 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
   }];
 
   let extraClassDeclaration = [{
-    uint32_t getNumSourceConnections(WireBundle bundle);
-    uint32_t getNumDestConnections(WireBundle bundle);
-    uint32_t colIndex() { return getCol(); }
-    uint32_t rowIndex() { return getRow(); }
+    int getNumSourceConnections(WireBundle bundle);
+    int getNumDestConnections(WireBundle bundle);
+    int colIndex() { return getCol(); }
+    int rowIndex() { return getRow(); }
     TileID getTileID() { return {getCol(), getRow()}; }
     bool isShimTile() { return getRow() == 0; }
     bool isMemTile();
@@ -166,7 +166,7 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
   let hasVerifier = 1;
 
   let builders = [
-    OpBuilder<(ins "uint32_t":$col, "uint32_t":$row),
+    OpBuilder<(ins "int":$col, "int":$row),
     [{
       build($_builder, $_state, $_builder.getIndexType(),
             $_builder.getI32IntegerAttr(col),
@@ -208,10 +208,10 @@ def AIE_SwitchboxOp: AIE_Op<"switchbox", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t getNumSourceConnections(WireBundle bundle);
-    uint32_t getNumDestConnections(WireBundle bundle);
-    uint32_t colIndex();
-    uint32_t rowIndex();
+    int getNumSourceConnections(WireBundle bundle);
+    int getNumDestConnections(WireBundle bundle);
+    int colIndex();
+    int rowIndex();
     TileOp getTileOp();
   }];
 
@@ -275,10 +275,10 @@ def AIE_ShimMuxOp: AIE_Op<"shimmux", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t colIndex();
-    uint32_t rowIndex();
-    uint32_t getNumSourceConnections(WireBundle bundle);
-    uint32_t getNumDestConnections(WireBundle bundle);
+    int colIndex();
+    int rowIndex();
+    int getNumSourceConnections(WireBundle bundle);
+    int getNumDestConnections(WireBundle bundle);
     TileOp getTileOp();
   }];
 
@@ -324,8 +324,8 @@ def AIE_ShimDMAOp: AIE_Op<"shimDMA", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t colIndex();
-    uint32_t rowIndex();
+    int colIndex();
+    int rowIndex();
     TileOp getTileOp();
     static StringRef getDefaultDialect() { return "AIE"; }
   }];
@@ -374,8 +374,8 @@ def AIE_CoreOp: AIE_Op<"core", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t colIndex();
-    uint32_t rowIndex();
+    int colIndex();
+    int rowIndex();
     bool isMemWest() { return ((rowIndex() % 2) == 0); };
     TileOp getTileOp();
   }];
@@ -407,7 +407,7 @@ def AIE_PLIOOp: AIE_Op<"plio", []>, Results<(outs Index)> {
   let assemblyFormat = [{ `(` $col `)` attr-dict }];
 
   let extraClassDeclaration = [{
-    uint32_t colIndex() { return getCol(); }
+    int colIndex() { return getCol(); }
   }];
 }
 
@@ -441,8 +441,8 @@ def AIE_ConnectOp: AIE_Op<"connect", [ParentOneOf<["SwitchboxOp", "ShimMuxOp"]> 
   }];
 
   let extraClassDeclaration = [{
-    uint32_t sourceIndex() { return getSourceChannel(); }
-    uint32_t destIndex() { return getDestChannel(); }
+    int sourceIndex() { return getSourceChannel(); }
+    int destIndex() { return getDestChannel(); }
     Port sourcePort() { return {getSourceBundle(), sourceIndex()}; }
     Port destPort() { return {getDestBundle(), destIndex()}; }
   }];
@@ -478,8 +478,8 @@ def AIE_FlowOp: AIE_Op<"flow", []> {
   }];
 
   let extraClassDeclaration = [{
-    uint32_t sourceIndex() { return getSourceChannel(); }
-    uint32_t destIndex() { return getDestChannel(); }
+    int sourceIndex() { return getSourceChannel(); }
+    int destIndex() { return getDestChannel(); }
   }];
 }
 
@@ -563,7 +563,7 @@ def AIE_MasterSetOp: AIE_Op<"masterset", [HasParent<"SwitchboxOp">]>, Results<(o
   }];
 
   let extraClassDeclaration = [{
-    uint32_t destIndex() { return getDestChannel(); }
+    int destIndex() { return getDestChannel(); }
     Port destPort() { return {getDestBundle(), destIndex()}; }
   }];
 }
@@ -607,7 +607,7 @@ def AIE_PacketRulesOp: AIE_Op<"packetrules", [SingleBlockImplicitTerminator<"End
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t sourceIndex() { return getSourceChannel(); }
+    int sourceIndex() { return getSourceChannel(); }
     Port sourcePort() { return {getSourceBundle(), sourceIndex()}; }
   }];
 }
@@ -707,7 +707,7 @@ def AIE_PacketSourceOp: AIE_Op<"packet_source", [HasParent<"PacketFlowOp">]> {
   }];
 
   let extraClassDeclaration = [{
-    uint32_t channelIndex() { return getChannel(); }
+    int channelIndex() { return getChannel(); }
     Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
@@ -732,7 +732,7 @@ def AIE_PacketDestOp: AIE_Op<"packet_dest", [HasParent<"PacketFlowOp">]> {
   }];
 
   let extraClassDeclaration = [{
-    uint32_t channelIndex() { return getChannel(); }
+    int channelIndex() { return getChannel(); }
     Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
@@ -777,7 +777,7 @@ def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
   }];
 
   let extraClassDeclaration = [{
-    uint32_t getPacketID() { return getPacketId(); }
+    int getPacketID() { return getPacketId(); }
   }];
 }
 
@@ -882,15 +882,15 @@ def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
 
   let extraClassDeclaration = [{
     BufferOp getBufferOp();
-    uint32_t getOffsetValue() { return getOffset(); }
-    uint32_t getLenValue() { return getLen(); }
+    int getOffsetValue() { return getOffset(); }
+    int getLenValue() { return getLen(); }
     bool isA() { return (getAB() == 0); }
     bool isB() { return (getAB() == 1); }
   }];
 
   let hasVerifier = 1;
   let builders = [
-    OpBuilder<(ins "Value":$buffer, "uint32_t":$offset, "uint32_t":$len, "uint32_t":$AB), [{
+    OpBuilder<(ins "Value":$buffer, "int":$offset, "int":$len, "int":$AB), [{
       odsState.addOperands(buffer);
       odsState.addAttribute(getOffsetAttrName(odsState.name), $_builder.getI32IntegerAttr(offset));
       odsState.addAttribute(getLenAttrName(odsState.name), $_builder.getI32IntegerAttr(len));
@@ -943,7 +943,7 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [
   }];
 
   let builders = [
-    OpBuilder<(ins "DMAChannelDir":$channelDir, "uint32_t":$channelIndex, "Block *":$dest, "Block *":$chain),
+    OpBuilder<(ins "DMAChannelDir":$channelDir, "int":$channelIndex, "Block *":$dest, "Block *":$chain),
     [{
       build($_builder, $_state, $_builder.getIntegerType(1), channelDir, channelIndex, dest, chain);
     }]>
@@ -984,10 +984,10 @@ def AIE_MemOp: AIE_Op<"mem", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t colIndex();
-    uint32_t rowIndex();
+    int colIndex();
+    int rowIndex();
     TileOp getTileOp();
-    uint32_t maxSizeInBytes() { return 32768; }
+    int maxSizeInBytes() { return 32768; }
     // CallableOpInterface
     Region *getCallableRegion();
     ArrayRef<Type> getArgumentTypes() { return getOperand().getType(); }
@@ -1040,8 +1040,8 @@ def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t colIndex();
-    uint32_t rowIndex();
+    int colIndex();
+    int rowIndex();
     TileOp getTileOp();
     // CallableOpInterface
     Region *getCallableRegion();
@@ -1132,12 +1132,12 @@ def AIE_LockOp: AIE_Op<"lock", [TileElement]>, Results<(outs Index)> {
       }
       llvm_unreachable("unreachable");
     }
-    uint32_t getLockIDValue() {
+    int getLockIDValue() {
       assert(getLockID().has_value() && "Lock has no ID value");
       return getLockID().value();
     }
-    uint32_t colIndex();
-    uint32_t rowIndex();
+    int colIndex();
+    int rowIndex();
     TileOp getTileOp();
   }];
 
@@ -1188,8 +1188,8 @@ def AIE_UseLockOp: AIE_Op<"useLock", []> {
     bool acquire() { return (getAction() == LockAction::Acquire); }
     bool acquire_ge() { return (getAction() == LockAction::AcquireGreaterEqual); }
     bool release() { return (getAction() == LockAction::Release); }
-    uint32_t getLockValue() { return getValue(); }
-    uint32_t getTimeout() { if(auto val = getBlocking()) return (int)*val; else return 1;}
+    int getLockValue() { return getValue(); }
+    int getTimeout() { if(auto val = getBlocking()) return (int)*val; else return 1;}
     LockOp getLockOp() { return dyn_cast<xilinx::AIE::LockOp>(getLock().getDefiningOp()); }
   }];
 }
@@ -1504,7 +1504,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint32_t size( uint32_t index = 0) {
+    int size(int index = 0) {
       if (isa<ArrayAttr>(getElemNumber()))
         return dyn_cast<IntegerAttr>(dyn_cast<ArrayAttr>(getElemNumber())[index]).getInt(); 
       else 
@@ -1669,7 +1669,7 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
 
   let extraClassDeclaration = [{
     ObjectFifoCreateOp getObjectFifo();
-    uint32_t acqNumber() { return getSize(); }
+    int acqNumber() { return getSize(); }
   }];
 }
 
@@ -1703,7 +1703,7 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
 
   let extraClassDeclaration = [{
     ObjectFifoCreateOp getObjectFifo();
-    uint32_t relNumber() { return getSize(); }
+    int relNumber() { return getSize(); }
   }];
 }
 
@@ -1805,7 +1805,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
           .cast<DenseIntElementsAttr>();
     }
 
-    uint32_t getProcessLength() {
+    int getProcessLength() {
       return getLength()
           .getDefiningOp<arith::ConstantOp>()
           .getValue()

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -130,11 +130,11 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
   }];
 
   let extraClassDeclaration = [{
-    int getNumSourceConnections(WireBundle bundle);
-    int getNumDestConnections(WireBundle bundle);
-    int colIndex() { return getCol(); }
-    int rowIndex() { return getRow(); }
-    TileID getTileID() { return std::make_pair(getCol(), getRow()); }
+    uint32_t getNumSourceConnections(WireBundle bundle);
+    uint32_t getNumDestConnections(WireBundle bundle);
+    uint32_t colIndex() { return getCol(); }
+    uint32_t rowIndex() { return getRow(); }
+    TileID getTileID() { return {getCol(), getRow()}; }
     bool isShimTile() { return getRow() == 0; }
     bool isMemTile();
     bool isShimNOCTile();
@@ -204,10 +204,10 @@ def AIE_SwitchboxOp: AIE_Op<"switchbox", [Interconnect, TileElement,
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int getNumSourceConnections(WireBundle bundle);
-    int getNumDestConnections(WireBundle bundle);
-    int colIndex();
-    int rowIndex();
+    uint32_t getNumSourceConnections(WireBundle bundle);
+    uint32_t getNumDestConnections(WireBundle bundle);
+    uint32_t colIndex();
+    uint32_t rowIndex();
     TileOp getTileOp();
   }];
   let builders = [
@@ -273,10 +273,10 @@ def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect, TileElement, IsShimTile,
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int colIndex();
-    int rowIndex();
-    int getNumSourceConnections(WireBundle bundle);
-    int getNumDestConnections(WireBundle bundle);
+    uint32_t colIndex();
+    uint32_t rowIndex();
+    uint32_t getNumSourceConnections(WireBundle bundle);
+    uint32_t getNumDestConnections(WireBundle bundle);
     TileOp getTileOp();
   }];
  let builders = [
@@ -319,8 +319,8 @@ def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint, TileElement, HasValidBDs, Ha
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int colIndex();
-    int rowIndex();
+    uint32_t colIndex();
+    uint32_t rowIndex();
     TileOp getTileOp();
     static StringRef getDefaultDialect() { return "AIE"; }
   }];
@@ -365,8 +365,8 @@ def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint, IsCoreTile, TileElement]>, Results
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int colIndex();
-    int rowIndex();
+    uint32_t colIndex();
+    uint32_t rowIndex();
     bool isMemWest() { return ((rowIndex() % 2) == 0); };
     TileOp getTileOp();
   }];
@@ -398,7 +398,7 @@ def AIE_PLIOOp: AIE_Op<"plio", []>, Results<(outs Index)> {
   }];
   let assemblyFormat = [{ `(` $col `)` attr-dict }];
   let extraClassDeclaration = [{
-    int colIndex() { return getCol(); }
+    uint32_t colIndex() { return getCol(); }
   }];
 }
 
@@ -430,10 +430,10 @@ def AIE_ConnectOp: AIE_Op<"connect", [ParentOneOf<["SwitchboxOp", "ShimMuxOp"]> 
     `<` $sourceBundle `:` $sourceChannel `,` $destBundle `:` $destChannel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int sourceIndex() { return getSourceChannel(); }
-    int destIndex() { return getDestChannel(); }
-    Port sourcePort() { return std::make_pair(getSourceBundle(), sourceIndex()); }
-    Port destPort() { return std::make_pair(getDestBundle(), destIndex()); }
+    uint32_t sourceIndex() { return getSourceChannel(); }
+    uint32_t destIndex() { return getDestChannel(); }
+    Port sourcePort() { return {getSourceBundle(), sourceIndex()}; }
+    Port destPort() { return {getDestBundle(), destIndex()}; }
   }];
 }
 
@@ -465,21 +465,9 @@ def AIE_FlowOp: AIE_Op<"flow", []> {
     `(` $source `,` $sourceBundle `:` $sourceChannel `,` $dest `,` $destBundle `:` $destChannel `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int sourceIndex() { return getSourceChannel(); }
-    int destIndex() { return getDestChannel(); }
+    uint32_t sourceIndex() { return getSourceChannel(); }
+    uint32_t destIndex() { return getDestChannel(); }
   }];
-  // let builders = [
-  //   OpBuilder<(ins "Value":$source, "int":$sourceBundle,
-  //     "int":$sourceChannel, "Value":$dest, "int":$destBundle, "int":$destChannel), [{
-  //     build($_builder, $_state,
-  //           source,
-  //           $_builder.getI32IntegerAttr(sourceBundle),
-  //           $_builder.getI32IntegerAttr(sourceChannel),
-  //           dest,
-  //           $_builder.getI32IntegerAttr(destBundle),
-  //           $_builder.getI32IntegerAttr(destChannel));
-  //     }]>
-  // ];
 }
 
 def AIE_AMSelOp: AIE_Op<"amsel", [HasParent<"SwitchboxOp">]>, Results<(outs Index)> {
@@ -512,17 +500,17 @@ def AIE_AMSelOp: AIE_Op<"amsel", [HasParent<"SwitchboxOp">]>, Results<(outs Inde
     `<` $arbiterID `>` `(` $msel `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int arbiterIndex() { return getArbiterID(); }
-    int getMselValue() { return getMsel(); }
+    uint8_t arbiterIndex() { return getArbiterID(); }
+    uint8_t getMselValue() { return getMsel(); }
   }];
 
   let builders = [
-    OpBuilder<(ins "int":$arbiterID, "int":$msel),
+    OpBuilder<(ins "uint8_t":$arbiterID, "uint8_t":$msel),
     [{
-              build($_builder, $_state, $_builder.getIndexType(),
-                    $_builder.getI8IntegerAttr(arbiterID),
-                    $_builder.getI8IntegerAttr(msel));
-              }]>
+      build($_builder, $_state, $_builder.getIndexType(),
+            $_builder.getI8IntegerAttr(arbiterID),
+            $_builder.getI8IntegerAttr(msel));
+    }]>
   ];
 }
 
@@ -559,8 +547,8 @@ def AIE_MasterSetOp: AIE_Op<"masterset", [HasParent<"SwitchboxOp">]>, Results<(o
     `(` $destBundle `:` $destChannel `,` $amsels `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int destIndex() { return getDestChannel(); }
-    Port destPort() { return std::make_pair(getDestBundle(), destIndex()); }
+    uint32_t destIndex() { return getDestChannel(); }
+    Port destPort() { return {getDestBundle(), destIndex()}; }
   }];
 }
 
@@ -580,16 +568,6 @@ def AIE_WireOp: AIE_Op<"wire", []> {
   let assemblyFormat = [{
     `(` $source `:` $sourceBundle `,` $dest `:` $destBundle `)` attr-dict
   }];
-  // let builders = [
-  //   OpBuilder<(ins "Value":$source, "int":$sourceBundle, "Value":$dest,
-  //     "int":$destBundle), [{
-  //     build($_builder, $_state,
-  //           source,
-  //           $_builder.getI32IntegerAttr((int)sourceBundle),
-  //           dest,
-  //           $_builder.getI32IntegerAttr((int)destBundle));
-  //     }]>
-  // ];
 }
 
 def AIE_PacketRulesOp: AIE_Op<"packetrules", [/*HasParent<"SwitchboxOp">*/
@@ -611,8 +589,8 @@ def AIE_PacketRulesOp: AIE_Op<"packetrules", [/*HasParent<"SwitchboxOp">*/
   let assemblyFormat = [{ `(` $sourceBundle `:` $sourceChannel `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int sourceIndex() { return getSourceChannel(); }
-    Port sourcePort() { return std::make_pair(getSourceBundle(), sourceIndex()); }
+    uint32_t sourceIndex() { return getSourceChannel(); }
+    Port sourcePort() { return {getSourceBundle(), sourceIndex()}; }
   }];
 }
 
@@ -654,20 +632,12 @@ def AIE_PacketRuleOp: AIE_Op<"rule", [HasParent<"PacketRulesOp">]> {
     ```
   }];
   let extraClassDeclaration = [{
-    int maskInt() { return getMask(); }
-    int valueInt() { return getValue(); }
+    uint8_t maskInt() { return getMask(); }
+    uint8_t valueInt() { return getValue(); }
   }];
   let assemblyFormat = [{
     `(` $mask `,` $value `,` $amsel `)` attr-dict
   }];
-  // let builders = [
-  //   OpBuilder<(ins "int":$mask, "int":$value, "Value":$amsel), [{
-  //     build($_builder, $_state,
-  //           $_builder.getI8IntegerAttr(mask),
-  //           $_builder.getI8IntegerAttr(value),
-  //           amsel);
-  //     }]>
-  // ];
 }
 
 
@@ -694,7 +664,7 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int IDInt() { return getID(); }
+    uint8_t IDInt() { return getID(); }
   }];
 }
 
@@ -715,8 +685,8 @@ def AIE_PacketSourceOp: AIE_Op<"packet_source", [HasParent<"PacketFlowOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return getChannel(); }
-    Port port() { return std::make_pair(getBundle(), channelIndex()); }
+    uint32_t channelIndex() { return getChannel(); }
+    Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
 
@@ -738,8 +708,8 @@ def AIE_PacketDestOp: AIE_Op<"packet_dest", [HasParent<"PacketFlowOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return getChannel(); }
-    Port port() { return std::make_pair(getBundle(), channelIndex()); }
+    uint32_t channelIndex() { return getChannel(); }
+    Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
 
@@ -770,9 +740,7 @@ def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
         AIE.dmaBd(<$buf0 : memref<512xi32>, 0, 512>, 1)
         AIE.useLock(%lck, "Release", 1)
         br ^bd6 // point to the next Block, which is also a different Block Descriptor
-
     ```
-    
   }];
 
   let arguments = (
@@ -785,7 +753,7 @@ def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
   }];
 
   let extraClassDeclaration = [{
-    int getPacketID() { return getPacketId(); }
+    uint32_t getPacketID() { return getPacketId(); }
   }];
 
 }
@@ -891,15 +859,15 @@ def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
 
   let extraClassDeclaration = [{
     BufferOp getBufferOp();
-    int getOffsetValue() { return getOffset(); }
-    int getLenValue() { return getLen(); }
+    uint32_t getOffsetValue() { return getOffset(); }
+    uint32_t getLenValue() { return getLen(); }
     bool isA() { return (getAB() == 0); }
     bool isB() { return (getAB() == 1); }
   }];
 
   let hasVerifier = 1;
   let builders = [
-    OpBuilder<(ins "Value":$buffer, "int":$offset, "int":$len, "int":$AB), [{
+    OpBuilder<(ins "Value":$buffer, "uint32_t":$offset, "uint32_t":$len, "uint32_t":$AB), [{
       odsState.addOperands(buffer);
       odsState.addAttribute(getOffsetAttrName(odsState.name), $_builder.getI32IntegerAttr(offset));
       odsState.addAttribute(getLenAttrName(odsState.name), $_builder.getI32IntegerAttr(len));
@@ -952,8 +920,8 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "MemTileDMAOp", "f
   let builders = [
     OpBuilder<(ins "DMAChannelDir":$channelDir, "int":$channelIndex, "Block *":$dest, "Block *":$chain),
     [{
-              build($_builder, $_state, $_builder.getIntegerType(1), channelDir, channelIndex, dest, chain);
-              }]>
+      build($_builder, $_state, $_builder.getIntegerType(1), channelDir, channelIndex, dest, chain);
+    }]>
   ];
 }
 
@@ -989,10 +957,10 @@ def AIE_MemOp: AIE_Op<"mem", [TileElement, FlowEndPoint, CallableOpInterface, Is
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int colIndex();
-    int rowIndex();
+    uint32_t colIndex();
+    uint32_t rowIndex();
     TileOp getTileOp();
-    int maxSizeInBytes() { return 32768; }
+    uint32_t maxSizeInBytes() { return 32768; }
     // CallableOpInterface
     Region *getCallableRegion();
     ArrayRef<Type> getArgumentTypes() { return getOperand().getType(); }
@@ -1042,8 +1010,8 @@ def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [TileElement, FlowEndPoint, CallableO
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int colIndex();
-    int rowIndex();
+    uint32_t colIndex();
+    uint32_t rowIndex();
     TileOp getTileOp();
     // CallableOpInterface
     Region *getCallableRegion();
@@ -1127,12 +1095,12 @@ def AIE_LockOp: AIE_Op<"lock", [TileElement]>, Results<(outs Index)> {
       }
       llvm_unreachable("unreachable");
     }
-    int getLockIDValue() { 
+    uint32_t getLockIDValue() {
       assert(getLockID().has_value() && "Lock has no ID value");
       return getLockID().value();
     }
-    int colIndex();
-    int rowIndex();
+    uint32_t colIndex();
+    uint32_t rowIndex();
     TileOp getTileOp();
   }];
   let builders = [
@@ -1181,8 +1149,8 @@ def AIE_UseLockOp: AIE_Op<"useLock", []> {
     bool acquire() { return (getAction() == LockAction::Acquire); }
     bool acquire_ge() { return (getAction() == LockAction::AcquireGreaterEqual); }
     bool release() { return (getAction() == LockAction::Release); }
-    int getLockValue() { return getValue(); }
-    int getTimeout() { if(auto val = getBlocking()) return (int)*val; else return 1;}
+    uint32_t getLockValue() { return getValue(); }
+    uint32_t getTimeout() { if(auto val = getBlocking()) return (int)*val; else return 1;}
     LockOp getLockOp() { return dyn_cast<xilinx::AIE::LockOp>(getLock().getDefiningOp()); }
   }];
 }
@@ -1483,7 +1451,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    int size(int index = 0) { 
+    uint32_t size( uint32_t index = 0) {
       if (isa<ArrayAttr>(getElemNumber()))
         return dyn_cast<IntegerAttr>(dyn_cast<ArrayAttr>(getElemNumber())[index]).getInt(); 
       else 
@@ -1641,7 +1609,7 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
 
   let extraClassDeclaration = [{
     ObjectFifoCreateOp getObjectFifo();
-    int acqNumber() { return getSize(); }
+    uint32_t acqNumber() { return getSize(); }
   }];
 }
 
@@ -1675,7 +1643,7 @@ def AIE_ObjectFifoReleaseOp: AIE_Op<"objectFifo.release", []> {
 
   let extraClassDeclaration = [{
     ObjectFifoCreateOp getObjectFifo();
-    int relNumber() { return getSize(); }
+    uint32_t relNumber() { return getSize(); }
   }];
 }
 
@@ -1759,7 +1727,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
     ObjectFifoCreateOp getObjectFifo();
     DenseIntElementsAttr getAcquirePattern() { return getAcquirePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
     DenseIntElementsAttr getReleasePattern() { return getReleasePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
-    int getProcessLength() { return getLength().getDefiningOp<arith::ConstantOp>().getValue().cast<IntegerAttr>().getInt(); }
+    uint32_t getProcessLength() { return getLength().getDefiningOp<arith::ConstantOp>().getValue().cast<IntegerAttr>().getInt(); }
   }];
 }
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -25,12 +25,12 @@ def AIE_Dialect : Dialect {
   let cppNamespace = "::xilinx::AIE";
   let description = [{
 
-This is a dialect for describing netlists of AIE components in a
-Versal device.  It focuses on representing logical stream connections
-between cores and DMAs, along with the implementation of those logical
-connections in the various switch components.  In the dialect, a
-switch is referred to as `switchbox` to avoid confusion with the
-`switch` keyword in C/C++.
+    This is a dialect for describing netlists of AIE components in a
+    Versal device.  It focuses on representing logical stream connections
+    between cores and DMAs, along with the implementation of those logical
+    connections in the various switch components.  In the dialect, a
+    switch is referred to as `switchbox` to avoid confusion with the
+    `switch` keyword in C/C++.
 
   }];
   let useDefaultTypePrinterParser = 1;
@@ -70,9 +70,10 @@ def AnyScalar : TypeConstraint<Or<[Index.predicate,
                                   "scalar">;
 
 
-def AIE_DeviceOp: AIE_Op<"device", [AIETarget,
-                                    HasParent<"ModuleOp">,
-                                    SymbolTable, SingleBlock, NoTerminator, IsolatedFromAbove]> {
+def AIE_DeviceOp: AIE_Op<"device", [
+    AIETarget, HasParent<"ModuleOp">,
+    SymbolTable, SingleBlock, NoTerminator, IsolatedFromAbove
+  ]> {
   let summary = "Define an AIE design targetting a complete device";
   let description = [{
     This operation describes a design that executes on a particular AIEngine device.
@@ -97,9 +98,8 @@ def AIE_DeviceOp: AIE_Op<"device", [AIETarget,
     }
     ```
   }];
-  let arguments = (
-    ins AIEDevice:$device
-  );
+
+  let arguments = (ins AIEDevice:$device);
   let regions = (region AnyRegion:$bodyRegion);
   let assemblyFormat = [{
     `(` $device `)` regions attr-dict
@@ -141,6 +141,7 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
     bool isShimPLTile();
     bool isShimNOCorPLTile();
     bool isInternalMemWest() { return ((rowIndex() % 2) == 0); };
+
     MemOp getMemOp() {
       auto users = getResult().getUsers();
       for(auto user : users)
@@ -148,6 +149,7 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
           return memOp;
       return nullptr;
     }
+
     CoreOp getCoreOp() {
       auto users = getResult().getUsers();
       for(auto user : users)
@@ -160,15 +162,16 @@ def AIE_TileOp: AIE_Op<"tile", [FlowEndPoint]>, Results<(outs Index:$result)> {
   let assemblyFormat = [{
     `(` $col `,` $row `)` attr-dict
   }];
+
   let hasVerifier = 1;
 
   let builders = [
-    OpBuilder<(ins "int":$col, "int":$row),
+    OpBuilder<(ins "uint32_t":$col, "uint32_t":$row),
     [{
-              build($_builder, $_state, $_builder.getIndexType(),
-                    $_builder.getI32IntegerAttr(col),
-                    $_builder.getI32IntegerAttr(row));
-              }]>
+      build($_builder, $_state, $_builder.getIndexType(),
+            $_builder.getI32IntegerAttr(col),
+            $_builder.getI32IntegerAttr(row));
+    }]>
   ];
 }
 
@@ -180,12 +183,11 @@ def AIE_EndOp: AIE_Op<"end", [Terminator]> {
   let assemblyFormat = [{ attr-dict }];
 }
 
-def AIE_SwitchboxOp: AIE_Op<"switchbox", [Interconnect, TileElement,
-                                          SingleBlockImplicitTerminator<"EndOp">]>,
-                     Results<(outs Index)> {
-  let arguments = (
-    ins Index:$tile
-  );
+def AIE_SwitchboxOp: AIE_Op<"switchbox", [
+    Interconnect, TileElement,
+    SingleBlockImplicitTerminator<"EndOp">
+  ]>, Results<(outs Index)> {
+  let arguments = (ins Index:$tile);
 
   let summary = "Declare a switch";
   let description = [{
@@ -200,9 +202,11 @@ def AIE_SwitchboxOp: AIE_Op<"switchbox", [Interconnect, TileElement,
     }
     ```
   }];
+
   let regions = (region AnyRegion:$connections);
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint32_t getNumSourceConnections(WireBundle bundle);
     uint32_t getNumDestConnections(WireBundle bundle);
@@ -210,16 +214,18 @@ def AIE_SwitchboxOp: AIE_Op<"switchbox", [Interconnect, TileElement,
     uint32_t rowIndex();
     TileOp getTileOp();
   }];
+
   let builders = [
     OpBuilder<(ins "Value":$tile),
     [{
-              build($_builder, $_state, $_builder.getIndexType(), tile);
-              }]>
+      build($_builder, $_state, $_builder.getIndexType(), tile);
+    }]>
   ];
 }
 
-def AIE_ShimSwitchboxOp: AIE_Op<"shimswitchbox", [SingleBlockImplicitTerminator<"EndOp">]>,
-                         Results<(outs Index)> {
+def AIE_ShimSwitchboxOp: AIE_Op<"shimswitchbox", [
+    SingleBlockImplicitTerminator<"EndOp">
+  ]>, Results<(outs Index)> {
   let arguments = (
     ins I32Attr:$col
   );
@@ -241,17 +247,12 @@ def AIE_ShimSwitchboxOp: AIE_Op<"shimswitchbox", [SingleBlockImplicitTerminator<
   let regions = (region AnyRegion:$connections);
   let assemblyFormat = [{ `(` $col `)` regions attr-dict }];
   let hasVerifier = 1;
-  let builders = [
-    OpBuilder<(ins "Type":$resultType,
-                      "int":$col), [{
-        build($_builder, $_state, resultType, $_builder.getI32IntegerAttr(col));
-    }]>
-  ];
 }
 
-def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect, TileElement, IsShimTile,
-                                      SingleBlockImplicitTerminator<"EndOp">]>,
-                         Results<(outs Index)> {
+def AIE_ShimMuxOp: AIE_Op<"shimmux", [
+    Interconnect, TileElement, IsShimTile,
+    SingleBlockImplicitTerminator<"EndOp">
+  ]>, Results<(outs Index)> {
   let arguments = (
     ins Index:$tile
   );
@@ -272,6 +273,7 @@ def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect, TileElement, IsShimTile,
   let regions = (region AnyRegion:$connections);
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint32_t colIndex();
     uint32_t rowIndex();
@@ -279,6 +281,7 @@ def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect, TileElement, IsShimTile,
     uint32_t getNumDestConnections(WireBundle bundle);
     TileOp getTileOp();
   }];
+
  let builders = [
     OpBuilder<(ins "Value":$tile), [{
       build($_builder, $_state, $_builder.getIndexType(), tile);
@@ -286,9 +289,10 @@ def AIE_ShimMuxOp: AIE_Op<"shimmux", [Interconnect, TileElement, IsShimTile,
  ];
 }
 
-def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint, TileElement, HasValidBDs, HasValidDMAChannels, IsShimNOCTile
-                                      /*, CallableOpInterface*/]>,
-                         Results<(outs Index)> {
+def AIE_ShimDMAOp: AIE_Op<"shimDMA", [
+    FlowEndPoint, TileElement, HasValidBDs,
+    HasValidDMAChannels, IsShimNOCTile
+  ]>, Results<(outs Index)> {
   let arguments = (
     ins Index:$tile
   );
@@ -318,6 +322,7 @@ def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint, TileElement, HasValidBDs, Ha
   let regions = (region AnyRegion:$body);
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint32_t colIndex();
     uint32_t rowIndex();
@@ -326,7 +331,9 @@ def AIE_ShimDMAOp: AIE_Op<"shimDMA", [FlowEndPoint, TileElement, HasValidBDs, Ha
   }];
 }
 
-def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint, IsCoreTile, TileElement]>, Results<(outs Index)> {
+def AIE_CoreOp: AIE_Op<"core", [
+    FlowEndPoint, IsCoreTile, TileElement
+  ]>, Results<(outs Index)> {
   let arguments = (
     ins Index:$tile,
     DefaultValuedAttr<I32Attr, "0x400">:$stackSize
@@ -361,15 +368,18 @@ def AIE_CoreOp: AIE_Op<"core", [FlowEndPoint, IsCoreTile, TileElement]>, Results
     } { stackSize = 2048 : i32, elf_file = "core_33.elf" }
     ```
   }];
+
   let regions = (region AnyRegion:$body);
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint32_t colIndex();
     uint32_t rowIndex();
     bool isMemWest() { return ((rowIndex() % 2) == 0); };
     TileOp getTileOp();
   }];
+
   let builders = [
     OpBuilder<(ins "Value":$tile), [{
       build($_builder, $_state, $_builder.getIndexType(), tile);
@@ -389,14 +399,13 @@ def AIE_DebugOp: AIE_Op<"debug", []> {
 }
 
 def AIE_PLIOOp: AIE_Op<"plio", []>, Results<(outs Index)> {
-  let arguments = (
-    ins I32Attr:$col
-  );
+  let arguments = (ins I32Attr:$col);
   let summary = "Declare an interface to the PL";
   let description = [{
     An interface to the PL.
   }];
   let assemblyFormat = [{ `(` $col `)` attr-dict }];
+
   let extraClassDeclaration = [{
     uint32_t colIndex() { return getCol(); }
   }];
@@ -426,9 +435,11 @@ def AIE_ConnectOp: AIE_Op<"connect", [ParentOneOf<["SwitchboxOp", "ShimMuxOp"]> 
     }
     ```
   }];
+
   let assemblyFormat = [{
     `<` $sourceBundle `:` $sourceChannel `,` $destBundle `:` $destChannel `>` attr-dict
   }];
+
   let extraClassDeclaration = [{
     uint32_t sourceIndex() { return getSourceChannel(); }
     uint32_t destIndex() { return getDestChannel(); }
@@ -461,9 +472,11 @@ def AIE_FlowOp: AIE_Op<"flow", []> {
       aie.flow(%00, "DMA" : 0, %11, "Core" : 1)
     ```
   }];
+
   let assemblyFormat = [{
     `(` $source `,` $sourceBundle `:` $sourceChannel `,` $dest `,` $destBundle `:` $destChannel `)` attr-dict
   }];
+
   let extraClassDeclaration = [{
     uint32_t sourceIndex() { return getSourceChannel(); }
     uint32_t destIndex() { return getDestChannel(); }
@@ -499,6 +512,7 @@ def AIE_AMSelOp: AIE_Op<"amsel", [HasParent<"SwitchboxOp">]>, Results<(outs Inde
   let assemblyFormat = [{
     `<` $arbiterID `>` `(` $msel `)` attr-dict
   }];
+
   let extraClassDeclaration = [{
     uint8_t arbiterIndex() { return getArbiterID(); }
     uint8_t getMselValue() { return getMsel(); }
@@ -543,9 +557,11 @@ def AIE_MasterSetOp: AIE_Op<"masterset", [HasParent<"SwitchboxOp">]>, Results<(o
       AIE.masterset("West" : 2, %a1_0, %a2_3) // this is illegal, please don't do this
       AIE.masterset("West" : 3, %a1_0, %a1_1) // this is OK
   }];
+
   let assemblyFormat = [{
     `(` $destBundle `:` $destChannel `,` $amsels `)` attr-dict
   }];
+
   let extraClassDeclaration = [{
     uint32_t destIndex() { return getDestChannel(); }
     Port destPort() { return {getDestBundle(), destIndex()}; }
@@ -565,13 +581,13 @@ def AIE_WireOp: AIE_Op<"wire", []> {
     Typically, these components are switches, represented by an `aie.switchbox` operation, and tiles,
     represented by an [aie.tile](#aietile-aietileop) operation.
   }];
+
   let assemblyFormat = [{
     `(` $source `:` $sourceBundle `,` $dest `:` $destBundle `)` attr-dict
   }];
 }
 
-def AIE_PacketRulesOp: AIE_Op<"packetrules", [/*HasParent<"SwitchboxOp">*/
-                                              SingleBlockImplicitTerminator<"EndOp">]> {
+def AIE_PacketRulesOp: AIE_Op<"packetrules", [SingleBlockImplicitTerminator<"EndOp">]> {
   let arguments = (
     ins WireBundle:$sourceBundle,
         ConfinedAttr<I32Attr, [IntMinValue<0>]>:$sourceChannel
@@ -586,8 +602,10 @@ def AIE_PacketRulesOp: AIE_Op<"packetrules", [/*HasParent<"SwitchboxOp">*/
 
     See [AIE.rule](#aierule-aiepacketruleop) for an example.
   }];
+
   let assemblyFormat = [{ `(` $sourceBundle `:` $sourceChannel `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint32_t sourceIndex() { return getSourceChannel(); }
     Port sourcePort() { return {getSourceBundle(), sourceIndex()}; }
@@ -631,10 +649,12 @@ def AIE_PacketRuleOp: AIE_Op<"rule", [HasParent<"PacketRulesOp">]> {
       }
     ```
   }];
+
   let extraClassDeclaration = [{
     uint8_t maskInt() { return getMask(); }
     uint8_t valueInt() { return getValue(); }
   }];
+
   let assemblyFormat = [{
     `(` $mask `,` $value `,` $amsel `)` attr-dict
   }];
@@ -642,9 +662,7 @@ def AIE_PacketRuleOp: AIE_Op<"rule", [HasParent<"PacketRulesOp">]> {
 
 
 def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndOp">]> {
-  let arguments = (
-    ins I8Attr:$ID
-  );
+  let arguments = (ins I8Attr:$ID);
   let regions = (region AnyRegion:$ports);
   let summary = "Packet switched flow";
   let description = [{
@@ -661,8 +679,10 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
       }
     ```
   }];
+
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint8_t IDInt() { return getID(); }
   }];
@@ -681,9 +701,11 @@ def AIE_PacketSourceOp: AIE_Op<"packet_source", [HasParent<"PacketFlowOp">]> {
 
     See [AIE.packet_flow](#aiepacketflow-aiepacketflowop) for an example.
   }];
+
   let assemblyFormat = [{
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
+
   let extraClassDeclaration = [{
     uint32_t channelIndex() { return getChannel(); }
     Port port() { return {getBundle(), channelIndex()}; }
@@ -704,9 +726,11 @@ def AIE_PacketDestOp: AIE_Op<"packet_dest", [HasParent<"PacketFlowOp">]> {
 
     See [AIE.packet_flow](#aiepacketflow-aiepacketflowop) for an example.
   }];
+
   let assemblyFormat = [{
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
+
   let extraClassDeclaration = [{
     uint32_t channelIndex() { return getChannel(); }
     Port port() { return {getBundle(), channelIndex()}; }
@@ -755,7 +779,6 @@ def AIE_DMABDPACKETOp: AIE_Op<"dmaBdPacket", []> {
   let extraClassDeclaration = [{
     uint32_t getPacketID() { return getPacketId(); }
   }];
-
 }
 
 def AIE_DimTupleAttr : AttrDef<AIE_Dialect, "DimTuple", []> {
@@ -876,8 +899,10 @@ def AIE_DMABDOp: AIE_Op<"dmaBd", []> {
   ];
 }
 
-def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "MemTileDMAOp", "func::FuncOp", "ShimDMAOp"]>, Terminator]>,
-                     Results<(outs I1:$valid)> {
+def AIE_DMAStartOp: AIE_Op<"dmaStart", [
+    ParentOneOf<["MemOp", "MemTileDMAOp", "func::FuncOp", "ShimDMAOp"]>,
+    Terminator
+  ]>, Results<(outs I1:$valid)> {
 
   let summary = "An op to start DMA";
   let description = [{
@@ -918,7 +943,7 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "MemTileDMAOp", "f
   }];
 
   let builders = [
-    OpBuilder<(ins "DMAChannelDir":$channelDir, "int":$channelIndex, "Block *":$dest, "Block *":$chain),
+    OpBuilder<(ins "DMAChannelDir":$channelDir, "uint32_t":$channelIndex, "Block *":$dest, "Block *":$chain),
     [{
       build($_builder, $_state, $_builder.getIntegerType(1), channelDir, channelIndex, dest, chain);
     }]>
@@ -927,8 +952,10 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "MemTileDMAOp", "f
 
 // MemOps are not actually Callable, but we want to inline code into them, so we have to 
 // implement CallableOpInterface
-def AIE_MemOp: AIE_Op<"mem", [TileElement, FlowEndPoint, CallableOpInterface, IsCoreTile, HasValidBDs, HasValidDMAChannels]>,
-                     Results<(outs Index)> {
+def AIE_MemOp: AIE_Op<"mem", [
+    TileElement, FlowEndPoint, CallableOpInterface,
+    IsCoreTile, HasValidBDs, HasValidDMAChannels
+  ]>, Results<(outs Index)> {
   let summary = "Declare a memory op";
   let description = [{
     This operation creates a Memory module that belongs to a tile.
@@ -950,12 +977,12 @@ def AIE_MemOp: AIE_Op<"mem", [TileElement, FlowEndPoint, CallableOpInterface, Is
     ```
     Create the memory module for tile %t73 and setup one DMA channel and one Buffer Descriptor.
   }];
-  let arguments = (
-    ins Index:$tile
-  );
+
+  let arguments = (ins Index:$tile);
   let regions = (region AnyRegion:$body);
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint32_t colIndex();
     uint32_t rowIndex();
@@ -967,6 +994,7 @@ def AIE_MemOp: AIE_Op<"mem", [TileElement, FlowEndPoint, CallableOpInterface, Is
     ArrayRef<Type> getResultTypes() { return getType(); }
     static StringRef getDefaultDialect() { return "AIE"; }
   }];
+
   let builders = [
     OpBuilder<(ins "Value":$tile), [{
       build($_builder, $_state, $_builder.getIndexType(), tile);
@@ -976,8 +1004,10 @@ def AIE_MemOp: AIE_Op<"mem", [TileElement, FlowEndPoint, CallableOpInterface, Is
 
 // This op is not actually Callable, but we want to inline code into them, so we have to
 // implement CallableOpInterface
-def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [TileElement, FlowEndPoint, CallableOpInterface, IsMemTile, HasValidBDs, HasValidDMAChannels]>,
-                     Results<(outs Index)> {
+def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [
+    TileElement, FlowEndPoint, CallableOpInterface,
+    IsMemTile, HasValidBDs, HasValidDMAChannels
+  ]>, Results<(outs Index)> {
   let summary = "Declare a memTileDMA op";
   let description = [{
     This operation describes a DMA inside an AIE2 MemTile.
@@ -1003,12 +1033,12 @@ def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [TileElement, FlowEndPoint, CallableO
     ```
     Create a description for tile %t73 and setup one DMA channel and one Buffer Descriptor.
   }];
-  let arguments = (
-    ins Index:$tile
-  );
+
+  let arguments = (ins Index:$tile);
   let regions = (region AnyRegion:$body);
   let assemblyFormat = [{ `(` $tile `)` regions attr-dict }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     uint32_t colIndex();
     uint32_t rowIndex();
@@ -1019,6 +1049,7 @@ def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [TileElement, FlowEndPoint, CallableO
     ArrayRef<Type> getResultTypes() { return getType(); }
     static StringRef getDefaultDialect() { return "AIE"; }
   }];
+
   let builders = [
     OpBuilder<(ins "Value":$tile), [{
       build($_builder, $_state, $_builder.getIndexType(), tile);
@@ -1026,7 +1057,9 @@ def AIE_MemTileDMAOp: AIE_Op<"memTileDMA", [TileElement, FlowEndPoint, CallableO
   ];
 }
 
-def AIE_NextBDOp: AIE_Op<"nextBd", [Terminator, ParentOneOf<["MemOp", "MemTileDMAOp", "func::FuncOp", "ShimDMAOp"]>]> {
+def AIE_NextBDOp: AIE_Op<"nextBd", [
+    Terminator, ParentOneOf<["MemOp", "MemTileDMAOp", "func::FuncOp", "ShimDMAOp"]>
+  ]> {
   let summary = "The next buffer descriptor";
   let description = [{
     This operation terminates the basic block describing a buffer descriptor inside
@@ -1048,6 +1081,7 @@ def AIE_NextBDOp: AIE_Op<"nextBd", [Terminator, ParentOneOf<["MemOp", "MemTileDM
       }
     ```
   }];
+
   let successors = (successor AnySuccessor:$dest);
 
   let assemblyFormat = [{
@@ -1072,12 +1106,15 @@ def AIE_LockOp: AIE_Op<"lock", [TileElement]>, Results<(outs Index)> {
       Before AIEAssignLockIDs: %tile33 = AIE.tile(3)
       After AIEAssignLockIDs: %tile33 = AIE.tile(3, $assigned_value)
   }];
+
   let arguments = (
     ins Index:$tile,
         OptionalAttr<ConfinedAttr<I32Attr, [IntMinValue<0>]>>:$lockID,
         OptionalAttr<I32Attr>:$init
   );
+
   let assemblyFormat = [{ `(` $tile (`,` $lockID^ )? `)` attr-dict }];
+
   let extraClassDeclaration = [{
     bool hasName() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
@@ -1103,6 +1140,7 @@ def AIE_LockOp: AIE_Op<"lock", [TileElement]>, Results<(outs Index)> {
     uint32_t rowIndex();
     TileOp getTileOp();
   }];
+
   let builders = [
     OpBuilder<(ins "Value":$tile, "int":$lockID, "int":$init), [{
       build($_builder, $_state,
@@ -1110,10 +1148,9 @@ def AIE_LockOp: AIE_Op<"lock", [TileElement]>, Results<(outs Index)> {
         tile,
         $_builder.getI32IntegerAttr(lockID),
         $_builder.getI32IntegerAttr(init));
-      }]>
+    }]>
   ];
   let hasVerifier = 1;
-  // let hasCanonicalizer = 1;
 }
 
 def AIE_UseLockOp: AIE_Op<"useLock", []> {
@@ -1126,21 +1163,23 @@ def AIE_UseLockOp: AIE_Op<"useLock", []> {
     the tile can be determined (A CoreOp, a ShimDMAOp, a MemOp, or a
     MemTileDMAOp).
   }];
+
   let arguments = (
     ins Index:$lock,
         I32Attr:$value,
         LockAction:$action,
         OptionalAttr<LockBlocking>:$blocking
   );
+
   let assemblyFormat = [{
     `(` $lock `,` $action `,` $value ( `,` $blocking^ )? `)` attr-dict
   }];
+
   let hasVerifier = 1;
   let builders = [
     OpBuilder<(ins "::mlir::Value":$lock,
                    "uint32_t":$value,
-                   "xilinx::AIE::LockAction":$action),
-    [{
+                   "xilinx::AIE::LockAction":$action), [{
       build($_builder, $_state, lock, value, action, nullptr);
     }]>
   ];
@@ -1155,7 +1194,9 @@ def AIE_UseLockOp: AIE_Op<"useLock", []> {
   }];
 }
 
-def AIE_BufferOp: AIE_Op<"buffer", [TileElement, IsTileWithMemory]>, Results<(outs AnyMemRef)> {
+def AIE_BufferOp: AIE_Op<"buffer", [
+    TileElement, IsTileWithMemory
+  ]>, Results<(outs AnyMemRef)> {
   let summary = "Declare a buffer";
   let description = [{
     This operation instantiates a buffer that belongs to a Memory Module of a tile.
@@ -1167,12 +1208,11 @@ def AIE_BufferOp: AIE_Op<"buffer", [TileElement, IsTileWithMemory]>, Results<(ou
     ```
     This operation represents a buffer in tile (3, 3) of 256 elements, each a 64-bit integer.
   }];
-  let arguments = (
-    ins Index:$tile
-  );
+  let arguments = (ins Index:$tile);
   let results = (outs AnyMemRef:$buffer);
   let assemblyFormat = [{ `(` $tile `)` attr-dict `:` type($buffer) }];
   let hasVerifier = 1;
+
   let extraClassDeclaration = [{
     bool hasName() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
@@ -1181,6 +1221,7 @@ def AIE_BufferOp: AIE_Op<"buffer", [TileElement, IsTileWithMemory]>, Results<(ou
         return false;
       }
     }
+
     StringAttr name() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
         return attr;
@@ -1190,6 +1231,7 @@ def AIE_BufferOp: AIE_Op<"buffer", [TileElement, IsTileWithMemory]>, Results<(ou
       }
       llvm_unreachable("unreachable");
     }
+
     // Return the address of this buffer
     int64_t address() {
       if(auto attr = getOperation()->getAttrOfType<IntegerAttr>("address")) {
@@ -1199,6 +1241,7 @@ def AIE_BufferOp: AIE_Op<"buffer", [TileElement, IsTileWithMemory]>, Results<(ou
       }
       llvm_unreachable("unreachable");
     }
+
     // Return the number of bytes that need to be allocated for this buffer.
     int64_t getAllocationSize();
     TileOp getTileOp();
@@ -1223,8 +1266,10 @@ def AIE_ExternalBufferOp: AIE_Op<"external_buffer", []>, Results<(outs AnyMemRef
     ```
     This operation represents an external buffer.
   }];
+
   let results = (outs AnyMemRef:$buffer);
   let assemblyFormat = [{ attr-dict `:` type($buffer) }];
+
   let extraClassDeclaration = [{
     bool hasName() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
@@ -1233,6 +1278,7 @@ def AIE_ExternalBufferOp: AIE_Op<"external_buffer", []>, Results<(outs AnyMemRef
         return false;
       }
     }
+
     StringAttr name() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
         return attr;
@@ -1257,19 +1303,21 @@ def AIE_EventOp: AIE_Op<"event", []> {
   }];
 }
 
-def AIE_GetStreamOp: AIE_Op<"getStream", [HasParent<"CoreOp">]>,
-                 Results<(outs AnyTypeOf<[F32, I32, I<128>]>)> {
+def AIE_GetStreamOp: AIE_Op<"getStream", [
+    HasParent<"CoreOp">
+  ]>, Results<(outs AnyTypeOf<[F32, I32, I<128>]>)> {
   let summary = "An op to read from a stream channel/port of a switchbox";
   let description = [{
     An op to read from a stream channel/port of a switchbox.
   }];
-  let arguments = (
-    ins AnyInteger:$channel
-  );
+
+  let arguments = (ins AnyInteger:$channel);
   let results = (outs AnyTypeOf<[F32, I32, I<128>]>:$streamValue);
+
   let assemblyFormat = [{
     `(` $channel `:` type($channel) `)` attr-dict `:` type($streamValue)
   }];
+
   let extraClassDeclaration = [{
     bool isWideStream() { return getStreamValue().getType().isInteger(128); }
     bool isFloatStream() { return getStreamValue().getType().isa<FloatType>(); }
@@ -1281,21 +1329,23 @@ def AIE_PutStreamOp: AIE_Op<"putStream", [HasParent<"CoreOp">]> {
   let description = [{
     An op to write to a stream channel/port of a switchbox.
   }];
+
   let arguments = (
     ins AnyInteger:$channel,
         AnyTypeOf<[F32, I32, I<128>]>:$streamValue
   );
+
   let assemblyFormat = [{
     `(` $channel `:` type($channel) `,` $streamValue `:` type($streamValue) `)` attr-dict
   }];
+
   let extraClassDeclaration = [{
     bool isWideStream() { return getStreamValue().getType().isInteger(128); }
     bool isFloatStream() { return getStreamValue().getType().isa<FloatType>(); }
   }];
 }
 
-def AIE_GetCascadeOp: AIE_Op<"getCascade", [HasParent<"CoreOp">]>,
-                      Results<(outs AnyI<384>)> {
+def AIE_GetCascadeOp: AIE_Op<"getCascade", [HasParent<"CoreOp">]>, Results<(outs AnyI<384>)> {
   let summary = "An op to read from a cascading stream from a neighboring core";
   let description = [{
     An op to read from a cascading stream from a neighboring core.
@@ -1309,9 +1359,9 @@ def AIE_PutCascadeOp: AIE_Op<"putCascade", [HasParent<"CoreOp">]> {
   let description = [{
     An op to write to a cascading stream from a neighboring core.
   }];
-  let arguments = (
-    ins AnyI<384>:$cascadeValue
-  );
+
+  let arguments = (ins AnyI<384>:$cascadeValue);
+
   let assemblyFormat = [{ `(` $cascadeValue `:` type($cascadeValue) `)` attr-dict }];
 }
 
@@ -1337,13 +1387,16 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shimDMAAllocation", [HasParent<"DeviceOp">
       AIE.shimDMAAllocation @of_in_0 (MM2S, 1, 0)
     ```
   }];
+
   let arguments = (
     ins FlatSymbolRefAttr:$sym_name,
         DMAChannelDir:$channelDir,
         I64Attr:$channelIndex,
         I64Attr:$col
   );
+
   let results = (outs);
+
   let assemblyFormat = [{
     $sym_name `(` $channelDir `,` $channelIndex `,` $col `)` attr-dict
   }];
@@ -1457,7 +1510,9 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
       else 
         return dyn_cast<IntegerAttr>(getElemNumber()).getInt();
     }
+
     TileOp getProducerTileOp();
+
     StringAttr name() {
       auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
       return attr;
@@ -1468,8 +1523,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
     OpBuilder<(ins "StringAttr":$sym_name, "Value":$producerTile,
                    "ValueRange":$consumerTiles, "Attribute":$elemNumber, "Type":$elem_type,
                    CArg<"ArrayRef<AIE::DimTupleAttr>", "{}">:$dimensionsToStream,
-                   CArg<"ArrayRef<AIE::DimTupleArrayAttr>", "{}">:$dimensionsFromStreamPerConsumer),
-    [{
+                   CArg<"ArrayRef<AIE::DimTupleArrayAttr>", "{}">:$dimensionsFromStreamPerConsumer), [{
       odsState.addOperands(producerTile);
       odsState.addOperands(consumerTiles);
       odsState.addAttribute(getSymNameAttrName(odsState.name), sym_name);
@@ -1512,6 +1566,7 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
     ins ArrayAttr:$fifoIns,
         ArrayAttr:$fifoOuts
   );
+
   let hasCustomAssemblyFormat = 1;
 
   let assemblyFormat = [{
@@ -1523,17 +1578,22 @@ def AIE_ObjectFifoLinkOp: AIE_Op<"objectFifo.link", [HasParent<"DeviceOp">]> {
   let extraClassDeclaration = [{
     std::vector<ObjectFifoCreateOp> getInputObjectFifos();
     std::vector<ObjectFifoCreateOp> getOutputObjectFifos();
+
     bool isJoin() {
       return getFifoIns().size() > 1;
     }
+
     bool isDistribute() {
       return getFifoOuts().size() > 1;
     }
+
     std::optional<Value> getOptionalSharedTile();
   }];
 }
 
-def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [HasParent<"DeviceOp">, TileElement, IsShimNOCTile]> {
+def AIE_ObjectFifoRegisterExternalBuffersOp: AIE_Op<"objectFifo.registerExternalBuffers", [
+    HasParent<"DeviceOp">, TileElement, IsShimNOCTile
+  ]> {
   let summary = "Registers external buffers to given object fifo shim tile(s) to use in the associated shim DMA(s)";
   let description = [{
     The `aie.objectFifo.registerExternalBuffers` operation is used to register one or multiple external buffers 
@@ -1718,16 +1778,40 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectFifo.registerProcess", []> {
   );
 
   let assemblyFormat = [{
-    attr-dict $objFifo_name `(` $port `,` $acquirePatternTensor `:` type($acquirePatternTensor) `,` $releasePatternTensor `:` type($releasePatternTensor) `,` $callee `,` $length`)`
+    attr-dict $objFifo_name `(`
+        $port `,`
+        $acquirePatternTensor `:` type($acquirePatternTensor) `,`
+        $releasePatternTensor `:` type($releasePatternTensor) `,`
+        $callee `,` $length
+    `)`
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
     ObjectFifoCreateOp getObjectFifo();
-    DenseIntElementsAttr getAcquirePattern() { return getAcquirePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
-    DenseIntElementsAttr getReleasePattern() { return getReleasePatternTensor().getDefiningOp<arith::ConstantOp>().getValue().cast<DenseIntElementsAttr>(); }
-    uint32_t getProcessLength() { return getLength().getDefiningOp<arith::ConstantOp>().getValue().cast<IntegerAttr>().getInt(); }
+
+    DenseIntElementsAttr getAcquirePattern() {
+      return getAcquirePatternTensor()
+          .getDefiningOp<arith::ConstantOp>()
+          .getValue()
+          .cast<DenseIntElementsAttr>();
+    }
+
+    DenseIntElementsAttr getReleasePattern() {
+      return getReleasePatternTensor()
+          .getDefiningOp<arith::ConstantOp>()
+          .getValue()
+          .cast<DenseIntElementsAttr>();
+    }
+
+    uint32_t getProcessLength() {
+      return getLength()
+          .getDefiningOp<arith::ConstantOp>()
+          .getValue()
+          .cast<IntegerAttr>()
+          .getInt();
+    }
   }];
 }
 

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -514,12 +514,12 @@ def AIE_AMSelOp: AIE_Op<"amsel", [HasParent<"SwitchboxOp">]>, Results<(outs Inde
   }];
 
   let extraClassDeclaration = [{
-    uint8_t arbiterIndex() { return getArbiterID(); }
-    uint8_t getMselValue() { return getMsel(); }
+    int arbiterIndex() { return getArbiterID(); }
+    int getMselValue() { return getMsel(); }
   }];
 
   let builders = [
-    OpBuilder<(ins "uint8_t":$arbiterID, "uint8_t":$msel),
+    OpBuilder<(ins "int":$arbiterID, "int":$msel),
     [{
       build($_builder, $_state, $_builder.getIndexType(),
             $_builder.getI8IntegerAttr(arbiterID),
@@ -651,8 +651,8 @@ def AIE_PacketRuleOp: AIE_Op<"rule", [HasParent<"PacketRulesOp">]> {
   }];
 
   let extraClassDeclaration = [{
-    uint8_t maskInt() { return getMask(); }
-    uint8_t valueInt() { return getValue(); }
+    int maskInt() { return getMask(); }
+    int valueInt() { return getValue(); }
   }];
 
   let assemblyFormat = [{
@@ -684,7 +684,7 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    uint8_t IDInt() { return getID(); }
+    int IDInt() { return getID(); }
   }];
 }
 

--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -150,7 +150,7 @@ namespace AIE {
 
 typedef struct Port {
   WireBundle bundle;
-  uint32_t channel;
+  int channel;
 
   inline bool operator==(const Port &rhs) const {
     return std::tie(bundle, channel) == std::tie(rhs.bundle, rhs.channel);
@@ -175,7 +175,7 @@ typedef struct Connect {
 
 typedef struct DMAChannel {
   DMAChannelDir direction;
-  uint32_t channel;
+  int channel;
 
   inline bool operator==(const DMAChannel &rhs) const {
     return std::tie(direction, channel) == std::tie(rhs.direction, rhs.channel);
@@ -280,7 +280,7 @@ template <> struct DenseMapInfo<ObjectFifoCreateOp> {
 
 template <> struct DenseMapInfo<DMAChannel> {
   using FirstInfo = DenseMapInfo<DMAChannelDir>;
-  using SecondInfo = DenseMapInfo<uint32_t>;
+  using SecondInfo = DenseMapInfo<int>;
   static inline DMAChannel getEmptyKey() {
     return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};
   }
@@ -301,7 +301,7 @@ template <> struct DenseMapInfo<DMAChannel> {
 
 template <> struct DenseMapInfo<Port> {
   using FirstInfo = DenseMapInfo<WireBundle>;
-  using SecondInfo = DenseMapInfo<uint32_t>;
+  using SecondInfo = DenseMapInfo<int>;
   static inline Port getEmptyKey() {
     return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};
   }

--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -259,58 +259,59 @@ template <> struct DenseMapInfo<xilinx::AIE::ObjectFifoAcquireOp> {
 } // namespace llvm
 
 namespace llvm {
-using namespace xilinx::AIE;
 // Functions hash just like pointers.
-template <> struct DenseMapInfo<ObjectFifoCreateOp> {
-  static ObjectFifoCreateOp getEmptyKey() {
+template <> struct DenseMapInfo<xilinx::AIE::ObjectFifoCreateOp> {
+  static xilinx::AIE::ObjectFifoCreateOp getEmptyKey() {
     auto *pointer = llvm::DenseMapInfo<void *>::getEmptyKey();
-    return ObjectFifoCreateOp::getFromOpaquePointer(pointer);
+    return xilinx::AIE::ObjectFifoCreateOp::getFromOpaquePointer(pointer);
   }
-  static ObjectFifoCreateOp getTombstoneKey() {
+  static xilinx::AIE::ObjectFifoCreateOp getTombstoneKey() {
     auto *pointer = llvm::DenseMapInfo<void *>::getTombstoneKey();
-    return ObjectFifoCreateOp::getFromOpaquePointer(pointer);
+    return xilinx::AIE::ObjectFifoCreateOp::getFromOpaquePointer(pointer);
   }
-  static unsigned getHashValue(ObjectFifoCreateOp val) {
+  static unsigned getHashValue(xilinx::AIE::ObjectFifoCreateOp val) {
     return hash_value(val.getAsOpaquePointer());
   }
-  static bool isEqual(ObjectFifoCreateOp lhs, ObjectFifoCreateOp rhs) {
+  static bool isEqual(xilinx::AIE::ObjectFifoCreateOp lhs,
+                      xilinx::AIE::ObjectFifoCreateOp rhs) {
     return lhs == rhs;
   }
 };
 
-template <> struct DenseMapInfo<DMAChannel> {
-  using FirstInfo = DenseMapInfo<DMAChannelDir>;
+template <> struct DenseMapInfo<xilinx::AIE::DMAChannel> {
+  using FirstInfo = DenseMapInfo<xilinx::AIE::DMAChannelDir>;
   using SecondInfo = DenseMapInfo<int>;
-  static inline DMAChannel getEmptyKey() {
+  static inline xilinx::AIE::DMAChannel getEmptyKey() {
     return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};
   }
 
-  static inline DMAChannel getTombstoneKey() {
+  static inline xilinx::AIE::DMAChannel getTombstoneKey() {
     return {FirstInfo::getTombstoneKey(), SecondInfo::getTombstoneKey()};
   }
 
-  static unsigned getHashValue(const DMAChannel &d) {
+  static unsigned getHashValue(const xilinx::AIE::DMAChannel &d) {
     return detail::combineHashValue(FirstInfo::getHashValue(d.direction),
                                     SecondInfo::getHashValue(d.channel));
   }
 
-  static bool isEqual(const DMAChannel &lhs, const DMAChannel &rhs) {
+  static bool isEqual(const xilinx::AIE::DMAChannel &lhs,
+                      const xilinx::AIE::DMAChannel &rhs) {
     return lhs == rhs;
   }
 };
 
-template <> struct DenseMapInfo<Port> {
-  using FirstInfo = DenseMapInfo<WireBundle>;
+template <> struct DenseMapInfo<xilinx::AIE::Port> {
+  using FirstInfo = DenseMapInfo<xilinx::AIE::WireBundle>;
   using SecondInfo = DenseMapInfo<int>;
-  static inline Port getEmptyKey() {
+  static inline xilinx::AIE::Port getEmptyKey() {
     return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};
   }
 
-  static inline Port getTombstoneKey() {
+  static inline xilinx::AIE::Port getTombstoneKey() {
     return {FirstInfo::getTombstoneKey(), SecondInfo::getTombstoneKey()};
   }
 
-  static unsigned getHashValue(const Port &d) {
+  static unsigned getHashValue(const xilinx::AIE::Port &d) {
     return detail::combineHashValue(FirstInfo::getHashValue(d.bundle),
                                     SecondInfo::getHashValue(d.channel));
   }
@@ -321,9 +322,9 @@ template <> struct DenseMapInfo<Port> {
 } // namespace llvm
 
 namespace std {
-using namespace xilinx::AIE;
-template <> struct less<Port> {
-  bool operator()(const Port &a, const Port &b) const {
+template <> struct less<xilinx::AIE::Port> {
+  bool operator()(const xilinx::AIE::Port &a,
+                  const xilinx::AIE::Port &b) const {
     return a.bundle == b.bundle ? a.channel < b.channel : a.bundle < b.bundle;
   }
 };

--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -49,10 +49,10 @@ def FlowEndPoint : OpInterface<"FlowEndPoint"> {
   let cppNamespace = "::xilinx::AIE";
   let methods = [
     InterfaceMethod<[{}],
-      "uint32_t", "colIndex", (ins )
+      "int", "colIndex", (ins )
     >,
     InterfaceMethod<[{}],
-      "uint32_t", "rowIndex", (ins )
+      "int", "rowIndex", (ins )
     >
   ];
 }
@@ -69,16 +69,16 @@ def Interconnect : OpInterface<"Interconnect"> {
       "::mlir::Region &", "getConnections", (ins )
     >,
     InterfaceMethod<[{}],
-      "uint32_t", "colIndex", (ins )
+      "int", "colIndex", (ins )
     >,
     InterfaceMethod<[{}],
-      "uint32_t", "rowIndex", (ins )
+      "int", "rowIndex", (ins )
     >,
     InterfaceMethod<[{}],
-      "uint32_t", "getNumSourceConnections", (ins "WireBundle":$bundle)
+      "int", "getNumSourceConnections", (ins "WireBundle":$bundle)
     >,
     InterfaceMethod<[{}],
-      "uint32_t", "getNumDestConnections", (ins "WireBundle":$bundle)
+      "int", "getNumDestConnections", (ins "WireBundle":$bundle)
     >
   ];
 }

--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -25,14 +25,14 @@ def HasValidDMAChannels : NativeOpTrait<"HasValidDMAChannels"> {
   string cppNamespace = "::xilinx::AIE";
 }
 
-def PredIsCoreTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isCoreTile(cast<xilinx::AIE::TileElement>($_op).getTileID().first,"
-                                                                       "cast<xilinx::AIE::TileElement>($_op).getTileID().second)">;
-def PredIsMemTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isMemTile(cast<xilinx::AIE::TileElement>($_op).getTileID().first,"
-                                                                       "cast<xilinx::AIE::TileElement>($_op).getTileID().second)">;
-def PredIsShimNOCTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isShimNOCTile(cast<xilinx::AIE::TileElement>($_op).getTileID().first,"
-                                                                        "cast<xilinx::AIE::TileElement>($_op).getTileID().second)">;
-def PredIsShimPLTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isShimPLTile(cast<xilinx::AIE::TileElement>($_op).getTileID().first,"
-                                                                        "cast<xilinx::AIE::TileElement>($_op).getTileID().second)">;
+def PredIsCoreTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isCoreTile(cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+                                                                       "cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
+def PredIsMemTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isMemTile(cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+                                                                       "cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
+def PredIsShimNOCTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isShimNOCTile(cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+                                                                        "cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
+def PredIsShimPLTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isShimPLTile(cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+                                                                        "cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
 
 def IsCoreTile : PredOpTrait<"op exists in a core tile", PredIsCoreTile>;
 def IsMemTile : PredOpTrait<"op exists in a MemTile", PredIsMemTile>;
@@ -48,12 +48,10 @@ def FlowEndPoint : OpInterface<"FlowEndPoint"> {
   }];
   let cppNamespace = "::xilinx::AIE";
   let methods = [
-    InterfaceMethod<[{
-      }],
+    InterfaceMethod<[{}],
       "int", "colIndex", (ins )
     >,
-    InterfaceMethod<[{
-      }],
+    InterfaceMethod<[{}],
       "int", "rowIndex", (ins )
     >
   ];
@@ -67,26 +65,19 @@ def Interconnect : OpInterface<"Interconnect"> {
   let cppNamespace = "::xilinx::AIE";
 
   let methods = [
-    InterfaceMethod<[{
-      }],
+    InterfaceMethod<[{}],
       "::mlir::Region &", "getConnections", (ins )
     >,
-    InterfaceMethod<[{
-      }],
+    InterfaceMethod<[{}],
       "int", "colIndex", (ins )
     >,
-    InterfaceMethod<[{
-      }],
+    InterfaceMethod<[{}],
       "int", "rowIndex", (ins )
     >,
-    InterfaceMethod<[{
-        int FooOp::getNumSourceConnections(WireBundle bundle) {
-      }],
+    InterfaceMethod<[{}],
       "int", "getNumSourceConnections", (ins "WireBundle":$bundle)
     >,
-    InterfaceMethod<[{
-        int FooOp::getNumDestConnections(WireBundle bundle) {
-      }],
+    InterfaceMethod<[{}],
       "int", "getNumDestConnections", (ins "WireBundle":$bundle)
     >
   ];

--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -49,10 +49,10 @@ def FlowEndPoint : OpInterface<"FlowEndPoint"> {
   let cppNamespace = "::xilinx::AIE";
   let methods = [
     InterfaceMethod<[{}],
-      "int", "colIndex", (ins )
+      "uint32_t", "colIndex", (ins )
     >,
     InterfaceMethod<[{}],
-      "int", "rowIndex", (ins )
+      "uint32_t", "rowIndex", (ins )
     >
   ];
 }
@@ -69,16 +69,16 @@ def Interconnect : OpInterface<"Interconnect"> {
       "::mlir::Region &", "getConnections", (ins )
     >,
     InterfaceMethod<[{}],
-      "int", "colIndex", (ins )
+      "uint32_t", "colIndex", (ins )
     >,
     InterfaceMethod<[{}],
-      "int", "rowIndex", (ins )
+      "uint32_t", "rowIndex", (ins )
     >,
     InterfaceMethod<[{}],
-      "int", "getNumSourceConnections", (ins "WireBundle":$bundle)
+      "uint32_t", "getNumSourceConnections", (ins "WireBundle":$bundle)
     >,
     InterfaceMethod<[{}],
-      "int", "getNumDestConnections", (ins "WireBundle":$bundle)
+      "uint32_t", "getNumDestConnections", (ins "WireBundle":$bundle)
     >
   ];
 }

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -19,7 +19,22 @@
 namespace xilinx {
 namespace AIE {
 
-typedef std::pair<int, int> TileID;
+typedef struct TileID {
+  uint32_t col;
+  uint32_t row;
+
+  inline bool operator==(const TileID &rhs) const {
+    return std::tie(col, row) == std::tie(rhs.col, rhs.row);
+  }
+
+  inline bool operator!=(const TileID &rhs) const {
+    return std::tie(col, row) != std::tie(rhs.col, rhs.row);
+  }
+
+  inline bool operator<(const TileID &rhs) const {
+    return col == rhs.col ? row < rhs.row : col < rhs.col;
+  }
+} TileID;
 
 class AIETargetModel {
 public:
@@ -30,43 +45,44 @@ public:
   virtual AIEArch getTargetArch() const = 0;
 
   /// Return the number of columns in the device.
-  virtual int columns() const = 0;
+  virtual uint32_t columns() const = 0;
 
   /// Return the number of rows in the device.
-  virtual int rows() const = 0;
+  virtual uint32_t rows() const = 0;
 
   /// Return true if the given tile is a 'Core' tile.  These tiles
   /// include a Core, TileDMA, tile memory, and stream connections.
-  virtual bool isCoreTile(int col, int row) const = 0;
+  virtual bool isCoreTile(uint32_t col, uint32_t row) const = 0;
 
   /// Return true if the given tile is an AIE2 'Memory' tile.  These tiles
   /// include a TileDMA, tile memory, and stream connections, but no core.
-  virtual bool isMemTile(int col, int row) const = 0;
+  virtual bool isMemTile(uint32_t col, uint32_t row) const = 0;
 
   /// Return true if the given tile is a Shim NOC tile.  These tiles include a
   /// ShimDMA and a connection to the memory-mapped NOC.  They do not contain
   /// any memory.
-  virtual bool isShimNOCTile(int col, int row) const = 0;
+  virtual bool isShimNOCTile(uint32_t col, uint32_t row) const = 0;
 
-  /// Return true if the given tile is a Shim PL interface tile.  These tiles do
-  /// not include a ShimDMA and instead include connections to the PL.  They do
-  /// not contain any memory.
-  virtual bool isShimPLTile(int col, int row) const = 0;
+  /// Return true if the given tile is a Shim PL uint32_terface tile.  These
+  /// tiles do not include a ShimDMA and instead include connections to the PL.
+  /// They do not contain any memory.
+  virtual bool isShimPLTile(uint32_t col, uint32_t row) const = 0;
 
   /// Return true if the given tile is either a Shim NOC or a Shim PL interface
   /// tile.
-  virtual bool isShimNOCorPLTile(int col, int row) const = 0;
+  virtual bool isShimNOCorPLTile(uint32_t col, uint32_t row) const = 0;
 
   /// Return true if the given tile ID is valid.
   virtual bool isValidTile(TileID src) const {
-    return (src.first >= 0) && (src.first < columns()) && (src.second >= 0) &&
-           (src.second < rows());
+    return (src.col >= 0) && (src.col < columns()) && (src.row >= 0) &&
+           (src.row < rows());
   }
 
   /// Return true if the given port in the given tile is a valid destination for
   /// traces
-  virtual bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                                  int destIndex) const = 0;
+  virtual bool isValidTraceMaster(uint32_t col, uint32_t row,
+                                  WireBundle destBundle,
+                                  uint32_t destIndex) const = 0;
 
   /// Return the tile ID of the memory to the west of the given tile, if it
   /// exists.
@@ -82,42 +98,47 @@ public:
   virtual std::optional<TileID> getMemSouth(TileID src) const = 0;
 
   /// Return true if src is the internal memory of dst
-  bool isInternal(int srcCol, int srcRow, int dstCol, int dstRow) const {
+  bool isInternal(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                  uint32_t dstRow) const {
     return ((srcCol == dstCol) && (srcRow == dstRow));
   }
   /// Return true if src is West of dst
-  bool isWest(int srcCol, int srcRow, int dstCol, int dstRow) const {
+  bool isWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+              uint32_t dstRow) const {
     return ((srcCol == dstCol + 1) && (srcRow == dstRow));
   }
   /// Return true if src is East of dst
-  bool isEast(int srcCol, int srcRow, int dstCol, int dstRow) const {
+  bool isEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+              uint32_t dstRow) const {
     return ((srcCol == dstCol - 1) && (srcRow == dstRow));
   }
   /// Return true if src is North of dst
-  bool isNorth(int srcCol, int srcRow, int dstCol, int dstRow) const {
+  bool isNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+               uint32_t dstRow) const {
     return ((srcCol == dstCol) && (srcRow == dstRow - 1));
   }
   /// Return true if src is South of dst
-  bool isSouth(int srcCol, int srcRow, int dstCol, int dstRow) const {
+  bool isSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+               uint32_t dstRow) const {
     return ((srcCol == dstCol) && (srcRow == dstRow + 1));
   }
 
   /// Return true if src has a memory tile which is West of dst
-  virtual bool isMemWest(int srcCol, int srcRow, int dstCol,
-                         int dstRow) const = 0;
+  virtual bool isMemWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                         uint32_t dstRow) const = 0;
   /// Return true if src has a memory tile which is East of dst
-  virtual bool isMemEast(int srcCol, int srcRow, int dstCol,
-                         int dstRow) const = 0;
+  virtual bool isMemEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                         uint32_t dstRow) const = 0;
   /// Return true if src has a memory tile which is North of dst
-  virtual bool isMemNorth(int srcCol, int srcRow, int dstCol,
-                          int dstRow) const = 0;
+  virtual bool isMemNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                          uint32_t dstRow) const = 0;
   /// Return true if src has a memory tile which is South of dst
-  virtual bool isMemSouth(int srcCol, int srcRow, int dstCol,
-                          int dstRow) const = 0;
+  virtual bool isMemSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                          uint32_t dstRow) const = 0;
 
   /// Return true if core can access the memory in mem
-  virtual bool isLegalMemAffinity(int coreCol, int coreRow, int memCol,
-                                  int memRow) const = 0;
+  virtual bool isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
+                                  uint32_t memCol, uint32_t memRow) const = 0;
 
   /// Return the base address in the local address map of differnet memories.
   virtual uint32_t getMemInternalBaseAddress(TileID src) const = 0;
@@ -130,37 +151,37 @@ public:
   virtual uint32_t getLocalMemorySize() const = 0;
 
   /// Return the number of lock objects
-  virtual uint32_t getNumLocks(int col, int row) const = 0;
+  virtual uint32_t getNumLocks(uint32_t col, uint32_t row) const = 0;
 
   /// Return the number of buffer descriptors supported by the DMA in the given
   /// tile.
-  virtual uint32_t getNumBDs(int col, int row) const = 0;
+  virtual uint32_t getNumBDs(uint32_t col, uint32_t row) const = 0;
 
   virtual uint32_t getNumMemTileRows() const = 0;
   /// Return the size (in bytes) of a MemTile.
   virtual uint32_t getMemTileSize() const = 0;
   /// Return the number of destinations of connections inside a switchbox. These
   /// are the targets of connect operations in the switchbox.
-  virtual uint32_t getNumDestSwitchboxConnections(int col, int row,
+  virtual uint32_t getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
                                                   WireBundle bundle) const = 0;
   /// Return the number of sources of connections inside a switchbox.  These are
   /// the origins of connect operations in the switchbox.
   virtual uint32_t
-  getNumSourceSwitchboxConnections(int col, int row,
+  getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
                                    WireBundle bundle) const = 0;
   /// Return the number of destinations of connections inside a shimmux.  These
   /// are the targets of connect operations in the switchbox.
-  virtual uint32_t getNumDestShimMuxConnections(int col, int row,
+  virtual uint32_t getNumDestShimMuxConnections(uint32_t col, uint32_t row,
                                                 WireBundle bundle) const = 0;
   /// Return the number of sources of connections inside a shimmux.  These are
   /// the origins of connect operations in the switchbox.
-  virtual uint32_t getNumSourceShimMuxConnections(int col, int row,
+  virtual uint32_t getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
                                                   WireBundle bundle) const = 0;
 
   // Return true if the stream switch connection is legal, false otherwise.
-  virtual bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
+  virtual bool isLegalMemtileConnection(WireBundle srcBundle, uint32_t srcChan,
                                         WireBundle dstBundle,
-                                        int dstChan) const = 0;
+                                        uint32_t dstChan) const = 0;
 
   // Run consistency checks on the target model.
   void validate() const;
@@ -170,8 +191,8 @@ class AIE1TargetModel : public AIETargetModel {
 public:
   AIE1TargetModel() {}
 
-  bool isCoreTile(int col, int row) const override { return row > 0; }
-  bool isMemTile(int col, int row) const override { return false; }
+  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 0; }
+  bool isMemTile(uint32_t col, uint32_t row) const override { return false; }
 
   AIEArch getTargetArch() const override;
 
@@ -180,18 +201,20 @@ public:
   std::optional<TileID> getMemNorth(TileID src) const override;
   std::optional<TileID> getMemSouth(TileID src) const override;
 
-  bool isMemWest(int srcCol, int srcRow, int dstCol, int dstRow) const override;
-  bool isMemEast(int srcCol, int srcRow, int dstCol, int dstRow) const override;
-  bool isMemNorth(int srcCol, int srcRow, int dstCol,
-                  int dstRow) const override;
-  bool isMemSouth(int srcCol, int srcRow, int dstCol,
-                  int dstRow) const override;
+  bool isMemWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                 uint32_t dstRow) const override;
+  bool isMemEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                 uint32_t dstRow) const override;
+  bool isMemNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                  uint32_t dstRow) const override;
+  bool isMemSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                  uint32_t dstRow) const override;
 
-  bool isLegalMemAffinity(int coreCol, int coreRow, int memCol,
-                          int memRow) const override;
+  bool isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow, uint32_t memCol,
+                          uint32_t memRow) const override;
 
   uint32_t getMemInternalBaseAddress(TileID src) const override {
-    bool IsEvenRow = ((src.second % 2) == 0);
+    bool IsEvenRow = ((src.row % 2) == 0);
     if (IsEvenRow)
       // Internal is West
       return getMemWestBaseAddress();
@@ -204,25 +227,25 @@ public:
   uint32_t getMemNorthBaseAddress() const override { return 0x00030000; }
   uint32_t getMemEastBaseAddress() const override { return 0x00038000; }
   uint32_t getLocalMemorySize() const override { return 0x00008000; }
-  uint32_t getNumLocks(int col, int row) const override { return 16; }
-  uint32_t getNumBDs(int col, int row) const override { return 16; }
+  uint32_t getNumLocks(uint32_t col, uint32_t row) const override { return 16; }
+  uint32_t getNumBDs(uint32_t col, uint32_t row) const override { return 16; }
   uint32_t getNumMemTileRows() const override { return 0; }
   uint32_t getMemTileSize() const override { return 0; }
 
-  uint32_t getNumDestSwitchboxConnections(int col, int row,
+  uint32_t getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
                                           WireBundle bundle) const override;
-  uint32_t getNumSourceSwitchboxConnections(int col, int row,
+  uint32_t getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
                                             WireBundle bundle) const override;
-  uint32_t getNumDestShimMuxConnections(int col, int row,
+  uint32_t getNumDestShimMuxConnections(uint32_t col, uint32_t row,
                                         WireBundle bundle) const override;
-  uint32_t getNumSourceShimMuxConnections(int col, int row,
+  uint32_t getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
                                           WireBundle bundle) const override;
-  bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
+  bool isLegalMemtileConnection(WireBundle srcBundle, uint32_t srcChan,
                                 WireBundle dstBundle,
-                                int dstChan) const override;
+                                uint32_t dstChan) const override;
 
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override {
+  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
+                          uint32_t destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::South)
@@ -242,15 +265,17 @@ public:
   std::optional<TileID> getMemNorth(TileID src) const override;
   std::optional<TileID> getMemSouth(TileID src) const override;
 
-  bool isMemWest(int srcCol, int srcRow, int dstCol, int dstRow) const override;
-  bool isMemEast(int srcCol, int srcRow, int dstCol, int dstRow) const override;
-  bool isMemNorth(int srcCol, int srcRow, int dstCol,
-                  int dstRow) const override;
-  bool isMemSouth(int srcCol, int srcRow, int dstCol,
-                  int dstRow) const override;
+  bool isMemWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                 uint32_t dstRow) const override;
+  bool isMemEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                 uint32_t dstRow) const override;
+  bool isMemNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                  uint32_t dstRow) const override;
+  bool isMemSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
+                  uint32_t dstRow) const override;
 
-  bool isLegalMemAffinity(int coreCol, int coreRow, int memCol,
-                          int memRow) const override;
+  bool isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow, uint32_t memCol,
+                          uint32_t memRow) const override;
 
   uint32_t getMemInternalBaseAddress(TileID src) const override {
     return getMemEastBaseAddress();
@@ -260,25 +285,25 @@ public:
   uint32_t getMemNorthBaseAddress() const override { return 0x00060000; }
   uint32_t getMemEastBaseAddress() const override { return 0x00070000; }
   uint32_t getLocalMemorySize() const override { return 0x00010000; }
-  uint32_t getNumLocks(int col, int row) const override {
+  uint32_t getNumLocks(uint32_t col, uint32_t row) const override {
     return isMemTile(col, row) ? 64 : 16;
   }
-  uint32_t getNumBDs(int col, int row) const override {
+  uint32_t getNumBDs(uint32_t col, uint32_t row) const override {
     return isMemTile(col, row) ? 48 : 16;
   }
   uint32_t getMemTileSize() const override { return 0x00080000; }
 
-  uint32_t getNumDestSwitchboxConnections(int col, int row,
+  uint32_t getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
                                           WireBundle bundle) const override;
-  uint32_t getNumSourceSwitchboxConnections(int col, int row,
+  uint32_t getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
                                             WireBundle bundle) const override;
-  uint32_t getNumDestShimMuxConnections(int col, int row,
+  uint32_t getNumDestShimMuxConnections(uint32_t col, uint32_t row,
                                         WireBundle bundle) const override;
-  uint32_t getNumSourceShimMuxConnections(int col, int row,
+  uint32_t getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
                                           WireBundle bundle) const override;
-  bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
+  bool isLegalMemtileConnection(WireBundle srcBundle, uint32_t srcChan,
                                 WireBundle dstBundle,
-                                int dstChan) const override;
+                                uint32_t dstChan) const override;
 };
 
 class VC1902TargetModel : public AIE1TargetModel {
@@ -288,16 +313,18 @@ class VC1902TargetModel : public AIE1TargetModel {
 public:
   VC1902TargetModel() {}
 
-  int columns() const override { return 50; }
-  int rows() const override { return 9; /* One Shim row and 8 Core rows. */ }
+  uint32_t columns() const override { return 50; }
+  uint32_t rows() const override {
+    return 9; /* One Shim row and 8 Core rows. */
+  }
 
-  bool isShimNOCTile(int col, int row) const override {
+  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(int col, int row) const override {
+  bool isShimPLTile(uint32_t col, uint32_t row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(int col, int row) const override {
+  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
 };
@@ -308,25 +335,25 @@ class VE2302TargetModel : public AIE2TargetModel {
 public:
   VE2302TargetModel() {}
 
-  int columns() const override { return 17; }
-  int rows() const override {
+  uint32_t columns() const override { return 17; }
+  uint32_t rows() const override {
     return 4; /* One Shim row, 1 memtile rows, and 2 Core rows. */
   }
 
-  bool isCoreTile(int col, int row) const override { return row > 1; }
-  bool isMemTile(int col, int row) const override { return row == 1; }
-  bool isShimNOCTile(int col, int row) const override {
+  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 1; }
+  bool isMemTile(uint32_t col, uint32_t row) const override { return row == 1; }
+  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(int col, int row) const override {
+  bool isShimPLTile(uint32_t col, uint32_t row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(int col, int row) const override {
+  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
   uint32_t getNumMemTileRows() const override { return 1; }
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override {
+  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
+                          uint32_t destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isCoreTile(col, row) && destBundle == WireBundle::DMA &&
@@ -356,27 +383,27 @@ class VE2802TargetModel : public AIE2TargetModel {
 public:
   VE2802TargetModel() {}
 
-  int columns() const override { return 38; }
-  int rows() const override {
+  uint32_t columns() const override { return 38; }
+  uint32_t rows() const override {
     return 11; /* One Shim row, 2 memtile rows, and 8 Core rows. */
   }
 
-  bool isCoreTile(int col, int row) const override { return row > 2; }
-  bool isMemTile(int col, int row) const override {
+  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 2; }
+  bool isMemTile(uint32_t col, uint32_t row) const override {
     return (row == 1) || (row == 2);
   }
-  bool isShimNOCTile(int col, int row) const override {
+  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(int col, int row) const override {
+  bool isShimPLTile(uint32_t col, uint32_t row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(int col, int row) const override {
+  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
   uint32_t getNumMemTileRows() const override { return 2; }
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override {
+  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
+                          uint32_t destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isCoreTile(col, row) && destBundle == WireBundle::DMA &&
@@ -405,26 +432,26 @@ class IPUTargetModel : public AIE2TargetModel {
 public:
   IPUTargetModel() {}
 
-  int columns() const override { return 5; }
-  int rows() const override {
+  uint32_t columns() const override { return 5; }
+  uint32_t rows() const override {
     return 6; /* 1 Shim row, 1 memtile row, and 4 Core rows. */
   }
 
-  bool isCoreTile(int col, int row) const override { return row > 1; }
-  bool isMemTile(int col, int row) const override { return row == 1; }
+  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 1; }
+  bool isMemTile(uint32_t col, uint32_t row) const override { return row == 1; }
 
-  bool isShimNOCTile(int col, int row) const override {
+  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(int col, int row) const override {
+  bool isShimPLTile(uint32_t col, uint32_t row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(int col, int row) const override {
+  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
   uint32_t getNumMemTileRows() const override { return 1; }
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override {
+  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
+                          uint32_t destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isCoreTile(col, row) && destBundle == WireBundle::DMA &&
@@ -449,5 +476,30 @@ public:
 
 } // namespace AIE
 } // namespace xilinx
+
+namespace llvm {
+using namespace xilinx::AIE;
+template <> struct DenseMapInfo<TileID> {
+  using FirstInfo = DenseMapInfo<uint32_t>;
+  using SecondInfo = DenseMapInfo<uint32_t>;
+
+  static inline TileID getEmptyKey() {
+    return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};
+  }
+
+  static inline TileID getTombstoneKey() {
+    return {FirstInfo::getTombstoneKey(), SecondInfo::getTombstoneKey()};
+  }
+
+  static unsigned getHashValue(const TileID &t) {
+    return detail::combineHashValue(FirstInfo::getHashValue(t.col),
+                                    SecondInfo::getHashValue(t.row));
+  }
+
+  static bool isEqual(const TileID &lhs, const TileID &rhs) {
+    return lhs == rhs;
+  }
+};
+} // namespace llvm
 
 #endif

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -20,8 +20,8 @@ namespace xilinx {
 namespace AIE {
 
 typedef struct TileID {
-  uint32_t col;
-  uint32_t row;
+  int col;
+  int row;
 
   inline bool operator==(const TileID &rhs) const {
     return std::tie(col, row) == std::tie(rhs.col, rhs.row);
@@ -45,32 +45,32 @@ public:
   virtual AIEArch getTargetArch() const = 0;
 
   /// Return the number of columns in the device.
-  virtual uint32_t columns() const = 0;
+  virtual int columns() const = 0;
 
   /// Return the number of rows in the device.
-  virtual uint32_t rows() const = 0;
+  virtual int rows() const = 0;
 
   /// Return true if the given tile is a 'Core' tile.  These tiles
   /// include a Core, TileDMA, tile memory, and stream connections.
-  virtual bool isCoreTile(uint32_t col, uint32_t row) const = 0;
+  virtual bool isCoreTile(int col, int row) const = 0;
 
   /// Return true if the given tile is an AIE2 'Memory' tile.  These tiles
   /// include a TileDMA, tile memory, and stream connections, but no core.
-  virtual bool isMemTile(uint32_t col, uint32_t row) const = 0;
+  virtual bool isMemTile(int col, int row) const = 0;
 
   /// Return true if the given tile is a Shim NOC tile.  These tiles include a
   /// ShimDMA and a connection to the memory-mapped NOC.  They do not contain
   /// any memory.
-  virtual bool isShimNOCTile(uint32_t col, uint32_t row) const = 0;
+  virtual bool isShimNOCTile(int col, int row) const = 0;
 
-  /// Return true if the given tile is a Shim PL uint32_terface tile.  These
+  /// Return true if the given tile is a Shim PL interface tile.  These
   /// tiles do not include a ShimDMA and instead include connections to the PL.
   /// They do not contain any memory.
-  virtual bool isShimPLTile(uint32_t col, uint32_t row) const = 0;
+  virtual bool isShimPLTile(int col, int row) const = 0;
 
   /// Return true if the given tile is either a Shim NOC or a Shim PL interface
   /// tile.
-  virtual bool isShimNOCorPLTile(uint32_t col, uint32_t row) const = 0;
+  virtual bool isShimNOCorPLTile(int col, int row) const = 0;
 
   /// Return true if the given tile ID is valid.
   virtual bool isValidTile(TileID src) const {
@@ -80,9 +80,8 @@ public:
 
   /// Return true if the given port in the given tile is a valid destination for
   /// traces
-  virtual bool isValidTraceMaster(uint32_t col, uint32_t row,
-                                  WireBundle destBundle,
-                                  uint32_t destIndex) const = 0;
+  virtual bool isValidTraceMaster(int col, int row, WireBundle destBundle,
+                                  int destIndex) const = 0;
 
   /// Return the tile ID of the memory to the west of the given tile, if it
   /// exists.
@@ -98,47 +97,42 @@ public:
   virtual std::optional<TileID> getMemSouth(TileID src) const = 0;
 
   /// Return true if src is the internal memory of dst
-  bool isInternal(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                  uint32_t dstRow) const {
+  bool isInternal(int srcCol, int srcRow, int dstCol, int dstRow) const {
     return ((srcCol == dstCol) && (srcRow == dstRow));
   }
   /// Return true if src is West of dst
-  bool isWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-              uint32_t dstRow) const {
+  bool isWest(int srcCol, int srcRow, int dstCol, int dstRow) const {
     return ((srcCol == dstCol + 1) && (srcRow == dstRow));
   }
   /// Return true if src is East of dst
-  bool isEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-              uint32_t dstRow) const {
+  bool isEast(int srcCol, int srcRow, int dstCol, int dstRow) const {
     return ((srcCol == dstCol - 1) && (srcRow == dstRow));
   }
   /// Return true if src is North of dst
-  bool isNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-               uint32_t dstRow) const {
+  bool isNorth(int srcCol, int srcRow, int dstCol, int dstRow) const {
     return ((srcCol == dstCol) && (srcRow == dstRow - 1));
   }
   /// Return true if src is South of dst
-  bool isSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-               uint32_t dstRow) const {
+  bool isSouth(int srcCol, int srcRow, int dstCol, int dstRow) const {
     return ((srcCol == dstCol) && (srcRow == dstRow + 1));
   }
 
   /// Return true if src has a memory tile which is West of dst
-  virtual bool isMemWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                         uint32_t dstRow) const = 0;
+  virtual bool isMemWest(int srcCol, int srcRow, int dstCol,
+                         int dstRow) const = 0;
   /// Return true if src has a memory tile which is East of dst
-  virtual bool isMemEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                         uint32_t dstRow) const = 0;
+  virtual bool isMemEast(int srcCol, int srcRow, int dstCol,
+                         int dstRow) const = 0;
   /// Return true if src has a memory tile which is North of dst
-  virtual bool isMemNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                          uint32_t dstRow) const = 0;
+  virtual bool isMemNorth(int srcCol, int srcRow, int dstCol,
+                          int dstRow) const = 0;
   /// Return true if src has a memory tile which is South of dst
-  virtual bool isMemSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                          uint32_t dstRow) const = 0;
+  virtual bool isMemSouth(int srcCol, int srcRow, int dstCol,
+                          int dstRow) const = 0;
 
   /// Return true if core can access the memory in mem
-  virtual bool isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
-                                  uint32_t memCol, uint32_t memRow) const = 0;
+  virtual bool isLegalMemAffinity(int coreCol, int coreRow, int memCol,
+                                  int memRow) const = 0;
 
   /// Return the base address in the local address map of differnet memories.
   virtual uint32_t getMemInternalBaseAddress(TileID src) const = 0;
@@ -151,37 +145,37 @@ public:
   virtual uint32_t getLocalMemorySize() const = 0;
 
   /// Return the number of lock objects
-  virtual uint32_t getNumLocks(uint32_t col, uint32_t row) const = 0;
+  virtual uint32_t getNumLocks(int col, int row) const = 0;
 
   /// Return the number of buffer descriptors supported by the DMA in the given
   /// tile.
-  virtual uint32_t getNumBDs(uint32_t col, uint32_t row) const = 0;
+  virtual uint32_t getNumBDs(int col, int row) const = 0;
 
   virtual uint32_t getNumMemTileRows() const = 0;
   /// Return the size (in bytes) of a MemTile.
   virtual uint32_t getMemTileSize() const = 0;
   /// Return the number of destinations of connections inside a switchbox. These
   /// are the targets of connect operations in the switchbox.
-  virtual uint32_t getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
+  virtual uint32_t getNumDestSwitchboxConnections(int col, int row,
                                                   WireBundle bundle) const = 0;
   /// Return the number of sources of connections inside a switchbox.  These are
   /// the origins of connect operations in the switchbox.
   virtual uint32_t
-  getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
+  getNumSourceSwitchboxConnections(int col, int row,
                                    WireBundle bundle) const = 0;
   /// Return the number of destinations of connections inside a shimmux.  These
   /// are the targets of connect operations in the switchbox.
-  virtual uint32_t getNumDestShimMuxConnections(uint32_t col, uint32_t row,
+  virtual uint32_t getNumDestShimMuxConnections(int col, int row,
                                                 WireBundle bundle) const = 0;
   /// Return the number of sources of connections inside a shimmux.  These are
   /// the origins of connect operations in the switchbox.
-  virtual uint32_t getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
+  virtual uint32_t getNumSourceShimMuxConnections(int col, int row,
                                                   WireBundle bundle) const = 0;
 
   // Return true if the stream switch connection is legal, false otherwise.
-  virtual bool isLegalMemtileConnection(WireBundle srcBundle, uint32_t srcChan,
+  virtual bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
                                         WireBundle dstBundle,
-                                        uint32_t dstChan) const = 0;
+                                        int dstChan) const = 0;
 
   // Run consistency checks on the target model.
   void validate() const;
@@ -191,8 +185,8 @@ class AIE1TargetModel : public AIETargetModel {
 public:
   AIE1TargetModel() {}
 
-  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 0; }
-  bool isMemTile(uint32_t col, uint32_t row) const override { return false; }
+  bool isCoreTile(int col, int row) const override { return row > 0; }
+  bool isMemTile(int col, int row) const override { return false; }
 
   AIEArch getTargetArch() const override;
 
@@ -201,17 +195,15 @@ public:
   std::optional<TileID> getMemNorth(TileID src) const override;
   std::optional<TileID> getMemSouth(TileID src) const override;
 
-  bool isMemWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                 uint32_t dstRow) const override;
-  bool isMemEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                 uint32_t dstRow) const override;
-  bool isMemNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                  uint32_t dstRow) const override;
-  bool isMemSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                  uint32_t dstRow) const override;
+  bool isMemWest(int srcCol, int srcRow, int dstCol, int dstRow) const override;
+  bool isMemEast(int srcCol, int srcRow, int dstCol, int dstRow) const override;
+  bool isMemNorth(int srcCol, int srcRow, int dstCol,
+                  int dstRow) const override;
+  bool isMemSouth(int srcCol, int srcRow, int dstCol,
+                  int dstRow) const override;
 
-  bool isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow, uint32_t memCol,
-                          uint32_t memRow) const override;
+  bool isLegalMemAffinity(int coreCol, int coreRow, int memCol,
+                          int memRow) const override;
 
   uint32_t getMemInternalBaseAddress(TileID src) const override {
     bool IsEvenRow = ((src.row % 2) == 0);
@@ -227,25 +219,25 @@ public:
   uint32_t getMemNorthBaseAddress() const override { return 0x00030000; }
   uint32_t getMemEastBaseAddress() const override { return 0x00038000; }
   uint32_t getLocalMemorySize() const override { return 0x00008000; }
-  uint32_t getNumLocks(uint32_t col, uint32_t row) const override { return 16; }
-  uint32_t getNumBDs(uint32_t col, uint32_t row) const override { return 16; }
+  uint32_t getNumLocks(int col, int row) const override { return 16; }
+  uint32_t getNumBDs(int col, int row) const override { return 16; }
   uint32_t getNumMemTileRows() const override { return 0; }
   uint32_t getMemTileSize() const override { return 0; }
 
-  uint32_t getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumDestSwitchboxConnections(int col, int row,
                                           WireBundle bundle) const override;
-  uint32_t getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumSourceSwitchboxConnections(int col, int row,
                                             WireBundle bundle) const override;
-  uint32_t getNumDestShimMuxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumDestShimMuxConnections(int col, int row,
                                         WireBundle bundle) const override;
-  uint32_t getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumSourceShimMuxConnections(int col, int row,
                                           WireBundle bundle) const override;
-  bool isLegalMemtileConnection(WireBundle srcBundle, uint32_t srcChan,
+  bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
                                 WireBundle dstBundle,
-                                uint32_t dstChan) const override;
+                                int dstChan) const override;
 
-  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
-                          uint32_t destIndex) const override {
+  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
+                          int destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::South)
@@ -265,17 +257,15 @@ public:
   std::optional<TileID> getMemNorth(TileID src) const override;
   std::optional<TileID> getMemSouth(TileID src) const override;
 
-  bool isMemWest(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                 uint32_t dstRow) const override;
-  bool isMemEast(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                 uint32_t dstRow) const override;
-  bool isMemNorth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                  uint32_t dstRow) const override;
-  bool isMemSouth(uint32_t srcCol, uint32_t srcRow, uint32_t dstCol,
-                  uint32_t dstRow) const override;
+  bool isMemWest(int srcCol, int srcRow, int dstCol, int dstRow) const override;
+  bool isMemEast(int srcCol, int srcRow, int dstCol, int dstRow) const override;
+  bool isMemNorth(int srcCol, int srcRow, int dstCol,
+                  int dstRow) const override;
+  bool isMemSouth(int srcCol, int srcRow, int dstCol,
+                  int dstRow) const override;
 
-  bool isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow, uint32_t memCol,
-                          uint32_t memRow) const override;
+  bool isLegalMemAffinity(int coreCol, int coreRow, int memCol,
+                          int memRow) const override;
 
   uint32_t getMemInternalBaseAddress(TileID src) const override {
     return getMemEastBaseAddress();
@@ -285,25 +275,25 @@ public:
   uint32_t getMemNorthBaseAddress() const override { return 0x00060000; }
   uint32_t getMemEastBaseAddress() const override { return 0x00070000; }
   uint32_t getLocalMemorySize() const override { return 0x00010000; }
-  uint32_t getNumLocks(uint32_t col, uint32_t row) const override {
+  uint32_t getNumLocks(int col, int row) const override {
     return isMemTile(col, row) ? 64 : 16;
   }
-  uint32_t getNumBDs(uint32_t col, uint32_t row) const override {
+  uint32_t getNumBDs(int col, int row) const override {
     return isMemTile(col, row) ? 48 : 16;
   }
   uint32_t getMemTileSize() const override { return 0x00080000; }
 
-  uint32_t getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumDestSwitchboxConnections(int col, int row,
                                           WireBundle bundle) const override;
-  uint32_t getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumSourceSwitchboxConnections(int col, int row,
                                             WireBundle bundle) const override;
-  uint32_t getNumDestShimMuxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumDestShimMuxConnections(int col, int row,
                                         WireBundle bundle) const override;
-  uint32_t getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
+  uint32_t getNumSourceShimMuxConnections(int col, int row,
                                           WireBundle bundle) const override;
-  bool isLegalMemtileConnection(WireBundle srcBundle, uint32_t srcChan,
+  bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
                                 WireBundle dstBundle,
-                                uint32_t dstChan) const override;
+                                int dstChan) const override;
 };
 
 class VC1902TargetModel : public AIE1TargetModel {
@@ -313,18 +303,16 @@ class VC1902TargetModel : public AIE1TargetModel {
 public:
   VC1902TargetModel() {}
 
-  uint32_t columns() const override { return 50; }
-  uint32_t rows() const override {
-    return 9; /* One Shim row and 8 Core rows. */
-  }
+  int columns() const override { return 50; }
+  int rows() const override { return 9; /* One Shim row and 8 Core rows. */ }
 
-  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
+  bool isShimNOCTile(int col, int row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimPLTile(int col, int row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimNOCorPLTile(int col, int row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
 };
@@ -335,25 +323,25 @@ class VE2302TargetModel : public AIE2TargetModel {
 public:
   VE2302TargetModel() {}
 
-  uint32_t columns() const override { return 17; }
-  uint32_t rows() const override {
+  int columns() const override { return 17; }
+  int rows() const override {
     return 4; /* One Shim row, 1 memtile rows, and 2 Core rows. */
   }
 
-  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 1; }
-  bool isMemTile(uint32_t col, uint32_t row) const override { return row == 1; }
-  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
+  bool isCoreTile(int col, int row) const override { return row > 1; }
+  bool isMemTile(int col, int row) const override { return row == 1; }
+  bool isShimNOCTile(int col, int row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimPLTile(int col, int row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimNOCorPLTile(int col, int row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
   uint32_t getNumMemTileRows() const override { return 1; }
-  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
-                          uint32_t destIndex) const override {
+  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
+                          int destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isCoreTile(col, row) && destBundle == WireBundle::DMA &&
@@ -383,27 +371,27 @@ class VE2802TargetModel : public AIE2TargetModel {
 public:
   VE2802TargetModel() {}
 
-  uint32_t columns() const override { return 38; }
-  uint32_t rows() const override {
+  int columns() const override { return 38; }
+  int rows() const override {
     return 11; /* One Shim row, 2 memtile rows, and 8 Core rows. */
   }
 
-  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 2; }
-  bool isMemTile(uint32_t col, uint32_t row) const override {
+  bool isCoreTile(int col, int row) const override { return row > 2; }
+  bool isMemTile(int col, int row) const override {
     return (row == 1) || (row == 2);
   }
-  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
+  bool isShimNOCTile(int col, int row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimPLTile(int col, int row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimNOCorPLTile(int col, int row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
   uint32_t getNumMemTileRows() const override { return 2; }
-  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
-                          uint32_t destIndex) const override {
+  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
+                          int destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isCoreTile(col, row) && destBundle == WireBundle::DMA &&
@@ -432,26 +420,26 @@ class IPUTargetModel : public AIE2TargetModel {
 public:
   IPUTargetModel() {}
 
-  uint32_t columns() const override { return 5; }
-  uint32_t rows() const override {
+  int columns() const override { return 5; }
+  int rows() const override {
     return 6; /* 1 Shim row, 1 memtile row, and 4 Core rows. */
   }
 
-  bool isCoreTile(uint32_t col, uint32_t row) const override { return row > 1; }
-  bool isMemTile(uint32_t col, uint32_t row) const override { return row == 1; }
+  bool isCoreTile(int col, int row) const override { return row > 1; }
+  bool isMemTile(int col, int row) const override { return row == 1; }
 
-  bool isShimNOCTile(uint32_t col, uint32_t row) const override {
+  bool isShimNOCTile(int col, int row) const override {
     return row == 0 && noc_columns.contains(col);
   }
-  bool isShimPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimPLTile(int col, int row) const override {
     return row == 0 && !noc_columns.contains(col);
   }
-  bool isShimNOCorPLTile(uint32_t col, uint32_t row) const override {
+  bool isShimNOCorPLTile(int col, int row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
   uint32_t getNumMemTileRows() const override { return 1; }
-  bool isValidTraceMaster(uint32_t col, uint32_t row, WireBundle destBundle,
-                          uint32_t destIndex) const override {
+  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
+                          int destIndex) const override {
     if (isCoreTile(col, row) && destBundle == WireBundle::South)
       return true;
     else if (isCoreTile(col, row) && destBundle == WireBundle::DMA &&
@@ -480,8 +468,8 @@ public:
 namespace llvm {
 using namespace xilinx::AIE;
 template <> struct DenseMapInfo<TileID> {
-  using FirstInfo = DenseMapInfo<uint32_t>;
-  using SecondInfo = DenseMapInfo<uint32_t>;
+  using FirstInfo = DenseMapInfo<int>;
+  using SecondInfo = DenseMapInfo<int>;
 
   static inline TileID getEmptyKey() {
     return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -31,6 +31,7 @@ typedef struct TileID {
     return std::tie(col, row) != std::tie(rhs.col, rhs.row);
   }
 
+  // Imposes a lexical order on TileIDs.
   inline bool operator<(const TileID &rhs) const {
     return col == rhs.col ? row < rhs.row : col < rhs.col;
   }

--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -30,9 +30,9 @@ using SwitchboxGraphBase = llvm::DirectedGraph<Switchbox, Channel>;
 class Switchbox : public SwitchboxBase {
 public:
   Switchbox() = delete;
-  Switchbox(const int col, const int row) : col(col), row(row) {}
+  Switchbox(const uint32_t col, const uint32_t row) : col(col), row(row) {}
 
-  int col, row;
+  uint32_t col, row;
 };
 
 class Channel : public ChannelBase {
@@ -81,13 +81,35 @@ public:
 // A SwitchSetting defines the required settings for a Switchbox for a flow
 // SwitchSetting.first is the incoming signal
 // SwitchSetting.second is the fanout
-typedef std::pair<Port, std::set<Port>> SwitchSetting;
+typedef struct SwitchSetting {
+  Port src;
+  std::set<Port> dsts;
+} SwitchSetting;
+
 typedef std::map<Switchbox *, SwitchSetting> SwitchSettings;
 
 // A Flow defines source and destination vertices
 // Only one source, but any number of destinations (fanout)
-typedef std::pair<Switchbox *, Port> PathEndPoint;
-typedef std::pair<PathEndPoint, std::vector<PathEndPoint>> Flow;
+typedef struct PathEndPoint {
+  Switchbox *sb;
+  Port port;
+
+  inline bool operator<(const PathEndPoint &rhs) const {
+    return sb->col == rhs.sb->col
+               ? (sb->row == rhs.sb->row
+                      ? (port.bundle == rhs.port.bundle
+                             ? port.channel < rhs.port.channel
+                             : port.bundle < rhs.port.bundle)
+                      : sb->row < rhs.sb->row)
+               : sb->col < rhs.sb->col;
+  }
+
+} PathEndPoint;
+
+typedef struct Flow {
+  PathEndPoint src;
+  std::vector<PathEndPoint> dsts;
+} Flow;
 
 class Pathfinder {
   SwitchboxGraph graph;
@@ -100,7 +122,7 @@ class Pathfinder {
 
 public:
   Pathfinder() = default;
-  Pathfinder(int maxCol, int maxRow, DeviceOp &d);
+  Pathfinder(uint32_t maxCol, uint32_t maxRow, DeviceOp &d);
   void addFlow(TileID srcCoords, Port srcPort, TileID dstCoords, Port dstPort);
   bool addFixedConnection(TileID coord, Port port);
   bool isLegal();
@@ -108,7 +130,7 @@ public:
 
   Switchbox *getSwitchbox(TileID coords) {
     auto sb = std::find_if(graph.begin(), graph.end(), [&](Switchbox *sb) {
-      return sb->col == coords.first && sb->row == coords.second;
+      return sb->col == coords.col && sb->row == coords.row;
     });
     assert(sb != graph.end() && "couldn't find sb");
     return *sb;

--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -30,9 +30,9 @@ using SwitchboxGraphBase = llvm::DirectedGraph<Switchbox, Channel>;
 class Switchbox : public SwitchboxBase {
 public:
   Switchbox() = delete;
-  Switchbox(const uint32_t col, const uint32_t row) : col(col), row(row) {}
+  Switchbox(const int col, const int row) : col(col), row(row) {}
 
-  uint32_t col, row;
+  int col, row;
 };
 
 class Channel : public ChannelBase {
@@ -122,7 +122,7 @@ class Pathfinder {
 
 public:
   Pathfinder() = default;
-  Pathfinder(uint32_t maxCol, uint32_t maxRow, DeviceOp &d);
+  Pathfinder(int maxCol, int maxRow, DeviceOp &d);
   void addFlow(TileID srcCoords, Port srcPort, TileID dstCoords, Port dstPort);
   bool addFixedConnection(TileID coord, Port port);
   bool isLegal();

--- a/include/aie/Dialect/AIEX/AIETokenAnalysis.h
+++ b/include/aie/Dialect/AIEX/AIETokenAnalysis.h
@@ -35,7 +35,7 @@ namespace AIEX {
 
 class TokenAnalysis {
   AIE::DeviceOp &device;
-  DenseMap<StringRef, uint32_t> tokenSymbols;
+  DenseMap<StringRef, int> tokenSymbols;
   DenseMap<StringRef, SmallVector<Operation *, 4>> tokenAcqMap;
   DenseMap<StringRef, SmallVector<Operation *, 4>> tokenRelMap;
   SmallVector<std::pair<Operation *, Operation *>, 4> tokenChains;

--- a/include/aie/Dialect/AIEX/AIETokenAnalysis.h
+++ b/include/aie/Dialect/AIEX/AIETokenAnalysis.h
@@ -12,6 +12,8 @@
 #define AIEX_TOKENANALYSIS_H
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/IR/AIETargetModel.h"
+
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -26,18 +28,19 @@
 #include <map>
 
 using namespace mlir;
+using namespace xilinx::AIE;
 
 namespace xilinx {
 namespace AIEX {
 
 class TokenAnalysis {
   AIE::DeviceOp &device;
-  DenseMap<StringRef, int> tokenSymbols;
+  DenseMap<StringRef, uint32_t> tokenSymbols;
   DenseMap<StringRef, SmallVector<Operation *, 4>> tokenAcqMap;
   DenseMap<StringRef, SmallVector<Operation *, 4>> tokenRelMap;
   SmallVector<std::pair<Operation *, Operation *>, 4> tokenChains;
   SmallVector<std::pair<Operation *, Operation *>, 4> tokenPairs;
-  DenseMap<std::pair<int, int>, Operation *> tiles;
+  DenseMap<TileID, Operation *> tiles;
 
 public:
   TokenAnalysis(AIE::DeviceOp &d) : device(d) {}
@@ -59,7 +62,7 @@ public:
   // CoreOp or MemOp
   Operation *getTokenUserOp(Operation *Op);
   Operation *getShareableTileOp(Operation *Op1, Operation *Op2);
-  std::pair<int, int> getCoord(Operation *Op);
+  TileID getCoord(Operation *Op);
 
   void print(raw_ostream &os);
 };

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -85,21 +85,9 @@ def AIE_ConnectionOp: AIEX_Op<"connection", []> {
     `(` $source `,` $sourceBundle `:` $sourceChannel `,` $dest `,` $destBundle `:` $destChannel `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int sourceIndex() { return getSourceChannel(); }
-    int destIndex() { return getDestChannel(); }
+    uint32_t sourceIndex() { return getSourceChannel(); }
+    uint32_t destIndex() { return getDestChannel(); }
   }];
-  // let builders = [
-  //   OpBuilder<(ins "Value":$source, "int":$sourceBundle,
-  //     "int":$sourceChannel, "Value":$dest, "int":$destBundle, "int":$destChannel), [{
-  //     build($_builder, $_state,
-  //           source,
-  //           $_builder.getI32IntegerAttr(sourceBundle),
-  //           $_builder.getI32IntegerAttr(sourceChannel),
-  //           dest,
-  //           $_builder.getI32IntegerAttr(destBundle),
-  //           $_builder.getI32IntegerAttr(destChannel));
-  //     }]>
-  // ];
 }
 
 def AIE_MulticastOp: AIEX_Op<"multicast", [SingleBlockImplicitTerminator<"AIE::EndOp">]> {
@@ -132,8 +120,8 @@ def AIE_MulticastOp: AIEX_Op<"multicast", [SingleBlockImplicitTerminator<"AIE::E
   let assemblyFormat = [{ `(` $tile `,` $bundle `:` $channel `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int channelIndex() { return getChannel(); }
-    AIE::Port port() { return std::make_pair(getBundle(), channelIndex()); }
+    uint32_t channelIndex() { return getChannel(); }
+    AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
 
@@ -155,8 +143,8 @@ def AIE_MultiDestOp: AIEX_Op<"multi_dest", [HasParent<"MulticastOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return getChannel(); }
-    AIE::Port port() { return std::make_pair(getBundle(), channelIndex()); }
+    uint32_t channelIndex() { return getChannel(); }
+    AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
 
@@ -195,8 +183,8 @@ def AIE_BroadcastPacketOp: AIEX_Op<"broadcast_packet", [SingleBlockImplicitTermi
   let assemblyFormat = [{ `(` $tile `,` $bundle `:` $channel `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    int channelIndex() { return getChannel(); }
-    AIE::Port port() { return std::make_pair(getBundle(), channelIndex()); }
+    uint32_t channelIndex() { return getChannel(); }
+    AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
 
@@ -213,7 +201,7 @@ def AIE_BPIDOp: AIEX_Op<"bp_id", [SingleBlockImplicitTerminator<"AIE::EndOp">]> 
   }];
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let extraClassDeclaration = [{
-    int IDInt() { return getID(); }
+    uint32_t IDInt() { return getID(); }
   }];
 }
 
@@ -233,8 +221,8 @@ def AIE_BPDestOp: AIEX_Op<"bp_dest", [HasParent<"BPIDOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    int channelIndex() { return getChannel(); }
-    AIE::Port port() { return std::make_pair(getBundle(), channelIndex()); }
+    uint32_t channelIndex() { return getChannel(); }
+    AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
 
@@ -263,7 +251,7 @@ def AIE_TokenOp: AIEX_Op<"token", [Symbol]> {
   let arguments = (ins I32Attr:$value);
   let assemblyFormat = [{ `(` $value `)` attr-dict }];
   let extraClassDeclaration = [{
-    int getTokenValue() { return getValue(); }
+    uint32_t getTokenValue() { return getValue(); }
   }];
 }
 
@@ -283,7 +271,7 @@ def AIE_UseTokenOp: AIEX_Op<"useToken", []> {
   let extraClassDeclaration = [{
     bool acquire() { return (getAction() == AIE::LockAction::Acquire); }
     bool release() { return (getAction() == AIE::LockAction::Release); }
-    int getTokenValue() { return getValue(); }
+    uint32_t getTokenValue() { return getValue(); }
   }];
 }
 
@@ -316,12 +304,12 @@ def AIE_MemcpyOp: AIEX_Op<"memcpy", []> {
         attr-dict `:` `(` type($srcBuf) `,` type($dstBuf) `)`
   }];
   let extraClassDeclaration = [{
-    int getAcquireTokenValue() { return getAcqValue(); }
-    int getReleaseTokenValue() { return getRelValue(); }
-    int getSrcOffsetValue() { return getSrcOffset(); }
-    int getDstOffsetValue() { return getDstOffset(); }
-    int getSrcLenValue() { return getSrcLen(); }
-    int getDstLenValue() { return getDstLen(); }
+    uint32_t getAcquireTokenValue() { return getAcqValue(); }
+    uint32_t getReleaseTokenValue() { return getRelValue(); }
+    uint32_t getSrcOffsetValue() { return getSrcOffset(); }
+    uint32_t getDstOffsetValue() { return getDstOffset(); }
+    uint32_t getSrcLenValue() { return getSrcLen(); }
+    uint32_t getDstLenValue() { return getDstLen(); }
   }];
 }
 
@@ -356,9 +344,9 @@ def AIE_HerdOp: AIEX_Op<"herd", []>, Results<(outs Index)> {
         I32Attr:$height
   );
   let extraClassDeclaration = [{
-    int getHerdWidth()   { return getWidth(); }
-    int getHerdHeight()  { return getHeight(); }
-    int getNumAIETiles() { return getHerdWidth() * getHerdHeight(); }
+    uint32_t getHerdWidth()   { return getWidth(); }
+    uint32_t getHerdHeight()  { return getHeight(); }
+    uint32_t getNumAIETiles() { return getHerdWidth() * getHerdHeight(); }
     StringAttr name() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
         return attr;
@@ -393,8 +381,8 @@ def AIE_PlaceOp: AIEX_Op<"place", []> {
   );
   let assemblyFormat = [{ `(` $sourceHerd `,` $destHerd `,` $distX `,` $distY `)` attr-dict }];
   let extraClassDeclaration = [{
-    int getDistXValue() { return getDistX(); }
-    int getDistYValue() { return getDistY(); }
+    uint32_t getDistXValue() { return getDistX(); }
+    uint32_t getDistYValue() { return getDistY(); }
   }];
 }
 
@@ -416,8 +404,8 @@ def AIE_RouteOp: AIEX_Op<"route", []> {
         `<` $destHerds   `,` $destBundle   `:` $destChannel   `>` `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    int getSourceChannelValue()  { return getSourceChannel(); }
-    int getDestChannelValue()  { return getDestChannel(); }
+    uint32_t getSourceChannelValue()  { return getSourceChannel(); }
+    uint32_t getDestChannelValue()  { return getDestChannel(); }
   }];
 }
 
@@ -438,9 +426,9 @@ def AIE_IterOp: AIEX_Op<"iter", []>, Results<(outs Index)> {
   );
   let assemblyFormat = [{ `(` $start `,` $end `,` $stride `)` attr-dict }];
   let extraClassDeclaration = [{
-    int getStartValue()  { return getStart(); }
-    int getEndValue()    { return getEnd(); }
-    int getStrideValue() { return getStride(); }
+    uint32_t getStartValue()  { return getStart(); }
+    uint32_t getEndValue()    { return getEnd(); }
+    uint32_t getStrideValue() { return getStride(); }
   }];
   let builders = [
     OpBuilder<(ins "int":$start, "int":$end, "int":$stride), [{

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -201,7 +201,7 @@ def AIE_BPIDOp: AIEX_Op<"bp_id", [SingleBlockImplicitTerminator<"AIE::EndOp">]> 
   }];
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let extraClassDeclaration = [{
-    uint8_t IDInt() { return getID(); }
+    int IDInt() { return getID(); }
   }];
 }
 

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -85,8 +85,8 @@ def AIE_ConnectionOp: AIEX_Op<"connection", []> {
     `(` $source `,` $sourceBundle `:` $sourceChannel `,` $dest `,` $destBundle `:` $destChannel `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    uint32_t sourceIndex() { return getSourceChannel(); }
-    uint32_t destIndex() { return getDestChannel(); }
+    int sourceIndex() { return getSourceChannel(); }
+    int destIndex() { return getDestChannel(); }
   }];
 }
 
@@ -120,7 +120,7 @@ def AIE_MulticastOp: AIEX_Op<"multicast", [SingleBlockImplicitTerminator<"AIE::E
   let assemblyFormat = [{ `(` $tile `,` $bundle `:` $channel `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    uint32_t channelIndex() { return getChannel(); }
+    int channelIndex() { return getChannel(); }
     AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
@@ -143,7 +143,7 @@ def AIE_MultiDestOp: AIEX_Op<"multi_dest", [HasParent<"MulticastOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    uint32_t channelIndex() { return getChannel(); }
+    int channelIndex() { return getChannel(); }
     AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
@@ -183,7 +183,7 @@ def AIE_BroadcastPacketOp: AIEX_Op<"broadcast_packet", [SingleBlockImplicitTermi
   let assemblyFormat = [{ `(` $tile `,` $bundle `:` $channel `)` regions attr-dict }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
-    uint32_t channelIndex() { return getChannel(); }
+    int channelIndex() { return getChannel(); }
     AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
@@ -201,7 +201,7 @@ def AIE_BPIDOp: AIEX_Op<"bp_id", [SingleBlockImplicitTerminator<"AIE::EndOp">]> 
   }];
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let extraClassDeclaration = [{
-    uint32_t IDInt() { return getID(); }
+    uint8_t IDInt() { return getID(); }
   }];
 }
 
@@ -221,7 +221,7 @@ def AIE_BPDestOp: AIEX_Op<"bp_dest", [HasParent<"BPIDOp">]> {
     `<` $tile `,` $bundle `:` $channel `>` attr-dict
   }];
   let extraClassDeclaration = [{
-    uint32_t channelIndex() { return getChannel(); }
+    int channelIndex() { return getChannel(); }
     AIE::Port port() { return {getBundle(), channelIndex()}; }
   }];
 }
@@ -251,7 +251,7 @@ def AIE_TokenOp: AIEX_Op<"token", [Symbol]> {
   let arguments = (ins I32Attr:$value);
   let assemblyFormat = [{ `(` $value `)` attr-dict }];
   let extraClassDeclaration = [{
-    uint32_t getTokenValue() { return getValue(); }
+    int getTokenValue() { return getValue(); }
   }];
 }
 
@@ -271,7 +271,7 @@ def AIE_UseTokenOp: AIEX_Op<"useToken", []> {
   let extraClassDeclaration = [{
     bool acquire() { return (getAction() == AIE::LockAction::Acquire); }
     bool release() { return (getAction() == AIE::LockAction::Release); }
-    uint32_t getTokenValue() { return getValue(); }
+    int getTokenValue() { return getValue(); }
   }];
 }
 
@@ -304,12 +304,12 @@ def AIE_MemcpyOp: AIEX_Op<"memcpy", []> {
         attr-dict `:` `(` type($srcBuf) `,` type($dstBuf) `)`
   }];
   let extraClassDeclaration = [{
-    uint32_t getAcquireTokenValue() { return getAcqValue(); }
-    uint32_t getReleaseTokenValue() { return getRelValue(); }
-    uint32_t getSrcOffsetValue() { return getSrcOffset(); }
-    uint32_t getDstOffsetValue() { return getDstOffset(); }
-    uint32_t getSrcLenValue() { return getSrcLen(); }
-    uint32_t getDstLenValue() { return getDstLen(); }
+    int getAcquireTokenValue() { return getAcqValue(); }
+    int getReleaseTokenValue() { return getRelValue(); }
+    int getSrcOffsetValue() { return getSrcOffset(); }
+    int getDstOffsetValue() { return getDstOffset(); }
+    int getSrcLenValue() { return getSrcLen(); }
+    int getDstLenValue() { return getDstLen(); }
   }];
 }
 
@@ -344,9 +344,9 @@ def AIE_HerdOp: AIEX_Op<"herd", []>, Results<(outs Index)> {
         I32Attr:$height
   );
   let extraClassDeclaration = [{
-    uint32_t getHerdWidth()   { return getWidth(); }
-    uint32_t getHerdHeight()  { return getHeight(); }
-    uint32_t getNumAIETiles() { return getHerdWidth() * getHerdHeight(); }
+    int getHerdWidth()   { return getWidth(); }
+    int getHerdHeight()  { return getHeight(); }
+    int getNumAIETiles() { return getHerdWidth() * getHerdHeight(); }
     StringAttr name() {
       if(auto attr = getOperation()->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName())) {
         return attr;
@@ -381,8 +381,8 @@ def AIE_PlaceOp: AIEX_Op<"place", []> {
   );
   let assemblyFormat = [{ `(` $sourceHerd `,` $destHerd `,` $distX `,` $distY `)` attr-dict }];
   let extraClassDeclaration = [{
-    uint32_t getDistXValue() { return getDistX(); }
-    uint32_t getDistYValue() { return getDistY(); }
+    int getDistXValue() { return getDistX(); }
+    int getDistYValue() { return getDistY(); }
   }];
 }
 
@@ -404,8 +404,8 @@ def AIE_RouteOp: AIEX_Op<"route", []> {
         `<` $destHerds   `,` $destBundle   `:` $destChannel   `>` `)` attr-dict
   }];
   let extraClassDeclaration = [{
-    uint32_t getSourceChannelValue()  { return getSourceChannel(); }
-    uint32_t getDestChannelValue()  { return getDestChannel(); }
+    int getSourceChannelValue()  { return getSourceChannel(); }
+    int getDestChannelValue()  { return getDestChannel(); }
   }];
 }
 
@@ -426,9 +426,9 @@ def AIE_IterOp: AIEX_Op<"iter", []>, Results<(outs Index)> {
   );
   let assemblyFormat = [{ `(` $start `,` $end `,` $stride `)` attr-dict }];
   let extraClassDeclaration = [{
-    uint32_t getStartValue()  { return getStart(); }
-    uint32_t getEndValue()    { return getEnd(); }
-    uint32_t getStrideValue() { return getStride(); }
+    int getStartValue()  { return getStart(); }
+    int getEndValue()    { return getEnd(); }
+    int getStrideValue() { return getStride(); }
   }];
   let builders = [
     OpBuilder<(ins "int":$start, "int":$end, "int":$stride), [{

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -411,8 +411,9 @@ xilinx::AIE::HasValidDMAChannels<ConcreteType>::verifyTrait(Operation *op) {
   for (auto &bodyOp : element.getBody().getOps()) {
     // check for duplicate DMA channels within the same MemTileDMAOp
     if (auto dmaStart = dyn_cast<xilinx::AIE::DMAStartOp>(bodyOp)) {
-      xilinx::AIE::DMAChannel dmaChan = {dmaStart.getChannelDir(),
-                                         dmaStart.getChannelIndex()};
+      xilinx::AIE::DMAChannel dmaChan = {
+          dmaStart.getChannelDir(),
+          static_cast<int>(dmaStart.getChannelIndex())};
       if (usedChannels.count(dmaChan))
         return dmaStart.emitOpError()
                << "duplicate DMA channel "
@@ -1108,14 +1109,14 @@ LogicalResult xilinx::AIE::ShimMuxOp::verify() {
   return success();
 }
 
-uint32_t xilinx::AIE::ShimMuxOp::getNumSourceConnections(WireBundle bundle) {
+int xilinx::AIE::ShimMuxOp::getNumSourceConnections(WireBundle bundle) {
   auto tile = getTileOp();
   const auto &target_model = getTargetModel(*this);
   return target_model.getNumSourceShimMuxConnections(tile.getCol(),
                                                      tile.getRow(), bundle);
 }
 
-uint32_t xilinx::AIE::ShimMuxOp::getNumDestConnections(WireBundle bundle) {
+int xilinx::AIE::ShimMuxOp::getNumDestConnections(WireBundle bundle) {
   auto tile = getTileOp();
   const auto &target_model = getTargetModel(*this);
   return target_model.getNumDestShimMuxConnections(tile.getCol(), tile.getRow(),
@@ -1126,9 +1127,9 @@ xilinx::AIE::TileOp xilinx::AIE::ShimMuxOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 
-uint32_t xilinx::AIE::ShimMuxOp::colIndex() { return getTileOp().colIndex(); }
+int xilinx::AIE::ShimMuxOp::colIndex() { return getTileOp().colIndex(); }
 
-uint32_t xilinx::AIE::ShimMuxOp::rowIndex() { return getTileOp().rowIndex(); }
+int xilinx::AIE::ShimMuxOp::rowIndex() { return getTileOp().rowIndex(); }
 
 // ShimDMAOp
 LogicalResult xilinx::AIE::ShimDMAOp::verify() {
@@ -1152,9 +1153,9 @@ xilinx::AIE::TileOp xilinx::AIE::ShimDMAOp::getTileOp() {
   return cast<TileOp>(getTile().getDefiningOp());
 }
 
-uint32_t xilinx::AIE::ShimDMAOp::colIndex() { return getTileOp().colIndex(); }
+int xilinx::AIE::ShimDMAOp::colIndex() { return getTileOp().colIndex(); }
 
-uint32_t xilinx::AIE::ShimDMAOp::rowIndex() { return getTileOp().rowIndex(); }
+int xilinx::AIE::ShimDMAOp::rowIndex() { return getTileOp().rowIndex(); }
 
 LogicalResult xilinx::AIE::PacketRulesOp::verify() {
   Region &body = getRules();
@@ -1192,9 +1193,9 @@ LogicalResult xilinx::AIE::CoreOp::verify() {
   return success();
 }
 
-uint32_t xilinx::AIE::CoreOp::colIndex() { return getTileOp().colIndex(); }
+int xilinx::AIE::CoreOp::colIndex() { return getTileOp().colIndex(); }
 
-uint32_t xilinx::AIE::CoreOp::rowIndex() { return getTileOp().rowIndex(); }
+int xilinx::AIE::CoreOp::rowIndex() { return getTileOp().rowIndex(); }
 
 xilinx::AIE::TileOp xilinx::AIE::CoreOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
@@ -1234,8 +1235,9 @@ LogicalResult xilinx::AIE::MemOp::verify() {
   for (auto &bodyOp : body.getOps()) {
     // check for duplicate DMA channels within the same MemOp
     if (auto dmaStart = dyn_cast<xilinx::AIE::DMAStartOp>(bodyOp)) {
-      xilinx::AIE::DMAChannel dmaChan = {dmaStart.getChannelDir(),
-                                         dmaStart.getChannelIndex()};
+      xilinx::AIE::DMAChannel dmaChan = {
+          dmaStart.getChannelDir(),
+          static_cast<int>(dmaStart.getChannelIndex())};
       if (usedChannels.count(dmaChan))
         return dmaStart.emitOpError()
                << "duplicate DMA channel "
@@ -1257,9 +1259,9 @@ xilinx::AIE::TileOp xilinx::AIE::MemOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 
-uint32_t xilinx::AIE::MemOp::colIndex() { return getTileOp().colIndex(); }
+int xilinx::AIE::MemOp::colIndex() { return getTileOp().colIndex(); }
 
-uint32_t xilinx::AIE::MemOp::rowIndex() { return getTileOp().rowIndex(); }
+int xilinx::AIE::MemOp::rowIndex() { return getTileOp().rowIndex(); }
 
 /// Returns the region on the current operation that is callable. This may
 /// return nullptr in the case of an external callable object, e.g. an external
@@ -1417,13 +1419,9 @@ xilinx::AIE::TileOp xilinx::AIE::MemTileDMAOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 
-uint32_t xilinx::AIE::MemTileDMAOp::colIndex() {
-  return getTileOp().colIndex();
-}
+int xilinx::AIE::MemTileDMAOp::colIndex() { return getTileOp().colIndex(); }
 
-uint32_t xilinx::AIE::MemTileDMAOp::rowIndex() {
-  return getTileOp().rowIndex();
-}
+int xilinx::AIE::MemTileDMAOp::rowIndex() { return getTileOp().rowIndex(); }
 
 /// Returns the region on the current operation that is callable. This may
 /// return nullptr in the case of an external callable object, e.g. an external
@@ -1435,9 +1433,9 @@ xilinx::AIE::TileOp xilinx::AIE::SwitchboxOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 
-uint32_t xilinx::AIE::SwitchboxOp::colIndex() { return getTileOp().colIndex(); }
+int xilinx::AIE::SwitchboxOp::colIndex() { return getTileOp().colIndex(); }
 
-uint32_t xilinx::AIE::SwitchboxOp::rowIndex() { return getTileOp().rowIndex(); }
+int xilinx::AIE::SwitchboxOp::rowIndex() { return getTileOp().rowIndex(); }
 
 template <typename... ParentOpTypes> struct HasSomeParent {
   static LogicalResult verifyTrait(Operation *op) {
@@ -1455,9 +1453,9 @@ xilinx::AIE::TileOp xilinx::AIE::LockOp::getTileOp() {
   return cast<xilinx::AIE::TileOp>(getTile().getDefiningOp());
 }
 
-uint32_t xilinx::AIE::LockOp::colIndex() { return getTileOp().colIndex(); }
+int xilinx::AIE::LockOp::colIndex() { return getTileOp().colIndex(); }
 
-uint32_t xilinx::AIE::LockOp::rowIndex() { return getTileOp().rowIndex(); }
+int xilinx::AIE::LockOp::rowIndex() { return getTileOp().rowIndex(); }
 
 LogicalResult xilinx::AIE::LockOp::verify() {
   auto result = UsesAreAccessable::verifyTrait(*this);
@@ -1583,21 +1581,21 @@ LogicalResult xilinx::AIE::UseLockOp::verify() {
 namespace xilinx {
 namespace AIE {
 
-uint32_t SwitchboxOp::getNumSourceConnections(WireBundle bundle) {
+int SwitchboxOp::getNumSourceConnections(WireBundle bundle) {
   auto tile = getTileOp();
   const auto &target_model = getTargetModel(*this);
   return target_model.getNumSourceSwitchboxConnections(tile.getCol(),
                                                        tile.getRow(), bundle);
 }
 
-uint32_t SwitchboxOp::getNumDestConnections(WireBundle bundle) {
+int SwitchboxOp::getNumDestConnections(WireBundle bundle) {
   auto tile = getTileOp();
   const auto &target_model = getTargetModel(*this);
   return target_model.getNumDestSwitchboxConnections(tile.getCol(),
                                                      tile.getRow(), bundle);
 }
 
-uint32_t TileOp::getNumSourceConnections(WireBundle bundle) {
+int TileOp::getNumSourceConnections(WireBundle bundle) {
   const auto &target_model = getTargetModel(*this);
   if (bundle == WireBundle::Core || bundle == WireBundle::DMA)
     // Note dest is correct here, since direction is reversed.
@@ -1612,7 +1610,7 @@ uint32_t TileOp::getNumSourceConnections(WireBundle bundle) {
     return 0;
 }
 
-uint32_t TileOp::getNumDestConnections(WireBundle bundle) {
+int TileOp::getNumDestConnections(WireBundle bundle) {
   const auto &target_model = getTargetModel(*this);
   if (bundle == WireBundle::Core || bundle == WireBundle::DMA)
     // Note source is correct here, since direction is reversed.

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -27,22 +27,22 @@ AIEArch AIE1TargetModel::getTargetArch() const { return AIEArch::AIE1; }
 
 // Return the tile ID of the memory to the west of the given tile, if it exists.
 std::optional<TileID> AIE1TargetModel::getMemWest(TileID src) const {
-  bool isEvenRow = ((src.second % 2) == 0);
+  bool isEvenRow = ((src.row % 2) == 0);
   std::optional<TileID> ret;
   if (isEvenRow)
     ret = src;
   else
-    ret = std::make_pair(src.first - 1, src.second);
+    ret = {src.col - 1, src.row};
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
 }
 // Return the tile ID of the memory to the west of the given tile, if it exists.
 std::optional<TileID> AIE1TargetModel::getMemEast(TileID src) const {
-  bool isEvenRow = ((src.second % 2) == 0);
+  bool isEvenRow = ((src.row % 2) == 0);
   std::optional<TileID> ret;
   if (isEvenRow)
-    ret = std::make_pair(src.first + 1, src.second);
+    ret = {src.col + 1, src.row};
   else
     ret = src;
   if (!isValidTile(*ret))
@@ -51,45 +51,46 @@ std::optional<TileID> AIE1TargetModel::getMemEast(TileID src) const {
 }
 // Return the tile ID of the memory to the west of the given tile, if it exists.
 std::optional<TileID> AIE1TargetModel::getMemNorth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second + 1);
+  std::optional<TileID> ret({src.col, src.row + 1});
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
 }
 std::optional<TileID> AIE1TargetModel::getMemSouth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second - 1);
+  std::optional<TileID> ret({src.col, src.row - 1});
   // The first row doesn't have a tile memory south
-  if (!isValidTile(*ret) || ret->second == 0)
+  if (!isValidTile(*ret) || ret->row == 0)
     ret.reset();
   return ret;
 }
 
-bool AIE1TargetModel::isMemWest(int srcCol, int srcRow, int dstCol,
-                                int dstRow) const {
+bool AIE1TargetModel::isMemWest(uint32_t srcCol, uint32_t srcRow,
+                                uint32_t dstCol, uint32_t dstRow) const {
   bool IsEvenRow = ((srcRow % 2) == 0);
   return (IsEvenRow && isInternal(srcCol, srcRow, dstCol, dstRow)) ||
          (!IsEvenRow && isWest(srcCol, srcRow, dstCol, dstRow));
 }
 
-bool AIE1TargetModel::isMemEast(int srcCol, int srcRow, int dstCol,
-                                int dstRow) const {
+bool AIE1TargetModel::isMemEast(uint32_t srcCol, uint32_t srcRow,
+                                uint32_t dstCol, uint32_t dstRow) const {
   bool IsEvenRow = ((srcRow % 2) == 0);
   return (!IsEvenRow && isInternal(srcCol, srcRow, dstCol, dstRow)) ||
          (IsEvenRow && isEast(srcCol, srcRow, dstCol, dstRow));
 }
 
-bool AIE1TargetModel::isMemNorth(int srcCol, int srcRow, int dstCol,
-                                 int dstRow) const {
+bool AIE1TargetModel::isMemNorth(uint32_t srcCol, uint32_t srcRow,
+                                 uint32_t dstCol, uint32_t dstRow) const {
   return isNorth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE1TargetModel::isMemSouth(int srcCol, int srcRow, int dstCol,
-                                 int dstRow) const {
+bool AIE1TargetModel::isMemSouth(uint32_t srcCol, uint32_t srcRow,
+                                 uint32_t dstCol, uint32_t dstRow) const {
   return isSouth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE1TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
-                                         int memRow) const {
+bool AIE1TargetModel::isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
+                                         uint32_t memCol,
+                                         uint32_t memRow) const {
   bool IsEvenRow = ((coreRow % 2) == 0);
 
   bool IsMemWest = (isWest(coreCol, coreRow, memCol, memRow) && !IsEvenRow) ||
@@ -104,7 +105,7 @@ bool AIE1TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
   return IsMemSouth || IsMemNorth || IsMemWest || IsMemEast;
 }
 uint32_t
-AIE1TargetModel::getNumDestSwitchboxConnections(int col, int row,
+AIE1TargetModel::getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
                                                 WireBundle bundle) const {
   if (isShimNOCTile(col, row) || isShimPLTile(col, row))
     switch (bundle) {
@@ -157,7 +158,7 @@ AIE1TargetModel::getNumDestSwitchboxConnections(int col, int row,
     }
 }
 uint32_t
-AIE1TargetModel::getNumSourceSwitchboxConnections(int col, int row,
+AIE1TargetModel::getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
                                                   WireBundle bundle) const {
   if (isShimNOCTile(col, row) || isShimPLTile(col, row))
     switch (bundle) {
@@ -214,7 +215,7 @@ AIE1TargetModel::getNumSourceSwitchboxConnections(int col, int row,
     }
 }
 uint32_t
-AIE1TargetModel::getNumDestShimMuxConnections(int col, int row,
+AIE1TargetModel::getNumDestShimMuxConnections(uint32_t col, uint32_t row,
                                               WireBundle bundle) const {
   if (isShimNOCorPLTile(col, row))
     switch (bundle) {
@@ -233,7 +234,7 @@ AIE1TargetModel::getNumDestShimMuxConnections(int col, int row,
     return 0;
 }
 uint32_t
-AIE1TargetModel::getNumSourceShimMuxConnections(int col, int row,
+AIE1TargetModel::getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
                                                 WireBundle bundle) const {
   if (isShimNOCTile(col, row))
     switch (bundle) {
@@ -253,9 +254,9 @@ AIE1TargetModel::getNumSourceShimMuxConnections(int col, int row,
 }
 
 bool AIE1TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
-                                               int srcChan,
+                                               uint32_t srcChan,
                                                WireBundle dstBundle,
-                                               int dstChan) const {
+                                               uint32_t dstChan) const {
   return false;
 }
 
@@ -267,7 +268,7 @@ AIEArch AIE2TargetModel::getTargetArch() const { return AIEArch::AIE2; }
 
 // Return the tile ID of the memory to the west of the given tile, if it exists.
 std::optional<TileID> AIE2TargetModel::getMemWest(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first - 1, src.second);
+  std::optional<TileID> ret({src.col - 1, src.row});
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
@@ -281,43 +282,43 @@ std::optional<TileID> AIE2TargetModel::getMemEast(TileID src) const {
 }
 // Return the tile ID of the memory to the west of the given tile, if it exists.
 std::optional<TileID> AIE2TargetModel::getMemNorth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second + 1);
+  std::optional<TileID> ret({src.col, src.row + 1});
   if (!isValidTile(*ret))
     ret.reset();
   return ret;
 }
 std::optional<TileID> AIE2TargetModel::getMemSouth(TileID src) const {
-  std::optional<TileID> ret = std::make_pair(src.first, src.second - 1);
+  std::optional<TileID> ret({src.col, src.row - 1});
   // The first row doesn't have a tile memory south
   // Memtiles don't have memory adjacency to neighboring core tiles.
-  if (!isValidTile(*ret) || ret->second == 0 ||
-      isMemTile(ret->first, ret->second))
+  if (!isValidTile(*ret) || ret->row == 0 || isMemTile(ret->col, ret->row))
     ret.reset();
   return ret;
 }
 
-bool AIE2TargetModel::isMemWest(int srcCol, int srcRow, int dstCol,
-                                int dstRow) const {
+bool AIE2TargetModel::isMemWest(uint32_t srcCol, uint32_t srcRow,
+                                uint32_t dstCol, uint32_t dstRow) const {
   return isWest(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isMemEast(int srcCol, int srcRow, int dstCol,
-                                int dstRow) const {
+bool AIE2TargetModel::isMemEast(uint32_t srcCol, uint32_t srcRow,
+                                uint32_t dstCol, uint32_t dstRow) const {
   return isInternal(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isMemNorth(int srcCol, int srcRow, int dstCol,
-                                 int dstRow) const {
+bool AIE2TargetModel::isMemNorth(uint32_t srcCol, uint32_t srcRow,
+                                 uint32_t dstCol, uint32_t dstRow) const {
   return isNorth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isMemSouth(int srcCol, int srcRow, int dstCol,
-                                 int dstRow) const {
+bool AIE2TargetModel::isMemSouth(uint32_t srcCol, uint32_t srcRow,
+                                 uint32_t dstCol, uint32_t dstRow) const {
   return isSouth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
-                                         int memRow) const {
+bool AIE2TargetModel::isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
+                                         uint32_t memCol,
+                                         uint32_t memRow) const {
 
   bool IsMemWest = isMemWest(coreCol, coreRow, memCol, memRow);
   bool IsMemEast = isMemEast(coreCol, coreRow, memCol, memRow);
@@ -333,7 +334,7 @@ bool AIE2TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
            IsMemWest || IsMemEast;
 }
 uint32_t
-AIE2TargetModel::getNumDestSwitchboxConnections(int col, int row,
+AIE2TargetModel::getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
                                                 WireBundle bundle) const {
   if (isMemTile(col, row))
     switch (bundle) {
@@ -397,7 +398,7 @@ AIE2TargetModel::getNumDestSwitchboxConnections(int col, int row,
     }
 }
 uint32_t
-AIE2TargetModel::getNumSourceSwitchboxConnections(int col, int row,
+AIE2TargetModel::getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
                                                   WireBundle bundle) const {
   if (isMemTile(col, row))
     switch (bundle) {
@@ -468,7 +469,7 @@ AIE2TargetModel::getNumSourceSwitchboxConnections(int col, int row,
     }
 }
 uint32_t
-AIE2TargetModel::getNumDestShimMuxConnections(int col, int row,
+AIE2TargetModel::getNumDestShimMuxConnections(uint32_t col, uint32_t row,
                                               WireBundle bundle) const {
   if (isShimNOCorPLTile(col, row))
     switch (bundle) {
@@ -487,7 +488,7 @@ AIE2TargetModel::getNumDestShimMuxConnections(int col, int row,
     return 0;
 }
 uint32_t
-AIE2TargetModel::getNumSourceShimMuxConnections(int col, int row,
+AIE2TargetModel::getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
                                                 WireBundle bundle) const {
   if (isShimNOCTile(col, row))
     switch (bundle) {
@@ -507,9 +508,9 @@ AIE2TargetModel::getNumSourceShimMuxConnections(int col, int row,
 }
 
 bool AIE2TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
-                                               int srcChan,
+                                               uint32_t srcChan,
                                                WireBundle dstBundle,
-                                               int dstChan) const {
+                                               uint32_t dstChan) const {
   // Memtile north-south stream switch constraint
   // Memtile stream interconnect master South and slave North must have equal
   // channel indices
@@ -534,57 +535,57 @@ bool AIE2TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
 void AIETargetModel::validate() const {
   // Every tile in a shimtile row must be a shimtile, and can only be one type
   // of shim tile.
-  for (int j = 0; j < columns(); j++) {
+  for (uint32_t j = 0; j < columns(); j++) {
     assert(!isMemTile(j, 0) && (isShimPLTile(j, 0) || isShimNOCTile(j, 0)) &&
            !isCoreTile(j, 0));
     assert(isShimPLTile(j, 0) ^ isShimNOCTile(j, 0));
   }
 
   // Every tile in a memtile row must be a memtile.
-  for (int i = 1; i < 1 + (int)getNumMemTileRows(); i++)
-    for (int j = 0; j < columns(); j++)
+  for (uint32_t i = 1; i < 1 + getNumMemTileRows(); i++)
+    for (uint32_t j = 0; j < columns(); j++)
       assert(isMemTile(j, i) && !isShimPLTile(j, i) && !isShimNOCTile(j, i) &&
              !isCoreTile(j, i));
 
   // Every other tile is a coretile.
-  for (int i = 1 + (int)getNumMemTileRows(); i < rows(); i++)
-    for (int j = 0; j < columns(); j++)
+  for (uint32_t i = 1 + getNumMemTileRows(); i < rows(); i++)
+    for (uint32_t j = 0; j < columns(); j++)
       assert(!isMemTile(j, i) && !isShimPLTile(j, i) && !isShimNOCTile(j, i) &&
              isCoreTile(j, i));
 
-  // Looking North, busses must match
-  for (int i = 0; i < rows() - 1; i++)
-    for (int j = 0; j < columns(); j++)
+  // Looking North, buses must match
+  for (uint32_t i = 0; i < rows() - 1; i++)
+    for (uint32_t j = 0; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::North) ==
              getNumDestSwitchboxConnections(j, i + 1, WireBundle::South));
-  // Looking South, busses must match
-  for (int i = 1; i < rows(); i++)
-    for (int j = 0; j < columns(); j++)
+  // Looking South, buses must match
+  for (uint32_t i = 1; i < rows(); i++)
+    for (uint32_t j = 0; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::South) ==
              getNumDestSwitchboxConnections(j, i - 1, WireBundle::North));
-  // Looking East, busses must match
-  for (int i = 0; i < rows(); i++)
-    for (int j = 0; j < columns() - 1; j++)
+  // Looking East, buses must match
+  for (uint32_t i = 0; i < rows(); i++)
+    for (uint32_t j = 0; j < columns() - 1; j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::East) ==
              getNumDestSwitchboxConnections(j + 1, i, WireBundle::West));
-  // Looking West, busses must match
-  for (int i = 0; i < rows(); i++)
-    for (int j = 1; j < columns(); j++)
+  // Looking West, buses must match
+  for (uint32_t i = 0; i < rows(); i++)
+    for (uint32_t j = 1; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::West) ==
              getNumDestSwitchboxConnections(j - 1, i, WireBundle::East));
   // Edges have no connections
-  for (int j = 0; j < columns(); j++)
+  for (uint32_t j = 0; j < columns(); j++)
     assert(getNumSourceSwitchboxConnections(j, rows() - 1, WireBundle::North) ==
            0);
-  for (int i = 0; i < rows(); i++)
+  for (uint32_t i = 0; i < rows(); i++)
     assert(getNumSourceSwitchboxConnections(columns() - 1, i,
                                             WireBundle::East) == 0);
-  for (int i = 0; i < rows(); i++)
+  for (uint32_t i = 0; i < rows(); i++)
     assert(getNumSourceSwitchboxConnections(0, i, WireBundle::West) == 0);
 
   // FIFOS are consistent
-  for (int i = 0; i < rows(); i++)
-    for (int j = 0; j < columns(); j++)
+  for (uint32_t i = 0; i < rows(); i++)
+    for (uint32_t j = 0; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::FIFO) ==
              getNumDestSwitchboxConnections(j, i, WireBundle::FIFO));
 }

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -64,33 +64,32 @@ std::optional<TileID> AIE1TargetModel::getMemSouth(TileID src) const {
   return ret;
 }
 
-bool AIE1TargetModel::isMemWest(uint32_t srcCol, uint32_t srcRow,
-                                uint32_t dstCol, uint32_t dstRow) const {
+bool AIE1TargetModel::isMemWest(int srcCol, int srcRow, int dstCol,
+                                int dstRow) const {
   bool IsEvenRow = ((srcRow % 2) == 0);
   return (IsEvenRow && isInternal(srcCol, srcRow, dstCol, dstRow)) ||
          (!IsEvenRow && isWest(srcCol, srcRow, dstCol, dstRow));
 }
 
-bool AIE1TargetModel::isMemEast(uint32_t srcCol, uint32_t srcRow,
-                                uint32_t dstCol, uint32_t dstRow) const {
+bool AIE1TargetModel::isMemEast(int srcCol, int srcRow, int dstCol,
+                                int dstRow) const {
   bool IsEvenRow = ((srcRow % 2) == 0);
   return (!IsEvenRow && isInternal(srcCol, srcRow, dstCol, dstRow)) ||
          (IsEvenRow && isEast(srcCol, srcRow, dstCol, dstRow));
 }
 
-bool AIE1TargetModel::isMemNorth(uint32_t srcCol, uint32_t srcRow,
-                                 uint32_t dstCol, uint32_t dstRow) const {
+bool AIE1TargetModel::isMemNorth(int srcCol, int srcRow, int dstCol,
+                                 int dstRow) const {
   return isNorth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE1TargetModel::isMemSouth(uint32_t srcCol, uint32_t srcRow,
-                                 uint32_t dstCol, uint32_t dstRow) const {
+bool AIE1TargetModel::isMemSouth(int srcCol, int srcRow, int dstCol,
+                                 int dstRow) const {
   return isSouth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE1TargetModel::isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
-                                         uint32_t memCol,
-                                         uint32_t memRow) const {
+bool AIE1TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
+                                         int memRow) const {
   bool IsEvenRow = ((coreRow % 2) == 0);
 
   bool IsMemWest = (isWest(coreCol, coreRow, memCol, memRow) && !IsEvenRow) ||
@@ -105,7 +104,7 @@ bool AIE1TargetModel::isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
   return IsMemSouth || IsMemNorth || IsMemWest || IsMemEast;
 }
 uint32_t
-AIE1TargetModel::getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
+AIE1TargetModel::getNumDestSwitchboxConnections(int col, int row,
                                                 WireBundle bundle) const {
   if (isShimNOCTile(col, row) || isShimPLTile(col, row))
     switch (bundle) {
@@ -158,7 +157,7 @@ AIE1TargetModel::getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
     }
 }
 uint32_t
-AIE1TargetModel::getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
+AIE1TargetModel::getNumSourceSwitchboxConnections(int col, int row,
                                                   WireBundle bundle) const {
   if (isShimNOCTile(col, row) || isShimPLTile(col, row))
     switch (bundle) {
@@ -215,7 +214,7 @@ AIE1TargetModel::getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
     }
 }
 uint32_t
-AIE1TargetModel::getNumDestShimMuxConnections(uint32_t col, uint32_t row,
+AIE1TargetModel::getNumDestShimMuxConnections(int col, int row,
                                               WireBundle bundle) const {
   if (isShimNOCorPLTile(col, row))
     switch (bundle) {
@@ -234,7 +233,7 @@ AIE1TargetModel::getNumDestShimMuxConnections(uint32_t col, uint32_t row,
     return 0;
 }
 uint32_t
-AIE1TargetModel::getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
+AIE1TargetModel::getNumSourceShimMuxConnections(int col, int row,
                                                 WireBundle bundle) const {
   if (isShimNOCTile(col, row))
     switch (bundle) {
@@ -254,9 +253,9 @@ AIE1TargetModel::getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
 }
 
 bool AIE1TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
-                                               uint32_t srcChan,
+                                               int srcChan,
                                                WireBundle dstBundle,
-                                               uint32_t dstChan) const {
+                                               int dstChan) const {
   return false;
 }
 
@@ -296,29 +295,28 @@ std::optional<TileID> AIE2TargetModel::getMemSouth(TileID src) const {
   return ret;
 }
 
-bool AIE2TargetModel::isMemWest(uint32_t srcCol, uint32_t srcRow,
-                                uint32_t dstCol, uint32_t dstRow) const {
+bool AIE2TargetModel::isMemWest(int srcCol, int srcRow, int dstCol,
+                                int dstRow) const {
   return isWest(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isMemEast(uint32_t srcCol, uint32_t srcRow,
-                                uint32_t dstCol, uint32_t dstRow) const {
+bool AIE2TargetModel::isMemEast(int srcCol, int srcRow, int dstCol,
+                                int dstRow) const {
   return isInternal(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isMemNorth(uint32_t srcCol, uint32_t srcRow,
-                                 uint32_t dstCol, uint32_t dstRow) const {
+bool AIE2TargetModel::isMemNorth(int srcCol, int srcRow, int dstCol,
+                                 int dstRow) const {
   return isNorth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isMemSouth(uint32_t srcCol, uint32_t srcRow,
-                                 uint32_t dstCol, uint32_t dstRow) const {
+bool AIE2TargetModel::isMemSouth(int srcCol, int srcRow, int dstCol,
+                                 int dstRow) const {
   return isSouth(srcCol, srcRow, dstCol, dstRow);
 }
 
-bool AIE2TargetModel::isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
-                                         uint32_t memCol,
-                                         uint32_t memRow) const {
+bool AIE2TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
+                                         int memRow) const {
 
   bool IsMemWest = isMemWest(coreCol, coreRow, memCol, memRow);
   bool IsMemEast = isMemEast(coreCol, coreRow, memCol, memRow);
@@ -334,7 +332,7 @@ bool AIE2TargetModel::isLegalMemAffinity(uint32_t coreCol, uint32_t coreRow,
            IsMemWest || IsMemEast;
 }
 uint32_t
-AIE2TargetModel::getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
+AIE2TargetModel::getNumDestSwitchboxConnections(int col, int row,
                                                 WireBundle bundle) const {
   if (isMemTile(col, row))
     switch (bundle) {
@@ -398,7 +396,7 @@ AIE2TargetModel::getNumDestSwitchboxConnections(uint32_t col, uint32_t row,
     }
 }
 uint32_t
-AIE2TargetModel::getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
+AIE2TargetModel::getNumSourceSwitchboxConnections(int col, int row,
                                                   WireBundle bundle) const {
   if (isMemTile(col, row))
     switch (bundle) {
@@ -469,7 +467,7 @@ AIE2TargetModel::getNumSourceSwitchboxConnections(uint32_t col, uint32_t row,
     }
 }
 uint32_t
-AIE2TargetModel::getNumDestShimMuxConnections(uint32_t col, uint32_t row,
+AIE2TargetModel::getNumDestShimMuxConnections(int col, int row,
                                               WireBundle bundle) const {
   if (isShimNOCorPLTile(col, row))
     switch (bundle) {
@@ -488,7 +486,7 @@ AIE2TargetModel::getNumDestShimMuxConnections(uint32_t col, uint32_t row,
     return 0;
 }
 uint32_t
-AIE2TargetModel::getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
+AIE2TargetModel::getNumSourceShimMuxConnections(int col, int row,
                                                 WireBundle bundle) const {
   if (isShimNOCTile(col, row))
     switch (bundle) {
@@ -508,9 +506,9 @@ AIE2TargetModel::getNumSourceShimMuxConnections(uint32_t col, uint32_t row,
 }
 
 bool AIE2TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
-                                               uint32_t srcChan,
+                                               int srcChan,
                                                WireBundle dstBundle,
-                                               uint32_t dstChan) const {
+                                               int dstChan) const {
   // Memtile north-south stream switch constraint
   // Memtile stream interconnect master South and slave North must have equal
   // channel indices
@@ -535,57 +533,57 @@ bool AIE2TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
 void AIETargetModel::validate() const {
   // Every tile in a shimtile row must be a shimtile, and can only be one type
   // of shim tile.
-  for (uint32_t j = 0; j < columns(); j++) {
+  for (int j = 0; j < columns(); j++) {
     assert(!isMemTile(j, 0) && (isShimPLTile(j, 0) || isShimNOCTile(j, 0)) &&
            !isCoreTile(j, 0));
     assert(isShimPLTile(j, 0) ^ isShimNOCTile(j, 0));
   }
 
   // Every tile in a memtile row must be a memtile.
-  for (uint32_t i = 1; i < 1 + getNumMemTileRows(); i++)
-    for (uint32_t j = 0; j < columns(); j++)
+  for (int i = 1; i < 1 + (int)getNumMemTileRows(); i++)
+    for (int j = 0; j < columns(); j++)
       assert(isMemTile(j, i) && !isShimPLTile(j, i) && !isShimNOCTile(j, i) &&
              !isCoreTile(j, i));
 
   // Every other tile is a coretile.
-  for (uint32_t i = 1 + getNumMemTileRows(); i < rows(); i++)
-    for (uint32_t j = 0; j < columns(); j++)
+  for (int i = 1 + (int)getNumMemTileRows(); i < rows(); i++)
+    for (int j = 0; j < columns(); j++)
       assert(!isMemTile(j, i) && !isShimPLTile(j, i) && !isShimNOCTile(j, i) &&
              isCoreTile(j, i));
 
   // Looking North, buses must match
-  for (uint32_t i = 0; i < rows() - 1; i++)
-    for (uint32_t j = 0; j < columns(); j++)
+  for (int i = 0; i < rows() - 1; i++)
+    for (int j = 0; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::North) ==
              getNumDestSwitchboxConnections(j, i + 1, WireBundle::South));
   // Looking South, buses must match
-  for (uint32_t i = 1; i < rows(); i++)
-    for (uint32_t j = 0; j < columns(); j++)
+  for (int i = 1; i < rows(); i++)
+    for (int j = 0; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::South) ==
              getNumDestSwitchboxConnections(j, i - 1, WireBundle::North));
   // Looking East, buses must match
-  for (uint32_t i = 0; i < rows(); i++)
-    for (uint32_t j = 0; j < columns() - 1; j++)
+  for (int i = 0; i < rows(); i++)
+    for (int j = 0; j < columns() - 1; j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::East) ==
              getNumDestSwitchboxConnections(j + 1, i, WireBundle::West));
   // Looking West, buses must match
-  for (uint32_t i = 0; i < rows(); i++)
-    for (uint32_t j = 1; j < columns(); j++)
+  for (int i = 0; i < rows(); i++)
+    for (int j = 1; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::West) ==
              getNumDestSwitchboxConnections(j - 1, i, WireBundle::East));
   // Edges have no connections
-  for (uint32_t j = 0; j < columns(); j++)
+  for (int j = 0; j < columns(); j++)
     assert(getNumSourceSwitchboxConnections(j, rows() - 1, WireBundle::North) ==
            0);
-  for (uint32_t i = 0; i < rows(); i++)
+  for (int i = 0; i < rows(); i++)
     assert(getNumSourceSwitchboxConnections(columns() - 1, i,
                                             WireBundle::East) == 0);
-  for (uint32_t i = 0; i < rows(); i++)
+  for (int i = 0; i < rows(); i++)
     assert(getNumSourceSwitchboxConnections(0, i, WireBundle::West) == 0);
 
   // FIFOS are consistent
-  for (uint32_t i = 0; i < rows(); i++)
-    for (uint32_t j = 0; j < columns(); j++)
+  for (int i = 0; i < rows(); i++)
+    for (int j = 0; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::FIFO) ==
              getNumDestSwitchboxConnections(j, i, WireBundle::FIFO));
 }

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -400,7 +400,7 @@ struct AIECoreToStandardPass
     // Create an LLVM func for each CoreOp
     // Clone the region body of each CoreOp to the newly created LLVM func
 
-    DenseMap<std::pair<int, int>, Operation *> tiles;
+    DenseMap<TileID, Operation *> tiles;
     DenseMap<Operation *, CoreOp> cores;
     DenseMap<Operation *, MemOp> mems;
     DenseMap<std::pair<Operation *, int>, LockOp> locks;

--- a/lib/Dialect/AIE/Transforms/AIECreatePacketFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePacketFlows.cpp
@@ -8,14 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "aie/Dialect/AIE/AIENetlistAnalysis.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
+
 #include "mlir/IR/Attributes.h"
-#include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Transforms/DialectConversion.h"
+
 #include "llvm/ADT/Twine.h"
 
 #define DEBUG_TYPE "aie-create-packet-flows"
@@ -29,7 +29,7 @@ struct AIEOpRemoval : public OpConversionPattern<MyOp> {
   using OpConversionPattern<MyOp>::OpConversionPattern;
   using OpAdaptor = typename MyOp::Adaptor;
 
-  AIEOpRemoval(MLIRContext *context, PatternBenefit benefit = 1)
+  explicit AIEOpRemoval(MLIRContext *context, PatternBenefit benefit = 1)
       : OpConversionPattern<MyOp>(context, benefit) {}
 
   LogicalResult
@@ -45,14 +45,15 @@ struct AIEOpRemoval : public OpConversionPattern<MyOp> {
 // A port on a switch is identified by the tile and port name.
 typedef std::pair<Operation *, Port> PhysPort;
 
-int getAvailableDestChannel(SmallVector<std::pair<Connect, int>, 8> &connects,
-                            Port sourcePort, int flowID,
-                            WireBundle destBundle) {
+std::optional<uint32_t>
+getAvailableDestChannel(SmallVector<std::pair<Connect, uint32_t>, 8> &connects,
+                        Port sourcePort, uint32_t flowID,
+                        WireBundle destBundle) {
 
-  if (connects.size() == 0)
+  if (connects.empty())
     return 0;
 
-  int numChannels;
+  uint32_t numChannels;
 
   if (destBundle == WireBundle::North)
     numChannels = 6;
@@ -63,15 +64,14 @@ int getAvailableDestChannel(SmallVector<std::pair<Connect, int>, 8> &connects,
     numChannels = 2;
 
   // look for existing connect that has a matching destination
-  for (int i = 0; i < numChannels; i++) {
-    Port port = std::make_pair(destBundle, i);
+  for (uint32_t i = 0; i < numChannels; i++) {
+    Port port = {destBundle, i};
     int countFlows = 0;
-    for (auto conn : connects) {
-      Port connDest = conn.first.second;
+    for (const auto &[conn, _flowID] : connects) {
       // Since we are doing packet-switched routing, dest ports can be shared
       // among multiple sources. Therefore, we don't need to worry about
       // checking the same source
-      if (connDest == port)
+      if (conn.dst == port)
         countFlows++;
     }
 
@@ -83,25 +83,25 @@ int getAvailableDestChannel(SmallVector<std::pair<Connect, int>, 8> &connects,
   }
 
   // if not, look for available destination port
-  for (int i = 0; i < numChannels; i++) {
-    Port port = std::make_pair(destBundle, i);
+  for (uint32_t i = 0; i < numChannels; i++) {
+    Port port = {destBundle, i};
     SmallVector<Port, 8> ports;
-    for (auto connect : connects)
-      ports.push_back(connect.first.second);
+    for (const auto &[conn, _flowID] : connects)
+      ports.push_back(conn.dst);
 
     if (std::find(ports.begin(), ports.end(), port) == ports.end())
       return i;
   }
 
-  return -1;
+  return std::nullopt;
 }
 
 // Same function as above, but scanning from the last connect backwards
-int getAvailableDestChannelReverseOrder(
-    SmallVector<std::pair<Connect, int>, 8> &connects, Port sourcePort,
-    int flowID, WireBundle destBundle) {
+std::optional<uint32_t> getAvailableDestChannelReverseOrder(
+    SmallVector<std::pair<Connect, uint32_t>, 8> &connects, Port sourcePort,
+    uint32_t flowID, WireBundle destBundle) {
 
-  int numChannels;
+  uint32_t numChannels;
 
   if (destBundle == WireBundle::North)
     numChannels = 6;
@@ -111,34 +111,36 @@ int getAvailableDestChannelReverseOrder(
   else
     numChannels = 2;
 
-  if (connects.size() == 0)
+  if (connects.empty()) {
+    assert(numChannels > 0 && "numChannels <= 0");
     return numChannels - 1;
+  }
 
-  for (int i = numChannels - 1; i >= 0; i--) {
-    Port port = std::make_pair(destBundle, i);
+  for (uint32_t i = numChannels - 1; i >= 0; i--) {
+    Port port = {destBundle, i};
     int countFlows = 0;
-    for (auto conn : connects) {
-      Port connDest = conn.first.second;
+    for (const auto &[conn, _flowID] : connects) {
+      Port connDest = conn.dst;
       if (connDest == port)
         countFlows++;
     }
     if (countFlows > 0 && countFlows < 32)
-      return i;
+      return {i};
   }
-  for (int i = numChannels - 1; i >= 0; i--) {
-    Port port = std::make_pair(destBundle, i);
+  for (uint32_t i = numChannels - 1; i >= 0; i--) {
+    Port port = {destBundle, i};
     SmallVector<Port, 8> ports;
     for (auto connect : connects)
-      ports.push_back(connect.first.second);
+      ports.push_back(connect.first.dst);
 
     if (std::find(ports.begin(), ports.end(), port) == ports.end())
-      return i;
+      return {i};
   }
 
-  return -1;
+  return std::nullopt;
 }
 
-void update_coordinates(int &xCur, int &yCur, WireBundle move) {
+void updateCoordinates(uint32_t &xCur, uint32_t &yCur, WireBundle move) {
   if (move == WireBundle::East) {
     xCur = xCur + 1;
     // yCur = yCur;
@@ -157,20 +159,19 @@ void update_coordinates(int &xCur, int &yCur, WireBundle move) {
 // Build a packet-switched route from the sourse to the destination with the
 // given ID. The route is recorded in the given map of switchboxes.
 void buildPSRoute(
-    int xSrc, int ySrc, Port sourcePort, int xDest, int yDest, Port destPort,
-    int flowID,
-    DenseMap<std::pair<int, int>, SmallVector<std::pair<Connect, int>, 8>>
-        &switchboxes,
+    uint32_t xSrc, uint32_t ySrc, Port sourcePort, uint32_t xDest,
+    uint32_t yDest, Port destPort, uint32_t flowID,
+    DenseMap<TileID, SmallVector<std::pair<Connect, uint32_t>, 8>> &switchboxes,
     bool reverseOrder = false) {
-  int xCur = xSrc;
-  int yCur = ySrc;
+  uint32_t xCur = xSrc;
+  uint32_t yCur = ySrc;
   WireBundle curBundle;
-  int curChannel;
-  int xLast, yLast;
+  uint32_t curChannel;
+  uint32_t xLast, yLast;
   WireBundle lastBundle;
   Port lastPort = sourcePort;
 
-  SmallVector<std::pair<int, int>, 4> congestion;
+  SmallVector<TileID, 4> congestion;
 
   LLVM_DEBUG(llvm::dbgs() << "Build route ID " << flowID << ": " << xSrc << " "
                           << ySrc << " --> " << xDest << " " << yDest << '\n');
@@ -178,7 +179,7 @@ void buildPSRoute(
   while (!((xCur == xDest) && (yCur == yDest))) {
     LLVM_DEBUG(llvm::dbgs() << "Tile " << xCur << " " << yCur << " ");
 
-    auto curCoord = std::make_pair(xCur, yCur);
+    TileID curCoord = {xCur, yCur};
     xLast = xCur;
     yLast = yCur;
 
@@ -202,24 +203,26 @@ void buildPSRoute(
     if (std::find(moves.begin(), moves.end(), WireBundle::South) == moves.end())
       moves.push_back(WireBundle::South);
 
-    for (unsigned i = 0; i < moves.size(); i++) {
-      WireBundle move = moves[i];
-      if (reverseOrder)
-        curChannel = getAvailableDestChannelReverseOrder(
-            switchboxes[curCoord], lastPort, flowID, move);
+    for (auto move : moves) {
+      if (reverseOrder) {
+        if (auto maybeDestChannel = getAvailableDestChannelReverseOrder(
+                switchboxes[curCoord], lastPort, flowID, move))
+          curChannel = maybeDestChannel.value();
+        else
+          continue;
+      } else if (auto maybeDestChannel = getAvailableDestChannel(
+                     switchboxes[curCoord], lastPort, flowID, move))
+        curChannel = maybeDestChannel.value();
       else
-        curChannel = getAvailableDestChannel(switchboxes[curCoord], lastPort,
-                                             flowID, move);
-      if (curChannel == -1)
         continue;
 
       if (move == lastBundle)
         continue;
 
-      update_coordinates(xCur, yCur, move);
+      updateCoordinates(xCur, yCur, move);
 
-      if (std::find(congestion.begin(), congestion.end(),
-                    std::make_pair(xCur, yCur)) != congestion.end())
+      if (std::find(congestion.begin(), congestion.end(), TileID{xCur, yCur}) !=
+          congestion.end())
         continue;
 
       curBundle = move;
@@ -234,35 +237,34 @@ void buildPSRoute(
     assert(curChannel >= 0 && "Could not find available destination port!");
 
     if (curChannel == -1) {
-      congestion.push_back(
-          std::make_pair(xLast, yLast)); // this switchbox is congested
-      switchboxes[curCoord].pop_back();  // back up, remove the last connection
+      congestion.push_back({xLast, yLast}); // this switchbox is congested
+      switchboxes[curCoord].pop_back(); // back up, remove the last connection
     } else {
       LLVM_DEBUG(llvm::dbgs()
-                 << stringifyWireBundle(lastPort.first) << " "
-                 << lastPort.second << " -> " << stringifyWireBundle(curBundle)
+                 << stringifyWireBundle(lastPort.bundle) << " "
+                 << lastPort.channel << " -> " << stringifyWireBundle(curBundle)
                  << " " << curChannel << "\n");
 
-      Port curPort = std::make_pair(curBundle, curChannel);
-      Connect connect = std::make_pair(lastPort, curPort);
-      // If there is no connection with this ID going where we want to go..
+      Port curPort = {curBundle, curChannel};
+      Connect connect = {lastPort, curPort};
+      // If there is no connection with this ID going where we want to go.
       if (std::find(switchboxes[curCoord].begin(), switchboxes[curCoord].end(),
-                    std::make_pair(connect, flowID)) ==
+                    std::pair<Connect, uint32_t>{connect, flowID}) ==
           switchboxes[curCoord].end())
         // then add one.
-        switchboxes[curCoord].push_back(std::make_pair(connect, flowID));
-      lastPort = std::make_pair(lastBundle, curChannel);
+        switchboxes[curCoord].push_back({connect, flowID});
+      lastPort = {lastBundle, curChannel};
     }
   }
 
   LLVM_DEBUG(llvm::dbgs() << "Tile " << xCur << " " << yCur << " ");
-  LLVM_DEBUG(llvm::dbgs() << stringifyWireBundle(lastPort.first) << " "
-                          << lastPort.second << " -> "
+  LLVM_DEBUG(llvm::dbgs() << stringifyWireBundle(lastPort.bundle) << " "
+                          << lastPort.channel << " -> "
                           << stringifyWireBundle(curBundle) << " " << curChannel
                           << "\n");
 
-  switchboxes[std::make_pair(xCur, yCur)].push_back(
-      std::make_pair(std::make_pair(lastPort, destPort), flowID));
+  switchboxes[{xCur, yCur}].push_back(
+      std::make_pair(Connect{lastPort, destPort}, flowID));
 }
 
 SwitchboxOp getOrCreateSwitchbox(OpBuilder &builder, TileOp tile) {
@@ -276,9 +278,9 @@ SwitchboxOp getOrCreateSwitchbox(OpBuilder &builder, TileOp tile) {
 struct AIERoutePacketFlowsPass
     : public AIERoutePacketFlowsBase<AIERoutePacketFlowsPass> {
   // Map from tile coordinates to TileOp
-  DenseMap<std::pair<int, int>, Operation *> tiles;
-  Operation *getOrCreateTile(OpBuilder &builder, int col, int row) {
-    auto index = std::make_pair(col, row);
+  DenseMap<TileID, Operation *> tiles;
+  Operation *getOrCreateTile(OpBuilder &builder, uint32_t col, uint32_t row) {
+    TileID index = {col, row};
     Operation *tileOp = tiles[index];
     if (!tileOp) {
       auto tile = builder.create<TileOp>(builder.getUnknownLoc(), col, row);
@@ -319,19 +321,18 @@ struct AIERoutePacketFlowsPass
     DenseMap<PhysPort, Attribute> keepPktHeaderAttr;
 
     for (auto tileOp : device.getOps<TileOp>()) {
-      int col = tileOp.colIndex();
-      int row = tileOp.rowIndex();
-      tiles[std::make_pair(col, row)] = tileOp;
+      uint32_t col = tileOp.colIndex();
+      uint32_t row = tileOp.rowIndex();
+      tiles[{col, row}] = tileOp;
     }
 
     // The logical model of all the switchboxes.
-    DenseMap<std::pair<int, int>, SmallVector<std::pair<Connect, int>, 8>>
-        switchboxes;
+    DenseMap<TileID, SmallVector<std::pair<Connect, uint32_t>, 8>> switchboxes;
     for (auto pktflow : device.getOps<PacketFlowOp>()) {
       Region &r = pktflow.getPorts();
       Block &b = r.front();
-      int flowID = pktflow.IDInt();
-      int xSrc, ySrc;
+      uint32_t flowID = pktflow.IDInt();
+      uint32_t xSrc, ySrc;
       Port sourcePort;
 
       for (Operation &Op : b.getOperations()) {
@@ -343,8 +344,8 @@ struct AIERoutePacketFlowsPass
           sourcePort = pktSource.port();
         } else if (PacketDestOp pktDest = dyn_cast<PacketDestOp>(Op)) {
           TileOp destTile = dyn_cast<TileOp>(pktDest.getTile().getDefiningOp());
-          int xDest = destTile.colIndex();
-          int yDest = destTile.rowIndex();
+          uint32_t xDest = destTile.colIndex();
+          uint32_t yDest = destTile.rowIndex();
           Port destPort = pktDest.port();
 
           buildPSRoute(xSrc, ySrc, sourcePort, xDest, yDest, destPort, flowID,
@@ -352,7 +353,7 @@ struct AIERoutePacketFlowsPass
 
           // Assign "keep_pkt_header flag"
           if (pktflow->hasAttr("keep_pkt_header"))
-            keepPktHeaderAttr[std::make_pair(destTile, destPort)] =
+            keepPktHeaderAttr[{destTile, destPort}] =
                 StringAttr::get(Op.getContext(), "true");
         }
       }
@@ -360,31 +361,28 @@ struct AIERoutePacketFlowsPass
 
     LLVM_DEBUG(llvm::dbgs() << "Check switchboxes\n");
 
-    for (auto swbox : switchboxes) {
-      int col = swbox.first.first;
-      int row = swbox.first.second;
+    for (const auto &[tileId, connects] : switchboxes) {
+      uint32_t col = tileId.col;
+      uint32_t row = tileId.row;
       Operation *tileOp = getOrCreateTile(builder, col, row);
 
       LLVM_DEBUG(llvm::dbgs()
                  << "***switchbox*** " << col << " " << row << '\n');
-      SmallVector<std::pair<Connect, int>, 8> connects(swbox.second);
-      for (auto connect : connects) {
-        Port sourcePort = connect.first.first;
-        Port destPort = connect.first.second;
-        int flowID = connect.second;
-
-        int nextCol = col, nextRow = row;
-        update_coordinates(nextCol, nextRow, sourcePort.first);
+      for (const auto &[conn, flowID] : connects) {
+        Port sourcePort = conn.src;
+        Port destPort = conn.dst;
+        uint32_t nextCol = col, nextRow = row;
+        updateCoordinates(nextCol, nextRow, sourcePort.bundle);
         LLVM_DEBUG(llvm::dbgs() << "flowID " << flowID << ':'
-                                << stringifyWireBundle(sourcePort.first) << " "
-                                << sourcePort.second << " -> "
-                                << stringifyWireBundle(destPort.first) << " "
-                                << destPort.second << " tile " << nextCol << " "
-                                << nextRow << "\n");
+                                << stringifyWireBundle(sourcePort.bundle) << " "
+                                << sourcePort.channel << " -> "
+                                << stringifyWireBundle(destPort.bundle) << " "
+                                << destPort.channel << " tile " << nextCol
+                                << " " << nextRow << "\n");
 
         auto sourceFlow =
             std::make_pair(std::make_pair(tileOp, sourcePort), flowID);
-        packetFlows[sourceFlow].push_back(std::make_pair(tileOp, destPort));
+        packetFlows[sourceFlow].push_back({tileOp, destPort});
         slavePorts.push_back(sourceFlow);
       }
     }
@@ -412,7 +410,7 @@ struct AIERoutePacketFlowsPass
     // destination ports at the same time For destination ports that appear in
     // different (multicast) flows, it should have a different <arbiterID, msel>
     // value pair for each flow
-    for (auto packetFlow : packetFlows) {
+    for (const auto &packetFlow : packetFlows) {
       // The Source Tile of the flow
       Operation *tileOp = packetFlow.first.first.first;
       if (amselValues.count(tileOp) == 0)
@@ -433,15 +431,14 @@ struct AIERoutePacketFlowsPass
       // assign all the master ports here with the same arbiter but different
       // msel
       bool foundMatchedDest = false;
-      for (auto map : masterAMSels) {
+      for (const auto &map : masterAMSels) {
         if (map.first.first != tileOp)
           continue;
         amselValue = map.first.second;
 
         // check if same destinations
         // SmallVector<Port, 4> ports(map.second);
-        SmallVector<Port, 4> ports(
-            masterAMSels[std::make_pair(tileOp, amselValue)]);
+        SmallVector<Port, 4> ports(masterAMSels[{tileOp, amselValue}]);
         if (ports.size() != packetFlow.second.size())
           continue;
 
@@ -465,7 +462,7 @@ struct AIERoutePacketFlowsPass
         for (int a = 0; a < numArbiters; a++) {
           for (int i = 0; i < numMsels; i++) {
             amselValue = a + i * numArbiters;
-            if (masterAMSels.count(std::make_pair(tileOp, amselValue)) == 0) {
+            if (masterAMSels.count({tileOp, amselValue}) == 0) {
               foundAMSelValue = true;
               break;
             }
@@ -477,7 +474,7 @@ struct AIERoutePacketFlowsPass
 
         for (auto dest : packetFlow.second) {
           Port port = dest.second;
-          masterAMSels[std::make_pair(tileOp, amselValue)].push_back(port);
+          masterAMSels[{tileOp, amselValue}].push_back(port);
         }
       }
 
@@ -488,28 +485,28 @@ struct AIERoutePacketFlowsPass
     // Compute the master set IDs
     // A map from a switchbox output port to the number of that port.
     DenseMap<PhysPort, SmallVector<int, 4>> mastersets;
-    for (auto master : masterAMSels) {
-      Operation *tileOp = master.first.first;
+    for (const auto &[physPort, ports] : masterAMSels) {
+      Operation *tileOp = physPort.first;
       assert(tileOp);
-      int amselValue = master.first.second;
-      for (auto port : master.second) {
-        auto physPort = std::make_pair(tileOp, port);
+      int amselValue = physPort.second;
+      for (auto port : ports) {
+        PhysPort physPort = {tileOp, port};
         mastersets[physPort].push_back(amselValue);
       }
     }
 
     LLVM_DEBUG(llvm::dbgs() << "CHECK mastersets\n");
 #ifndef NDEBUG
-    for (auto map : mastersets) {
-      Operation *tileOp = map.first.first;
-      WireBundle bundle = map.first.second.first;
-      int channel = map.first.second.second;
+    for (const auto &[physPort, values] : mastersets) {
+      Operation *tileOp = physPort.first;
+      WireBundle bundle = physPort.second.bundle;
+      uint32_t channel = physPort.second.channel;
       assert(tileOp);
       TileOp tile = dyn_cast<TileOp>(tileOp);
       LLVM_DEBUG(llvm::dbgs()
                  << "master " << tile << " " << stringifyWireBundle(bundle)
                  << " : " << channel << '\n');
-      for (auto value : map.second)
+      for (auto value : values)
         LLVM_DEBUG(llvm::dbgs() << "amsel: " << value << '\n');
     }
 #endif
@@ -558,7 +555,7 @@ struct AIERoutePacketFlowsPass
     }
 
     DenseMap<std::pair<PhysPort, int>, int> slaveMasks;
-    for (auto group : slaveGroups) {
+    for (const auto &group : slaveGroups) {
       // Iterate over all the ID values in a group
       // If bit n-th (n <= 5) of an ID value differs from bit n-th of another ID
       // value, the bit position should be "don't care", and we will set the
@@ -591,10 +588,10 @@ struct AIERoutePacketFlowsPass
     for (auto map : slaveMasks) {
       auto port = map.first.first;
       TileOp tile = dyn_cast<TileOp>(port.first);
-      WireBundle bundle = port.second.first;
-      int channel = port.second.second;
-      int ID = map.first.second;
-      int mask = map.second;
+      WireBundle bundle = port.second.bundle;
+      uint32_t channel = port.second.channel;
+      uint32_t ID = map.first.second;
+      uint32_t mask = map.second;
 
       LLVM_DEBUG(llvm::dbgs()
                  << "Port " << tile << " " << stringifyWireBundle(bundle) << " "
@@ -619,13 +616,13 @@ struct AIERoutePacketFlowsPass
       // Create a switchbox for the routes and insert inside it.
       builder.setInsertionPointAfter(tileOp);
       SwitchboxOp swbox = getOrCreateSwitchbox(builder, tile);
-      swbox.ensureTerminator(swbox.getConnections(), builder,
-                             builder.getUnknownLoc());
+      SwitchboxOp::ensureTerminator(swbox.getConnections(), builder,
+                                    builder.getUnknownLoc());
       Block &b = swbox.getConnections().front();
       builder.setInsertionPoint(b.getTerminator());
 
       std::vector<bool> amselOpNeededVector(32);
-      for (auto map : mastersets) {
+      for (const auto &map : mastersets) {
         if (tileOp != map.first.first)
           continue;
 
@@ -639,7 +636,7 @@ struct AIERoutePacketFlowsPass
         if (amselOpNeededVector[i]) {
           int arbiterID = i % numArbiters;
           int msel = i / numArbiters;
-          AMSelOp amsel =
+          auto amsel =
               builder.create<AMSelOp>(builder.getUnknownLoc(), arbiterID, msel);
           amselOps[i] = amsel;
         }
@@ -647,7 +644,7 @@ struct AIERoutePacketFlowsPass
       // Create all the master set Ops
       // First collect the master sets for this tile.
       SmallVector<Port, 4> tileMasters;
-      for (auto map : mastersets) {
+      for (const auto &map : mastersets) {
         if (tileOp != map.first.first)
           continue;
         tileMasters.push_back(map.first.second);
@@ -655,10 +652,9 @@ struct AIERoutePacketFlowsPass
       // Sort them so we get a reasonable order
       std::sort(tileMasters.begin(), tileMasters.end());
       for (auto tileMaster : tileMasters) {
-        WireBundle bundle = tileMaster.first;
-        int channel = tileMaster.second;
-        SmallVector<int, 4> msels =
-            mastersets[std::make_pair(tileOp, tileMaster)];
+        WireBundle bundle = tileMaster.bundle;
+        uint32_t channel = tileMaster.channel;
+        SmallVector<int, 4> msels = mastersets[{tileOp, tileMaster}];
         SmallVector<Value, 4> amsels;
         for (auto msel : msels) {
           assert(amselOps.count(msel) == 1);
@@ -668,8 +664,7 @@ struct AIERoutePacketFlowsPass
         auto ms_op = builder.create<MasterSetOp>(builder.getUnknownLoc(),
                                                  builder.getIndexType(), bundle,
                                                  channel, amsels);
-        if (auto pktFlowAttrs =
-                keepPktHeaderAttr[std::make_pair(tileOp, tileMaster)])
+        if (auto pktFlowAttrs = keepPktHeaderAttr[{tileOp, tileMaster}])
           ms_op->setAttr("keep_pkt_header", pktFlowAttrs);
       }
 
@@ -682,8 +677,8 @@ struct AIERoutePacketFlowsPass
         if (tileOp != port.first)
           continue;
 
-        WireBundle bundle = port.second.first;
-        int channel = port.second.second;
+        WireBundle bundle = port.second.bundle;
+        uint32_t channel = port.second.channel;
         auto slave = port.second;
 
         int mask = slaveMasks[group.front()];
@@ -700,8 +695,8 @@ struct AIERoutePacketFlowsPass
         if (slaveRules.count(slave) == 0) {
           packetrules = builder.create<PacketRulesOp>(builder.getUnknownLoc(),
                                                       bundle, channel);
-          packetrules.ensureTerminator(packetrules.getRules(), builder,
-                                       builder.getUnknownLoc());
+          PacketRulesOp::ensureTerminator(packetrules.getRules(), builder,
+                                          builder.getUnknownLoc());
           slaveRules[slave] = packetrules;
         } else
           packetrules = slaveRules[slave];
@@ -727,7 +722,7 @@ struct AIERoutePacketFlowsPass
       if (!tileOp.isShimNOCTile())
         continue;
 
-      // Check if it the switchbox is empty
+      // Check if the switchbox is empty
       if (&switchbox.getBody()->front() == switchbox.getBody()->getTerminator())
         continue;
 

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -79,7 +79,7 @@ std::string stringifySwitchSettings(SwitchSettings settings) {
 class DynamicTileAnalysis {
 public:
   DeviceOp &device;
-  uint32_t maxCol, maxRow;
+  int maxCol, maxRow;
   Pathfinder pathfinder;
   std::map<PathEndPoint, SwitchSettings> flowSolutions;
   std::map<PathEndPoint, bool> processedFlows;
@@ -155,7 +155,7 @@ public:
 
     // fill in coords to TileOps, SwitchboxOps, and ShimMuxOps
     for (auto tileOp : device.getOps<TileOp>()) {
-      uint32_t col, row;
+      int col, row;
       col = tileOp.colIndex();
       row = tileOp.rowIndex();
       maxCol = std::max(maxCol, col);
@@ -164,14 +164,14 @@ public:
       coordToTile[{col, row}] = tileOp;
     }
     for (auto switchboxOp : device.getOps<SwitchboxOp>()) {
-      uint32_t col, row;
+      int col, row;
       col = switchboxOp.colIndex();
       row = switchboxOp.rowIndex();
       assert(coordToSwitchbox.count({col, row}) == 0);
       coordToSwitchbox[{col, row}] = switchboxOp;
     }
     for (auto shimmuxOp : device.getOps<ShimMuxOp>()) {
-      uint32_t col, row;
+      int col, row;
       col = shimmuxOp.colIndex();
       row = shimmuxOp.rowIndex();
       assert(coordToShimMux.count({col, row}) == 0);
@@ -184,7 +184,7 @@ public:
   int getMaxCol() { return maxCol; }
   int getMaxRow() { return maxRow; }
 
-  TileOp getTile(OpBuilder &builder, uint32_t col, uint32_t row) {
+  TileOp getTile(OpBuilder &builder, int col, int row) {
     if (coordToTile.count({col, row})) {
       return coordToTile[{col, row}];
     } else {
@@ -196,7 +196,7 @@ public:
     }
   }
 
-  SwitchboxOp getSwitchbox(OpBuilder &builder, uint32_t col, uint32_t row) {
+  SwitchboxOp getSwitchbox(OpBuilder &builder, int col, int row) {
     assert(col >= 0);
     assert(row >= 0);
     if (coordToSwitchbox.count({col, row})) {
@@ -213,9 +213,9 @@ public:
     }
   }
 
-  ShimMuxOp getShimMux(OpBuilder &builder, uint32_t col) {
+  ShimMuxOp getShimMux(OpBuilder &builder, int col) {
     assert(col >= 0);
-    uint32_t row = 0;
+    int row = 0;
     if (coordToShimMux.count({col, row})) {
       return coordToShimMux[{col, row}];
     } else {
@@ -438,8 +438,8 @@ struct AIEPathfinderPass
       signalPassFailure();
 
     // Populate wires between switchboxes and tiles.
-    for (uint32_t col = 0; col <= analyzer.getMaxCol(); col++) {
-      for (uint32_t row = 0; row <= analyzer.getMaxRow(); row++) {
+    for (int col = 0; col <= analyzer.getMaxCol(); col++) {
+      for (int row = 0; row <= analyzer.getMaxRow(); row++) {
         TileOp tile;
         if (analyzer.coordToTile.count({col, row}))
           tile = analyzer.coordToTile[{col, row}];

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -21,8 +21,8 @@ using namespace xilinx;
 using namespace xilinx::AIE;
 
 typedef struct MaskValue {
-  uint8_t mask;
-  uint8_t value;
+  int mask;
+  int value;
 } MaskValue;
 
 typedef struct PortConnection {
@@ -135,10 +135,9 @@ private:
         // Incoming packets cannot match this rule. Skip it.
         continue;
       }
-      MaskValue newMaskValue = {
-          static_cast<uint8_t>((maskValue.mask | nextMaskValue.mask)),
-          static_cast<uint8_t>(
-              (maskValue.value | (nextMaskValue.mask & nextMaskValue.value)))};
+      MaskValue newMaskValue = {maskValue.mask | nextMaskValue.mask,
+                                maskValue.value |
+                                    (nextMaskValue.mask & nextMaskValue.value)};
       auto nextConnection = getConnectionThroughWire(switchOp, nextPort);
 
       // If there is no wire to follow then bail out.

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -25,19 +25,16 @@ typedef struct MaskValue {
   uint8_t value;
 } MaskValue;
 
-// typedef std::pair<Operation *, Port> PortConnection;
 typedef struct PortConnection {
   Operation *op;
   Port port;
 } PortConnection;
 
-// typedef std::pair<Port, MaskValue> PortMaskValue;
 typedef struct PortMaskValue {
   Port port;
   MaskValue mv;
 } PortMaskValue;
 
-// typedef std::pair<PortConnection, MaskValue> PacketConnection;
 typedef struct PacketConnection {
   PortConnection portConnection;
   MaskValue mv;
@@ -126,7 +123,7 @@ private:
     for (auto &nextPortMaskValue : nextPortMaskValues) {
       Port nextPort = nextPortMaskValue.port;
       MaskValue nextMaskValue = nextPortMaskValue.mv;
-      uint32_t maskConflicts = nextMaskValue.mask & maskValue.mask;
+      int maskConflicts = nextMaskValue.mask & maskValue.mask;
       LLVM_DEBUG(llvm::dbgs() << "Mask: " << maskValue.mask << " "
                               << maskValue.value << "\n");
       LLVM_DEBUG(llvm::dbgs() << "NextMask: " << nextMaskValue.mask << " "
@@ -237,7 +234,7 @@ static void findFlowsFrom(AIE::TileOp op, ConnectivityAnalysis &analysis,
     LLVM_DEBUG(llvm::dbgs()
                << op << stringifyWireBundle(bundle) << " has "
                << op.getNumSourceConnections(bundle) << " Connections\n");
-    for (uint32_t i = 0; i < op.getNumSourceConnections(bundle); i++) {
+    for (int i = 0; i < op.getNumSourceConnections(bundle); i++) {
       std::vector<PacketConnection> tiles =
           analysis.getConnectedTiles(op, {bundle, i});
       LLVM_DEBUG(llvm::dbgs() << tiles.size() << " Flows\n");

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -13,7 +13,6 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/DialectConversion.h"
 
 #define DEBUG_TYPE "aie-find-flows"
 
@@ -21,10 +20,28 @@ using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::AIE;
 
-typedef std::pair<int, int> MaskValue;
-typedef std::pair<Operation *, Port> PortConnection;
-typedef std::pair<Port, MaskValue> PortMaskValue;
-typedef std::pair<PortConnection, MaskValue> PacketConnection;
+typedef struct MaskValue {
+  uint8_t mask;
+  uint8_t value;
+} MaskValue;
+
+// typedef std::pair<Operation *, Port> PortConnection;
+typedef struct PortConnection {
+  Operation *op;
+  Port port;
+} PortConnection;
+
+// typedef std::pair<Port, MaskValue> PortMaskValue;
+typedef struct PortMaskValue {
+  Port port;
+  MaskValue mv;
+} PortMaskValue;
+
+// typedef std::pair<PortConnection, MaskValue> PacketConnection;
+typedef struct PacketConnection {
+  PortConnection portConnection;
+  MaskValue mv;
+} PacketConnection;
 
 class ConnectivityAnalysis {
   DeviceOp &device;
@@ -35,29 +52,28 @@ public:
 private:
   std::optional<PortConnection>
   getConnectionThroughWire(Operation *op, Port masterPort) const {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Wire:" << *op << " " << stringifyWireBundle(masterPort.first)
-               << " " << masterPort.second << "\n");
+    LLVM_DEBUG(llvm::dbgs() << "Wire:" << *op << " "
+                            << stringifyWireBundle(masterPort.bundle) << " "
+                            << masterPort.channel << "\n");
     for (auto wireOp : device.getOps<WireOp>()) {
       if (wireOp.getSource().getDefiningOp() == op &&
-          wireOp.getSourceBundle() == masterPort.first) {
+          wireOp.getSourceBundle() == masterPort.bundle) {
         Operation *other = wireOp.getDest().getDefiningOp();
-        Port otherPort =
-            std::make_pair(wireOp.getDestBundle(), masterPort.second);
+        Port otherPort = {wireOp.getDestBundle(), masterPort.channel};
         LLVM_DEBUG(llvm::dbgs() << "Connects To:" << *other << " "
-                                << stringifyWireBundle(otherPort.first) << " "
-                                << otherPort.second << "\n");
-        return std::make_pair(other, otherPort);
+                                << stringifyWireBundle(otherPort.bundle) << " "
+                                << otherPort.channel << "\n");
+
+        return PortConnection{other, otherPort};
       }
       if (wireOp.getDest().getDefiningOp() == op &&
-          wireOp.getDestBundle() == masterPort.first) {
+          wireOp.getDestBundle() == masterPort.bundle) {
         Operation *other = wireOp.getSource().getDefiningOp();
-        Port otherPort =
-            std::make_pair(wireOp.getSourceBundle(), masterPort.second);
+        Port otherPort = {wireOp.getSourceBundle(), masterPort.channel};
         LLVM_DEBUG(llvm::dbgs() << "Connects To:" << *other << " "
-                                << stringifyWireBundle(otherPort.first) << " "
-                                << otherPort.second << "\n");
-        return std::make_pair(other, otherPort);
+                                << stringifyWireBundle(otherPort.bundle) << " "
+                                << otherPort.channel << "\n");
+        return PortConnection{other, otherPort};
       }
     }
     LLVM_DEBUG(llvm::dbgs() << "*** Missing Wire!\n");
@@ -71,19 +87,19 @@ private:
     std::vector<PortMaskValue> portSet;
     for (auto connectOp : b.getOps<ConnectOp>()) {
       if (connectOp.sourcePort() == sourcePort) {
-        MaskValue maskValue = std::make_pair(0, 0);
-        portSet.push_back(std::make_pair(connectOp.destPort(), maskValue));
+        MaskValue maskValue = {0, 0};
+        portSet.push_back({connectOp.destPort(), maskValue});
         LLVM_DEBUG(llvm::dbgs()
-                   << "To:" << stringifyWireBundle(connectOp.destPort().first)
-                   << " " << connectOp.destPort().second << "\n");
+                   << "To:" << stringifyWireBundle(connectOp.destPort().bundle)
+                   << " " << connectOp.destPort().channel << "\n");
       }
     }
     for (auto connectOp : b.getOps<PacketRulesOp>()) {
       if (connectOp.sourcePort() == sourcePort) {
         LLVM_DEBUG(llvm::dbgs()
                    << "Packet From: "
-                   << stringifyWireBundle(connectOp.sourcePort().first) << " "
-                   << (int)sourcePort.first << "\n");
+                   << stringifyWireBundle(connectOp.sourcePort().bundle) << " "
+                   << (int)sourcePort.channel << "\n");
         for (auto masterSetOp : b.getOps<MasterSetOp>())
           for (Value amsel : masterSetOp.getAmsels())
             for (auto ruleOp :
@@ -91,12 +107,10 @@ private:
               if (ruleOp.getAmsel() == amsel) {
                 LLVM_DEBUG(llvm::dbgs()
                            << "To:"
-                           << stringifyWireBundle(masterSetOp.destPort().first)
-                           << " " << masterSetOp.destPort().second << "\n");
-                MaskValue maskValue =
-                    std::make_pair(ruleOp.maskInt(), ruleOp.valueInt());
-                portSet.push_back(
-                    std::make_pair(masterSetOp.destPort(), maskValue));
+                           << stringifyWireBundle(masterSetOp.destPort().bundle)
+                           << " " << masterSetOp.destPort().channel << "\n");
+                MaskValue maskValue = {ruleOp.maskInt(), ruleOp.valueInt()};
+                portSet.push_back({masterSetOp.destPort(), maskValue});
               }
             }
       }
@@ -110,30 +124,31 @@ private:
                            MaskValue maskValue) const {
     std::vector<PacketConnection> worklist;
     for (auto &nextPortMaskValue : nextPortMaskValues) {
-      Port nextPort = nextPortMaskValue.first;
-      MaskValue nextMaskValue = nextPortMaskValue.second;
-      int maskConflicts = nextMaskValue.first & maskValue.first;
-      LLVM_DEBUG(llvm::dbgs() << "Mask: " << maskValue.first << " "
-                              << maskValue.second << "\n");
-      LLVM_DEBUG(llvm::dbgs() << "NextMask: " << nextMaskValue.first << " "
-                              << nextMaskValue.second << "\n");
+      Port nextPort = nextPortMaskValue.port;
+      MaskValue nextMaskValue = nextPortMaskValue.mv;
+      uint32_t maskConflicts = nextMaskValue.mask & maskValue.mask;
+      LLVM_DEBUG(llvm::dbgs() << "Mask: " << maskValue.mask << " "
+                              << maskValue.value << "\n");
+      LLVM_DEBUG(llvm::dbgs() << "NextMask: " << nextMaskValue.mask << " "
+                              << nextMaskValue.value << "\n");
       LLVM_DEBUG(llvm::dbgs() << maskConflicts << "\n");
 
-      if ((maskConflicts & nextMaskValue.second) !=
-          (maskConflicts & maskValue.second)) {
+      if ((maskConflicts & nextMaskValue.value) !=
+          (maskConflicts & maskValue.value)) {
         // Incoming packets cannot match this rule. Skip it.
         continue;
       }
-      MaskValue newMaskValue = std::make_pair(
-          maskValue.first | nextMaskValue.first,
-          maskValue.second | (nextMaskValue.first & nextMaskValue.second));
+      MaskValue newMaskValue = {
+          static_cast<uint8_t>((maskValue.mask | nextMaskValue.mask)),
+          static_cast<uint8_t>(
+              (maskValue.value | (nextMaskValue.mask & nextMaskValue.value)))};
       auto nextConnection = getConnectionThroughWire(switchOp, nextPort);
 
       // If there is no wire to follow then bail out.
       if (!nextConnection)
         continue;
 
-      worklist.push_back(std::make_pair(*nextConnection, newMaskValue));
+      worklist.push_back({*nextConnection, newMaskValue});
     }
     return worklist;
   }
@@ -146,8 +161,8 @@ public:
                                                   Port port) const {
 
     LLVM_DEBUG(llvm::dbgs()
-               << "getConnectedTile(" << stringifyWireBundle(port.first) << " "
-               << (int)port.second << ")");
+               << "getConnectedTile(" << stringifyWireBundle(port.bundle) << " "
+               << (int)port.channel << ")");
     LLVM_DEBUG(tileOp.dump());
 
     // The accumulated result;
@@ -162,15 +177,15 @@ public:
     // If there is no wire to traverse, then just return no connection
     if (!t)
       return connectedTiles;
-    worklist.push_back(std::make_pair(*t, std::make_pair(0, 0)));
+    worklist.push_back({*t, {0, 0}});
 
     while (!worklist.empty()) {
       PacketConnection t = worklist.back();
       worklist.pop_back();
-      PortConnection portConnection = t.first;
-      MaskValue maskValue = t.second;
-      Operation *other = portConnection.first;
-      Port otherPort = portConnection.second;
+      PortConnection portConnection = t.portConnection;
+      MaskValue maskValue = t.mv;
+      Operation *other = portConnection.op;
+      Port otherPort = portConnection.port;
       if (isa<FlowEndPoint>(other)) {
         // If we got to a tile, then add it to the result.
         connectedTiles.push_back(t);
@@ -182,7 +197,7 @@ public:
             maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
         // append to the worklist
         worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (nextPortMaskValues.size() > 0 && newWorkList.size() == 0) {
+        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
           // No rule matched some incoming packet.  This is likely a
           // configuration error.
           LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
@@ -196,7 +211,7 @@ public:
             maskSwitchboxConnections(switchOp, nextPortMaskValues, maskValue);
         // append to the worklist
         worklist.insert(worklist.end(), newWorkList.begin(), newWorkList.end());
-        if (nextPortMaskValues.size() > 0 && newWorkList.size() == 0) {
+        if (!nextPortMaskValues.empty() && newWorkList.empty()) {
           // No rule matched some incoming packet.  This is likely a
           // configuration error.
           LLVM_DEBUG(llvm::dbgs() << "No rule matched incoming packet here: ");
@@ -222,30 +237,31 @@ static void findFlowsFrom(AIE::TileOp op, ConnectivityAnalysis &analysis,
     LLVM_DEBUG(llvm::dbgs()
                << op << stringifyWireBundle(bundle) << " has "
                << op.getNumSourceConnections(bundle) << " Connections\n");
-    for (int i = 0; i < op.getNumSourceConnections(bundle); i++) {
+    for (uint32_t i = 0; i < op.getNumSourceConnections(bundle); i++) {
       std::vector<PacketConnection> tiles =
-          analysis.getConnectedTiles(op, std::make_pair(bundle, i));
+          analysis.getConnectedTiles(op, {bundle, i});
       LLVM_DEBUG(llvm::dbgs() << tiles.size() << " Flows\n");
 
       for (PacketConnection &c : tiles) {
-        PortConnection portConnection = c.first;
-        MaskValue maskValue = c.second;
-        Operation *destOp = portConnection.first;
-        Port destPort = portConnection.second;
-        if (maskValue.first == 0) {
+        PortConnection portConnection = c.portConnection;
+        MaskValue maskValue = c.mv;
+        Operation *destOp = portConnection.op;
+        Port destPort = portConnection.port;
+        if (maskValue.mask == 0) {
           rewriter.create<FlowOp>(Op->getLoc(), Op->getResult(0), bundle, i,
-                                  destOp->getResult(0), destPort.first,
-                                  destPort.second);
+                                  destOp->getResult(0), destPort.bundle,
+                                  destPort.channel);
         } else {
           PacketFlowOp flowOp =
-              rewriter.create<PacketFlowOp>(Op->getLoc(), maskValue.second);
-          flowOp.ensureTerminator(flowOp.getPorts(), rewriter, Op->getLoc());
+              rewriter.create<PacketFlowOp>(Op->getLoc(), maskValue.value);
+          PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter,
+                                         Op->getLoc());
           OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();
           rewriter.setInsertionPoint(flowOp.getPorts().front().getTerminator());
           rewriter.create<PacketSourceOp>(Op->getLoc(), Op->getResult(0),
                                           bundle, (int)i);
           rewriter.create<PacketDestOp>(Op->getLoc(), destOp->getResult(0),
-                                        destPort.first, (int)destPort.second);
+                                        destPort.bundle, (int)destPort.channel);
           rewriter.restoreInsertionPoint(ip);
         }
       }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -88,8 +88,8 @@ public:
 // TileDMA Channel Analysis
 //===----------------------------------------------------------------------===//
 class DMAChannelAnalysis {
-  DenseMap<Value, uint32_t> masterChannelsPerTile;
-  DenseMap<Value, uint32_t> slaveChannelsPerTile;
+  DenseMap<Value, int> masterChannelsPerTile;
+  DenseMap<Value, int> slaveChannelsPerTile;
 
 public:
   DMAChannelAnalysis(DeviceOp &device) {
@@ -116,7 +116,7 @@ public:
     } else {
       assert([&] {
         TileOp tileOp = tile.getDefiningOp<TileOp>();
-        uint32_t numChannels = tileOp.getNumSourceConnections(WireBundle::DMA);
+        int numChannels = tileOp.getNumSourceConnections(WireBundle::DMA);
         if (masterChannelsPerTile[tile] >= (numChannels - 1)) {
           printf("All tile DMA master channels are already in use.\n");
           return false;
@@ -137,7 +137,7 @@ public:
     } else {
       assert([&] {
         TileOp tileOp = tile.getDefiningOp<TileOp>();
-        uint32_t numChannels = tileOp.getNumDestConnections(WireBundle::DMA);
+        int numChannels = tileOp.getNumDestConnections(WireBundle::DMA);
         if (slaveChannelsPerTile[tile] >= (numChannels - 1)) {
           printf("All tile DMA slave channels are already in use.\n");
           return false;
@@ -1205,10 +1205,9 @@ struct AIEObjectFifoStatefulTransformPass
   /// shimDMAAllocationOp containing the channelDir, channelIndex and
   /// shimTile col assigned by the objectFifo lowering.
   void createObjectFifoAllocationInfo(OpBuilder &builder, MLIRContext *ctx,
-                                      FlatSymbolRefAttr obj_fifo,
-                                      uint32_t colIndex,
+                                      FlatSymbolRefAttr obj_fifo, int colIndex,
                                       DMAChannelDir channelDir,
-                                      uint32_t channelIndex) {
+                                      int channelIndex) {
     builder.create<ShimDMAAllocationOp>(builder.getUnknownLoc(), obj_fifo,
                                         DMAChannelDirAttr::get(ctx, channelDir),
                                         builder.getI64IntegerAttr(channelIndex),

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -116,7 +116,7 @@ public:
     } else {
       assert([&] {
         TileOp tileOp = tile.getDefiningOp<TileOp>();
-        int numChannels = tileOp.getNumSourceConnections(WireBundle::DMA);
+        uint32_t numChannels = tileOp.getNumSourceConnections(WireBundle::DMA);
         if (masterChannelsPerTile[tile] >= (numChannels - 1)) {
           printf("All tile DMA master channels are already in use.\n");
           return false;
@@ -137,7 +137,7 @@ public:
     } else {
       assert([&] {
         TileOp tileOp = tile.getDefiningOp<TileOp>();
-        int numChannels = tileOp.getNumDestConnections(WireBundle::DMA);
+        uint32_t numChannels = tileOp.getNumDestConnections(WireBundle::DMA);
         if (slaveChannelsPerTile[tile] >= (numChannels - 1)) {
           printf("All tile DMA slave channels are already in use.\n");
           return false;

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -36,11 +36,11 @@ WireBundle getConnectingBundle(WireBundle dir) {
   }
 }
 
-Pathfinder::Pathfinder(uint32_t maxCol, uint32_t maxRow, DeviceOp &d) {
+Pathfinder::Pathfinder(int maxCol, int maxRow, DeviceOp &d) {
   const auto &targetModel = d.getTargetModel();
   // make grid of switchboxes
-  for (uint32_t col = 0; col <= maxCol; col++) {
-    for (uint32_t row = 0; row <= maxRow; row++) {
+  for (int col = 0; col <= maxCol; col++) {
+    for (int row = 0; row <= maxRow; row++) {
       auto nodeIt = grid.insert({{col, row}, Switchbox{col, row}});
       (void)graph.addNode(nodeIt.first->second);
       Switchbox &thisNode = grid.at({col, row});

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -36,11 +36,11 @@ WireBundle getConnectingBundle(WireBundle dir) {
   }
 }
 
-Pathfinder::Pathfinder(int maxCol, int maxRow, DeviceOp &d) {
+Pathfinder::Pathfinder(uint32_t maxCol, uint32_t maxRow, DeviceOp &d) {
   const auto &targetModel = d.getTargetModel();
   // make grid of switchboxes
-  for (int col = 0; col <= maxCol; col++) {
-    for (int row = 0; row <= maxRow; row++) {
+  for (uint32_t col = 0; col <= maxCol; col++) {
+    for (uint32_t row = 0; row <= maxRow; row++) {
       auto nodeIt = grid.insert({{col, row}, Switchbox{col, row}});
       (void)graph.addNode(nodeIt.first->second);
       Switchbox &thisNode = grid.at({col, row});
@@ -97,18 +97,18 @@ void Pathfinder::addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
                          Port dstPort) {
   // check if a flow with this source already exists
   for (auto &flow : flows) {
-    Switchbox *existingSrc = flow.first.first;
+    Switchbox *existingSrc = flow.src.sb;
     assert(existingSrc && "nullptr flow source");
-    Port existingPort = flow.first.second;
-    if (existingSrc->col == srcCoords.first &&
-        existingSrc->row == srcCoords.second && existingPort == srcPort) {
+    Port existingPort = flow.src.port;
+    if (existingSrc->col == srcCoords.col &&
+        existingSrc->row == srcCoords.row && existingPort == srcPort) {
       // find the vertex corresponding to the destination
       auto matchingSb =
           std::find_if(graph.begin(), graph.end(), [&](const Switchbox *sb) {
-            return sb->col == dstCoords.first && sb->row == dstCoords.second;
+            return sb->col == dstCoords.col && sb->row == dstCoords.row;
           });
       assert(matchingSb != graph.end() && "didn't find flow dest");
-      flow.second.emplace_back(*matchingSb, dstPort);
+      flow.dsts.push_back({*matchingSb, dstPort});
       return;
     }
   }
@@ -116,16 +116,16 @@ void Pathfinder::addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
   // If no existing flow was found with this source, create a new flow.
   auto matchingSrcSb =
       std::find_if(graph.begin(), graph.end(), [&](const Switchbox *sb) {
-        return sb->col == srcCoords.first && sb->row == srcCoords.second;
+        return sb->col == srcCoords.col && sb->row == srcCoords.row;
       });
   assert(matchingSrcSb != graph.end() && "didn't find flow source");
   auto matchingDstSb =
       std::find_if(graph.begin(), graph.end(), [&](const Switchbox *sb) {
-        return sb->col == dstCoords.first && sb->row == dstCoords.second;
+        return sb->col == dstCoords.col && sb->row == dstCoords.row;
       });
   assert(matchingDstSb != graph.end() && "didn't add flow destinations");
-  flows.emplace_back(PathEndPoint{*matchingSrcSb, srcPort},
-                     std::vector<PathEndPoint>{{*matchingDstSb, dstPort}});
+  flows.push_back({PathEndPoint{*matchingSrcSb, srcPort},
+                   std::vector<PathEndPoint>{{*matchingDstSb, dstPort}}});
 }
 
 // Keep track of connections already used in the AIE; Pathfinder algorithm will
@@ -133,13 +133,13 @@ void Pathfinder::addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
 bool Pathfinder::addFixedConnection(TileID coords, Port port) {
   // find the correct Channel and indicate the fixed direction
   auto matchingCh = std::find_if(edges.begin(), edges.end(), [&](Channel &ch) {
-    return ch.src.col == coords.first && ch.src.row == coords.second &&
-           ch.bundle == port.first;
+    return ch.src.col == coords.col && ch.src.row == coords.row &&
+           ch.bundle == port.bundle;
   });
   if (matchingCh == edges.end())
     return false;
 
-  matchingCh->fixedCapacity.insert((uint32_t)port.second);
+  matchingCh->fixedCapacity.insert(port.channel);
   return true;
 }
 
@@ -224,7 +224,7 @@ Pathfinder::findPaths(const int maxIterations) {
     }
 
     // "rip up" all routes, i.e. set used capacity in each Channel to 0
-    routingSolution = {};
+    routingSolution.clear();
     for (auto &ch : edges)
       ch.usedCapacity = 0;
 
@@ -235,7 +235,7 @@ Pathfinder::findPaths(const int maxIterations) {
       // switchbox; find the shortest paths to each other switchbox. Output is
       // in the predecessor map, which must then be processed to get individual
       // switchbox settings
-      Switchbox *src = flow.first.first;
+      Switchbox *src = flow.src.sb;
       assert(src && "nonexistent flow source");
       std::set<Switchbox *> processed;
       std::map<Switchbox *, Switchbox *> preds =
@@ -245,13 +245,13 @@ Pathfinder::findPaths(const int maxIterations) {
       // increment used_capacity for the associated channels
       SwitchSettings switchSettings;
       // set the input bundle for the source endpoint
-      switchSettings[src].first = flow.first.second;
+      switchSettings[src].src = flow.src.port;
       processed.insert(src);
-      for (const PathEndPoint &endPoint : flow.second) {
-        Switchbox *curr = endPoint.first;
+      for (const PathEndPoint &endPoint : flow.dsts) {
+        Switchbox *curr = endPoint.sb;
         assert(curr && "endpoint has no source switchbox");
         // set the output bundle for this destination endpoint
-        switchSettings[curr].second.insert(endPoint.second);
+        switchSettings[curr].dsts.insert(endPoint.port);
 
         // trace backwards until a vertex already processed is reached
         while (!processed.count(curr)) {
@@ -270,11 +270,11 @@ Pathfinder::findPaths(const int maxIterations) {
             ch->usedCapacity++;
 
           // add the entrance port for this Switchbox
-          switchSettings[curr].first =
-              std::make_pair(getConnectingBundle(ch->bundle), ch->usedCapacity);
+          switchSettings[curr].src = {getConnectingBundle(ch->bundle),
+                                      ch->usedCapacity};
           // add the current Switchbox to the map of the predecessor
-          switchSettings[preds[curr]].second.insert(
-              std::make_pair(ch->bundle, ch->usedCapacity));
+          switchSettings[preds[curr]].dsts.insert(
+              {ch->bundle, ch->usedCapacity});
 
           ch->usedCapacity++;
           // if at capacity, bump demand to discourage using this Channel
@@ -288,7 +288,7 @@ Pathfinder::findPaths(const int maxIterations) {
         }
       }
       // add this flow to the proposed solution
-      routingSolution[flow.first] = switchSettings;
+      routingSolution[flow.src] = switchSettings;
     }
   } while (!isLegal()); // continue iterations until a legal routing is found
   return routingSolution;

--- a/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
@@ -1,12 +1,22 @@
-#include "aie/Dialect/AIE/AIENetlistAnalysis.h"
+//===- AIECreateBroadcastPacket.cpp -----------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2019 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+
 #include "mlir/IR/Attributes.h"
-#include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Transforms/DialectConversion.h"
+
 #include "llvm/ADT/Twine.h"
 
 #define DEBUG_TYPE "aie-create-lower-packet"
@@ -60,7 +70,7 @@ struct AIEBroadcastPacketPass
           Block *b_pkFlow = builder.createBlock(&r_pkFlow);
           builder.setInsertionPointToStart(b_pkFlow);
           builder.create<PacketSourceOp>(builder.getUnknownLoc(), srcTile,
-                                         sourcePort.first, sourcePort.second);
+                                         sourcePort.bundle, sourcePort.channel);
           for (Operation &op : b_bpid.getOperations()) {
             if (BPDestOp bpdest = dyn_cast<BPDestOp>(op)) {
               TileOp destTile =
@@ -68,7 +78,7 @@ struct AIEBroadcastPacketPass
               Port destPort = bpdest.port();
               builder.setInsertionPointToEnd(b_pkFlow);
               builder.create<PacketDestOp>(builder.getUnknownLoc(), destTile,
-                                           destPort.first, destPort.second);
+                                           destPort.bundle, destPort.channel);
             }
           }
           builder.setInsertionPointToEnd(b_pkFlow);

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -78,8 +78,8 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
 
     // Collect existing TileOps
     for (auto tile : device.getOps<TileOp>()) {
-      uint32_t colIndex = tile.colIndex();
-      uint32_t rowIndex = tile.rowIndex();
+      int colIndex = tile.colIndex();
+      int rowIndex = tile.rowIndex();
       tiles[{colIndex, rowIndex}] = tile;
     }
 
@@ -93,8 +93,8 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
       SmallVector<Value, 4> callOperands(callOp.getArgOperands());
       SmallVector<std::pair<MemRefType, int>, 4> coreBufTypes;
 
-      uint32_t colIndex = callOp->getAttrOfType<IntegerAttr>("aie.x").getInt();
-      uint32_t rowIndex = callOp->getAttrOfType<IntegerAttr>("aie.y").getInt();
+      int colIndex = callOp->getAttrOfType<IntegerAttr>("aie.x").getInt();
+      int rowIndex = callOp->getAttrOfType<IntegerAttr>("aie.y").getInt();
 
       // get or create TileOp
       if (!tiles[{colIndex, rowIndex}]) {

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -70,7 +70,7 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
     DeviceOp device = getOperation();
     OpBuilder builder = OpBuilder::atBlockEnd(device.getBody());
 
-    DenseMap<std::pair<int, int>, Operation *> tiles;
+    DenseMap<TileID, Operation *> tiles;
     DenseMap<Operation *, CoreOp> cores;
     DenseMap<Operation *, MemOp> mems;
     DenseMap<Value, Value> buffers;
@@ -78,9 +78,9 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
 
     // Collect existing TileOps
     for (auto tile : device.getOps<TileOp>()) {
-      int colIndex = tile.colIndex();
-      int rowIndex = tile.rowIndex();
-      tiles[std::make_pair(colIndex, rowIndex)] = tile;
+      uint32_t colIndex = tile.colIndex();
+      uint32_t rowIndex = tile.rowIndex();
+      tiles[{colIndex, rowIndex}] = tile;
     }
 
     // Bind FuncOp to an AIE core based on attributes of the CallOp
@@ -93,17 +93,17 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
       SmallVector<Value, 4> callOperands(callOp.getArgOperands());
       SmallVector<std::pair<MemRefType, int>, 4> coreBufTypes;
 
-      int colIndex = callOp->getAttrOfType<IntegerAttr>("aie.x").getInt();
-      int rowIndex = callOp->getAttrOfType<IntegerAttr>("aie.y").getInt();
+      uint32_t colIndex = callOp->getAttrOfType<IntegerAttr>("aie.x").getInt();
+      uint32_t rowIndex = callOp->getAttrOfType<IntegerAttr>("aie.y").getInt();
 
       // get or create TileOp
-      if (!tiles[std::make_pair(colIndex, rowIndex)]) {
+      if (!tiles[{colIndex, rowIndex}]) {
         builder.setInsertionPointToStart(device.getBody());
         TileOp tile =
             builder.create<TileOp>(builder.getUnknownLoc(), colIndex, rowIndex);
-        tiles[std::make_pair(colIndex, rowIndex)] = tile;
+        tiles[{colIndex, rowIndex}] = tile;
       }
-      Operation *tileOp = tiles[std::make_pair(colIndex, rowIndex)];
+      Operation *tileOp = tiles[{colIndex, rowIndex}];
       TileOp tile = dyn_cast<TileOp>(tileOp);
       builder.setInsertionPointAfter(tileOp);
 
@@ -121,7 +121,7 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
           }
 
           assert(t && "Unsupported type!");
-          coreBufTypes.push_back(std::make_pair(t, i));
+          coreBufTypes.push_back({t, i});
           BufferOp buf =
               builder.create<BufferOp>(builder.getUnknownLoc(), t, tile);
           //          buf.setAttr("sym_name",
@@ -146,7 +146,7 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
               dyn_cast<CallOpInterface>(callOp.getOperation())) {
         Operation *callable = call.resolveCallable();
         if (func::FuncOp func = dyn_cast<func::FuncOp>(callable)) {
-          funcs[func] = std::make_pair(colIndex, rowIndex);
+          funcs[func] = {colIndex, rowIndex};
 
           IRMapping mapper;
 

--- a/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
@@ -11,14 +11,15 @@
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/AIETokenAnalysis.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+
 #include "mlir/IR/Attributes.h"
-#include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 #define DEBUG_TYPE "aie-create-locks"
+
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::AIE;
@@ -146,7 +147,7 @@ struct AIECreateLocksPass : public AIECreateLocksBase<AIECreateLocksPass> {
         TA.getTokenChains());
     SmallVector<std::pair<Operation *, Operation *>, 4> tokenPairs(
         TA.getTokenPairs());
-    DenseMap<std::pair<int, int>, Operation *> tiles(TA.getTiles());
+    DenseMap<TileID, Operation *> tiles(TA.getTiles());
 
     DenseMap<std::pair<Operation *, int>, int> locks;
     DenseMap<std::pair<Operation *, Operation *>, std::pair<Value, int>>
@@ -169,13 +170,13 @@ struct AIECreateLocksPass : public AIECreateLocksBase<AIECreateLocksPass> {
                  release->print(llvm::dbgs());
                  if (IsRelUserCore) llvm::dbgs() << " @Core";
                  else llvm::dbgs() << " @DMA";
-                 llvm::dbgs() << " (" << TA.getCoord(relUser).first << ", "
-                              << TA.getCoord(relUser).second << ")" << '\n';
+                 llvm::dbgs() << " (" << TA.getCoord(relUser).col << ", "
+                              << TA.getCoord(relUser).row << ")" << '\n';
                  acquire->print(llvm::dbgs());
                  if (IsAcqUserCore) llvm::dbgs() << " @Core";
                  else llvm::dbgs() << " @DMA";
-                 llvm::dbgs() << " (" << TA.getCoord(acqUser).first << ", "
-                              << TA.getCoord(acqUser).second << ")" << '\n';);
+                 llvm::dbgs() << " (" << TA.getCoord(acqUser).col << ", "
+                              << TA.getCoord(acqUser).row << ")" << '\n';);
 
       // ignore chain that involves a MemOp (DMA) user and CoreOp user and they
       // don't have a shareable tile. This might be caused by MemcpyOp lowering

--- a/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
@@ -164,27 +164,21 @@ void buildRoute(int xSrc, int ySrc, int xDest, int yDest,
 
     assert(curChannel >= 0 && "Could not find available destination port!");
 
-    if (curChannel == -1) {
-      congestion.push_back({xLast, yLast}); // this switchbox is congested
-      switchboxes[std::make_pair(herdOp, curCoord)]
-          .pop_back(); // back up, remove the last connection
-    } else {
-      llvm::dbgs() << "[" << stringifyWireBundle(lastPort.bundle) << " : "
-                   << lastPort.channel
-                   << "], "
-                      "["
-                   << stringifyWireBundle(curBundle) << " : " << curChannel
-                   << "]\n";
+    llvm::dbgs() << "[" << stringifyWireBundle(lastPort.bundle) << " : "
+                 << lastPort.channel
+                 << "], "
+                    "["
+                 << stringifyWireBundle(curBundle) << " : " << curChannel
+                 << "]\n";
 
-      Port curPort = {curBundle, curChannel};
-      Connect connect = {lastPort, curPort};
-      if (std::find(switchboxes[std::make_pair(herdOp, curCoord)].begin(),
-                    switchboxes[std::make_pair(herdOp, curCoord)].end(),
-                    connect) ==
-          switchboxes[std::make_pair(herdOp, curCoord)].end())
-        switchboxes[std::make_pair(herdOp, curCoord)].push_back(connect);
-      lastPort = {lastBundle, curChannel};
-    }
+    Port curPort = {curBundle, curChannel};
+    Connect connect = {lastPort, curPort};
+    if (std::find(switchboxes[std::make_pair(herdOp, curCoord)].begin(),
+                  switchboxes[std::make_pair(herdOp, curCoord)].end(),
+                  connect) ==
+        switchboxes[std::make_pair(herdOp, curCoord)].end())
+      switchboxes[std::make_pair(herdOp, curCoord)].push_back(connect);
+    lastPort = {lastBundle, curChannel};
   }
 
   llvm::dbgs() << "coord " << xCur << " " << yCur << '\n';

--- a/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
@@ -8,11 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "aie/Dialect/AIE/AIENetlistAnalysis.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+
 #include "mlir/IR/Attributes.h"
-#include "mlir/IR/Location.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
@@ -28,7 +27,7 @@ struct AIEOpRemoval : public OpConversionPattern<MyOp> {
   using OpConversionPattern<MyOp>::OpConversionPattern;
   using OpAdaptor = typename MyOp::Adaptor;
 
-  AIEOpRemoval(MLIRContext *context, PatternBenefit benefit = 1)
+  explicit AIEOpRemoval(MLIRContext *context, PatternBenefit benefit = 1)
       : OpConversionPattern<MyOp>(context, benefit) {}
 
   LogicalResult
@@ -41,13 +40,14 @@ struct AIEOpRemoval : public OpConversionPattern<MyOp> {
   }
 };
 
-int getAvailableDestChannel(SmallVector<Connect, 8> &connects, Port sourcePort,
-                            WireBundle destBundle) {
+std::optional<uint32_t>
+getAvailableDestChannel(SmallVector<Connect, 8> &connects, Port sourcePort,
+                        WireBundle destBundle) {
 
-  if (connects.size() == 0)
-    return 0;
+  if (connects.empty())
+    return {0};
 
-  int numChannels;
+  uint32_t numChannels;
 
   if (destBundle == WireBundle::North)
     numChannels = 6;
@@ -58,42 +58,42 @@ int getAvailableDestChannel(SmallVector<Connect, 8> &connects, Port sourcePort,
     numChannels = 2;
 
   // look for existing connect
-  for (int i = 0; i < numChannels; i++) {
-    Port port = std::make_pair(destBundle, i);
+  for (uint32_t i = 0; i < numChannels; i++) {
+    Port port = {destBundle, i};
     if (std::find(connects.begin(), connects.end(),
-                  std::make_pair(sourcePort, port)) != connects.end())
-      return i;
+                  Connect{sourcePort, port}) != connects.end())
+      return {i};
   }
 
   // if not, look for available destination port
-  for (int i = 0; i < numChannels; i++) {
-    Port port = std::make_pair(destBundle, i);
+  for (uint32_t i = 0; i < numChannels; i++) {
+    Port port = {destBundle, i};
     SmallVector<Port, 8> ports;
     for (auto connect : connects)
-      ports.push_back(connect.second);
+      ports.push_back(connect.dst);
 
     if (std::find(ports.begin(), ports.end(), port) == ports.end())
-      return i;
+      return {i};
   }
 
-  return -1;
+  return std::nullopt;
 }
 
-void buildRoute(int xSrc, int ySrc, int xDest, int yDest,
-                WireBundle sourceBundle, int sourceChannel,
-                WireBundle destBundle, int destChannel, Operation *herdOp,
-                DenseMap<std::pair<Operation *, std::pair<int, int>>,
+void buildRoute(uint32_t xSrc, uint32_t ySrc, uint32_t xDest, uint32_t yDest,
+                WireBundle sourceBundle, uint32_t sourceChannel,
+                WireBundle destBundle, uint32_t destChannel, Operation *herdOp,
+                DenseMap<std::pair<Operation *, TileID>,
                          SmallVector<Connect, 8>> &switchboxes) {
 
-  int xCur = xSrc;
-  int yCur = ySrc;
+  uint32_t xCur = xSrc;
+  uint32_t yCur = ySrc;
   WireBundle curBundle;
-  int curChannel;
-  int xLast, yLast;
+  uint32_t curChannel;
+  uint32_t xLast, yLast;
   WireBundle lastBundle;
-  Port lastPort = std::make_pair(sourceBundle, sourceChannel);
+  Port lastPort = {sourceBundle, sourceChannel};
 
-  SmallVector<std::pair<int, int>, 4> congestion;
+  SmallVector<TileID, 4> congestion;
 
   llvm::dbgs() << "Build route: " << xSrc << " " << ySrc << " --> " << xDest
                << " " << yDest << '\n';
@@ -101,7 +101,7 @@ void buildRoute(int xSrc, int ySrc, int xDest, int yDest,
   while (!((xCur == xDest) && (yCur == yDest))) {
     llvm::dbgs() << "coord " << xCur << " " << yCur << '\n';
 
-    auto curCoord = std::make_pair(xCur, yCur);
+    TileID curCoord = {xCur, yCur};
     xLast = xCur;
     yLast = yCur;
 
@@ -125,11 +125,11 @@ void buildRoute(int xSrc, int ySrc, int xDest, int yDest,
     if (std::find(moves.begin(), moves.end(), WireBundle::South) == moves.end())
       moves.push_back(WireBundle::South);
 
-    for (unsigned i = 0; i < moves.size(); i++) {
-      WireBundle move = moves[i];
-      curChannel = getAvailableDestChannel(
-          switchboxes[std::make_pair(herdOp, curCoord)], lastPort, move);
-      if (curChannel == -1)
+    for (auto move : moves) {
+      if (auto maybeDestChannel = getAvailableDestChannel(
+              switchboxes[std::make_pair(herdOp, curCoord)], lastPort, move))
+        curChannel = maybeDestChannel.value();
+      else
         continue;
 
       if (move == lastBundle)
@@ -149,8 +149,8 @@ void buildRoute(int xSrc, int ySrc, int xDest, int yDest,
         yCur = yCur - 1;
       }
 
-      if (std::find(congestion.begin(), congestion.end(),
-                    std::make_pair(xCur, yCur)) != congestion.end())
+      if (std::find(congestion.begin(), congestion.end(), TileID{xCur, yCur}) !=
+          congestion.end())
         continue;
 
       curBundle = move;
@@ -165,39 +165,38 @@ void buildRoute(int xSrc, int ySrc, int xDest, int yDest,
     assert(curChannel >= 0 && "Could not find available destination port!");
 
     if (curChannel == -1) {
-      congestion.push_back(
-          std::make_pair(xLast, yLast)); // this switchbox is congested
+      congestion.push_back({xLast, yLast}); // this switchbox is congested
       switchboxes[std::make_pair(herdOp, curCoord)]
           .pop_back(); // back up, remove the last connection
     } else {
-      llvm::dbgs() << "[" << stringifyWireBundle(lastPort.first) << " : "
-                   << lastPort.second
+      llvm::dbgs() << "[" << stringifyWireBundle(lastPort.bundle) << " : "
+                   << lastPort.channel
                    << "], "
                       "["
                    << stringifyWireBundle(curBundle) << " : " << curChannel
                    << "]\n";
 
-      Port curPort = std::make_pair(curBundle, curChannel);
-      Connect connect = std::make_pair(lastPort, curPort);
+      Port curPort = {curBundle, curChannel};
+      Connect connect = {lastPort, curPort};
       if (std::find(switchboxes[std::make_pair(herdOp, curCoord)].begin(),
                     switchboxes[std::make_pair(herdOp, curCoord)].end(),
                     connect) ==
           switchboxes[std::make_pair(herdOp, curCoord)].end())
         switchboxes[std::make_pair(herdOp, curCoord)].push_back(connect);
-      lastPort = std::make_pair(lastBundle, curChannel);
+      lastPort = {lastBundle, curChannel};
     }
   }
 
   llvm::dbgs() << "coord " << xCur << " " << yCur << '\n';
-  llvm::dbgs() << "[" << stringifyWireBundle(lastPort.first) << " : "
-               << lastPort.second
+  llvm::dbgs() << "[" << stringifyWireBundle(lastPort.bundle) << " : "
+               << lastPort.channel
                << "], "
                   "["
                << stringifyWireBundle(destBundle) << " : " << destChannel
                << "]\n";
 
-  switchboxes[std::make_pair(herdOp, std::make_pair(xCur, yCur))].push_back(
-      std::make_pair(lastPort, std::make_pair(destBundle, destChannel)));
+  switchboxes[std::make_pair(herdOp, TileID{xCur, yCur})].push_back(
+      {lastPort, Port{destBundle, destChannel}});
 }
 
 struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
@@ -211,9 +210,11 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
     SmallVector<Operation *, 4> routeOps;
     DenseMap<std::pair<Operation *, Operation *>, std::pair<int, int>>
         distances;
-    SmallVector<std::pair<std::pair<int, int>, std::pair<int, int>>, 4> routes;
-    DenseMap<std::pair<Operation *, std::pair<int, int>>,
-             SmallVector<Connect, 8>>
+    SmallVector<
+        std::pair<std::pair<uint32_t, uint32_t>, std::pair<uint32_t, uint32_t>>,
+        4>
+        routes;
+    DenseMap<std::pair<Operation *, TileID>, SmallVector<Connect, 8>>
         switchboxes;
 
     for (auto herd : device.getOps<HerdOp>()) {
@@ -224,8 +225,8 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
       placeOps.push_back(placeOp);
       Operation *sourceHerd = placeOp.getSourceHerd().getDefiningOp();
       Operation *destHerd = placeOp.getDestHerd().getDefiningOp();
-      int distX = placeOp.getDistXValue();
-      int distY = placeOp.getDistYValue();
+      uint32_t distX = placeOp.getDistXValue();
+      uint32_t distY = placeOp.getDistYValue();
       distances[std::make_pair(sourceHerd, destHerd)] =
           std::make_pair(distX, distY);
     }
@@ -241,8 +242,8 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
           dyn_cast<AIEX::SelectOp>(routeOp.getDestHerds().getDefiningOp());
       WireBundle sourceBundle = routeOp.getSourceBundle();
       WireBundle destBundle = routeOp.getDestBundle();
-      int sourceChannel = routeOp.getSourceChannelValue();
-      int destChannel = routeOp.getDestChannelValue();
+      uint32_t sourceChannel = routeOp.getSourceChannelValue();
+      uint32_t destChannel = routeOp.getDestChannelValue();
 
       HerdOp sourceHerd =
           dyn_cast<HerdOp>(sourceHerds.getStartHerd().getDefiningOp());
@@ -256,19 +257,19 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
       IterOp destIterX = dyn_cast<IterOp>(destHerds.getIterX().getDefiningOp());
       IterOp destIterY = dyn_cast<IterOp>(destHerds.getIterY().getDefiningOp());
 
-      int sourceStartX = sourceIterX.getStartValue();
-      int sourceEndX = sourceIterX.getEndValue();
-      int sourceStrideX = sourceIterX.getStrideValue();
-      int sourceStartY = sourceIterY.getStartValue();
-      int sourceEndY = sourceIterY.getEndValue();
-      int sourceStrideY = sourceIterY.getStrideValue();
+      uint32_t sourceStartX = sourceIterX.getStartValue();
+      uint32_t sourceEndX = sourceIterX.getEndValue();
+      uint32_t sourceStrideX = sourceIterX.getStrideValue();
+      uint32_t sourceStartY = sourceIterY.getStartValue();
+      uint32_t sourceEndY = sourceIterY.getEndValue();
+      uint32_t sourceStrideY = sourceIterY.getStrideValue();
 
-      int destStartX = destIterX.getStartValue();
-      int destEndX = destIterX.getEndValue();
-      int destStrideX = destIterX.getStrideValue();
-      int destStartY = destIterY.getStartValue();
-      int destEndY = destIterY.getEndValue();
-      int destStrideY = destIterY.getStrideValue();
+      uint32_t destStartX = destIterX.getStartValue();
+      uint32_t destEndX = destIterX.getEndValue();
+      uint32_t destStrideX = destIterX.getStrideValue();
+      uint32_t destStartY = destIterY.getStartValue();
+      uint32_t destEndY = destIterY.getEndValue();
+      uint32_t destStrideY = destIterY.getStrideValue();
 
       assert(distances.count(std::make_pair(sourceHerd, destHerd)) == 1);
 
@@ -277,16 +278,19 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
       int distX = distance.first;
       int distY = distance.second;
       // FIXME: this looks like it can be improved further ...
-      for (int xSrc = sourceStartX; xSrc < sourceEndX; xSrc += sourceStrideX) {
-        for (int ySrc = sourceStartY; ySrc < sourceEndY;
+      for (uint32_t xSrc = sourceStartX; xSrc < sourceEndX;
+           xSrc += sourceStrideX) {
+        for (uint32_t ySrc = sourceStartY; ySrc < sourceEndY;
              ySrc += sourceStrideY) {
-          for (int xDst = destStartX; xDst < destEndX; xDst += destStrideX) {
-            for (int yDst = destStartY; yDst < destEndY; yDst += destStrideY) {
+          for (uint32_t xDst = destStartX; xDst < destEndX;
+               xDst += destStrideX) {
+            for (uint32_t yDst = destStartY; yDst < destEndY;
+                 yDst += destStrideY) {
               // Build route (x0, y0) --> (x1, y1)
-              int x0 = xSrc;
-              int y0 = ySrc;
-              int x1 = xDst;
-              int y1 = yDst;
+              uint32_t x0 = xSrc;
+              uint32_t y0 = ySrc;
+              uint32_t x1 = xDst;
+              uint32_t y1 = yDst;
               if (destIterX == sourceIterX)
                 x1 = x0;
               if (destIterY == sourceIterX)
@@ -314,35 +318,32 @@ struct AIEHerdRoutingPass : public AIEHerdRoutingBase<AIEHerdRoutingPass> {
       }
     }
 
-    for (auto swboxCfg : switchboxes) {
+    for (const auto &swboxCfg : switchboxes) {
       Operation *herdOp = swboxCfg.first.first;
-      int x = swboxCfg.first.second.first;
-      int y = swboxCfg.first.second.second;
+      uint32_t x = swboxCfg.first.second.col;
+      uint32_t y = swboxCfg.first.second.row;
       auto connects = swboxCfg.second;
       HerdOp herd = dyn_cast<HerdOp>(herdOp);
 
       builder.setInsertionPoint(device.getBody()->getTerminator());
 
-      IterOp iterx =
-          builder.create<IterOp>(builder.getUnknownLoc(), x, x + 1, 1);
-      IterOp itery =
-          builder.create<IterOp>(builder.getUnknownLoc(), y, y + 1, 1);
-      AIEX::SelectOp sel = builder.create<AIEX::SelectOp>(
-          builder.getUnknownLoc(), herd, iterx, itery);
-      SwitchboxOp swbox =
-          builder.create<SwitchboxOp>(builder.getUnknownLoc(), sel);
-      swbox.ensureTerminator(swbox.getConnections(), builder,
-                             builder.getUnknownLoc());
+      auto iterx = builder.create<IterOp>(builder.getUnknownLoc(), x, x + 1, 1);
+      auto itery = builder.create<IterOp>(builder.getUnknownLoc(), y, y + 1, 1);
+      auto sel = builder.create<AIEX::SelectOp>(builder.getUnknownLoc(), herd,
+                                                iterx, itery);
+      auto swbox = builder.create<SwitchboxOp>(builder.getUnknownLoc(), sel);
+      SwitchboxOp::ensureTerminator(swbox.getConnections(), builder,
+                                    builder.getUnknownLoc());
       Block &b = swbox.getConnections().front();
       builder.setInsertionPoint(b.getTerminator());
 
       for (auto connect : connects) {
-        Port sourcePort = connect.first;
-        Port destPort = connect.second;
-        WireBundle sourceBundle = sourcePort.first;
-        int sourceChannel = sourcePort.second;
-        WireBundle destBundle = destPort.first;
-        int destChannel = destPort.second;
+        Port sourcePort = connect.src;
+        Port destPort = connect.dst;
+        WireBundle sourceBundle = sourcePort.bundle;
+        uint32_t sourceChannel = sourcePort.channel;
+        WireBundle destBundle = destPort.bundle;
+        uint32_t destChannel = destPort.channel;
 
         builder.create<ConnectOp>(builder.getUnknownLoc(), sourceBundle,
                                   sourceChannel, destBundle, destChannel);

--- a/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 #include "mlir/Transforms/DialectConversion.h"
+
 #include "llvm/ADT/Twine.h"
 
 #define DEBUG_TYPE "aie-lower-multicast"
@@ -60,8 +61,8 @@ struct AIELowerMulticastPass : public AIEMulticastBase<AIELowerMulticastPass> {
               dyn_cast<TileOp>(multiDest.getTile().getDefiningOp());
           Port destPort = multiDest.port();
           builder.create<FlowOp>(builder.getUnknownLoc(), srcTile,
-                                 sourcePort.first, sourcePort.second, destTile,
-                                 destPort.first, destPort.second);
+                                 sourcePort.bundle, sourcePort.channel,
+                                 destTile, destPort.bundle, destPort.channel);
         }
       }
     }

--- a/lib/Dialect/AIEX/Utils/AIETokenAnalysis.cpp
+++ b/lib/Dialect/AIEX/Utils/AIETokenAnalysis.cpp
@@ -29,7 +29,7 @@ void xilinx::AIEX::TokenAnalysis::runAnalysis() {
     StringRef tokenName =
         op->getAttrOfType<StringAttr>(::mlir::SymbolTable::getSymbolAttrName())
             .getValue();
-    uint32_t value = op.getTokenValue();
+    int value = op.getTokenValue();
     tokenSymbols[tokenName] = value;
   }
 
@@ -93,7 +93,7 @@ void xilinx::AIEX::TokenAnalysis::runAnalysis() {
     auto tokenRels = map.second;
     auto tokenAcqs = tokenAcqMap[tokenName];
     for (auto ROp : tokenRels) {
-      uint32_t releaseValue;
+      int releaseValue;
 
       if (auto op = dyn_cast<UseTokenOp>(ROp))
         releaseValue = op.getTokenValue();
@@ -101,7 +101,7 @@ void xilinx::AIEX::TokenAnalysis::runAnalysis() {
         releaseValue = op.getReleaseTokenValue();
 
       for (auto AOp : tokenAcqs) {
-        uint32_t acquireValue;
+        int acquireValue;
 
         if (auto op = dyn_cast<UseTokenOp>(AOp))
           acquireValue = op.getTokenValue();
@@ -121,8 +121,8 @@ void xilinx::AIEX::TokenAnalysis::runAnalysis() {
   }
 
   for (auto tile : device.getOps<TileOp>()) {
-    uint32_t colIndex = tile.colIndex();
-    uint32_t rowIndex = tile.rowIndex();
+    int colIndex = tile.colIndex();
+    int rowIndex = tile.rowIndex();
     tiles[{colIndex, rowIndex}] = tile;
   }
 }
@@ -141,8 +141,8 @@ Operation *xilinx::AIEX::TokenAnalysis::getTokenUserOp(Operation *Op) {
 }
 
 TileID xilinx::AIEX::TokenAnalysis::getCoord(Operation *Op) {
-  uint32_t colIndex = 0;
-  uint32_t rowIndex = 0;
+  int colIndex = 0;
+  int rowIndex = 0;
 
   if (CoreOp core = dyn_cast<CoreOp>(Op)) {
     colIndex = core.colIndex();
@@ -169,10 +169,10 @@ Operation *xilinx::AIEX::TokenAnalysis::getShareableTileOp(Operation *Op1,
   TileID coord1 = getCoord(Op1);
   TileID coord2 = getCoord(Op2);
 
-  uint32_t col1 = coord1.col;
-  uint32_t row1 = coord1.row;
-  uint32_t col2 = coord2.col;
-  uint32_t row2 = coord2.row;
+  int col1 = coord1.col;
+  int row1 = coord1.row;
+  int col2 = coord2.col;
+  int row2 = coord2.row;
 
   const auto &target_model = xilinx::AIE::getTargetModel(Op1);
 

--- a/lib/Targets/AIETargetShared.cpp
+++ b/lib/Targets/AIETargetShared.cpp
@@ -22,8 +22,7 @@ using namespace xilinx;
 using namespace xilinx::AIE;
 using namespace xilinx::AIEX;
 
-namespace xilinx {
-namespace AIE {
+namespace xilinx::AIE {
 
 std::string tileLocStr(StringRef col, StringRef row) {
   std::string str;
@@ -32,7 +31,7 @@ std::string tileLocStr(StringRef col, StringRef row) {
   return str;
 }
 
-std::string tileLocStr(int col, int row) {
+std::string tileLocStr(uint32_t col, uint32_t row) {
   return tileLocStr(std::to_string(col), std::to_string(row));
 }
 
@@ -43,7 +42,7 @@ std::string tileDMAInstStr(StringRef col, StringRef row, StringRef bdNum) {
   return str;
 }
 
-std::string tileDMAInstStr(int col, int row, int bdNum) {
+std::string tileDMAInstStr(uint32_t col, uint32_t row, uint32_t bdNum) {
   return tileDMAInstStr(std::to_string(col), std::to_string(row),
                         std::to_string(bdNum));
 }
@@ -55,7 +54,7 @@ std::string tileDMAInstRefStr(StringRef col, StringRef row, StringRef bdNum) {
   return str;
 }
 
-std::string tileDMAInstRefStr(int col, int row, int bdNum) {
+std::string tileDMAInstRefStr(uint32_t col, uint32_t row, uint32_t bdNum) {
   return tileDMAInstRefStr(std::to_string(col), std::to_string(row),
                            std::to_string(bdNum));
 }
@@ -67,7 +66,7 @@ std::string packetStr(StringRef id, StringRef type) {
   return str;
 }
 
-std::string packetStr(int id, int type) {
+std::string packetStr(uint32_t id, uint32_t type) {
   return packetStr(std::to_string(id), std::to_string(type));
 }
 
@@ -79,15 +78,17 @@ static std::string tileDMATensorStr(StringRef col, StringRef row,
   return str;
 }
 
-static std::string tileDMATensorStr(int col, int row, int bdNum) {
+static std::string tileDMATensorStr(uint32_t col, uint32_t row,
+                                    uint32_t bdNum) {
   return tileDMATensorStr(std::to_string(col), std::to_string(row),
                           std::to_string(bdNum));
 }
 
-void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
-                                    ArrayRef<DimTupleAttr> dims, int col,
-                                    int row, int bdNum, int baseAddrA,
-                                    int offsetA, int lenA, int bytesA,
+void generateXAieDmaSetMultiDimAddr(raw_ostream &output, uint32_t ndims,
+                                    ArrayRef<DimTupleAttr> dims, uint32_t col,
+                                    uint32_t row, uint32_t bdNum,
+                                    uint32_t baseAddrA, uint32_t offsetA,
+                                    uint32_t lenA, uint32_t bytesA,
                                     const char *error_retval) {
   std::string tensor = tileDMATensorStr(col, row, bdNum);
   output << "XAie_DmaTensor " << tensor << " = {};\n";
@@ -118,5 +119,4 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
   // TODO: Might need to adjust step sizes / wraps by -1
 }
 
-} // namespace AIE
-} // namespace xilinx
+} // namespace xilinx::AIE

--- a/lib/Targets/AIETargetShared.cpp
+++ b/lib/Targets/AIETargetShared.cpp
@@ -31,7 +31,7 @@ std::string tileLocStr(StringRef col, StringRef row) {
   return str;
 }
 
-std::string tileLocStr(uint32_t col, uint32_t row) {
+std::string tileLocStr(int col, int row) {
   return tileLocStr(std::to_string(col), std::to_string(row));
 }
 
@@ -42,7 +42,7 @@ std::string tileDMAInstStr(StringRef col, StringRef row, StringRef bdNum) {
   return str;
 }
 
-std::string tileDMAInstStr(uint32_t col, uint32_t row, uint32_t bdNum) {
+std::string tileDMAInstStr(int col, int row, int bdNum) {
   return tileDMAInstStr(std::to_string(col), std::to_string(row),
                         std::to_string(bdNum));
 }
@@ -54,7 +54,7 @@ std::string tileDMAInstRefStr(StringRef col, StringRef row, StringRef bdNum) {
   return str;
 }
 
-std::string tileDMAInstRefStr(uint32_t col, uint32_t row, uint32_t bdNum) {
+std::string tileDMAInstRefStr(int col, int row, int bdNum) {
   return tileDMAInstRefStr(std::to_string(col), std::to_string(row),
                            std::to_string(bdNum));
 }
@@ -66,7 +66,7 @@ std::string packetStr(StringRef id, StringRef type) {
   return str;
 }
 
-std::string packetStr(uint32_t id, uint32_t type) {
+std::string packetStr(int id, int type) {
   return packetStr(std::to_string(id), std::to_string(type));
 }
 
@@ -78,17 +78,15 @@ static std::string tileDMATensorStr(StringRef col, StringRef row,
   return str;
 }
 
-static std::string tileDMATensorStr(uint32_t col, uint32_t row,
-                                    uint32_t bdNum) {
+static std::string tileDMATensorStr(int col, int row, int bdNum) {
   return tileDMATensorStr(std::to_string(col), std::to_string(row),
                           std::to_string(bdNum));
 }
 
-void generateXAieDmaSetMultiDimAddr(raw_ostream &output, uint32_t ndims,
-                                    ArrayRef<DimTupleAttr> dims, uint32_t col,
-                                    uint32_t row, uint32_t bdNum,
-                                    uint32_t baseAddrA, uint32_t offsetA,
-                                    uint32_t lenA, uint32_t bytesA,
+void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
+                                    ArrayRef<DimTupleAttr> dims, int col,
+                                    int row, int bdNum, int baseAddrA,
+                                    int offsetA, int lenA, int bytesA,
                                     const char *error_retval) {
   std::string tensor = tileDMATensorStr(col, row, bdNum);
   output << "XAie_DmaTensor " << tensor << " = {};\n";

--- a/lib/Targets/AIETargetShared.h
+++ b/lib/Targets/AIETargetShared.h
@@ -32,24 +32,25 @@ namespace AIE {
 
 std::string tileLocStr(StringRef col, StringRef row);
 
-std::string tileLocStr(int col, int row);
+std::string tileLocStr(uint32_t col, uint32_t row);
 
 std::string tileDMAInstStr(StringRef col, StringRef row, StringRef bdNum);
 
-std::string tileDMAInstStr(int col, int row, int bdNum);
+std::string tileDMAInstStr(uint32_t col, uint32_t row, uint32_t bdNum);
 
 std::string tileDMAInstRefStr(StringRef col, StringRef row, StringRef bdNum);
 
-std::string tileDMAInstRefStr(int col, int row, int bdNum);
+std::string tileDMAInstRefStr(uint32_t col, uint32_t row, uint32_t bdNum);
 
 std::string packetStr(StringRef id, StringRef type);
 
-std::string packetStr(int id, int type);
+std::string packetStr(uint32_t id, uint32_t type);
 
-void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
-                                    ArrayRef<DimTupleAttr> dims, int col,
-                                    int row, int bdNum, int baseAddrA,
-                                    int offsetA, int lenA, int bytesA,
+void generateXAieDmaSetMultiDimAddr(raw_ostream &output, uint32_t ndims,
+                                    ArrayRef<DimTupleAttr> dims, uint32_t col,
+                                    uint32_t row, uint32_t bdNum,
+                                    uint32_t baseAddrA, uint32_t offsetA,
+                                    uint32_t lenA, uint32_t bytesA,
                                     const char *error_ret);
 
 } // namespace AIE

--- a/lib/Targets/AIETargetShared.h
+++ b/lib/Targets/AIETargetShared.h
@@ -32,25 +32,24 @@ namespace AIE {
 
 std::string tileLocStr(StringRef col, StringRef row);
 
-std::string tileLocStr(uint32_t col, uint32_t row);
+std::string tileLocStr(int col, int row);
 
 std::string tileDMAInstStr(StringRef col, StringRef row, StringRef bdNum);
 
-std::string tileDMAInstStr(uint32_t col, uint32_t row, uint32_t bdNum);
+std::string tileDMAInstStr(int col, int row, int bdNum);
 
 std::string tileDMAInstRefStr(StringRef col, StringRef row, StringRef bdNum);
 
-std::string tileDMAInstRefStr(uint32_t col, uint32_t row, uint32_t bdNum);
+std::string tileDMAInstRefStr(int col, int row, int bdNum);
 
 std::string packetStr(StringRef id, StringRef type);
 
-std::string packetStr(uint32_t id, uint32_t type);
+std::string packetStr(int id, int type);
 
-void generateXAieDmaSetMultiDimAddr(raw_ostream &output, uint32_t ndims,
-                                    ArrayRef<DimTupleAttr> dims, uint32_t col,
-                                    uint32_t row, uint32_t bdNum,
-                                    uint32_t baseAddrA, uint32_t offsetA,
-                                    uint32_t lenA, uint32_t bytesA,
+void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
+                                    ArrayRef<DimTupleAttr> dims, int col,
+                                    int row, int bdNum, int baseAddrA,
+                                    int offsetA, int lenA, int bytesA,
                                     const char *error_ret);
 
 } // namespace AIE

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -801,7 +801,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   //---------------------------------------------------------------------------
   for (auto tile : tiles) {
     Operation *tileOp = tile.second;
-    TileID coord = NL.getCoord(tileOp);
+    TileID coord = cast<TileOp>(tileOp).getTileID();
     uint32_t col = coord.col;
     uint32_t row = coord.row;
     auto loc = tileLocStr(col, row);

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -306,7 +306,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   //  StringRef deviceInst = "ctx->DevInst";       // TODO
   StringRef deviceInstRef = "&(ctx->DevInst)"; // TODO
 
-  DenseMap<std::pair<int, int>, Operation *> tiles;
+  DenseMap<TileID, Operation *> tiles;
   DenseMap<Operation *, CoreOp> cores;
   DenseMap<Operation *, MemOp> mems;
   DenseMap<std::pair<Operation *, int>, LockOp> locks;
@@ -801,9 +801,9 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   //---------------------------------------------------------------------------
   for (auto tile : tiles) {
     Operation *tileOp = tile.second;
-    std::pair<int, int> coord = NL.getCoord(tileOp);
-    int col = coord.first;
-    int row = coord.second;
+    TileID coord = NL.getCoord(tileOp);
+    uint32_t col = coord.col;
+    uint32_t row = coord.row;
     auto loc = tileLocStr(col, row);
 
     auto bufferAccessor = [&](std::optional<TileID> tile, BufferOp buf) {
@@ -867,8 +867,8 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   }
 
   auto lockAccessor = [&](LockOp lock) {
-    int col = lock.colIndex();
-    int row = lock.rowIndex();
+    uint32_t col = lock.colIndex();
+    uint32_t row = lock.rowIndex();
     if (!lock.hasName())
       return;
     std::string lockName(lock.name().getValue());

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -802,8 +802,8 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   for (auto tile : tiles) {
     Operation *tileOp = tile.second;
     TileID coord = cast<TileOp>(tileOp).getTileID();
-    uint32_t col = coord.col;
-    uint32_t row = coord.row;
+    int col = coord.col;
+    int row = coord.row;
     auto loc = tileLocStr(col, row);
 
     auto bufferAccessor = [&](std::optional<TileID> tile, BufferOp buf) {
@@ -867,8 +867,8 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   }
 
   auto lockAccessor = [&](LockOp lock) {
-    uint32_t col = lock.colIndex();
-    uint32_t row = lock.rowIndex();
+    int col = lock.colIndex();
+    int row = lock.rowIndex();
     if (!lock.hasName())
       return;
     std::string lockName(lock.name().getValue());

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -151,7 +151,7 @@ void registerAIETranslations() {
 
         for (auto tile : tiles) {
           Operation *srcTileOp = tile.second;
-          TileID srcCoord = NL.getCoord(srcTileOp);
+          TileID srcCoord = cast<TileOp>(srcTileOp).getTileID();
           uint32_t srcCol = srcCoord.col;
           uint32_t srcRow = srcCoord.row;
 

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -152,8 +152,8 @@ void registerAIETranslations() {
         for (auto tile : tiles) {
           Operation *srcTileOp = tile.second;
           TileID srcCoord = cast<TileOp>(srcTileOp).getTileID();
-          uint32_t srcCol = srcCoord.col;
-          uint32_t srcRow = srcCoord.row;
+          int srcCol = srcCoord.col;
+          int srcRow = srcCoord.row;
 
           output << "// Tile(" << srcCol << ", " << srcRow << ")\n";
           output << "// Memory map: name base_address num_bytes\n";
@@ -266,10 +266,10 @@ void registerAIETranslations() {
 
             // Figure out how much memory we have left for random allocations
             auto core = tile.getCoreOp();
-            uint32_t max = core.getStackSize();
+            int max = core.getStackSize();
             for (auto buf : buffers[tiles[srcCoord]]) {
-              uint32_t bufferBaseAddr = NL.getBufferBaseAddress(buf);
-              uint32_t numBytes = buf.getAllocationSize();
+              int bufferBaseAddr = NL.getBufferBaseAddress(buf);
+              int numBytes = buf.getAllocationSize();
               max = std::max(max, bufferBaseAddr + numBytes);
             }
             int origin = target_model.getMemInternalBaseAddress(srcCoord) + max;

--- a/test/dialect/AIE/badconnect.mlir
+++ b/test/dialect/AIE/badconnect.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not %PYTHON aiecc.py %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'AIE.connect' op source index cannot be less than zero
+// CHECK: error{{.*}} 'AIE.connect' op attribute 'sourceChannel' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 0
 
 module {
   %20 = AIE.tile(2, 0)

--- a/test/dialect/AIE/badconnect.mlir
+++ b/test/dialect/AIE/badconnect.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not %PYTHON aiecc.py %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'AIE.connect' op attribute 'sourceChannel' failed to satisfy constraint: 32-bit signless integer attribute whose minimum value is 0
+// CHECK: error{{.*}} 'AIE.connect' op source index cannot be less than zero
 
 module {
   %20 = AIE.tile(2, 0)


### PR DESCRIPTION
Let's use structs instead of pairs so that semantic info is preserved (and code is more readable).