### PR TITLE
Scripts to enable local build from github actions workflow using nektos/act

### DIFF
--- a/.github/workflows/buildAndTestLocal.yml
+++ b/.github/workflows/buildAndTestLocal.yml
@@ -43,7 +43,8 @@ jobs:
 
     container:
       image:  amd/acdcbuild:1.1
-
+      volumes: 
+        - ${{github.workspace}}/llvm-central-repo:/workspace/llvm-central-repo
     steps:
       
       - name: Display environment variables
@@ -110,13 +111,6 @@ jobs:
       - name: Configure ccache environment
         run :  echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH  
         
-      - name: Install Dependencies
-        run: |
-          apt-get update
-          apt-get install -y git nodejs pip ninja-build clang lld zstd
-          pip install cmake numpy psutil pybind11 rich
-        
-
       # Clone the repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get the project repository
@@ -127,7 +121,7 @@ jobs:
 
       - name: Get LLVM
         id: clone-llvm
-        run: utils/clone-llvm.sh
+        run: ${{github.workspace}}/utils/clone-llvm.sh --llvm-worktree /workspace/llvm-central-repo
 
       - name: Get LLVM commit hash
         id: get-llvm-commit-hash

--- a/.github/workflows/buildAndTestLocal.yml
+++ b/.github/workflows/buildAndTestLocal.yml
@@ -21,7 +21,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
-  build-repo:
+  build-repo-local:
     name: Build and Test
 
     # By latest GitHub means actually latest LTS only
@@ -40,10 +40,12 @@ jobs:
     # Action has also the advantage of having 2 CPU instead of 1, so
     # it runs faster. But these images have quite less software
     # installed compared to the GitHub Ubuntu distribution for example.
+
     container:
-      image: ubuntu:${{matrix.ubuntu_version}}
+      image:  amd/acdcbuild:1.1
 
     steps:
+      
       - name: Display environment variables
         run: env
 
@@ -104,15 +106,16 @@ jobs:
           echo "::endgroup::"
 
       - name: Configure environment
-        run: echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
-
-      - name: Install git
+        run:  echo "$GITHUB_WORKSPACE/llvm/install/bin" >> $GITHUB_PATH
+      - name: Configure ccache environment
+        run :  echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH  
+        
+      - name: Install Dependencies
         run: |
           apt-get update
-          apt-get install -y git
-          
-      - name: Install node
-        run: apt-get install -y nodejs
+          apt-get install -y git nodejs pip ninja-build clang lld zstd
+          pip install cmake numpy psutil pybind11 rich
+        
 
       # Clone the repo and its submodules. Do shallow clone to save clone
       # time.
@@ -121,24 +124,6 @@ jobs:
         with:
           fetch-depth: 2
           submodules: "true"
-
-      - name: Install Python and other packages
-        # Install cmake here to get the latest version to compile
-        # LLVM. The Ubuntu 20.04 cmake version is only 3.16.3
-        run: |
-          apt-get install -y pip
-          pip install cmake numpy psutil pybind11 rich
-
-      - name: Install Ninja
-        # Can not use the following since it wants to use `sudo` not
-        # available in the case of Docker execution
-        # https://github.com/llvm/actions/tree/main/install-ninja
-        # uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c
-        # So just use the specific implementation instead:
-        run: apt-get install -y ninja-build
-
-      - name: Install lld and clang (for aiecc)
-        run: apt-get install -y clang lld
 
       - name: Get LLVM
         id: clone-llvm
@@ -158,6 +143,7 @@ jobs:
           # use a different key per job to avoid a ccache writing race condition
           key: ${{ matrix.build_type }}-${{ runner.os }}-${{ matrix.ubuntu_version }}-${{ steps.get-llvm-commit-hash.outputs.hash }}
           max-size: 1G
+          append-timestamp: false
 
       - name: Build and install LLVM
         run: utils/build-llvm.sh

