### PR TITLE
Remove objectfifo types

### DIFF
--- a/include/aie-c/Dialects.h
+++ b/include/aie-c/Dialects.h
@@ -18,20 +18,6 @@ MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIE, aie);
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIEVec, aievec);
 MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(AIEX, aiex);
 
-//===---------------------------------------------------------------------===//
-// ObjectFifoType
-//===---------------------------------------------------------------------===//
-
-MLIR_CAPI_EXPORTED bool aieTypeIsObjectFifoType(MlirType type);
-MLIR_CAPI_EXPORTED MlirType aieObjectFifoTypeGet(MlirType type);
-
-//===---------------------------------------------------------------------===//
-// ObjectFifoSubviewType
-//===---------------------------------------------------------------------===//
-
-MLIR_CAPI_EXPORTED bool aieTypeIsObjectFifoSubviewType(MlirType type);
-MLIR_CAPI_EXPORTED MlirType aieObjectFifoSubviewTypeGet(MlirType type);
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/aie/Dialect/AIE/IR/AIE.td
+++ b/include/aie/Dialect/AIE/IR/AIE.td
@@ -26,7 +26,7 @@ def AIE_Dialect : Dialect {
     `switch` keyword in C/C++.
 
   }];
-  let useDefaultTypePrinterParser = 1;
+  let useDefaultTypePrinterParser = 0;
   let useDefaultAttributePrinterParser = 1;
 }
 

--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -68,57 +68,6 @@ void registerAIETranslations();
 #define GET_TYPEDEF_CLASSES 1
 #include "aie/Dialect/AIE/IR/AIETypes.h.inc"
 
-namespace xilinx::AIE {
-namespace detail {
-struct AIEObjectFifoTypeStorage;
-}
-
-/// This class defines the AIE ObjectFifo type.
-class AIEObjectFifoType
-    : public mlir::Type::TypeBase<AIEObjectFifoType, mlir::Type,
-                                  detail::AIEObjectFifoTypeStorage> {
-public:
-  /// Inherit some necessary constructors from 'TypeBase'.
-  using Base::Base;
-
-  /// Create an instance of a `ObjectFifoType` with the given element type.
-  static AIEObjectFifoType get(Type elementType);
-
-  /// This method is used to verify the construction invariants.
-  static mlir::LogicalResult
-  verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
-         Type elementType);
-
-  /// Returns the element type of this ObjectFifoType.
-  Type getElementType();
-};
-
-namespace detail {
-struct AIEObjectFifoSubviewTypeStorage;
-}
-
-/// This class defines the AIE ObjectFifoSubview type.
-class AIEObjectFifoSubviewType
-    : public mlir::Type::TypeBase<AIEObjectFifoSubviewType, mlir::Type,
-                                  detail::AIEObjectFifoSubviewTypeStorage> {
-public:
-  /// Inherit some necessary constructors from 'TypeBase'.
-  using Base::Base;
-
-  /// Create an instance of a `SubviewType` with the given element type.
-  static AIEObjectFifoSubviewType get(Type elementType);
-
-  /// This method is used to verify the construction invariants.
-  static mlir::LogicalResult
-  verify(llvm::function_ref<mlir::InFlightDiagnostic()> emitError,
-         Type elementType);
-
-  /// Returns the element type of this SubviewType.
-  Type getElementType();
-};
-
-} // namespace xilinx::AIE
-
 ////////////////////////////////////////////////////////////////////////////////
 // Custom Attributes ///////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1418,7 +1418,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
         Index:$producerTile,
         Variadic<Index>:$consumerTiles,
         AIE_ObjectFifo_Depth:$elemNumber,
-        TypeAttrOf<AIE_ObjectFifoType>:$elem_type,
+        TypeAttrOf<AnyMemRef>:$elem_type,
         AIE_DimTupleArrayAttr:$dimensionsToStream,
         AIE_DimTupleArrayArrayAttr:$dimensionsFromStreamPerConsumer
   );
@@ -1597,7 +1597,7 @@ def AIE_ObjectFifoAcquireOp: AIE_Op<"objectFifo.acquire", []> {
         ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$size
   );
 
-  let results = (outs AIE_ObjectFifoSubviewType:$subview);
+  let results = (outs AnyMemRef:$subview);
 
   let assemblyFormat = [{
     attr-dict $objFifo_name `(` $port `,` $size `)` `:` type($subview)
@@ -1661,7 +1661,7 @@ def AIE_ObjectFifoSubviewAccessOp : AIE_Op<"objectFifo.subview.access", []> {
   }];
 
   let arguments = (
-    ins AIE_ObjectFifoSubviewType:$subview, 
+    ins AnyMemRef:$subview, 
         ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$index
   );
 

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1418,7 +1418,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
         Index:$producerTile,
         Variadic<Index>:$consumerTiles,
         AIE_ObjectFifo_Depth:$elemNumber,
-        TypeAttrOf<AnyMemRef>:$elem_type,
+        TypeAttrOf<AnyMemRef>:$elemType,
         AIE_DimTupleArrayAttr:$dimensionsToStream,
         AIE_DimTupleArrayArrayAttr:$dimensionsFromStreamPerConsumer
   );
@@ -1432,7 +1432,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
         `}` 
         `,` 
         $elemNumber 
-    `)` attr-dict `:` $elem_type
+    `)` attr-dict `:` $elemType
   }];
   
   let hasVerifier = 1;
@@ -1457,14 +1457,14 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectFifo", [HasParent<"DeviceOp">, Symbol]
 
   let builders = [
     OpBuilder<(ins "mlir::StringAttr":$sym_name, "mlir::Value":$producerTile,
-                   "mlir::ValueRange":$consumerTiles, "mlir::Attribute":$elemNumber, "mlir::Type":$elem_type,
+                   "mlir::ValueRange":$consumerTiles, "mlir::Attribute":$elemNumber, "mlir::Type":$elemType,
                    CArg<"llvm::ArrayRef<AIE::DimTupleAttr>", "{}">:$dimensionsToStream,
                    CArg<"llvm::ArrayRef<AIE::DimTupleArrayAttr>", "{}">:$dimensionsFromStreamPerConsumer), [{
       odsState.addOperands(producerTile);
       odsState.addOperands(consumerTiles);
       odsState.addAttribute(getSymNameAttrName(odsState.name), sym_name);
       odsState.addAttribute(getElemNumberAttrName(odsState.name), elemNumber);
-      odsState.addAttribute(getElemTypeAttrName(odsState.name), mlir::TypeAttr::get(elem_type));
+      odsState.addAttribute(getElemTypeAttrName(odsState.name), mlir::TypeAttr::get(elemType));
       odsState.addAttribute(getDimensionsToStreamAttrName(odsState.name),
                             odsBuilder.getAttr<DimTupleArrayAttr>(dimensionsToStream));
       odsState.addAttribute(getDimensionsFromStreamPerConsumerAttrName(odsState.name),

--- a/include/aie/Dialect/AIE/IR/AIETypes.td
+++ b/include/aie/Dialect/AIE/IR/AIETypes.td
@@ -16,16 +16,6 @@ include "aie/Dialect/AIE/IR/AIEAttrs.td"
 
 include "mlir/IR/AttrTypeBase.td"
 
-def AIE_ObjectFifoType :
-    DialectType<AIE_Dialect, CPred<"$_self.isa<AIEObjectFifoType>()">,
-                "AIE objectFifo type">;
-
-def AIE_ObjectFifoSubviewType :
-    DialectType<AIE_Dialect, CPred<"$_self.isa<AIEObjectFifoSubviewType>()">,
-                "AIE ObjectFifoSubview type">;
-
-def AIE_Type : AnyTypeOf<[AIE_ObjectFifoType, AIE_ObjectFifoSubviewType]>;
-
 def AIE_ObjectFifo_Depth : AnyAttrOf<[ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>, ArrayAttr]>;
 
 def AnyScalarOrTensor : TypeConstraint<Or<[AnySignlessInteger.predicate,

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -18,26 +18,4 @@ MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIEX, aiex, xilinx::AIEX::AIEXDialect)
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(AIEVec, aievec,
                                       xilinx::aievec::AIEVecDialect)
 
-//===---------------------------------------------------------------------===//
-// ObjectFifoType
-//===---------------------------------------------------------------------===//
 
-bool aieTypeIsObjectFifoType(MlirType type) {
-  return unwrap(type).isa<xilinx::AIE::AIEObjectFifoType>();
-}
-
-MlirType aieObjectFifoTypeGet(MlirType type) {
-  return wrap(xilinx::AIE::AIEObjectFifoType::get(unwrap(type)));
-}
-
-//===---------------------------------------------------------------------===//
-// ObjectFifoSubviewType
-//===---------------------------------------------------------------------===//
-
-bool aieTypeIsObjectFifoSubviewType(MlirType type) {
-  return unwrap(type).isa<xilinx::AIE::AIEObjectFifoSubviewType>();
-}
-
-MlirType aieObjectFifoSubviewTypeGet(MlirType type) {
-  return wrap(xilinx::AIE::AIEObjectFifoSubviewType::get(unwrap(type)));
-}

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -39,24 +39,5 @@ PYBIND11_MODULE(_aie, m) {
       },
       py::arg("registry"));
 
-  // AIE types bindings
-  mlir_type_subclass(m, "ObjectFifoType", aieTypeIsObjectFifoType)
-      .def_classmethod(
-          "get",
-          [](py::object cls, MlirType type) {
-            return cls(aieObjectFifoTypeGet(type));
-          },
-          "Get an instance of ObjectFifoType with given element type.",
-          py::arg("self"), py::arg("type") = py::none());
-
-  mlir_type_subclass(m, "ObjectFifoSubviewType", aieTypeIsObjectFifoSubviewType)
-      .def_classmethod(
-          "get",
-          [](py::object cls, MlirType type) {
-            return cls(aieObjectFifoSubviewTypeGet(type));
-          },
-          "Get an instance of ObjectFifoSubviewType with given element type.",
-          py::arg("self"), py::arg("type") = py::none());
-
   m.attr("__version__") = "dev";
 }

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -212,7 +212,7 @@ class OrderedObjectBuffer(ObjectFifoCreateOp):
             for d in depth:
                 int_depths.append(IntegerAttr.get(int_ty, d))
             int_depth = ArrayAttr.get(int_depths)
-        of_Ty = ObjectFifoType.get(datatype)
+        of_Ty = datatype
         super().__init__(
             sym_name=name,
             producerTile=tile0,

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -12,7 +12,6 @@ from .extras.arith import constant
 from .func import CallOp, FuncOp
 from .._mlir_libs import get_dialect_registry
 from .._mlir_libs._aie import *
-from .._mlir_libs._aie import ObjectFifoType
 from ..extras import types as T
 from ..ir import (
     Attribute,
@@ -229,7 +228,7 @@ class OrderedObjectBuffer(ObjectFifoCreateOp):
 # from objFifo with given name.
 class ObjectFifoAcquireOp(ObjectFifoAcquireOp):
     def __init__(self, port, of_name, num_elem, datatype):
-        subview_t = ObjectFifoSubviewType.get(datatype)
+        subview_t = T.memref(num_elem, datatype)
         self.datatype = datatype
         super().__init__(subview_t, port, of_name, num_elem)
 

--- a/test/ipu-xrt/add_one_objFifo/aie.mlir
+++ b/test/ipu-xrt/add_one_objFifo/aie.mlir
@@ -11,11 +11,11 @@ module {
     %t01 = AIE.tile(0, 1)
     %t02 = AIE.tile(0, 2)
   
-    AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
+    AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : memref<2xmemref<16xi32>>
+    AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : memref<2xmemref<8xi32>>
     AIE.objectFifo.link [@objFifo_in0] -> [@objFifo_in1] ()
-    AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
+    AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : memref<2xmemref<16xi32>>
+    AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : memref<2xmemref<8xi32>>
     AIE.objectFifo.link [@objFifo_out1] -> [@objFifo_out0] ()
   
     AIE.core(%t02) {
@@ -25,10 +25,10 @@ module {
       %c1_32 = arith.constant 1 : i32
   
       scf.for %steps = %c0 to %c8 step %c1 {
-        %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : !AIE.objectFifoSubview<memref<8xi32>>
-        %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
-        %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : !AIE.objectFifoSubview<memref<8xi32>>
-        %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
+        %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : memref<1xmemref<8xi32>>
+        %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<8xi32>> -> memref<8xi32>
+        %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : memref<1xmemref<8xi32>>
+        %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<8xi32>> -> memref<8xi32>
         scf.for %arg3 = %c0 to %c8 step %c1 {
             %0 = memref.load %elem0[%arg3] : memref<8xi32>
             %1 = arith.addi %0, %c1_32 : i32

--- a/test/ipu-xrt/add_one_objFifo/aie.mlir
+++ b/test/ipu-xrt/add_one_objFifo/aie.mlir
@@ -11,11 +11,11 @@ module {
     %t01 = AIE.tile(0, 1)
     %t02 = AIE.tile(0, 2)
   
-    AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
+    AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : memref<16xi32>
+    AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : memref<8xi32>
     AIE.objectFifo.link [@objFifo_in0] -> [@objFifo_in1] ()
-    AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-    AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
+    AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : memref<16xi32>
+    AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : memref<8xi32>
     AIE.objectFifo.link [@objFifo_out1] -> [@objFifo_out0] ()
   
     AIE.core(%t02) {
@@ -25,10 +25,10 @@ module {
       %c1_32 = arith.constant 1 : i32
   
       scf.for %steps = %c0 to %c8 step %c1 {
-        %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : !AIE.objectFifoSubview<memref<8xi32>>
-        %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
-        %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : !AIE.objectFifoSubview<memref<8xi32>>
-        %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
+        %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : memref<8xi32>
+        %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<8xi32> -> memref<8xi32>
+        %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : memref<8xi32>
+        %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<8xi32> -> memref<8xi32>
         scf.for %arg3 = %c0 to %c8 step %c1 {
             %0 = memref.load %elem0[%arg3] : memref<8xi32>
             %1 = arith.addi %0, %c1_32 : i32

--- a/test/ipu-xrt/add_one_objFifo/aie.mlir
+++ b/test/ipu-xrt/add_one_objFifo/aie.mlir
@@ -11,11 +11,11 @@ module {
     %t01 = AIE.tile(0, 1)
     %t02 = AIE.tile(0, 2)
   
-    AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : memref<16xi32>
-    AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : memref<8xi32>
+    AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
     AIE.objectFifo.link [@objFifo_in0] -> [@objFifo_in1] ()
-    AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : memref<16xi32>
-    AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : memref<8xi32>
+    AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
     AIE.objectFifo.link [@objFifo_out1] -> [@objFifo_out0] ()
   
     AIE.core(%t02) {
@@ -25,10 +25,10 @@ module {
       %c1_32 = arith.constant 1 : i32
   
       scf.for %steps = %c0 to %c8 step %c1 {
-        %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : memref<8xi32>
-        %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<8xi32> -> memref<8xi32>
-        %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : memref<8xi32>
-        %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<8xi32> -> memref<8xi32>
+        %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : !AIE.objectFifoSubview<memref<8xi32>>
+        %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
+        %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : !AIE.objectFifoSubview<memref<8xi32>>
+        %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
         scf.for %arg3 = %c0 to %c8 step %c1 {
             %0 = memref.load %elem0[%arg3] : memref<8xi32>
             %1 = arith.addi %0, %c1_32 : i32

--- a/test/objectFifo-register-process/base_test_1.aie.mlir
+++ b/test/objectFifo-register-process/base_test_1.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -27,8 +27,8 @@
 // CHECK:             %[[VAL_7:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
+// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -41,7 +41,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_1.aie.mlir
+++ b/test/objectFifo-register-process/base_test_1.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -27,8 +27,8 @@
 // CHECK:             %[[VAL_7:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
-// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -41,7 +41,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_1.aie.mlir
+++ b/test/objectFifo-register-process/base_test_1.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<4xmemref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -27,8 +27,8 @@
 // CHECK:             %[[VAL_7:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<1xmemref<16xi32>>
+// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -41,7 +41,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_2.aie.mlir
+++ b/test/objectFifo-register-process/base_test_2.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<4xmemref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<[2, 3, 3, 2]> : tensor<4xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 2]> : tensor<4xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -23,24 +23,24 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<2xmemref<16xi32>>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : memref<2xmemref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_12:.*]] = %[[VAL_9]] to %[[VAL_10]] step %[[VAL_11]] {
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<3xmemref<16xi32>>
+// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : memref<3xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<2xmemref<16xi32>>
+// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : memref<2xmemref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.end
@@ -52,7 +52,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
         %acquirePattern = arith.constant dense<[2,3,3,2]> : tensor<4xi32>
         %releasePattern = arith.constant dense<[0,1,1,2]> : tensor<4xi32>

--- a/test/objectFifo-register-process/base_test_2.aie.mlir
+++ b/test/objectFifo-register-process/base_test_2.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<[2, 3, 3, 2]> : tensor<4xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 2]> : tensor<4xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -23,24 +23,24 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<16xi32>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<16xi32> -> memref<16xi32>
-// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_12:.*]] = %[[VAL_9]] to %[[VAL_10]] step %[[VAL_11]] {
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<16xi32>
-// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : memref<16xi32> -> memref<16xi32>
-// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : memref<16xi32> -> memref<16xi32>
-// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<16xi32>
-// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<16xi32> -> memref<16xi32>
-// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.end
@@ -52,7 +52,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %acquirePattern = arith.constant dense<[2,3,3,2]> : tensor<4xi32>
         %releasePattern = arith.constant dense<[0,1,1,2]> : tensor<4xi32>

--- a/test/objectFifo-register-process/base_test_2.aie.mlir
+++ b/test/objectFifo-register-process/base_test_2.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<[2, 3, 3, 2]> : tensor<4xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 2]> : tensor<4xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -23,24 +23,24 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<16xi32>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : memref<16xi32> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_12:.*]] = %[[VAL_9]] to %[[VAL_10]] step %[[VAL_11]] {
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<16xi32>
+// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<16xi32>
+// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : memref<16xi32> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.end
@@ -52,7 +52,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
         %acquirePattern = arith.constant dense<[2,3,3,2]> : tensor<4xi32>
         %releasePattern = arith.constant dense<[0,1,1,2]> : tensor<4xi32>

--- a/test/objectFifo-register-process/base_test_3.aie.mlir
+++ b/test/objectFifo-register-process/base_test_3.aie.mlir
@@ -16,7 +16,7 @@
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
 // CHECK:           %[[VAL_2:.*]] = AIE.tile(3, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_2]], %[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_2]], %[[VAL_1]]}, 2 : i32) : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 10 : index
@@ -40,8 +40,8 @@
 // CHECK:             %[[VAL_14:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_15:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_16:.*]] = %[[VAL_13]] to %[[VAL_14]] step %[[VAL_15]] {
-// CHECK:               %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
+// CHECK:               %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -52,8 +52,8 @@
 // CHECK:             %[[VAL_21:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_22:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_23:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_22]] {
-// CHECK:               %[[VAL_24:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_25:.*]] = AIE.objectFifo.subview.access %[[VAL_24]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_24:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : memref<16xi32>
+// CHECK:               %[[VAL_25:.*]] = AIE.objectFifo.subview.access %[[VAL_24]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @consumer_work1() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:             }
@@ -64,8 +64,8 @@
 // CHECK:             %[[VAL_28:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_29:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_30:.*]] = %[[VAL_27]] to %[[VAL_28]] step %[[VAL_29]] {
-// CHECK:               %[[VAL_31:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_32:.*]] = AIE.objectFifo.subview.access %[[VAL_31]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_31:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : memref<16xi32>
+// CHECK:               %[[VAL_32:.*]] = AIE.objectFifo.subview.access %[[VAL_31]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @consumer_work2() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:             }
@@ -80,7 +80,7 @@ module @registerPatterns  {
         %tile13 = AIE.tile(1, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : memref<16xi32>
 
         %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
         %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_3.aie.mlir
+++ b/test/objectFifo-register-process/base_test_3.aie.mlir
@@ -16,7 +16,7 @@
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
 // CHECK:           %[[VAL_2:.*]] = AIE.tile(3, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_2]], %[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_2]], %[[VAL_1]]}, 2 : i32) : memref<2xmemref<16xi32>>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 10 : index
@@ -40,8 +40,8 @@
 // CHECK:             %[[VAL_14:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_15:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_16:.*]] = %[[VAL_13]] to %[[VAL_14]] step %[[VAL_15]] {
-// CHECK:               %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<1xmemref<16xi32>>
+// CHECK:               %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -52,8 +52,8 @@
 // CHECK:             %[[VAL_21:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_22:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_23:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_22]] {
-// CHECK:               %[[VAL_24:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_25:.*]] = AIE.objectFifo.subview.access %[[VAL_24]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_24:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : memref<1xmemref<16xi32>>
+// CHECK:               %[[VAL_25:.*]] = AIE.objectFifo.subview.access %[[VAL_24]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @consumer_work1() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:             }
@@ -64,8 +64,8 @@
 // CHECK:             %[[VAL_28:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_29:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_30:.*]] = %[[VAL_27]] to %[[VAL_28]] step %[[VAL_29]] {
-// CHECK:               %[[VAL_31:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_32:.*]] = AIE.objectFifo.subview.access %[[VAL_31]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_31:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : memref<1xmemref<16xi32>>
+// CHECK:               %[[VAL_32:.*]] = AIE.objectFifo.subview.access %[[VAL_31]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @consumer_work2() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:             }
@@ -80,7 +80,7 @@ module @registerPatterns  {
         %tile13 = AIE.tile(1, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : memref<2xmemref<16xi32>>
 
         %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
         %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_3.aie.mlir
+++ b/test/objectFifo-register-process/base_test_3.aie.mlir
@@ -16,7 +16,7 @@
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
 // CHECK:           %[[VAL_2:.*]] = AIE.tile(3, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_2]], %[[VAL_1]]}, 2 : i32) : memref<16xi32>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_2]], %[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_5:.*]] = arith.constant 10 : index
@@ -40,8 +40,8 @@
 // CHECK:             %[[VAL_14:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_15:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_16:.*]] = %[[VAL_13]] to %[[VAL_14]] step %[[VAL_15]] {
-// CHECK:               %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
-// CHECK:               %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -52,8 +52,8 @@
 // CHECK:             %[[VAL_21:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_22:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_23:.*]] = %[[VAL_20]] to %[[VAL_21]] step %[[VAL_22]] {
-// CHECK:               %[[VAL_24:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : memref<16xi32>
-// CHECK:               %[[VAL_25:.*]] = AIE.objectFifo.subview.access %[[VAL_24]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_24:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_25:.*]] = AIE.objectFifo.subview.access %[[VAL_24]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @consumer_work1() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:             }
@@ -64,8 +64,8 @@
 // CHECK:             %[[VAL_28:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_29:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_30:.*]] = %[[VAL_27]] to %[[VAL_28]] step %[[VAL_29]] {
-// CHECK:               %[[VAL_31:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : memref<16xi32>
-// CHECK:               %[[VAL_32:.*]] = AIE.objectFifo.subview.access %[[VAL_31]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_31:.*]] = AIE.objectFifo.acquire @objfifo(Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_32:.*]] = AIE.objectFifo.subview.access %[[VAL_31]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @consumer_work2() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Consume, 1)
 // CHECK:             }
@@ -80,7 +80,7 @@ module @registerPatterns  {
         %tile13 = AIE.tile(1, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile33, %tile13}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
         %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/base_test_4.aie.mlir
+++ b/test/objectFifo-register-process/base_test_4.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<4xmemref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<[2, 3, 3, 3, 0]> : tensor<5xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 2, 1]> : tensor<5xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -23,25 +23,25 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<2xmemref<16xi32>>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : memref<2xmemref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_12:.*]] = %[[VAL_9]] to %[[VAL_10]] step %[[VAL_11]] {
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<3xmemref<16xi32>>
+// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : memref<3xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_20:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<3xmemref<16xi32>>
+// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_20:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][2] : memref<3xmemref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 1)
@@ -54,7 +54,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
         %acquirePattern = arith.constant dense<[2,3,3,3,0]> : tensor<5xi32>
         %releasePattern = arith.constant dense<[0,1,1,2,1]> : tensor<5xi32>

--- a/test/objectFifo-register-process/base_test_4.aie.mlir
+++ b/test/objectFifo-register-process/base_test_4.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<[2, 3, 3, 3, 0]> : tensor<5xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 2, 1]> : tensor<5xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -23,25 +23,25 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<16xi32>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : memref<16xi32> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_12:.*]] = %[[VAL_9]] to %[[VAL_10]] step %[[VAL_11]] {
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<16xi32>
+// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-// CHECK:             %[[VAL_20:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<16xi32>
+// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_20:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][2] : memref<16xi32> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 1)
@@ -54,7 +54,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
         %acquirePattern = arith.constant dense<[2,3,3,3,0]> : tensor<5xi32>
         %releasePattern = arith.constant dense<[0,1,1,2,1]> : tensor<5xi32>

--- a/test/objectFifo-register-process/base_test_4.aie.mlir
+++ b/test/objectFifo-register-process/base_test_4.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<[2, 3, 3, 3, 0]> : tensor<5xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 2, 1]> : tensor<5xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -23,25 +23,25 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : memref<16xi32>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<16xi32> -> memref<16xi32>
-// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_8:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 2 : index
 // CHECK:             %[[VAL_11:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_12:.*]] = %[[VAL_9]] to %[[VAL_10]] step %[[VAL_11]] {
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<16xi32>
-// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : memref<16xi32> -> memref<16xi32>
-// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : memref<16xi32> -> memref<16xi32>
-// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_14:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_16:.*]] = AIE.objectFifo.subview.access %[[VAL_13]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : memref<16xi32>
-// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : memref<16xi32> -> memref<16xi32>
-// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : memref<16xi32> -> memref<16xi32>
-// CHECK:             %[[VAL_20:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][2] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_17:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:             %[[VAL_18:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_19:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_20:.*]] = AIE.objectFifo.subview.access %[[VAL_17]][2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 1)
@@ -54,7 +54,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %acquirePattern = arith.constant dense<[2,3,3,3,0]> : tensor<5xi32>
         %releasePattern = arith.constant dense<[0,1,1,2,1]> : tensor<5xi32>

--- a/test/objectFifo-register-process/base_test_5.aie.mlir
+++ b/test/objectFifo-register-process/base_test_5.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 1, 2]> : tensor<5xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 5 : index
@@ -23,20 +23,20 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_8:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_9:.*]] = arith.constant 3 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_11:.*]] = %[[VAL_8]] to %[[VAL_9]] step %[[VAL_10]] {
-// CHECK:               %[[VAL_12:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_12:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_14:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
-// CHECK:             %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_14]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:             %[[VAL_14:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:             %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_14]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.end
@@ -48,7 +48,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[0,1,1,1,2]> : tensor<5xi32>

--- a/test/objectFifo-register-process/base_test_5.aie.mlir
+++ b/test/objectFifo-register-process/base_test_5.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<4xmemref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 1, 2]> : tensor<5xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 5 : index
@@ -23,20 +23,20 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<1xmemref<16xi32>>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_8:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_9:.*]] = arith.constant 3 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_11:.*]] = %[[VAL_8]] to %[[VAL_9]] step %[[VAL_10]] {
-// CHECK:               %[[VAL_12:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_12:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<1xmemref<16xi32>>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_14:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_14]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_14:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<1xmemref<16xi32>>
+// CHECK:             %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_14]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.end
@@ -48,7 +48,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[0,1,1,1,2]> : tensor<5xi32>

--- a/test/objectFifo-register-process/base_test_5.aie.mlir
+++ b/test/objectFifo-register-process/base_test_5.aie.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]], {%[[VAL_1]]}, 4 : i32) : memref<16xi32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<[0, 1, 1, 1, 2]> : tensor<5xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 5 : index
@@ -23,20 +23,20 @@
 // CHECK:             return
 // CHECK:           }
 // CHECK:           %[[VAL_5:.*]] = AIE.core(%[[VAL_0]]) {
-// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_6:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
+// CHECK:             %[[VAL_7:.*]] = AIE.objectFifo.subview.access %[[VAL_6]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             %[[VAL_8:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_9:.*]] = arith.constant 3 : index
 // CHECK:             %[[VAL_10:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_11:.*]] = %[[VAL_8]] to %[[VAL_9]] step %[[VAL_10]] {
-// CHECK:               %[[VAL_12:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_12:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
+// CHECK:               %[[VAL_13:.*]] = AIE.objectFifo.subview.access %[[VAL_12]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
-// CHECK:             %[[VAL_14:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:             %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_14]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:             %[[VAL_14:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
+// CHECK:             %[[VAL_15:.*]] = AIE.objectFifo.subview.access %[[VAL_14]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:             func.call @producer_work() : () -> ()
 // CHECK:             AIE.objectFifo.release @objfifo(Produce, 2)
 // CHECK:             AIE.end
@@ -48,7 +48,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[0,1,1,1,2]> : tensor<5xi32>

--- a/test/objectFifo-register-process/nd_dma_test_aie2.mlir
+++ b/test/objectFifo-register-process/nd_dma_test_aie2.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcve2302) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]] toStream [<1, 2>], {%[[VAL_1]] fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]] toStream [<1, 2>], {%[[VAL_1]] fromStream [<3, 4>]}, 4 : i32) : memref<16xi32>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -27,8 +27,8 @@
 // CHECK:             %[[VAL_7:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
+// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : memref<16xi32> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -41,7 +41,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12 toStream [<1, 2>], {%tile13 fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12 toStream [<1, 2>], {%tile13 fromStream [<3, 4>]}, 4 : i32) : memref<16xi32>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/nd_dma_test_aie2.mlir
+++ b/test/objectFifo-register-process/nd_dma_test_aie2.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcve2302) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]] toStream [<1, 2>], {%[[VAL_1]] fromStream [<3, 4>]}, 4 : i32) : memref<16xi32>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]] toStream [<1, 2>], {%[[VAL_1]] fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -27,8 +27,8 @@
 // CHECK:             %[[VAL_7:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<16xi32>
-// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : memref<16xi32> -> memref<16xi32>
+// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -41,7 +41,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12 toStream [<1, 2>], {%tile13 fromStream [<3, 4>]}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12 toStream [<1, 2>], {%tile13 fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-register-process/nd_dma_test_aie2.mlir
+++ b/test/objectFifo-register-process/nd_dma_test_aie2.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:   AIE.device(xcve2302) {
 // CHECK:           %[[VAL_0:.*]] = AIE.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = AIE.tile(1, 3)
-// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]] toStream [<1, 2>], {%[[VAL_1]] fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+// CHECK:           AIE.objectFifo @objfifo(%[[VAL_0]] toStream [<1, 2>], {%[[VAL_1]] fromStream [<3, 4>]}, 4 : i32) : memref<4xmemref<16xi32>>
 // CHECK:           %[[VAL_2:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_3:.*]] = arith.constant dense<1> : tensor<1xi32>
 // CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
@@ -27,8 +27,8 @@
 // CHECK:             %[[VAL_7:.*]] = arith.constant 10 : index
 // CHECK:             %[[VAL_8:.*]] = arith.constant 1 : index
 // CHECK:             scf.for %[[VAL_9:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] {
-// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+// CHECK:               %[[VAL_10:.*]] = AIE.objectFifo.acquire @objfifo(Produce, 1) : memref<1xmemref<16xi32>>
+// CHECK:               %[[VAL_11:.*]] = AIE.objectFifo.subview.access %[[VAL_10]][0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 // CHECK:               func.call @producer_work() : () -> ()
 // CHECK:               AIE.objectFifo.release @objfifo(Produce, 1)
 // CHECK:             }
@@ -41,7 +41,7 @@ module @registerPatterns  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12 toStream [<1, 2>], {%tile13 fromStream [<3, 4>]}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12 toStream [<1, 2>], {%tile13 fromStream [<3, 4>]}, 4 : i32) : memref<4xmemref<16xi32>>
 
         %acquirePattern = arith.constant dense<[1]> : tensor<1xi32>
         %releasePattern = arith.constant dense<[1]> : tensor<1xi32>

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
@@ -93,7 +93,7 @@ module @aie2_cyclostatic_dma {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile83}, 4 : i32) : memref<i32>
+        AIE.objectFifo @fifo (%tile22, {%tile83}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -103,26 +103,26 @@ module @aie2_cyclostatic_dma {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
@@ -138,16 +138,16 @@ module @aie2_cyclostatic_dma {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf83[%i0] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<i32> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf83[%i1] : memref<4xi32>
@@ -155,8 +155,8 @@ module @aie2_cyclostatic_dma {
             AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf83[%i3] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
@@ -93,7 +93,7 @@ module @aie2_cyclostatic_dma {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile83}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile83}, 4 : i32) : memref<i32>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -103,26 +103,26 @@ module @aie2_cyclostatic_dma {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
@@ -138,16 +138,16 @@ module @aie2_cyclostatic_dma {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf83[%i0] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<i32> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf83[%i1] : memref<4xi32>
@@ -155,8 +155,8 @@ module @aie2_cyclostatic_dma {
             AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf83[%i3] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
@@ -93,7 +93,7 @@ module @aie2_cyclostatic_dma {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile83}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile83}, 4 : i32) : memref<4xmemref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -103,26 +103,26 @@ module @aie2_cyclostatic_dma {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
@@ -138,16 +138,16 @@ module @aie2_cyclostatic_dma {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<i32>> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf83[%i0] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<2xmemref<i32>>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<2xmemref<i32>> -> memref<i32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<2xmemref<i32>> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf83[%i1] : memref<4xi32>
@@ -155,8 +155,8 @@ module @aie2_cyclostatic_dma {
             AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<i32>> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf83[%i3] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
@@ -51,7 +51,7 @@ module @aie2_cyclostatic_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -61,26 +61,26 @@ module @aie2_cyclostatic_l1 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
@@ -96,16 +96,16 @@ module @aie2_cyclostatic_l1 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf23[%i0] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<i32> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf23[%i1] : memref<4xi32>
@@ -113,8 +113,8 @@ module @aie2_cyclostatic_l1 {
             AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf23[%i3] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
@@ -51,7 +51,7 @@ module @aie2_cyclostatic_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<4xmemref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -61,26 +61,26 @@ module @aie2_cyclostatic_l1 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<1xmemref<i32>> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
@@ -96,16 +96,16 @@ module @aie2_cyclostatic_l1 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<i32>> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf23[%i0] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<2xmemref<i32>>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<2xmemref<i32>> -> memref<i32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<2xmemref<i32>> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf23[%i1] : memref<4xi32>
@@ -113,8 +113,8 @@ module @aie2_cyclostatic_l1 {
             AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<i32>> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf23[%i3] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l1.mlir
@@ -51,7 +51,7 @@ module @aie2_cyclostatic_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -61,26 +61,26 @@ module @aie2_cyclostatic_l1 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
             memref.store %c55, %subview0_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
             memref.store %c66, %subview1_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
             memref.store %c77, %subview2_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
             memref.store %c88, %subview3_obj[] : memref<i32>
             AIE.objectFifo.release @fifo (Produce, 1)
 
@@ -96,16 +96,16 @@ module @aie2_cyclostatic_l1 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
             %v55 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v55, %buf23[%i0] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<i32> -> memref<i32>
             %v66 = memref.load %subview1_obj0[] : memref<i32>
             %v77 = memref.load %subview1_obj1[] : memref<i32>
             memref.store %v66, %buf23[%i1] : memref<4xi32>
@@ -113,8 +113,8 @@ module @aie2_cyclostatic_l1 {
             AIE.objectFifo.release @fifo (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
             %v88 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v88, %buf23[%i3] : memref<4xi32>
             AIE.objectFifo.release @fifo (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -281,7 +281,7 @@ module @aie2_cyclostatic_l2 {
 
         // ObjectFifo that can hold 4 memref<1xi32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : !AIE.objectFifo<memref<1xi32>>
+        AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : memref<4xmemref<1xi32>>
         AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : !AIE.objectFifo<memref<1xi32>>
         AIE.objectFifo.link [@fifo0] -> [@fifo1] ()
 
@@ -294,26 +294,26 @@ module @aie2_cyclostatic_l2 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xmemref<1xi32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<1xi32>> -> memref<1xi32>
             memref.store %c55, %subview0_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xmemref<1xi32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<1xi32>> -> memref<1xi32>
             memref.store %c66, %subview1_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xmemref<1xi32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<1xi32>> -> memref<1xi32>
             memref.store %c77, %subview2_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview3 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xmemref<1xi32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<1xmemref<1xi32>> -> memref<1xi32>
             memref.store %c88, %subview3_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
@@ -329,16 +329,16 @@ module @aie2_cyclostatic_l2 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : memref<1xmemref<1xi32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<1xi32>> -> memref<1xi32>
             %v55 = memref.load %subview0_obj[%i0] : memref<1xi32>
             memref.store %v55, %buf83[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo1 (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo1 (Consume, 2) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview1 = AIE.objectFifo.acquire @fifo1 (Consume, 2) : memref<2xmemref<1xi32>>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<2xmemref<1xi32>> -> memref<1xi32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<2xmemref<1xi32>> -> memref<1xi32>
             %v66 = memref.load %subview1_obj0[%i0] : memref<1xi32>
             %v77 = memref.load %subview1_obj1[%i0] : memref<1xi32>
             memref.store %v66, %buf83[%i1] : memref<1xi32>
@@ -346,8 +346,8 @@ module @aie2_cyclostatic_l2 {
             AIE.objectFifo.release @fifo1 (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : memref<1xmemref<1xi32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<1xi32>> -> memref<1xi32>
             %v88 = memref.load %subview2_obj[%i0] : memref<1xi32>
             memref.store %v88, %buf83[%i3] : memref<1xi32>
             AIE.objectFifo.release @fifo1 (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -281,8 +281,8 @@ module @aie2_cyclostatic_l2 {
 
         // ObjectFifo that can hold 4 memref<1xi32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : !AIE.objectFifo<memref<1xi32>>
-        AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : !AIE.objectFifo<memref<1xi32>>
+        AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : memref<1xi32>
+        AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : memref<1xi32>
         AIE.objectFifo.link [@fifo0] -> [@fifo1] ()
 
         // Producer core
@@ -294,26 +294,26 @@ module @aie2_cyclostatic_l2 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xi32> -> memref<1xi32>
             memref.store %c55, %subview0_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xi32> -> memref<1xi32>
             memref.store %c66, %subview1_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xi32> -> memref<1xi32>
             memref.store %c77, %subview2_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview3 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<1xi32> -> memref<1xi32>
             memref.store %c88, %subview3_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
@@ -329,16 +329,16 @@ module @aie2_cyclostatic_l2 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : memref<1xi32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xi32> -> memref<1xi32>
             %v55 = memref.load %subview0_obj[%i0] : memref<1xi32>
             memref.store %v55, %buf83[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo1 (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo1 (Consume, 2) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview1 = AIE.objectFifo.acquire @fifo1 (Consume, 2) : memref<1xi32>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<1xi32> -> memref<1xi32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<1xi32> -> memref<1xi32>
             %v66 = memref.load %subview1_obj0[%i0] : memref<1xi32>
             %v77 = memref.load %subview1_obj1[%i0] : memref<1xi32>
             memref.store %v66, %buf83[%i1] : memref<1xi32>
@@ -346,8 +346,8 @@ module @aie2_cyclostatic_l2 {
             AIE.objectFifo.release @fifo1 (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : memref<1xi32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xi32> -> memref<1xi32>
             %v88 = memref.load %subview2_obj[%i0] : memref<1xi32>
             memref.store %v88, %buf83[%i3] : memref<1xi32>
             AIE.objectFifo.release @fifo1 (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -281,8 +281,8 @@ module @aie2_cyclostatic_l2 {
 
         // ObjectFifo that can hold 4 memref<1xi32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : memref<1xi32>
-        AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : memref<1xi32>
+        AIE.objectFifo @fifo0 (%tile22, {%memtile}, 4 : i32) : !AIE.objectFifo<memref<1xi32>>
+        AIE.objectFifo @fifo1 (%memtile, {%tile83}, [4, 4]) : !AIE.objectFifo<memref<1xi32>>
         AIE.objectFifo.link [@fifo0] -> [@fifo1] ()
 
         // Producer core
@@ -294,26 +294,26 @@ module @aie2_cyclostatic_l2 {
             %c88 = arith.constant 88 : i32
             
             // Push 55
-            %subview0 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xi32> -> memref<1xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c55, %subview0_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 66
-            %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xi32> -> memref<1xi32>
+            %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c66, %subview1_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 77
-            %subview2 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xi32> -> memref<1xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c77, %subview2_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
             // Push 88
-            %subview3 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xi32>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<1xi32> -> memref<1xi32>
+            %subview3 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             memref.store %c88, %subview3_obj[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo0 (Produce, 1)
 
@@ -329,16 +329,16 @@ module @aie2_cyclostatic_l2 {
             %i3 = arith.constant 3 : index
 
             // Pop 1 object off queue
-            %subview0 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : memref<1xi32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xi32> -> memref<1xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             %v55 = memref.load %subview0_obj[%i0] : memref<1xi32>
             memref.store %v55, %buf83[%i0] : memref<1xi32>
             AIE.objectFifo.release @fifo1 (Consume, 1)
 
             // Pop 2 objects off queue
-            %subview1 = AIE.objectFifo.acquire @fifo1 (Consume, 2) : memref<1xi32>
-            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : memref<1xi32> -> memref<1xi32>
-            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<1xi32> -> memref<1xi32>
+            %subview1 = AIE.objectFifo.acquire @fifo1 (Consume, 2) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview1_obj0 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
+            %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             %v66 = memref.load %subview1_obj0[%i0] : memref<1xi32>
             %v77 = memref.load %subview1_obj1[%i0] : memref<1xi32>
             memref.store %v66, %buf83[%i1] : memref<1xi32>
@@ -346,8 +346,8 @@ module @aie2_cyclostatic_l2 {
             AIE.objectFifo.release @fifo1 (Consume, 2)
 
             // Pop 1 object off queue
-            %subview2 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : memref<1xi32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<1xi32> -> memref<1xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo1 (Consume, 1) : !AIE.objectFifoSubview<memref<1xi32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<1xi32>> -> memref<1xi32>
             %v88 = memref.load %subview2_obj[%i0] : memref<1xi32>
             memref.store %v88, %buf83[%i3] : memref<1xi32>
             AIE.objectFifo.release @fifo1 (Consume, 1)

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
@@ -123,7 +123,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {
@@ -133,8 +133,8 @@ module @AIE2_delayed_release {
             %i4 = arith.constant 4 : index
             scf.for %it = %i0 to %i4 step %i1 {
                 // Produce one 1 element (acquire producer lock) ...
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-                %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+                %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 memref.store %c99, %subview_obj[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // ... done producing (release consumer lock)
@@ -150,26 +150,26 @@ module @AIE2_delayed_release {
             %i3 = arith.constant 3 : index
 
             // Begin consuming 2 elements (acquire consumer lock with value 2)
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v0 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v0, %buf23[%i0] : memref<4xi32>
 
             // For the next step, we only need one element (this could be a subroutine that acquires 1, not knowing that we already acquired 2)
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v1 = memref.load %subview1_obj[] : memref<i32>
             memref.store %v1, %buf23[%i1] : memref<4xi32>
 
             // Actually, give us the two from before and one more for three objects total (consumer lock should increase by one)
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : memref<i32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v2 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v2, %buf23[%i2] : memref<4xi32>
 
             // Now let's just work on one element (consumer lock should not change value)
-            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v3 = memref.load %subview3_obj[] : memref<i32>
             memref.store %v3, %buf23[%i3] : memref<4xi32>
 

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
@@ -123,7 +123,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {
@@ -133,8 +133,8 @@ module @AIE2_delayed_release {
             %i4 = arith.constant 4 : index
             scf.for %it = %i0 to %i4 step %i1 {
                 // Produce one 1 element (acquire producer lock) ...
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-                %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+                %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
                 memref.store %c99, %subview_obj[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // ... done producing (release consumer lock)
@@ -150,26 +150,26 @@ module @AIE2_delayed_release {
             %i3 = arith.constant 3 : index
 
             // Begin consuming 2 elements (acquire consumer lock with value 2)
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
             %v0 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v0, %buf23[%i0] : memref<4xi32>
 
             // For the next step, we only need one element (this could be a subroutine that acquires 1, not knowing that we already acquired 2)
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
             %v1 = memref.load %subview1_obj[] : memref<i32>
             memref.store %v1, %buf23[%i1] : memref<4xi32>
 
             // Actually, give us the two from before and one more for three objects total (consumer lock should increase by one)
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : memref<i32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
             %v2 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v2, %buf23[%i2] : memref<4xi32>
 
             // Now let's just work on one element (consumer lock should not change value)
-            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
             %v3 = memref.load %subview3_obj[] : memref<i32>
             memref.store %v3, %buf23[%i3] : memref<4xi32>
 

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release.mlir
@@ -123,7 +123,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<4xmemref<i32>>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {
@@ -133,8 +133,8 @@ module @AIE2_delayed_release {
             %i4 = arith.constant 4 : index
             scf.for %it = %i0 to %i4 step %i1 {
                 // Produce one 1 element (acquire producer lock) ...
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-                %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+                %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<i32>> -> memref<i32>
                 memref.store %c99, %subview_obj[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // ... done producing (release consumer lock)
@@ -150,26 +150,26 @@ module @AIE2_delayed_release {
             %i3 = arith.constant 3 : index
 
             // Begin consuming 2 elements (acquire consumer lock with value 2)
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<2xmemref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<2xmemref<i32>> -> memref<i32>
             %v0 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v0, %buf23[%i0] : memref<4xi32>
 
             // For the next step, we only need one element (this could be a subroutine that acquires 1, not knowing that we already acquired 2)
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<i32>> -> memref<i32>
             %v1 = memref.load %subview1_obj[] : memref<i32>
             memref.store %v1, %buf23[%i1] : memref<4xi32>
 
             // Actually, give us the two from before and one more for three objects total (consumer lock should increase by one)
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : memref<3xmemref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<3xmemref<i32>> -> memref<i32>
             %v2 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v2, %buf23[%i2] : memref<4xi32>
 
             // Now let's just work on one element (consumer lock should not change value)
-            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<1xmemref<i32>> -> memref<i32>
             %v3 = memref.load %subview3_obj[] : memref<i32>
             memref.store %v3, %buf23[%i3] : memref<4xi32>
 

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
@@ -25,7 +25,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<4xmemref<i32>>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {
@@ -35,8 +35,8 @@ module @AIE2_delayed_release {
             %i4 = arith.constant 4 : index
             scf.for %it = %i0 to %i4 step %i1 {
                 // Produce one 1 element (acquire producer lock) ...
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-                %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+                %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<i32>> -> memref<i32>
                 memref.store %c99, %subview_obj[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // ... done producing (release consumer lock)
@@ -50,8 +50,8 @@ module @AIE2_delayed_release {
             %i0 = arith.constant 0 : index
             // Begin consuming 2 elements (acquire consumer lock with value 2)
             // expected-error@+1 {{op must be called from inside a CoreOp}}
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<2xmemref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<2xmemref<i32>> -> memref<i32>
             %v0 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v0, %buf[%i0] : memref<4xi32>
             return
@@ -60,8 +60,8 @@ module @AIE2_delayed_release {
         func.func @step2(%buf : memref<4xi32>) -> () {
             %i1 = arith.constant 1 : index
             // For the next step, we only need one element (this could be a subroutine that acquires 1, not knowing that we already acquired 2)
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<i32>> -> memref<i32>
             %v1 = memref.load %subview1_obj[] : memref<i32>
             memref.store %v1, %buf[%i1] : memref<4xi32>
             return
@@ -70,8 +70,8 @@ module @AIE2_delayed_release {
         func.func @step3(%buf : memref<4xi32>) -> () {
             %i2 = arith.constant 2 : index
             // Actually, give us the two from before and one more for three objects total (consumer lock should increase by one)
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : memref<3xmemref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<3xmemref<i32>> -> memref<i32>
             %v2 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v2, %buf[%i2] : memref<4xi32>
             return
@@ -80,8 +80,8 @@ module @AIE2_delayed_release {
         func.func @step4(%buf : memref<4xi32>) -> () {
             %i3 = arith.constant 3 : index
             // Now let's just work on one element (consumer lock should not change value)
-            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<1xmemref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<1xmemref<i32>> -> memref<i32>
             %v3 = memref.load %subview3_obj[] : memref<i32>
             memref.store %v3, %buf[%i3] : memref<4xi32>
             return

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
@@ -25,7 +25,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {
@@ -35,8 +35,8 @@ module @AIE2_delayed_release {
             %i4 = arith.constant 4 : index
             scf.for %it = %i0 to %i4 step %i1 {
                 // Produce one 1 element (acquire producer lock) ...
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-                %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+                %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 memref.store %c99, %subview_obj[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // ... done producing (release consumer lock)
@@ -50,8 +50,8 @@ module @AIE2_delayed_release {
             %i0 = arith.constant 0 : index
             // Begin consuming 2 elements (acquire consumer lock with value 2)
             // expected-error@+1 {{op must be called from inside a CoreOp}}
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v0 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v0, %buf[%i0] : memref<4xi32>
             return
@@ -60,8 +60,8 @@ module @AIE2_delayed_release {
         func.func @step2(%buf : memref<4xi32>) -> () {
             %i1 = arith.constant 1 : index
             // For the next step, we only need one element (this could be a subroutine that acquires 1, not knowing that we already acquired 2)
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v1 = memref.load %subview1_obj[] : memref<i32>
             memref.store %v1, %buf[%i1] : memref<4xi32>
             return
@@ -70,8 +70,8 @@ module @AIE2_delayed_release {
         func.func @step3(%buf : memref<4xi32>) -> () {
             %i2 = arith.constant 2 : index
             // Actually, give us the two from before and one more for three objects total (consumer lock should increase by one)
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : memref<i32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : !AIE.objectFifoSubview<memref<i32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v2 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v2, %buf[%i2] : memref<4xi32>
             return
@@ -80,8 +80,8 @@ module @AIE2_delayed_release {
         func.func @step4(%buf : memref<4xi32>) -> () {
             %i3 = arith.constant 3 : index
             // Now let's just work on one element (consumer lock should not change value)
-            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
             %v3 = memref.load %subview3_obj[] : memref<i32>
             memref.store %v3, %buf[%i3] : memref<4xi32>
             return

--- a/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_delayed_release_inside_funcs.mlir
@@ -25,7 +25,7 @@ module @AIE2_delayed_release {
         %tile23 = AIE.tile(2, 3)
         %buf23 = AIE.buffer(%tile23) {sym_name = "buf23"} : memref<4xi32>
 
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
 
         // Producer -- produces one element at a time
         %core22 = AIE.core(%tile22) {
@@ -35,8 +35,8 @@ module @AIE2_delayed_release {
             %i4 = arith.constant 4 : index
             scf.for %it = %i0 to %i4 step %i1 {
                 // Produce one 1 element (acquire producer lock) ...
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-                %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+                %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
                 memref.store %c99, %subview_obj[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // ... done producing (release consumer lock)
@@ -50,8 +50,8 @@ module @AIE2_delayed_release {
             %i0 = arith.constant 0 : index
             // Begin consuming 2 elements (acquire consumer lock with value 2)
             // expected-error@+1 {{op must be called from inside a CoreOp}}
-            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview0 = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<i32> -> memref<i32>
             %v0 = memref.load %subview0_obj[] : memref<i32>
             memref.store %v0, %buf[%i0] : memref<4xi32>
             return
@@ -60,8 +60,8 @@ module @AIE2_delayed_release {
         func.func @step2(%buf : memref<4xi32>) -> () {
             %i1 = arith.constant 1 : index
             // For the next step, we only need one element (this could be a subroutine that acquires 1, not knowing that we already acquired 2)
-            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview1 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<i32> -> memref<i32>
             %v1 = memref.load %subview1_obj[] : memref<i32>
             memref.store %v1, %buf[%i1] : memref<4xi32>
             return
@@ -70,8 +70,8 @@ module @AIE2_delayed_release {
         func.func @step3(%buf : memref<4xi32>) -> () {
             %i2 = arith.constant 2 : index
             // Actually, give us the two from before and one more for three objects total (consumer lock should increase by one)
-            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : !AIE.objectFifoSubview<memref<i32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview2 = AIE.objectFifo.acquire @fifo (Consume, 3) : memref<i32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<i32> -> memref<i32>
             %v2 = memref.load %subview2_obj[] : memref<i32>
             memref.store %v2, %buf[%i2] : memref<4xi32>
             return
@@ -80,8 +80,8 @@ module @AIE2_delayed_release {
         func.func @step4(%buf : memref<4xi32>) -> () {
             %i3 = arith.constant 3 : index
             // Now let's just work on one element (consumer lock should not change value)
-            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : !AIE.objectFifoSubview<memref<i32>>
-            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+            %subview3 = AIE.objectFifo.acquire @fifo (Consume, 1) : memref<i32>
+            %subview3_obj = AIE.objectFifo.subview.access %subview3[0] : memref<i32> -> memref<i32>
             %v3 = memref.load %subview3_obj[] : memref<i32>
             memref.store %v3, %buf[%i3] : memref<4xi32>
             return

--- a/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
@@ -165,7 +165,7 @@ module @aie2_dynamic_locks {
     AIE.device(xcve2302) {
         %tile22 = AIE.tile(2, 2)  // producer tile
         %tile43 = AIE.tile(4, 3)  // consumer tile
-        AIE.objectFifo @fifo (%tile22, {%tile43}, 1 : i32) : !AIE.objectFifo<memref<i64>>
+        AIE.objectFifo @fifo (%tile22, {%tile43}, 1 : i32) : memref<i64>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -177,7 +177,7 @@ module @aie2_dynamic_locks {
             %c1 = arith.constant 1 : i64
 
             // Acquire one element.
-            %subview0  = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
+            %subview0  = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i64>
 
             scf.for %idx = %i_c0 to %i_c3 step %i_c1 {
                 // Acquire one element (again). In the first iteration of the
@@ -186,8 +186,8 @@ module @aie2_dynamic_locks {
                 // just above the loop. In the second iteration, that object
                 // has been released, and now a lock acquire 1 would be 
                 // required.
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
-                %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i64>> -> memref<i64>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i64>
+                %elem = AIE.objectFifo.subview.access %subview[0] : memref<i64> -> memref<i64>
                 memref.store %c1, %elem[] : memref<i64>
                 AIE.objectFifo.release @fifo (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
@@ -165,7 +165,7 @@ module @aie2_dynamic_locks {
     AIE.device(xcve2302) {
         %tile22 = AIE.tile(2, 2)  // producer tile
         %tile43 = AIE.tile(4, 3)  // consumer tile
-        AIE.objectFifo @fifo (%tile22, {%tile43}, 1 : i32) : memref<i64>
+        AIE.objectFifo @fifo (%tile22, {%tile43}, 1 : i32) : !AIE.objectFifo<memref<i64>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -177,7 +177,7 @@ module @aie2_dynamic_locks {
             %c1 = arith.constant 1 : i64
 
             // Acquire one element.
-            %subview0  = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i64>
+            %subview0  = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
 
             scf.for %idx = %i_c0 to %i_c3 step %i_c1 {
                 // Acquire one element (again). In the first iteration of the
@@ -186,8 +186,8 @@ module @aie2_dynamic_locks {
                 // just above the loop. In the second iteration, that object
                 // has been released, and now a lock acquire 1 would be 
                 // required.
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i64>
-                %elem = AIE.objectFifo.subview.access %subview[0] : memref<i64> -> memref<i64>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
+                %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i64>> -> memref<i64>
                 memref.store %c1, %elem[] : memref<i64>
                 AIE.objectFifo.release @fifo (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
@@ -165,7 +165,7 @@ module @aie2_dynamic_locks {
     AIE.device(xcve2302) {
         %tile22 = AIE.tile(2, 2)  // producer tile
         %tile43 = AIE.tile(4, 3)  // consumer tile
-        AIE.objectFifo @fifo (%tile22, {%tile43}, 1 : i32) : !AIE.objectFifo<memref<i64>>
+        AIE.objectFifo @fifo (%tile22, {%tile43}, 1 : i32) : memref<1xmemref<i64>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -177,7 +177,7 @@ module @aie2_dynamic_locks {
             %c1 = arith.constant 1 : i64
 
             // Acquire one element.
-            %subview0  = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
+            %subview0  = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i64>>
 
             scf.for %idx = %i_c0 to %i_c3 step %i_c1 {
                 // Acquire one element (again). In the first iteration of the
@@ -186,8 +186,8 @@ module @aie2_dynamic_locks {
                 // just above the loop. In the second iteration, that object
                 // has been released, and now a lock acquire 1 would be 
                 // required.
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i64>>
-                %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i64>> -> memref<i64>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i64>>
+                %elem = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<i64>> -> memref<i64>
                 memref.store %c1, %elem[] : memref<i64>
                 AIE.objectFifo.release @fifo (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
@@ -60,7 +60,7 @@ module @aie2_static_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<4xmemref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -73,8 +73,8 @@ module @aie2_static_l1 {
             scf.for %idx = %i_c0 to %i_c16 step %i_c1 {
                 %val0 = memref.load %srcbuf22[] : memref<i32>
                 // Produce 1 elements, so acquire 1 element
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-                %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<1xmemref<i32>>
+                %elem = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<i32>> -> memref<i32>
                 memref.store %val0, %elem[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // Increment
@@ -89,9 +89,9 @@ module @aie2_static_l1 {
         %core23 = AIE.core(%tile23) {
             scf.for %idx = %i_c0 to %i_c16 step %i_c2 {
                 // Consume _two_ elements at once (cyclo static)
-                %subview = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<2xmemref<i32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<2xmemref<i32>> -> memref<i32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<2xmemref<i32>> -> memref<i32>
                 %val0 = memref.load %elem0[] : memref<i32>
                 %val1 = memref.load %elem1[] : memref<i32>
                 // Pass through to destination buffer

--- a/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
@@ -60,7 +60,7 @@ module @aie2_static_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -73,8 +73,8 @@ module @aie2_static_l1 {
             scf.for %idx = %i_c0 to %i_c16 step %i_c1 {
                 %val0 = memref.load %srcbuf22[] : memref<i32>
                 // Produce 1 elements, so acquire 1 element
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
-                %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
+                %elem = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
                 memref.store %val0, %elem[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // Increment
@@ -89,9 +89,9 @@ module @aie2_static_l1 {
         %core23 = AIE.core(%tile23) {
             scf.for %idx = %i_c0 to %i_c16 step %i_c2 {
                 // Consume _two_ elements at once (cyclo static)
-                %subview = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<i32> -> memref<i32>
                 %val0 = memref.load %elem0[] : memref<i32>
                 %val1 = memref.load %elem1[] : memref<i32>
                 // Pass through to destination buffer

--- a/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_static_l1.mlir
@@ -60,7 +60,7 @@ module @aie2_static_l1 {
 
         // ObjectFifo that can hold 4 memref<i32>s, populated by tile22 and
         // consumed by tile23
-        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : memref<i32>
+        AIE.objectFifo @fifo (%tile22, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<i32>>
 
         // Producer core
         %core22 = AIE.core(%tile22) {
@@ -73,8 +73,8 @@ module @aie2_static_l1 {
             scf.for %idx = %i_c0 to %i_c16 step %i_c1 {
                 %val0 = memref.load %srcbuf22[] : memref<i32>
                 // Produce 1 elements, so acquire 1 element
-                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : memref<i32>
-                %elem = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Produce, 1) : !AIE.objectFifoSubview<memref<i32>>
+                %elem = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 memref.store %val0, %elem[] : memref<i32>
                 AIE.objectFifo.release @fifo (Produce, 1)
                 // Increment
@@ -89,9 +89,9 @@ module @aie2_static_l1 {
         %core23 = AIE.core(%tile23) {
             scf.for %idx = %i_c0 to %i_c16 step %i_c2 {
                 // Consume _two_ elements at once (cyclo static)
-                %subview = AIE.objectFifo.acquire @fifo (Consume, 2) : memref<i32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<i32> -> memref<i32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<i32> -> memref<i32>
+                %subview = AIE.objectFifo.acquire @fifo (Consume, 2) : !AIE.objectFifoSubview<memref<i32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<i32>> -> memref<i32>
                 %val0 = memref.load %elem0[] : memref<i32>
                 %val1 = memref.load %elem1[] : memref<i32>
                 // Pass through to destination buffer

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -32,10 +32,10 @@ module @alloc {
         %tile22 = AIE.tile(2, 2)
         %tile23 = AIE.tile(2, 3)
 
-        AIE.objectFifo @of_in_0 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
-        AIE.objectFifo @of_out_0 (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_in_0 (%tile20, {%tile22}, 2 : i32) : memref<2xmemref<64xi16>>
+        AIE.objectFifo @of_out_0 (%tile22, {%tile20}, 2 : i32) : memref<2xmemref<64xi16>>
 
-        AIE.objectFifo @of_in_1 (%tile20, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
-        AIE.objectFifo @of_out_1 (%tile23, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_in_1 (%tile20, {%tile23}, 2 : i32) : memref<2xmemref<64xi16>>
+        AIE.objectFifo @of_out_1 (%tile23, {%tile20}, 2 : i32) : memref<2xmemref<64xi16>>
     }
 }

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -32,10 +32,10 @@ module @alloc {
         %tile22 = AIE.tile(2, 2)
         %tile23 = AIE.tile(2, 3)
 
-        AIE.objectFifo @of_in_0 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
-        AIE.objectFifo @of_out_0 (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_in_0 (%tile20, {%tile22}, 2 : i32) : memref<64xi16>
+        AIE.objectFifo @of_out_0 (%tile22, {%tile20}, 2 : i32) : memref<64xi16>
 
-        AIE.objectFifo @of_in_1 (%tile20, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
-        AIE.objectFifo @of_out_1 (%tile23, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_in_1 (%tile20, {%tile23}, 2 : i32) : memref<64xi16>
+        AIE.objectFifo @of_out_1 (%tile23, {%tile20}, 2 : i32) : memref<64xi16>
     }
 }

--- a/test/objectFifo-stateful-transform/allocation_info_test.mlir
+++ b/test/objectFifo-stateful-transform/allocation_info_test.mlir
@@ -32,10 +32,10 @@ module @alloc {
         %tile22 = AIE.tile(2, 2)
         %tile23 = AIE.tile(2, 3)
 
-        AIE.objectFifo @of_in_0 (%tile20, {%tile22}, 2 : i32) : memref<64xi16>
-        AIE.objectFifo @of_out_0 (%tile22, {%tile20}, 2 : i32) : memref<64xi16>
+        AIE.objectFifo @of_in_0 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_out_0 (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
 
-        AIE.objectFifo @of_in_1 (%tile20, {%tile23}, 2 : i32) : memref<64xi16>
-        AIE.objectFifo @of_out_1 (%tile23, {%tile20}, 2 : i32) : memref<64xi16>
+        AIE.objectFifo @of_in_1 (%tile20, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
+        AIE.objectFifo @of_out_1 (%tile23, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<64xi16>>
     }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE1.mlir
@@ -75,10 +75,10 @@ module @elementGenerationAIE1 {
       %tile33 = AIE.tile(3, 3)
 
       // In the shared memory case, the number of elements does not change.
-      AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
       // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
       // the processes running on each core (here nothing is specified so it cannot be derived).
-      AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
    }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE1.mlir
@@ -75,10 +75,10 @@ module @elementGenerationAIE1 {
       %tile33 = AIE.tile(3, 3)
 
       // In the shared memory case, the number of elements does not change.
-      AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+      AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
       // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
       // the processes running on each core (here nothing is specified so it cannot be derived).
-      AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+      AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
    }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE1.mlir
@@ -75,10 +75,10 @@ module @elementGenerationAIE1 {
       %tile33 = AIE.tile(3, 3)
 
       // In the shared memory case, the number of elements does not change.
-      AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
       // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
       // the processes running on each core (here nothing is specified so it cannot be derived).
-      AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
    }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE2.mlir
@@ -73,10 +73,10 @@ module @elementGenerationAIE2 {
     %tile33 = AIE.tile(3, 3)
 
     // In the shared memory case, the number of elements does not change.
-    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
     // the processes running on each core (here nothing is specified so it cannot be derived).
-    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE2.mlir
@@ -73,10 +73,10 @@ module @elementGenerationAIE2 {
     %tile33 = AIE.tile(3, 3)
 
     // In the shared memory case, the number of elements does not change.
-    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
     // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
     // the processes running on each core (here nothing is specified so it cannot be derived).
-    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
  }
 }

--- a/test/objectFifo-stateful-transform/base_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE2.mlir
@@ -73,10 +73,10 @@ module @elementGenerationAIE2 {
     %tile33 = AIE.tile(3, 3)
 
     // In the shared memory case, the number of elements does not change.
-    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of0 (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
     // In the non-adjacent memory case, the number of elements depends on the max amount acquired by
     // the processes running on each core (here nothing is specified so it cannot be derived).
-    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @of1 (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/broadcast_error_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_error_test.mlir
@@ -22,6 +22,6 @@ module @broadcast_error {
         %tile32 = AIE.tile(3, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3]) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3]) : memref<16xi32>
     }
 }

--- a/test/objectFifo-stateful-transform/broadcast_error_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_error_test.mlir
@@ -22,6 +22,6 @@ module @broadcast_error {
         %tile32 = AIE.tile(3, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3]) : memref<16xi32>
+        AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3]) : !AIE.objectFifo<memref<16xi32>>
     }
 }

--- a/test/objectFifo-stateful-transform/broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_test.mlir
@@ -274,7 +274,7 @@ module @broadcast {
     %tile32 = AIE.tile(3, 2)
     %tile33 = AIE.tile(3, 3)
 
-    AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3, 4, 3]) : memref<16xi32>
+    AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3, 4, 3]) : !AIE.objectFifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return
@@ -286,8 +286,8 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Produce, 1) : memref<16xi32>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Produce, 1)
         }
@@ -301,8 +301,8 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 1) : memref<16xi32>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 1)
         }
@@ -316,9 +316,9 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : memref<16xi32>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 2)
@@ -333,10 +333,10 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 3) : memref<16xi32>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
-            %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<16xi32> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             func.call @some_work(%elem2) : (memref<16xi32>) -> ()
@@ -352,9 +352,9 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : memref<16xi32>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 1)

--- a/test/objectFifo-stateful-transform/broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_test.mlir
@@ -286,8 +286,8 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Produce, 1) : memref<1xmemref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Produce, 1)
         }
@@ -301,8 +301,8 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 1) : memref<1xmemref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 1)
         }
@@ -316,9 +316,9 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : memref<2xmemref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 2)
@@ -333,10 +333,10 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 3) : memref<3xmemref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<3xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             func.call @some_work(%elem2) : (memref<16xi32>) -> ()
@@ -352,9 +352,9 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : memref<2xmemref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 1)

--- a/test/objectFifo-stateful-transform/broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_test.mlir
@@ -274,7 +274,7 @@ module @broadcast {
     %tile32 = AIE.tile(3, 2)
     %tile33 = AIE.tile(3, 3)
 
-    AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3, 4, 3]) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @broadcast_of (%tile13, {%tile12, %tile14, %tile32, %tile33}, [2, 2, 3, 4, 3]) : memref<16xi32>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
         return
@@ -286,8 +286,8 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Produce, 1) : memref<16xi32>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Produce, 1)
         }
@@ -301,8 +301,8 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 1) : memref<16xi32>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 1)
         }
@@ -316,9 +316,9 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : memref<16xi32>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 2)
@@ -333,10 +333,10 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 3) : memref<16xi32>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+            %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             func.call @some_work(%elem2) : (memref<16xi32>) -> ()
@@ -352,9 +352,9 @@ module @broadcast {
         %height = arith.constant 12 : index
 
         scf.for %indexInHeight = %c0 to %height step %c1 {
-            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @broadcast_of (Consume, 2) : memref<16xi32>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem0) : (memref<16xi32>) -> ()
             func.call @some_work(%elem1) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @broadcast_of (Consume, 1)

--- a/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
+++ b/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
@@ -95,7 +95,7 @@ module @cyclostatic {
         %tile12 = AIE.tile(1, 2)
         %tile23 = AIE.tile(2, 2)
 
-        AIE.objectFifo @fifo0 (%tile12, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @fifo0 (%tile12, {%tile23}, 4 : i32) : memref<4xmemref<16xi32>>
 
         %core12 = AIE.core(%tile12) {
             %v11 = arith.constant 11 : i32
@@ -104,8 +104,8 @@ module @cyclostatic {
             %c9 = arith.constant 9 : index
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<1xmemref<16xi32>>
+                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 memref.store %v11, %subview1_obj[%c0] : memref<16xi32>
                 AIE.objectFifo.release @fifo0 (Produce, 1)
             }
@@ -118,25 +118,25 @@ module @cyclostatic {
             %c1 = arith.constant 1 : index
             %c9 = arith.constant 9 : index
 
-            %subview0 = AIE.objectFifo.acquire @fifo0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Consume, 1) : memref<1xmemref<16xi32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             %v0 = memref.load %subview0_obj[%c0] : memref<16xi32>
             AIE.objectFifo.release @fifo0 (Consume, 1)
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire @fifo0 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %subview1_obj2 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Consume, 3) : memref<3xmemref<16xi32>>
+                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+                %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+                %subview1_obj2 = AIE.objectFifo.subview.access %subview1[2] : memref<3xmemref<16xi32>> -> memref<16xi32>
                 %v1 = memref.load %subview1_obj[%c0] : memref<16xi32>
                 %v2 = memref.load %subview1_obj1[%c0] : memref<16xi32>
                 %v3 = memref.load %subview1_obj2[%c0] : memref<16xi32>
                 AIE.objectFifo.release @fifo0 (Consume, 1)
             }
 
-            %subview2 = AIE.objectFifo.acquire @fifo0 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %subview2_obj1 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Consume, 2) : memref<2xmemref<16xi32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %subview2_obj1 = AIE.objectFifo.subview.access %subview2[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             %v4 = memref.load %subview2_obj[%c0] : memref<16xi32>
             %v5 = memref.load %subview2_obj1[%c0] : memref<16xi32>
             AIE.objectFifo.release @fifo0 (Consume, 2)

--- a/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
+++ b/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
@@ -95,7 +95,7 @@ module @cyclostatic {
         %tile12 = AIE.tile(1, 2)
         %tile23 = AIE.tile(2, 2)
 
-        AIE.objectFifo @fifo0 (%tile12, {%tile23}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @fifo0 (%tile12, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %core12 = AIE.core(%tile12) {
             %v11 = arith.constant 11 : i32
@@ -104,8 +104,8 @@ module @cyclostatic {
             %c9 = arith.constant 9 : index
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<16xi32>
-                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 memref.store %v11, %subview1_obj[%c0] : memref<16xi32>
                 AIE.objectFifo.release @fifo0 (Produce, 1)
             }
@@ -118,25 +118,25 @@ module @cyclostatic {
             %c1 = arith.constant 1 : index
             %c9 = arith.constant 9 : index
 
-            %subview0 = AIE.objectFifo.acquire @fifo0 (Consume, 1) : memref<16xi32>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %v0 = memref.load %subview0_obj[%c0] : memref<16xi32>
             AIE.objectFifo.release @fifo0 (Consume, 1)
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire @fifo0 (Consume, 3) : memref<16xi32>
-                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
-                %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
-                %subview1_obj2 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview1_obj2 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 %v1 = memref.load %subview1_obj[%c0] : memref<16xi32>
                 %v2 = memref.load %subview1_obj1[%c0] : memref<16xi32>
                 %v3 = memref.load %subview1_obj2[%c0] : memref<16xi32>
                 AIE.objectFifo.release @fifo0 (Consume, 1)
             }
 
-            %subview2 = AIE.objectFifo.acquire @fifo0 (Consume, 2) : memref<16xi32>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<16xi32> -> memref<16xi32>
-            %subview2_obj1 = AIE.objectFifo.subview.access %subview2[1] : memref<16xi32> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview2_obj1 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             %v4 = memref.load %subview2_obj[%c0] : memref<16xi32>
             %v5 = memref.load %subview2_obj1[%c0] : memref<16xi32>
             AIE.objectFifo.release @fifo0 (Consume, 2)

--- a/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
+++ b/test/objectFifo-stateful-transform/cyclostatic_AIE2_sharedMem.mlir
@@ -95,7 +95,7 @@ module @cyclostatic {
         %tile12 = AIE.tile(1, 2)
         %tile23 = AIE.tile(2, 2)
 
-        AIE.objectFifo @fifo0 (%tile12, {%tile23}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @fifo0 (%tile12, {%tile23}, 4 : i32) : memref<16xi32>
 
         %core12 = AIE.core(%tile12) {
             %v11 = arith.constant 11 : i32
@@ -104,8 +104,8 @@ module @cyclostatic {
             %c9 = arith.constant 9 : index
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Produce, 1) : memref<16xi32>
+                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
                 memref.store %v11, %subview1_obj[%c0] : memref<16xi32>
                 AIE.objectFifo.release @fifo0 (Produce, 1)
             }
@@ -118,25 +118,25 @@ module @cyclostatic {
             %c1 = arith.constant 1 : index
             %c9 = arith.constant 9 : index
 
-            %subview0 = AIE.objectFifo.acquire @fifo0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @fifo0 (Consume, 1) : memref<16xi32>
+            %subview0_obj = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
             %v0 = memref.load %subview0_obj[%c0] : memref<16xi32>
             AIE.objectFifo.release @fifo0 (Consume, 1)
 
             scf.for %indexInHeight = %c0 to %c9 step %c1 {
-                %subview1 = AIE.objectFifo.acquire @fifo0 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %subview1_obj2 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview1 = AIE.objectFifo.acquire @fifo0 (Consume, 3) : memref<16xi32>
+                %subview1_obj = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+                %subview1_obj1 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
+                %subview1_obj2 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
                 %v1 = memref.load %subview1_obj[%c0] : memref<16xi32>
                 %v2 = memref.load %subview1_obj1[%c0] : memref<16xi32>
                 %v3 = memref.load %subview1_obj2[%c0] : memref<16xi32>
                 AIE.objectFifo.release @fifo0 (Consume, 1)
             }
 
-            %subview2 = AIE.objectFifo.acquire @fifo0 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %subview2_obj1 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @fifo0 (Consume, 2) : memref<16xi32>
+            %subview2_obj = AIE.objectFifo.subview.access %subview2[0] : memref<16xi32> -> memref<16xi32>
+            %subview2_obj1 = AIE.objectFifo.subview.access %subview2[1] : memref<16xi32> -> memref<16xi32>
             %v4 = memref.load %subview2_obj[%c0] : memref<16xi32>
             %v5 = memref.load %subview2_obj1[%c0] : memref<16xi32>
             AIE.objectFifo.release @fifo0 (Consume, 2)

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -93,8 +93,8 @@ module @link_AIE1 {
         %tile22 = AIE.tile(2, 2)
         %tile24 = AIE.tile(2, 4)
 
-        AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : memref<16xi32>
-        AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         AIE.objectFifo.link [@of1] -> [@of2] ()
 

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -93,8 +93,8 @@ module @link_AIE1 {
         %tile22 = AIE.tile(2, 2)
         %tile24 = AIE.tile(2, 4)
 
-        AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : memref<2xmemref<16xi32>>
+        AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : memref<2xmemref<16xi32>>
 
         AIE.objectFifo.link [@of1] -> [@of2] ()
 

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -93,8 +93,8 @@ module @link_AIE1 {
         %tile22 = AIE.tile(2, 2)
         %tile24 = AIE.tile(2, 4)
 
-        AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of1 (%tile20, {%tile22}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @of2 (%tile22, {%tile24}, 2 : i32) : memref<16xi32>
 
         AIE.objectFifo.link [@of1] -> [@of2] ()
 

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -187,16 +187,16 @@ module @link_AIE2 {
         %tile02 = AIE.tile(0, 2)
         %tile03 = AIE.tile(0, 3)
 
-        AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : !AIE.objectFifo<memref<3000xi32>>
-        AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : !AIE.objectFifo<memref<3000xi32>>
+        AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : memref<3000xi32>
+        AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : memref<3000xi32>
         AIE.objectFifo.link [@mem_in] -> [@mem_out] ()
 
         %core02 = AIE.core(%tile02) {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire @mem_in (Consume, 1) : !AIE.objectFifoSubview<memref<3000xi32>>
-            %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
+            %subview = AIE.objectFifo.acquire @mem_in (Consume, 1) : memref<3000xi32>
+            %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<3000xi32> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end
         }
@@ -205,8 +205,8 @@ module @link_AIE2 {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire @mem_out (Consume, 3) : !AIE.objectFifoSubview<memref<3000xi32>>
-            %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
+            %subview = AIE.objectFifo.acquire @mem_out (Consume, 3) : memref<3000xi32>
+            %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<3000xi32> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -188,15 +188,15 @@ module @link_AIE2 {
         %tile03 = AIE.tile(0, 3)
 
         AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : !AIE.objectFifo<memref<3000xi32>>
-        AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : !AIE.objectFifo<memref<3000xi32>>
+        AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : memref<7xmemref<3000xi32>>
         AIE.objectFifo.link [@mem_in] -> [@mem_out] ()
 
         %core02 = AIE.core(%tile02) {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire @mem_in (Consume, 1) : !AIE.objectFifoSubview<memref<3000xi32>>
-            %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
+            %subview = AIE.objectFifo.acquire @mem_in (Consume, 1) : memref<1xmemref<3000xi32>>
+            %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<3000xi32>> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end
         }
@@ -205,8 +205,8 @@ module @link_AIE2 {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire @mem_out (Consume, 3) : !AIE.objectFifoSubview<memref<3000xi32>>
-            %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
+            %subview = AIE.objectFifo.acquire @mem_out (Consume, 3) : memref<3xmemref<3000xi32>>
+            %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<3xmemref<3000xi32>> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -187,16 +187,16 @@ module @link_AIE2 {
         %tile02 = AIE.tile(0, 2)
         %tile03 = AIE.tile(0, 3)
 
-        AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : memref<3000xi32>
-        AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : memref<3000xi32>
+        AIE.objectFifo @mem_in (%tile00, {%tile02, %tile01}, [2,2,7]) : !AIE.objectFifo<memref<3000xi32>>
+        AIE.objectFifo @mem_out (%tile01, {%tile03}, 7 : i32) : !AIE.objectFifo<memref<3000xi32>>
         AIE.objectFifo.link [@mem_in] -> [@mem_out] ()
 
         %core02 = AIE.core(%tile02) {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire @mem_in (Consume, 1) : memref<3000xi32>
-            %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<3000xi32> -> memref<3000xi32>
+            %subview = AIE.objectFifo.acquire @mem_in (Consume, 1) : !AIE.objectFifoSubview<memref<3000xi32>>
+            %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end
         }
@@ -205,8 +205,8 @@ module @link_AIE2 {
             %v11 = arith.constant 11 : i32
             %c0 = arith.constant 0 : index
 
-            %subview = AIE.objectFifo.acquire @mem_out (Consume, 3) : memref<3000xi32>
-            %subview_obj = AIE.objectFifo.subview.access %subview[0] : memref<3000xi32> -> memref<3000xi32>
+            %subview = AIE.objectFifo.acquire @mem_out (Consume, 3) : !AIE.objectFifoSubview<memref<3000xi32>>
+            %subview_obj = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<3000xi32>> -> memref<3000xi32>
             memref.store %v11, %subview_obj[%c0] : memref<3000xi32>
             AIE.end
         }

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -94,8 +94,8 @@ module @link_DDR_L1 {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : memref<2xmemref<16xi32>>
+        AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : memref<2xmemref<16xi32>>
 
         AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -94,8 +94,8 @@ module @link_DDR_L1 {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : memref<16xi32>
 
         AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -94,8 +94,8 @@ module @link_DDR_L1 {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : memref<16xi32>
-        AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @to_memTile (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @from_memTile (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -94,8 +94,8 @@ module @link_L1_DDR {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : memref<48xi32>
 
         AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -94,8 +94,8 @@ module @link_L1_DDR {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : memref<2xmemref<16xi32>>
+        AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : memref<2xmemref<48xi32>>
 
         AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -94,8 +94,8 @@ module @link_L1_DDR {
         %tile21 = AIE.tile(2, 1)
         %tile22 = AIE.tile(2, 2)
 
-        AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : memref<16xi32>
-        AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : memref<48xi32>
+        AIE.objectFifo @to_memTile (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @from_memTile (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
 
         AIE.objectFifo.link [@to_memTile] -> [@from_memTile] ()
 

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -147,10 +147,10 @@ module @link_broadcast {
         %tile22 = AIE.tile(2, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : memref<48xi32>
-        AIE.objectFifo @link2 (%tile21, {%tile22, %tile33}, [2, 2, 3]) : memref<16xi32>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @link2 (%tile21, {%tile22, %tile33}, [2, 2, 3]) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         AIE.objectFifo.link [@link1] -> [@link2] ()
     }

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -147,10 +147,10 @@ module @link_broadcast {
         %tile22 = AIE.tile(2, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
-        AIE.objectFifo @link2 (%tile21, {%tile22, %tile33}, [2, 2, 3]) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : memref<48xi32>
+        AIE.objectFifo @link2 (%tile21, {%tile22, %tile33}, [2, 2, 3]) : memref<16xi32>
 
-        AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : memref<16xi32>
 
         AIE.objectFifo.link [@link1] -> [@link2] ()
     }

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -147,10 +147,10 @@ module @link_broadcast {
         %tile22 = AIE.tile(2, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : memref<2xmemref<48xi32>>
         AIE.objectFifo @link2 (%tile21, {%tile22, %tile33}, [2, 2, 3]) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @skip_connection (%tile22, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
         AIE.objectFifo.link [@link1] -> [@link2] ()
     }

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -166,10 +166,10 @@ module @link_distribute {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
-        AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<4x4xi32>>
-        AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<20xi32>>
-        AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<12xi32>>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : memref<48xi32>
+        AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : memref<4x4xi32>
+        AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : memref<20xi32>
+        AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : memref<12xi32>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers @link1 (%tile20, {%ext_buffer_in}) : (memref<48xi32>)

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -166,10 +166,10 @@ module @link_distribute {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
-        AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<4x4xi32>>
-        AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<20xi32>>
-        AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<12xi32>>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : memref<2xmemref<48xi32>>
+        AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : memref<2xmemref<4x4xi32>>
+        AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : memref<2xmemref<20xi32>>
+        AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : memref<2xmemref<12xi32>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers @link1 (%tile20, {%ext_buffer_in}) : (memref<48xi32>)

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -166,10 +166,10 @@ module @link_distribute {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : memref<48xi32>
-        AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : memref<4x4xi32>
-        AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : memref<20xi32>
-        AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : memref<12xi32>
+        AIE.objectFifo @link1 (%tile20, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<48xi32>>
+        AIE.objectFifo @link2 (%tile21, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<4x4xi32>>
+        AIE.objectFifo @link3 (%tile21, {%tile23}, 2 : i32) : !AIE.objectFifo<memref<20xi32>>
+        AIE.objectFifo @link4 (%tile21, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<12xi32>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<48xi32>
         AIE.objectFifo.registerExternalBuffers @link1 (%tile20, {%ext_buffer_in}) : (memref<48xi32>)

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -202,11 +202,11 @@ module @link_join {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile12, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link5 (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<512xi8>>
+        AIE.objectFifo @link1 (%tile12, {%tile21}, 2 : i32) : memref<128xi8>
+        AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : memref<128xi8>
+        AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : memref<128xi8>
+        AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : memref<128xi8>
+        AIE.objectFifo @link5 (%tile21, {%tile20}, 2 : i32) : memref<512xi8>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
         AIE.objectFifo.registerExternalBuffers @link5 (%tile20, {%ext_buffer_in}) : (memref<512xi8>)

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -202,11 +202,11 @@ module @link_join {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile12, {%tile21}, 2 : i32) : memref<128xi8>
-        AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : memref<128xi8>
-        AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : memref<128xi8>
-        AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : memref<128xi8>
-        AIE.objectFifo @link5 (%tile21, {%tile20}, 2 : i32) : memref<512xi8>
+        AIE.objectFifo @link1 (%tile12, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
+        AIE.objectFifo @link5 (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<512xi8>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
         AIE.objectFifo.registerExternalBuffers @link5 (%tile20, {%ext_buffer_in}) : (memref<512xi8>)

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -202,11 +202,11 @@ module @link_join {
         %tile23 = AIE.tile(2, 3)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @link1 (%tile12, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : !AIE.objectFifo<memref<128xi8>>
-        AIE.objectFifo @link5 (%tile21, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<512xi8>>
+        AIE.objectFifo @link1 (%tile12, {%tile21}, 2 : i32) : memref<2xmemref<128xi8>>
+        AIE.objectFifo @link2 (%tile22, {%tile21}, 2 : i32) : memref<2xmemref<128xi8>>
+        AIE.objectFifo @link3 (%tile23, {%tile21}, 2 : i32) : memref<2xmemref<128xi8>>
+        AIE.objectFifo @link4 (%tile33, {%tile21}, 2 : i32) : memref<2xmemref<128xi8>>
+        AIE.objectFifo @link5 (%tile21, {%tile20}, 2 : i32) : memref<2xmemref<512xi8>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<512xi8>
         AIE.objectFifo.registerExternalBuffers @link5 (%tile20, {%ext_buffer_in}) : (memref<512xi8>)

--- a/test/objectFifo-stateful-transform/loop_test.aie.mlir
+++ b/test/objectFifo-stateful-transform/loop_test.aie.mlir
@@ -89,7 +89,7 @@ module @loop  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
             return
@@ -102,21 +102,21 @@ module @loop  {
             %c4 = arith.constant 4 : index
             %c21 = arith.constant 21 : index
 
-            %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<16xi32>
-            %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : memref<16xi32> -> memref<16xi32>
+            %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
             AIE.objectFifo.release @loop_of (Produce, 1)
 
             scf.for %indexInHeight = %c1 to %c21 step %c2 {
-                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
                 AIE.objectFifo.release @loop_of (Produce, 1)
             }
 
             scf.for %indexInHeight = %c1 to %c4 step %c1 {
-                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
                 AIE.objectFifo.release @loop_of (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/loop_test.aie.mlir
+++ b/test/objectFifo-stateful-transform/loop_test.aie.mlir
@@ -89,7 +89,7 @@ module @loop  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
         func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
             return
@@ -102,21 +102,21 @@ module @loop  {
             %c4 = arith.constant 4 : index
             %c21 = arith.constant 21 : index
 
-            %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<16xi32>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
             AIE.objectFifo.release @loop_of (Produce, 1)
 
             scf.for %indexInHeight = %c1 to %c21 step %c2 {
-                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
                 AIE.objectFifo.release @loop_of (Produce, 1)
             }
 
             scf.for %indexInHeight = %c1 to %c4 step %c1 {
-                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
                 AIE.objectFifo.release @loop_of (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/loop_test.aie.mlir
+++ b/test/objectFifo-stateful-transform/loop_test.aie.mlir
@@ -89,7 +89,7 @@ module @loop  {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @loop_of (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
             return
@@ -102,21 +102,21 @@ module @loop  {
             %c4 = arith.constant 4 : index
             %c21 = arith.constant 21 : index
 
-            %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTop0 = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<1xmemref<16xi32>>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
             AIE.objectFifo.release @loop_of (Produce, 1)
 
             scf.for %indexInHeight = %c1 to %c21 step %c2 {
-                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
                 AIE.objectFifo.release @loop_of (Produce, 1)
             }
 
             scf.for %indexInHeight = %c1 to %c4 step %c1 {
-                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @loop_of (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
                 AIE.objectFifo.release @loop_of (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/matmul_test.mlir
+++ b/test/objectFifo-stateful-transform/matmul_test.mlir
@@ -131,9 +131,9 @@ module @matmul {
     %t00 = AIE.tile(0, 0)
     %t02 = AIE.tile(0, 2)
 
-    AIE.objectFifo @inA  (%t00, { %t02 }, 2 : i32) : !AIE.objectFifo<memref<16x8xi16>>
-    AIE.objectFifo @inB  (%t00, { %t02 }, 2 : i32) : !AIE.objectFifo<memref<8x16xi16>>
-    AIE.objectFifo @outC (%t02, { %t00 }, 2 : i32) : !AIE.objectFifo<memref<16x16xi16>>
+    AIE.objectFifo @inA  (%t00, { %t02 }, 2 : i32) : memref<16x8xi16>
+    AIE.objectFifo @inB  (%t00, { %t02 }, 2 : i32) : memref<8x16xi16>
+    AIE.objectFifo @outC (%t02, { %t00 }, 2 : i32) : memref<16x16xi16>
 
     func.func @zero_scalar_i16(%elem0 : memref<16x16xi16>) -> () { return }
     func.func @matmul_scalar_i16_i16(%elem0 : memref<16x8xi16>, %elem1 : memref<8x16xi16>, %elem2 : memref<16x16xi16>) -> () { return }
@@ -147,15 +147,15 @@ module @matmul {
       scf.for %reps = %c0 to %intmax step %c1 {
 
         scf.for %arg2 = %c0 to %c4 step %c1 {
-          %subview2 = AIE.objectFifo.acquire @outC (Produce, 1) : !AIE.objectFifoSubview<memref<16x16xi16>>
-          %elem2 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16x16xi16>> -> memref<16x16xi16>
+          %subview2 = AIE.objectFifo.acquire @outC (Produce, 1) : memref<16x16xi16>
+          %elem2 = AIE.objectFifo.subview.access %subview2[0] : memref<16x16xi16> -> memref<16x16xi16>
           func.call @zero_scalar_i16(%elem2) : (memref<16x16xi16>) -> ()
 
           scf.for %arg3 = %c0 to %c4 step %c1 {
-            %subview0 = AIE.objectFifo.acquire @inA (Consume, 1) : !AIE.objectFifoSubview<memref<16x8xi16>>
-            %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16x8xi16>> -> memref<16x8xi16>
-            %subview1 = AIE.objectFifo.acquire @inB (Consume, 1) : !AIE.objectFifoSubview<memref<8x16xi16>>
-            %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8x16xi16>> -> memref<8x16xi16>
+            %subview0 = AIE.objectFifo.acquire @inA (Consume, 1) : memref<16x8xi16>
+            %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<16x8xi16> -> memref<16x8xi16>
+            %subview1 = AIE.objectFifo.acquire @inB (Consume, 1) : memref<8x16xi16>
+            %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<8x16xi16> -> memref<8x16xi16>
 
             func.call @matmul_scalar_i16_i16(%elem0, %elem1, %elem2) : (memref<16x8xi16>, memref<8x16xi16>, memref<16x16xi16>) -> ()
 

--- a/test/objectFifo-stateful-transform/matmul_test.mlir
+++ b/test/objectFifo-stateful-transform/matmul_test.mlir
@@ -131,9 +131,9 @@ module @matmul {
     %t00 = AIE.tile(0, 0)
     %t02 = AIE.tile(0, 2)
 
-    AIE.objectFifo @inA  (%t00, { %t02 }, 2 : i32) : memref<16x8xi16>
-    AIE.objectFifo @inB  (%t00, { %t02 }, 2 : i32) : memref<8x16xi16>
-    AIE.objectFifo @outC (%t02, { %t00 }, 2 : i32) : memref<16x16xi16>
+    AIE.objectFifo @inA  (%t00, { %t02 }, 2 : i32) : !AIE.objectFifo<memref<16x8xi16>>
+    AIE.objectFifo @inB  (%t00, { %t02 }, 2 : i32) : !AIE.objectFifo<memref<8x16xi16>>
+    AIE.objectFifo @outC (%t02, { %t00 }, 2 : i32) : !AIE.objectFifo<memref<16x16xi16>>
 
     func.func @zero_scalar_i16(%elem0 : memref<16x16xi16>) -> () { return }
     func.func @matmul_scalar_i16_i16(%elem0 : memref<16x8xi16>, %elem1 : memref<8x16xi16>, %elem2 : memref<16x16xi16>) -> () { return }
@@ -147,15 +147,15 @@ module @matmul {
       scf.for %reps = %c0 to %intmax step %c1 {
 
         scf.for %arg2 = %c0 to %c4 step %c1 {
-          %subview2 = AIE.objectFifo.acquire @outC (Produce, 1) : memref<16x16xi16>
-          %elem2 = AIE.objectFifo.subview.access %subview2[0] : memref<16x16xi16> -> memref<16x16xi16>
+          %subview2 = AIE.objectFifo.acquire @outC (Produce, 1) : !AIE.objectFifoSubview<memref<16x16xi16>>
+          %elem2 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16x16xi16>> -> memref<16x16xi16>
           func.call @zero_scalar_i16(%elem2) : (memref<16x16xi16>) -> ()
 
           scf.for %arg3 = %c0 to %c4 step %c1 {
-            %subview0 = AIE.objectFifo.acquire @inA (Consume, 1) : memref<16x8xi16>
-            %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<16x8xi16> -> memref<16x8xi16>
-            %subview1 = AIE.objectFifo.acquire @inB (Consume, 1) : memref<8x16xi16>
-            %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<8x16xi16> -> memref<8x16xi16>
+            %subview0 = AIE.objectFifo.acquire @inA (Consume, 1) : !AIE.objectFifoSubview<memref<16x8xi16>>
+            %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16x8xi16>> -> memref<16x8xi16>
+            %subview1 = AIE.objectFifo.acquire @inB (Consume, 1) : !AIE.objectFifoSubview<memref<8x16xi16>>
+            %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8x16xi16>> -> memref<8x16xi16>
 
             func.call @matmul_scalar_i16_i16(%elem0, %elem1, %elem2) : (memref<16x8xi16>, memref<8x16xi16>, memref<16x16xi16>) -> ()
 

--- a/test/objectFifo-stateful-transform/matmul_test.mlir
+++ b/test/objectFifo-stateful-transform/matmul_test.mlir
@@ -131,9 +131,9 @@ module @matmul {
     %t00 = AIE.tile(0, 0)
     %t02 = AIE.tile(0, 2)
 
-    AIE.objectFifo @inA  (%t00, { %t02 }, 2 : i32) : !AIE.objectFifo<memref<16x8xi16>>
-    AIE.objectFifo @inB  (%t00, { %t02 }, 2 : i32) : !AIE.objectFifo<memref<8x16xi16>>
-    AIE.objectFifo @outC (%t02, { %t00 }, 2 : i32) : !AIE.objectFifo<memref<16x16xi16>>
+    AIE.objectFifo @inA  (%t00, { %t02 }, 2 : i32) : memref<2xmemref<16x8xi16>>
+    AIE.objectFifo @inB  (%t00, { %t02 }, 2 : i32) : memref<2xmemref<8x16xi16>>
+    AIE.objectFifo @outC (%t02, { %t00 }, 2 : i32) : memref<2xmemref<16x16xi16>>
 
     func.func @zero_scalar_i16(%elem0 : memref<16x16xi16>) -> () { return }
     func.func @matmul_scalar_i16_i16(%elem0 : memref<16x8xi16>, %elem1 : memref<8x16xi16>, %elem2 : memref<16x16xi16>) -> () { return }
@@ -147,15 +147,15 @@ module @matmul {
       scf.for %reps = %c0 to %intmax step %c1 {
 
         scf.for %arg2 = %c0 to %c4 step %c1 {
-          %subview2 = AIE.objectFifo.acquire @outC (Produce, 1) : !AIE.objectFifoSubview<memref<16x16xi16>>
-          %elem2 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16x16xi16>> -> memref<16x16xi16>
+          %subview2 = AIE.objectFifo.acquire @outC (Produce, 1) : memref<1xmemref<16x16xi16>>
+          %elem2 = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<16x16xi16>> -> memref<16x16xi16>
           func.call @zero_scalar_i16(%elem2) : (memref<16x16xi16>) -> ()
 
           scf.for %arg3 = %c0 to %c4 step %c1 {
-            %subview0 = AIE.objectFifo.acquire @inA (Consume, 1) : !AIE.objectFifoSubview<memref<16x8xi16>>
-            %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16x8xi16>> -> memref<16x8xi16>
-            %subview1 = AIE.objectFifo.acquire @inB (Consume, 1) : !AIE.objectFifoSubview<memref<8x16xi16>>
-            %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8x16xi16>> -> memref<8x16xi16>
+            %subview0 = AIE.objectFifo.acquire @inA (Consume, 1) : memref<1xmemref<16x8xi16>>
+            %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<16x8xi16>> -> memref<16x8xi16>
+            %subview1 = AIE.objectFifo.acquire @inB (Consume, 1) : memref<1xmemref<8x16xi16>>
+            %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<8x16xi16>> -> memref<8x16xi16>
 
             func.call @matmul_scalar_i16_i16(%elem0, %elem1, %elem2) : (memref<16x8xi16>, memref<8x16xi16>, memref<16x16xi16>) -> ()
 

--- a/test/objectFifo-stateful-transform/memTile_test.mlir
+++ b/test/objectFifo-stateful-transform/memTile_test.mlir
@@ -64,6 +64,6 @@ module @memTile {
       %tile11 = AIE.tile(2, 1)
       %tile12 = AIE.tile(2, 2)
 
-      AIE.objectFifo @of (%tile11, {%tile12}, 2 : i32) : memref<16xi32>
+      AIE.objectFifo @of (%tile11, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
    }
 }

--- a/test/objectFifo-stateful-transform/memTile_test.mlir
+++ b/test/objectFifo-stateful-transform/memTile_test.mlir
@@ -64,6 +64,6 @@ module @memTile {
       %tile11 = AIE.tile(2, 1)
       %tile12 = AIE.tile(2, 2)
 
-      AIE.objectFifo @of (%tile11, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of (%tile11, {%tile12}, 2 : i32) : memref<16xi32>
    }
 }

--- a/test/objectFifo-stateful-transform/memTile_test.mlir
+++ b/test/objectFifo-stateful-transform/memTile_test.mlir
@@ -64,6 +64,6 @@ module @memTile {
       %tile11 = AIE.tile(2, 1)
       %tile12 = AIE.tile(2, 2)
 
-      AIE.objectFifo @of (%tile11, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of (%tile11, {%tile12}, 2 : i32) : memref<2xmemref<16xi32>>
    }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -134,9 +134,9 @@ module @ndDMAObjFifoAIE2 {
     // layout transformation with toStream and fromStream was specified.
     AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          {%tile13 fromStream [<1, 1>]},
-                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         4 : i32) : memref<256xi32>
 
     AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33},
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<256xi32>
  }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -134,9 +134,9 @@ module @ndDMAObjFifoAIE2 {
     // layout transformation with toStream and fromStream was specified.
     AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          {%tile13 fromStream [<1, 1>]},
-                         4 : i32) : memref<256xi32>
+                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33},
-                         2 : i32) : memref<256xi32>
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -134,9 +134,9 @@ module @ndDMAObjFifoAIE2 {
     // layout transformation with toStream and fromStream was specified.
     AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          {%tile13 fromStream [<1, 1>]},
-                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         4 : i32) : memref<4xmemref<256xi32>>
 
     AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33},
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<2xmemref<256xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
@@ -120,19 +120,19 @@ module @ndDMAObjFifoAIE2 {
     %tile23 = AIE.tile(2, 3)
 
     AIE.objectFifo @of0 (%tile10, {%tile11}, 
-                         2 : i32) : memref<256xi32>
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile22}, 2 : i32) : memref<128xi32>
+                        {%tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile23}, 2 : i32) : memref<128xi32>
+                        {%tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsFromStreamPerConsumer.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
@@ -120,19 +120,19 @@ module @ndDMAObjFifoAIE2 {
     %tile23 = AIE.tile(2, 3)
 
     AIE.objectFifo @of0 (%tile10, {%tile11}, 
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<256xi32>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile22}, 2 : i32) : memref<128xi32>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile23}, 2 : i32) : memref<128xi32>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsFromStreamPerConsumer.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
@@ -120,19 +120,19 @@ module @ndDMAObjFifoAIE2 {
     %tile23 = AIE.tile(2, 3)
 
     AIE.objectFifo @of0 (%tile10, {%tile11}, 
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<2xmemref<256xi32>>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile22}, 2 : i32) : memref<2xmemref<128xi32>>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile23}, 2 : i32) : memref<2xmemref<128xi32>>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsFromStreamPerConsumer.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2_bad.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2_bad.mlir
@@ -19,19 +19,19 @@ module @ndDMAObjFifoAIE2 {
 
     AIE.objectFifo @of0 (%tile10, {%tile11 fromStream [<32, 16>,
                                                        < 8,  1>]}, 
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<256xi32>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile22}, 2 : i32) : memref<128xi32>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile23}, 2 : i32) : memref<128xi32>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsFromStreamPerConsumer.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2_bad.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2_bad.mlir
@@ -19,19 +19,19 @@ module @ndDMAObjFifoAIE2 {
 
     AIE.objectFifo @of0 (%tile10, {%tile11 fromStream [<32, 16>,
                                                        < 8,  1>]}, 
-                         2 : i32) : memref<256xi32>
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile22}, 2 : i32) : memref<128xi32>
+                        {%tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile23}, 2 : i32) : memref<128xi32>
+                        {%tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsFromStreamPerConsumer.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2_bad.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2_bad.mlir
@@ -19,19 +19,19 @@ module @ndDMAObjFifoAIE2 {
 
     AIE.objectFifo @of0 (%tile10, {%tile11 fromStream [<32, 16>,
                                                        < 8,  1>]}, 
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<2xmemref<256xi32>>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile22}, 2 : i32) : memref<2xmemref<128xi32>>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile23}, 2 : i32) : memref<2xmemref<128xi32>>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsFromStreamPerConsumer.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2_bad.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2_bad.mlir
@@ -20,19 +20,19 @@ module @ndDMAObjFifoAIE2 {
     %tile23 = AIE.tile(2, 3)
 
     AIE.objectFifo @of0 (%tile10, {%tile11}, 
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<256xi32>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile12, %tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile12, %tile22}, 2 : i32) : memref<128xi32>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile13, %tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile13, %tile23}, 2 : i32) : memref<128xi32>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsToStream and multiple consumers.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2_bad.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2_bad.mlir
@@ -20,19 +20,19 @@ module @ndDMAObjFifoAIE2 {
     %tile23 = AIE.tile(2, 3)
 
     AIE.objectFifo @of0 (%tile10, {%tile11}, 
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<2xmemref<256xi32>>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile12, %tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile12, %tile22}, 2 : i32) : memref<2xmemref<128xi32>>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile13, %tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
+                        {%tile13, %tile23}, 2 : i32) : memref<2xmemref<128xi32>>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsToStream and multiple consumers.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2_bad.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2_bad.mlir
@@ -20,19 +20,19 @@ module @ndDMAObjFifoAIE2 {
     %tile23 = AIE.tile(2, 3)
 
     AIE.objectFifo @of0 (%tile10, {%tile11}, 
-                         2 : i32) : memref<256xi32>
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo @of1 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile12, %tile22}, 2 : i32) : memref<128xi32>
+                        {%tile12, %tile22}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
 
     AIE.objectFifo @of2 (%tile11 toStream [< 4,64>,
                                            < 2, 4>, 
                                            < 8, 8>, 
                                            < 4, 1>],
-                        {%tile13, %tile23}, 2 : i32) : memref<128xi32>
+                        {%tile13, %tile23}, 2 : i32) : !AIE.objectFifo<memref<128xi32>>
    // expected-error@+1 {{'AIE.objectFifo.link' op currently does not support objectFifos with dimensionsToStream and multiple consumers.}}
    AIE.objectFifo.link [ @of0 ] -> [ @of1, @of2 ] ()
  }

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -201,12 +201,12 @@ module @ndDMAObjFifoAIE2 {
     AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          {%tile13 fromStream [<1, 1>],
                           %tile33 fromStream [<3, 4>]},
-                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         4 : i32) : memref<256xi32>
 
     AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33},
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<256xi32>
 
     AIE.objectFifo @of3 (%tile22, {%tile23 fromStream [<9, 9>]},
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<256xi32>
  }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -201,12 +201,12 @@ module @ndDMAObjFifoAIE2 {
     AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          {%tile13 fromStream [<1, 1>],
                           %tile33 fromStream [<3, 4>]},
-                         4 : i32) : memref<256xi32>
+                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33},
-                         2 : i32) : memref<256xi32>
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo @of3 (%tile22, {%tile23 fromStream [<9, 9>]},
-                         2 : i32) : memref<256xi32>
+                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -201,12 +201,12 @@ module @ndDMAObjFifoAIE2 {
     AIE.objectFifo @of0 (%tile12 toStream [<16, 1>, <16, 16>, <1, 1>], // transpose
                          {%tile13 fromStream [<1, 1>],
                           %tile33 fromStream [<3, 4>]},
-                         4 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         4 : i32) : memref<4xmemref<256xi32>>
 
     AIE.objectFifo @of1 (%tile12 toStream [<128, 2>], {%tile33},
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<2xmemref<256xi32>>
 
     AIE.objectFifo @of3 (%tile22, {%tile23 fromStream [<9, 9>]},
-                         2 : i32) : !AIE.objectFifo<memref<256xi32>>
+                         2 : i32) : memref<2xmemref<256xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
@@ -96,7 +96,7 @@ module @non_adjacency {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -108,8 +108,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -123,8 +123,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
@@ -96,7 +96,7 @@ module @non_adjacency {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -108,8 +108,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -123,8 +123,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
@@ -96,7 +96,7 @@ module @non_adjacency {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -108,8 +108,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -123,8 +123,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
@@ -118,7 +118,7 @@ module @non_adjacency {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -130,8 +130,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -145,10 +145,10 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 3) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
@@ -118,7 +118,7 @@ module @non_adjacency {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -130,8 +130,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -145,10 +145,10 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 3) : memref<3xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<3xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
@@ -118,7 +118,7 @@ module @non_adjacency {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -130,8 +130,8 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -145,10 +145,10 @@ module @non_adjacency {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 3) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
-                %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
@@ -97,7 +97,7 @@ module @non_adjacency_AIE2 {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -109,8 +109,8 @@ module @non_adjacency_AIE2 {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @of (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @of (Produce, 1)
             }
@@ -124,8 +124,8 @@ module @non_adjacency_AIE2 {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @of (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
@@ -97,7 +97,7 @@ module @non_adjacency_AIE2 {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -109,8 +109,8 @@ module @non_adjacency_AIE2 {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @of (Produce, 1)
             }
@@ -124,8 +124,8 @@ module @non_adjacency_AIE2 {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @of (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
@@ -97,7 +97,7 @@ module @non_adjacency_AIE2 {
         %tile12 = AIE.tile(1, 2)
         %tile33 = AIE.tile(3, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -109,8 +109,8 @@ module @non_adjacency_AIE2 {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @of (Produce, 1)
             }
@@ -124,8 +124,8 @@ module @non_adjacency_AIE2 {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of (Consume, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @of (Consume, 1)
             }

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -78,7 +78,7 @@ module @register_external_buffers {
     %tile71 = AIE.tile(7, 1)
     %tile70 = AIE.tile(7, 0)
 
-    AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : memref<16xi32>
+    AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
     %ext_buffer_in = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
     AIE.objectFifo.registerExternalBuffers @ext_of (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
@@ -92,9 +92,9 @@ module @register_external_buffers {
         %c1 = arith.constant 1 : index
         %height = arith.constant 12 : index
 
-        %subview = AIE.objectFifo.acquire @ext_of (Consume, 2) : memref<16xi32>
-        %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-        %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+        %subview = AIE.objectFifo.acquire @ext_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+        %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
         func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
         AIE.objectFifo.release @ext_of (Consume, 1)
         

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -78,7 +78,7 @@ module @register_external_buffers {
     %tile71 = AIE.tile(7, 1)
     %tile70 = AIE.tile(7, 0)
 
-    AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : memref<3xmemref<16xi32>>
 
     %ext_buffer_in = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
     AIE.objectFifo.registerExternalBuffers @ext_of (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
@@ -92,9 +92,9 @@ module @register_external_buffers {
         %c1 = arith.constant 1 : index
         %height = arith.constant 12 : index
 
-        %subview = AIE.objectFifo.acquire @ext_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        %subview = AIE.objectFifo.acquire @ext_of (Consume, 2) : memref<2xmemref<16xi32>>
+        %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+        %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
         func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
         AIE.objectFifo.release @ext_of (Consume, 1)
         

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -78,7 +78,7 @@ module @register_external_buffers {
     %tile71 = AIE.tile(7, 1)
     %tile70 = AIE.tile(7, 0)
 
-    AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+    AIE.objectFifo @ext_of (%tile70, {%tile71}, 3 : i32) : memref<16xi32>
 
     %ext_buffer_in = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
     AIE.objectFifo.registerExternalBuffers @ext_of (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
@@ -92,9 +92,9 @@ module @register_external_buffers {
         %c1 = arith.constant 1 : index
         %height = arith.constant 12 : index
 
-        %subview = AIE.objectFifo.acquire @ext_of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-        %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-        %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+        %subview = AIE.objectFifo.acquire @ext_of (Consume, 2) : memref<16xi32>
+        %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+        %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
         func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
         AIE.objectFifo.release @ext_of (Consume, 1)
         

--- a/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
+++ b/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
@@ -44,7 +44,7 @@ module @same_core {
     AIE.device(xcve2302) {
         %tile12 = AIE.tile(1, 2)
 
-        AIE.objectFifo @of (%tile12, {%tile12}, 3 : i32) : memref<16xi32>
+        AIE.objectFifo @of (%tile12, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
@@ -52,25 +52,25 @@ module @same_core {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<16xi32>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 1)
 
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 1)
 
-            %subview2 = AIE.objectFifo.acquire @of (Produce, 1) : memref<16xi32>
-            %elem20 = AIE.objectFifo.subview.access %subview2[0] : memref<16xi32> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 1)
 
-            %subview3 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
-            %elem30 = AIE.objectFifo.subview.access %subview3[0] : memref<16xi32> -> memref<16xi32>
+            %subview3 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem30) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 1)
 

--- a/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
+++ b/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
@@ -44,7 +44,7 @@ module @same_core {
     AIE.device(xcve2302) {
         %tile12 = AIE.tile(1, 2)
 
-        AIE.objectFifo @of (%tile12, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile12}, 3 : i32) : memref<16xi32>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
@@ -52,25 +52,25 @@ module @same_core {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<16xi32>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 1)
 
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 1)
 
-            %subview2 = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @of (Produce, 1) : memref<16xi32>
+            %elem20 = AIE.objectFifo.subview.access %subview2[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 1)
 
-            %subview3 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview3 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
+            %elem30 = AIE.objectFifo.subview.access %subview3[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem30) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 1)
 

--- a/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
+++ b/test/objectFifo-stateful-transform/same_core_producer_consumer_test.mlir
@@ -44,7 +44,7 @@ module @same_core {
     AIE.device(xcve2302) {
         %tile12 = AIE.tile(1, 2)
 
-        AIE.objectFifo @of (%tile12, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile12}, 3 : i32) : memref<3xmemref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
@@ -52,25 +52,25 @@ module @same_core {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 1)
 
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 1) : memref<1xmemref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 1)
 
-            %subview2 = AIE.objectFifo.acquire @of (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @of (Produce, 1) : memref<1xmemref<16xi32>>
+            %elem20 = AIE.objectFifo.subview.access %subview2[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 1)
 
-            %subview3 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview3 = AIE.objectFifo.acquire @of (Consume, 1) : memref<1xmemref<16xi32>>
+            %elem30 = AIE.objectFifo.subview.access %subview3[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem30) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 1)
 

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -76,7 +76,7 @@ module @shimRow_mem {
         %tile71 = AIE.tile(7, 1)
         %tile70 = AIE.tile(7, 0)
 
-        AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : memref<3xmemref<16xi32>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
         AIE.objectFifo.registerExternalBuffers @objfifo (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
@@ -90,9 +90,9 @@ module @shimRow_mem {
             %c1 = arith.constant 1 : index
             %height = arith.constant 12 : index
 
-            %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : memref<2xmemref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
             AIE.objectFifo.release @objfifo (Consume, 1)
             

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -76,7 +76,7 @@ module @shimRow_mem {
         %tile71 = AIE.tile(7, 1)
         %tile70 = AIE.tile(7, 0)
 
-        AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : memref<16xi32>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
         AIE.objectFifo.registerExternalBuffers @objfifo (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
@@ -90,9 +90,9 @@ module @shimRow_mem {
             %c1 = arith.constant 1 : index
             %height = arith.constant 12 : index
 
-            %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : memref<16xi32>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
             AIE.objectFifo.release @objfifo (Consume, 1)
             

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -76,7 +76,7 @@ module @shimRow_mem {
         %tile71 = AIE.tile(7, 1)
         %tile70 = AIE.tile(7, 0)
 
-        AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile70, {%tile71}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
         AIE.objectFifo.registerExternalBuffers @objfifo (%tile70, {%ext_buffer_in}) : (memref<64xi32>)
@@ -90,9 +90,9 @@ module @shimRow_mem {
             %c1 = arith.constant 1 : index
             %height = arith.constant 12 : index
 
-            %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : memref<16xi32>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-            %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem0, %elem1) : (memref<16xi32>, memref<16xi32>) -> ()
             AIE.objectFifo.release @objfifo (Consume, 1)
             

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -84,8 +84,8 @@ module @shim_AIE2 {
       %tile22 = AIE.tile(2, 2)
       %tile20 = AIE.tile(2, 0)
 
-      AIE.objectFifo @of_in (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-      AIE.objectFifo @of_out (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_in (%tile20, {%tile22}, 2 : i32) : memref<2xmemref<16xi32>>
+      AIE.objectFifo @of_out (%tile22, {%tile20}, 2 : i32) : memref<2xmemref<16xi32>>
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
       %ext_buffer_out  = AIE.external_buffer {sym_name = "ext_buffer_out"}: memref<64xi32>

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -84,8 +84,8 @@ module @shim_AIE2 {
       %tile22 = AIE.tile(2, 2)
       %tile20 = AIE.tile(2, 0)
 
-      AIE.objectFifo @of_in (%tile20, {%tile22}, 2 : i32) : memref<16xi32>
-      AIE.objectFifo @of_out (%tile22, {%tile20}, 2 : i32) : memref<16xi32>
+      AIE.objectFifo @of_in (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_out (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
       %ext_buffer_out  = AIE.external_buffer {sym_name = "ext_buffer_out"}: memref<64xi32>

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -84,8 +84,8 @@ module @shim_AIE2 {
       %tile22 = AIE.tile(2, 2)
       %tile20 = AIE.tile(2, 0)
 
-      AIE.objectFifo @of_in (%tile20, {%tile22}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-      AIE.objectFifo @of_out (%tile22, {%tile20}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_in (%tile20, {%tile22}, 2 : i32) : memref<16xi32>
+      AIE.objectFifo @of_out (%tile22, {%tile20}, 2 : i32) : memref<16xi32>
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
       %ext_buffer_out  = AIE.external_buffer {sym_name = "ext_buffer_out"}: memref<64xi32>

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -100,7 +100,7 @@ module @shim_broadcast {
       %tile23 = AIE.tile(2, 3)
       %tile33 = AIE.tile(3, 3)
 
-      AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
       AIE.objectFifo.registerExternalBuffers @of_in (%tile20, {%ext_buffer_in}) : (memref<64xi32>)

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -100,7 +100,7 @@ module @shim_broadcast {
       %tile23 = AIE.tile(2, 3)
       %tile33 = AIE.tile(3, 3)
 
-      AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : memref<16xi32>
+      AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
       AIE.objectFifo.registerExternalBuffers @of_in (%tile20, {%ext_buffer_in}) : (memref<64xi32>)

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -100,7 +100,7 @@ module @shim_broadcast {
       %tile23 = AIE.tile(2, 3)
       %tile33 = AIE.tile(3, 3)
 
-      AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+      AIE.objectFifo @of_in (%tile20, {%tile22, %tile23, %tile33}, 2 : i32) : memref<16xi32>
 
       %ext_buffer_in  = AIE.external_buffer {sym_name = "ext_buffer_in"}: memref<64xi32>
       AIE.objectFifo.registerExternalBuffers @of_in (%tile20, {%ext_buffer_in}) : (memref<64xi32>)

--- a/test/objectFifo-stateful-transform/subview_test_1.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_1.mlir
@@ -51,7 +51,7 @@ module @singleFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
@@ -59,17 +59,17 @@ module @singleFifo {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<16xi32>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
             // this should only acquire one new element, previous two are still acquired
-            %subview1 = AIE.objectFifo.acquire @objfifo (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @objfifo (Produce, 3) : memref<16xi32>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
@@ -77,16 +77,16 @@ module @singleFifo {
             // one new acquire should take place
             AIE.objectFifo.release @objfifo (Produce, 1)
             AIE.objectFifo.release @objfifo (Produce, 1)
-            %subview2 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem21 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<16xi32>
+            %elem20 = AIE.objectFifo.subview.access %subview2[0] : memref<16xi32> -> memref<16xi32>
+            %elem21 = AIE.objectFifo.subview.access %subview2[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> ()
             func.call @some_work(%elem21) : (memref<16xi32>) -> ()
 
             // no new acquires should take place, elem30 should be third element of objFifo (with index 2)
-            %subview3 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem31 = AIE.objectFifo.subview.access %subview3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview3 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<16xi32>
+            %elem30 = AIE.objectFifo.subview.access %subview3[0] : memref<16xi32> -> memref<16xi32>
+            %elem31 = AIE.objectFifo.subview.access %subview3[1] : memref<16xi32> -> memref<16xi32>
             //%elem32 = AIE.subview.access %subview3[2] : !AIE.subview<memref<16xi32>> -> memref<16xi32> // expected to fail if this line is uncommented
             func.call @some_work(%elem30) : (memref<16xi32>) -> ()
             func.call @some_work(%elem31) : (memref<16xi32>) -> ()

--- a/test/objectFifo-stateful-transform/subview_test_1.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_1.mlir
@@ -51,7 +51,7 @@ module @singleFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
@@ -59,17 +59,17 @@ module @singleFifo {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
             // this should only acquire one new element, previous two are still acquired
-            %subview1 = AIE.objectFifo.acquire @objfifo (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @objfifo (Produce, 3) : memref<3xmemref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<3xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
@@ -77,16 +77,16 @@ module @singleFifo {
             // one new acquire should take place
             AIE.objectFifo.release @objfifo (Produce, 1)
             AIE.objectFifo.release @objfifo (Produce, 1)
-            %subview2 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem21 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem20 = AIE.objectFifo.subview.access %subview2[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem21 = AIE.objectFifo.subview.access %subview2[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> ()
             func.call @some_work(%elem21) : (memref<16xi32>) -> ()
 
             // no new acquires should take place, elem30 should be third element of objFifo (with index 2)
-            %subview3 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem31 = AIE.objectFifo.subview.access %subview3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview3 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem30 = AIE.objectFifo.subview.access %subview3[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem31 = AIE.objectFifo.subview.access %subview3[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             //%elem32 = AIE.subview.access %subview3[2] : !AIE.subview<memref<16xi32>> -> memref<16xi32> // expected to fail if this line is uncommented
             func.call @some_work(%elem30) : (memref<16xi32>) -> ()
             func.call @some_work(%elem31) : (memref<16xi32>) -> ()

--- a/test/objectFifo-stateful-transform/subview_test_1.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_1.mlir
@@ -51,7 +51,7 @@ module @singleFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
@@ -59,17 +59,17 @@ module @singleFifo {
 
         %core12 = AIE.core(%tile12) {
             // this acquires 2 elements
-            %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<16xi32>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
             // this should only acquire one new element, previous two are still acquired
-            %subview1 = AIE.objectFifo.acquire @objfifo (Produce, 3) : memref<16xi32>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @objfifo (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
@@ -77,16 +77,16 @@ module @singleFifo {
             // one new acquire should take place
             AIE.objectFifo.release @objfifo (Produce, 1)
             AIE.objectFifo.release @objfifo (Produce, 1)
-            %subview2 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<16xi32>
-            %elem20 = AIE.objectFifo.subview.access %subview2[0] : memref<16xi32> -> memref<16xi32>
-            %elem21 = AIE.objectFifo.subview.access %subview2[1] : memref<16xi32> -> memref<16xi32>
+            %subview2 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem20 = AIE.objectFifo.subview.access %subview2[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem21 = AIE.objectFifo.subview.access %subview2[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem20) : (memref<16xi32>) -> ()
             func.call @some_work(%elem21) : (memref<16xi32>) -> ()
 
             // no new acquires should take place, elem30 should be third element of objFifo (with index 2)
-            %subview3 = AIE.objectFifo.acquire @objfifo (Produce, 2) : memref<16xi32>
-            %elem30 = AIE.objectFifo.subview.access %subview3[0] : memref<16xi32> -> memref<16xi32>
-            %elem31 = AIE.objectFifo.subview.access %subview3[1] : memref<16xi32> -> memref<16xi32>
+            %subview3 = AIE.objectFifo.acquire @objfifo (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem30 = AIE.objectFifo.subview.access %subview3[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem31 = AIE.objectFifo.subview.access %subview3[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             //%elem32 = AIE.subview.access %subview3[2] : !AIE.subview<memref<16xi32>> -> memref<16xi32> // expected to fail if this line is uncommented
             func.call @some_work(%elem30) : (memref<16xi32>) -> ()
             func.call @some_work(%elem31) : (memref<16xi32>) -> ()

--- a/test/objectFifo-stateful-transform/subview_test_2.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_2.mlir
@@ -83,38 +83,38 @@ module @multiFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile12, {%tile13}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @of2 (%tile12, {%tile13}, 3 : i32) : memref<16xi32>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
         }
 
         %core12 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<16xi32>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
             AIE.objectFifo.release @of (Produce, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : memref<16xi32>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 3)
             
             AIE.objectFifo.release @of2 (Produce, 1)
-            %subview12 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview12 = AIE.objectFifo.acquire @of2 (Produce, 2) : memref<16xi32>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : memref<16xi32> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Produce, 1)
@@ -123,21 +123,21 @@ module @multiFifo {
         }
 
         %core13 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 2)
 
             AIE.objectFifo.release @of (Consume, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : memref<16xi32>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 2)

--- a/test/objectFifo-stateful-transform/subview_test_2.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_2.mlir
@@ -83,38 +83,38 @@ module @multiFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
-        AIE.objectFifo @of2 (%tile12, {%tile13}, 3 : i32) : memref<16xi32>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile12, {%tile13}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
         }
 
         %core12 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<16xi32>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
             AIE.objectFifo.release @of (Produce, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : memref<16xi32>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 3)
             
             AIE.objectFifo.release @of2 (Produce, 1)
-            %subview12 = AIE.objectFifo.acquire @of2 (Produce, 2) : memref<16xi32>
-            %elem102 = AIE.objectFifo.subview.access %subview12[0] : memref<16xi32> -> memref<16xi32>
-            %elem112 = AIE.objectFifo.subview.access %subview12[1] : memref<16xi32> -> memref<16xi32>
+            %subview12 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Produce, 1)
@@ -123,21 +123,21 @@ module @multiFifo {
         }
 
         %core13 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
-            %elem012 = AIE.objectFifo.subview.access %subview02[1] : memref<16xi32> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 2)
 
             AIE.objectFifo.release @of (Consume, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : memref<16xi32>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 2)

--- a/test/objectFifo-stateful-transform/subview_test_2.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_2.mlir
@@ -83,38 +83,38 @@ module @multiFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile12, {%tile13}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
+        AIE.objectFifo @of2 (%tile12, {%tile13}, 3 : i32) : memref<3xmemref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
         }
 
         %core12 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<1xmemref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
             AIE.objectFifo.release @of (Produce, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : memref<3xmemref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<3xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 3)
             
             AIE.objectFifo.release @of2 (Produce, 1)
-            %subview12 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview12 = AIE.objectFifo.acquire @of2 (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Produce, 1)
@@ -123,21 +123,21 @@ module @multiFifo {
         }
 
         %core13 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : memref<1xmemref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<2xmemref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 2)
 
             AIE.objectFifo.release @of (Consume, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : memref<2xmemref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 2)

--- a/test/objectFifo-stateful-transform/subview_test_3.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_3.mlir
@@ -81,38 +81,38 @@ module @multiCoreMixedFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile13, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
+        AIE.objectFifo @of2 (%tile13, {%tile12}, 3 : i32) : memref<3xmemref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
         }
 
         %core11 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 1) : memref<1xmemref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
             AIE.objectFifo.release @of (Produce, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : memref<3xmemref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<3xmemref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<3xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 3)
             
             AIE.objectFifo.release @of2 (Consume, 1)
-            %subview12 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview12 = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<2xmemref<16xi32>>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 1)
@@ -121,21 +121,21 @@ module @multiCoreMixedFifo {
         }
 
         %core12 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : memref<1xmemref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 2) : memref<2xmemref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Produce, 2)
 
             AIE.objectFifo.release @of (Consume, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : memref<2xmemref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<2xmemref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<2xmemref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 2)

--- a/test/objectFifo-stateful-transform/subview_test_3.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_3.mlir
@@ -81,38 +81,38 @@ module @multiCoreMixedFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile13, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @of2 (%tile13, {%tile12}, 3 : i32) : memref<16xi32>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
         }
 
         %core11 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<16xi32>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 1) : memref<16xi32>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
             AIE.objectFifo.release @of (Produce, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : memref<16xi32>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 3)
             
             AIE.objectFifo.release @of2 (Consume, 1)
-            %subview12 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview12 = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : memref<16xi32> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 1)
@@ -121,21 +121,21 @@ module @multiCoreMixedFifo {
         }
 
         %core12 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 2) : memref<16xi32>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Produce, 2)
 
             AIE.objectFifo.release @of (Consume, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : memref<16xi32>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 2)

--- a/test/objectFifo-stateful-transform/subview_test_3.mlir
+++ b/test/objectFifo-stateful-transform/subview_test_3.mlir
@@ -81,38 +81,38 @@ module @multiCoreMixedFifo {
         %tile12 = AIE.tile(1, 2)
         %tile13 = AIE.tile(1, 3)
 
-        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
-        AIE.objectFifo @of2 (%tile13, {%tile12}, 3 : i32) : memref<16xi32>
+        AIE.objectFifo @of (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile13, {%tile12}, 3 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%line_in:memref<16xi32>) -> () {
             return
         }
 
         %core11 = AIE.core(%tile12) {
-            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : memref<16xi32>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
-            %elem01 = AIE.objectFifo.subview.access %subview0[1] : memref<16xi32> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem01 = AIE.objectFifo.subview.access %subview0[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
             func.call @some_work(%elem01) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 1) : memref<16xi32>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
 
             AIE.objectFifo.release @of (Produce, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : memref<16xi32>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
-            %elem12 = AIE.objectFifo.subview.access %subview1[2] : memref<16xi32> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Produce, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem12 = AIE.objectFifo.subview.access %subview1[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             func.call @some_work(%elem12) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Produce, 3)
             
             AIE.objectFifo.release @of2 (Consume, 1)
-            %subview12 = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
-            %elem102 = AIE.objectFifo.subview.access %subview12[0] : memref<16xi32> -> memref<16xi32>
-            %elem112 = AIE.objectFifo.subview.access %subview12[1] : memref<16xi32> -> memref<16xi32>
+            %subview12 = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem102 = AIE.objectFifo.subview.access %subview12[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem112 = AIE.objectFifo.subview.access %subview12[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem102) : (memref<16xi32>) -> ()
             func.call @some_work(%elem112) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 1)
@@ -121,21 +121,21 @@ module @multiCoreMixedFifo {
         }
 
         %core12 = AIE.core(%tile13) {
-            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : memref<16xi32>
-            %elem00 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+            %subview0 = AIE.objectFifo.acquire @of (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem00 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem00) : (memref<16xi32>) -> ()
 
-            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 2) : memref<16xi32>
-            %elem002 = AIE.objectFifo.subview.access %subview02[0] : memref<16xi32> -> memref<16xi32>
-            %elem012 = AIE.objectFifo.subview.access %subview02[1] : memref<16xi32> -> memref<16xi32>
+            %subview02 = AIE.objectFifo.acquire @of2 (Produce, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem002 = AIE.objectFifo.subview.access %subview02[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem012 = AIE.objectFifo.subview.access %subview02[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem002) : (memref<16xi32>) -> ()
             func.call @some_work(%elem012) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of2 (Produce, 2)
 
             AIE.objectFifo.release @of (Consume, 1)
-            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : memref<16xi32>
-            %elem10 = AIE.objectFifo.subview.access %subview1[0] : memref<16xi32> -> memref<16xi32>
-            %elem11 = AIE.objectFifo.subview.access %subview1[1] : memref<16xi32> -> memref<16xi32>
+            %subview1 = AIE.objectFifo.acquire @of (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem10 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elem11 = AIE.objectFifo.subview.access %subview1[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @some_work(%elem10) : (memref<16xi32>) -> ()
             func.call @some_work(%elem11) : (memref<16xi32>) -> ()
             AIE.objectFifo.release @of (Consume, 2)

--- a/test/objectFifo-stateful-transform/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/tileDMA_test.mlir
@@ -112,7 +112,7 @@ module @tileDMA_channels {
         %buff2 = AIE.buffer(%tile12) : memref<16xi32>
         %lock2 = AIE.lock(%tile12, 2)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -124,8 +124,8 @@ module @tileDMA_channels {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/tileDMA_test.mlir
@@ -112,7 +112,7 @@ module @tileDMA_channels {
         %buff2 = AIE.buffer(%tile12) : memref<16xi32>
         %lock2 = AIE.lock(%tile12, 2)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -124,8 +124,8 @@ module @tileDMA_channels {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }

--- a/test/objectFifo-stateful-transform/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/tileDMA_test.mlir
@@ -112,7 +112,7 @@ module @tileDMA_channels {
         %buff2 = AIE.buffer(%tile12) : memref<16xi32>
         %lock2 = AIE.lock(%tile12, 2)
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
@@ -124,8 +124,8 @@ module @tileDMA_channels {
             %height = arith.constant 12 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @some_work(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }

--- a/test/objectFifo_tests/broadcast/aie.mlir
+++ b/test/objectFifo_tests/broadcast/aie.mlir
@@ -33,7 +33,7 @@ module @broadcast {
         %buff_out_33 = AIE.buffer(%tile33) { sym_name = "out33" } :  memref<4x16xi32>
         %lock_out_33 = AIE.lock(%tile33, 0) { sym_name = "lock_out33" }
 
-        AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
             %c0 = arith.constant 0 : index
@@ -53,8 +53,8 @@ module @broadcast {
             %height = arith.constant 4 : index
             
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+                %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @generateLineScalar(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -82,8 +82,8 @@ module @broadcast {
             AIE.useLock(%lock_out_12, "Acquire", 0)
 
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview0 = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
+                %subview0 = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_12) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }
@@ -102,9 +102,9 @@ module @broadcast {
             AIE.useLock(%lock_out_14, "Acquire", 0)
             
             scf.for %indexInLine = %c0 to %height step %c2 {
-                %subview = AIE.objectFifo.acquire  @objfifo (Consume, 2) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire  @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
                 %indexPlusOne = arith.addi %indexInLine, %c1 : index
                 func.call @storeLineScalar(%elem1, %indexPlusOne, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
@@ -139,15 +139,15 @@ module @broadcast {
             AIE.useLock(%lock_out_33, "Acquire", 0)
 
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @addAndStore(%elem0, %elem1, %indexInLine, %buff_out_33) : (memref<16xi32>, memref<16xi32>, index, memref<4x16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }
 
-            %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @storeLineScalar(%elem0, %c3, %buff_out_33) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
             AIE.objectFifo.release @objfifo (Consume, 1)
 

--- a/test/objectFifo_tests/broadcast/aie.mlir
+++ b/test/objectFifo_tests/broadcast/aie.mlir
@@ -33,7 +33,7 @@ module @broadcast {
         %buff_out_33 = AIE.buffer(%tile33) { sym_name = "out33" } :  memref<4x16xi32>
         %lock_out_33 = AIE.lock(%tile33, 0) { sym_name = "lock_out33" }
 
-        AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : memref<16xi32>
 
         func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
             %c0 = arith.constant 0 : index
@@ -53,8 +53,8 @@ module @broadcast {
             %height = arith.constant 4 : index
             
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
                 func.call @generateLineScalar(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -82,8 +82,8 @@ module @broadcast {
             AIE.useLock(%lock_out_12, "Acquire", 0)
 
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview0 = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview0 = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<16xi32> -> memref<16xi32>
                 func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_12) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }
@@ -102,9 +102,9 @@ module @broadcast {
             AIE.useLock(%lock_out_14, "Acquire", 0)
             
             scf.for %indexInLine = %c0 to %height step %c2 {
-                %subview = AIE.objectFifo.acquire  @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire  @objfifo (Consume, 2) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
                 func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
                 %indexPlusOne = arith.addi %indexInLine, %c1 : index
                 func.call @storeLineScalar(%elem1, %indexPlusOne, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
@@ -139,15 +139,15 @@ module @broadcast {
             AIE.useLock(%lock_out_33, "Acquire", 0)
 
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
                 func.call @addAndStore(%elem0, %elem1, %indexInLine, %buff_out_33) : (memref<16xi32>, memref<16xi32>, index, memref<4x16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }
 
-            %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
             func.call @storeLineScalar(%elem0, %c3, %buff_out_33) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
             AIE.objectFifo.release @objfifo (Consume, 1)
 

--- a/test/objectFifo_tests/broadcast/aie.mlir
+++ b/test/objectFifo_tests/broadcast/aie.mlir
@@ -33,7 +33,7 @@ module @broadcast {
         %buff_out_33 = AIE.buffer(%tile33) { sym_name = "out33" } :  memref<4x16xi32>
         %lock_out_33 = AIE.lock(%tile33, 0) { sym_name = "lock_out33" }
 
-        AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile13, {%tile12, %tile14, %tile33}, 7 : i32) : memref<7xmemref<16xi32>>
 
         func.func @generateLineScalar(%lineOut : memref<16xi32>) -> () {
             %c0 = arith.constant 0 : index
@@ -53,8 +53,8 @@ module @broadcast {
             %height = arith.constant 4 : index
             
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview0 = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @generateLineScalar(%elem0) : (memref<16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Produce, 1)
             }
@@ -82,8 +82,8 @@ module @broadcast {
             AIE.useLock(%lock_out_12, "Acquire", 0)
 
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview0 = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview0 = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_12) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }
@@ -102,9 +102,9 @@ module @broadcast {
             AIE.useLock(%lock_out_14, "Acquire", 0)
             
             scf.for %indexInLine = %c0 to %height step %c2 {
-                %subview = AIE.objectFifo.acquire  @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire  @objfifo (Consume, 2) : memref<2xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @storeLineScalar(%elem0, %indexInLine, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
                 %indexPlusOne = arith.addi %indexInLine, %c1 : index
                 func.call @storeLineScalar(%elem1, %indexPlusOne, %buff_out_14) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
@@ -139,15 +139,15 @@ module @broadcast {
             AIE.useLock(%lock_out_33, "Acquire", 0)
 
             scf.for %indexInLine = %c0 to %height step %c1 {
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 2) : memref<2xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @addAndStore(%elem0, %elem1, %indexInLine, %buff_out_33) : (memref<16xi32>, memref<16xi32>, index, memref<4x16xi32>) -> ()
                 AIE.objectFifo.release @objfifo (Consume, 1)
             }
 
-            %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<1xmemref<16xi32>>
+            %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @storeLineScalar(%elem0, %c3, %buff_out_33) : (memref<16xi32>, index, memref<4x16xi32>) -> ()
             AIE.objectFifo.release @objfifo (Consume, 1)
 

--- a/test/objectFifo_tests/ping_pong/aie.mlir
+++ b/test/objectFifo_tests/ping_pong/aie.mlir
@@ -26,7 +26,7 @@ module @ping_pong {
         %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         // Fills the given memref with the same input index value.
         func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
@@ -50,8 +50,8 @@ module @ping_pong {
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
                 // acquire next element for produce
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
                 // call generator function
                 func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
@@ -86,8 +86,8 @@ module @ping_pong {
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
                 // acquire next element for consume
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
                 // call consumer function
                 func.call @storeLineScalar(%elem0, %indexInHeight, %buff_out) : (memref<16xi32>, index, memref<10x16xi32>) -> ()

--- a/test/objectFifo_tests/ping_pong/aie.mlir
+++ b/test/objectFifo_tests/ping_pong/aie.mlir
@@ -26,7 +26,7 @@ module @ping_pong {
         %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
 
         // Fills the given memref with the same input index value.
         func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
@@ -50,8 +50,8 @@ module @ping_pong {
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
                 // acquire next element for produce
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
 
                 // call generator function
                 func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
@@ -86,8 +86,8 @@ module @ping_pong {
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
                 // acquire next element for consume
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
 
                 // call consumer function
                 func.call @storeLineScalar(%elem0, %indexInHeight, %buff_out) : (memref<16xi32>, index, memref<10x16xi32>) -> ()

--- a/test/objectFifo_tests/ping_pong/aie.mlir
+++ b/test/objectFifo_tests/ping_pong/aie.mlir
@@ -26,7 +26,7 @@ module @ping_pong {
         %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @objfifo (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
         // Fills the given memref with the same input index value.
         func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
@@ -50,8 +50,8 @@ module @ping_pong {
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
                 // acquire next element for produce
-                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
                 // call generator function
                 func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
@@ -86,8 +86,8 @@ module @ping_pong {
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
                 // acquire next element for consume
-                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @objfifo (Consume, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
                 // call consumer function
                 func.call @storeLineScalar(%elem0, %indexInHeight, %buff_out) : (memref<16xi32>, index, memref<10x16xi32>) -> ()

--- a/test/objectFifo_tests/tileDMA_channels/aie.mlir
+++ b/test/objectFifo_tests/tileDMA_channels/aie.mlir
@@ -27,11 +27,11 @@ module @dmaChannels {
         %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : memref<2xmemref<16xi32>>
+        AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : memref<2xmemref<16xi32>>
 
-        AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
+        AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : memref<2xmemref<16xi32>>
 
         func.func @copy(%lineIn : memref<16xi32>, %lineOut : memref<16xi32>) -> () {
             %c0 = arith.constant 0 : index
@@ -51,17 +51,17 @@ module @dmaChannels {
             %height = arith.constant 10 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subviewIn0 = AIE.objectFifo.acquire @of_in0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn0 = AIE.objectFifo.acquire @of_in0 (Consume, 1) : memref<1xmemref<16xi32>>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-                %subviewIn1 = AIE.objectFifo.acquire @of_in1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn1 = AIE.objectFifo.acquire @of_in1 (Consume, 1) : memref<1xmemref<16xi32>>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-                %subviewOut0 = AIE.objectFifo.acquire @of_out0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut0 = AIE.objectFifo.acquire @of_out0 (Produce, 1) : memref<1xmemref<16xi32>>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-                %subviewOut1 = AIE.objectFifo.acquire @of_out1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut1 = AIE.objectFifo.acquire @of_out1 (Produce, 1) : memref<1xmemref<16xi32>>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
                 func.call @copy(%elemIn0, %elemOut0) : (memref<16xi32>, memref<16xi32>) -> ()
                 func.call @copy(%elemIn1, %elemOut1) : (memref<16xi32>, memref<16xi32>) -> ()
@@ -112,11 +112,11 @@ module @dmaChannels {
             AIE.useLock(%lock_out, "Acquire", 0) // acquire for produce
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subviewOut0 = AIE.objectFifo.acquire @of_in0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut0 = AIE.objectFifo.acquire @of_in0 (Produce, 1) : memref<1xmemref<16xi32>>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-                %subviewOut1 = AIE.objectFifo.acquire @of_in1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut1 = AIE.objectFifo.acquire @of_in1 (Produce, 1) : memref<1xmemref<16xi32>>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
                 func.call @generateLineScalar(%elemOut0) : (memref<16xi32>) -> ()
                 func.call @generateLineScalar(%elemOut1) : (memref<16xi32>) -> ()
@@ -125,11 +125,11 @@ module @dmaChannels {
                 AIE.objectFifo.release @of_in1 (Produce, 1)
 
 
-                %subviewIn0 = AIE.objectFifo.acquire @of_out0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn0 = AIE.objectFifo.acquire @of_out0 (Consume, 1) : memref<1xmemref<16xi32>>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-                %subviewIn1 = AIE.objectFifo.acquire @of_out1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn1 = AIE.objectFifo.acquire @of_out1 (Consume, 1) : memref<1xmemref<16xi32>>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
                 func.call @addAndStore(%elemIn0, %elemIn1, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
 

--- a/test/objectFifo_tests/tileDMA_channels/aie.mlir
+++ b/test/objectFifo_tests/tileDMA_channels/aie.mlir
@@ -27,11 +27,11 @@ module @dmaChannels {
         %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : memref<16xi32>
 
-        AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
 
         func.func @copy(%lineIn : memref<16xi32>, %lineOut : memref<16xi32>) -> () {
             %c0 = arith.constant 0 : index
@@ -51,17 +51,17 @@ module @dmaChannels {
             %height = arith.constant 10 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subviewIn0 = AIE.objectFifo.acquire @of_in0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn0 = AIE.objectFifo.acquire @of_in0 (Consume, 1) : memref<16xi32>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : memref<16xi32> -> memref<16xi32>
 
-                %subviewIn1 = AIE.objectFifo.acquire @of_in1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn1 = AIE.objectFifo.acquire @of_in1 (Consume, 1) : memref<16xi32>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : memref<16xi32> -> memref<16xi32>
 
-                %subviewOut0 = AIE.objectFifo.acquire @of_out0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut0 = AIE.objectFifo.acquire @of_out0 (Produce, 1) : memref<16xi32>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : memref<16xi32> -> memref<16xi32>
 
-                %subviewOut1 = AIE.objectFifo.acquire @of_out1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut1 = AIE.objectFifo.acquire @of_out1 (Produce, 1) : memref<16xi32>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : memref<16xi32> -> memref<16xi32>
 
                 func.call @copy(%elemIn0, %elemOut0) : (memref<16xi32>, memref<16xi32>) -> ()
                 func.call @copy(%elemIn1, %elemOut1) : (memref<16xi32>, memref<16xi32>) -> ()
@@ -112,11 +112,11 @@ module @dmaChannels {
             AIE.useLock(%lock_out, "Acquire", 0) // acquire for produce
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subviewOut0 = AIE.objectFifo.acquire @of_in0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut0 = AIE.objectFifo.acquire @of_in0 (Produce, 1) : memref<16xi32>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : memref<16xi32> -> memref<16xi32>
 
-                %subviewOut1 = AIE.objectFifo.acquire @of_in1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOut1 = AIE.objectFifo.acquire @of_in1 (Produce, 1) : memref<16xi32>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : memref<16xi32> -> memref<16xi32>
 
                 func.call @generateLineScalar(%elemOut0) : (memref<16xi32>) -> ()
                 func.call @generateLineScalar(%elemOut1) : (memref<16xi32>) -> ()
@@ -125,11 +125,11 @@ module @dmaChannels {
                 AIE.objectFifo.release @of_in1 (Produce, 1)
 
 
-                %subviewIn0 = AIE.objectFifo.acquire @of_out0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn0 = AIE.objectFifo.acquire @of_out0 (Consume, 1) : memref<16xi32>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : memref<16xi32> -> memref<16xi32>
 
-                %subviewIn1 = AIE.objectFifo.acquire @of_out1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewIn1 = AIE.objectFifo.acquire @of_out1 (Consume, 1) : memref<16xi32>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : memref<16xi32> -> memref<16xi32>
 
                 func.call @addAndStore(%elemIn0, %elemIn1, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
 

--- a/test/objectFifo_tests/tileDMA_channels/aie.mlir
+++ b/test/objectFifo_tests/tileDMA_channels/aie.mlir
@@ -27,11 +27,11 @@ module @dmaChannels {
         %buff_out = AIE.buffer(%tile33) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile33, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : memref<16xi32>
-        AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @of_in0 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_in1 (%tile33, {%tile12}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
-        AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
-        AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : memref<16xi32>
+        AIE.objectFifo @of_out0 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of_out1 (%tile12, {%tile33}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         func.func @copy(%lineIn : memref<16xi32>, %lineOut : memref<16xi32>) -> () {
             %c0 = arith.constant 0 : index
@@ -51,17 +51,17 @@ module @dmaChannels {
             %height = arith.constant 10 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subviewIn0 = AIE.objectFifo.acquire @of_in0 (Consume, 1) : memref<16xi32>
-                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : memref<16xi32> -> memref<16xi32>
+                %subviewIn0 = AIE.objectFifo.acquire @of_in0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-                %subviewIn1 = AIE.objectFifo.acquire @of_in1 (Consume, 1) : memref<16xi32>
-                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : memref<16xi32> -> memref<16xi32>
+                %subviewIn1 = AIE.objectFifo.acquire @of_in1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-                %subviewOut0 = AIE.objectFifo.acquire @of_out0 (Produce, 1) : memref<16xi32>
-                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : memref<16xi32> -> memref<16xi32>
+                %subviewOut0 = AIE.objectFifo.acquire @of_out0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-                %subviewOut1 = AIE.objectFifo.acquire @of_out1 (Produce, 1) : memref<16xi32>
-                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : memref<16xi32> -> memref<16xi32>
+                %subviewOut1 = AIE.objectFifo.acquire @of_out1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
                 func.call @copy(%elemIn0, %elemOut0) : (memref<16xi32>, memref<16xi32>) -> ()
                 func.call @copy(%elemIn1, %elemOut1) : (memref<16xi32>, memref<16xi32>) -> ()
@@ -112,11 +112,11 @@ module @dmaChannels {
             AIE.useLock(%lock_out, "Acquire", 0) // acquire for produce
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subviewOut0 = AIE.objectFifo.acquire @of_in0 (Produce, 1) : memref<16xi32>
-                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : memref<16xi32> -> memref<16xi32>
+                %subviewOut0 = AIE.objectFifo.acquire @of_in0 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut0 = AIE.objectFifo.subview.access %subviewOut0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-                %subviewOut1 = AIE.objectFifo.acquire @of_in1 (Produce, 1) : memref<16xi32>
-                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : memref<16xi32> -> memref<16xi32>
+                %subviewOut1 = AIE.objectFifo.acquire @of_in1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOut1 = AIE.objectFifo.subview.access %subviewOut1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
                 func.call @generateLineScalar(%elemOut0) : (memref<16xi32>) -> ()
                 func.call @generateLineScalar(%elemOut1) : (memref<16xi32>) -> ()
@@ -125,11 +125,11 @@ module @dmaChannels {
                 AIE.objectFifo.release @of_in1 (Produce, 1)
 
 
-                %subviewIn0 = AIE.objectFifo.acquire @of_out0 (Consume, 1) : memref<16xi32>
-                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : memref<16xi32> -> memref<16xi32>
+                %subviewIn0 = AIE.objectFifo.acquire @of_out0 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn0 = AIE.objectFifo.subview.access %subviewIn0[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-                %subviewIn1 = AIE.objectFifo.acquire @of_out1 (Consume, 1) : memref<16xi32>
-                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : memref<16xi32> -> memref<16xi32>
+                %subviewIn1 = AIE.objectFifo.acquire @of_out1 (Consume, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemIn1 = AIE.objectFifo.subview.access %subviewIn1[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
                 func.call @addAndStore(%elemIn0, %elemIn1, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
 

--- a/test/objectFifo_tests/twoFilter2D/aie.mlir
+++ b/test/objectFifo_tests/twoFilter2D/aie.mlir
@@ -27,8 +27,8 @@ module @twoFilter2D  {
         %buff_out = AIE.buffer(%tile14) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile14, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
-        AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
 
         // Kernel Functions
         func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
@@ -112,8 +112,8 @@ module @twoFilter2D  {
             %height = arith.constant 10 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subview = AIE.objectFifo.acquire @of1 (Produce, 1) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
                 AIE.objectFifo.release @of1 (Produce, 1)
             }
@@ -130,12 +130,12 @@ module @twoFilter2D  {
             %height = arith.constant 9 : index
 
             // Top Border
-            %subviewOneTop = AIE.objectFifo.acquire @of1 (Consume, 2) : memref<16xi32>
-            %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : memref<16xi32> -> memref<16xi32>
-            %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : memref<16xi32> -> memref<16xi32>
+            %subviewOneTop = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-            %subviewTwoTop = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
-            %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : memref<16xi32> -> memref<16xi32>
+            %subviewTwoTop = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
             func.call @firstFilterTwoLines(%elemOneTop0, %elemOneTop1, %elemTwoTop0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -143,13 +143,13 @@ module @twoFilter2D  {
 
             // Middle 
             scf.for %indexInHeight = %c1 to %height step %c1 { 
-                %subviewOne = AIE.objectFifo.acquire @of1 (Consume, 3) : memref<16xi32>
-                %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : memref<16xi32> -> memref<16xi32>
-                %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : memref<16xi32> -> memref<16xi32>
-                %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : memref<16xi32> -> memref<16xi32>
+                %subviewOne = AIE.objectFifo.acquire @of1 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-                %subviewTwo = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
-                %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : memref<16xi32> -> memref<16xi32>
+                %subviewTwo = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 
                 func.call @firstFilterThreeLines(%elemOne0, %elemOne1, %elemOne2, %elemTwo0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -158,12 +158,12 @@ module @twoFilter2D  {
             }
 
             // Bottom Border
-            %subviewOneBottom = AIE.objectFifo.acquire @of1 (Consume, 2) : memref<16xi32>
-            %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : memref<16xi32> -> memref<16xi32>
-            %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : memref<16xi32> -> memref<16xi32>
+            %subviewOneBottom = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
 
-            %subviewTwoBottom = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
-            %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : memref<16xi32> -> memref<16xi32>
+            %subviewTwoBottom = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             
             func.call @firstFilterTwoLines(%elemOneBottom0, %elemOneBottom1, %elemTwoBottom0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -184,25 +184,25 @@ module @twoFilter2D  {
             AIE.useLock(%lock_out, "Acquire", 0) // acquire output buffer for produce
 
             // Top Border
-            %subviewTop = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
-            %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : memref<16xi32> -> memref<16xi32>
-            %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : memref<16xi32> -> memref<16xi32>
+            %subviewTop = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @secondFilterTwoLines(%elemTop0, %elemTop1, %c0, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
 
             // Middle
             scf.for %indexInHeight = %c1 to %height step %c1 { 
-                %subview = AIE.objectFifo.acquire @of2 (Consume, 3) : memref<16xi32>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
-                %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<16xi32> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of2 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
                 func.call @secondFilterThreeLines(%elem0, %elem1, %elem2, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
                 AIE.objectFifo.release @of2 (Consume, 1)
             }
 
             // Bottom Border
-            %subviewBottom = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
-            %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : memref<16xi32> -> memref<16xi32>
-            %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : memref<16xi32> -> memref<16xi32>
+            %subviewBottom = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
+            %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
             func.call @secondFilterTwoLines(%elemBottom0, %elemBottom1, %height, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 2)
 

--- a/test/objectFifo_tests/twoFilter2D/aie.mlir
+++ b/test/objectFifo_tests/twoFilter2D/aie.mlir
@@ -27,8 +27,8 @@ module @twoFilter2D  {
         %buff_out = AIE.buffer(%tile14) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile14, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : memref<4xmemref<16xi32>>
+        AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : memref<4xmemref<16xi32>>
 
         // Kernel Functions
         func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
@@ -112,8 +112,8 @@ module @twoFilter2D  {
             %height = arith.constant 10 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subview = AIE.objectFifo.acquire @of1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of1 (Produce, 1) : memref<1xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
                 AIE.objectFifo.release @of1 (Produce, 1)
             }
@@ -130,12 +130,12 @@ module @twoFilter2D  {
             %height = arith.constant 9 : index
 
             // Top Border
-            %subviewOneTop = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewOneTop = AIE.objectFifo.acquire @of1 (Consume, 2) : memref<2xmemref<16xi32>>
+            %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+            %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-            %subviewTwoTop = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTwoTop = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<1xmemref<16xi32>>
+            %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
             func.call @firstFilterTwoLines(%elemOneTop0, %elemOneTop1, %elemTwoTop0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -143,13 +143,13 @@ module @twoFilter2D  {
 
             // Middle 
             scf.for %indexInHeight = %c1 to %height step %c1 { 
-                %subviewOne = AIE.objectFifo.acquire @of1 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOne = AIE.objectFifo.acquire @of1 (Consume, 3) : memref<3xmemref<16xi32>>
+                %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+                %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
+                %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-                %subviewTwo = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewTwo = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<1xmemref<16xi32>>
+                %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 
                 func.call @firstFilterThreeLines(%elemOne0, %elemOne1, %elemOne2, %elemTwo0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -158,12 +158,12 @@ module @twoFilter2D  {
             }
 
             // Bottom Border
-            %subviewOneBottom = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewOneBottom = AIE.objectFifo.acquire @of1 (Consume, 2) : memref<2xmemref<16xi32>>
+            %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+            %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
 
-            %subviewTwoBottom = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTwoBottom = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<1xmemref<16xi32>>
+            %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
             
             func.call @firstFilterTwoLines(%elemOneBottom0, %elemOneBottom1, %elemTwoBottom0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -184,25 +184,25 @@ module @twoFilter2D  {
             AIE.useLock(%lock_out, "Acquire", 0) // acquire output buffer for produce
 
             // Top Border
-            %subviewTop = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTop = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<2xmemref<16xi32>>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+            %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @secondFilterTwoLines(%elemTop0, %elemTop1, %c0, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
 
             // Middle
             scf.for %indexInHeight = %c1 to %height step %c1 { 
-                %subview = AIE.objectFifo.acquire @of2 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of2 (Consume, 3) : memref<3xmemref<16xi32>>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<1xmemref<16xi32>> -> memref<16xi32>
                 func.call @secondFilterThreeLines(%elem0, %elem1, %elem2, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
                 AIE.objectFifo.release @of2 (Consume, 1)
             }
 
             // Bottom Border
-            %subviewBottom = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewBottom = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<2xmemref<16xi32>>
+            %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : memref<1xmemref<16xi32>> -> memref<16xi32>
+            %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : memref<1xmemref<16xi32>> -> memref<16xi32>
             func.call @secondFilterTwoLines(%elemBottom0, %elemBottom1, %height, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 2)
 

--- a/test/objectFifo_tests/twoFilter2D/aie.mlir
+++ b/test/objectFifo_tests/twoFilter2D/aie.mlir
@@ -27,8 +27,8 @@ module @twoFilter2D  {
         %buff_out = AIE.buffer(%tile14) { sym_name = "out" } :  memref<10x16xi32>
         %lock_out = AIE.lock(%tile14, 0) { sym_name = "lock_out" }
 
-        AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
-        AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : !AIE.objectFifo<memref<16xi32>>
+        AIE.objectFifo @of1 (%tile12, {%tile13}, 4 : i32) : memref<16xi32>
+        AIE.objectFifo @of2 (%tile13, {%tile14}, 4 : i32) : memref<16xi32>
 
         // Kernel Functions
         func.func @generateLineScalar(%valueIndex : index, %lineOut : memref<16xi32>) -> () {
@@ -112,8 +112,8 @@ module @twoFilter2D  {
             %height = arith.constant 10 : index
 
             scf.for %indexInHeight = %c0 to %height step %c1 { 
-                %subview = AIE.objectFifo.acquire @of1 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of1 (Produce, 1) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
                 func.call @generateLineScalar(%indexInHeight, %elem0) : (index, memref<16xi32>) -> ()
                 AIE.objectFifo.release @of1 (Produce, 1)
             }
@@ -130,12 +130,12 @@ module @twoFilter2D  {
             %height = arith.constant 9 : index
 
             // Top Border
-            %subviewOneTop = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewOneTop = AIE.objectFifo.acquire @of1 (Consume, 2) : memref<16xi32>
+            %elemOneTop0 = AIE.objectFifo.subview.access %subviewOneTop[0] : memref<16xi32> -> memref<16xi32>
+            %elemOneTop1 = AIE.objectFifo.subview.access %subviewOneTop[1] : memref<16xi32> -> memref<16xi32>
 
-            %subviewTwoTop = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTwoTop = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
+            %elemTwoTop0 = AIE.objectFifo.subview.access %subviewTwoTop[0] : memref<16xi32> -> memref<16xi32>
 
             func.call @firstFilterTwoLines(%elemOneTop0, %elemOneTop1, %elemTwoTop0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -143,13 +143,13 @@ module @twoFilter2D  {
 
             // Middle 
             scf.for %indexInHeight = %c1 to %height step %c1 { 
-                %subviewOne = AIE.objectFifo.acquire @of1 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewOne = AIE.objectFifo.acquire @of1 (Consume, 3) : memref<16xi32>
+                %elemOne0 = AIE.objectFifo.subview.access %subviewOne[0] : memref<16xi32> -> memref<16xi32>
+                %elemOne1 = AIE.objectFifo.subview.access %subviewOne[1] : memref<16xi32> -> memref<16xi32>
+                %elemOne2 = AIE.objectFifo.subview.access %subviewOne[2] : memref<16xi32> -> memref<16xi32>
 
-                %subviewTwo = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subviewTwo = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
+                %elemTwo0 = AIE.objectFifo.subview.access %subviewTwo[0] : memref<16xi32> -> memref<16xi32>
                 
                 func.call @firstFilterThreeLines(%elemOne0, %elemOne1, %elemOne2, %elemTwo0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -158,12 +158,12 @@ module @twoFilter2D  {
             }
 
             // Bottom Border
-            %subviewOneBottom = AIE.objectFifo.acquire @of1 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewOneBottom = AIE.objectFifo.acquire @of1 (Consume, 2) : memref<16xi32>
+            %elemOneBottom0 = AIE.objectFifo.subview.access %subviewOneBottom[0] : memref<16xi32> -> memref<16xi32>
+            %elemOneBottom1 = AIE.objectFifo.subview.access %subviewOneBottom[1] : memref<16xi32> -> memref<16xi32>
 
-            %subviewTwoBottom = AIE.objectFifo.acquire @of2 (Produce, 1) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTwoBottom = AIE.objectFifo.acquire @of2 (Produce, 1) : memref<16xi32>
+            %elemTwoBottom0 = AIE.objectFifo.subview.access %subviewTwoBottom[0] : memref<16xi32> -> memref<16xi32>
             
             func.call @firstFilterTwoLines(%elemOneBottom0, %elemOneBottom1, %elemTwoBottom0) : (memref<16xi32>, memref<16xi32>, memref<16xi32>) -> ()
 
@@ -184,25 +184,25 @@ module @twoFilter2D  {
             AIE.useLock(%lock_out, "Acquire", 0) // acquire output buffer for produce
 
             // Top Border
-            %subviewTop = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewTop = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
+            %elemTop0 = AIE.objectFifo.subview.access %subviewTop[0] : memref<16xi32> -> memref<16xi32>
+            %elemTop1 = AIE.objectFifo.subview.access %subviewTop[1] : memref<16xi32> -> memref<16xi32>
             func.call @secondFilterTwoLines(%elemTop0, %elemTop1, %c0, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
 
             // Middle
             scf.for %indexInHeight = %c1 to %height step %c1 { 
-                %subview = AIE.objectFifo.acquire @of2 (Consume, 3) : !AIE.objectFifoSubview<memref<16xi32>>
-                %elem0 = AIE.objectFifo.subview.access %subview[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem1 = AIE.objectFifo.subview.access %subview[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-                %elem2 = AIE.objectFifo.subview.access %subview[2] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+                %subview = AIE.objectFifo.acquire @of2 (Consume, 3) : memref<16xi32>
+                %elem0 = AIE.objectFifo.subview.access %subview[0] : memref<16xi32> -> memref<16xi32>
+                %elem1 = AIE.objectFifo.subview.access %subview[1] : memref<16xi32> -> memref<16xi32>
+                %elem2 = AIE.objectFifo.subview.access %subview[2] : memref<16xi32> -> memref<16xi32>
                 func.call @secondFilterThreeLines(%elem0, %elem1, %elem2, %indexInHeight, %buff_out) : (memref<16xi32>, memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
                 AIE.objectFifo.release @of2 (Consume, 1)
             }
 
             // Bottom Border
-            %subviewBottom = AIE.objectFifo.acquire @of2 (Consume, 2) : !AIE.objectFifoSubview<memref<16xi32>>
-            %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
-            %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : !AIE.objectFifoSubview<memref<16xi32>> -> memref<16xi32>
+            %subviewBottom = AIE.objectFifo.acquire @of2 (Consume, 2) : memref<16xi32>
+            %elemBottom0 = AIE.objectFifo.subview.access %subviewBottom[0] : memref<16xi32> -> memref<16xi32>
+            %elemBottom1 = AIE.objectFifo.subview.access %subviewBottom[1] : memref<16xi32> -> memref<16xi32>
             func.call @secondFilterTwoLines(%elemBottom0, %elemBottom1, %height, %buff_out) : (memref<16xi32>, memref<16xi32>, index, memref<10x16xi32>) -> ()
             AIE.objectFifo.release @of2 (Consume, 2)
 

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -12,7 +12,6 @@ from aie.dialects.aie import (
     ExternalBuffer,
     MemOp,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     end,
     objectFifo,
@@ -91,7 +90,7 @@ def externalBufferOp():
 # CHECK-LABEL: objFifo
 # CHECK: %[[VAL0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @of0(%[[VAL0]] toStream [<1, 2>], {%[[VAL1]] fromStream [<1, 2>]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: AIE.objectFifo @of0(%[[VAL0]] toStream [<1, 2>], {%[[VAL1]] fromStream [<1, 2>]}, 2 : i32) : memref<12xf16>
 @construct_and_print_module
 def objFifo():
     dev = Device(AIEDevice.xcvc1902)
@@ -104,7 +103,7 @@ def objFifo():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(12, T.f16())),
             [(1, 2)],
             [[(1, 2)]],
         )
@@ -115,8 +114,8 @@ def objFifo():
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
 # CHECK: %[[VAL_2:.*]] = AIE.tile(7, 7)
-# CHECK: AIE.objectFifo @[[VAL_3:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
-# CHECK: AIE.objectFifo @[[VAL_4:.*]](%[[VAL_1]], {%[[VAL_2]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_3:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
+# CHECK: AIE.objectFifo @[[VAL_4:.*]](%[[VAL_1]], {%[[VAL_2]]}, 2 : i32) : memref<12xf16>
 # CHECK: AIE.objectFifo.link [@[[VAL_3]]] -> [@[[VAL_4]]]()
 @construct_and_print_module
 def objFifoLink():
@@ -131,7 +130,7 @@ def objFifoLink():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(12, T.f16())),
             [],
             [],
         )
@@ -140,7 +139,7 @@ def objFifoLink():
             tile1,
             [tile2],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(12, T.f16())),
             [],
             [],
         )
@@ -151,8 +150,8 @@ def objFifoLink():
 # CHECK-LABEL: objFifoAcquire
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
-# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : !AIE.objectFifoSubview<memref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
+# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : memref<12xf16>
 @construct_and_print_module
 def objFifoAcquire():
     dev = Device(AIEDevice.xcvc1902)
@@ -165,7 +164,7 @@ def objFifoAcquire():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(12, T.f16())),
             [],
             [],
         )
@@ -184,9 +183,9 @@ def objFifoAcquire():
 # CHECK-LABEL: objFifoSubviewAccess
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
-# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : !AIE.objectFifoSubview<memref<12xf16>>
-# CHECK: %[[VAL_4:.*]] = AIE.objectFifo.subview.access %[[VAL_3]][0] : !AIE.objectFifoSubview<memref<12xf16>> -> memref<12xf16>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
+# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : memref<12xf16>
+# CHECK: %[[VAL_4:.*]] = AIE.objectFifo.subview.access %[[VAL_3]][0] : memref<12xf16> -> memref<12xf16>
 @construct_and_print_module
 def objFifoSubviewAccess():
     dev = Device(AIEDevice.xcvc1902)
@@ -199,7 +198,7 @@ def objFifoSubviewAccess():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(12, T.f16())),
             [],
             [],
         )
@@ -221,7 +220,7 @@ def objFifoSubviewAccess():
 # CHECK-LABEL: objFifoRelease
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
 # CHECK: AIE.objectFifo.release @[[VAL_2]](Produce, 1)
 @construct_and_print_module
 def objFifoRelease():
@@ -235,7 +234,7 @@ def objFifoRelease():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(12, T.f16())),
             [],
             [],
         )

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -12,6 +12,7 @@ from aie.dialects.aie import (
     ExternalBuffer,
     MemOp,
     ObjectFifoPort,
+    ObjectFifoType,
     acquire,
     end,
     objectFifo,
@@ -90,7 +91,7 @@ def externalBufferOp():
 # CHECK-LABEL: objFifo
 # CHECK: %[[VAL0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @of0(%[[VAL0]] toStream [<1, 2>], {%[[VAL1]] fromStream [<1, 2>]}, 2 : i32) : memref<12xf16>
+# CHECK: AIE.objectFifo @of0(%[[VAL0]] toStream [<1, 2>], {%[[VAL1]] fromStream [<1, 2>]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
 @construct_and_print_module
 def objFifo():
     dev = Device(AIEDevice.xcvc1902)
@@ -103,7 +104,7 @@ def objFifo():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(T.memref(12, T.f16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
             [(1, 2)],
             [[(1, 2)]],
         )
@@ -114,8 +115,8 @@ def objFifo():
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
 # CHECK: %[[VAL_2:.*]] = AIE.tile(7, 7)
-# CHECK: AIE.objectFifo @[[VAL_3:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
-# CHECK: AIE.objectFifo @[[VAL_4:.*]](%[[VAL_1]], {%[[VAL_2]]}, 2 : i32) : memref<12xf16>
+# CHECK: AIE.objectFifo @[[VAL_3:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_4:.*]](%[[VAL_1]], {%[[VAL_2]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
 # CHECK: AIE.objectFifo.link [@[[VAL_3]]] -> [@[[VAL_4]]]()
 @construct_and_print_module
 def objFifoLink():
@@ -130,7 +131,7 @@ def objFifoLink():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(T.memref(12, T.f16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -139,7 +140,7 @@ def objFifoLink():
             tile1,
             [tile2],
             2,
-            TypeAttr.get(T.memref(12, T.f16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -150,8 +151,8 @@ def objFifoLink():
 # CHECK-LABEL: objFifoAcquire
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
-# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : memref<12xf16>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : !AIE.objectFifoSubview<memref<12xf16>>
 @construct_and_print_module
 def objFifoAcquire():
     dev = Device(AIEDevice.xcvc1902)
@@ -164,7 +165,7 @@ def objFifoAcquire():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(T.memref(12, T.f16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -183,9 +184,9 @@ def objFifoAcquire():
 # CHECK-LABEL: objFifoSubviewAccess
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
-# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : memref<12xf16>
-# CHECK: %[[VAL_4:.*]] = AIE.objectFifo.subview.access %[[VAL_3]][0] : memref<12xf16> -> memref<12xf16>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : !AIE.objectFifoSubview<memref<12xf16>>
+# CHECK: %[[VAL_4:.*]] = AIE.objectFifo.subview.access %[[VAL_3]][0] : !AIE.objectFifoSubview<memref<12xf16>> -> memref<12xf16>
 @construct_and_print_module
 def objFifoSubviewAccess():
     dev = Device(AIEDevice.xcvc1902)
@@ -198,7 +199,7 @@ def objFifoSubviewAccess():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(T.memref(12, T.f16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -220,7 +221,7 @@ def objFifoSubviewAccess():
 # CHECK-LABEL: objFifoRelease
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<12xf16>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
 # CHECK: AIE.objectFifo.release @[[VAL_2]](Produce, 1)
 @construct_and_print_module
 def objFifoRelease():
@@ -234,7 +235,7 @@ def objFifoRelease():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(T.memref(12, T.f16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
             [],
             [],
         )

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -12,7 +12,6 @@ from aie.dialects.aie import (
     ExternalBuffer,
     MemOp,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     end,
     objectFifo,
@@ -91,7 +90,7 @@ def externalBufferOp():
 # CHECK-LABEL: objFifo
 # CHECK: %[[VAL0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @of0(%[[VAL0]] toStream [<1, 2>], {%[[VAL1]] fromStream [<1, 2>]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: AIE.objectFifo @of0(%[[VAL0]] toStream [<1, 2>], {%[[VAL1]] fromStream [<1, 2>]}, 2 : i32) : memref<2xmemref<12xf16>>
 @construct_and_print_module
 def objFifo():
     dev = Device(AIEDevice.xcvc1902)
@@ -104,7 +103,7 @@ def objFifo():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(2, T.memref(12, T.f16()))),
             [(1, 2)],
             [[(1, 2)]],
         )
@@ -115,8 +114,8 @@ def objFifo():
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
 # CHECK: %[[VAL_2:.*]] = AIE.tile(7, 7)
-# CHECK: AIE.objectFifo @[[VAL_3:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
-# CHECK: AIE.objectFifo @[[VAL_4:.*]](%[[VAL_1]], {%[[VAL_2]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_3:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<2xmemref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_4:.*]](%[[VAL_1]], {%[[VAL_2]]}, 2 : i32) : memref<2xmemref<12xf16>>
 # CHECK: AIE.objectFifo.link [@[[VAL_3]]] -> [@[[VAL_4]]]()
 @construct_and_print_module
 def objFifoLink():
@@ -131,7 +130,7 @@ def objFifoLink():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(2, T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -140,7 +139,7 @@ def objFifoLink():
             tile1,
             [tile2],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(2, T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -151,8 +150,8 @@ def objFifoLink():
 # CHECK-LABEL: objFifoAcquire
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
-# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : !AIE.objectFifoSubview<memref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<2xmemref<12xf16>>
+# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : memref<1xmemref<12xf16>>
 @construct_and_print_module
 def objFifoAcquire():
     dev = Device(AIEDevice.xcvc1902)
@@ -165,7 +164,7 @@ def objFifoAcquire():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(2, T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -184,9 +183,9 @@ def objFifoAcquire():
 # CHECK-LABEL: objFifoSubviewAccess
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
-# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : !AIE.objectFifoSubview<memref<12xf16>>
-# CHECK: %[[VAL_4:.*]] = AIE.objectFifo.subview.access %[[VAL_3]][0] : !AIE.objectFifoSubview<memref<12xf16>> -> memref<12xf16>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<2xmemref<12xf16>>
+# CHECK: %[[VAL_3:.*]] = AIE.objectFifo.acquire @[[VAL_2]](Consume, 1) : memref<1xmemref<12xf16>>
+# CHECK: %[[VAL_4:.*]] = AIE.objectFifo.subview.access %[[VAL_3]][0] : memref<1xmemref<12xf16>> -> memref<12xf16>
 @construct_and_print_module
 def objFifoSubviewAccess():
     dev = Device(AIEDevice.xcvc1902)
@@ -199,7 +198,7 @@ def objFifoSubviewAccess():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(2, T.memref(12, T.f16()))),
             [],
             [],
         )
@@ -221,7 +220,7 @@ def objFifoSubviewAccess():
 # CHECK-LABEL: objFifoRelease
 # CHECK: %[[VAL_0:.*]] = AIE.tile(6, 6)
 # CHECK: %[[VAL_1:.*]] = AIE.tile(2, 2)
-# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : !AIE.objectFifo<memref<12xf16>>
+# CHECK: AIE.objectFifo @[[VAL_2:.*]](%[[VAL_0]], {%[[VAL_1]]}, 2 : i32) : memref<2xmemref<12xf16>>
 # CHECK: AIE.objectFifo.release @[[VAL_2]](Produce, 1)
 @construct_and_print_module
 def objFifoRelease():
@@ -235,7 +234,7 @@ def objFifoRelease():
             tile0,
             [tile1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(12, T.f16()))),
+            TypeAttr.get(T.memref(2, T.memref(12, T.f16()))),
             [],
             [],
         )

--- a/test/python/code_region.py
+++ b/test/python/code_region.py
@@ -8,7 +8,6 @@ from aie.dialects.aie import (
     AIEDevice,
     Call,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     core,
     device,
@@ -31,16 +30,16 @@ range_ = for_
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_3_3 = AIE.tile(3, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !AIE.objectFifo<memref<8x8xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<2xmemref<256xi32>>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : memref<2xmemref<8x8xi32>>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
 # CHECK:      %core_3_3 = AIE.core(%tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index
 # CHECK:        scf.for %arg0 = %c0 to %c10 step %c1 {
-# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : !AIE.objectFifoSubview<memref<8x8xi32>>
-# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<8x8xi32>> -> memref<8x8xi32>
+# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : memref<1xmemref<8x8xi32>>
+# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<8x8xi32>> -> memref<8x8xi32>
 # CHECK:          %2 = func.call @test_func(%1) : (memref<8x8xi32>) -> i32
 # CHECK:          AIE.objectFifo.release @of1(Consume, 1)
 # CHECK:        }
@@ -63,7 +62,7 @@ def codeRegion():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(256, T.i32()))),
             [],
             [],
         )
@@ -72,7 +71,7 @@ def codeRegion():
             M,
             [N],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(8, 8, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(8, 8, T.i32()))),
             [],
             [],
         )

--- a/test/python/code_region.py
+++ b/test/python/code_region.py
@@ -8,7 +8,6 @@ from aie.dialects.aie import (
     AIEDevice,
     Call,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     core,
     device,
@@ -31,16 +30,16 @@ range_ = for_
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_3_3 = AIE.tile(3, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !AIE.objectFifo<memref<8x8xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : memref<8x8xi32>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
 # CHECK:      %core_3_3 = AIE.core(%tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index
 # CHECK:        scf.for %arg0 = %c0 to %c10 step %c1 {
-# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : !AIE.objectFifoSubview<memref<8x8xi32>>
-# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<8x8xi32>> -> memref<8x8xi32>
+# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : memref<8x8xi32>
+# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : memref<8x8xi32> -> memref<8x8xi32>
 # CHECK:          %2 = func.call @test_func(%1) : (memref<8x8xi32>) -> i32
 # CHECK:          AIE.objectFifo.release @of1(Consume, 1)
 # CHECK:        }
@@ -63,7 +62,7 @@ def codeRegion():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(256, T.i32())),
             [],
             [],
         )
@@ -72,7 +71,7 @@ def codeRegion():
             M,
             [N],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(8, 8, T.i32()))),
+            TypeAttr.get(T.memref(8, 8, T.i32())),
             [],
             [],
         )

--- a/test/python/code_region.py
+++ b/test/python/code_region.py
@@ -8,6 +8,7 @@ from aie.dialects.aie import (
     AIEDevice,
     Call,
     ObjectFifoPort,
+    ObjectFifoType,
     acquire,
     core,
     device,
@@ -30,16 +31,16 @@ range_ = for_
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_3_3 = AIE.tile(3, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : memref<8x8xi32>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !AIE.objectFifo<memref<8x8xi32>>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
 # CHECK:      %core_3_3 = AIE.core(%tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index
 # CHECK:        scf.for %arg0 = %c0 to %c10 step %c1 {
-# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : memref<8x8xi32>
-# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : memref<8x8xi32> -> memref<8x8xi32>
+# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : !AIE.objectFifoSubview<memref<8x8xi32>>
+# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<8x8xi32>> -> memref<8x8xi32>
 # CHECK:          %2 = func.call @test_func(%1) : (memref<8x8xi32>) -> i32
 # CHECK:          AIE.objectFifo.release @of1(Consume, 1)
 # CHECK:        }
@@ -62,7 +63,7 @@ def codeRegion():
             S,
             [M],
             2,
-            TypeAttr.get(T.memref(256, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
             [],
             [],
         )
@@ -71,7 +72,7 @@ def codeRegion():
             M,
             [N],
             2,
-            TypeAttr.get(T.memref(8, 8, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(8, 8, T.i32()))),
             [],
             [],
         )

--- a/test/python/core_ext_kernel.py
+++ b/test/python/core_ext_kernel.py
@@ -11,7 +11,6 @@ from aie.dialects.aie import (
     Core,
     Device,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     external_func,
     objectFifo,
@@ -34,16 +33,16 @@ range_ = for_
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_3_3 = AIE.tile(3, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !AIE.objectFifo<memref<8x8xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : memref<8x8xi32>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
 # CHECK:      %core_3_3 = AIE.core(%tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index
 # CHECK:        scf.for %arg0 = %c0 to %c10 step %c1 {
-# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : !AIE.objectFifoSubview<memref<8x8xi32>>
-# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<8x8xi32>> -> memref<8x8xi32>
+# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : memref<8x8xi32>
+# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : memref<8x8xi32> -> memref<8x8xi32>
 # CHECK:          %c4_i32 = arith.constant 4 : i32
 # CHECK:          %2 = func.call @test_func(%1, %c4_i32) : (memref<8x8xi32>, i32) -> i32
 # CHECK:          AIE.objectFifo.release @of1(Consume, 1)
@@ -70,7 +69,7 @@ def core_ext_kernel():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(256, T.i32())),
             [],
             [],
         )
@@ -79,7 +78,7 @@ def core_ext_kernel():
             M,
             [N],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(8, 8, T.i32()))),
+            TypeAttr.get(T.memref(8, 8, T.i32())),
             [],
             [],
         )

--- a/test/python/core_ext_kernel.py
+++ b/test/python/core_ext_kernel.py
@@ -11,6 +11,7 @@ from aie.dialects.aie import (
     Core,
     Device,
     ObjectFifoPort,
+    ObjectFifoType,
     acquire,
     external_func,
     objectFifo,
@@ -33,16 +34,16 @@ range_ = for_
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_3_3 = AIE.tile(3, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : memref<8x8xi32>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !AIE.objectFifo<memref<8x8xi32>>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
 # CHECK:      %core_3_3 = AIE.core(%tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index
 # CHECK:        scf.for %arg0 = %c0 to %c10 step %c1 {
-# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : memref<8x8xi32>
-# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : memref<8x8xi32> -> memref<8x8xi32>
+# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : !AIE.objectFifoSubview<memref<8x8xi32>>
+# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<8x8xi32>> -> memref<8x8xi32>
 # CHECK:          %c4_i32 = arith.constant 4 : i32
 # CHECK:          %2 = func.call @test_func(%1, %c4_i32) : (memref<8x8xi32>, i32) -> i32
 # CHECK:          AIE.objectFifo.release @of1(Consume, 1)
@@ -69,7 +70,7 @@ def core_ext_kernel():
             S,
             [M],
             2,
-            TypeAttr.get(T.memref(256, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
             [],
             [],
         )
@@ -78,7 +79,7 @@ def core_ext_kernel():
             M,
             [N],
             2,
-            TypeAttr.get(T.memref(8, 8, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(8, 8, T.i32()))),
             [],
             [],
         )

--- a/test/python/core_ext_kernel.py
+++ b/test/python/core_ext_kernel.py
@@ -11,7 +11,6 @@ from aie.dialects.aie import (
     Core,
     Device,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     external_func,
     objectFifo,
@@ -34,16 +33,16 @@ range_ = for_
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_3_3 = AIE.tile(3, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !AIE.objectFifo<memref<8x8xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<2xmemref<256xi32>>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : memref<2xmemref<8x8xi32>>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
 # CHECK:      %core_3_3 = AIE.core(%tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index
 # CHECK:        scf.for %arg0 = %c0 to %c10 step %c1 {
-# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : !AIE.objectFifoSubview<memref<8x8xi32>>
-# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<8x8xi32>> -> memref<8x8xi32>
+# CHECK:          %0 = AIE.objectFifo.acquire @of1(Consume, 1) : memref<1xmemref<8x8xi32>>
+# CHECK:          %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<8x8xi32>> -> memref<8x8xi32>
 # CHECK:          %c4_i32 = arith.constant 4 : i32
 # CHECK:          %2 = func.call @test_func(%1, %c4_i32) : (memref<8x8xi32>, i32) -> i32
 # CHECK:          AIE.objectFifo.release @of1(Consume, 1)
@@ -70,7 +69,7 @@ def core_ext_kernel():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(256, T.i32()))),
             [],
             [],
         )
@@ -79,7 +78,7 @@ def core_ext_kernel():
             M,
             [N],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(8, 8, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(8, 8, T.i32()))),
             [],
             [],
         )

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -11,6 +11,7 @@ from aie.dialects.aie import (
     AIEDevice,
     Call,
     ObjectFifoPort,
+    ObjectFifoType,
     acquire,
     core,
     device,
@@ -49,8 +50,8 @@ def construct_and_print_module(f):
 # CHECK:     func.func private @scale_int32(memref<1024xi32>, memref<1024xi32>)
 # CHECK:     %tile_0_0 = AIE.tile(0, 0)
 # CHECK:     %tile_0_2 = AIE.tile(0, 2)
-# CHECK:     AIE.objectFifo @in(%tile_0_0, {%tile_0_2}, 2 : i32) : memref<1024xi32>
-# CHECK:     AIE.objectFifo @out(%tile_0_2, {%tile_0_0}, 2 : i32) : memref<1024xi32>
+# CHECK:     AIE.objectFifo @in(%tile_0_0, {%tile_0_2}, 2 : i32) : !AIE.objectFifo<memref<1024xi32>>
+# CHECK:     AIE.objectFifo @out(%tile_0_2, {%tile_0_0}, 2 : i32) : !AIE.objectFifo<memref<1024xi32>>
 # CHECK:     %core_0_2 = AIE.core(%tile_0_2) {
 # CHECK:       %c4 = arith.constant 4 : index
 # CHECK:       %c0 = arith.constant 0 : index
@@ -58,10 +59,10 @@ def construct_and_print_module(f):
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c4294967295 step %c1 {
 # CHECK:         scf.for %arg1 = %c0 to %c4 step %c1 {
-# CHECK:           %0 = AIE.objectFifo.acquire @out(Produce, 1) : memref<1024xi32>
-# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : memref<1024xi32> -> memref<1024xi32>
-# CHECK:           %2 = AIE.objectFifo.acquire @in(Consume, 1) : memref<1024xi32>
-# CHECK:           %3 = AIE.objectFifo.subview.access %2[0] : memref<1024xi32> -> memref<1024xi32>
+# CHECK:           %0 = AIE.objectFifo.acquire @out(Produce, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
+# CHECK:           %2 = AIE.objectFifo.acquire @in(Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
+# CHECK:           %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
 # CHECK:           func.call @scale_int32(%3, %1) : (memref<1024xi32>, memref<1024xi32>) -> ()
 # CHECK:           AIE.objectFifo.release @in(Consume, 1)
 # CHECK:           AIE.objectFifo.release @out(Produce, 1)
@@ -104,7 +105,7 @@ def my_vector_scalar():
             S,
             [M],
             buffer_depth,
-            TypeAttr.get(T.memref(n, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(n, T.i32()))),
             [],
             [],
         )
@@ -113,7 +114,7 @@ def my_vector_scalar():
             M,
             [S],
             buffer_depth,
-            TypeAttr.get(T.memref(n, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(n, T.i32()))),
             [],
             [],
         )
@@ -154,9 +155,9 @@ def my_vector_scalar():
 # CHECK:     func.func private @matmul_i16_i16(memref<64x32xi16>, memref<32x64xi16>, memref<64x64xi16>)
 # CHECK:     %tile_0_0 = AIE.tile(0, 0)
 # CHECK:     %tile_0_2 = AIE.tile(0, 2)
-# CHECK:     AIE.objectFifo @inA(%tile_0_0, {%tile_0_2}, 2 : i32) : memref<64x32xi16>
-# CHECK:     AIE.objectFifo @inB(%tile_0_0, {%tile_0_2}, 2 : i32) : memref<32x64xi16>
-# CHECK:     AIE.objectFifo @outC(%tile_0_2, {%tile_0_0}, 2 : i32) : memref<64x64xi16>
+# CHECK:     AIE.objectFifo @inA(%tile_0_0, {%tile_0_2}, 2 : i32) : !AIE.objectFifo<memref<64x32xi16>>
+# CHECK:     AIE.objectFifo @inB(%tile_0_0, {%tile_0_2}, 2 : i32) : !AIE.objectFifo<memref<32x64xi16>>
+# CHECK:     AIE.objectFifo @outC(%tile_0_2, {%tile_0_0}, 2 : i32) : !AIE.objectFifo<memref<64x64xi16>>
 # CHECK:     %core_0_2 = AIE.core(%tile_0_2) {
 # CHECK:       %c4 = arith.constant 4 : index
 # CHECK:       %c0 = arith.constant 0 : index
@@ -164,14 +165,14 @@ def my_vector_scalar():
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c4294967295 step %c1 {
 # CHECK:         scf.for %arg1 = %c0 to %c4 step %c1 {
-# CHECK:           %0 = AIE.objectFifo.acquire @outC(Produce, 1) : memref<64x64xi16>
-# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : memref<64x64xi16> -> memref<64x64xi16>
+# CHECK:           %0 = AIE.objectFifo.acquire @outC(Produce, 1) : !AIE.objectFifoSubview<memref<64x64xi16>>
+# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64x64xi16>> -> memref<64x64xi16>
 # CHECK:           func.call @zero_i16(%1) : (memref<64x64xi16>) -> ()
 # CHECK:           scf.for %arg2 = %c0 to %c4 step %c1 {
-# CHECK:             %2 = AIE.objectFifo.acquire @inA(Consume, 1) : memref<64x32xi16>
-# CHECK:             %3 = AIE.objectFifo.subview.access %2[0] : memref<64x32xi16> -> memref<64x32xi16>
-# CHECK:             %4 = AIE.objectFifo.acquire @inB(Consume, 1) : memref<32x64xi16>
-# CHECK:             %5 = AIE.objectFifo.subview.access %4[0] : memref<32x64xi16> -> memref<32x64xi16>
+# CHECK:             %2 = AIE.objectFifo.acquire @inA(Consume, 1) : !AIE.objectFifoSubview<memref<64x32xi16>>
+# CHECK:             %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<64x32xi16>> -> memref<64x32xi16>
+# CHECK:             %4 = AIE.objectFifo.acquire @inB(Consume, 1) : !AIE.objectFifoSubview<memref<32x64xi16>>
+# CHECK:             %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<32x64xi16>> -> memref<32x64xi16>
 # CHECK:             func.call @matmul_i16_i16(%3, %5, %1) : (memref<64x32xi16>, memref<32x64xi16>, memref<64x64xi16>) -> ()
 # CHECK:             AIE.objectFifo.release @inA(Consume, 1)
 # CHECK:             AIE.objectFifo.release @inB(Consume, 1)
@@ -268,7 +269,7 @@ def my_matmul():
             S,
             [M],
             2,
-            TypeAttr.get(T.memref(m, k, T.i16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(m, k, T.i16()))),
             [],
             [],
         )
@@ -277,7 +278,7 @@ def my_matmul():
             S,
             [M],
             2,
-            TypeAttr.get(T.memref(k, n, T.i16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(k, n, T.i16()))),
             [],
             [],
         )
@@ -286,7 +287,7 @@ def my_matmul():
             M,
             [S],
             2,
-            TypeAttr.get(T.memref(m, n, T.i16())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(m, n, T.i16()))),
             [],
             [],
         )
@@ -388,26 +389,26 @@ def my_matmul():
 # CHECK:     %tile_0_3 = AIE.tile(0, 3)
 # CHECK:     %tile_0_4 = AIE.tile(0, 4)
 # CHECK:     %tile_0_5 = AIE.tile(0, 5)
-# CHECK:     AIE.objectFifo @inOF_L3L2(%tile_0_0, {%tile_0_1}, 2 : i32) : memref<256xui8>
-# CHECK:     AIE.objectFifo @inOF_L2L1(%tile_0_1, {%tile_0_2, %tile_0_5}, [2 : i32, 2 : i32, 7 : i32]) : memref<256xui8>
+# CHECK:     AIE.objectFifo @inOF_L3L2(%tile_0_0, {%tile_0_1}, 2 : i32) : !AIE.objectFifo<memref<256xui8>>
+# CHECK:     AIE.objectFifo @inOF_L2L1(%tile_0_1, {%tile_0_2, %tile_0_5}, [2 : i32, 2 : i32, 7 : i32]) : !AIE.objectFifo<memref<256xui8>>
 # CHECK:     AIE.objectFifo.link [@inOF_L3L2] -> [@inOF_L2L1]()
-# CHECK:     AIE.objectFifo @outOF_L2L3(%tile_0_1, {%tile_0_0}, 2 : i32) : memref<256xui8>
-# CHECK:     AIE.objectFifo @outOF_L1L2(%tile_0_5, {%tile_0_1}, 2 : i32) : memref<256xui8>
+# CHECK:     AIE.objectFifo @outOF_L2L3(%tile_0_1, {%tile_0_0}, 2 : i32) : !AIE.objectFifo<memref<256xui8>>
+# CHECK:     AIE.objectFifo @outOF_L1L2(%tile_0_5, {%tile_0_1}, 2 : i32) : !AIE.objectFifo<memref<256xui8>>
 # CHECK:     AIE.objectFifo.link [@outOF_L1L2] -> [@outOF_L2L3]()
-# CHECK:     AIE.objectFifo @OF_2to3(%tile_0_2, {%tile_0_3}, 4 : i32) : memref<64xui8>
-# CHECK:     AIE.objectFifo @OF_3to4(%tile_0_3, {%tile_0_4}, 2 : i32) : memref<64xui8>
-# CHECK:     AIE.objectFifo @OF_4to5(%tile_0_4, {%tile_0_5}, 2 : i32) : memref<64xui8>
-# CHECK:     AIE.objectFifo @OF_5to5(%tile_0_5, {%tile_0_5}, 1 : i32) : memref<256xui8>
+# CHECK:     AIE.objectFifo @OF_2to3(%tile_0_2, {%tile_0_3}, 4 : i32) : !AIE.objectFifo<memref<64xui8>>
+# CHECK:     AIE.objectFifo @OF_3to4(%tile_0_3, {%tile_0_4}, 2 : i32) : !AIE.objectFifo<memref<64xui8>>
+# CHECK:     AIE.objectFifo @OF_4to5(%tile_0_4, {%tile_0_5}, 2 : i32) : !AIE.objectFifo<memref<64xui8>>
+# CHECK:     AIE.objectFifo @OF_5to5(%tile_0_5, {%tile_0_5}, 1 : i32) : !AIE.objectFifo<memref<256xui8>>
 # CHECK:     %core_0_2 = AIE.core(%tile_0_2) {
 # CHECK:       %c64_i32 = arith.constant 64 : i32
 # CHECK:       %c0 = arith.constant 0 : index
 # CHECK:       %c36 = arith.constant 36 : index
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c36 step %c1 {
-# CHECK:         %0 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : memref<256xui8>
-# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : memref<256xui8> -> memref<256xui8>
-# CHECK:         %2 = AIE.objectFifo.acquire @OF_2to3(Produce, 1) : memref<64xui8>
-# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : memref<64xui8> -> memref<64xui8>
+# CHECK:         %0 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : !AIE.objectFifoSubview<memref<256xui8>>
+# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
+# CHECK:         %2 = AIE.objectFifo.acquire @OF_2to3(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
 # CHECK:         func.call @rgba2gray_line(%1, %3, %c64_i32) : (memref<256xui8>, memref<64xui8>, i32) -> ()
 # CHECK:         AIE.objectFifo.release @inOF_L2L1(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_2to3(Produce, 1)
@@ -433,29 +434,29 @@ def my_matmul():
 # CHECK:       memref.store %c0_i16, %alloc[%c2, %c0] : memref<3x3xi16>
 # CHECK:       memref.store %c4096_i16, %alloc[%c2, %c1] : memref<3x3xi16>
 # CHECK:       memref.store %c0_i16, %alloc[%c2, %c2] : memref<3x3xi16>
-# CHECK:       %0 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : memref<64xui8>
-# CHECK:       %1 = AIE.objectFifo.subview.access %0[0] : memref<64xui8> -> memref<64xui8>
-# CHECK:       %2 = AIE.objectFifo.subview.access %0[1] : memref<64xui8> -> memref<64xui8>
-# CHECK:       %3 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : memref<64xui8>
-# CHECK:       %4 = AIE.objectFifo.subview.access %3[0] : memref<64xui8> -> memref<64xui8>
+# CHECK:       %0 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:       %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:       %2 = AIE.objectFifo.subview.access %0[1] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:       %3 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:       %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
 # CHECK:       func.call @filter2d_line(%1, %1, %2, %4, %c64_i32, %alloc) : (memref<64xui8>, memref<64xui8>, memref<64xui8>, memref<64xui8>, i32, memref<3x3xi16>) -> ()
 # CHECK:       AIE.objectFifo.release @OF_3to4(Produce, 1)
 # CHECK:       scf.for %arg0 = %c1 to %c35 step %c1 {
-# CHECK:         %10 = AIE.objectFifo.acquire @OF_2to3(Consume, 3) : memref<64xui8>
-# CHECK:         %11 = AIE.objectFifo.subview.access %10[0] : memref<64xui8> -> memref<64xui8>
-# CHECK:         %12 = AIE.objectFifo.subview.access %10[1] : memref<64xui8> -> memref<64xui8>
-# CHECK:         %13 = AIE.objectFifo.subview.access %10[2] : memref<64xui8> -> memref<64xui8>
-# CHECK:         %14 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : memref<64xui8>
-# CHECK:         %15 = AIE.objectFifo.subview.access %14[0] : memref<64xui8> -> memref<64xui8>
+# CHECK:         %10 = AIE.objectFifo.acquire @OF_2to3(Consume, 3) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:         %11 = AIE.objectFifo.subview.access %10[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %12 = AIE.objectFifo.subview.access %10[1] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %13 = AIE.objectFifo.subview.access %10[2] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %14 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:         %15 = AIE.objectFifo.subview.access %14[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
 # CHECK:         func.call @filter2d_line(%11, %12, %13, %15, %c64_i32, %alloc) : (memref<64xui8>, memref<64xui8>, memref<64xui8>, memref<64xui8>, i32, memref<3x3xi16>) -> ()
 # CHECK:         AIE.objectFifo.release @OF_2to3(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_3to4(Produce, 1)
 # CHECK:       }
-# CHECK:       %5 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : memref<64xui8>
-# CHECK:       %6 = AIE.objectFifo.subview.access %5[0] : memref<64xui8> -> memref<64xui8>
-# CHECK:       %7 = AIE.objectFifo.subview.access %5[1] : memref<64xui8> -> memref<64xui8>
-# CHECK:       %8 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : memref<64xui8>
-# CHECK:       %9 = AIE.objectFifo.subview.access %8[0] : memref<64xui8> -> memref<64xui8>
+# CHECK:       %5 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:       %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:       %7 = AIE.objectFifo.subview.access %5[1] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:       %8 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:       %9 = AIE.objectFifo.subview.access %8[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
 # CHECK:       func.call @filter2d_line(%6, %7, %7, %9, %c64_i32, %alloc) : (memref<64xui8>, memref<64xui8>, memref<64xui8>, memref<64xui8>, i32, memref<3x3xi16>) -> ()
 # CHECK:       AIE.objectFifo.release @OF_2to3(Consume, 2)
 # CHECK:       AIE.objectFifo.release @OF_3to4(Produce, 1)
@@ -470,10 +471,10 @@ def my_matmul():
 # CHECK:       %c36 = arith.constant 36 : index
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c36 step %c1 {
-# CHECK:         %0 = AIE.objectFifo.acquire @OF_3to4(Consume, 1) : memref<64xui8>
-# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : memref<64xui8> -> memref<64xui8>
-# CHECK:         %2 = AIE.objectFifo.acquire @OF_4to5(Produce, 1) : memref<64xui8>
-# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : memref<64xui8> -> memref<64xui8>
+# CHECK:         %0 = AIE.objectFifo.acquire @OF_3to4(Consume, 1) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %2 = AIE.objectFifo.acquire @OF_4to5(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
 # CHECK:         func.call @threshold_line(%1, %3, %c64_i32, %c10_i16, %c255_i16, %c0_i8) : (memref<64xui8>, memref<64xui8>, i32, i16, i16, i8) -> ()
 # CHECK:         AIE.objectFifo.release @OF_3to4(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_4to5(Produce, 1)
@@ -489,19 +490,19 @@ def my_matmul():
 # CHECK:       %c36 = arith.constant 36 : index
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c36 step %c1 {
-# CHECK:         %0 = AIE.objectFifo.acquire @OF_4to5(Consume, 1) : memref<64xui8>
-# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : memref<64xui8> -> memref<64xui8>
-# CHECK:         %2 = AIE.objectFifo.acquire @OF_5to5(Produce, 1) : memref<256xui8>
-# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : memref<256xui8> -> memref<256xui8>
+# CHECK:         %0 = AIE.objectFifo.acquire @OF_4to5(Consume, 1) : !AIE.objectFifoSubview<memref<64xui8>>
+# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %2 = AIE.objectFifo.acquire @OF_5to5(Produce, 1) : !AIE.objectFifoSubview<memref<256xui8>>
+# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
 # CHECK:         func.call @gray2rgba_line(%1, %3, %c64_i32) : (memref<64xui8>, memref<256xui8>, i32) -> ()
 # CHECK:         AIE.objectFifo.release @OF_4to5(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_5to5(Produce, 1)
-# CHECK:         %4 = AIE.objectFifo.acquire @OF_5to5(Consume, 1) : memref<256xui8>
-# CHECK:         %5 = AIE.objectFifo.subview.access %4[0] : memref<256xui8> -> memref<256xui8>
-# CHECK:         %6 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : memref<256xui8>
-# CHECK:         %7 = AIE.objectFifo.subview.access %6[0] : memref<256xui8> -> memref<256xui8>
-# CHECK:         %8 = AIE.objectFifo.acquire @outOF_L1L2(Produce, 1) : memref<256xui8>
-# CHECK:         %9 = AIE.objectFifo.subview.access %8[0] : memref<256xui8> -> memref<256xui8>
+# CHECK:         %4 = AIE.objectFifo.acquire @OF_5to5(Consume, 1) : !AIE.objectFifoSubview<memref<256xui8>>
+# CHECK:         %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
+# CHECK:         %6 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : !AIE.objectFifoSubview<memref<256xui8>>
+# CHECK:         %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
+# CHECK:         %8 = AIE.objectFifo.acquire @outOF_L1L2(Produce, 1) : !AIE.objectFifoSubview<memref<256xui8>>
+# CHECK:         %9 = AIE.objectFifo.subview.access %8[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
 # CHECK:         func.call @add_weighted_line(%5, %7, %9, %c256_i32, %c16384_i16, %c16384_i16, %c0_i8) : (memref<256xui8>, memref<256xui8>, memref<256xui8>, i32, i16, i16, i8) -> ()
 # CHECK:         AIE.objectFifo.release @OF_5to5(Consume, 1)
 # CHECK:         AIE.objectFifo.release @inOF_L2L1(Consume, 1)
@@ -582,7 +583,7 @@ def edge_detect():
             S,
             [M],
             2,
-            TypeAttr.get(T.memref(256, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -591,7 +592,7 @@ def edge_detect():
             M,
             [T2, T5],
             [2, 2, 7],
-            TypeAttr.get(T.memref(256, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -602,7 +603,7 @@ def edge_detect():
             M,
             [S],
             2,
-            TypeAttr.get(T.memref(256, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -611,7 +612,7 @@ def edge_detect():
             T5,
             [M],
             2,
-            TypeAttr.get(T.memref(256, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -622,7 +623,7 @@ def edge_detect():
             T2,
             [T3],
             4,
-            TypeAttr.get(T.memref(64, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.ui8()))),
             [],
             [],
         )
@@ -631,7 +632,7 @@ def edge_detect():
             T3,
             [T4],
             2,
-            TypeAttr.get(T.memref(64, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.ui8()))),
             [],
             [],
         )
@@ -640,7 +641,7 @@ def edge_detect():
             T4,
             [T5],
             2,
-            TypeAttr.get(T.memref(64, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.ui8()))),
             [],
             [],
         )
@@ -649,7 +650,7 @@ def edge_detect():
             T5,
             [T5],
             1,
-            TypeAttr.get(T.memref(256, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -848,11 +849,11 @@ def edge_detect():
 #     %t01 = AIE.tile(0, 1)
 #     %t02 = AIE.tile(0, 2)
 #
-#     AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : memref<16xi32>
-#     AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : memref<8xi32>
+#     AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+#     AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
 #     AIE.objectFifo.link [@objFifo_in0] -> [@objFifo_in1] ()
-#     AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : memref<16xi32>
-#     AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : memref<8xi32>
+#     AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
+#     AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
 #     AIE.objectFifo.link [@objFifo_out1] -> [@objFifo_out0] ()
 #
 #     AIE.core(%t02) {
@@ -862,10 +863,10 @@ def edge_detect():
 #       %c1_32 = arith.constant 1 : i32
 #
 #       scf.for %steps = %c0 to %c8 step %c1 {
-#         %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : memref<8xi32>
-#         %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<8xi32> -> memref<8xi32>
-#         %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : memref<8xi32>
-#         %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<8xi32> -> memref<8xi32>
+#         %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : !AIE.objectFifoSubview<memref<8xi32>>
+#         %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
+#         %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : !AIE.objectFifoSubview<memref<8xi32>>
+#         %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
 #         scf.for %arg3 = %c0 to %c8 step %c1 {
 #             %0 = memref.load %elem0[%arg3] : memref<8xi32>
 #             %1 = arith.addi %0, %c1_32 : i32
@@ -900,7 +901,7 @@ def my_add_one_objFifo():
             shim_tile,
             [mem_tile],
             2,
-            TypeAttr.get(T.memref(16, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(16, T.i32()))),
             [],
             [],
         )
@@ -909,7 +910,7 @@ def my_add_one_objFifo():
             mem_tile,
             [compute_tile2],
             2,
-            TypeAttr.get(T.memref(8, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(8, T.i32()))),
             [],
             [],
         )
@@ -919,7 +920,7 @@ def my_add_one_objFifo():
             mem_tile,
             [shim_tile],
             2,
-            TypeAttr.get(T.memref(8, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(8, T.i32()))),
             [],
             [],
         )
@@ -928,7 +929,7 @@ def my_add_one_objFifo():
             compute_tile2,
             [mem_tile],
             2,
-            TypeAttr.get(T.memref(16, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(16, T.i32()))),
             [],
             [],
         )

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -11,7 +11,6 @@ from aie.dialects.aie import (
     AIEDevice,
     Call,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     core,
     device,
@@ -50,8 +49,8 @@ def construct_and_print_module(f):
 # CHECK:     func.func private @scale_int32(memref<1024xi32>, memref<1024xi32>)
 # CHECK:     %tile_0_0 = AIE.tile(0, 0)
 # CHECK:     %tile_0_2 = AIE.tile(0, 2)
-# CHECK:     AIE.objectFifo @in(%tile_0_0, {%tile_0_2}, 2 : i32) : !AIE.objectFifo<memref<1024xi32>>
-# CHECK:     AIE.objectFifo @out(%tile_0_2, {%tile_0_0}, 2 : i32) : !AIE.objectFifo<memref<1024xi32>>
+# CHECK:     AIE.objectFifo @in(%tile_0_0, {%tile_0_2}, 2 : i32) : memref<2xmemref<1024xi32>>
+# CHECK:     AIE.objectFifo @out(%tile_0_2, {%tile_0_0}, 2 : i32) : memref<2xmemref<1024xi32>>
 # CHECK:     %core_0_2 = AIE.core(%tile_0_2) {
 # CHECK:       %c4 = arith.constant 4 : index
 # CHECK:       %c0 = arith.constant 0 : index
@@ -59,10 +58,10 @@ def construct_and_print_module(f):
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c4294967295 step %c1 {
 # CHECK:         scf.for %arg1 = %c0 to %c4 step %c1 {
-# CHECK:           %0 = AIE.objectFifo.acquire @out(Produce, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
-# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
-# CHECK:           %2 = AIE.objectFifo.acquire @in(Consume, 1) : !AIE.objectFifoSubview<memref<1024xi32>>
-# CHECK:           %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<1024xi32>> -> memref<1024xi32>
+# CHECK:           %0 = AIE.objectFifo.acquire @out(Produce, 1) : memref<1xmemref<1024xi32>>
+# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<1024xi32>> -> memref<1024xi32>
+# CHECK:           %2 = AIE.objectFifo.acquire @in(Consume, 1) : memref<1xmemref<1024xi32>>
+# CHECK:           %3 = AIE.objectFifo.subview.access %2[0] : memref<1xmemref<1024xi32>> -> memref<1024xi32>
 # CHECK:           func.call @scale_int32(%3, %1) : (memref<1024xi32>, memref<1024xi32>) -> ()
 # CHECK:           AIE.objectFifo.release @in(Consume, 1)
 # CHECK:           AIE.objectFifo.release @out(Produce, 1)
@@ -105,7 +104,7 @@ def my_vector_scalar():
             S,
             [M],
             buffer_depth,
-            TypeAttr.get(ObjectFifoType.get(T.memref(n, T.i32()))),
+            TypeAttr.get(T.memref(buffer_depth, T.memref(n, T.i32()))),
             [],
             [],
         )
@@ -114,7 +113,7 @@ def my_vector_scalar():
             M,
             [S],
             buffer_depth,
-            TypeAttr.get(ObjectFifoType.get(T.memref(n, T.i32()))),
+            TypeAttr.get(T.memref(buffer_depth, T.memref(n, T.i32()))),
             [],
             [],
         )
@@ -155,9 +154,9 @@ def my_vector_scalar():
 # CHECK:     func.func private @matmul_i16_i16(memref<64x32xi16>, memref<32x64xi16>, memref<64x64xi16>)
 # CHECK:     %tile_0_0 = AIE.tile(0, 0)
 # CHECK:     %tile_0_2 = AIE.tile(0, 2)
-# CHECK:     AIE.objectFifo @inA(%tile_0_0, {%tile_0_2}, 2 : i32) : !AIE.objectFifo<memref<64x32xi16>>
-# CHECK:     AIE.objectFifo @inB(%tile_0_0, {%tile_0_2}, 2 : i32) : !AIE.objectFifo<memref<32x64xi16>>
-# CHECK:     AIE.objectFifo @outC(%tile_0_2, {%tile_0_0}, 2 : i32) : !AIE.objectFifo<memref<64x64xi16>>
+# CHECK:     AIE.objectFifo @inA(%tile_0_0, {%tile_0_2}, 2 : i32) : memref<2xmemref<64x32xi16>>
+# CHECK:     AIE.objectFifo @inB(%tile_0_0, {%tile_0_2}, 2 : i32) : memref<2xmemref<32x64xi16>>
+# CHECK:     AIE.objectFifo @outC(%tile_0_2, {%tile_0_0}, 2 : i32) : memref<2xmemref<64x64xi16>>
 # CHECK:     %core_0_2 = AIE.core(%tile_0_2) {
 # CHECK:       %c4 = arith.constant 4 : index
 # CHECK:       %c0 = arith.constant 0 : index
@@ -165,14 +164,14 @@ def my_vector_scalar():
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c4294967295 step %c1 {
 # CHECK:         scf.for %arg1 = %c0 to %c4 step %c1 {
-# CHECK:           %0 = AIE.objectFifo.acquire @outC(Produce, 1) : !AIE.objectFifoSubview<memref<64x64xi16>>
-# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64x64xi16>> -> memref<64x64xi16>
+# CHECK:           %0 = AIE.objectFifo.acquire @outC(Produce, 1) : memref<1xmemref<64x64xi16>>
+# CHECK:           %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<64x64xi16>> -> memref<64x64xi16>
 # CHECK:           func.call @zero_i16(%1) : (memref<64x64xi16>) -> ()
 # CHECK:           scf.for %arg2 = %c0 to %c4 step %c1 {
-# CHECK:             %2 = AIE.objectFifo.acquire @inA(Consume, 1) : !AIE.objectFifoSubview<memref<64x32xi16>>
-# CHECK:             %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<64x32xi16>> -> memref<64x32xi16>
-# CHECK:             %4 = AIE.objectFifo.acquire @inB(Consume, 1) : !AIE.objectFifoSubview<memref<32x64xi16>>
-# CHECK:             %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<32x64xi16>> -> memref<32x64xi16>
+# CHECK:             %2 = AIE.objectFifo.acquire @inA(Consume, 1) : memref<1xmemref<64x32xi16>>
+# CHECK:             %3 = AIE.objectFifo.subview.access %2[0] : memref<1xmemref<64x32xi16>> -> memref<64x32xi16>
+# CHECK:             %4 = AIE.objectFifo.acquire @inB(Consume, 1) : memref<1xmemref<32x64xi16>>
+# CHECK:             %5 = AIE.objectFifo.subview.access %4[0] : memref<1xmemref<32x64xi16>> -> memref<32x64xi16>
 # CHECK:             func.call @matmul_i16_i16(%3, %5, %1) : (memref<64x32xi16>, memref<32x64xi16>, memref<64x64xi16>) -> ()
 # CHECK:             AIE.objectFifo.release @inA(Consume, 1)
 # CHECK:             AIE.objectFifo.release @inB(Consume, 1)
@@ -269,7 +268,7 @@ def my_matmul():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(m, k, T.i16()))),
+            TypeAttr.get(T.memref(2, T.memref(m, k, T.i16()))),
             [],
             [],
         )
@@ -278,7 +277,7 @@ def my_matmul():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(k, n, T.i16()))),
+            TypeAttr.get(T.memref(2, T.memref(k, n, T.i16()))),
             [],
             [],
         )
@@ -287,7 +286,7 @@ def my_matmul():
             M,
             [S],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(m, n, T.i16()))),
+            TypeAttr.get(T.memref(2, T.memref(m, n, T.i16()))),
             [],
             [],
         )
@@ -389,26 +388,26 @@ def my_matmul():
 # CHECK:     %tile_0_3 = AIE.tile(0, 3)
 # CHECK:     %tile_0_4 = AIE.tile(0, 4)
 # CHECK:     %tile_0_5 = AIE.tile(0, 5)
-# CHECK:     AIE.objectFifo @inOF_L3L2(%tile_0_0, {%tile_0_1}, 2 : i32) : !AIE.objectFifo<memref<256xui8>>
+# CHECK:     AIE.objectFifo @inOF_L3L2(%tile_0_0, {%tile_0_1}, 2 : i32) : memref<2xmemref<256xui8>>
 # CHECK:     AIE.objectFifo @inOF_L2L1(%tile_0_1, {%tile_0_2, %tile_0_5}, [2 : i32, 2 : i32, 7 : i32]) : !AIE.objectFifo<memref<256xui8>>
 # CHECK:     AIE.objectFifo.link [@inOF_L3L2] -> [@inOF_L2L1]()
-# CHECK:     AIE.objectFifo @outOF_L2L3(%tile_0_1, {%tile_0_0}, 2 : i32) : !AIE.objectFifo<memref<256xui8>>
-# CHECK:     AIE.objectFifo @outOF_L1L2(%tile_0_5, {%tile_0_1}, 2 : i32) : !AIE.objectFifo<memref<256xui8>>
+# CHECK:     AIE.objectFifo @outOF_L2L3(%tile_0_1, {%tile_0_0}, 2 : i32) : memref<2xmemref<256xui8>>
+# CHECK:     AIE.objectFifo @outOF_L1L2(%tile_0_5, {%tile_0_1}, 2 : i32) : memref<2xmemref<256xui8>>
 # CHECK:     AIE.objectFifo.link [@outOF_L1L2] -> [@outOF_L2L3]()
-# CHECK:     AIE.objectFifo @OF_2to3(%tile_0_2, {%tile_0_3}, 4 : i32) : !AIE.objectFifo<memref<64xui8>>
-# CHECK:     AIE.objectFifo @OF_3to4(%tile_0_3, {%tile_0_4}, 2 : i32) : !AIE.objectFifo<memref<64xui8>>
-# CHECK:     AIE.objectFifo @OF_4to5(%tile_0_4, {%tile_0_5}, 2 : i32) : !AIE.objectFifo<memref<64xui8>>
-# CHECK:     AIE.objectFifo @OF_5to5(%tile_0_5, {%tile_0_5}, 1 : i32) : !AIE.objectFifo<memref<256xui8>>
+# CHECK:     AIE.objectFifo @OF_2to3(%tile_0_2, {%tile_0_3}, 4 : i32) : memref<4xmemref<64xui8>>
+# CHECK:     AIE.objectFifo @OF_3to4(%tile_0_3, {%tile_0_4}, 2 : i32) : memref<2xmemref<64xui8>>
+# CHECK:     AIE.objectFifo @OF_4to5(%tile_0_4, {%tile_0_5}, 2 : i32) : memref<2xmemref<64xui8>>
+# CHECK:     AIE.objectFifo @OF_5to5(%tile_0_5, {%tile_0_5}, 1 : i32) : memref<1xmemref<256xui8>>
 # CHECK:     %core_0_2 = AIE.core(%tile_0_2) {
 # CHECK:       %c64_i32 = arith.constant 64 : i32
 # CHECK:       %c0 = arith.constant 0 : index
 # CHECK:       %c36 = arith.constant 36 : index
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c36 step %c1 {
-# CHECK:         %0 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : !AIE.objectFifoSubview<memref<256xui8>>
-# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
-# CHECK:         %2 = AIE.objectFifo.acquire @OF_2to3(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %0 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : memref<1xmemref<256xui8>>
+# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<256xui8>> -> memref<256xui8>
+# CHECK:         %2 = AIE.objectFifo.acquire @OF_2to3(Produce, 1) : memref<1xmemref<64xui8>>
+# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
 # CHECK:         func.call @rgba2gray_line(%1, %3, %c64_i32) : (memref<256xui8>, memref<64xui8>, i32) -> ()
 # CHECK:         AIE.objectFifo.release @inOF_L2L1(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_2to3(Produce, 1)
@@ -434,29 +433,29 @@ def my_matmul():
 # CHECK:       memref.store %c0_i16, %alloc[%c2, %c0] : memref<3x3xi16>
 # CHECK:       memref.store %c4096_i16, %alloc[%c2, %c1] : memref<3x3xi16>
 # CHECK:       memref.store %c0_i16, %alloc[%c2, %c2] : memref<3x3xi16>
-# CHECK:       %0 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:       %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:       %2 = AIE.objectFifo.subview.access %0[1] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:       %3 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:       %4 = AIE.objectFifo.subview.access %3[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:       %0 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : memref<2xmemref<64xui8>>
+# CHECK:       %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:       %2 = AIE.objectFifo.subview.access %0[1] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:       %3 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : memref<1xmemref<64xui8>>
+# CHECK:       %4 = AIE.objectFifo.subview.access %3[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
 # CHECK:       func.call @filter2d_line(%1, %1, %2, %4, %c64_i32, %alloc) : (memref<64xui8>, memref<64xui8>, memref<64xui8>, memref<64xui8>, i32, memref<3x3xi16>) -> ()
 # CHECK:       AIE.objectFifo.release @OF_3to4(Produce, 1)
 # CHECK:       scf.for %arg0 = %c1 to %c35 step %c1 {
-# CHECK:         %10 = AIE.objectFifo.acquire @OF_2to3(Consume, 3) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:         %11 = AIE.objectFifo.subview.access %10[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:         %12 = AIE.objectFifo.subview.access %10[1] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:         %13 = AIE.objectFifo.subview.access %10[2] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:         %14 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:         %15 = AIE.objectFifo.subview.access %14[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %10 = AIE.objectFifo.acquire @OF_2to3(Consume, 3) : memref<3xmemref<64xui8>>
+# CHECK:         %11 = AIE.objectFifo.subview.access %10[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:         %12 = AIE.objectFifo.subview.access %10[1] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:         %13 = AIE.objectFifo.subview.access %10[2] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:         %14 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : memref<1xmemref<64xui8>>
+# CHECK:         %15 = AIE.objectFifo.subview.access %14[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
 # CHECK:         func.call @filter2d_line(%11, %12, %13, %15, %c64_i32, %alloc) : (memref<64xui8>, memref<64xui8>, memref<64xui8>, memref<64xui8>, i32, memref<3x3xi16>) -> ()
 # CHECK:         AIE.objectFifo.release @OF_2to3(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_3to4(Produce, 1)
 # CHECK:       }
-# CHECK:       %5 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:       %6 = AIE.objectFifo.subview.access %5[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:       %7 = AIE.objectFifo.subview.access %5[1] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:       %8 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:       %9 = AIE.objectFifo.subview.access %8[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:       %5 = AIE.objectFifo.acquire @OF_2to3(Consume, 2) : memref<2xmemref<64xui8>>
+# CHECK:       %6 = AIE.objectFifo.subview.access %5[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:       %7 = AIE.objectFifo.subview.access %5[1] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:       %8 = AIE.objectFifo.acquire @OF_3to4(Produce, 1) : memref<1xmemref<64xui8>>
+# CHECK:       %9 = AIE.objectFifo.subview.access %8[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
 # CHECK:       func.call @filter2d_line(%6, %7, %7, %9, %c64_i32, %alloc) : (memref<64xui8>, memref<64xui8>, memref<64xui8>, memref<64xui8>, i32, memref<3x3xi16>) -> ()
 # CHECK:       AIE.objectFifo.release @OF_2to3(Consume, 2)
 # CHECK:       AIE.objectFifo.release @OF_3to4(Produce, 1)
@@ -471,10 +470,10 @@ def my_matmul():
 # CHECK:       %c36 = arith.constant 36 : index
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c36 step %c1 {
-# CHECK:         %0 = AIE.objectFifo.acquire @OF_3to4(Consume, 1) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:         %2 = AIE.objectFifo.acquire @OF_4to5(Produce, 1) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
+# CHECK:         %0 = AIE.objectFifo.acquire @OF_3to4(Consume, 1) : memref<1xmemref<64xui8>>
+# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:         %2 = AIE.objectFifo.acquire @OF_4to5(Produce, 1) : memref<1xmemref<64xui8>>
+# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
 # CHECK:         func.call @threshold_line(%1, %3, %c64_i32, %c10_i16, %c255_i16, %c0_i8) : (memref<64xui8>, memref<64xui8>, i32, i16, i16, i8) -> ()
 # CHECK:         AIE.objectFifo.release @OF_3to4(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_4to5(Produce, 1)
@@ -490,19 +489,19 @@ def my_matmul():
 # CHECK:       %c36 = arith.constant 36 : index
 # CHECK:       %c1 = arith.constant 1 : index
 # CHECK:       scf.for %arg0 = %c0 to %c36 step %c1 {
-# CHECK:         %0 = AIE.objectFifo.acquire @OF_4to5(Consume, 1) : !AIE.objectFifoSubview<memref<64xui8>>
-# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<64xui8>> -> memref<64xui8>
-# CHECK:         %2 = AIE.objectFifo.acquire @OF_5to5(Produce, 1) : !AIE.objectFifoSubview<memref<256xui8>>
-# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
+# CHECK:         %0 = AIE.objectFifo.acquire @OF_4to5(Consume, 1) : memref<1xmemref<64xui8>>
+# CHECK:         %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<64xui8>> -> memref<64xui8>
+# CHECK:         %2 = AIE.objectFifo.acquire @OF_5to5(Produce, 1) : memref<1xmemref<256xui8>>
+# CHECK:         %3 = AIE.objectFifo.subview.access %2[0] : memref<1xmemref<256xui8>> -> memref<256xui8>
 # CHECK:         func.call @gray2rgba_line(%1, %3, %c64_i32) : (memref<64xui8>, memref<256xui8>, i32) -> ()
 # CHECK:         AIE.objectFifo.release @OF_4to5(Consume, 1)
 # CHECK:         AIE.objectFifo.release @OF_5to5(Produce, 1)
-# CHECK:         %4 = AIE.objectFifo.acquire @OF_5to5(Consume, 1) : !AIE.objectFifoSubview<memref<256xui8>>
-# CHECK:         %5 = AIE.objectFifo.subview.access %4[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
-# CHECK:         %6 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : !AIE.objectFifoSubview<memref<256xui8>>
-# CHECK:         %7 = AIE.objectFifo.subview.access %6[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
-# CHECK:         %8 = AIE.objectFifo.acquire @outOF_L1L2(Produce, 1) : !AIE.objectFifoSubview<memref<256xui8>>
-# CHECK:         %9 = AIE.objectFifo.subview.access %8[0] : !AIE.objectFifoSubview<memref<256xui8>> -> memref<256xui8>
+# CHECK:         %4 = AIE.objectFifo.acquire @OF_5to5(Consume, 1) : memref<1xmemref<256xui8>>
+# CHECK:         %5 = AIE.objectFifo.subview.access %4[0] : memref<1xmemref<256xui8>> -> memref<256xui8>
+# CHECK:         %6 = AIE.objectFifo.acquire @inOF_L2L1(Consume, 1) : memref<1xmemref<256xui8>>
+# CHECK:         %7 = AIE.objectFifo.subview.access %6[0] : memref<1xmemref<256xui8>> -> memref<256xui8>
+# CHECK:         %8 = AIE.objectFifo.acquire @outOF_L1L2(Produce, 1) : memref<1xmemref<256xui8>>
+# CHECK:         %9 = AIE.objectFifo.subview.access %8[0] : memref<1xmemref<256xui8>> -> memref<256xui8>
 # CHECK:         func.call @add_weighted_line(%5, %7, %9, %c256_i32, %c16384_i16, %c16384_i16, %c0_i8) : (memref<256xui8>, memref<256xui8>, memref<256xui8>, i32, i16, i16, i8) -> ()
 # CHECK:         AIE.objectFifo.release @OF_5to5(Consume, 1)
 # CHECK:         AIE.objectFifo.release @inOF_L2L1(Consume, 1)
@@ -583,7 +582,7 @@ def edge_detect():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
+            TypeAttr.get(T.memref(2, T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -603,7 +602,7 @@ def edge_detect():
             M,
             [S],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
+            TypeAttr.get(T.memref(2, T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -612,7 +611,7 @@ def edge_detect():
             T5,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
+            TypeAttr.get(T.memref(2, T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -623,7 +622,7 @@ def edge_detect():
             T2,
             [T3],
             4,
-            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.ui8()))),
+            TypeAttr.get(T.memref(4, T.memref(64, T.ui8()))),
             [],
             [],
         )
@@ -632,7 +631,7 @@ def edge_detect():
             T3,
             [T4],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.ui8()))),
+            TypeAttr.get(T.memref(2, T.memref(64, T.ui8()))),
             [],
             [],
         )
@@ -641,7 +640,7 @@ def edge_detect():
             T4,
             [T5],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.ui8()))),
+            TypeAttr.get(T.memref(2, T.memref(64, T.ui8()))),
             [],
             [],
         )
@@ -650,7 +649,7 @@ def edge_detect():
             T5,
             [T5],
             1,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
+            TypeAttr.get(T.memref(1, T.memref(256, T.ui8()))),
             [],
             [],
         )
@@ -849,11 +848,11 @@ def edge_detect():
 #     %t01 = AIE.tile(0, 1)
 #     %t02 = AIE.tile(0, 2)
 #
-#     AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-#     AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
+#     AIE.objectFifo @objFifo_in0(%t00, {%t01}, 2 : i32) : memref<2xmemref<16xi32>>
+#     AIE.objectFifo @objFifo_in1(%t01, {%t02}, 2 : i32) : memref<2xmemref<8xi32>>
 #     AIE.objectFifo.link [@objFifo_in0] -> [@objFifo_in1] ()
-#     AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : !AIE.objectFifo<memref<16xi32>>
-#     AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : !AIE.objectFifo<memref<8xi32>>
+#     AIE.objectFifo @objFifo_out0(%t01, {%t00}, 2 : i32) : memref<2xmemref<16xi32>>
+#     AIE.objectFifo @objFifo_out1(%t02, {%t01}, 2 : i32) : memref<2xmemref<8xi32>>
 #     AIE.objectFifo.link [@objFifo_out1] -> [@objFifo_out0] ()
 #
 #     AIE.core(%t02) {
@@ -863,10 +862,10 @@ def edge_detect():
 #       %c1_32 = arith.constant 1 : i32
 #
 #       scf.for %steps = %c0 to %c8 step %c1 {
-#         %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : !AIE.objectFifoSubview<memref<8xi32>>
-#         %elem0 = AIE.objectFifo.subview.access %subview0[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
-#         %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : !AIE.objectFifoSubview<memref<8xi32>>
-#         %elem1 = AIE.objectFifo.subview.access %subview1[0] : !AIE.objectFifoSubview<memref<8xi32>> -> memref<8xi32>
+#         %subview0 = AIE.objectFifo.acquire @objFifo_in1(Consume, 1) : memref<1xmemref<8xi32>>
+#         %elem0 = AIE.objectFifo.subview.access %subview0[0] : memref<1xmemref<8xi32>> -> memref<8xi32>
+#         %subview1 = AIE.objectFifo.acquire @objFifo_out1(Produce, 1) : memref<1xmemref<8xi32>>
+#         %elem1 = AIE.objectFifo.subview.access %subview1[0] : memref<1xmemref<8xi32>> -> memref<8xi32>
 #         scf.for %arg3 = %c0 to %c8 step %c1 {
 #             %0 = memref.load %elem0[%arg3] : memref<8xi32>
 #             %1 = arith.addi %0, %c1_32 : i32
@@ -901,7 +900,7 @@ def my_add_one_objFifo():
             shim_tile,
             [mem_tile],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(16, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(16, T.i32()))),
             [],
             [],
         )
@@ -910,7 +909,7 @@ def my_add_one_objFifo():
             mem_tile,
             [compute_tile2],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(8, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(8, T.i32()))),
             [],
             [],
         )
@@ -920,7 +919,7 @@ def my_add_one_objFifo():
             mem_tile,
             [shim_tile],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(8, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(8, T.i32()))),
             [],
             [],
         )
@@ -929,7 +928,7 @@ def my_add_one_objFifo():
             compute_tile2,
             [mem_tile],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(16, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(16, T.i32()))),
             [],
             [],
         )

--- a/test/python/objFifo.py
+++ b/test/python/objFifo.py
@@ -7,6 +7,7 @@ import aie.extras.types as T
 from aie.dialects.aie import (
     AIEDevice,
     ObjectFifoPort,
+    ObjectFifoType,
     acquire,
     objectFifo,
     objectFifo_release,
@@ -25,10 +26,10 @@ from util import construct_and_print_module
 # CHECK:    AIE.device(xcve2302) {
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
 # CHECK:      %core_1_2 = AIE.core(%tile_1_2) {
-# CHECK:        %0 = AIE.objectFifo.acquire @of0(Consume, 1) : memref<256xi32>
-# CHECK:        %1 = AIE.objectFifo.subview.access %0[0] : memref<256xi32> -> memref<256xi32>
+# CHECK:        %0 = AIE.objectFifo.acquire @of0(Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+# CHECK:        %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 # CHECK:        %c10_i32 = arith.constant 10 : i32
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        memref.store %c10_i32, %1[%c0] : memref<256xi32>
@@ -50,7 +51,7 @@ def objFifo_example():
             S,
             [T_],
             2,
-            TypeAttr.get(T.memref(256, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
             [],
             [],
         )

--- a/test/python/objFifo.py
+++ b/test/python/objFifo.py
@@ -7,7 +7,6 @@ import aie.extras.types as T
 from aie.dialects.aie import (
     AIEDevice,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     objectFifo,
     objectFifo_release,
@@ -26,10 +25,10 @@ from util import construct_and_print_module
 # CHECK:    AIE.device(xcve2302) {
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
 # CHECK:      %core_1_2 = AIE.core(%tile_1_2) {
-# CHECK:        %0 = AIE.objectFifo.acquire @of0(Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-# CHECK:        %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+# CHECK:        %0 = AIE.objectFifo.acquire @of0(Consume, 1) : memref<256xi32>
+# CHECK:        %1 = AIE.objectFifo.subview.access %0[0] : memref<256xi32> -> memref<256xi32>
 # CHECK:        %c10_i32 = arith.constant 10 : i32
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        memref.store %c10_i32, %1[%c0] : memref<256xi32>
@@ -51,7 +50,7 @@ def objFifo_example():
             S,
             [T_],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(256, T.i32())),
             [],
             [],
         )

--- a/test/python/objFifo.py
+++ b/test/python/objFifo.py
@@ -7,7 +7,6 @@ import aie.extras.types as T
 from aie.dialects.aie import (
     AIEDevice,
     ObjectFifoPort,
-    ObjectFifoType,
     acquire,
     objectFifo,
     objectFifo_release,
@@ -26,10 +25,10 @@ from util import construct_and_print_module
 # CHECK:    AIE.device(xcve2302) {
 # CHECK:      %tile_0_2 = AIE.tile(0, 2)
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<2xmemref<256xi32>>
 # CHECK:      %core_1_2 = AIE.core(%tile_1_2) {
-# CHECK:        %0 = AIE.objectFifo.acquire @of0(Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-# CHECK:        %1 = AIE.objectFifo.subview.access %0[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+# CHECK:        %0 = AIE.objectFifo.acquire @of0(Consume, 1) : memref<1xmemref<256xi32>>
+# CHECK:        %1 = AIE.objectFifo.subview.access %0[0] : memref<1xmemref<256xi32>> -> memref<256xi32>
 # CHECK:        %c10_i32 = arith.constant 10 : i32
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        memref.store %c10_i32, %1[%c0] : memref<256xi32>
@@ -51,7 +50,7 @@ def objFifo_example():
             S,
             [T_],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(256, T.i32()))),
             [],
             [],
         )

--- a/test/python/objFifo_link.py
+++ b/test/python/objFifo_link.py
@@ -6,7 +6,6 @@
 import aie.extras.types as T
 from aie.dialects.aie import (
     AIEDevice,
-    ObjectFifoType,
     objectFifo,
     objectFifo_link,
     tile,
@@ -23,8 +22,8 @@ from util import construct_and_print_module
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_2_2 = AIE.tile(2, 2)
 # CHECK:      %tile_2_3 = AIE.tile(2, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_2_2, %tile_2_3}, 2 : i32) : !AIE.objectFifo<memref<64xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<2xmemref<256xi32>>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_2_2, %tile_2_3}, 2 : i32) : memref<2xmemref<64xi32>>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
 # CHECK:      AIE.objectFifo @of2(%tile_1_2 toStream [<1, 2>], {%tile_2_2 fromStream [<1, 2>], %tile_2_3 fromStream [<1, 2>]}, [2 : i32, 2 : i32, 7 : i32]) : !AIE.objectFifo<memref<256xui8>>
 # CHECK:    }
@@ -44,7 +43,7 @@ def link_example():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(256, T.i32()))),
             [],
             [],
         )
@@ -53,7 +52,7 @@ def link_example():
             M,
             [T0, T1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.i32()))),
+            TypeAttr.get(T.memref(2, T.memref(64, T.i32()))),
             [],
             [],
         )

--- a/test/python/objFifo_link.py
+++ b/test/python/objFifo_link.py
@@ -6,7 +6,6 @@
 import aie.extras.types as T
 from aie.dialects.aie import (
     AIEDevice,
-    ObjectFifoType,
     objectFifo,
     objectFifo_link,
     tile,
@@ -23,10 +22,10 @@ from util import construct_and_print_module
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_2_2 = AIE.tile(2, 2)
 # CHECK:      %tile_2_3 = AIE.tile(2, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_2_2, %tile_2_3}, 2 : i32) : !AIE.objectFifo<memref<64xi32>>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_2_2, %tile_2_3}, 2 : i32) : memref<64xi32>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
-# CHECK:      AIE.objectFifo @of2(%tile_1_2 toStream [<1, 2>], {%tile_2_2 fromStream [<1, 2>], %tile_2_3 fromStream [<1, 2>]}, [2 : i32, 2 : i32, 7 : i32]) : !AIE.objectFifo<memref<256xui8>>
+# CHECK:      AIE.objectFifo @of2(%tile_1_2 toStream [<1, 2>], {%tile_2_2 fromStream [<1, 2>], %tile_2_3 fromStream [<1, 2>]}, [2 : i32, 2 : i32, 7 : i32]) : memref<256xui8>
 # CHECK:    }
 # CHECK:  }
 @construct_and_print_module
@@ -44,7 +43,7 @@ def link_example():
             S,
             [M],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
+            TypeAttr.get(T.memref(256, T.i32())),
             [],
             [],
         )
@@ -53,7 +52,7 @@ def link_example():
             M,
             [T0, T1],
             2,
-            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.i32()))),
+            TypeAttr.get(T.memref(64, T.i32())),
             [],
             [],
         )
@@ -64,7 +63,7 @@ def link_example():
             M,
             [T0, T1],
             [2, 2, 7],
-            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
+            TypeAttr.get(T.memref(256, T.ui8())),
             [(1, 2)],
             [[(1, 2)], [(1, 2)]],
         )

--- a/test/python/objFifo_link.py
+++ b/test/python/objFifo_link.py
@@ -6,6 +6,7 @@
 import aie.extras.types as T
 from aie.dialects.aie import (
     AIEDevice,
+    ObjectFifoType,
     objectFifo,
     objectFifo_link,
     tile,
@@ -22,10 +23,10 @@ from util import construct_and_print_module
 # CHECK:      %tile_1_2 = AIE.tile(1, 2)
 # CHECK:      %tile_2_2 = AIE.tile(2, 2)
 # CHECK:      %tile_2_3 = AIE.tile(2, 3)
-# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : memref<256xi32>
-# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_2_2, %tile_2_3}, 2 : i32) : memref<64xi32>
+# CHECK:      AIE.objectFifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !AIE.objectFifo<memref<256xi32>>
+# CHECK:      AIE.objectFifo @of1(%tile_1_2, {%tile_2_2, %tile_2_3}, 2 : i32) : !AIE.objectFifo<memref<64xi32>>
 # CHECK:      AIE.objectFifo.link [@of0] -> [@of1]()
-# CHECK:      AIE.objectFifo @of2(%tile_1_2 toStream [<1, 2>], {%tile_2_2 fromStream [<1, 2>], %tile_2_3 fromStream [<1, 2>]}, [2 : i32, 2 : i32, 7 : i32]) : memref<256xui8>
+# CHECK:      AIE.objectFifo @of2(%tile_1_2 toStream [<1, 2>], {%tile_2_2 fromStream [<1, 2>], %tile_2_3 fromStream [<1, 2>]}, [2 : i32, 2 : i32, 7 : i32]) : !AIE.objectFifo<memref<256xui8>>
 # CHECK:    }
 # CHECK:  }
 @construct_and_print_module
@@ -43,7 +44,7 @@ def link_example():
             S,
             [M],
             2,
-            TypeAttr.get(T.memref(256, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.i32()))),
             [],
             [],
         )
@@ -52,7 +53,7 @@ def link_example():
             M,
             [T0, T1],
             2,
-            TypeAttr.get(T.memref(64, T.i32())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(64, T.i32()))),
             [],
             [],
         )
@@ -63,7 +64,7 @@ def link_example():
             M,
             [T0, T1],
             [2, 2, 7],
-            TypeAttr.get(T.memref(256, T.ui8())),
+            TypeAttr.get(ObjectFifoType.get(T.memref(256, T.ui8()))),
             [(1, 2)],
             [[(1, 2)], [(1, 2)]],
         )

--- a/test/unit_tests/aie/24_host_loop/aie.mlir
+++ b/test/unit_tests/aie/24_host_loop/aie.mlir
@@ -28,8 +28,8 @@ AIE.device(xcvc1902) {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32>
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<256xi32>
 
-    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
-    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : memref<1xmemref<256xi32>>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : memref<1xmemref<256xi32>>
 
     AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
     AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<256xi32>)
@@ -47,11 +47,11 @@ AIE.device(xcvc1902) {
             ^bb0(%arg2: i32):
             %next = func.call @payload(%arg2) : (i32) -> i32
 
-            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<1xmemref<256xi32>>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : memref<1xmemref<256xi32>>
 
-            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
-            %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : memref<1xmemref<256xi32>> -> memref<256xi32>
+            %output = AIE.objectFifo.subview.access %outputSubview[0] : memref<1xmemref<256xi32>> -> memref<256xi32>
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
                 %d1 = memref.load %input[%indexInHeight] : memref<256xi32>

--- a/test/unit_tests/aie/24_host_loop/aie.mlir
+++ b/test/unit_tests/aie/24_host_loop/aie.mlir
@@ -28,8 +28,8 @@ AIE.device(xcvc1902) {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32>
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<256xi32>
 
-    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : memref<256xi32>
-    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : memref<256xi32>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
 
     AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
     AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<256xi32>)
@@ -47,11 +47,11 @@ AIE.device(xcvc1902) {
             ^bb0(%arg2: i32):
             %next = func.call @payload(%arg2) : (i32) -> i32
 
-            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<256xi32>
-            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : memref<256xi32>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
 
-            %input = AIE.objectFifo.subview.access %inputSubview[0] : memref<256xi32> -> memref<256xi32>
-            %output = AIE.objectFifo.subview.access %outputSubview[0] : memref<256xi32> -> memref<256xi32>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+            %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
                 %d1 = memref.load %input[%indexInHeight] : memref<256xi32>

--- a/test/unit_tests/aie/24_host_loop/aie.mlir
+++ b/test/unit_tests/aie/24_host_loop/aie.mlir
@@ -28,8 +28,8 @@ AIE.device(xcvc1902) {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32>
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<256xi32>
 
-    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
-    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<256xi32>>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : memref<256xi32>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : memref<256xi32>
 
     AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
     AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<256xi32>)
@@ -47,11 +47,11 @@ AIE.device(xcvc1902) {
             ^bb0(%arg2: i32):
             %next = func.call @payload(%arg2) : (i32) -> i32
 
-            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<256xi32>>
-            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<256xi32>>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<256xi32>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : memref<256xi32>
 
-            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
-            %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<256xi32>> -> memref<256xi32>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : memref<256xi32> -> memref<256xi32>
+            %output = AIE.objectFifo.subview.access %outputSubview[0] : memref<256xi32> -> memref<256xi32>
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
                 %d1 = memref.load %input[%indexInHeight] : memref<256xi32>

--- a/test/unit_tests/aie/25_host_multirate/aie.mlir
+++ b/test/unit_tests/aie/25_host_multirate/aie.mlir
@@ -30,8 +30,8 @@ AIE.device(xcvc1902) {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32>
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<64xi32>
 
-    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : memref<64xi32>
-    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : memref<64xi32>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<64xi32>>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<64xi32>>
 
     AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
     AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<64xi32>)
@@ -51,11 +51,11 @@ AIE.device(xcvc1902) {
 
             AIE.useLock(%hostLock, Acquire, 1)
 
-            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<64xi32>
-            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : memref<64xi32>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<64xi32>>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<64xi32>>
 
-            %input = AIE.objectFifo.subview.access %inputSubview[0] : memref<64xi32> -> memref<64xi32>
-            %output = AIE.objectFifo.subview.access %outputSubview[0] : memref<64xi32> -> memref<64xi32>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
+            %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
                 %d1 = memref.load %input[%indexInHeight] : memref<64xi32>

--- a/test/unit_tests/aie/25_host_multirate/aie.mlir
+++ b/test/unit_tests/aie/25_host_multirate/aie.mlir
@@ -30,8 +30,8 @@ AIE.device(xcvc1902) {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32>
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<64xi32>
 
-    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<64xi32>>
-    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<64xi32>>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : memref<64xi32>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : memref<64xi32>
 
     AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
     AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<64xi32>)
@@ -51,11 +51,11 @@ AIE.device(xcvc1902) {
 
             AIE.useLock(%hostLock, Acquire, 1)
 
-            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<64xi32>>
-            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<64xi32>>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<64xi32>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : memref<64xi32>
 
-            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
-            %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : memref<64xi32> -> memref<64xi32>
+            %output = AIE.objectFifo.subview.access %outputSubview[0] : memref<64xi32> -> memref<64xi32>
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
                 %d1 = memref.load %input[%indexInHeight] : memref<64xi32>

--- a/test/unit_tests/aie/25_host_multirate/aie.mlir
+++ b/test/unit_tests/aie/25_host_multirate/aie.mlir
@@ -30,8 +30,8 @@ AIE.device(xcvc1902) {
     %ext_buf70_in  = AIE.external_buffer {sym_name = "ddr_test_buffer_in"}: memref<256xi32>
     %ext_buf70_out = AIE.external_buffer {sym_name = "ddr_test_buffer_out"}: memref<64xi32>
 
-    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : !AIE.objectFifo<memref<64xi32>>
-    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : !AIE.objectFifo<memref<64xi32>>
+    AIE.objectFifo @of_in (%tile70, {%tile34}, 1 : i32) : memref<1xmemref<64xi32>>
+    AIE.objectFifo @of_out (%tile34, {%tile70}, 1 : i32) : memref<1xmemref<64xi32>>
 
     AIE.objectFifo.registerExternalBuffers @of_in (%tile70, {%ext_buf70_in}) : (memref<256xi32>)
     AIE.objectFifo.registerExternalBuffers @of_out (%tile70, {%ext_buf70_out}) : (memref<64xi32>)
@@ -51,11 +51,11 @@ AIE.device(xcvc1902) {
 
             AIE.useLock(%hostLock, Acquire, 1)
 
-            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<64xi32>>
-            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : !AIE.objectFifoSubview<memref<64xi32>>
+            %inputSubview = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<1xmemref<64xi32>>
+            %outputSubview = AIE.objectFifo.acquire @of_out (Produce, 1) : memref<1xmemref<64xi32>>
 
-            %input = AIE.objectFifo.subview.access %inputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
-            %output = AIE.objectFifo.subview.access %outputSubview[0] : !AIE.objectFifoSubview<memref<64xi32>> -> memref<64xi32>
+            %input = AIE.objectFifo.subview.access %inputSubview[0] : memref<1xmemref<64xi32>> -> memref<64xi32>
+            %output = AIE.objectFifo.subview.access %outputSubview[0] : memref<1xmemref<64xi32>> -> memref<64xi32>
 
             scf.for %indexInHeight = %c0 to %height step %c1 {
                 %d1 = memref.load %input[%indexInHeight] : memref<64xi32>

--- a/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
@@ -22,8 +22,8 @@ module @multi_depth {
         %lock_out = AIE.lock(%tile25, 1) {sym_name = "lock_out"}
         %buff_out = AIE.buffer(%tile25) {sym_name = "buff_out"} : memref<4x32xi32>
 
-        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, [2, 2, 3]) : !AIE.objectFifo<memref<32xi32>>
-        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, [2, 2, 3]) : memref<32xi32>
+        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : memref<32xi32>
 
         %ext_buffer_in_0  = AIE.external_buffer {sym_name = "ext_buffer_in_0"} : memref<32xi32>
         %ext_buffer_in_1  = AIE.external_buffer {sym_name = "ext_buffer_in_1"} : memref<32xi32>
@@ -63,11 +63,11 @@ module @multi_depth {
             %iter_max = arith.constant 4 : index
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
+                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : memref<32xi32> -> memref<32xi32>
 
-                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : memref<32xi32>
+                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : memref<32xi32> -> memref<32xi32>
 
                 func.call @add_one(%elemIn, %elemOut) : (memref<32xi32>, memref<32xi32>) -> ()
 
@@ -89,11 +89,11 @@ module @multi_depth {
             AIE.useLock(%lock_out, Acquire, 0)
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
+                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : memref<32xi32> -> memref<32xi32>
 
-                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : memref<32xi32>
+                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : memref<32xi32> -> memref<32xi32>
 
                 func.call @add_store(%elemIn_21, %elemIn_22, %buff_out, %iter) : (memref<32xi32>, memref<32xi32>, memref<4x32xi32>, index) -> ()
 

--- a/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
@@ -22,8 +22,8 @@ module @multi_depth {
         %lock_out = AIE.lock(%tile25, 1) {sym_name = "lock_out"}
         %buff_out = AIE.buffer(%tile25) {sym_name = "buff_out"} : memref<4x32xi32>
 
-        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, [2, 2, 3]) : memref<32xi32>
-        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : memref<32xi32>
+        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, [2, 2, 3]) : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
 
         %ext_buffer_in_0  = AIE.external_buffer {sym_name = "ext_buffer_in_0"} : memref<32xi32>
         %ext_buffer_in_1  = AIE.external_buffer {sym_name = "ext_buffer_in_1"} : memref<32xi32>
@@ -63,11 +63,11 @@ module @multi_depth {
             %iter_max = arith.constant 4 : index
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
-                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : memref<32xi32> -> memref<32xi32>
+                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
-                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : memref<32xi32>
-                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : memref<32xi32> -> memref<32xi32>
+                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
                 func.call @add_one(%elemIn, %elemOut) : (memref<32xi32>, memref<32xi32>) -> ()
 
@@ -89,11 +89,11 @@ module @multi_depth {
             AIE.useLock(%lock_out, Acquire, 0)
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
-                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : memref<32xi32> -> memref<32xi32>
+                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
-                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : memref<32xi32>
-                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : memref<32xi32> -> memref<32xi32>
+                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
                 func.call @add_store(%elemIn_21, %elemIn_22, %buff_out, %iter) : (memref<32xi32>, memref<32xi32>, memref<4x32xi32>, index) -> ()
 

--- a/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
@@ -23,7 +23,7 @@ module @multi_depth {
         %buff_out = AIE.buffer(%tile25) {sym_name = "buff_out"} : memref<4x32xi32>
 
         AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, [2, 2, 3]) : !AIE.objectFifo<memref<32xi32>>
-        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : memref<2xmemref<32xi32>>
 
         %ext_buffer_in_0  = AIE.external_buffer {sym_name = "ext_buffer_in_0"} : memref<32xi32>
         %ext_buffer_in_1  = AIE.external_buffer {sym_name = "ext_buffer_in_1"} : memref<32xi32>
@@ -63,11 +63,11 @@ module @multi_depth {
             %iter_max = arith.constant 4 : index
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<1xmemref<32xi32>>
+                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
-                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : memref<1xmemref<32xi32>>
+                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
                 func.call @add_one(%elemIn, %elemOut) : (memref<32xi32>, memref<32xi32>) -> ()
 
@@ -89,11 +89,11 @@ module @multi_depth {
             AIE.useLock(%lock_out, Acquire, 0)
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<1xmemref<32xi32>>
+                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
-                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : memref<1xmemref<32xi32>>
+                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
                 func.call @add_store(%elemIn_21, %elemIn_22, %buff_out, %iter) : (memref<32xi32>, memref<32xi32>, memref<4x32xi32>, index) -> ()
 

--- a/test/unit_tests/aie/28_multidepth_objectFifos/single_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/single_depth/aie.mlir
@@ -23,8 +23,8 @@ module @single_depth {
         %buff_out = AIE.buffer(%tile25) {sym_name = "buff_out"} : memref<4x32xi32>
 
 
-        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, 2 : i32) : memref<32xi32>
-        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : memref<32xi32>
+        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
 
         %ext_buffer_in_0  = AIE.external_buffer {sym_name = "ext_buffer_in_0"} : memref<32xi32>
         %ext_buffer_in_1  = AIE.external_buffer {sym_name = "ext_buffer_in_1"} : memref<32xi32>
@@ -64,11 +64,11 @@ module @single_depth {
             %iter_max = arith.constant 4 : index
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
-                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : memref<32xi32> -> memref<32xi32>
+                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
-                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : memref<32xi32>
-                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : memref<32xi32> -> memref<32xi32>
+                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
                 func.call @add_one(%elemIn, %elemOut) : (memref<32xi32>, memref<32xi32>) -> ()
 
@@ -90,11 +90,11 @@ module @single_depth {
             AIE.useLock(%lock_out, Acquire, 0)
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
-                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : memref<32xi32> -> memref<32xi32>
+                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
-                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : memref<32xi32>
-                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : memref<32xi32> -> memref<32xi32>
+                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
+                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
 
                 func.call @add_store(%elemIn_21, %elemIn_22, %buff_out, %iter) : (memref<32xi32>, memref<32xi32>, memref<4x32xi32>, index) -> ()
 

--- a/test/unit_tests/aie/28_multidepth_objectFifos/single_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/single_depth/aie.mlir
@@ -23,8 +23,8 @@ module @single_depth {
         %buff_out = AIE.buffer(%tile25) {sym_name = "buff_out"} : memref<4x32xi32>
 
 
-        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
-        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, 2 : i32) : memref<32xi32>
+        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : memref<32xi32>
 
         %ext_buffer_in_0  = AIE.external_buffer {sym_name = "ext_buffer_in_0"} : memref<32xi32>
         %ext_buffer_in_1  = AIE.external_buffer {sym_name = "ext_buffer_in_1"} : memref<32xi32>
@@ -64,11 +64,11 @@ module @single_depth {
             %iter_max = arith.constant 4 : index
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
+                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : memref<32xi32> -> memref<32xi32>
 
-                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : memref<32xi32>
+                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : memref<32xi32> -> memref<32xi32>
 
                 func.call @add_one(%elemIn, %elemOut) : (memref<32xi32>, memref<32xi32>) -> ()
 
@@ -90,11 +90,11 @@ module @single_depth {
             AIE.useLock(%lock_out, Acquire, 0)
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<32xi32>
+                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : memref<32xi32> -> memref<32xi32>
 
-                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : memref<32xi32>
+                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : memref<32xi32> -> memref<32xi32>
 
                 func.call @add_store(%elemIn_21, %elemIn_22, %buff_out, %iter) : (memref<32xi32>, memref<32xi32>, memref<4x32xi32>, index) -> ()
 

--- a/test/unit_tests/aie/28_multidepth_objectFifos/single_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/single_depth/aie.mlir
@@ -23,8 +23,8 @@ module @single_depth {
         %buff_out = AIE.buffer(%tile25) {sym_name = "buff_out"} : memref<4x32xi32>
 
 
-        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
-        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : !AIE.objectFifo<memref<32xi32>>
+        AIE.objectFifo @of_in (%tile20, {%tile23, %tile25}, 2 : i32) : memref<2xmemref<32xi32>>
+        AIE.objectFifo @of_inter (%tile23, {%tile25}, 2 : i32) : memref<2xmemref<32xi32>>
 
         %ext_buffer_in_0  = AIE.external_buffer {sym_name = "ext_buffer_in_0"} : memref<32xi32>
         %ext_buffer_in_1  = AIE.external_buffer {sym_name = "ext_buffer_in_1"} : memref<32xi32>
@@ -64,11 +64,11 @@ module @single_depth {
             %iter_max = arith.constant 4 : index
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<1xmemref<32xi32>>
+                %elemIn = AIE.objectFifo.subview.access %subviewIn[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
-                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewOut = AIE.objectFifo.acquire @of_inter (Produce, 1) : memref<1xmemref<32xi32>>
+                %elemOut = AIE.objectFifo.subview.access %subviewOut[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
                 func.call @add_one(%elemIn, %elemOut) : (memref<32xi32>, memref<32xi32>) -> ()
 
@@ -90,11 +90,11 @@ module @single_depth {
             AIE.useLock(%lock_out, Acquire, 0)
 
             scf.for %iter = %c0 to %iter_max step %c1 {
-                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_21 = AIE.objectFifo.acquire @of_in (Consume, 1) : memref<1xmemref<32xi32>>
+                %elemIn_21 = AIE.objectFifo.subview.access %subviewIn_21[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
-                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : !AIE.objectFifoSubview<memref<32xi32>>
-                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : !AIE.objectFifoSubview<memref<32xi32>> -> memref<32xi32>
+                %subviewIn_22 = AIE.objectFifo.acquire @of_inter (Consume, 1) : memref<1xmemref<32xi32>>
+                %elemIn_22 = AIE.objectFifo.subview.access %subviewIn_22[0] : memref<1xmemref<32xi32>> -> memref<32xi32>
 
                 func.call @add_store(%elemIn_21, %elemIn_22, %buff_out, %iter) : (memref<32xi32>, memref<32xi32>, memref<4x32xi32>, index) -> ()
 


### PR DESCRIPTION
This PR removes the `AIEObjectFifoType` and `AIEObjectFifoSubviewType` types. They're thin wrappers around memrefs and everywhere used like this:

```
    auto fifoType = fifoOut.getElemType().cast<AIEObjectFifoType>();
    auto elemType = fifoType.getElementType().cast<MemRefType>();
```

This simplifies code and IR.