### PR TITLE
fix cmakes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,11 +173,47 @@ add_subdirectory(lib)
 add_subdirectory(python)
 add_subdirectory(runtime_lib)
 add_subdirectory(aie_runtime_lib)
-add_subdirectory(reference_designs)
+add_subdirectory(data)
+add_subdirectory(tools)
+
+option(ENABLE_CHESS_TESTS "Enable backend tests using xchesscc" ${DEFAULT_ENABLE_CHESS_TESTS})
+option(ENABLE_BOARD_TESTS "Enable board tests" ${DEFAULT_ENABLE_BOARD_TESTS})
+
+if(Vitis_FOUND)
+  set(DEFAULT_ENABLE_CHESS_TESTS ON)
+else()
+  set(DEFAULT_ENABLE_CHESS_TESTS OFF)
+endif()
+
+if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64)
+  set(DEFAULT_ENABLE_BOARD_TESTS ON)
+else()
+  set(DEFAULT_ENABLE_BOARD_TESTS OFF)
+endif()
+
+if(ENABLE_CHESS_TESTS)
+  set(CONFIG_ENABLE_CHESS_TESTS 1)
+else()
+  set(CONFIG_ENABLE_CHESS_TESTS 0)
+endif()
+
+if(ENABLE_BOARD_TESTS)
+  set(CONFIG_ENABLE_BOARD_TESTS 1)
+else()
+  set(CONFIG_ENABLE_BOARD_TESTS 0)
+endif()
+
+if(LibXAIE_FOUND)
+  set(CONFIG_HAS_LIBXAIE 1)
+else()
+  set(CONFIG_HAS_LIBXAIE 0)
+endif()
+
+set(ENABLE_PYTHON_TESTS 1)
+
 add_subdirectory(test)
 add_subdirectory(tutorials)
