### PR TITLE
Fix CDO backend aie-rt dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "cmake/modulesXilinx"]
 	path = cmake/modulesXilinx
 	url = https://github.com/Xilinx/cmakeModules.git
+[submodule "runtime_lib/xaiengine/aie-rt"]
+	path = runtime_lib/xaiengine/aie-rt
+	url = https://github.com/stephenneuendorffer/aie-rt.git

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -398,7 +398,7 @@ all:
       shutil.copytree(data_path, self.tmpdirname, dirs_exist_ok=True)
 
       runtime_xaiengine_path = os.path.join(install_path, 'runtime_lib',
-                                            opts.host_target.split('-')[0], 'xaiengine')
+                                            opts.host_target.split('-')[0], 'xaiengine', 'cdo')
       xaiengine_include_path = os.path.join(runtime_xaiengine_path, "include")
       xaiengine_lib_path = os.path.join(runtime_xaiengine_path, "lib")
 
@@ -409,7 +409,7 @@ all:
 
       p0 = self.do_call(task, ['clang++',
                                '-fPIC', '-c', '-std=c++17',
-                               '-D__AIEARCH__=20',
+                               *self.aie_target_defines(),
                                '-D__AIESIM__',
                                '-D__CDO__',
                                '-D__PS_INIT_AIE__',
@@ -433,7 +433,7 @@ all:
       await self.do_call(task, ['clang++',
                                 '-L' + xaiengine_lib_path,
                                 '-L' + os.path.join(opts.aietools_path, "lib", "lnx64.o"),
-                                '-lxaiengine','-lcdo_driver',
+                                '-lxaienginecdo','-lcdo_driver',
                                 '-o', os.path.join(self.tmpdirname, 'cdo_main.out'),
                                 os.path.join(self.tmpdirname, 'gen_cdo.o'),
                                 os.path.join(self.tmpdirname, 'cdo_main.o')

--- a/runtime_lib/xaiengine/CMakeLists.txt
+++ b/runtime_lib/xaiengine/CMakeLists.txt
@@ -7,6 +7,7 @@
 cmake_minimum_required(VERSION 3.20.1)
 
 project("xaiengine lib for ${AIE_RUNTIME_TARGET}")
+include("aiert.cmake")
 
 if (${CMAKE_CROSSCOMPILING})
 
@@ -19,48 +20,21 @@ if (${CMAKE_CROSSCOMPILING})
         message(FATAL_ERROR "Unsupported Vitis version: ${Vitis_VERSION_MAJOR}")
     endif()
 
-    message("Building xaiengine for ${AIE_RUNTIME_TARGET} from Vitis at ${VITIS_ROOT}.") 
-    file(GLOB libheaders ${aieRTIncludePath}/*.h)
-    file(GLOB libheadersSub ${aieRTIncludePath}/*/*.h)
-
-    # copy header files into build area
-    foreach(file ${libheaders})
-        cmake_path(GET file FILENAME basefile)
-        # message("basefile: ${basefile}")
-        set(dest ${CMAKE_CURRENT_BINARY_DIR}/include/${basefile})
-        add_custom_target(aie-copy-runtime-libs-${basefile} ALL DEPENDS ${dest})
-        add_custom_command(OUTPUT ${dest}
-                        COMMAND ${CMAKE_COMMAND} -E copy ${file} ${dest}
-                        DEPENDS ${file})
-    endforeach()
-    foreach(file ${libheadersSub})
-        cmake_path(GET file FILENAME basefile)
-        # message("basefile: ${basefile}")
-        set(dest ${CMAKE_CURRENT_BINARY_DIR}/include/xaiengine/${basefile})
-        add_custom_target(aie-copy-runtime-libs-${basefile} ALL DEPENDS ${dest})
-        add_custom_command(OUTPUT ${dest}
-                        COMMAND ${CMAKE_COMMAND} -E copy ${file} ${dest}
-                        DEPENDS ${file})
-    endforeach()
-
-    # Install too
-    install(FILES ${libheaders} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include)
-    install(FILES ${libheadersSub} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include/xaiengine)
+    message("Building xaiengine for ${AIE_RUNTIME_TARGET} from Vitis at ${VITIS_ROOT}.")
+    add_aiert_headers(xaiengine
+                        ${aieRTIncludePath}
+                        ${CMAKE_CURRENT_BINARY_DIR}/include
+                        ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include)
 
     add_subdirectory(lib)
 
 else()
 
     message("Copying xaiengine for ${AIE_RUNTIME_TARGET} from ${AIERT_LIBS}.") 
-
-    file(GLOB libheaders ${AIERT_INCLUDE_DIR}/*.h)
-    file(GLOB libheadersSub ${AIERT_INCLUDE_DIR}/*/*.h)
-
-    # copy header files into build area
-    set(dest ${CMAKE_CURRENT_BINARY_DIR}/include)
-    add_custom_target(aie-copy-runtime-headers ALL DEPENDS ${dest})
-    add_custom_command(OUTPUT ${dest}
-                    COMMAND ${CMAKE_COMMAND} -E copy_directory ${AIERT_INCLUDE_DIR} ${dest})
+    add_aiert_headers(xaiengine
+                        ${AIERT_INCLUDE_DIR}
+                        ${CMAKE_CURRENT_BINARY_DIR}/include
+                        ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include)
 
     # copy library file to build area
     set(libs
@@ -72,8 +46,8 @@ else()
     endforeach()
 
     # install library and headers
-    install(FILES ${libheaders} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include)
-    install(FILES ${libheadersSub} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/include/xaiengine)
     install(FILES ${libs} DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/lib)
 
 endif()
+
+add_subdirectory(cdo)

--- a/runtime_lib/xaiengine/aiert.cmake
+++ b/runtime_lib/xaiengine/aiert.cmake
@@ -1,0 +1,67 @@
+
+
+function(add_aiert_headers TARGET SRCPATH BUILDPATH INSTALLPATH)
+    message("${TARGET} ${SRCPATH} ${BUILDPATH}")
+    file(GLOB libheaders ${SRCPATH}/*.h)
+    file(GLOB libheadersSub ${SRCPATH}/*/*.h)
+
+    # copy header files into build area
+    foreach(file ${libheaders})
+        cmake_path(GET file FILENAME basefile)
+        # message("basefile: ${basefile}")
+        set(dest ${BUILDPATH}/${basefile})
+        add_custom_target(${TARGET}-${basefile} ALL DEPENDS ${dest})
+        add_custom_command(OUTPUT ${dest}
+                        COMMAND ${CMAKE_COMMAND} -E copy ${file} ${dest}
+                        DEPENDS ${file})
+    endforeach()
+    foreach(file ${libheadersSub})
+        cmake_path(GET file FILENAME basefile)
+        # message("basefile: ${basefile}")
+        set(dest ${BUILDPATH}/xaiengine/${basefile})
+        add_custom_target(${TARGET}-${basefile} ALL DEPENDS ${dest})
+        add_custom_command(OUTPUT ${dest}
+                        COMMAND ${CMAKE_COMMAND} -E copy ${file} ${dest}
+                        DEPENDS ${file})
+    endforeach()
+
+    # Install too
+    install(FILES ${libheaders} DESTINATION ${INSTALLPATH})
+    install(FILES ${libheadersSub} DESTINATION ${INSTALLPATH}/xaiengine)
+
+endfunction()
+
+function(add_aiert_library TARGET XAIE_SOURCE)
+
+    file(GLOB libsources ${XAIE_SOURCE}/*/*.c ${XAIE_SOURCE}/*/*/*.c)
+
+    include_directories(
+        ${XAIE_SOURCE}
+        ${XAIE_SOURCE}/common
+        ${XAIE_SOURCE}/core
+        ${XAIE_SOURCE}/device
+        ${XAIE_SOURCE}/dma
+        ${XAIE_SOURCE}/events
+        ${XAIE_SOURCE}/global
+        ${XAIE_SOURCE}/interrupt
+        ${XAIE_SOURCE}/io_backend
+        ${XAIE_SOURCE}/io_backend/ext
+        ${XAIE_SOURCE}/io_backend/privilege
+        ${XAIE_SOURCE}/lite
+        ${XAIE_SOURCE}/locks
+        ${XAIE_SOURCE}/memory
+        ${XAIE_SOURCE}/npi
+        ${XAIE_SOURCE}/perfcnt
+        ${XAIE_SOURCE}/pl
+        ${XAIE_SOURCE}/pm
+        ${XAIE_SOURCE}/rsc
+        ${XAIE_SOURCE}/stream_switch
+        ${XAIE_SOURCE}/timer
+        ${XAIE_SOURCE}/trace
+        ${XAIE_SOURCE}/util
+    )
+
+    add_library(${TARGET} SHARED ${libsources})
+    target_compile_options(${TARGET} PRIVATE -fPIC -Wno-gnu-designator)
+
+endfunction()

--- a/runtime_lib/xaiengine/cdo/CMakeLists.txt
+++ b/runtime_lib/xaiengine/cdo/CMakeLists.txt
@@ -1,0 +1,22 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+include("../aiert.cmake")
+
+message("Building xaiengine for ${AIE_RUNTIME_TARGET} for CDO backend.")
+
+set(XAIE_SOURCE ../aie-rt/driver/src)
+
+add_aiert_headers(xaienginecdo
+                    ${XAIE_SOURCE}
+                    ${CMAKE_CURRENT_BINARY_DIR}/include
+                    ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/cdo/include)
+
+add_aiert_library(xaienginecdo ${XAIE_SOURCE})
+
+target_compile_definitions(xaienginecdo PRIVATE -D__AIECDO__)
+
+install(TARGETS xaienginecdo DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/cdo/lib)

--- a/runtime_lib/xaiengine/lib/CMakeLists.txt
+++ b/runtime_lib/xaiengine/lib/CMakeLists.txt
@@ -4,37 +4,11 @@
 #
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
+include("../aiert.cmake")
+
 set(XAIE_SOURCE ${VITIS_ROOT}/data/embeddedsw/XilinxProcessorIPLib/drivers/aienginev2_v3_0/src)
-file(GLOB libsources ${XAIE_SOURCE}/*/*.c ${XAIE_SOURCE}/*/*/*.c)
 
-include_directories(
-    ${XAIE_SOURCE}
-    ${XAIE_SOURCE}/common
-    ${XAIE_SOURCE}/core
-    ${XAIE_SOURCE}/device
-    ${XAIE_SOURCE}/dma
-    ${XAIE_SOURCE}/events
-    ${XAIE_SOURCE}/global
-    ${XAIE_SOURCE}/interrupt
-    ${XAIE_SOURCE}/io_backend
-    ${XAIE_SOURCE}/io_backend/ext
-    ${XAIE_SOURCE}/io_backend/privilege
-    ${XAIE_SOURCE}/lite
-    ${XAIE_SOURCE}/locks
-    ${XAIE_SOURCE}/memory
-    ${XAIE_SOURCE}/npi
-    ${XAIE_SOURCE}/perfcnt
-    ${XAIE_SOURCE}/pl
-    ${XAIE_SOURCE}/pm
-    ${XAIE_SOURCE}/rsc
-    ${XAIE_SOURCE}/stream_switch
-    ${XAIE_SOURCE}/timer
-    ${XAIE_SOURCE}/trace
-    ${XAIE_SOURCE}/util
-)
-
-add_library(xaiengine STATIC ${libsources})
-target_compile_options(xaiengine PRIVATE -fPIC -Wno-gnu-designator)
+add_aiert_librart(xaiengine ${XAIE_SOURCE})
 
 if (${AIE_RUNTIME_TARGET} STREQUAL "aarch64")
 target_compile_definitions(xaiengine PRIVATE __AIELINUX__)

--- a/utils/build-mlir-aie-ryzen-ai.sh
+++ b/utils/build-mlir-aie-ryzen-ai.sh
@@ -35,34 +35,6 @@ mkdir -p $BUILD_DIR
 mkdir -p $INSTALL_DIR
 
 ##
-## FIXME: move to CMake and reduce aie-rt differences
-## build phoenix branch of aie-rt 
-##
-
-git clone --branch xlnx_rel_v2023.2 --depth 1 https://github.com/Xilinx/aie-rt.git ${BUILD_DIR}/aie-rt
-
-mkdir -p $INSTALL_DIR/aie-rt/lib
-
-pushd ${BUILD_DIR}/aie-rt/driver/src/
-sed -i '32s/^/\/\//' ./io_backend/ext/xaie_cdo.c
-sed -i '62s/(ColType == 0U) || (ColType == 1U)/(DevInst->StartCol + Loc.Col) == 0U/' ./device/xaie_device_aieml.c
-make -f Makefile.Linux cdo
-success=$?
-popd
-
-if [ ${success} -ne 0 ]
-then
-    rm -rf ${INSTALL_DIR}/*
-    rm -rf ${BUILD_DIR}/*
-    exit 7
-fi
-
-cp -v ${BUILD_DIR}/aie-rt/driver/src/*.so* ${INSTALL_DIR}/aie-rt/lib
-cp -vr ${BUILD_DIR}/aie-rt/driver/include ${INSTALL_DIR}/aie-rt
-
-AIERT_DIR=`realpath ${INSTALL_DIR}/aie-rt`
-
-##
 ## build pynqMLIR-AIE
 ##
 
@@ -81,7 +53,6 @@ CMAKE_CONFIGS="\
     -DAIE_ENABLE_BINDINGS_PYTHON=ON \
     -DAIE_RUNTIME_TARGETS:STRING="x86_64" \
     -DAIE_RUNTIME_TEST_TARGET=x86_64 \
-    -DLibXAIE_x86_64_DIR=${AIERT_DIR} \
     ../.."
 
 if [ -x "$(command -v lld)" ]; then


### PR DESCRIPTION
The CDO backend requires a patched version of aie-rt.  Eventually, this should just be wrapped into the shipped version of libxaiengine.so, but for the time being we need a specially compiled version of it.

This patch also removes the old way of handling this, which relied on a special build script to inject the patch. Along the way, also refactor the cmake around aie-rt so that things are nicely encapsulated