### PR TITLE
Fix pathfinder semantics re cardinal directions

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -47,13 +47,13 @@ Pathfinder::Pathfinder(int maxCol, int maxRow, DeviceOp &d) {
       Switchbox &thisNode = grid.at({col, row});
       if (row > 0) { // if not in row 0 add channel to North/South
         Switchbox &southernNeighbor = grid.at({col, row - 1});
-        if (uint32_t maxCapacity = targetModel.getNumSourceSwitchboxConnections(
+        if (uint32_t maxCapacity = targetModel.getNumDestSwitchboxConnections(
                 col, row, WireBundle::South)) {
           edges.emplace_back(southernNeighbor, thisNode, WireBundle::North,
                              maxCapacity);
           (void)graph.connect(southernNeighbor, thisNode, edges.back());
         }
-        if (uint32_t maxCapacity = targetModel.getNumDestSwitchboxConnections(
+        if (uint32_t maxCapacity = targetModel.getNumSourceSwitchboxConnections(
                 col, row, WireBundle::South)) {
           edges.emplace_back(thisNode, southernNeighbor, WireBundle::South,
                              maxCapacity);
@@ -63,13 +63,13 @@ Pathfinder::Pathfinder(int maxCol, int maxRow, DeviceOp &d) {
 
       if (col > 0) { // if not in col 0 add channel to East/West
         Switchbox &westernNeighbor = grid.at({col - 1, row});
-        if (uint32_t maxCapacity = targetModel.getNumSourceSwitchboxConnections(
+        if (uint32_t maxCapacity = targetModel.getNumDestSwitchboxConnections(
                 col, row, WireBundle::West)) {
           edges.emplace_back(westernNeighbor, thisNode, WireBundle::East,
                              maxCapacity);
           (void)graph.connect(westernNeighbor, thisNode, edges.back());
         }
-        if (uint32_t maxCapacity = targetModel.getNumDestSwitchboxConnections(
+        if (uint32_t maxCapacity = targetModel.getNumSourceSwitchboxConnections(
                 col, row, WireBundle::West)) {
           edges.emplace_back(thisNode, westernNeighbor, WireBundle::West,
                              maxCapacity);


### PR DESCRIPTION
The [previous](https://github.com/Xilinx/mlir-aie/blob/923659114a9d5f3c80ff2fe49eac4cb709ffaf3c/lib/Dialect/AIE/Transforms/AIEPathfinder.cpp) version of `AIEPathfinder.cpp` initialized the graph like this:

```cpp
if (row > 0) { // if not in row 0 add channel to North/South
  if (auto max_capacity = targetModel.getNumSourceSwitchboxConnections(
          col, row, WireBundle::South)) {
    auto north_edge = add_edge(id - maxcol - 1, id, graph).first;
    graph[north_edge].bundle = WireBundle::North;
    graph[north_edge].max_capacity = max_capacity;
  }
  if (auto max_capacity = targetModel.getNumDestSwitchboxConnections(
          col, row, WireBundle::South)) {
    auto south_edge = add_edge(id, id - maxcol - 1, graph).first;
    graph[south_edge].bundle = WireBundle::South;
    graph[south_edge].max_capacity = max_capacity;
  }
}
if (col > 0) { // if not in col 0 add channel to East/West
  if (auto max_capacity = targetModel.getNumSourceSwitchboxConnections(
          col, row, WireBundle::West)) {
    auto east_edge = add_edge(id - 1, id, graph).first;
    graph[east_edge].bundle = WireBundle::East;
    graph[east_edge].max_capacity = max_capacity;
  }
  if (auto max_capacity = targetModel.getNumDestSwitchboxConnections(
          col, row, WireBundle::West)) {
    auto west_edge = add_edge(id, id - 1, graph).first;
    graph[west_edge].bundle = WireBundle::West;
    graph[west_edge].max_capacity = max_capacity;
  }
}
```

When I rewrote it, in using the ADT data structures I tried to name things to preserve the semantics I thought were expressed here but now I'm not sure if the original semantics are even corrent. Namely:

```cpp
if (auto max_capacity = targetModel.getNumSourceSwitchboxConnections(
        col, row, WireBundle::South)) {
  auto north_edge = add_edge(id - maxcol - 1, id, graph).first;
 graph[north_edge].bundle = WireBundle::North;
```

This says contradictory things: 

1. We are querying the maximum number `NumSourceSwitchboxConnections`;
2. We will add an edge from the southern neighbor (`id - maxcol - 1`)[^1] to this node (`id`) using the southern neighbor's northern bundle;

But why would we use the number of possible southern **source** connections on this node; the doc `getNumSourceSwitchboxConnections` is pretty clear:

```cpp
/// Return the number of sources of connections inside a switchbox.  
/// These are the origins of connect operations in the switchbox.
virtual uint32_t getNumSourceSwitchboxConnections(int col, int row, WireBundle bundle) const = 0;
```

A similar inversion of course happens for East/West. Flipping these two passes tests and restores sanity to the language so I have to believe/intuit that it hasn't broken anything prior because these numbers are the same in the tested cases? 

[^1]: Because the loop goes along rows and then columns:
    ```cpp
    for (int row = 0; row <= maxrow; row++) {
      for (int col = 0; col <= maxcol; col++) {
    ```
    right? And row numbers increase in the northern direction right?