### PR TITLE
disable glibcxx_assertions in mlir build

### DIFF
--- a/utils/mlir_wheels/patches/glibcxx_assertions.patch
+++ b/utils/mlir_wheels/patches/glibcxx_assertions.patch
@@ -1,0 +1,13 @@
+diff --git a/llvm/cmake/modules/HandleLLVMOptions.cmake b/llvm/cmake/modules/HandleLLVMOptions.cmake
+index 0699a8586fcc..ea8ac624d5f4 100644
+--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
++++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
+@@ -110,7 +110,7 @@ if( LLVM_ENABLE_ASSERTIONS )
+     endif()
+   endif()
+   # Enable assertions in libstdc++.
+-  add_compile_definitions(_GLIBCXX_ASSERTIONS)
++#  add_compile_definitions(_GLIBCXX_ASSERTIONS)
+   # Cautiously enable the extensive hardening mode in libc++.
+   if((DEFINED LIBCXX_HARDENING_MODE) AND
+      (NOT LIBCXX_HARDENING_MODE STREQUAL "extensive"))

--- a/utils/mlir_wheels/scripts/apply_patches.sh
+++ b/utils/mlir_wheels/scripts/apply_patches.sh
@@ -3,6 +3,7 @@ set -uxo pipefail
 
 # note that space before slash is important
 PATCHES="\
+glibcxx_assertions \
 mscv \
 register_test_pass \
 "


### PR DESCRIPTION
This patch https://reviews.llvm.org/D142279 enabled assertions in libstdc++ (by doing `add_compile_definitions(_GLIBCXX_ASSERTIONS)`). This ?somehow? necessarily entails a dep on libstdc++ and thus to a particular version. The wheels are built against *some* version of libstdc++ that roughly is compatible with gcc >= 11.4 (and some version of clang...) but no matter, just disable.