-add_subdirectory(tools)
-add_subdirectory(data)
+add_subdirectory(reference_designs)
 
 if(NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,10 @@ if(POLICY CMP0116)
   cmake_policy(SET CMP0116 OLD)
 endif()
 
+if(POLICY CMP0127)
+  cmake_policy(SET CMP0127 NEW)
+endif()
+
 project(AIE LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -125,6 +129,7 @@ include(AddLLVM)
 include(AddMLIR)
 include(HandleLLVMOptions)
 include(ExternalProject)
+include(CMakeDependentOption)
 
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
@@ -176,40 +181,9 @@ add_subdirectory(aie_runtime_lib)
 add_subdirectory(data)
 add_subdirectory(tools)
 
-option(ENABLE_CHESS_TESTS "Enable backend tests using xchesscc" ${DEFAULT_ENABLE_CHESS_TESTS})
-option(ENABLE_BOARD_TESTS "Enable board tests" ${DEFAULT_ENABLE_BOARD_TESTS})
-
-if(Vitis_FOUND)
-  set(DEFAULT_ENABLE_CHESS_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_CHESS_TESTS OFF)
-endif()
-
-if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64)
-  set(DEFAULT_ENABLE_BOARD_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_BOARD_TESTS OFF)
-endif()
-
-if(ENABLE_CHESS_TESTS)
-  set(CONFIG_ENABLE_CHESS_TESTS 1)
-else()
-  set(CONFIG_ENABLE_CHESS_TESTS 0)
-endif()
-
-if(ENABLE_BOARD_TESTS)
-  set(CONFIG_ENABLE_BOARD_TESTS 1)
-else()
-  set(CONFIG_ENABLE_BOARD_TESTS 0)
-endif()
-
-if(LibXAIE_FOUND)
-  set(CONFIG_HAS_LIBXAIE 1)
-else()
-  set(CONFIG_HAS_LIBXAIE 0)
-endif()
-
-set(ENABLE_PYTHON_TESTS 1)
+cmake_dependent_option(ENABLE_CHESS_TESTS "Enable backend tests using xchesscc" ON "Vitis_FOUND" OFF)
+cmake_dependent_option(ENABLE_BOARD_TESTS "Enable board tests" ON "CMAKE_HOST_SYSTEM_PROCESSOR MATCHES aarch64" OFF)
+option(ENABLE_PYTHON_TESTS "Enable Python tests" ON)
 
 add_subdirectory(test)
 add_subdirectory(tutorials)

--- a/reference_designs/CMakeLists.txt
+++ b/reference_designs/CMakeLists.txt
@@ -1,123 +1,9 @@
-#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 
-cmake_minimum_required(VERSION 3.10)
-
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-if(POLICY CMP0068)
-  cmake_policy(SET CMP0068 NEW)
-  set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
-endif()
-
-if(POLICY CMP0075)
-  cmake_policy(SET CMP0075 NEW)
-endif()
-
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
-project(ref-designs LANGUAGES CXX C)
-
-# find package AIE if running tests from AIE installation
-if(NOT AIE_BINARY_DIR)
-  find_package(AIE REQUIRED CONFIG)
-  set(LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR CACHE STRING "") #pick up libxaiengine from installation folder if no other location specified
-endif()
-
-# default to x86_64 system architecture for runtime target
-set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runtime libraries for.")
-list(GET AIE_RUNTIME_TARGETS 0 firstRuntimeTarget)
-set(AIE_RUNTIME_TEST_TARGET ${firstRuntimeTarget} CACHE STRING "Runtime architecture to test with.")
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-
-option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
-option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
-
-if(Vitis_FOUND)
-  set(DEFAULT_ENABLE_CHESS_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_CHESS_TESTS OFF)
-endif()
-option(ENABLE_CHESS_TESTS "Enable backend tests using xchesscc" ${DEFAULT_ENABLE_CHESS_TESTS})
-
-if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64)
-  set(DEFAULT_ENABLE_BOARD_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_BOARD_TESTS OFF)
-endif()
-option(ENABLE_BOARD_TESTS "Enable board tests" ${DEFAULT_ENABLE_BOARD_TESTS})
-
-find_package(MLIR REQUIRED CONFIG)
-
-message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
-set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
-set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
-set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
-
-find_package(Vitis 2023.2 COMPONENTS AIE AIE2)
-find_package(Python3 COMPONENTS Interpreter)
-
-# Look for LibXAIE
-if (DEFINED LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR)
-    message("Ref designs using xaiengine from LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR=${LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR}")
-    set(LibXAIE_ROOT ${LibXAIE_${target}_DIR})
-    find_package(LibXAIE)
-else()
-  if(DEFINED VITIS_ROOT)
-    message(STATUS "Ref designs have Vitis available, no libxaie location specified so pick up from build area")
-    set(LibXAIE_FOUND TRUE)
-  endif()
-endif()
-
-# Define the default arguments to use with 'lit', and an option for the user to
-# override.
-set(LIT_ARGS_DEFAULT "-sv")
-if (MSVC_IDE OR XCODE)
-  set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
-endif()
-set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
-
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
-include(HandleLLVMOptions)
-
-include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_BINARY_DIR}/include)
-add_definitions(${LLVM_DEFINITIONS})
-
-if(ENABLE_CHESS_TESTS)
-set(CONFIG_ENABLE_CHESS_TESTS 1)
-else()
-set(CONFIG_ENABLE_CHESS_TESTS 0)
-endif()
-if(ENABLE_BOARD_TESTS)
-set(CONFIG_ENABLE_BOARD_TESTS 1)
-else()
-set(CONFIG_ENABLE_BOARD_TESTS 0)
-endif()
-if(LibXAIE_FOUND)
-set(CONFIG_HAS_LIBXAIE 1)
-else()
-set(CONFIG_HAS_LIBXAIE 0)
-endif()
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
@@ -130,13 +16,14 @@ set(TEST_DEPENDS
   aiecc.py
   aie-opt
   aie-translate
-  )
+)
 
 add_lit_testsuite(check-reference-designs "Running the aie reference designs"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${TEST_DEPENDS}
   ARGS "-sv --timeout 300 --time-tests"
-  )
-set_target_properties(check-reference-designs PROPERTIES FOLDER "Tutorials")
+)
+
+set_target_properties(check-reference-designs PROPERTIES FOLDER "Reference Designs")
 
 add_lit_testsuites(REFERENCE_DESIGNS ${CMAKE_CURRENT_BINARY_DIR} DEPENDS ${TEST_DEPENDS} ARGS "-sv --timeout 300 --time-tests")

