### PR TITLE
[aiecc] Be explicit about peano path

### DIFF
--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -13,6 +13,16 @@ import shutil
 
 from aie.compiler.aiecc.configure import *
 
+aie_dir = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+peano_install_dir = ""
+# The expected location in an install area
+peano_install_dir = os.path.join(aie_dir, "peano")
+if(not os.path.exists(peano_install_dir)):
+  # The expected location in a build area
+  peano_install_dir = os.path.realpath(os.path.join(aie_dir, "..", "peano"))
+if(not os.path.exists(peano_install_dir)):
+  peano_install_dir = "peano_not_found"
+
 def parse_args(args=None):
     if (args is None):
         args = sys.argv[1:]

--- a/test/aiecc/simple.mlir
+++ b/test/aiecc/simple.mlir
@@ -17,15 +17,15 @@
 
 // Note that llc determines the architecture from the llvm IR.
 
-// XCHESSCC-NOT: {{^llc}}
+// XCHESSCC-NOT: {{^[^ ]*llc}}
 // XCHESSCC: xchesscc_wrapper aie
-// XCHESSCC-NOT: {{^llc}}
+// XCHESSCC-NOT: {{^[^ ]*llc}}
 // PEANO-NOT: xchesscc_wrapper
-// PEANO: {{^llc}}
+// PEANO: {{^[^ ]*llc}}
 // PEANO-SAME: --march=aie
 // PEANO-NOT: xchesscc_wrapper
 // NOCOMPILE-NOT: xchesscc_wrapper
-// NOCOMPILE-NOT: {{^llc}}
+// NOCOMPILE-NOT: {{^[^ ]*llc}}
 
 module {
   %12 = AIE.tile(1, 2)

--- a/test/aiecc/simple_aie2.mlir
+++ b/test/aiecc/simple_aie2.mlir
@@ -16,15 +16,15 @@
 // RUN: %PYTHON aiecc.py --no-unified --no-compile --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
 
 // Note that llc determines the architecture from the llvm IR.
-// XCHESSCC-NOT: {{^llc}}
+// XCHESSCC-NOT: {{^[^ ]*llc}}
 // XCHESSCC: xchesscc_wrapper aie2
-// XCHESSCC-NOT: {{^llc}}
+// XCHESSCC-NOT: {{^[^ ]*llc}}
 // PEANO-NOT: xchesscc_wrapper
-// PEANO: {{^llc}}
+// PEANO: {{^[^ ]*llc}}
 // PEANO-SAME: --march=aie2
 // PEANO-NOT: xchesscc_wrapper
 // NOCOMPILE-NOT: xchesscc_wrapper
-// NOCOMPILE-NOT: {{^llc}}
+// NOCOMPILE-NOT: {{^[^ ]*llc}}
 
 module {
   AIE.device(xcve2302) {

--- a/tools/aiecc/aiecc/configure.py.in
+++ b/tools/aiecc/aiecc/configure.py.in
@@ -13,7 +13,6 @@ aie_disable_link = @CONFIG_DISABLE_LINK@
 aie_disable_compile = @CONFIG_DISABLE_COMPILE@
 aie_unified_compile = True
 host_disable_compile = @CONFIG_DISABLE_HOST_COMPILE@
-peano_install_dir = "@CONFIG_PEANO_INSTALL_DIR@"
 host_architecture = "@LLVM_HOST_TRIPLE@"
 
 def install_path():


### PR DESCRIPTION
Historically, we assumed that peano was primarily accessed from the user's path, which causes some issues where peano binaries conflict with other LLVMs on the user path.  This patch removes this use of the path in favor of referencing peano using explicit paths. These explicit paths are discovered when aiecc runs, relative to the location of the python code.  This replaces the (bogus) compile-time setting of peano_install_dir, which was completely wrong when distributing a packaged build.

Fixes #118 