### PR TITLE
Refactor AIEX headers

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEXDialect.h
+++ b/include/aie/Dialect/AIEX/IR/AIEXDialect.h
@@ -50,26 +50,4 @@ public:
 #define GET_OP_CLASSES
 #include "aie/Dialect/AIEX/IR/AIEX.h.inc"
 
-namespace xilinx::AIEX {
-
-#define GEN_PASS_CLASSES
-#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
-
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIECreateCoresPass();
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIECreateLocksPass();
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIEHerdRoutingPass();
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIELowerMemcpyPass();
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
-createAIELowerMulticastPass();
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
-createAIEBroadcastPacketPass();
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIEDmaToIpuPass();
-std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createAIEXToStandardPass();
-
-/// Generate the code for registering passes.
-#define GEN_PASS_REGISTRATION
-#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
-
-} // namespace xilinx::AIEX
-
 #endif

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -15,16 +15,26 @@
 
 #include "mlir/Pass/Pass.h"
 
-namespace xilinx::AIE {
+namespace xilinx::AIEX {
 
-//===----------------------------------------------------------------------===//
-// Registration
-//===----------------------------------------------------------------------===//
+#define GEN_PASS_CLASSES
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIECreateCoresPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIECreateLocksPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIEHerdRoutingPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIELowerMemcpyPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
+createAIELowerMulticastPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
+createAIEBroadcastPacketPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIEDmaToIpuPass();
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createAIEXToStandardPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
 
-} // namespace xilinx::AIE
+} // namespace xilinx::AIEX
 
 #endif // AIEX_PASSES_H

--- a/lib/CAPI/Registration.cpp
+++ b/lib/CAPI/Registration.cpp
@@ -10,10 +10,10 @@
 #include "aie/InitialAllDialect.h"
 
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h"
-#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 #include "aie/Dialect/AIEVec/Analysis/Passes.h"
 #include "aie/Dialect/AIEVec/Pipelines/Passes.h"
 #include "aie/Dialect/AIEVec/Transforms/Passes.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 void aieRegisterAllDialects(MlirContext context) {
   mlir::DialectRegistry registry;

--- a/lib/CAPI/Registration.cpp
+++ b/lib/CAPI/Registration.cpp
@@ -10,6 +10,7 @@
 #include "aie/InitialAllDialect.h"
 
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 #include "aie/Dialect/AIEVec/Analysis/Passes.h"
 #include "aie/Dialect/AIEVec/Pipelines/Passes.h"
 #include "aie/Dialect/AIEVec/Transforms/Passes.h"

--- a/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
@@ -10,6 +10,7 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/PatternMatch.h"

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -10,6 +10,7 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
@@ -11,6 +11,7 @@
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/AIETokenAnalysis.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/PatternMatch.h"

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"

--- a/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
@@ -10,6 +10,7 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/PatternMatch.h"

--- a/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
@@ -11,6 +11,8 @@
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/AIETokenAnalysis.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Attributes.h"

--- a/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
@@ -10,6 +10,7 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/PatternMatch.h"

--- a/lib/Dialect/AIEX/Transforms/AIEXToStandard.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEXToStandard.cpp
@@ -10,6 +10,7 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/IRMapping.h"


### PR DESCRIPTION
For some reason, part of the Pass definitions were still in the main Dialect header file.