### PR TITLE
[MLIR][AIE] Avoid documentation target collision

### DIFF
--- a/include/aie/Conversion/CMakeLists.txt
+++ b/include/aie/Conversion/CMakeLists.txt
@@ -4,4 +4,4 @@ mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header -prefix Conversion)
 mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl -prefix Conversion)
 add_public_tablegen_target(MLIRAIEConversionPassIncGen)
 
-add_mlir_doc(Passes ConversionPasses ./ -gen-pass-doc)
+add_mlir_doc(Passes MLIRAIEConversionPasses ./ -gen-pass-doc)


### PR DESCRIPTION
When compiling at the same time as MLIR, there is already a ConversionPassesDocGen defined by mlir/include/mlir/Conversion/CMakeLists.txt