### PR TITLE
new API for instruction buffer creation

### DIFF
--- a/lib/Targets/AIETargets.h
+++ b/lib/Targets/AIETargets.h
@@ -27,7 +27,9 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
                                          llvm::raw_ostream &);
 mlir::LogicalResult AIETranslateToCDO(mlir::ModuleOp module,
                                       llvm::raw_ostream &output);
+
 mlir::LogicalResult AIETranslateToIPU(mlir::ModuleOp module,
                                       llvm::raw_ostream &output);
+std::vector<uint32_t> AIETranslateToIPU(mlir::ModuleOp);
 } // namespace AIE
 } // namespace xilinx

--- a/test/Targets/IPU/ipu_instgen.mlir
+++ b/test/Targets/IPU/ipu_instgen.mlir
@@ -12,6 +12,26 @@
 module {
   AIE.device(ipu) {
     func.func @test0(%arg0: memref<16xf32>, %arg1: memref<16xf32>) {
+
+      // look for the prolog.
+      // CHECK:      00000011
+      // CHECK-NEXT: 01000405
+      // CHECK-NEXT: 01000100
+      // CHECK-NEXT: 0B590100
+      // CHECK-NEXT: 000055FF
+      // CHECK-NEXT: 00000001
+      // CHECK-NEXT: 00000010
+      // CHECK-NEXT: 314E5A5F
+      // CHECK-NEXT: 635F5F31
+      // CHECK-NEXT: 676E696C
+      // CHECK-NEXT: 39354E5F
+      // CHECK-NEXT: 6E693131
+      // CHECK-NEXT: 5F727473
+      // CHECK-NEXT: 64726F77
+      // CHECK-NEXT: 00004573
+      // CHECK-NEXT: 07BD9630
+      // CHECK-NEXT: 000055FF
+
       %c16_i64 = arith.constant 16 : i64
       %c1_i64 = arith.constant 1 : i64
       %c0_i64 = arith.constant 0 : i64
@@ -65,4 +85,3 @@ module {
     }
   }
 }
-


### PR DESCRIPTION
A vector based API:

```
std::vector<uint32_t> AIETranslateToIPU(mlir::ModuleOp);
```

is introduced. This is more useful to IREE than the existing API

```
mlir::LogicalResult AIETranslateToIPU(mlir::ModuleOp module, llvm::raw_ostream &output);
```

because the flatbuffer (flatbuffer = the file type which IREE will store the instructions in) can be generated directly from a container of uint32_t's. 

Actually this API isn't specific to IREE, it seems like a layer of copying could be removed from the AIR example with this API: https://github.com/Xilinx/mlir-air/blob/main/examples/air_to_ipu/test.cpp#L52-L65

Final API open to suggestions. 