--- a/platforms/build/Dockerfile
+++ b/platforms/build/Dockerfile
@@ -1,0 +1,6 @@
+     FROM ubuntu:20.04
+     ARG DEBIAN_FRONTEND=noninteractive
+     ENV TZ=Etc/UTC
+     RUN apt-get -qq update && \
+          apt-get -qq install -y git nodejs pip ninja-build clang lld zstd && \
+          pip install cmake numpy psutil pybind11 rich

--- a/platforms/build/Makefile
+++ b/platforms/build/Makefile
@@ -1,13 +1,17 @@
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+LOCAL_LLVM_REPO:=$(realpath ${ROOT_DIR}/../../)/llvm-central-repo
+
+export ACT_CACHE_AUTH_KEY=$(shell id -u --name)-cache-server
 
 # make a temporary file and fix up the Build and Test
 
+#  the local container if it doesn't exist
+
+
+# Create a directory for a local LLVM if it doesn't exist
+
 # Download act and install in temporary location
-
-# Build the local container if it doesn't exist
-
-# checkout a local LLVM if it doesn't exist
 test : ${ROOT_DIR}/bin/act
 
 ${ROOT_DIR}/bin/act : ${ROOT_DIR}/install.sh
@@ -16,9 +20,43 @@ ${ROOT_DIR}/bin/act : ${ROOT_DIR}/install.sh
 ${ROOT_DIR}/install.sh :
 	mkdir -p $(dir $@) && curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh -o $(dir $@)/install.sh
 
-all: ${ROOT_DIR}/bin/act
-	$< -j build-repo-local \
+${LOCAL_LLVM_REPO} :
+	mkdir -p $@
+
+checkip:
+	@docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${ACT_CACHE_AUTH_KEY}-app-1
+
+
+container : ${ROOT_DIR}/Dockerfile
+	docker build -t amd/acdcbuild:1.1 ${ROOT_DIR}
+
+all: ${ROOT_DIR}/bin/act ${LOCAL_LLVM_REPO}
+	export ACTIONS_IP=`docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${ACT_CACHE_AUTH_KEY}-app-1` && \
+	$< -C ${ROOT_DIR}/../.. -j build-repo-local \
 	--pull=false \
 	--workflows ${ROOT_DIR}/buildAndTestLocal.yml \
 	-P build-latest=amd/acdcbuild:1.1 \
-    --container-options "--volume $(realpath ${ROOT_DIR}/../../)/llvm-central-repo:$(realpath ${ROOT_DIR}/../../)/llvm-central-repo"
+    --container-options "--volume ${LOCAL_LLVM_REPO}:${LOCAL_LLVM_REPO}" \
+	--env ACTIONS_CACHE_URL=http://$${ACTIONS_IP}:8080/   \
+	--env ACTIONS_RUNTIME_URL=http://$${ACTIONS_IP}:8080/ \
+	--env ACTIONS_RUNTIME_TOKEN=${ACT_CACHE_AUTH_KEY} \
+	--network="${ACT_CACHE_AUTH_KEY}_default"
+
+# What is the value of this cache server? 
+# - Compatibility with github
+# - Sharing with other developers. 
+
+${ROOT_DIR}/cache-server : 
+	mkdir -p $@
+
+${ROOT_DIR}/cache-server/docker-compose.yml: 
+	git clone git@github.com:sp-ricard-valverde/github-act-cache-server.git $(dir $@) 
+
+.PHONY : cacheup
+cacheup : ${ROOT_DIR}/cache-server/docker-compose.yml
+	docker compose -f $<  --project-name ${ACT_CACHE_AUTH_KEY} up --build --detach
+
+cachedown:  ${ROOT_DIR}/cache-server/docker-compose.yml
+	docker compose -f $<  --project-name ${ACT_CACHE_AUTH_KEY} down 
+
+

