### PR TITLE
fix path issues

### DIFF
--- a/utils/build-mlir-aie-ryzen-ai.sh
+++ b/utils/build-mlir-aie-ryzen-ai.sh
@@ -9,7 +9,7 @@
 # This script builds mlir-aie given <llvm dir>.
 # Assuming they are all in the same subfolder, it would look like:
 #
-# build-mlir-aie.sh <llvm dir> <build dir> <install dir>
+# build-mlir-aie.sh <llvm build dir> <build dir> <install dir>
 #
 # e.g. build-mlir-aie.sh /scratch/llvm/build
 #
@@ -92,7 +92,7 @@ if [ -x "$(command -v ccache)" ]; then
   CMAKE_CONFIGS="${CMAKE_CONFIGS} -DLLVM_CCACHE_BUILD=ON"
 fi
 
-cmake $CMAKE_CONFIGS ../llvm 2>&1 | tee cmake.log
+cmake $CMAKE_CONFIGS  2>&1 | tee cmake.log
 ninja 2>&1 | tee mlir-aie-ninja.log
 ninja install 2>&1 | tee mlir-aie-ninja-install.log
 success=$?

--- a/utils/build-mlir-aie.sh
+++ b/utils/build-mlir-aie.sh
@@ -9,9 +9,9 @@
 # This script builds mlir-aie given <llvm dir>.
 # Assuming they are all in the same subfolder, it would look like:
 #
-# build-mlir-aie.sh <llvm dir> <build dir> <install dir>
+# build-mlir-aie.sh <llvm build dir> <build dir> <install dir>
 #
-# e.g. build-mlir-aie.sh /scratch/llvm
+# e.g. build-mlir-aie.sh /scratch/llvm/build
 #
 # <build dir>    - optional, mlir-aie/build dir name, default is 'build'
 # <install dir>  - optional, mlir-aie/install dir name, default is 'install'
@@ -27,9 +27,10 @@ BASE_DIR=`realpath $(dirname $0)/..`
 CMAKEMODULES_DIR=$BASE_DIR/cmake
 
 LLVM_BUILD_DIR=`realpath $1`
+echo "LLVM BUILD DIR: $LLVM_BUILD_DIR"
 
-BUILD_DIR=${3:-"build"}
-INSTALL_DIR=${4:-"install"}
+BUILD_DIR=${2:-"build"}
+INSTALL_DIR=${3:-"install"}
 
 mkdir -p $BUILD_DIR
 mkdir -p $INSTALL_DIR
@@ -56,6 +57,6 @@ if [ -x "$(command -v ccache)" ]; then
   CMAKE_CONFIGS="${CMAKE_CONFIGS} -DLLVM_CCACHE_BUILD=ON"
 fi
 
-cmake $CMAKE_CONFIGS ../llvm 2>&1 | tee cmake.log
+cmake $CMAKE_CONFIGS .. 2>&1 | tee cmake.log
 ninja 2>&1 | tee ninja.log
 ninja install 2>&1 | tee ninja-install.log


### PR DESCRIPTION
the mlir-aie build script will find its CMakeLists.txt in to root folder, not in the llvm subfolder. I think this is a cut and paste mistake from the llvm build scripts.
Most likely other mlir-aie build scripts need fix as well.