### PR TITLE
[aiecc] reconcile build and install location of libxaienginecdo.so

### DIFF
--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -399,7 +399,7 @@ all:
       runtime_xaiengine_path = os.path.join(install_path, 'runtime_lib',
                                             opts.host_target.split('-')[0], 'xaiengine', 'cdo')
       xaiengine_include_path = os.path.join(runtime_xaiengine_path, "include")
-      xaiengine_lib_path = os.path.join(runtime_xaiengine_path, "lib")
+      xaiengine_lib_path = os.path.join(runtime_xaiengine_path)
 
       for elf in glob.glob('*.elf'):
         shutil.copy(elf, self.tmpdirname)

--- a/runtime_lib/xaiengine/cdo/CMakeLists.txt
+++ b/runtime_lib/xaiengine/cdo/CMakeLists.txt
@@ -19,4 +19,4 @@ add_aiert_library(xaienginecdo ${XAIE_SOURCE})
 
 target_compile_definitions(xaienginecdo PRIVATE -D__AIECDO__)
 
-install(TARGETS xaienginecdo DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/cdo/lib)
+install(TARGETS xaienginecdo DESTINATION ${CMAKE_INSTALL_PREFIX}/runtime_lib/${AIE_RUNTIME_TARGET}/xaiengine/cdo)


### PR DESCRIPTION
There was a small mismatch between the build path and the install path of this library.