--- a/platforms/build/Makefile
+++ b/platforms/build/Makefile
@@ -1,0 +1,24 @@
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+
+# make a temporary file and fix up the Build and Test
+
+# Download act and install in temporary location
+
+# Build the local container if it doesn't exist
+
+# checkout a local LLVM if it doesn't exist
+test : ${ROOT_DIR}/bin/act
+
+${ROOT_DIR}/bin/act : ${ROOT_DIR}/install.sh
+	bash $< -b $(dir $@)
+
+${ROOT_DIR}/install.sh :
+	mkdir -p $(dir $@) && curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh -o $(dir $@)/install.sh
+
+all: ${ROOT_DIR}/bin/act
+	$< -j build-repo-local \
+	--pull=false \
+	--workflows ${ROOT_DIR}/buildAndTestLocal.yml \
+	-P build-latest=amd/acdcbuild:1.1 \
+    --container-options "--volume $(realpath ${ROOT_DIR}/../../)/llvm-central-repo:$(realpath ${ROOT_DIR}/../../)/llvm-central-repo"

--- a/platforms/build/Readme.md
+++ b/platforms/build/Readme.md
@@ -1,0 +1,23 @@
+# Tools to build locally
+
+This directory contains tools that all the project to be built locally using the github workflow. 
+
+This is achieved using nektos/act - a utility that allows github actions to be executed in local docker instances. 
+
+# Dependencies
+
+Docker ( configured with unprivileged access using 'docker' group)
+
+# How to use
+
+To start the docker cache service ( compatible with the ccache github action)
+
+    make cacheup
+
+To build the local container used for build and test
+
+    make container
+
+To run a local build ( with ccache on all subsequent runs)
+
+    make all

--- a/platforms/build/build.sh
+++ b/platforms/build/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t amd/acdcbuild:1.1 .

--- a/platforms/build/buildAndTestLocal.yml
+++ b/platforms/build/buildAndTestLocal.yml
@@ -1,12 +1,5 @@
 name: Build and Test
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [assigned, opened, synchronize, reopened]
-  workflow_dispatch:
+on :
 
 defaults:
   run:
@@ -25,7 +18,7 @@ jobs:
     name: Build and Test
 
     # By latest GitHub means actually latest LTS only
-    runs-on: ubuntu-latest
+    runs-on: build-latest
 
     strategy:
       # Run all the test even if there are some which fail
@@ -41,12 +34,18 @@ jobs:
     # it runs faster. But these images have quite less software
     # installed compared to the GitHub Ubuntu distribution for example.
 
-    container:
-      image:  amd/acdcbuild:1.1
-      volumes: 
-        - ${{github.workspace}}/llvm-central-repo:/workspace/llvm-central-repo
+    #container:
+     # image:  amd/acdcbuild:1.1
+     # Replicated this using container-options
+ 
+      # Attempted using options
+      #volumes:
+       # - /scratch/samuelb/source-mlir-aie/llvm-central-repo:/scratch/samuelb/source-mlir-aie/llvm-central-repo
+
     steps:
-      
+      - name : Echo workspace
+        run : echo `ls ${{github.workspace}}`
+
       - name: Display environment variables
         run: env
 
@@ -118,10 +117,12 @@ jobs:
         with:
           fetch-depth: 2
           submodules: "true"
+      - name: printthecommithash
+        run: echo "mlir-aie hash=$(git log -1 --format='%H')"
 
       - name: Get LLVM
         id: clone-llvm
-        run: ${{github.workspace}}/utils/clone-llvm.sh --llvm-worktree /workspace/llvm-central-repo
+        run: ${{github.workspace}}/utils/clone-llvm.sh --llvm-worktree ${{github.workspace}}/llvm-central-repo
 
       - name: Get LLVM commit hash
         id: get-llvm-commit-hash

--- a/platforms/build/interactive.sh
+++ b/platforms/build/interactive.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export GITHUB_WORKSPACE=`pwd`
+export WORKSPACE=/workspace
+
+docker run -it \
+-v ${GITHUB_WORKSPACE}:${WORKSPACE} \
+amd/acdcbuild:1.1 \
+bash


### PR DESCRIPTION
These script enable a containerized build locally using nektos/act. If these are widely adopted we can have many people able to replicate the CI flow exactly in their local machine ( with an environment controlled using the same mechanisms as the CI). 

These scripts contain some additions to make this go fast. 
- CCache usage backed by a persistent container
- Worktree checkout enabled by a bind-mount of LLVM
- Substitution of local pre-built development container, rather than fetching packages on each build. 