### PR TITLE
[nfc] Resolve incompatible type comparison warnings

### DIFF
--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -540,7 +540,7 @@ void AIETargetModel::validate() const {
   }
 
   // Every tile in a memtile row must be a memtile.
-  for (int i = 1; i < 1 + getNumMemTileRows(); i++)
+  for (int i = 1; i < 1 + static_cast<int>(getNumMemTileRows()); i++)
     for (int j = 0; j < columns(); j++)
       assert(isMemTile(j, i) && !isShimPLTile(j, i) && !isShimNOCTile(j, i) &&
              !isCoreTile(j, i));

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -204,7 +204,8 @@ Pathfinder::findPaths(const int maxIterations) {
                << "Begin findPaths iteration #" << iterationCount << "\n");
     // update demand on all channels
     for (auto &ch : edges) {
-      if (ch.fixedCapacity.size() >= ch.maxCapacity) {
+      if (ch.fixedCapacity.size() >=
+          static_cast<unsigned int>(ch.maxCapacity)) {
         ch.demand = INF;
       } else {
         double history = 1.0 + OVER_CAPACITY_COEFF * ch.overCapacityCount;

--- a/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
@@ -1177,7 +1177,7 @@ LogicalResult ExtOp::verify() {
 
   // Verify validity of index
   unsigned factor = sourceLanes / resultLanes;
-  if (getIndex() >= factor)
+  if (static_cast<unsigned>(getIndex()) >= factor)
     return emitError("index out of bounds");
 
   // The datatype of source and result must match

--- a/lib/Targets/AIETargetSimulationFiles.cpp
+++ b/lib/Targets/AIETargetSimulationFiles.cpp
@@ -380,7 +380,8 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
       int row = tileOp.rowIndex();
 
       // NOTE: row == 0 assumes shim always row 0
-      if (row == 0 || row > targetOp.getTargetModel().getNumMemTileRows())
+      if (row == 0 ||
+          row > static_cast<int>(targetOp.getTargetModel().getNumMemTileRows()))
         continue; // Skip regular tiles (handled above)
 
       output << "      <MEM name=\"MEM(" << std::to_string(col) << ", "

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -348,7 +348,8 @@ static LogicalResult createLinearizedAccess(CppEmitter &emitter, Value source,
   ArrayRef<int64_t> stride = memRefType.getShape();
 
   // The stride and indices size must match
-  if (stride.size() != indices.size() || stride.size() != memRefType.getRank())
+  if (stride.size() != indices.size() ||
+      static_cast<int64_t>(stride.size()) != memRefType.getRank())
     return failure();
 
   // A stride contains two parts:


### PR DESCRIPTION
The recent changes from PR #723 cause a handful of comparisons in the code to trigger warnings. None of them are actual problems, and this patch disambiguates the comparisons to remove the warning.