### PR TITLE
Patch 1x4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ add_subdirectory(reference_designs)
 add_subdirectory(test)
 add_subdirectory(tutorials)
 add_subdirectory(tools)
+add_subdirectory(data)
 
 if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   install(

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -6,7 +6,6 @@
 # (c) Copyright 2023, Advanced Micro Devices, Inc.
 
 set(DATA_FILES
-  1x4.xclbin
   generated-source/gen_cdo.h
   generated-source/gen_cdo.cpp
   generated-source/cdo_main.cpp

--- a/docs/buildHostWin.md
+++ b/docs/buildHostWin.md
@@ -37,12 +37,12 @@ All steps in WSL Ubuntu terminal.
       ip link set vmnic0 addr <yourMACaddress> || true
       ```
 
-1. Before building the MLIR-AIE tools copy the base XCLBIN to the data directory:
-    ```
-    cp /mnt/c/Windows/System32/AMD/ (youPathToMLIR-AIE)/data
-    ```
-
 1. Build MLIR-AIE tools under WSL2 following regular get started instructions [https://xilinx.github.io/mlir-aie/Building.html](https://xilinx.github.io/mlir-aie/Building.html)
+
+1. After building the MLIR-AIE tools copy the base XCLBIN to the data directory in the installation:
+    ```
+    cp /mnt/c/Windows/System32/AMD/ (youPathToMLIR-AIE)/install/data
+    ```
 
 1. After installing the updated RyzenAI driver (see next subsection), use the gendef tool (from the mingw-w64-tools package) to create a .def file with the symbols:
     ```


### PR DESCRIPTION
@denolf Could we set up find 1x4.xclbin and then copy it? This would eliminate a possible gotcha with the base xclbin.