--- a/reference_designs/lit.cfg.py
+++ b/reference_designs/lit.cfg.py
@@ -23,80 +23,99 @@ from lit.llvm.subst import FindTool
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'AIE_REFERENCE_DESIGNS'
+config.name = "AIE_REFERENCE_DESIGNS"
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.mlir']
+config.suffixes = [".mlir"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
-config.substitutions.append(('%PATH%', config.environment['PATH']))
-config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
-config.substitutions.append(('%extraAieCcFlags%', config.extraAieCcFlags))
-config.substitutions.append(('%host_runtime_lib%', os.path.join(config.aie_obj_root, "runtime_lib",config.aieHostTarget)))
-config.substitutions.append(('%aietools', config.vitis_aietools_dir))
+config.substitutions.append(("%PATH%", config.environment["PATH"]))
+config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
+config.substitutions.append(("%extraAieCcFlags%", config.extraAieCcFlags))
+config.substitutions.append(
+    (
+        "%host_runtime_lib%",
+        os.path.join(config.aie_obj_root, "runtime_lib", config.aieHostTarget),
+    )
+)
+config.substitutions.append(("%aietools", config.vitis_aietools_dir))
 # for xchesscc_wrapper
-llvm_config.with_environment('AIETOOLS', config.vitis_aietools_dir)
+llvm_config.with_environment("AIETOOLS", config.vitis_aietools_dir)
 
-if(config.enable_board_tests):
-    config.substitutions.append(('%run_on_board', "echo %T >> /home/xilinx/testlog | sync | sudo"))
+if config.enable_board_tests:
+    config.substitutions.append(
+        ("%run_on_board", "echo %T >> /home/xilinx/testlog | sync | sudo")
+    )
 else:
-    config.substitutions.append(('%run_on_board', "echo"))
+    config.substitutions.append(("%run_on_board", "echo"))
 
-VitisSysrootFlag = ''
-if (config.aieHostTarget == 'x86_64'):
-    config.substitutions.append(('%aieHostTargetTriplet%', 'x86_64-unknown-linux-gnu'))
-elif (config.aieHostTarget == 'aarch64'):
-    config.substitutions.append(('%aieHostTargetTriplet%', 'aarch64-linux-gnu'))
-    VitisSysrootFlag = '--sysroot='+config.vitis_sysroot
+VitisSysrootFlag = ""
+if config.aieHostTarget == "x86_64":
+    config.substitutions.append(("%aieHostTargetTriplet%", "x86_64-unknown-linux-gnu"))
+elif config.aieHostTarget == "aarch64":
+    config.substitutions.append(("%aieHostTargetTriplet%", "aarch64-linux-gnu"))
+    VitisSysrootFlag = "--sysroot=" + config.vitis_sysroot
 
-config.substitutions.append(('%VitisSysrootFlag%', VitisSysrootFlag))
-config.substitutions.append(('%aieHostTargetArch%', config.aieHostTarget))
+config.substitutions.append(("%VitisSysrootFlag%", VitisSysrootFlag))
+config.substitutions.append(("%aieHostTargetArch%", config.aieHostTarget))
 
-llvm_config.with_system_environment(
-    ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP"])
 
 llvm_config.use_default_substitutions()
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.
-config.excludes = ['Inputs', 'Examples', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt', 'aie.mlir.prj']
+config.excludes = [
+    "Inputs",
+    "Examples",
+    "CMakeLists.txt",
+    "README.txt",
+    "LICENSE.txt",
+    "aie.mlir.prj",
+]
 
-config.aie_tools_dir = os.path.join(config.aie_obj_root, 'bin')
+config.aie_tools_dir = os.path.join(config.aie_obj_root, "bin")
+
 
 def prepend_path(path):
     global llvm_config
     paths = [path]
 
-    current_paths = llvm_config.config.environment.get('PATH', None)
+    current_paths = llvm_config.config.environment.get("PATH", None)
     if current_paths:
         paths.extend(current_paths.split(os.path.pathsep))
         paths = [os.path.normcase(os.path.normpath(p)) for p in paths]
     else:
         paths = []
 
-    llvm_config.config.environment['PATH'] = os.pathsep.join(paths)
+    llvm_config.config.environment["PATH"] = os.pathsep.join(paths)
+
 
 # Setup the path.
 prepend_path(config.llvm_tools_dir)
 prepend_path(config.peano_tools_dir)
 prepend_path(config.aie_tools_dir)
-#llvm_config.with_environment('LM_LICENSE_FILE', os.getenv('LM_LICENSE_FILE'))
-#llvm_config.with_environment('XILINXD_LICENSE_FILE', os.getenv('XILINXD_LICENSE_FILE'))
-if(config.vitis_root):
-  config.vitis_aietools_bin = os.path.join(config.vitis_aietools_dir, "bin")
-  prepend_path(config.vitis_aietools_bin)
-  llvm_config.with_environment('VITIS', config.vitis_root)
+# llvm_config.with_environment('LM_LICENSE_FILE', os.getenv('LM_LICENSE_FILE'))
+# llvm_config.with_environment('XILINXD_LICENSE_FILE', os.getenv('XILINXD_LICENSE_FILE'))
+if config.vitis_root:
+    config.vitis_aietools_bin = os.path.join(config.vitis_aietools_dir, "bin")
+    prepend_path(config.vitis_aietools_bin)
+    llvm_config.with_environment("VITIS", config.vitis_root)
 
 # Test to see if we have the peano backend.
 try:
-    result = subprocess.run([os.path.join(config.peano_tools_dir, 'llc'),'-mtriple=aie','--version'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-    if (re.search("Xilinx AI Engine", result.stdout.decode('utf-8')) is not None):
-        config.available_features.add('peano')
+    result = subprocess.run(
+        [os.path.join(config.peano_tools_dir, "llc"), "-mtriple=aie", "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if re.search("Xilinx AI Engine", result.stdout.decode("utf-8")) is not None:
+        config.available_features.add("peano")
         print("Peano found: " + shutil.which("llc"))
     else:
         print("Peano not found, but expected at ", config.peano_tools_dir)
@@ -104,51 +123,56 @@ except Exception as e:
     print("Peano not found, but expected at ", config.peano_tools_dir)
 
 print("Looking for Chess...")
-#test if LM_LICENSE_FILE valid
-if(config.enable_chess_tests):
+# test if LM_LICENSE_FILE valid
+if config.enable_chess_tests:
     result = None
-    if(config.vitis_root):
+    if config.vitis_root:
         result = shutil.which("xchesscc")
 
     if result != None:
         print("Chess found: " + result)
-        config.available_features.add('chess')
-        config.available_features.add('valid_xchess_license')
-        lm_license_file = os.getenv('LM_LICENSE_FILE')
-        if(lm_license_file != None):
-            llvm_config.with_environment('LM_LICENSE_FILE', lm_license_file)
-        xilinxd_license_file = os.getenv('XILINXD_LICENSE_FILE')
-        if(xilinxd_license_file != None):
-            llvm_config.with_environment('XILINXD_LICENSE_FILE', xilinxd_license_file)
+        config.available_features.add("chess")
+        config.available_features.add("valid_xchess_license")
+        lm_license_file = os.getenv("LM_LICENSE_FILE")
+        if lm_license_file != None:
+            llvm_config.with_environment("LM_LICENSE_FILE", lm_license_file)
+        xilinxd_license_file = os.getenv("XILINXD_LICENSE_FILE")
+        if xilinxd_license_file != None:
+            llvm_config.with_environment("XILINXD_LICENSE_FILE", xilinxd_license_file)
 
         validate_chess = False
-        if(validate_chess):
+        if validate_chess:
             import subprocess
-            result = subprocess.run(['xchesscc','+v'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-            validLMLicense = (len(result.stderr.decode('utf-8')) == 0)
+
+            result = subprocess.run(
+                ["xchesscc", "+v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            validLMLicense = len(result.stderr.decode("utf-8")) == 0
         else:
             validLMLicense = lm_license_file or xilinxd_license_file
 
-        if(not lm_license_file and not xilinxd_license_file):
-            print("WARNING: no valid xchess license that is required by some of the lit tests")
+        if not lm_license_file and not xilinxd_license_file:
+            print(
+                "WARNING: no valid xchess license that is required by some of the lit tests"
+            )
 
     else:
         print("Chess not found")
 
 tool_dirs = [config.aie_tools_dir, config.peano_tools_dir, config.llvm_tools_dir]
 tools = [
-    'aie-opt',
-    'aie-translate',
-    'aiecc.py',
-    'ld.lld',
-    'llc',
-    'llvm-objdump',
-    'opt',
-    'xchesscc_wrapper',
+    "aie-opt",
+    "aie-translate",
+    "aiecc.py",
+    "ld.lld",
+    "llc",
+    "llvm-objdump",
+    "opt",
+    "xchesscc_wrapper",
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
-if(config.enable_board_tests):
+if config.enable_board_tests:
     lit_config.parallelism_groups["board"] = 1
     config.parallelism_group = "board"

--- a/reference_designs/lit.site.cfg.py.in
+++ b/reference_designs/lit.site.cfg.py.in
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 @LIT_SITE_CFG_IN_HEADER@
 
@@ -70,4 +70,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/lit.cfg.py")
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/reference_designs/lit.cfg.py")

--- a/reference_designs/lit.site.cfg.py.in
+++ b/reference_designs/lit.site.cfg.py.in
@@ -9,6 +9,8 @@
 @LIT_SITE_CFG_IN_HEADER@
 
 import sys
+import lit.util
+
 
 config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@TARGET_TRIPLE@"
@@ -44,12 +46,13 @@ config.aie_obj_root = "@AIE_BINARY_DIR@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 
 # pass on vitis settings
-config.enable_chess_tests = @CONFIG_ENABLE_CHESS_TESTS@
-config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
+config.enable_board_tests = lit.util.pythonize_bool("@ENABLE_BOARD_TESTS@")
+config.enable_chess_tests = lit.util.pythonize_bool("@ENABLE_CHESS_TESTS@")
+config.has_libxaie = lit.util.pythonize_bool("@LibXAIE_FOUND@")
+
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"
 config.aieInstallPrefix = "@CMAKE_INSTALL_PREFIX@"
@@ -64,7 +67,6 @@ except KeyError:
     key, = e.args
     lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
 
-config.aie_include_integration_tests = "@AIE_INCLUDE_INTEGRATION_TESTS@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,125 +1,8 @@
-#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2021 Xilinx Inc.
-
-cmake_minimum_required(VERSION 3.10)
-
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-if(POLICY CMP0068)
-  cmake_policy(SET CMP0068 NEW)
-  set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
-endif()
-
-if(POLICY CMP0075)
-  cmake_policy(SET CMP0075 NEW)
-endif()
-
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
-project(aie-test LANGUAGES CXX C)
-
-# find package AIE if running tests from AIE installation
-if(NOT AIE_BINARY_DIR)
-  find_package(AIE REQUIRED CONFIG)
-  set(LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR CACHE STRING "") #pick up libxaiengine from installation folder if no other location specified
-endif()
-
-# default to x86_64 system architecture for runtime target
-set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runtime libraries for.")
-list(GET AIE_RUNTIME_TARGETS 0 firstRuntimeTarget)
-set(AIE_RUNTIME_TEST_TARGET ${firstRuntimeTarget} CACHE STRING "Runtime architecture to test with.")
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-
-option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
-option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
-
-find_package(MLIR REQUIRED CONFIG)
-
-message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
-set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
-set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
-set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
-
-find_package(Vitis 2023.2 COMPONENTS AIE AIE2)
-find_package(Python3 COMPONENTS Interpreter)
-
-if(Vitis_FOUND)
-  set(DEFAULT_ENABLE_CHESS_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_CHESS_TESTS OFF)
-endif()
-option(ENABLE_CHESS_TESTS "Enable backend tests using xchesscc" ${DEFAULT_ENABLE_CHESS_TESTS})
-
-if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64)
-  set(DEFAULT_ENABLE_BOARD_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_BOARD_TESTS OFF)
-endif()
-option(ENABLE_BOARD_TESTS "Enable board tests" ${DEFAULT_ENABLE_BOARD_TESTS})
-
-# Look for LibXAIE
-if (DEFINED LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR)
-    message("Test using xaiengine from LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR=${LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR}")
-    set(LibXAIE_ROOT ${LibXAIE_${target}_DIR})
-    find_package(LibXAIE)
-else()
-  if(DEFINED VITIS_ROOT)
-    message(STATUS "Test has Vitis available, no libxaie location specified so pick up from build area")
-    set(LibXAIE_FOUND TRUE)
-  endif()
-endif()
-
-# Define the default arguments to use with 'lit', and an option for the user to
-# override.
-set(LIT_ARGS_DEFAULT "-sv")
-if (MSVC_IDE OR XCODE)
-  set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
-endif()
-set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
-
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
-include(HandleLLVMOptions)
-
-include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_BINARY_DIR}/include)
-add_definitions(${LLVM_DEFINITIONS})
-
-if(ENABLE_CHESS_TESTS)
-set(CONFIG_ENABLE_CHESS_TESTS 1)
-else()
-set(CONFIG_ENABLE_CHESS_TESTS 0)
-endif()
-if(ENABLE_BOARD_TESTS)
-set(CONFIG_ENABLE_BOARD_TESTS 1)
-else()
-set(CONFIG_ENABLE_BOARD_TESTS 0)
-endif()
-if(LibXAIE_FOUND)
-set(CONFIG_HAS_LIBXAIE 1)
-else()
-set(CONFIG_HAS_LIBXAIE 0)
-endif()
-
-set(ENABLE_PYTHON_TESTS 1)
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
@@ -134,13 +17,14 @@ set(TEST_DEPENDS
   aie-opt
   aie-translate
   AIEPythonModules
-  )
+)
 
 add_lit_testsuite(check-aie "Running the aie regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${TEST_DEPENDS}
   ARGS "-sv --timeout 600 --time-tests --show-unsupported"
-  )
+)
+
 set_target_properties(check-aie PROPERTIES FOLDER "Tests")
 
 add_lit_testsuites(AIE ${CMAKE_CURRENT_BINARY_DIR} DEPENDS ${TEST_DEPENDS} ARGS "-sv --timeout 600 --time-tests --show-unsupported")

--- a/test/Integration/lit.local.cfg
+++ b/test/Integration/lit.local.cfg
@@ -5,7 +5,7 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
-if config.aie_include_integration_tests != 'ON':
+if not config.aie_include_integration_tests:
     config.unsupported = True
 
 tosa_to_linalg = '--pass-pipeline="builtin.module(func.func(tosa-to-linalg-named, tosa-to-linalg, tosa-to-tensor))"'

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -9,6 +9,7 @@
 @LIT_SITE_CFG_IN_HEADER@
 
 import sys
+import lit.util
 
 config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@TARGET_TRIPLE@"
@@ -44,16 +45,18 @@ config.aie_obj_root = "@AIE_BINARY_DIR@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 
 # pass on vitis settings
-config.enable_chess_tests = @CONFIG_ENABLE_CHESS_TESTS@
-config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
+config.enable_board_tests = lit.util.pythonize_bool("@ENABLE_BOARD_TESTS@")
+config.enable_chess_tests = lit.util.pythonize_bool("@ENABLE_CHESS_TESTS@")
+config.has_libxaie = lit.util.pythonize_bool("@LibXAIE_FOUND@")
+config.enable_python_tests = lit.util.pythonize_bool("@ENABLE_PYTHON_TESTS@")
+config.aie_include_integration_tests = lit.util.pythonize_bool("@AIE_INCLUDE_INTEGRATION_TESTS@")
+
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"
 config.aieInstallPrefix = "@CMAKE_INSTALL_PREFIX@"
-config.enable_python_tests = @ENABLE_PYTHON_TESTS@
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.
@@ -65,7 +68,6 @@ except KeyError:
     key, = e.args
     lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
 
-config.aie_include_integration_tests = "@AIE_INCLUDE_INTEGRATION_TESTS@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2021 Xilinx Inc.
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 @LIT_SITE_CFG_IN_HEADER@
 
@@ -71,4 +71,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/lit.cfg.py")
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/test/lit.cfg.py")

--- a/tutorials/CMakeLists.txt
+++ b/tutorials/CMakeLists.txt
@@ -1,123 +1,9 @@
-#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 
-cmake_minimum_required(VERSION 3.10)
-
-if(POLICY CMP0074)
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-if(POLICY CMP0068)
-  cmake_policy(SET CMP0068 NEW)
-  set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
-endif()
-
-if(POLICY CMP0075)
-  cmake_policy(SET CMP0075 NEW)
-endif()
-
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
-project(aie-tutorials LANGUAGES CXX C)
-
-# find package AIE if running tests from AIE installation
-if(NOT AIE_BINARY_DIR)
-  find_package(AIE REQUIRED CONFIG)
-  set(LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR CACHE STRING "") #pick up libxaiengine from installation folder if no other location specified
-endif()
-
-# default to x86_64 system architecture for runtime target
-set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runtime libraries for.")
-list(GET AIE_RUNTIME_TARGETS 0 firstRuntimeTarget)
-set(AIE_RUNTIME_TEST_TARGET ${firstRuntimeTarget} CACHE STRING "Runtime architecture to test with.")
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-
-option(LLVM_INCLUDE_TOOLS "Generate build targets for the LLVM tools." ON)
-option(LLVM_BUILD_TOOLS "Build the LLVM tools. If OFF, just generate build targets." ON)
-
-if(Vitis_FOUND)
-  set(DEFAULT_ENABLE_CHESS_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_CHESS_TESTS OFF)
-endif()
-option(ENABLE_CHESS_TESTS "Enable backend tests using xchesscc" ${DEFAULT_ENABLE_CHESS_TESTS})
-
-if(${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL aarch64)
-  set(DEFAULT_ENABLE_BOARD_TESTS ON)
-else()
-  set(DEFAULT_ENABLE_BOARD_TESTS OFF)
-endif()
-option(ENABLE_BOARD_TESTS "Enable board tests" ${DEFAULT_ENABLE_BOARD_TESTS})
-
-find_package(MLIR REQUIRED CONFIG)
-
-message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
-set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
-set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
-set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
-
-find_package(Vitis 2023.2 COMPONENTS AIE AIE2)
-find_package(Python3 COMPONENTS Interpreter)
-
-# Look for LibXAIE
-if (DEFINED LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR)
-    message("Tutorials using xaiengine from LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR=${LibXAIE_${AIE_RUNTIME_TEST_TARGET}_DIR}")
-    set(LibXAIE_ROOT ${LibXAIE_${target}_DIR})
-    find_package(LibXAIE) 
-else()
-  if(DEFINED VITIS_ROOT)
-    message(STATUS "Tutorials have Vitis available, no libxaie location specified so pick up from build area")
-    set(LibXAIE_FOUND TRUE)
-  endif()
-endif()
-
-# Define the default arguments to use with 'lit', and an option for the user to
-# override.
-set(LIT_ARGS_DEFAULT "-sv")
-if (MSVC_IDE OR XCODE)
-  set(LIT_ARGS_DEFAULT "${LIT_ARGS_DEFAULT} --no-progress-bar")
-endif()
-set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
-
-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-
-include(TableGen)
-include(AddLLVM)
-include(AddMLIR)
-include(HandleLLVMOptions)
-
-include_directories(${LLVM_INCLUDE_DIRS})
-include_directories(${MLIR_INCLUDE_DIRS})
-include_directories(${PROJECT_SOURCE_DIR}/include)
-include_directories(${PROJECT_BINARY_DIR}/include)
-add_definitions(${LLVM_DEFINITIONS})
-
-if(ENABLE_CHESS_TESTS)
-set(CONFIG_ENABLE_CHESS_TESTS 1)
-else()
-set(CONFIG_ENABLE_CHESS_TESTS 0)
-endif()
-if(ENABLE_BOARD_TESTS)
-set(CONFIG_ENABLE_BOARD_TESTS 1)
-else()
-set(CONFIG_ENABLE_BOARD_TESTS 0)
-endif()
-if(LibXAIE_FOUND)
-set(CONFIG_HAS_LIBXAIE 1)
-else()
-set(CONFIG_HAS_LIBXAIE 0)
-endif()
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
@@ -130,13 +16,14 @@ set(TEST_DEPENDS
   aiecc.py
   aie-opt
   aie-translate
-  )
+)
 
 add_lit_testsuite(check-tutorials "Running the aie tutorials tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${TEST_DEPENDS}
   ARGS "-sv --timeout 300 --time-tests"
-  )
+)
+
 set_target_properties(check-tutorials PROPERTIES FOLDER "Tutorials")
 
 add_lit_testsuites(TUTORIALS ${CMAKE_CURRENT_BINARY_DIR} DEPENDS ${TEST_DEPENDS} ARGS "-sv --timeout 300 --time-tests")

--- a/tutorials/lit.cfg.py
+++ b/tutorials/lit.cfg.py
@@ -23,80 +23,98 @@ from lit.llvm.subst import FindTool
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = 'AIE_TUTORIALS'
+config.name = "AIE_TUTORIALS"
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.mlir']
+config.suffixes = [".mlir"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 
-config.substitutions.append(('%PATH%', config.environment['PATH']))
-config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
-config.substitutions.append(('%extraAieCcFlags%', config.extraAieCcFlags))
-config.substitutions.append(('%host_runtime_lib%', os.path.join(config.aie_obj_root, "runtime_lib",config.aieHostTarget)))
-config.substitutions.append(('%aietools', config.vitis_aietools_dir))
+config.substitutions.append(("%PATH%", config.environment["PATH"]))
+config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
+config.substitutions.append(("%extraAieCcFlags%", config.extraAieCcFlags))
+config.substitutions.append(
+    (
+        "%host_runtime_lib%",
+        os.path.join(config.aie_obj_root, "runtime_lib", config.aieHostTarget),
+    )
+)
+config.substitutions.append(("%aietools", config.vitis_aietools_dir))
 # for xchesscc_wrapper
-llvm_config.with_environment('AIETOOLS', config.vitis_aietools_dir)
+llvm_config.with_environment("AIETOOLS", config.vitis_aietools_dir)
 
-if(config.enable_board_tests):
-    config.substitutions.append(('%run_on_board', "echo %T >> /home/xilinx/testlog | sync | sudo"))
+if config.enable_board_tests:
+    config.substitutions.append(
+        ("%run_on_board", "echo %T >> /home/xilinx/testlog | sync | sudo")
+    )
 else:
-    config.substitutions.append(('%run_on_board', "echo"))
+    config.substitutions.append(("%run_on_board", "echo"))
 
-VitisSysrootFlag = ''
-if (config.aieHostTarget == 'x86_64'):
-    config.substitutions.append(('%aieHostTargetTriplet%', 'x86_64-unknown-linux-gnu'))
-elif (config.aieHostTarget == 'aarch64'):
-    config.substitutions.append(('%aieHostTargetTriplet%', 'aarch64-linux-gnu'))
-    VitisSysrootFlag = '--sysroot='+config.vitis_sysroot
+VitisSysrootFlag = ""
+if config.aieHostTarget == "x86_64":
+    config.substitutions.append(("%aieHostTargetTriplet%", "x86_64-unknown-linux-gnu"))
+elif config.aieHostTarget == "aarch64":
+    config.substitutions.append(("%aieHostTargetTriplet%", "aarch64-linux-gnu"))
+    VitisSysrootFlag = "--sysroot=" + config.vitis_sysroot
 
-config.substitutions.append(('%VitisSysrootFlag%', VitisSysrootFlag))
-config.substitutions.append(('%aieHostTargetArch%', config.aieHostTarget))
+config.substitutions.append(("%VitisSysrootFlag%", VitisSysrootFlag))
+config.substitutions.append(("%aieHostTargetArch%", config.aieHostTarget))
 
-llvm_config.with_system_environment(
-    ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP'])
+llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP"])
 
 llvm_config.use_default_substitutions()
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.
-config.excludes = ['Inputs', 'Examples', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt', 'aie.mlir.prj']
+config.excludes = [
+    "Inputs",
+    "Examples",
+    "CMakeLists.txt",
+    "README.txt",
+    "LICENSE.txt",
+    "aie.mlir.prj",
+]
 
-config.aie_tools_dir = os.path.join(config.aie_obj_root, 'bin')
+config.aie_tools_dir = os.path.join(config.aie_obj_root, "bin")
+
 
 def prepend_path(path):
     global llvm_config
     paths = [path]
 
-    current_paths = llvm_config.config.environment.get('PATH', None)
+    current_paths = llvm_config.config.environment.get("PATH", None)
     if current_paths:
         paths.extend(current_paths.split(os.path.pathsep))
         paths = [os.path.normcase(os.path.normpath(p)) for p in paths]
     else:
         paths = []
 
-    llvm_config.config.environment['PATH'] = os.pathsep.join(paths)
+    llvm_config.config.environment["PATH"] = os.pathsep.join(paths)
+
 
 # Setup the path.
 prepend_path(config.llvm_tools_dir)
 prepend_path(config.peano_tools_dir)
 prepend_path(config.aie_tools_dir)
-#llvm_config.with_environment('LM_LICENSE_FILE', os.getenv('LM_LICENSE_FILE'))
-#llvm_config.with_environment('XILINXD_LICENSE_FILE', os.getenv('XILINXD_LICENSE_FILE'))
-if(config.vitis_root):
-  config.vitis_aietools_bin = os.path.join(config.vitis_aietools_dir, "bin")
-  prepend_path(config.vitis_aietools_bin)
-  llvm_config.with_environment('VITIS', config.vitis_root)
+
+if config.vitis_root:
+    config.vitis_aietools_bin = os.path.join(config.vitis_aietools_dir, "bin")
+    prepend_path(config.vitis_aietools_bin)
+    llvm_config.with_environment("VITIS", config.vitis_root)
 
 # Test to see if we have the peano backend.
 try:
-    result = subprocess.run([os.path.join(config.peano_tools_dir, 'llc'),'-mtriple=aie','--version'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-    if (re.search("Xilinx AI Engine", result.stdout.decode('utf-8')) is not None):
-        config.available_features.add('peano')
+    result = subprocess.run(
+        [os.path.join(config.peano_tools_dir, "llc"), "-mtriple=aie", "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if re.search("Xilinx AI Engine", result.stdout.decode("utf-8")) is not None:
+        config.available_features.add("peano")
         print("Peano found: " + shutil.which("llc"))
     else:
         print("Peano not found, but expected at ", config.peano_tools_dir)
@@ -104,51 +122,56 @@ except Exception as e:
     print("Peano not found, but expected at ", config.peano_tools_dir)
 
 print("Looking for Chess...")
-#test if LM_LICENSE_FILE valid
-if(config.enable_chess_tests):
+# test if LM_LICENSE_FILE valid
+if config.enable_chess_tests:
     result = None
-    if(config.vitis_root):
+    if config.vitis_root:
         result = shutil.which("xchesscc")
 
     if result != None:
         print("Chess found: " + result)
-        config.available_features.add('chess')
-        config.available_features.add('valid_xchess_license')
-        lm_license_file = os.getenv('LM_LICENSE_FILE')
-        if(lm_license_file != None):
-            llvm_config.with_environment('LM_LICENSE_FILE', lm_license_file)
-        xilinxd_license_file = os.getenv('XILINXD_LICENSE_FILE')
-        if(xilinxd_license_file != None):
-            llvm_config.with_environment('XILINXD_LICENSE_FILE', xilinxd_license_file)
+        config.available_features.add("chess")
+        config.available_features.add("valid_xchess_license")
+        lm_license_file = os.getenv("LM_LICENSE_FILE")
+        if lm_license_file != None:
+            llvm_config.with_environment("LM_LICENSE_FILE", lm_license_file)
+        xilinxd_license_file = os.getenv("XILINXD_LICENSE_FILE")
+        if xilinxd_license_file != None:
+            llvm_config.with_environment("XILINXD_LICENSE_FILE", xilinxd_license_file)
 
         validate_chess = False
-        if(validate_chess):
+        if validate_chess:
             import subprocess
-            result = subprocess.run(['xchesscc','+v'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-            validLMLicense = (len(result.stderr.decode('utf-8')) == 0)
+
+            result = subprocess.run(
+                ["xchesscc", "+v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            validLMLicense = len(result.stderr.decode("utf-8")) == 0
         else:
             validLMLicense = lm_license_file or xilinxd_license_file
 
-        if(not lm_license_file and not xilinxd_license_file):
-            print("WARNING: no valid xchess license that is required by some of the lit tests")
+        if not lm_license_file and not xilinxd_license_file:
+            print(
+                "WARNING: no valid xchess license that is required by some of the lit tests"
+            )
 
     else:
         print("Chess not found")
 
 tool_dirs = [config.aie_tools_dir, config.peano_tools_dir, config.llvm_tools_dir]
 tools = [
-    'aie-opt',
-    'aie-translate',
-    'aiecc.py',
-    'ld.lld',
-    'llc',
-    'llvm-objdump',
-    'opt',
-    'xchesscc_wrapper',
+    "aie-opt",
+    "aie-translate",
+    "aiecc.py",
+    "ld.lld",
+    "llc",
+    "llvm-objdump",
+    "opt",
+    "xchesscc_wrapper",
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
-if(config.enable_board_tests):
+if config.enable_board_tests:
     lit_config.parallelism_groups["board"] = 1
     config.parallelism_group = "board"

--- a/tutorials/lit.local.cfg
+++ b/tutorials/lit.local.cfg
@@ -1,9 +1,8 @@
-#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 config.unsupported = []
 

--- a/tutorials/lit.site.cfg.py.in
+++ b/tutorials/lit.site.cfg.py.in
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 @LIT_SITE_CFG_IN_HEADER@
 
@@ -70,4 +70,4 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/lit.cfg.py")
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/tutorials/lit.cfg.py")

--- a/tutorials/lit.site.cfg.py.in
+++ b/tutorials/lit.site.cfg.py.in
@@ -9,6 +9,7 @@
 @LIT_SITE_CFG_IN_HEADER@
 
 import sys
+import lit.util
 
 config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@TARGET_TRIPLE@"
@@ -44,12 +45,13 @@ config.aie_obj_root = "@AIE_BINARY_DIR@"
 config.test_exec_root = "@CMAKE_CURRENT_BINARY_DIR@"
 
 # pass on vitis settings
-config.enable_chess_tests = @CONFIG_ENABLE_CHESS_TESTS@
-config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
+config.enable_board_tests = lit.util.pythonize_bool("@ENABLE_BOARD_TESTS@")
+config.enable_chess_tests = lit.util.pythonize_bool("@ENABLE_CHESS_TESTS@")
+config.has_libxaie = lit.util.pythonize_bool("@LibXAIE_FOUND@")
+
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"
 config.aieInstallPrefix = "@CMAKE_INSTALL_PREFIX@"
@@ -64,7 +66,6 @@ except KeyError:
     key, = e.args
     lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
 
-config.aie_include_integration_tests = "@AIE_INCLUDE_INTEGRATION_TESTS@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
Not sure what the idea here is/was but having multiple reloads of everything (LLVM/MLIR/etc) resets CMake global properties like `MLIR_DIALECT_LIBS`, `MLIR_CONVERSION_LIBS`, etc..