### PR TITLE
[nfc] Sanitize headers (1/n)

### DIFF
--- a/include/aie/Dialect/AIEVec/Transforms/Passes.h
+++ b/include/aie/Dialect/AIEVec/Transforms/Passes.h
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // (c) Copyright 2022 Xilinx Inc.
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
 //
 //===----------------------------------------------------------------------===//
 // Register all the AIE vectorization passes
@@ -17,8 +18,6 @@
 
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassOptions.h"
-
-#include <limits>
 
 namespace mlir {
 
@@ -60,8 +59,6 @@ class FuncOp;
 
 namespace xilinx {
 namespace aievec {
-
-using mlir::affine::AffineDialect;
 
 #define GEN_PASS_DECL
 #define GEN_PASS_CLASSES

--- a/include/aie/Dialect/AIEX/AIETokenAnalysis.h
+++ b/include/aie/Dialect/AIEX/AIETokenAnalysis.h
@@ -5,31 +5,27 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // (c) Copyright 2019 Xilinx Inc.
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef AIEX_TOKENANALYSIS_H
 #define AIEX_TOKENANALYSIS_H
 
-#include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIE/IR/AIETargetModel.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
 
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dialect.h"
-#include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/TypeSupport.h"
-#include "mlir/IR/Types.h"
-#include "mlir/Interfaces/FunctionImplementation.h"
-#include "llvm/ADT/StringSwitch.h"
+namespace mlir {
+class Operation;
+} // namespace mlir
 
-#include <map>
+namespace xilinx::AIE {
+class DeviceOp;
+struct TileID;
+} // namespace xilinx::AIE
 
 namespace xilinx::AIEX {
-
-using namespace xilinx::AIE;
 
 class TokenAnalysis {
   AIE::DeviceOp &device;
@@ -42,7 +38,7 @@ class TokenAnalysis {
       tokenChains;
   llvm::SmallVector<std::pair<mlir::Operation *, mlir::Operation *>, 4>
       tokenPairs;
-  llvm::DenseMap<TileID, mlir::Operation *> tiles;
+  llvm::DenseMap<xilinx::AIE::TileID, mlir::Operation *> tiles;
 
 public:
   TokenAnalysis(AIE::DeviceOp &d) : device(d) {}
@@ -65,7 +61,7 @@ public:
   mlir::Operation *getTokenUserOp(mlir::Operation *Op);
   mlir::Operation *getShareableTileOp(mlir::Operation *Op1,
                                       mlir::Operation *Op2);
-  TileID getCoord(mlir::Operation *Op);
+  xilinx::AIE::TileID getCoord(mlir::Operation *Op);
 
   void print(llvm::raw_ostream &os);
 };

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // (c) Copyright 2022 Xilinx Inc.
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
 //
 //===----------------------------------------------------------------------===//
 // This file defines helpers to emit C++ code for AIE vector dialect.
@@ -27,6 +28,7 @@
 #include "mlir/Support/IndentedOstream.h"
 #include "mlir/Support/MathExtras.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/ScopedHashTable.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
@@ -36,6 +38,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <limits>
+#include <stack>
 
 #define DEBUG_TYPE "aievec-to-cpp"
 

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.h
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.h
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // (c) Copyright 2022 Xilinx Inc.
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
 //
 //===----------------------------------------------------------------------===//
 // This file defines helpers to emit C++ code for AIE vector dialect.
@@ -14,18 +15,13 @@
 #define TARGET_TRANSLATEAIEVECTOCPP_H
 
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Value.h"
-#include "llvm/ADT/ScopedHashTable.h"
-#include "llvm/Support/raw_ostream.h"
-#include <stack>
 
 namespace xilinx {
 namespace aievec {
-using namespace mlir;
 
 /// Translates the AIE vector dialect MLIR to C++ code.
-LogicalResult translateAIEVecToCpp(Operation *op, raw_ostream &os);
+mlir::LogicalResult translateAIEVecToCpp(mlir::Operation *op,
+                                         mlir::raw_ostream &os);
 
 } // namespace aievec
 } // namespace xilinx


### PR DESCRIPTION
This patch removes the last few uses of "using namespace" in headers, removes unnecessary includes, and replaces some of them with forward declarations.