### PR TITLE
Fixes for --assign-lock-ids pass 

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
@@ -57,9 +57,10 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
       if (isAssigned) {
         auto lockID = lockOp.getLockID().value();
         auto iter = tileToLocks.find(tileOp);
-        if (iter == tileToLocks.end()) {
+
+        if (iter == tileToLocks.end())
           tileToLocks.insert({tileOp, {{lockID}, /* unassigned = */ {}}});
-        } else {
+        else {
           if (iter->second.assigned.find(lockID) !=
               iter->second.assigned.end()) {
             auto diag = lockOp->emitOpError("is assigned to the same lock (")
@@ -70,26 +71,23 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
           }
           iter->second.assigned.insert(lockID);
         }
-      }
-
-      else {
+      } else {
         auto iter = tileToLocks.find(tileOp);
-        if (iter == tileToLocks.end()) {
+        if (iter == tileToLocks.end())
           tileToLocks.insert({tileOp, {/* assigned = */ {}, {lockOp}}});
-        } else {
+        else
           iter->second.unassigned.push_back(lockOp);
-        }
       }
     }
 
     // IR mutation: assign locks to all unassigned lock ops.
-    for (auto &&[tileOp, locks] : tileToLocks) {
+    for (auto [tileOp, locks] : tileToLocks) {
 
       const auto locksPerTile =
           getTargetModel(tileOp).getNumLocks(tileOp.getCol(), tileOp.getRow());
 
       uint32_t nextID = 0;
-      for (auto &&lockOp : locks.unassigned) {
+      for (auto lockOp : locks.unassigned) {
         while (nextID < locksPerTile &&
                (locks.assigned.find(nextID) != locks.assigned.end())) {
           ++nextID;

--- a/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
@@ -97,8 +97,8 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
         if (nextID == locksPerTile) {
           auto diag = lockOp->emitOpError("not allocated a lock.");
           diag.attachNote(tileOp.getLoc())
-              << "because tile has only " << locksPerTile
-              << " locks available.";
+              << "because only " << locksPerTile
+              << " locks available in this tile.";
           return signalPassFailure();
         }
         lockOp->setAttr("lockID", rewriter.getI32IntegerAttr(nextID));

--- a/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
@@ -96,9 +96,8 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
         }
         if (nextID == locksPerTile) {
           auto diag = lockOp->emitOpError("not allocated a lock.");
-          diag.attachNote(tileOp.getLoc())
-              << "because only " << locksPerTile
-              << " locks available in this tile.";
+          diag.attachNote(tileOp.getLoc()) << "because only " << locksPerTile
+                                           << " locks available in this tile.";
           return signalPassFailure();
         }
         lockOp->setAttr("lockID", rewriter.getI32IntegerAttr(nextID));

--- a/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
@@ -49,9 +49,9 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
     DenseMap<TileOp, TileLockOps> tileToLocks;
 
     // Construct data structure storing locks by tile.
-    for (auto lockOp : device.getOps<LockOp>()) {
+    for (LockOp lockOp : device.getOps<LockOp>()) {
 
-      auto tileOp = lockOp.getTileOp();
+      TileOp tileOp = lockOp.getTileOp();
       bool isAssigned = lockOp.getLockID().has_value();
 
       if (isAssigned) {
@@ -93,7 +93,8 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
           ++nextID;
         }
         if (nextID == locksPerTile) {
-          auto diag = lockOp->emitOpError("not allocated a lock.");
+          mlir::InFlightDiagnostic diag =
+              lockOp->emitOpError("not allocated a lock.");
           diag.attachNote(tileOp.getLoc()) << "because only " << locksPerTile
                                            << " locks available in this tile.";
           return signalPassFailure();

--- a/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
@@ -10,10 +10,10 @@
 
 // This pass aims to assign lockIDs to AIE.lock operations. The lockID is
 // numbered from the most recent AIE.lock within the same tile. If the lockID
-// exceeds 15 then the pass generates an error and terminates. AIE.lock
-// operations for different tiles are numbered independently. If there are
-// existing lock IDs, this pass is idempotent and only assign lock ids to locks
-// without an ID.
+// exceeds the number of locks on the tile, the pass generates an error and
+// terminates. AIE.lock operations for different tiles are numbered
+// independently. If there are existing lock IDs, this pass is idempotent
+// and only assigns lock IDs to locks without an ID.
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h"
@@ -21,6 +21,7 @@
 #include "mlir/IR/Attributes.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 
 #define DEBUG_TYPE "aie-assign-lock-ids"
 
@@ -39,67 +40,91 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
     DeviceOp device = getOperation();
     OpBuilder rewriter = OpBuilder::atBlockEnd(device.getBody());
 
-    // Map from tile to all its locks.
-    DenseMap<TileOp, SmallVector<LockOp>> tileToLockOps;
+    // Map from tiles to all their lock ops (stored by ID) which have been
+    // assigned to locks.
+    DenseMap<TileOp, DenseSet<int>> tileToAssignedLocks;
+
+    // Map from tiles to all lock ops which have not been assigned to locks.
+    DenseMap<TileOp, SmallVector<LockOp>> tileToUnassignedLocks;
+
+    // Separate lock ops into assigned and unassigned ops, and store by tile.
     for (auto lockOp : device.getOps<LockOp>()) {
+
       auto tileOp = lockOp.getTileOp();
-      auto iter = tileToLockOps.find(tileOp);
-      if (iter == tileToLockOps.end()) {
-        tileToLockOps.insert({tileOp, {lockOp}});
-      } else {
-        iter->second.push_back(lockOp);
-      }
-    }
+      bool isAssigned = lockOp.getLockID().has_value();
 
-    // For each tile, ensure that all its locks have unique and valid IDs.
-    for (auto &&[tileOp, lockOps] : tileToLockOps) {
-
-      const auto locksPerTile =
-          getTargetModel(tileOp).getNumLocks(tileOp.getCol(), tileOp.getRow());
-
-      // All lock IDs which are assigned to locks before this pass.
-      DenseSet<int> assignedLocks;
-
-      // All lock ops which do not have IDs before this pass.
-      SmallVector<LockOp> unassignedLocks;
-
-      for (auto &&lockOp : lockOps) {
-        if (lockOp.getLockID().has_value()) {
-          uint32_t lockID = lockOp.getLockID().value();
-
-          assert(lockID < locksPerTile &&
-                 "This should be checked in the lock op verifier");
-
-          // Duplicate lock ID:
-          if (assignedLocks.find(lockID) != assignedLocks.end()) {
+      // Append to set of assigned locks.
+      if (isAssigned) {
+        auto lockID = lockOp.getLockID().value();
+        auto assignedLocksIter = tileToAssignedLocks.find(tileOp);
+        if (assignedLocksIter == tileToAssignedLocks.end()) {
+          tileToAssignedLocks.insert({tileOp, {lockID}});
+        } else {
+          if (assignedLocksIter->second.find(lockID) !=
+              assignedLocksIter->second.end()) {
             auto diag = lockOp->emitOpError("is assigned to the same lock (")
                         << lockID << ") as another op.";
             diag.attachNote(tileOp.getLoc())
                 << "tile has lock ops assigned to same lock.";
             return signalPassFailure();
           }
-          assignedLocks.insert(lockID);
-        } else {
-          unassignedLocks.push_back(lockOp);
+          assignedLocksIter->second.insert(lockID);
         }
       }
 
-      assert(assignedLocks.size() + unassignedLocks.size() == lockOps.size());
-
-      uint32_t nextID = 0;
-      for (auto &&lockOp : unassignedLocks) {
-        while (nextID < locksPerTile &&
-               (assignedLocks.find(nextID) != assignedLocks.end())) {
-          ++nextID;
+      // Append to set of unassigned locks.
+      else {
+        auto unassignedLocksIter = tileToUnassignedLocks.find(tileOp);
+        if (unassignedLocksIter == tileToUnassignedLocks.end()) {
+          tileToUnassignedLocks.insert({tileOp, {lockOp}});
+        } else {
+          unassignedLocksIter->second.push_back(lockOp);
         }
-        if (nextID == locksPerTile) {
-          auto diag = lockOp->emitOpError("not allocated a lock.");
-          diag.attachNote(tileOp.getLoc())
-              << "tile has only " << locksPerTile << " locks available.";
+      }
+    }
+
+    // IR mutation: assign locks to all unassigned lock ops.
+    for (auto &&[tileOp, unassignedLocks] : tileToUnassignedLocks) {
+
+      const auto locksPerTile =
+          getTargetModel(tileOp).getNumLocks(tileOp.getCol(), tileOp.getRow());
+
+      auto assignedLocksIter = tileToAssignedLocks.find(tileOp);
+
+      // No locks have been assigned to this tile, so we don't do any collision
+      // checking.
+      if (assignedLocksIter == tileToAssignedLocks.end()) {
+        if (unassignedLocks.size() >= locksPerTile) {
+          auto diag = tileOp->emitOpError("has more lock ops (")
+                      << unassignedLocks.size() << ") than locks ("
+                      << locksPerTile << ").";
           return signalPassFailure();
         }
-        lockOp->setAttr("lockID", rewriter.getI32IntegerAttr(nextID));
-        ++nextID;
+        for (auto lockOp : llvm::enumerate(unassignedLocks)) {
+          lockOp.value()->setAttr("lockID",
+                                  rewriter.getI32IntegerAttr(lockOp.index()));
+        }
+      }
+
+      // Locks have been assigned to this tile, so we check for collisions when
+      // assigning locks to lock ops.
+      else {
+        const auto &assignedLocks = assignedLocksIter->second;
+        uint32_t nextID = 0;
+        for (auto &&lockOp : unassignedLocks) {
+          while (nextID < locksPerTile &&
+                 (assignedLocks.find(nextID) != assignedLocks.end())) {
+            ++nextID;
+          }
+          if (nextID == locksPerTile) {
+            auto diag = lockOp->emitOpError("not allocated a lock.");
+            diag.attachNote(tileOp.getLoc())
+                << "tile has only " << locksPerTile << " locks available.";
+            return signalPassFailure();
+          }
+          lockOp->setAttr("lockID", rewriter.getI32IntegerAttr(nextID));
+          ++nextID;
+        }
       }
     }
   }

--- a/test/assign-lock-ids/assign-lockIDs.mlir
+++ b/test/assign-lock-ids/assign-lockIDs.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-assign-lock-ids %s | FileCheck %s
+// RUN: aie-opt --aie-assign-lock-ids --split-input-file %s | FileCheck %s
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(2, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(2, 3)
 // CHECK:           %[[VAL_2:.*]] = AIE.tile(3, 3)
@@ -85,3 +85,40 @@ module @test_assign_lockIDs {
   %l60 = AIE.lock(%t60)
  }
 }
+
+// -----
+
+module @memTileTest {
+  AIE.device(xcve2802) {
+
+    // Memory tiles on xcve have 64 locks.
+    %tmemtile = AIE.tile(1,1)
+    %l0 = AIE.lock(%tmemtile, 1)
+    %l1 = AIE.lock(%tmemtile, 0)
+    %l2 = AIE.lock(%tmemtile)
+    %l3 = AIE.lock(%tmemtile)
+    %l4 = AIE.lock(%tmemtile)
+    %l5 = AIE.lock(%tmemtile)
+    %l6 = AIE.lock(%tmemtile)
+    %l7 = AIE.lock(%tmemtile)
+    %l8 = AIE.lock(%tmemtile)
+    %l9 = AIE.lock(%tmemtile)
+    %l10 = AIE.lock(%tmemtile)
+    %l11 = AIE.lock(%tmemtile)
+    %l12 = AIE.lock(%tmemtile)
+    %l13 = AIE.lock(%tmemtile)
+    %l14 = AIE.lock(%tmemtile,33)
+    %l15 = AIE.lock(%tmemtile)
+    %l16 = AIE.lock(%tmemtile)
+    %l17 = AIE.lock(%tmemtile)
+    %l18 = AIE.lock(%tmemtile)
+    %l19 = AIE.lock(%tmemtile,2)
+  }
+}
+
+
+// CHECK-LABEL: memTileTest
+// CHECK-COUNT-20: AIE.lock
+// CHECK-NOT: AIE.lock
+
+// -----

--- a/test/assign-lock-ids/assign-lockIDs.mlir
+++ b/test/assign-lock-ids/assign-lockIDs.mlir
@@ -121,4 +121,4 @@ module @memTileTest {
 // CHECK-COUNT-20: AIE.lock
 // CHECK-NOT: AIE.lock
 
-// -----
+

--- a/test/assign-lock-ids/assign-lockIDs.mlir
+++ b/test/assign-lock-ids/assign-lockIDs.mlir
@@ -120,5 +120,3 @@ module @memTileTest {
 // CHECK-LABEL: memTileTest
 // CHECK-COUNT-20: AIE.lock
 // CHECK-NOT: AIE.lock
-
-

--- a/test/assign-lock-ids/invalid.mlir
+++ b/test/assign-lock-ids/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aie-opt --aie-assign-lock-ids %s  -split-input-file -verify-diagnostics
 
 AIE.device(xcve2802) {
-  //expected-error @+1 {{op can have a maximum of 16 locks. No more available IDs.}}
+  //expected-note @below {{has only 16 locks}}
   %tMemTile = AIE.tile(4,4)
   %l0 = AIE.lock(%tMemTile)
   %l1 = AIE.lock(%tMemTile)
@@ -19,21 +19,19 @@ AIE.device(xcve2802) {
   %l13 = AIE.lock(%tMemTile)
   %l14 = AIE.lock(%tMemTile)
   %l15 = AIE.lock(%tMemTile)
+  //expected-error @below {{not allocated a lock}}
   %l16 = AIE.lock(%tMemTile)
   %l17 = AIE.lock(%tMemTile)
   %l18 = AIE.lock(%tMemTile)
   %l19 = AIE.lock(%tMemTile)
 }
 
-//  -----
+// -----
 
 AIE.device(xcve2802) {
-  //expected-error @+1 {{has multiple locks with ID 12.}}
-  %t44 = AIE.tile(4,4)
-  %l0 = AIE.lock(%t44, 12)
-  %l1 = AIE.lock(%t44)
-  %l2 = AIE.lock(%t44, 3)
-  %l3 = AIE.lock(%t44, 12)
-  %l4 = AIE.lock(%t44)
+ //expected-note @below {{tile has lock ops assigned to same lock}}
+  %t22 = AIE.tile(2,2)
+  %l0 = AIE.lock(%t22, 7)
+  // expected-error @below {{is assigned to the same lock (7) as another op}}
+  %l1 = AIE.lock(%t22, 7)
 }
-

--- a/test/assign-lock-ids/invalid.mlir
+++ b/test/assign-lock-ids/invalid.mlir
@@ -1,0 +1,39 @@
+// RUN: aie-opt --aie-assign-lock-ids %s  -split-input-file -verify-diagnostics
+
+AIE.device(xcve2802) {
+  //expected-error @+1 {{op can have a maximum of 16 locks. No more available IDs.}}
+  %tMemTile = AIE.tile(4,4)
+  %l0 = AIE.lock(%tMemTile)
+  %l1 = AIE.lock(%tMemTile)
+  %l2 = AIE.lock(%tMemTile)
+  %l3 = AIE.lock(%tMemTile)
+  %l4 = AIE.lock(%tMemTile)
+  %l5 = AIE.lock(%tMemTile)
+  %l6 = AIE.lock(%tMemTile)
+  %l7 = AIE.lock(%tMemTile)
+  %l8 = AIE.lock(%tMemTile)
+  %l9 = AIE.lock(%tMemTile)
+  %l10 = AIE.lock(%tMemTile)
+  %l11 = AIE.lock(%tMemTile)
+  %l12 = AIE.lock(%tMemTile)
+  %l13 = AIE.lock(%tMemTile)
+  %l14 = AIE.lock(%tMemTile)
+  %l15 = AIE.lock(%tMemTile)
+  %l16 = AIE.lock(%tMemTile)
+  %l17 = AIE.lock(%tMemTile)
+  %l18 = AIE.lock(%tMemTile)
+  %l19 = AIE.lock(%tMemTile)
+}
+
+//  -----
+
+AIE.device(xcve2802) {
+  //expected-error @+1 {{has multiple locks with ID 12.}}
+  %t44 = AIE.tile(4,4)
+  %l0 = AIE.lock(%t44, 12)
+  %l1 = AIE.lock(%t44)
+  %l2 = AIE.lock(%t44, 3)
+  %l3 = AIE.lock(%t44, 12)
+  %l4 = AIE.lock(%t44)
+}
+

--- a/test/assign-lock-ids/invalid.mlir
+++ b/test/assign-lock-ids/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aie-opt --aie-assign-lock-ids %s  -split-input-file -verify-diagnostics
 
 AIE.device(xcve2802) {
-  // expected-note @below {{tile has only 16 locks available}}
+  // expected-note @below {{because only 16 locks available in this tile}}
   %tMemTile = AIE.tile(4,4)
   %l0 = AIE.lock(%tMemTile)
   %l1 = AIE.lock(%tMemTile)
@@ -29,7 +29,7 @@ AIE.device(xcve2802) {
 // -----
 
 AIE.device(xcve2802) {
-  // expected-note @below {{tile has only 16 locks available}}
+  // expected-note @below {{because only 16 locks available in this tile}}
   %tMemTile = AIE.tile(4,4)
   %l0 = AIE.lock(%tMemTile)
   %l1 = AIE.lock(%tMemTile, 1)

--- a/test/assign-lock-ids/invalid.mlir
+++ b/test/assign-lock-ids/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aie-opt --aie-assign-lock-ids %s  -split-input-file -verify-diagnostics
 
 AIE.device(xcve2802) {
-  //expected-note @below {{has only 16 locks}}
+  // expected-error @below {{has more lock ops (20) than locks (16)}}
   %tMemTile = AIE.tile(4,4)
   %l0 = AIE.lock(%tMemTile)
   %l1 = AIE.lock(%tMemTile)
@@ -19,9 +19,36 @@ AIE.device(xcve2802) {
   %l13 = AIE.lock(%tMemTile)
   %l14 = AIE.lock(%tMemTile)
   %l15 = AIE.lock(%tMemTile)
-  //expected-error @below {{not allocated a lock}}
   %l16 = AIE.lock(%tMemTile)
   %l17 = AIE.lock(%tMemTile)
+  %l18 = AIE.lock(%tMemTile)
+  %l19 = AIE.lock(%tMemTile)
+}
+
+// -----
+
+AIE.device(xcve2802) {
+  // expected-note @below {{tile has only 16 locks available}}
+  %tMemTile = AIE.tile(4,4)
+  %l0 = AIE.lock(%tMemTile)
+  %l1 = AIE.lock(%tMemTile, 1)
+  %l2 = AIE.lock(%tMemTile)
+  %l3 = AIE.lock(%tMemTile)
+  %l4 = AIE.lock(%tMemTile)
+  %l5 = AIE.lock(%tMemTile)
+  %l6 = AIE.lock(%tMemTile)
+  %l7 = AIE.lock(%tMemTile, 2)
+  %l8 = AIE.lock(%tMemTile)
+  %l9 = AIE.lock(%tMemTile)
+  %l10 = AIE.lock(%tMemTile, 15)
+  %l11 = AIE.lock(%tMemTile)
+  %l12 = AIE.lock(%tMemTile)
+  %l13 = AIE.lock(%tMemTile)
+  %l14 = AIE.lock(%tMemTile)
+  // expected-error @below {{not allocated a lock}}
+  %l15 = AIE.lock(%tMemTile)
+  %l16 = AIE.lock(%tMemTile)
+  %l17 = AIE.lock(%tMemTile, 3)
   %l18 = AIE.lock(%tMemTile)
   %l19 = AIE.lock(%tMemTile)
 }

--- a/test/assign-lock-ids/invalid.mlir
+++ b/test/assign-lock-ids/invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: aie-opt --aie-assign-lock-ids %s  -split-input-file -verify-diagnostics
 
 AIE.device(xcve2802) {
-  // expected-error @below {{has more lock ops (20) than locks (16)}}
+  // expected-note @below {{tile has only 16 locks available}}
   %tMemTile = AIE.tile(4,4)
   %l0 = AIE.lock(%tMemTile)
   %l1 = AIE.lock(%tMemTile)
@@ -19,6 +19,7 @@ AIE.device(xcve2802) {
   %l13 = AIE.lock(%tMemTile)
   %l14 = AIE.lock(%tMemTile)
   %l15 = AIE.lock(%tMemTile)
+  // expected-error @below {{not allocated a lock}}
   %l16 = AIE.lock(%tMemTile)
   %l17 = AIE.lock(%tMemTile)
   %l18 = AIE.lock(%tMemTile)


### PR DESCRIPTION
This fixes a few issues with this pass. The issues were

1) hard coded number of locks per tile at 15. 
2) in some cases, locks were still being assigned IDs greater than the number of HW locks 
3) did not signal failure (just emitted error from op, and returned) to halt pass pipeline 

This PR also implements the pass a bit more efficiently (does less work to find a free ID). 