### PR TITLE
[aievec] Add conversion from MatMulOp to LLVM intrinsic call

### DIFF
--- a/include/aie/Conversion/Passes.td
+++ b/include/aie/Conversion/Passes.td
@@ -22,7 +22,9 @@ def ConvertAIEVecToLLVM : Pass<"convert-aievec-to-llvm", "mlir::ModuleOp"> {
     This pass converts AIEVec dialect ops to LLVM dialect calls to builtins.
   }];
   let constructor = "xilinx::aievec::createConvertAIEVecToLLVMPass()";
-  let dependentDialects = ["LLVM::LLVMDialect"];
+  let dependentDialects = ["LLVM::LLVMDialect",
+                           "mlir::arith::ArithDialect",
+                           "mlir::vector::VectorDialect"];
 }
 
 #endif // AIE_CONVERSION_PASSES

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -11,6 +11,8 @@
 #ifndef AIE_CONVERSION_PASSDETAIL_H_
 #define AIE_CONVERSION_PASSDETAIL_H_
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
 #include "mlir/Pass/Pass.h"

--- a/test/Conversion/AIEVecToLLVM/matmul.mlir
+++ b/test/Conversion/AIEVecToLLVM/matmul.mlir
@@ -1,0 +1,93 @@
+// RUN: aie-opt %s -split-input-file -convert-aievec-to-llvm | FileCheck %s
+
+func.func @matmul(%A : vector<4x8xbf16>, %B : vector<8x4xbf16>,
+                  %C : vector<4x4xf32>) -> vector<4x4xf32> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xbf16>, vector<8x4xbf16>
+                                  into vector<4x4xf32>
+  return %0 : vector<4x4xf32>
+}
+
+// CHECK-LABEL: llvm.func @llvm.aie2.bf.mac16.conf(vector<32xbf16>,
+// CHECK-SAME:  vector<32xbf16>, vector<16xf32>, i32) -> vector<16xf32>
+// CHECK-LABEL: @matmul
+// CHECK-SAME: %[[A:.*]]: vector<4x8xbf16>
+// CHECK-SAME: %[[B:.*]]: vector<8x4xbf16>
+// CHECK-SAME: %[[C:.*]]: vector<4x4xf32>
+// CHECK:      %[[FA:.*]] = vector.shape_cast %[[A]] :
+// CHECK-SAME:                      vector<4x8xbf16> to vector<32xbf16>
+// CHECK:      %[[FB:.*]] = vector.shape_cast %[[B]] :
+// CHECK-SAME:                      vector<8x4xbf16> to vector<32xbf16>
+// CHECK:      %[[FC:.*]] = vector.shape_cast %[[C]] :
+// CHECK-SAME:                      vector<4x4xf32> to vector<16xf32>
+// CHECK:      %[[CONF:.*]] = arith.constant 28 : i32
+// CHECK:      %[[FR:.*]] = llvm.call @llvm.aie2.bf.mac16.conf(
+// CHECK-SAME:         %[[FA]], %[[FB]], %[[FC]], %[[CONF]]) :
+// CHECK-SAME:         (vector<32xbf16>, vector<32xbf16>, vector<16xf32>, i32)
+// CHECK-SAME:         -> vector<16xf32>
+// CHECK:      %[[R:.*]] = vector.shape_cast %[[FR]] :
+// CHECK-SAME:                      vector<16xf32> to vector<4x4xf32>
+// CHECK:      return %[[R]] : vector<4x4xf32>
+
+// -----
+
+func.func @matmul(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
+                  %C : vector<4x8xi32>) -> vector<4x8xi32> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x8xi8>, vector<8x8xi8>
+                                  into vector<4x8xi32>
+  return %0 : vector<4x8xi32>
+}
+
+// CHECK-LABEL: llvm.func @llvm.aie2.i512.i512.acc1024.acc32.mac.conf(
+// CHECK-SAME:    vector<32xi8>, vector<64xi8>, vector<32xi32>, i32)
+// CHECK-SAME:      -> vector<32xi32>
+// CHECK-LABEL: @matmul
+// CHECK-SAME: %[[A:.*]]: vector<4x8xi8>
+// CHECK-SAME: %[[B:.*]]: vector<8x8xi8>
+// CHECK-SAME: %[[C:.*]]: vector<4x8xi32>
+// CHECK:      %[[FA:.*]] = vector.shape_cast %[[A]] :
+// CHECK-SAME:                      vector<4x8xi8> to vector<32xi8>
+// CHECK:      %[[FB:.*]] = vector.shape_cast %[[B]] :
+// CHECK-SAME:                      vector<8x8xi8> to vector<64xi8>
+// CHECK:      %[[FC:.*]] = vector.shape_cast %[[C]] :
+// CHECK-SAME:                      vector<4x8xi32> to vector<32xi32>
+// CHECK:      %[[CONF:.*]] = arith.constant 776 : i32
+// CHECK:      %[[FR:.*]] =
+// CHECK-SAME:         llvm.call @llvm.aie2.i512.i512.acc1024.acc32.mac.conf(
+// CHECK-SAME:           %[[FA]], %[[FB]], %[[FC]], %[[CONF]]) :
+// CHECK-SAME:           (vector<32xi8>, vector<64xi8>, vector<32xi32>, i32)
+// CHECK-SAME:           -> vector<32xi32>
+// CHECK:      %[[R:.*]] = vector.shape_cast %[[FR]] :
+// CHECK-SAME:                      vector<32xi32> to vector<4x8xi32>
+// CHECK:      return %[[R]] : vector<4x8xi32>
+
+// -----
+
+func.func @matmul(%A : vector<4x2xi32>, %B : vector<2x4xi16>,
+                  %C : vector<4x4xi64>) -> vector<4x4xi64> {
+  %0 = aievec.matmul %A, %B, %C : vector<4x2xi32>, vector<2x4xi16>
+                                  into vector<4x4xi64>
+  return %0 : vector<4x4xi64>
+}
+
+// CHECK-LABEL: llvm.func @llvm.aie2.i512.i512.acc1024.acc64.mac.conf(
+// CHECK-SAME:    vector<8xi32>, vector<8xi16>, vector<16xi64>, i32)
+// CHECK-SAME:      -> vector<16xi64>
+// CHECK-LABEL: @matmul
+// CHECK-SAME: %[[A:.*]]: vector<4x2xi32>
+// CHECK-SAME: %[[B:.*]]: vector<2x4xi16>
+// CHECK-SAME: %[[C:.*]]: vector<4x4xi64>
+// CHECK:      %[[FA:.*]] = vector.shape_cast %[[A]] :
+// CHECK-SAME:                      vector<4x2xi32> to vector<8xi32>
+// CHECK:      %[[FB:.*]] = vector.shape_cast %[[B]] :
+// CHECK-SAME:                      vector<2x4xi16> to vector<8xi16>
+// CHECK:      %[[FC:.*]] = vector.shape_cast %[[C]] :
+// CHECK-SAME:                      vector<4x4xi64> to vector<16xi64>
+// CHECK:      %[[CONF:.*]] = arith.constant 770 : i32
+// CHECK:      %[[FR:.*]] =
+// CHECK-SAME:         llvm.call @llvm.aie2.i512.i512.acc1024.acc64.mac.conf(
+// CHECK-SAME:           %[[FA]], %[[FB]], %[[FC]], %[[CONF]]) :
+// CHECK-SAME:           (vector<8xi32>, vector<8xi16>, vector<16xi64>, i32)
+// CHECK-SAME:           -> vector<16xi64>
+// CHECK:      %[[R:.*]] = vector.shape_cast %[[FR]] :
+// CHECK-SAME:                      vector<16xi64> to vector<4x4xi64>
+// CHECK:      return %[[R]] : vector<4x4xi64>


### PR DESCRIPTION
In order to flatten the 2D vectors we generate `vector.shape_cast` ops, which currently treat 2D vectors as a struct of 1D vectors in for LLVM IR purposes. Once we add support to lower the shape casts as bitcasts, this issue will disappear.