### PR TITLE
[nfc] Generalize type constraints for AIE operands

### DIFF
--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -751,14 +751,19 @@ def AIEVec_BxorOp:
     Pure,
     AllTypesMatch<["lhs", "rhs", "result"]>
   ]>,
-  Arguments<(ins AIEBitwiseOperand:$lhs, AIEBitwiseOperand:$rhs)>,
-  Results<(outs AIEBitwiseOperand:$result)> {
+  Arguments<(ins
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$lhs,
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$rhs)>,
+  Results<(outs
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$result)> {
   let summary = "AIE vector bitwise xor";
   let description = [{
-    AMD-specific intrinsic that computes bitwise xor of two vectors and returns the result.
+    AMD-specific intrinsic that computes bitwise xor of two vectors and returns
+    the result.
     `$result = bxor(`$lhs, $rhs`).
   }];
-  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `,` type($result)";
+  let assemblyFormat = [{$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs)
+                         `,` type($result)}];
   let hasVerifier = 0;
 }
 
@@ -767,11 +772,14 @@ def AIEVec_BnegOp:
     Pure,
     AllTypesMatch<["source", "result"]>
   ]>,
-  Arguments<(ins AIEBitwiseOperand:$source)>,
-  Results<(outs AIEBitwiseOperand:$result)> {
+  Arguments<(ins
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$source)>,
+  Results<(outs
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$result)> {
   let summary = "AIE vector bitwise negation";
   let description = [{
-    AMD-specific intrinsic that computes bitwise negation of a vector and returns the result.
+    AMD-specific intrinsic that computes bitwise negation of a vector and
+    returns the result.
     `$result = bneg(`$source`).
   }];
   let assemblyFormat = "$source attr-dict `:` type($result)";
@@ -783,14 +791,19 @@ def AIEVec_BorOp:
     Pure,
     AllTypesMatch<["lhs", "rhs", "result"]>
   ]>,
-  Arguments<(ins AIEBitwiseOperand:$lhs, AIEBitwiseOperand:$rhs)>,
-  Results<(outs AIEBitwiseOperand:$result)> {
+  Arguments<(ins
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$lhs,
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$rhs)>,
+  Results<(outs
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$result)> {
   let summary = "AIE vector bitwise or";
   let description = [{
-    AMD-specific intrinsic that computes bitwise or of two vectors and returns the result.
+    AMD-specific intrinsic that computes bitwise or of two vectors and returns
+    the result.
     `$result = bor(`$lhs, $rhs`).
   }];
-  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `,` type($result)";
+  let assemblyFormat = [{$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs)
+                         `,` type($result)}];
   let hasVerifier = 0;
 }
 
@@ -799,14 +812,19 @@ def AIEVec_BandOp:
     Pure,
     AllTypesMatch<["lhs", "rhs", "result"]>
   ]>,
-  Arguments<(ins AIEBitwiseOperand:$lhs, AIEBitwiseOperand:$rhs)>,
-  Results<(outs AIEBitwiseOperand:$result)> {
+  Arguments<(ins
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$lhs,
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$rhs)>,
+  Results<(outs
+      VectorOfBitWidthAndElementTypes<512, [I8, I16, I32, BF16]>:$result)> {
   let summary = "AIE vector bitwise and";
   let description = [{
-    AMD-specific intrinsic that computes bitwise and of two vectors and returns the result.
+    AMD-specific intrinsic that computes bitwise and of two vectors and returns
+    the result.
     `$result = band(`$lhs, $rhs`).
   }];
-  let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `,` type($result)";
+  let assemblyFormat = [{$lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs)
+                         `,` type($result)}];
   let hasVerifier = 0;
 }
 

--- a/include/aie/Dialect/AIEVec/IR/AIEVecTypeConstraints.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecTypeConstraints.td
@@ -38,6 +38,15 @@ class VectorOfShapeAndType<list<int> shape, Type type> :
         "vector of shape <" # !interleave(shape, "x") # "> and",
         "::mlir::VectorType">;
 
+class ShapedTypeBitWidth<string name> :
+  StrFunc<"(cast<::mlir::ShapedType>($" # name # ").getElementTypeBitWidth() * "
+          # !subst(".getType()", "", ElementCount<name>.result) # ")">;
+
+class VectorOfBitWidthAndElementTypes<int bitwidth, list<Type> allowedTypes> :
+  Type<And<[VectorOf<allowedTypes>.predicate,
+            CPred<ShapedTypeBitWidth<"_self">.result # " == " # bitwidth>]>,
+       bitwidth # "-bit wide vector, of " # AnyTypeOf<allowedTypes>.summary>;
+
 def AIE2MatMulLHS :
   AnyTypeOf<[VectorOfShapeAndType<[4, 16], I8>,
              VectorOfShapeAndType<[4, 8], I8>,
@@ -75,23 +84,6 @@ def AIE2MatMulACC :
             "a vector compatible with an accumulator of matrix-multiply and "
             # "accumulate",
             "::mlir::VectorType">;
-
-def AIEOperand_64xi8  : VectorOfShapeAndType<[64], I8>;
-def AIEOperand_32xi8  : VectorOfShapeAndType<[32], I8>;
-def AIEOperand_32xi16 : VectorOfShapeAndType<[32], I16>;
-def AIEOperand_16xi16  : VectorOfShapeAndType<[16], I16>;
-def AIEOperand_32xi32  : VectorOfShapeAndType<[32], I32>;
-def AIEOperand_16xi32  : VectorOfShapeAndType<[16], I32>;
-def AIEOperand_32xbf16 : VectorOfShapeAndType<[32], BF16>;
-def AIEOperand_16xbf16 : VectorOfShapeAndType<[16], BF16>;
-def AIEOperand_16xf32 : VectorOfShapeAndType<[16], F32>;
-
-def AIEBitwiseOperand :
-  AnyTypeOf<[AIEOperand_64xi8,
-             AIEOperand_32xi16,
-             AIEOperand_16xi32,
-             AIEOperand_32xbf16],
-            "a vector compatible with an operand of bitwise operators">;
 
 class ShapeDimsMatch<string lhs, int ld, string rhs, int rd> :
   CPred<Shape<lhs>.result # "[" # ld # "] == " #


### PR DESCRIPTION
Instead of using unnecessarily specific types, add classes that allow us to express the constraints in a more widely applicable way.