### PR TITLE
Remove dmabuffer entirely

### DIFF
--- a/docs/AIEDesignPatterns.md
+++ b/docs/AIEDesignPatterns.md
@@ -62,7 +62,7 @@ Start the Memory Map to Stream DMA from the source:
 	%dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
 	^bd0:
 		AIE.use_lock(%lock71, "Acquire", 0) // Acquire in State 0
-		AIE.dma_bd(<%buf71 : memref<512xi32>, 0, 512>, 0)
+		AIE.dma_bd(%buf71 : memref<512xi32>, 0, 512)
 		AIE.use_lock(%lock71, "Release", 1) // Release in State 1
 		br ^end 
 	^end:
@@ -76,7 +76,7 @@ Start the Stream to Memory Map DMA from the destination:
 	%dma0 = AIE.dma_start("S2MM", 0, ^bd0, ^end)
 	^bd0:
 		AIE.use_lock(%lock72, "Acquire", 0)
-		AIE.dma_bd(<%buf72 : memref<512xi32>, 0, 512>, 0)
+		AIE.dma_bd(%buf72 : memref<512xi32>, 0, 512)
 		AIE.use_lock(%lock72, "Release", 1)
 		br ^end 
 	^end:
@@ -118,12 +118,12 @@ Then we can write the Stream to Memory Map DMA transfer with 2 buffer descriptor
 	%dma0 = AIE.dma_start("S2MM", 0, ^bd0, ^end)
 	^bd0:
 		AIE.use_lock(%lock72_0, "Acquire", 0)
-		AIE.dma_bd(<%buf72_0: memref<256xi32>, 0, 256>, 0)
+		AIE.dma_bd(%buf72_0: memref<256xi32>, 0, 256)
 		AIE.use_lock(%lock72_0, "Release", 1)
 		br ^bd1 // point to the next BD, or termination
 	^bd1:
 		AIE.use_lock(%lock72_1, "Acquire", 0)
-		AIE.dma_bd(<%buf72_1: memref<256xi32>, 0, 256>, 0)
+		AIE.dma_bd(%buf72_1: memref<256xi32>, 0, 256)
 		AIE.use_lock(%lock72_1, "Release", 1)
 		br ^bd0 // point to the next BD, or termination
 	^end:
@@ -175,7 +175,7 @@ Start the Memory Map to Stream DMA from the source:
 	%dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
 	^bd0:
 		AIE.use_lock(%lock71, "Acquire", 1) // Acquire in State 0
-		AIE.dma_bd(<%buf71 : memref<512xi32>, 0, 512>, 0)
+		AIE.dma_bd(%buf71 : memref<512xi32>, 0, 512)
 		AIE.use_lock(%lock71, "Release", 1) // Release in State 1
 		br ^end 
 	^end:
@@ -189,7 +189,7 @@ Start the Stream to Memory Map DMA from the destination:
 	%dma0 = AIE.dma_start("S2MM", 0, ^bd0, ^end)
 	^bd0:
 		AIE.use_lock(%lock72, "Acquire", 0)
-		AIE.dma_bd(<%buf72 : memref<512xi32>, 0, 512>, 0)
+		AIE.dma_bd(%buf72 : memref<512xi32>, 0, 512)
 		AIE.use_lock(%lock72, "Release", 1)
 		br ^end 
 	^end:
@@ -232,7 +232,7 @@ We can then use the shim_dma to read/write from that location:
 	%dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end) \\Read
 	^bd0:
 		AIE.use_lock(%lock70 , "Acquire", 0)
-		AIE.dma_bd(<%ext_buffer : memref<512xi32>, 0, 512>, 0)
+		AIE.dma_bd(%ext_buffer : memref<512xi32>, 0, 512)
 		AIE.use_lock(%lolock70 k72, "Release", 1)
 		br ^end 
 	^end:
@@ -278,12 +278,12 @@ module {
 	%srcDma = AIE.dma_start("MM2S", 0, ^bd0, ^end)
 	^bd0:
 		AIE.use_lock(%l72_0, "Acquire", 1)
-		AIE.dma_bd(<%buf72_0 : memref<256xi32>, 0, 256>, 0)
+		AIE.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
 		AIE.use_lock(%l72_0, "Release", 0)
 	br ^bd1
 	^bd1:
 		AIE.use_lock(%l72_1, "Acquire", 1)
-		AIE.dma_bd(<%buf72_1 : memref<256xi32>, 0, 256>, 0)
+		AIE.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
 		AIE.use_lock(%l72_1, "Release", 0)
 	br ^bd0
 	^end:

--- a/include/aie/Dialect/AIE/IR/AIEAttrs.td
+++ b/include/aie/Dialect/AIE/IR/AIEAttrs.td
@@ -115,15 +115,6 @@ def DMAChannelDir: I32EnumAttr<"DMAChannelDir",
   let cppNamespace = "xilinx::AIE";
 }
 
-def DMABDBuffer: I32EnumAttr<"DMABDBuffer",
-  "DMA Block descriptor buffer type.",
-  [
-    I32EnumAttrCase<"A", 0>,
-    I32EnumAttrCase<"B", 1>
-  ]> {
-  let cppNamespace = "xilinx::AIE";
-}
-
 def BDDimLayoutAttr : AttrDef<AIE_Dialect, "BDDimLayout", []> {
   let mnemonic = "bd_dim_layout";
   let summary = [{

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -808,31 +808,27 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
     ins AnyMemRef:$buffer,
         AIEI32Attr:$offset,
         AIEI32Attr:$len,
-        DefaultValuedAttr<DMABDBuffer, "xilinx::AIE::DMABDBuffer::A">:$AB,
         OptionalAttr<BDDimLayoutArrayAttr>:$dimensions
   );
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `(` `<` $buffer  `:` type($buffer) `,` $offset `,` $len `>` `,` $AB (`,` $dimensions^ )? `)` attr-dict
+    `(` $buffer `:` type($buffer) `,` $offset `,` $len (`,` $dimensions^ )? `)` attr-dict
   }];
 
   let extraClassDeclaration = [{
     BufferOp getBufferOp();
     int getOffsetValue() { return getOffset(); }
     int getLenValue() { return getLen(); }
-    bool isA() { return (getAB() == DMABDBuffer::A); }
-    bool isB() { return (getAB() == DMABDBuffer::B); }
   }];
 
   let hasVerifier = 1;
   let builders = [
-    OpBuilder<(ins "mlir::Value":$buffer, "int":$offset, "int":$len, "DMABDBuffer":$AB), [{
+    OpBuilder<(ins "mlir::Value":$buffer, "int":$offset, "int":$len), [{
       odsState.addOperands(buffer);
       odsState.addAttribute(getOffsetAttrName(odsState.name), $_builder.getI32IntegerAttr(offset));
       odsState.addAttribute(getLenAttrName(odsState.name), $_builder.getI32IntegerAttr(len));
-      odsState.addAttribute(getABAttrName(odsState.name), DMABDBufferAttr::get($_builder.getContext(), AB));
     }]>
   ];
 }

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -800,7 +800,7 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
     elements:
 
     ```
-    AIE.dma_bd(<%buf : memref<128xi32>, 0, 128>, 0, [<8, 16>, <2, 1>, <8, 2>])
+    AIE.dma_bd(%buf : memref<128xi32>, 0, 128, [<8, 16>, <2, 1>, <8, 2>])
     ```
   }];
 
@@ -851,7 +851,7 @@ def AIE_DMAStartOp: AIE_Op<"dma_start", [
         AIE.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         AIE.use_lock(%lock0, "Acquire", 0)
-        AIE.dma_bd(<%buffer : memref<16 x f32>, 0, 16>, 0)
+        AIE.dma_bd(%buffer : memref<16 x f32>, 0, 16)
         AIE.use_lock(%lock0, "Release", 1)
         br ^bd0
       ^end:
@@ -897,7 +897,7 @@ def AIE_MemOp: AIE_Op<"mem", [
           %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
         ^bd0:
           AIE.use_lock(%lock, "Acquire", 0)
-          AIE.dma_bd(<%buf : memref<64xi16>, 0, 64>, 0)
+          AIE.dma_bd(%buf : memref<64xi16>, 0, 64)
           AIE.use_lock(%lock, "Release", 1)
           AIE.next_bd ^bd0
         ^end:
@@ -948,7 +948,7 @@ def AIE_MemTileDMAOp: AIE_Op<"memtile_dma", [
           %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
         ^bd0:
           AIE.use_lock(%lock, "Acquire", 0)
-          AIE.dma_bd(<%buf : memref<64xi16>, 0, 64>, 0)
+          AIE.dma_bd(%buf : memref<64xi16>, 0, 64>, 0)
           AIE.use_lock(%lock, "Release", 1)
           AIE.next_bd ^bd0
         ^end:
@@ -991,7 +991,7 @@ def AIE_NextBDOp: AIE_Op<"next_bd", [
           %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
         ^bd0:
           AIE.use_lock(%lock, "Acquire", 0)
-          AIE.dma_bd(<%buf : memref<64xi16>, 0, 64>, 0)
+          AIE.dma_bd(%buf : memref<64xi16>, 0, 64)
           AIE.use_lock(%lock, "Release", 1)
           AIE.next_bd ^bd0
         ^end:

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -422,11 +422,9 @@ struct AIEObjectFifoStatefulTransformPass
     builder.create<UseLockOp>(builder.getUnknownLoc(), acqLock, acqMode,
                               acqLockAction);
     if (!dims.getValue().empty())
-      builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len,
-                              DMABDBuffer::A, dims);
+      builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len, dims);
     else
-      builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len,
-                              DMABDBuffer::A);
+      builder.create<DMABDOp>(builder.getUnknownLoc(), buff, offset, len);
 
     builder.create<UseLockOp>(builder.getUnknownLoc(), relLock, relMode,
                               LockAction::Release);

--- a/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
@@ -62,8 +62,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     rewriter.setInsertionPointToStart(bdBlock);
     rewriter.create<UseTokenOp>(rewriter.getUnknownLoc(), tokenName,
                                 acquireTknVal, LockAction::Acquire);
-    rewriter.create<DMABDOp>(rewriter.getUnknownLoc(), buf, offset, len,
-                             DMABDBuffer::A); // A type for now
+    rewriter.create<DMABDOp>(rewriter.getUnknownLoc(), buf, offset, len);
     rewriter.create<UseTokenOp>(rewriter.getUnknownLoc(), tokenName,
                                 releaseTknVal, LockAction::Release);
     rewriter.create<NextBDOp>(rewriter.getUnknownLoc(), &endBlock);

--- a/lib/Targets/AIETargetCDO.cpp
+++ b/lib/Targets/AIETargetCDO.cpp
@@ -330,7 +330,6 @@ mlir::LogicalResult AIETranslateToCDO(ModuleOp m, raw_ostream &output) {
       bool hasA = false;
       bool hasB = false;
       StringRef bufA = "0";
-      StringRef bufB = "0";
       StringRef AbMode = disable;
       //      StringRef FifoMode = disable; // FIXME: when to enable FIFO mode?
       int ndims = 0;
@@ -339,21 +338,14 @@ mlir::LogicalResult AIETranslateToCDO(ModuleOp m, raw_ostream &output) {
         foundBd = true;
         ShapedType bufferType =
             op.getBuffer().getType().cast<::mlir::MemRefType>();
-        if (op.isA()) {
-          BaseAddrA =
-              cast<AIE::BufferOp>(op.getBuffer().getDefiningOp()).address();
-          lenA = op.getLenValue();
-          bytesA = bufferType.getElementTypeBitWidth() / 8;
-          offsetA = op.getOffsetValue();
-          bufA = "XAIEDMA_TILE_BD_ADDRA";
-          hasA = true;
-        }
-        if (op.isB()) {
-          lenB = op.getLenValue();
-          bytesB = bufferType.getElementTypeBitWidth() / 8;
-          bufB = "XAIEDMA_TILE_BD_ADDRB";
-          hasB = true;
-        }
+        BaseAddrA =
+            cast<AIE::BufferOp>(op.getBuffer().getDefiningOp()).address();
+        lenA = op.getLenValue();
+        bytesA = bufferType.getElementTypeBitWidth() / 8;
+        offsetA = op.getOffsetValue();
+        bufA = "XAIEDMA_TILE_BD_ADDRA";
+        hasA = true;
+
         if (op.getDimensions()) {
           dims = *op.getDimensions();
           ndims = dims.size();
@@ -519,7 +511,6 @@ mlir::LogicalResult AIETranslateToCDO(ModuleOp m, raw_ostream &output) {
       bool hasA = false;
       bool hasB = false;
       StringRef bufA = "0";
-      StringRef bufB = "0";
       StringRef AbMode = disable;
       int ndims = 0;
       ArrayRef<BDDimLayoutAttr> dims;
@@ -528,21 +519,15 @@ mlir::LogicalResult AIETranslateToCDO(ModuleOp m, raw_ostream &output) {
         foundBd = true;
         ShapedType bufferType =
             op.getBuffer().getType().cast<::mlir::MemRefType>();
-        if (op.isA()) {
-          BaseAddrA =
-              cast<AIE::BufferOp>(op.getBuffer().getDefiningOp()).address();
-          lenA = op.getLenValue();
-          bytesA = bufferType.getElementTypeBitWidth() / 8;
-          offsetA = op.getOffsetValue();
-          bufA = "XAIEDMA_TILE_BD_ADDRA";
-          hasA = true;
-        }
-        if (op.isB()) {
-          lenB = op.getLenValue();
-          bytesB = bufferType.getElementTypeBitWidth() / 8;
-          bufB = "XAIEDMA_TILE_BD_ADDRB";
-          hasB = true;
-        }
+        BaseAddrA =
+            cast<AIE::BufferOp>(op.getBuffer().getDefiningOp()).address();
+        lenA = op.getLenValue();
+        bytesA = bufferType.getElementTypeBitWidth() / 8;
+        offsetA = op.getOffsetValue();
+        bufA = "XAIEDMA_TILE_BD_ADDRA";
+        hasA = true;
+
+
         if (op.getDimensions()) {
           dims = *op.getDimensions();
           ndims = dims.size();

--- a/lib/Targets/AIETargetCDO.cpp
+++ b/lib/Targets/AIETargetCDO.cpp
@@ -527,7 +527,6 @@ mlir::LogicalResult AIETranslateToCDO(ModuleOp m, raw_ostream &output) {
         bufA = "XAIEDMA_TILE_BD_ADDRA";
         hasA = true;
 
-
         if (op.getDimensions()) {
           dims = *op.getDimensions();
           ndims = dims.size();

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -103,7 +103,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
       foundBd = true;
       ShapedType bufferType =
           op.getBuffer().getType().template cast<::mlir::MemRefType>();
-      if (op.isA() && !targetModel.isShimNOCTile(col, row)) {
+      if (!targetModel.isShimNOCTile(col, row)) {
         BaseAddrA = op.getBufferOp().address();
         int bufferCol = op.getBufferOp().getTileOp().colIndex();
         int bufferRow = op.getBufferOp().getTileOp().rowIndex();
@@ -119,17 +119,11 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
         }
       }
 
-      if (op.isA() || targetModel.isShimNOCTile(col, row)) {
-        lenA = op.getLenValue();
-        bytesA = bufferType.getElementTypeBitWidth() / 8;
-        offsetA = op.getOffsetValue() * bytesA;
-        hasA = true;
-      }
-      if (op.isB()) {
-        lenB = op.getLenValue();
-        bytesB = bufferType.getElementTypeBitWidth() / 8;
-        hasB = true;
-      }
+      lenA = op.getLenValue();
+      bytesA = bufferType.getElementTypeBitWidth() / 8;
+      offsetA = op.getOffsetValue() * bytesA;
+      hasA = true;
+
       if (op.getDimensions()) {
         dims = *op.getDimensions();
         ndims = dims.size();

--- a/reference_designs/MM_2x2/circuit_switched_version/aie.mlir
+++ b/reference_designs/MM_2x2/circuit_switched_version/aie.mlir
@@ -104,22 +104,22 @@ module @MM_2x2 {
       AIE.dma_start("S2MM", 1, ^bd7, ^end)
     ^bd4:
       AIE.use_lock(%lock60_0, "Acquire", 1)
-      AIE.dma_bd(<%buffer0 : memref<1024xi32>, 0, 1024>, A)    //send LHS_tile0
+      AIE.dma_bd(%buffer0 : memref<1024xi32>, 0, 1024)    //send LHS_tile0
       AIE.use_lock(%lock60_0, "Release", 0)
       AIE.next_bd ^bd4
     ^bd5:
       AIE.use_lock(%lock60_1, "Acquire", 1)
-      AIE.dma_bd(<%buffer1 : memref<1024xi32>, 0, 1024>, A)    //send LHS_tile1
+      AIE.dma_bd(%buffer1 : memref<1024xi32>, 0, 1024)    //send LHS_tile1
       AIE.use_lock(%lock60_1, "Release", 0)
       AIE.next_bd ^bd5
     ^bd6:
       AIE.use_lock(%lock60_2, "Acquire", 1)
-      AIE.dma_bd(<%buffer6 : memref<1025xi32>, 0, 1025>, A)    //send Out_tile0
+      AIE.dma_bd(%buffer6 : memref<1025xi32>, 0, 1025)    //send Out_tile0
       AIE.use_lock(%lock60_2, "Release", 0)
       AIE.next_bd ^bd6
     ^bd7:
       AIE.use_lock(%lock60_3, "Acquire", 1)
-      AIE.dma_bd(<%buffer7 : memref<1025xi32>, 0, 1025>, A)    //send Out_tile1
+      AIE.dma_bd(%buffer7 : memref<1025xi32>, 0, 1025)    //send Out_tile1
       AIE.use_lock(%lock60_3, "Release", 0)
       AIE.next_bd ^bd7
     ^end:
@@ -132,12 +132,12 @@ module @MM_2x2 {
       AIE.dma_start("MM2S", 1, ^bd5, ^end)
     ^bd4:
       AIE.use_lock(%lock70_0, "Acquire", 1)
-      AIE.dma_bd(<%buffer2 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile0
+      AIE.dma_bd(%buffer2 : memref<1024xi32>, 0, 1024)    //send RHS_tile0
       AIE.use_lock(%lock70_0, "Release", 0)
       AIE.next_bd ^bd4
     ^bd5:
       AIE.use_lock(%lock70_1, "Acquire", 1)
-      AIE.dma_bd(<%buffer3 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile1
+      AIE.dma_bd(%buffer3 : memref<1024xi32>, 0, 1024)    //send RHS_tile1
       AIE.use_lock(%lock70_1, "Release", 0)
       AIE.next_bd ^bd5
     ^end:
@@ -150,12 +150,12 @@ module @MM_2x2 {
       AIE.dma_start("MM2S", 1, ^bd5, ^end)
     ^bd4:
       AIE.use_lock(%lock100_0, "Acquire", 1)
-      AIE.dma_bd(<%buffer4 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile2
+      AIE.dma_bd(%buffer4 : memref<1024xi32>, 0, 1024)    //send RHS_tile2
       AIE.use_lock(%lock100_0, "Release", 0)
       AIE.next_bd ^bd4
     ^bd5:
       AIE.use_lock(%lock100_1, "Acquire", 1)
-      AIE.dma_bd(<%buffer5 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile3
+      AIE.dma_bd(%buffer5 : memref<1024xi32>, 0, 1024)    //send RHS_tile3
       AIE.use_lock(%lock100_1, "Release", 0)
       AIE.next_bd ^bd5
     ^end:
@@ -168,12 +168,12 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     AIE.use_lock(%lock63_0, Acquire, 0)
-    AIE.dma_bd(<%buf63_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf63_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock63_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock63_1, Acquire, 0)
-    AIE.dma_bd(<%buf63_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf63_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock63_1, Release, 1)
     AIE.next_bd ^bd1
   ^end: 
@@ -186,19 +186,19 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     AIE.use_lock(%lock64_0, Acquire, 0)
-    AIE.dma_bd(<%buf64_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf64_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock64_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock64_1, Acquire, 0)
-    AIE.dma_bd(<%buf64_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf64_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock64_1, Release, 1)
     AIE.next_bd ^bd1
   ^dma1:
     AIE.dma_start("MM2S", 0, ^bd2, ^end)
   ^bd2:
     AIE.use_lock(%lock64_2, Acquire, 1)
-    AIE.dma_bd(<%buf64_2 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf64_2 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock64_2, Release, 0)
     AIE.next_bd ^bd2
   ^end: 
@@ -237,12 +237,12 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     AIE.use_lock(%lock73_0, Acquire, 0)
-    AIE.dma_bd(<%buf73_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf73_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock73_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock73_1, Acquire, 0)
-    AIE.dma_bd(<%buf73_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf73_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock73_1, Release, 1)
     AIE.next_bd ^bd1
   ^end: 
@@ -255,19 +255,19 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     AIE.use_lock(%lock74_0, Acquire, 0)
-    AIE.dma_bd(<%buf74_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf74_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock74_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock74_1, Acquire, 0)
-    AIE.dma_bd(<%buf74_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf74_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock74_1, Release, 1)
     AIE.next_bd ^bd1
   ^dma1:
     AIE.dma_start("MM2S", 0, ^bd2, ^end)
   ^bd2:
     AIE.use_lock(%lock74_2, Acquire, 1)
-    AIE.dma_bd(<%buf74_2 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf74_2 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock74_2, Release, 0)
     AIE.next_bd ^bd2
   ^end: 

--- a/reference_designs/MM_2x2/packet_switched_version/aie.mlir
+++ b/reference_designs/MM_2x2/packet_switched_version/aie.mlir
@@ -105,25 +105,25 @@ module @MM_2x2 {
     ^bd4:
       AIE.use_lock(%lock60_0, "Acquire", 1)
       AIE.dma_bd_packet(0x0, 0x0)
-      AIE.dma_bd(<%buffer0 : memref<1024xi32>, 0, 1024>, A)    //send LHS_tile0 with Pack_ID=0
+      AIE.dma_bd(%buffer0 : memref<1024xi32>, 0, 1024)    //send LHS_tile0 with Pack_ID=0
       AIE.use_lock(%lock60_0, "Release", 0)
       AIE.next_bd ^bd5
     ^bd5:
       AIE.use_lock(%lock60_1, "Acquire", 1)
       AIE.dma_bd_packet(0x1, 0x1)
-      AIE.dma_bd(<%buffer1 : memref<1024xi32>, 0, 1024>, A)    //send LHS_tile1 with Pack_ID=1
+      AIE.dma_bd(%buffer1 : memref<1024xi32>, 0, 1024)    //send LHS_tile1 with Pack_ID=1
       AIE.use_lock(%lock60_1, "Release", 0)
       AIE.next_bd ^bd4
     ^bd6:
       AIE.use_lock(%lock60_2, "Acquire", 1)
       AIE.dma_bd_packet(0x2, 0x2)
-      AIE.dma_bd(<%buffer2 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile0 with Pack_ID=2
+      AIE.dma_bd(%buffer2 : memref<1024xi32>, 0, 1024)    //send RHS_tile0 with Pack_ID=2
       AIE.use_lock(%lock60_2, "Release", 0)
       AIE.next_bd ^bd7
     ^bd7:
       AIE.use_lock(%lock60_3, "Acquire", 1)
       AIE.dma_bd_packet(0x3, 0x3)
-      AIE.dma_bd(<%buffer3 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile1 with Pack_ID=3
+      AIE.dma_bd(%buffer3 : memref<1024xi32>, 0, 1024)    //send RHS_tile1 with Pack_ID=3
       AIE.use_lock(%lock60_3, "Release", 0)
       AIE.next_bd ^bd6
     ^end:
@@ -137,20 +137,20 @@ module @MM_2x2 {
     ^bd4:
       AIE.use_lock(%lock70_0, "Acquire", 1)
       AIE.dma_bd_packet(0x4, 0x4)
-      AIE.dma_bd(<%buffer4 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile2 with Pack_ID=4
+      AIE.dma_bd(%buffer4 : memref<1024xi32>, 0, 1024)    //send RHS_tile2 with Pack_ID=4
       AIE.use_lock(%lock70_0, "Release", 0)
       AIE.next_bd ^bd5
     ^bd5:
       AIE.use_lock(%lock70_1, "Acquire", 1)
       AIE.dma_bd_packet(0x5, 0x5)
-      AIE.dma_bd(<%buffer5 : memref<1024xi32>, 0, 1024>, A)    //send RHS_tile3 with Pack_ID=5
+      AIE.dma_bd(%buffer5 : memref<1024xi32>, 0, 1024)    //send RHS_tile3 with Pack_ID=5
       AIE.use_lock(%lock70_1, "Release", 0)
       AIE.next_bd ^bd4
     ^bd6:
-      AIE.dma_bd(<%buffer6 : memref<1025xi32>, 0, 1025>, A)    //send Out_tile0 with Pack_ID=6
+      AIE.dma_bd(%buffer6 : memref<1025xi32>, 0, 1025)    //send Out_tile0 with Pack_ID=6
       AIE.next_bd ^bd7
     ^bd7:
-      AIE.dma_bd(<%buffer7 : memref<1025xi32>, 0, 1025>, A)    //send Out_tile1 with Pack_ID=7
+      AIE.dma_bd(%buffer7 : memref<1025xi32>, 0, 1025)    //send Out_tile1 with Pack_ID=7
       AIE.next_bd ^bd6
     ^end:
       AIE.end
@@ -165,12 +165,12 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     AIE.use_lock(%lock63_0, Acquire, 0)
-    AIE.dma_bd(<%buf63_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf63_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock63_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock63_1, Acquire, 0)
-    AIE.dma_bd(<%buf63_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf63_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock63_1, Release, 1)
     AIE.next_bd ^bd1
   ^end: 
@@ -187,12 +187,12 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     AIE.use_lock(%lock64_0, Acquire, 0)
-    AIE.dma_bd(<%buf64_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf64_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock64_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock64_1, Acquire, 0)
-    AIE.dma_bd(<%buf64_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf64_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock64_1, Release, 1)
     AIE.next_bd ^bd1
   ^dma1:
@@ -200,7 +200,7 @@ module @MM_2x2 {
   ^bd2:
     AIE.use_lock(%lock64_2, Acquire, 1)
     AIE.dma_bd_packet(0x0, 0x6)
-    AIE.dma_bd(<%buf64_2 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf64_2 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock64_2, Release, 0)
     AIE.next_bd ^bd2
   ^end: 
@@ -247,12 +247,12 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     AIE.use_lock(%lock73_0, Acquire, 0)
-    AIE.dma_bd(<%buf73_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf73_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock73_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock73_1, Acquire, 0)
-    AIE.dma_bd(<%buf73_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf73_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock73_1, Release, 1)
     AIE.next_bd ^bd1
   ^end: 
@@ -269,12 +269,12 @@ module @MM_2x2 {
     AIE.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     AIE.use_lock(%lock74_0, Acquire, 0)
-    AIE.dma_bd(<%buf74_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf74_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock74_0, Release, 1)
     AIE.next_bd ^bd0
   ^bd1: 
     AIE.use_lock(%lock74_1, Acquire, 0)
-    AIE.dma_bd(<%buf74_1 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf74_1 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock74_1, Release, 1)
     AIE.next_bd ^bd1
   ^dma1:
@@ -282,7 +282,7 @@ module @MM_2x2 {
   ^bd2:
     AIE.use_lock(%lock74_2, Acquire, 1)
     AIE.dma_bd_packet(0x0, 0x7)
-    AIE.dma_bd(<%buf74_2 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf74_2 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock74_2, Release, 0)
     AIE.next_bd ^bd2
   ^end: 

--- a/reference_designs/autocorrelation/aie.mlir
+++ b/reference_designs/autocorrelation/aie.mlir
@@ -57,12 +57,12 @@ module @autocorrelation {
      AIE.dma_start("S2MM", 0, ^bdout, ^end)
     ^bdin:
       AIE.use_lock(%input_lock, "Acquire", 1)
-      AIE.dma_bd(<%input : memref<1024xi32>, 0, 1024>, A)
+      AIE.dma_bd(%input : memref<1024xi32>, 0, 1024)
       AIE.use_lock(%input_lock, "Release", 0)
       AIE.next_bd ^end
     ^bdout:
       AIE.use_lock(%output_lock, "Acquire", 0)
-      AIE.dma_bd(<%output : memref<1024xi32>, 0, 1024>, A)
+      AIE.dma_bd(%output : memref<1024xi32>, 0, 1024)
       AIE.use_lock(%output_lock, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -85,12 +85,12 @@ module @autocorrelation {
     AIE.dma_start("MM2S", 0, ^bd1, ^end)
   ^bd0: 
     AIE.use_lock(%buf1_in_lock, Acquire, 0)
-    AIE.dma_bd(<%buf1_in : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf1_in : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%buf1_in_lock, Release, 1)
     AIE.next_bd ^end
   ^bd1: 
     AIE.use_lock(%buf1_out_lock, Acquire, 1)
-    AIE.dma_bd(<%buf1_out : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf1_out : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%buf1_out_lock, Release, 0)
     AIE.next_bd ^end
   ^end: 
@@ -101,7 +101,7 @@ module @autocorrelation {
     AIE.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     AIE.use_lock(%buf2_in_lock, Acquire, 0)
-    AIE.dma_bd(<%buf2_in : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf2_in : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%buf2_in_lock, Release, 1)
     AIE.next_bd ^end
   ^end: 
@@ -112,7 +112,7 @@ module @autocorrelation {
     AIE.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     AIE.use_lock(%buf3_in_lock, Acquire, 0)
-    AIE.dma_bd(<%buf3_in : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf3_in : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%buf3_in_lock, Release, 1)
     AIE.next_bd ^end
   ^end: 
@@ -123,7 +123,7 @@ module @autocorrelation {
     AIE.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     AIE.use_lock(%buf4_in_lock, Acquire, 0)
-    AIE.dma_bd(<%buf4_in : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf4_in : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%buf4_in_lock, Release, 1)
     AIE.next_bd ^end
   ^end: 

--- a/reference_designs/idct/aie.mlir
+++ b/reference_designs/idct/aie.mlir
@@ -136,22 +136,22 @@ module @idct {
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_73_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_73_aping : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_73_aping : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_73_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_73_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_73_apong : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_73_apong : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_73_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_73_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_73_bping : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_73_bping : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_73_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_73_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_73_bpong : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_73_bpong : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_73_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -165,22 +165,22 @@ module @idct {
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_74_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_74_aping : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_74_aping : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_74_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_74_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_74_apong : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_74_apong : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_74_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_74_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_74_bping : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_74_bping : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_74_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_74_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_74_bpong : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_74_bpong : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_74_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -194,22 +194,22 @@ module @idct {
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_75_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_75_aping : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_75_aping : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_75_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_75_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_75_apong : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_75_apong : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_75_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_75_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_75_bping : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_75_bping : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_75_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_75_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_75_bpong : memref<64xi16>, 0, 64>, A)
+      AIE.dma_bd(%buf_75_bpong : memref<64xi16>, 0, 64)
       AIE.use_lock(%lock_75_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -230,12 +230,12 @@ module @idct {
       AIE.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%lock1, "Acquire", 1)
-      AIE.dma_bd(<%buffer_in : memref<512 x i16>, 0, 512>, A)
+      AIE.dma_bd(%buffer_in : memref<512 x i16>, 0, 512)
       AIE.use_lock(%lock1, "Release", 0)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%lock2, "Acquire", 1)
-      AIE.dma_bd(<%buffer_out : memref<512 x i16>, 0, 512>, A)
+      AIE.dma_bd(%buffer_out : memref<512 x i16>, 0, 512)
       AIE.use_lock(%lock2, "Release", 0)
       AIE.next_bd ^bd1
     ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
@@ -44,22 +44,22 @@ module @aie_module  {
       %dstDma = AIE.dma_start(MM2S, 0, ^bd3, ^end)
     ^bd0:
       AIE.use_lock(%l01_0, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_0 : memref<16xi32>, 0, 128>, A, [<wrap = 2, step = 1>, <wrap = 3, step = 2>, <wrap = 2, step = 4>, <wrap = 1, step = 1>])
+      AIE.dma_bd(%buf01_0 : memref<16xi32>, 0, 128, [<wrap = 2, step = 1>, <wrap = 3, step = 2>, <wrap = 2, step = 4>, <wrap = 1, step = 1>])
       AIE.use_lock(%l01_1, "Release", 1)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%l01_1, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_0 : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
       AIE.use_lock(%l01_0, "Release", 1)
       AIE.next_bd ^bd1
     ^bd2:
       AIE.use_lock(%l01_2, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_1 : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
       AIE.use_lock(%l01_3, "Release", 1)
       AIE.next_bd ^bd2
     ^bd3:
       AIE.use_lock(%l01_3, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_1 : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
       AIE.use_lock(%l01_2, "Release", 1)
       AIE.next_bd ^bd3
     ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA.mlir
@@ -35,7 +35,7 @@ module @aie_module  {
       ^bd0:
         // Note: acquire and release are different locks.
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_ping : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA2.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA2.mlir
@@ -36,7 +36,7 @@ module @aie_module  {
       ^bd0:
         // Note: acquire and release are different locks.
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_ping : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
         // AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA3.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA3.mlir
@@ -36,7 +36,7 @@ module @aie_module  {
       ^bd0:
         // Note: acquire and release are different locks.
         //AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_ping : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA_locks.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA_locks.mlir
@@ -43,19 +43,19 @@ module @aie_module  {
         %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
       ^bd0:
         AIE.use_lock(%lock_l1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_l2, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_l1, Release, 1)
         AIE.next_bd ^bd2
       ^bd2:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_l1, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_l1, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/memTileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/memTileDMA.mlir
@@ -58,22 +58,22 @@ module @aie_module  {
       %dstDma = AIE.dma_start(MM2S, 0, ^bd3, ^end)
     ^bd0:
       AIE.use_lock(%l01_0, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_0 : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
       AIE.use_lock(%l01_1, "Release", 1)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%l01_1, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_0 : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
       AIE.use_lock(%l01_0, "Release", 1)
       AIE.next_bd ^bd1
     ^bd2:
       AIE.use_lock(%l01_2, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_1 : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
       AIE.use_lock(%l01_3, "Release", 1)
       AIE.next_bd ^bd2
     ^bd3:
       AIE.use_lock(%l01_3, "AcquireGreaterEqual", 1)
-      AIE.dma_bd(<%buf01_1 : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
       AIE.use_lock(%l01_2, "Release", 1)
       AIE.next_bd ^bd3
     ^end:

--- a/test/Targets/AIEGenerateXAIE/memTileDMA2.mlir
+++ b/test/Targets/AIEGenerateXAIE/memTileDMA2.mlir
@@ -53,15 +53,15 @@ module @aie_module  {
   %m01 = AIE.memtile_dma(%t01) {
       %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
-      AIE.dma_bd(<%buf_w : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf_w : memref<16xi32>, 0, 16)
       AIE.use_lock(%lock_w, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf_l : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf_l : memref<16xi32>, 0, 16)
       AIE.use_lock(%lock_l, "Release", 1)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf_e : memref<16xi32>, 0, 16>, A)
+      AIE.dma_bd(%buf_e : memref<16xi32>, 0, 16)
       AIE.use_lock(%lock_e, "Release", 1)
       AIE.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/packet_drop_header.mlir
+++ b/test/Targets/AIEGenerateXAIE/packet_drop_header.mlir
@@ -69,13 +69,13 @@ module @aie_module {
     ^bb2:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%4, Acquire, 0)
       AIE.dma_bd_packet(2, 3)
-      AIE.dma_bd(<%5 : memref<16xi32, 2>, 0, 16>, A)
+      AIE.dma_bd(%5 : memref<16xi32, 2>, 0, 16)
       AIE.use_lock(%4, Release, 1)
       AIE.next_bd ^bb2
     ^bb3:  // 2 preds: ^bb1, ^bb3
       AIE.use_lock(%4, Acquire, 1)
       AIE.dma_bd_packet(6, 10)
-      AIE.dma_bd(<%5 : memref<16xi32, 2>, 0, 16>, A)
+      AIE.dma_bd(%5 : memref<16xi32, 2>, 0, 16)
       AIE.use_lock(%4, Release, 0)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb1

--- a/test/Targets/AIEGenerateXAIE/packet_shim_header.mlir
+++ b/test/Targets/AIEGenerateXAIE/packet_shim_header.mlir
@@ -61,7 +61,7 @@ module @aie_module {
       %10 = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%5, Acquire, 0)
-      AIE.dma_bd(<%6 : memref<32xi32, 2>, 0, 32>, A)
+      AIE.dma_bd(%6 : memref<32xi32, 2>, 0, 32)
       AIE.use_lock(%5, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb0
@@ -73,7 +73,7 @@ module @aie_module {
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%10, Acquire, 1)
       AIE.dma_bd_packet(6, 10)
-      AIE.dma_bd(<%7 : memref<32xi32>, 0, 32>, A)
+      AIE.dma_bd(%7 : memref<32xi32>, 0, 32)
       AIE.use_lock(%10, Release, 0)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb0

--- a/test/Targets/AIEGenerateXAIE/shim.mlir
+++ b/test/Targets/AIEGenerateXAIE/shim.mlir
@@ -64,12 +64,12 @@ module {
       AIE.dma_start(MM2S, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%lock0, Acquire, 0)
-      AIE.dma_bd(<%buffer : memref<16 x f32>, 0, 16>, A)
+      AIE.dma_bd(%buffer : memref<16 x f32>, 0, 16)
       AIE.use_lock(%lock0, Release, 1)
       AIE.next_bd ^bd0
     ^bd1:
       // AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer : memref<16 x f32>, 0, 4>, A)
+      AIE.dma_bd(%buffer : memref<16 x f32>, 0, 4)
       // AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd1
     ^end:

--- a/test/Targets/AIEGenerateXAIE/shim_dma_packet.mlir
+++ b/test/Targets/AIEGenerateXAIE/shim_dma_packet.mlir
@@ -36,7 +36,7 @@ module {
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.use_lock(%lock70, Acquire, 1)
     AIE.dma_bd_packet(0, 2)
-    AIE.dma_bd(<%buf : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%lock70, Release, 0)
     AIE.next_bd ^bb1
   ^bb2:  // pred: ^bb0

--- a/test/Targets/AIEGenerateXAIE/test_xaie1.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie1.mlir
@@ -32,7 +32,7 @@ module @test_xaie1 {
       %srcDma = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l33_0, Acquire, 0)
-      AIE.dma_bd(<%buf33_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_0, Release, 1)
       AIE.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
@@ -42,12 +42,12 @@ module @test_xaie2 {
       %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l33_0, Acquire, 0)
-      AIE.dma_bd(<%buf33_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_0, Release, 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%l33_0, Acquire, 0)
-      AIE.dma_bd(<%buf33_1 : memref<16xi32>, 0, 4>, A)
+      AIE.dma_bd(%buf33_1 : memref<16xi32>, 0, 4)
       AIE.use_lock(%l33_0, Release, 1)
       AIE.next_bd ^bd0
     ^end:

--- a/test/Targets/AIEGenerateXAIE/test_xaie3.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie3.mlir
@@ -27,7 +27,7 @@ module @test_xaie3 {
       %srcDma = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l33_0, Acquire, 1)
-      AIE.dma_bd(<%buf33_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_0, Release, 0)
       AIE.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
@@ -47,12 +47,12 @@ module @test_xaie3 {
       %destDma = AIE.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%l33_0, Acquire, 1)
-      AIE.dma_bd(<%buf33_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_0, Release, 0)
       AIE.next_bd ^end
     ^bd1:
       AIE.use_lock(%l33_1, Acquire, 1)
-      AIE.dma_bd(<%buf33_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_1, Release, 0)
       AIE.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/tileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/tileDMA.mlir
@@ -34,7 +34,7 @@ module @aie_module  {
     %38 = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.use_lock(%25, Acquire, 0)
-    AIE.dma_bd(<%24 : memref<64xi32, 2>, 0, 64>, A)
+    AIE.dma_bd(%24 : memref<64xi32, 2>, 0, 64)
     AIE.use_lock(%25, Release, 1)
     AIE.next_bd ^bb1
   ^bb2:  // pred: ^bb3
@@ -43,7 +43,7 @@ module @aie_module  {
     %39 = AIE.dma_start(MM2S, 0, ^bb4, ^bb2)
   ^bb4:  // 2 preds: ^bb3, ^bb4
     AIE.use_lock(%27, Acquire, 1)
-    AIE.dma_bd(<%26 : memref<64xi32, 2>, 0, 64>, A)
+    AIE.dma_bd(%26 : memref<64xi32, 2>, 0, 64)
     AIE.use_lock(%27, Release, 0)
     AIE.next_bd ^bb4
   }

--- a/test/benchmarks/01_DDR_SHIM_LM_FillRate/aie.mlir
+++ b/test/benchmarks/01_DDR_SHIM_LM_FillRate/aie.mlir
@@ -38,7 +38,7 @@ module @benchmark01_DDR_SHIM_fill_rate {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -54,7 +54,7 @@ module @benchmark01_DDR_SHIM_fill_rate {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l71_0, "Acquire", 0)
-      AIE.dma_bd(<%buf71_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf71_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l71_0, "Release", 1)
       AIE.next_bd ^end
     ^end:

--- a/test/benchmarks/02_LM_SHIM_DDR_FillRate/aie.mlir
+++ b/test/benchmarks/02_LM_SHIM_DDR_FillRate/aie.mlir
@@ -26,7 +26,7 @@ module @benchmark_02_LM2DDR {
       %srcDma = AIE.dma_start(MM2S, 1, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf71_0 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf71_0 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock_a_ping, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -40,7 +40,7 @@ module @benchmark_02_LM2DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:

--- a/test/benchmarks/03_Flood_DDR/aie.mlir
+++ b/test/benchmarks/03_Flood_DDR/aie.mlir
@@ -35,7 +35,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l21_0, "Acquire", 0)
-      AIE.dma_bd(<%buf21_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf21_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l21_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -50,7 +50,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%l20, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_20 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_20 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%l20, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -78,7 +78,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l31_0, "Acquire", 0)
-      AIE.dma_bd(<%buf31_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf31_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l31_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -94,7 +94,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_30 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_30 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -122,7 +122,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l61_0, "Acquire", 0)
-      AIE.dma_bd(<%buf61_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf61_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l61_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -137,7 +137,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_60 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_60 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -168,7 +168,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l71_0, "Acquire", 0)
-      AIE.dma_bd(<%buf71_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf71_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l71_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -184,7 +184,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_70 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_70 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -215,7 +215,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l101_0, "Acquire", 0)
-      AIE.dma_bd(<%buf101_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf101_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l101_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -230,7 +230,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_100 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_100 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -258,7 +258,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l111_0, "Acquire", 0)
-      AIE.dma_bd(<%buf111_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf111_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l111_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -273,7 +273,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_110 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_110 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -301,7 +301,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l181_0, "Acquire", 0)
-      AIE.dma_bd(<%buf181_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf181_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l181_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -317,7 +317,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_180 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_180 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -346,7 +346,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l191_0, "Acquire", 0)
-      AIE.dma_bd(<%buf191_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf191_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l191_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -361,7 +361,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_190 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_190 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -389,7 +389,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l261_0, "Acquire", 0)
-      AIE.dma_bd(<%buf261_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf261_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l261_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -405,7 +405,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_260 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_260 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -434,7 +434,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l271_0, "Acquire", 0)
-      AIE.dma_bd(<%buf271_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf271_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l271_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -450,7 +450,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_270 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_270 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -478,7 +478,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l341_0, "Acquire", 0)
-      AIE.dma_bd(<%buf341_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf341_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l341_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -493,7 +493,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_340 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_340 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -521,7 +521,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l351_0, "Acquire", 0)
-      AIE.dma_bd(<%buf351_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf351_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l351_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -536,7 +536,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_350 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_350 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -557,7 +557,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l421, "Acquire", 0)
-      AIE.dma_bd(<%buf421_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf421_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l421, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -573,7 +573,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_420 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_420 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -601,7 +601,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l431_0, "Acquire", 0)
-      AIE.dma_bd(<%buf431_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf431_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l431_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -617,7 +617,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%l430, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_430 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_430 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%l430, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -646,7 +646,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l461_0, "Acquire", 0)
-      AIE.dma_bd(<%buf461_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf461_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l461_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -661,7 +661,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%l460, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_460 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_460 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%l460, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -690,7 +690,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = AIE.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       AIE.use_lock(%l471_0, "Acquire", 0)
-      AIE.dma_bd(<%buf471_0 : memref< 7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buf471_0 : memref< 7168xi32>, 0, 7168)
       AIE.use_lock(%l471_0, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -706,7 +706,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       AIE.use_lock(%l470, Acquire, 1)
-      AIE.dma_bd(<%buffer_out_470 : memref<7168xi32>, 0, 7168>, A)
+      AIE.dma_bd(%buffer_out_470 : memref<7168xi32>, 0, 7168)
       AIE.use_lock(%l470, Release, 0)
       AIE.next_bd ^bd0
     ^end:

--- a/test/benchmarks/04_Tile_Tile_FillRate/aie.mlir
+++ b/test/benchmarks/04_Tile_Tile_FillRate/aie.mlir
@@ -29,7 +29,7 @@ module @test04_tile_tiledma {
     %dma0 = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock13_5, "Acquire", 1)
-      AIE.dma_bd(<%buf13_0 : memref<512xi32>, 0, 512>, A)
+      AIE.dma_bd(%buf13_0 : memref<512xi32>, 0, 512)
       AIE.use_lock(%lock13_5, "Release", 0)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -45,7 +45,7 @@ module @test04_tile_tiledma {
     %dma0 = AIE.dma_start(S2MM, 1, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock14_6, "Acquire", 0)
-      AIE.dma_bd(<%buf14_0: memref<512xi32>, 0, 512>, A)
+      AIE.dma_bd(%buf14_0: memref<512xi32>, 0, 512)
       AIE.use_lock(%lock14_6, "Release", 1)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:

--- a/test/benchmarks/12_Stream_Delay/aie.mlir
+++ b/test/benchmarks/12_Stream_Delay/aie.mlir
@@ -34,7 +34,7 @@ module @test12_stream_delay {
     %dma0 = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock13_5, "Acquire", 1)
-      AIE.dma_bd(<%buf13_0 : memref<512xi32>, 0, 512>, A)
+      AIE.dma_bd(%buf13_0 : memref<512xi32>, 0, 512)
       AIE.use_lock(%lock13_5, "Release", 0)
       AIE.next_bd ^end
     ^end:
@@ -52,7 +52,7 @@ module @test12_stream_delay {
      %dma0 = AIE.dma_start(S2MM, 1, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock43_6, "Acquire", 0)
-      AIE.dma_bd(<%buf43_0: memref<512xi32>, 0, 512>, A)
+      AIE.dma_bd(%buf43_0: memref<512xi32>, 0, 512)
       AIE.use_lock(%lock43_6, "Release", 1)
       AIE.next_bd ^end
     ^end:

--- a/test/create-cores/duplicate_dma.mlir
+++ b/test/create-cores/duplicate_dma.mlir
@@ -19,14 +19,14 @@ module @duplicate_dma  {
     %15 = AIE.dma_start(MM2S, 0, ^bb1, ^bb4)
   ^bb1:  // pred: ^bb0
     AIEX.useToken @token0(Acquire, 1)
-    AIE.dma_bd(<%1 : memref<256xi32>, 0, 256>, A)
+    AIE.dma_bd(%1 : memref<256xi32>, 0, 256)
     AIEX.useToken @token0(Release, 2)
     AIE.next_bd ^bb2
   ^bb2:  
     %16 = AIE.dma_start(MM2S, 0, ^bb3, ^bb4)
   ^bb3:  
     AIEX.useToken @token1(Acquire, 1)
-    AIE.dma_bd(<%1 : memref<256xi32>, 0, 256>, A)
+    AIE.dma_bd(%1 : memref<256xi32>, 0, 256)
     AIEX.useToken @token1(Release, 2)
     AIE.next_bd ^bb4
   ^bb4:  // 4 preds: ^bb0, ^bb1, ^bb2, ^bb3

--- a/test/create-cores/hello_world.mlir
+++ b/test/create-cores/hello_world.mlir
@@ -17,7 +17,7 @@
 // CHECK:           %[[VAL_3:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_1]] : memref<512xi32>, 0, 512>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_1]] : memref<512xi32>, 0, 512)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -29,7 +29,7 @@
 // CHECK:           %[[VAL_7:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_5]] : memref<512xi32>, 0, 512>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_5]] : memref<512xi32>, 0, 512)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-cores/test_dma0.mlir
+++ b/test/create-cores/test_dma0.mlir
@@ -17,7 +17,7 @@
 // CHECK:           %[[VAL_3:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -29,7 +29,7 @@
 // CHECK:           %[[VAL_7:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_5]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-cores/test_dma1.mlir
+++ b/test/create-cores/test_dma1.mlir
@@ -20,14 +20,14 @@
 // CHECK:           %[[VAL_3:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb4)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb4
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_4:.*]] = AIE.dma_start(MM2S, 0, ^bb3, ^bb4)
 // CHECK:         ^bb3:
 // CHECK:           AIEX.useToken @token1(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token1(Release, 2)
 // CHECK:           AIE.next_bd ^bb4
 // CHECK:         ^bb4:
@@ -39,7 +39,7 @@
 // CHECK:           %[[VAL_8:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_6]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_6]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -51,7 +51,7 @@
 // CHECK:           %[[VAL_12:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token1(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_10]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token1(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-cores/test_dma2.mlir
+++ b/test/create-cores/test_dma2.mlir
@@ -18,7 +18,7 @@
 // CHECK:           %[[VAL_3:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -30,7 +30,7 @@
 // CHECK:           %[[VAL_7:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token1(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_5]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token1(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -43,14 +43,14 @@
 // CHECK:           %[[VAL_12:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_9]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb4
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_13:.*]] = AIE.dma_start(S2MM, 0, ^bb3, ^bb4)
 // CHECK:         ^bb3:
 // CHECK:           AIEX.useToken @token1(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_10]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token1(Release, 2)
 // CHECK:           AIE.next_bd ^bb4
 // CHECK:         ^bb4:

--- a/test/create-cores/test_dma3.mlir
+++ b/test/create-cores/test_dma3.mlir
@@ -18,7 +18,7 @@
 // CHECK:           %[[VAL_3:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -30,14 +30,14 @@
 // CHECK:           %[[VAL_7:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 1)
-// CHECK:           AIE.dma_bd(<%[[VAL_5]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 2)
 // CHECK:           AIE.next_bd ^bb4
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_8:.*]] = AIE.dma_start(MM2S, 0, ^bb3, ^bb4)
 // CHECK:         ^bb3:
 // CHECK:           AIEX.useToken @token0(Acquire, 3)
-// CHECK:           AIE.dma_bd(<%[[VAL_5]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 4)
 // CHECK:           AIE.next_bd ^bb4
 // CHECK:         ^bb4:
@@ -49,7 +49,7 @@
 // CHECK:           %[[VAL_12:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           AIEX.useToken @token0(Acquire, 3)
-// CHECK:           AIE.dma_bd(<%[[VAL_10]] : memref<256xi32>, 0, 256>, A)
+// CHECK:           AIE.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
 // CHECK:           AIEX.useToken @token0(Release, 4)
 // CHECK:           AIE.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-flows/mmult.mlir
+++ b/test/create-flows/mmult.mlir
@@ -50,26 +50,26 @@ module @aie.herd_0  {
       %63 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%9, Acquire, 0)
-      AIE.dma_bd(<%10 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%10 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%9, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%4, Acquire, 0)
-      AIE.dma_bd(<%6 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%6 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%4, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%7, Acquire, 0)
-      AIE.dma_bd(<%8 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%8 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%7, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%5, Acquire, 1)
-      AIE.dma_bd(<%6 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%6 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%5, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -91,26 +91,26 @@ module @aie.herd_0  {
       %63 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%23, Acquire, 0)
-      AIE.dma_bd(<%24 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%24 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%23, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%18, Acquire, 0)
-      AIE.dma_bd(<%20 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%20 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%18, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%21, Acquire, 0)
-      AIE.dma_bd(<%22 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%22 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%21, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%19, Acquire, 1)
-      AIE.dma_bd(<%20 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%20 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%19, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -132,26 +132,26 @@ module @aie.herd_0  {
       %63 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%37, Acquire, 0)
-      AIE.dma_bd(<%38 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%38 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%37, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%32, Acquire, 0)
-      AIE.dma_bd(<%34 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%34 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%32, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%35, Acquire, 0)
-      AIE.dma_bd(<%36 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%36 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%35, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%33, Acquire, 1)
-      AIE.dma_bd(<%34 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%34 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%33, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -173,26 +173,26 @@ module @aie.herd_0  {
       %63 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%51, Acquire, 0)
-      AIE.dma_bd(<%52 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%52 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%51, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%46, Acquire, 0)
-      AIE.dma_bd(<%48 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%48 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%46, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%49, Acquire, 0)
-      AIE.dma_bd(<%50 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%50 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%49, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%47, Acquire, 1)
-      AIE.dma_bd(<%48 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%48 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%47, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3

--- a/test/create-flows/unit_mmult.mlir
+++ b/test/create-flows/unit_mmult.mlir
@@ -26,26 +26,26 @@
 // CHECK:             %[[VAL_12:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             AIE.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_13:.*]] = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             AIE.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_14:.*]] = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 0)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -67,26 +67,26 @@
 // CHECK:             %[[VAL_28:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_25]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_26]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_26]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_25]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             AIE.use_lock(%[[VAL_20]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_22]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_22]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_29:.*]] = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             AIE.use_lock(%[[VAL_23]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_24]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_24]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_23]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_30:.*]] = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             AIE.use_lock(%[[VAL_21]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_22]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_22]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 0)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -108,26 +108,26 @@
 // CHECK:             %[[VAL_44:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_41]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_42]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_42]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_41]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             AIE.use_lock(%[[VAL_36]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_38]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_38]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_36]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_45:.*]] = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             AIE.use_lock(%[[VAL_39]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_40]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_40]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_39]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_46:.*]] = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             AIE.use_lock(%[[VAL_37]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_38]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_38]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_37]], Release, 0)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -149,26 +149,26 @@
 // CHECK:             %[[VAL_60:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_57]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_58]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_58]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_57]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             AIE.use_lock(%[[VAL_52]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_54]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_54]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_52]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_61:.*]] = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             AIE.use_lock(%[[VAL_55]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_56]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_56]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_55]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_62:.*]] = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             AIE.use_lock(%[[VAL_53]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_54]] : memref<16x16xf32, 2>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_54]] : memref<16x16xf32, 2>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_53]], Release, 0)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -441,26 +441,26 @@ module @aie.herd_0 {
       %0 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%lock_8_3_3, Acquire, 0)
-      AIE.dma_bd(<%buffer_8_3_4 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_3_4 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_3_3, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%lock_8_3, Acquire, 0)
-      AIE.dma_bd(<%buffer_8_3 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_3 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_3, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%lock_8_3_1, Acquire, 0)
-      AIE.dma_bd(<%buffer_8_3_2 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_3_2 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_3_1, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%lock_8_3_0, Acquire, 1)
-      AIE.dma_bd(<%buffer_8_3 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_3 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_3_0, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -482,26 +482,26 @@ module @aie.herd_0 {
       %0 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%lock_7_3_8, Acquire, 0)
-      AIE.dma_bd(<%buffer_7_3_9 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_3_9 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_3_8, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%lock_7_3, Acquire, 0)
-      AIE.dma_bd(<%buffer_7_3 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_3 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_3, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%lock_7_3_6, Acquire, 0)
-      AIE.dma_bd(<%buffer_7_3_7 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_3_7 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_3_6, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%lock_7_3_5, Acquire, 1)
-      AIE.dma_bd(<%buffer_7_3 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_3 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_3_5, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -523,26 +523,26 @@ module @aie.herd_0 {
       %0 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%lock_8_2_13, Acquire, 0)
-      AIE.dma_bd(<%buffer_8_2_14 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_2_14 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_2_13, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%lock_8_2, Acquire, 0)
-      AIE.dma_bd(<%buffer_8_2 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_2 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_2, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%lock_8_2_11, Acquire, 0)
-      AIE.dma_bd(<%buffer_8_2_12 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_2_12 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_2_11, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%lock_8_2_10, Acquire, 1)
-      AIE.dma_bd(<%buffer_8_2 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_8_2 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_8_2_10, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -564,26 +564,26 @@ module @aie.herd_0 {
       %0 = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       AIE.use_lock(%lock_7_2_18, Acquire, 0)
-      AIE.dma_bd(<%buffer_7_2_19 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_2_19 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_2_18, Release, 1)
       AIE.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       AIE.use_lock(%lock_7_2, Acquire, 0)
-      AIE.dma_bd(<%buffer_7_2 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_2 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_2, Release, 1)
       AIE.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = AIE.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       AIE.use_lock(%lock_7_2_16, Acquire, 0)
-      AIE.dma_bd(<%buffer_7_2_17 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_2_17 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_2_16, Release, 1)
       AIE.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = AIE.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       AIE.use_lock(%lock_7_2_15, Acquire, 1)
-      AIE.dma_bd(<%buffer_7_2 : memref<16x16xf32, 2>, 0, 256>, A)
+      AIE.dma_bd(%buffer_7_2 : memref<16x16xf32, 2>, 0, 256)
       AIE.use_lock(%lock_7_2_15, Release, 0)
       AIE.next_bd ^bb6
     ^bb7:  // pred: ^bb3

--- a/test/create-flows/unit_vecmul_4x4.mlir
+++ b/test/create-flows/unit_vecmul_4x4.mlir
@@ -26,21 +26,21 @@
 // CHECK:             %[[VAL_12:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_13:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_14:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -80,21 +80,21 @@
 // CHECK:             %[[VAL_32:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_29]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_30]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_30]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_29]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_33:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_27]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_28]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_28]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_27]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_34:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_25]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_26]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_26]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_25]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -134,21 +134,21 @@
 // CHECK:             %[[VAL_52:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_49]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_50]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_50]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_49]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_53:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_47]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_48]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_48]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_47]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_54:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_45]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_46]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_46]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_45]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -188,21 +188,21 @@
 // CHECK:             %[[VAL_72:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_69]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_70]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_70]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_69]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_73:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_67]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_68]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_68]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_67]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_74:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_65]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_66]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_66]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_65]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -241,21 +241,21 @@
 // CHECK:             %[[VAL_91:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_88]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_89]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_89]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_88]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_92:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_86]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_87]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_87]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_86]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_93:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_84]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_85]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_85]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_84]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -294,21 +294,21 @@
 // CHECK:             %[[VAL_110:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_107]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_108]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_108]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_107]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_111:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_105]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_106]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_106]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_105]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_112:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_103]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_104]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_104]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_103]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -348,21 +348,21 @@
 // CHECK:             %[[VAL_130:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_127]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_128]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_128]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_127]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_131:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_125]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_126]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_126]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_125]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_132:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_123]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_124]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_124]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_123]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -402,21 +402,21 @@
 // CHECK:             %[[VAL_150:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_147]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_148]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_148]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_147]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_151:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_145]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_146]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_146]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_145]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_152:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_143]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_144]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_144]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_143]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -455,21 +455,21 @@
 // CHECK:             %[[VAL_169:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_166]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_167]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_167]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_166]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_170:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_164]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_165]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_165]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_164]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_171:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_162]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_163]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_163]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_162]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -508,21 +508,21 @@
 // CHECK:             %[[VAL_188:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_185]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_186]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_186]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_185]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_189:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_183]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_184]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_184]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_183]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_190:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_181]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_182]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_182]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_181]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -562,21 +562,21 @@
 // CHECK:             %[[VAL_208:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_205]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_206]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_206]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_205]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_209:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_203]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_204]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_204]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_203]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_210:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_201]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_202]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_202]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_201]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -615,21 +615,21 @@
 // CHECK:             %[[VAL_227:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_224]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_225]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_225]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_224]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_228:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_222]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_223]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_223]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_222]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_229:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_220]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_221]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_221]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_220]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -667,21 +667,21 @@
 // CHECK:             %[[VAL_245:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_242]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_243]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_243]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_242]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_246:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_240]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_241]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_241]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_240]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_247:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_238]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_239]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_239]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_238]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -720,21 +720,21 @@
 // CHECK:             %[[VAL_264:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_261]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_262]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_262]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_261]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_265:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_259]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_260]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_260]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_259]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_266:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_257]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_258]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_258]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_257]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -774,21 +774,21 @@
 // CHECK:             %[[VAL_284:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_281]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_282]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_282]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_281]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_285:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_279]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_280]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_280]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_279]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_286:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_277]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_278]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_278]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_277]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -828,21 +828,21 @@
 // CHECK:             %[[VAL_304:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_301]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_302]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_302]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_301]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_305:.*]] = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_299]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_300]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_300]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_299]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_306:.*]] = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             AIE.use_lock(%[[VAL_297]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_298]] : memref<64xi32, 2>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_298]] : memref<64xi32, 2>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_297]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -2971,21 +2971,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%9, Acquire, 0)
-      AIE.dma_bd(<%10 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%10 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%9, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%7, Acquire, 0)
-      AIE.dma_bd(<%8 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%8 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%7, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%5, Acquire, 1)
-      AIE.dma_bd(<%6 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%6 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%5, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3025,21 +3025,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%22, Acquire, 0)
-      AIE.dma_bd(<%23 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%23 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%22, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%20, Acquire, 0)
-      AIE.dma_bd(<%21 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%21 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%20, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%18, Acquire, 1)
-      AIE.dma_bd(<%19 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%19 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%18, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3079,21 +3079,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%35, Acquire, 0)
-      AIE.dma_bd(<%36 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%36 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%35, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%33, Acquire, 0)
-      AIE.dma_bd(<%34 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%34 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%33, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%31, Acquire, 1)
-      AIE.dma_bd(<%32 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%32 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%31, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3133,21 +3133,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%48, Acquire, 0)
-      AIE.dma_bd(<%49 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%49 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%48, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%46, Acquire, 0)
-      AIE.dma_bd(<%47 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%47 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%46, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%44, Acquire, 1)
-      AIE.dma_bd(<%45 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%45 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%44, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3186,21 +3186,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%60, Acquire, 0)
-      AIE.dma_bd(<%61 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%61 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%60, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%58, Acquire, 0)
-      AIE.dma_bd(<%59 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%59 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%58, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%56, Acquire, 1)
-      AIE.dma_bd(<%57 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%57 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%56, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3239,21 +3239,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%72, Acquire, 0)
-      AIE.dma_bd(<%73 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%73 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%72, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%70, Acquire, 0)
-      AIE.dma_bd(<%71 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%71 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%70, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%68, Acquire, 1)
-      AIE.dma_bd(<%69 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%69 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%68, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3293,21 +3293,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%85, Acquire, 0)
-      AIE.dma_bd(<%86 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%86 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%85, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%83, Acquire, 0)
-      AIE.dma_bd(<%84 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%84 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%83, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%81, Acquire, 1)
-      AIE.dma_bd(<%82 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%82 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%81, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3347,21 +3347,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%98, Acquire, 0)
-      AIE.dma_bd(<%99 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%99 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%98, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%96, Acquire, 0)
-      AIE.dma_bd(<%97 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%97 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%96, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%94, Acquire, 1)
-      AIE.dma_bd(<%95 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%95 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%94, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3400,21 +3400,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%110, Acquire, 0)
-      AIE.dma_bd(<%111 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%111 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%110, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%108, Acquire, 0)
-      AIE.dma_bd(<%109 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%109 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%108, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%106, Acquire, 1)
-      AIE.dma_bd(<%107 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%107 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%106, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3453,21 +3453,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%122, Acquire, 0)
-      AIE.dma_bd(<%123 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%123 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%122, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%120, Acquire, 0)
-      AIE.dma_bd(<%121 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%121 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%120, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%118, Acquire, 1)
-      AIE.dma_bd(<%119 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%119 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%118, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3507,21 +3507,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%135, Acquire, 0)
-      AIE.dma_bd(<%136 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%136 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%135, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%133, Acquire, 0)
-      AIE.dma_bd(<%134 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%134 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%133, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%131, Acquire, 1)
-      AIE.dma_bd(<%132 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%132 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%131, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3560,21 +3560,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%147, Acquire, 0)
-      AIE.dma_bd(<%148 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%148 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%147, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%145, Acquire, 0)
-      AIE.dma_bd(<%146 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%146 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%145, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%143, Acquire, 1)
-      AIE.dma_bd(<%144 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%144 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%143, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3612,21 +3612,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%158, Acquire, 0)
-      AIE.dma_bd(<%159 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%159 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%158, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%156, Acquire, 0)
-      AIE.dma_bd(<%157 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%157 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%156, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%154, Acquire, 1)
-      AIE.dma_bd(<%155 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%155 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%154, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3665,21 +3665,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%170, Acquire, 0)
-      AIE.dma_bd(<%171 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%171 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%170, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%168, Acquire, 0)
-      AIE.dma_bd(<%169 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%169 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%168, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%166, Acquire, 1)
-      AIE.dma_bd(<%167 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%167 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%166, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3719,21 +3719,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%183, Acquire, 0)
-      AIE.dma_bd(<%184 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%184 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%183, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%181, Acquire, 0)
-      AIE.dma_bd(<%182 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%182 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%181, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%179, Acquire, 1)
-      AIE.dma_bd(<%180 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%180 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%179, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3773,21 +3773,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%196, Acquire, 0)
-      AIE.dma_bd(<%197 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%197 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%196, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%194, Acquire, 0)
-      AIE.dma_bd(<%195 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%195 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%194, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%192, Acquire, 1)
-      AIE.dma_bd(<%193 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%193 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%192, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2

--- a/test/create-flows/vecmul_4x4.mlir
+++ b/test/create-flows/vecmul_4x4.mlir
@@ -109,21 +109,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%9, Acquire, 0)
-      AIE.dma_bd(<%10 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%10 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%9, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%7, Acquire, 0)
-      AIE.dma_bd(<%8 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%8 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%7, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%5, Acquire, 1)
-      AIE.dma_bd(<%6 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%6 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%5, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -163,21 +163,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%22, Acquire, 0)
-      AIE.dma_bd(<%23 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%23 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%22, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%20, Acquire, 0)
-      AIE.dma_bd(<%21 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%21 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%20, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%18, Acquire, 1)
-      AIE.dma_bd(<%19 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%19 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%18, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -217,21 +217,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%35, Acquire, 0)
-      AIE.dma_bd(<%36 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%36 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%35, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%33, Acquire, 0)
-      AIE.dma_bd(<%34 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%34 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%33, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%31, Acquire, 1)
-      AIE.dma_bd(<%32 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%32 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%31, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -271,21 +271,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%48, Acquire, 0)
-      AIE.dma_bd(<%49 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%49 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%48, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%46, Acquire, 0)
-      AIE.dma_bd(<%47 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%47 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%46, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%44, Acquire, 1)
-      AIE.dma_bd(<%45 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%45 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%44, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -324,21 +324,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%60, Acquire, 0)
-      AIE.dma_bd(<%61 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%61 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%60, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%58, Acquire, 0)
-      AIE.dma_bd(<%59 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%59 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%58, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%56, Acquire, 1)
-      AIE.dma_bd(<%57 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%57 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%56, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -377,21 +377,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%72, Acquire, 0)
-      AIE.dma_bd(<%73 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%73 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%72, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%70, Acquire, 0)
-      AIE.dma_bd(<%71 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%71 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%70, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%68, Acquire, 1)
-      AIE.dma_bd(<%69 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%69 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%68, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -431,21 +431,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%85, Acquire, 0)
-      AIE.dma_bd(<%86 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%86 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%85, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%83, Acquire, 0)
-      AIE.dma_bd(<%84 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%84 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%83, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%81, Acquire, 1)
-      AIE.dma_bd(<%82 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%82 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%81, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -485,21 +485,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%98, Acquire, 0)
-      AIE.dma_bd(<%99 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%99 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%98, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%96, Acquire, 0)
-      AIE.dma_bd(<%97 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%97 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%96, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%94, Acquire, 1)
-      AIE.dma_bd(<%95 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%95 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%94, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -538,21 +538,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%110, Acquire, 0)
-      AIE.dma_bd(<%111 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%111 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%110, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%108, Acquire, 0)
-      AIE.dma_bd(<%109 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%109 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%108, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%106, Acquire, 1)
-      AIE.dma_bd(<%107 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%107 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%106, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -591,21 +591,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%122, Acquire, 0)
-      AIE.dma_bd(<%123 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%123 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%122, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%120, Acquire, 0)
-      AIE.dma_bd(<%121 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%121 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%120, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%118, Acquire, 1)
-      AIE.dma_bd(<%119 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%119 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%118, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -645,21 +645,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%135, Acquire, 0)
-      AIE.dma_bd(<%136 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%136 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%135, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%133, Acquire, 0)
-      AIE.dma_bd(<%134 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%134 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%133, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%131, Acquire, 1)
-      AIE.dma_bd(<%132 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%132 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%131, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -698,21 +698,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%147, Acquire, 0)
-      AIE.dma_bd(<%148 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%148 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%147, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%145, Acquire, 0)
-      AIE.dma_bd(<%146 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%146 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%145, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%143, Acquire, 1)
-      AIE.dma_bd(<%144 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%144 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%143, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -750,21 +750,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%158, Acquire, 0)
-      AIE.dma_bd(<%159 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%159 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%158, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%156, Acquire, 0)
-      AIE.dma_bd(<%157 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%157 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%156, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%154, Acquire, 1)
-      AIE.dma_bd(<%155 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%155 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%154, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -803,21 +803,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%170, Acquire, 0)
-      AIE.dma_bd(<%171 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%171 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%170, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%168, Acquire, 0)
-      AIE.dma_bd(<%169 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%169 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%168, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%166, Acquire, 1)
-      AIE.dma_bd(<%167 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%167 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%166, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -857,21 +857,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%183, Acquire, 0)
-      AIE.dma_bd(<%184 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%184 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%183, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%181, Acquire, 0)
-      AIE.dma_bd(<%182 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%182 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%181, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%179, Acquire, 1)
-      AIE.dma_bd(<%180 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%180 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%179, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -911,21 +911,21 @@ module @vecmul_4x4  {
       %200 = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       AIE.use_lock(%196, Acquire, 0)
-      AIE.dma_bd(<%197 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%197 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%196, Release, 1)
       AIE.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = AIE.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       AIE.use_lock(%194, Acquire, 0)
-      AIE.dma_bd(<%195 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%195 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%194, Release, 1)
       AIE.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = AIE.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       AIE.use_lock(%192, Acquire, 1)
-      AIE.dma_bd(<%193 : memref<64xi32, 2>, 0, 64>, A)
+      AIE.dma_bd(%193 : memref<64xi32, 2>, 0, 64)
       AIE.use_lock(%192, Release, 0)
       AIE.next_bd ^bb5
     ^bb6:  // pred: ^bb2

--- a/test/create-locks/test_lock3.mlir
+++ b/test/create-locks/test_lock3.mlir
@@ -22,7 +22,7 @@
 // CHECK:             %[[VAL_7:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_3]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_3]], Release, 0)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -32,7 +32,7 @@
 // CHECK:             %[[VAL_9:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -66,7 +66,7 @@ module @test_lock3 {
       %dmaSt = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -76,7 +76,7 @@ module @test_lock3 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf44 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf44 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock4.mlir
+++ b/test/create-locks/test_lock4.mlir
@@ -26,7 +26,7 @@
 // CHECK:             %[[VAL_11:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_6]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 0)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -38,12 +38,12 @@
 // CHECK:             %[[VAL_14:.*]] = AIE.dma_start(MM2S, 0, ^bb3, ^bb4)
 // CHECK:           ^bb2:
 // CHECK:             AIE.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb3:
 // CHECK:             AIE.use_lock(%[[VAL_3]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_3]], Release, 0)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:
@@ -53,7 +53,7 @@
 // CHECK:             %[[VAL_16:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             AIE.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -98,7 +98,7 @@ module @test_lock4 {
       %dmaSt = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -111,12 +111,12 @@ module @test_lock4 {
       %dmaSt1 = AIE.dma_start(MM2S, 0, ^bd1, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf44 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf44 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^bd1:
       AIEX.useToken @token0(Acquire, 3)
-      AIE.dma_bd(<%buf44 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf44 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 4)
       AIE.next_bd ^end
     ^end:
@@ -127,7 +127,7 @@ module @test_lock4 {
     %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 3)
-      AIE.dma_bd(<%buf55 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf55 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 4)
       AIE.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock5.mlir
+++ b/test/create-locks/test_lock5.mlir
@@ -23,21 +23,21 @@
 // CHECK:           %[[VAL_9:.*]] = AIE.buffer(%[[VAL_0]]) : memref<256xi32>
 // CHECK:           %[[VAL_10:.*]] = AIE.mem(%[[VAL_4]]) {
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 0)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 0)
 // CHECK:           }
 // CHECK:           %[[VAL_13:.*]] = AIE.mem(%[[VAL_2]]) {
 // CHECK:             AIE.use_lock(%[[VAL_3]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:             AIE.end
 // CHECK:           }
 // CHECK:           %[[VAL_15:.*]] = AIE.mem(%[[VAL_0]]) {
 // CHECK:             AIE.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             AIE.end
 // CHECK:           }
@@ -86,12 +86,12 @@ module @test_lock5 {
       %dmaSt1 = AIE.dma_start("MM2S", 1, ^bd1, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^bd1:
       AIEX.useToken @token1(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token1(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -102,7 +102,7 @@ module @test_lock5 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf44 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf44 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -113,7 +113,7 @@ module @test_lock5 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token1(Acquire, 1)
-      AIE.dma_bd(<%buf55 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf55 : memref<256xi32>, 0, 256)
       AIEX.useToken @token1(Release, 2)
       AIE.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock6.mlir
+++ b/test/create-locks/test_lock6.mlir
@@ -26,22 +26,22 @@
 // CHECK:           AIEX.token(0) {sym_name = "token1"}
 // CHECK:           %[[VAL_11:.*]] = AIE.mem(%[[VAL_5]]) {
 // CHECK:             AIE.use_lock(%[[VAL_6]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 0)
 // CHECK:             AIE.end
 // CHECK:           }
 // CHECK:           %[[VAL_13:.*]] = AIE.mem(%[[VAL_3]]) {
 // CHECK:             AIE.use_lock(%[[VAL_4]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_4]], Release, 0)
 // CHECK:             AIE.end
 // CHECK:           }
 // CHECK:           %[[VAL_15:.*]] = AIE.mem(%[[VAL_0]]) {
 // CHECK:             AIE.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             AIE.use_lock(%[[VAL_2]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<256xi32>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_2]], Release, 1)
 // CHECK:             AIE.end
 // CHECK:           }
@@ -90,7 +90,7 @@ module @test_lock6 {
       %dmaSt = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -101,7 +101,7 @@ module @test_lock6 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token1(Acquire, 1)
-      AIE.dma_bd(<%buf44 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf44 : memref<256xi32>, 0, 256)
       AIEX.useToken @token1(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -114,12 +114,12 @@ module @test_lock6 {
       %dmaSt1 = AIE.dma_start("S2MM", 1, ^bd1, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf55_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf55_0 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^bd1:
       AIEX.useToken @token1(Acquire, 1)
-      AIE.dma_bd(<%buf55_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf55_1 : memref<256xi32>, 0, 256)
       AIEX.useToken @token1(Release, 2)
       AIE.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock7.mlir
+++ b/test/create-locks/test_lock7.mlir
@@ -28,22 +28,22 @@
 // CHECK:  AIEX.token(0) {sym_name = "token1"}
 // CHECK:  %10 = AIE.mem(%4) {
 // CHECK:    AIE.use_lock({{.*}}, Acquire, 1)
-// CHECK:    AIE.dma_bd(<%7 : memref<256xi32>, 0, 256>, A)
+// CHECK:    AIE.dma_bd(%7 : memref<256xi32>, 0, 256)
 // CHECK:    AIE.use_lock({{.*}}, Release, 0)
 // CHECK:    AIE.use_lock({{.*}}, Acquire, 1)
-// CHECK:    AIE.dma_bd(<%7 : memref<256xi32>, 0, 256>, A)
+// CHECK:    AIE.dma_bd(%7 : memref<256xi32>, 0, 256)
 // CHECK:    AIE.use_lock({{.*}}, Release, 0)
 // CHECK:    AIE.end
 // CHECK:  }
 // CHECK:  %11 = AIE.mem(%2) {
 // CHECK:    AIE.use_lock(%3, Acquire, 0)
-// CHECK:    AIE.dma_bd(<%8 : memref<256xi32>, 0, 256>, A)
+// CHECK:    AIE.dma_bd(%8 : memref<256xi32>, 0, 256)
 // CHECK:    AIE.use_lock(%3, Release, 1)
 // CHECK:    AIE.end
 // CHECK:  }
 // CHECK:  %12 = AIE.mem(%0) {
 // CHECK:    AIE.use_lock(%1, Acquire, 0)
-// CHECK:    AIE.dma_bd(<%9 : memref<256xi32>, 0, 256>, A)
+// CHECK:    AIE.dma_bd(%9 : memref<256xi32>, 0, 256)
 // CHECK:    AIE.use_lock(%1, Release, 1)
 // CHECK:    AIE.end
 // CHECK:  }
@@ -92,12 +92,12 @@ module @test_lock5 {
       %dmaSt1 = AIE.dma_start("MM2S1", ^bd1, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^bd1:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -108,7 +108,7 @@ module @test_lock5 {
       %dmaSt = AIE.dma_start(S2MM0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf44 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf44 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -119,7 +119,7 @@ module @test_lock5 {
       %dmaSt = AIE.dma_start(S2MM0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf55 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf55 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock_shimdma.mlir
+++ b/test/create-locks/test_lock_shimdma.mlir
@@ -25,7 +25,7 @@
 // CHECK:     %10 = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     AIE.use_lock(%2, Acquire, 0)
-// CHECK:     AIE.dma_bd(<%0 : memref<256xi32>, 0, 256>, A)
+// CHECK:     AIE.dma_bd(%0 : memref<256xi32>, 0, 256)
 // CHECK:     AIE.use_lock(%2, Release, 1)
 // CHECK:     AIE.next_bd ^bb2
 // CHECK:   ^bb2:  // 2 preds: ^bb0, ^bb1
@@ -43,7 +43,7 @@
 // CHECK:     %10 = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     AIE.use_lock(%6, Acquire, 1)
-// CHECK:     AIE.dma_bd(<%7 : memref<256xi32>, 0, 256>, A)
+// CHECK:     AIE.dma_bd(%7 : memref<256xi32>, 0, 256)
 // CHECK:     AIE.use_lock(%6, Release, 0)
 // CHECK:     AIE.next_bd ^bb2
 // CHECK:   ^bb2:  // 2 preds: ^bb0, ^bb1
@@ -73,7 +73,7 @@ module @test_lock_shimdma {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf_ext : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_ext : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:
@@ -91,7 +91,7 @@ module @test_lock_shimdma {
       %dmaSt = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIEX.useToken @token0(Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIEX.useToken @token0(Release, 2)
       AIE.next_bd ^end
     ^end:

--- a/test/dialect/AIE/badmem_toomanybds.mlir
+++ b/test/dialect/AIE/badmem_toomanybds.mlir
@@ -17,55 +17,55 @@ AIE.device(xcvc1902) {
   %mem = AIE.mem(%t1) {
     %dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^bd15)
     ^bd0:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd3
     ^bd3:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd4
     ^bd4:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd5
     ^bd5:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd6
     ^bd6:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd7
     ^bd7:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd8
     ^bd8:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd9
     ^bd9:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd10
     ^bd10:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd11
     ^bd11:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd12
     ^bd12:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd13
     ^bd13:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd14
     ^bd14:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd15
     ^bd15:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd16
     ^bd16:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.end
   }
 }

--- a/test/dialect/AIE/badmemtiledma_channel4buffer.mlir
+++ b/test/dialect/AIE/badmemtiledma_channel4buffer.mlir
@@ -26,10 +26,10 @@ AIE.device(xcve2802) {
     ^dma1:
     AIE.dma_start("MM2S", 4, ^bd1, ^dma1)
     ^bd0:
-      AIE.dma_bd(<%buf1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf1 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd1:
-      AIE.dma_bd(<%buf2 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf2 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
       AIE.end

--- a/test/dialect/AIE/badmemtiledma_channel4lock.mlir
+++ b/test/dialect/AIE/badmemtiledma_channel4lock.mlir
@@ -27,11 +27,11 @@ AIE.device(xcve2802) {
     AIE.dma_start("MM2S", 1, ^bd1, ^dma1)
     ^bd0:
       AIE.use_lock(%lock2, "Acquire", 1)
-      AIE.dma_bd(<%buf1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf1 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd1:
       AIE.use_lock(%lock1, "Acquire", 1)
-      AIE.dma_bd(<%buf1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf1 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
       AIE.end

--- a/test/dialect/AIE/badmemtiledma_neighboraccess.mlir
+++ b/test/dialect/AIE/badmemtiledma_neighboraccess.mlir
@@ -25,19 +25,19 @@ AIE.device(xcve2802) {
     ^dma1:
     AIE.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf0 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf2 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf2 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd15
     ^bd15:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd16
     ^bd16:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.end
   }
 }

--- a/test/dialect/AIE/badshim_toomanybds.mlir
+++ b/test/dialect/AIE/badshim_toomanybds.mlir
@@ -17,55 +17,55 @@ AIE.device(xcvc1902) {
   %mem = AIE.shim_dma(%t1) {
     %dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^bd15)
     ^bd0:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd3
     ^bd3:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd4
     ^bd4:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd5
     ^bd5:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd6
     ^bd6:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd7
     ^bd7:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd8
     ^bd8:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd9
     ^bd9:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd10
     ^bd10:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd11
     ^bd11:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd12
     ^bd12:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd13
     ^bd13:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd14
     ^bd14:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd15
     ^bd15:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd16
     ^bd16:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.end
   }
 }

--- a/test/dialect/AIE/badtiledma.mlir
+++ b/test/dialect/AIE/badtiledma.mlir
@@ -34,19 +34,19 @@ module @test {
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_l, Acquire, 0)
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_e, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_l, Release, 1)
         AIE.next_bd ^end
       ^bd2:
-        AIE.dma_bd(<%buf_n : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_n : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_n, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
-        AIE.dma_bd(<%buf_s : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_s : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_s, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/dialect/AIE/badtiledma2.mlir
+++ b/test/dialect/AIE/badtiledma2.mlir
@@ -33,19 +33,19 @@ module @test {
       ^dma1:
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_e, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_l, Release, 1)
         AIE.next_bd ^end
       ^bd2:
-        AIE.dma_bd(<%buf_n : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_n : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_n, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
-        AIE.dma_bd(<%buf_s : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_s : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_s, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/dialect/AIE/badtiledma3.mlir
+++ b/test/dialect/AIE/badtiledma3.mlir
@@ -33,19 +33,19 @@ module @test {
       ^dma1:
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_e, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_l, Release, 1)
         AIE.next_bd ^end
       ^bd2:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_n, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock_s, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/dialect/AIE/example0.mlir
+++ b/test/dialect/AIE/example0.mlir
@@ -49,12 +49,12 @@ module @example0 {
       %dmaSt1 = AIE.dma_start("MM2S", 1, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%l33_0, Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_0, Release, 0)
       AIE.next_bd ^end
     ^bd1:
       AIE.use_lock(%l33_1, Acquire, 0)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_1, Release, 1)
       AIE.next_bd ^end
     ^end:
@@ -65,7 +65,7 @@ module @example0 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l42_0, Acquire, 0)
-      AIE.dma_bd(<%buf42 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf42 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l42_0, Release, 1)
       AIE.next_bd ^end
     ^end:
@@ -76,7 +76,7 @@ module @example0 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l44_0, Acquire, 1)
-      AIE.dma_bd(<%buf44 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf44 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l44_0, Release, 0)
       AIE.next_bd ^end
     ^end:

--- a/test/dialect/AIE/memtiledma.mlir
+++ b/test/dialect/AIE/memtiledma.mlir
@@ -23,55 +23,55 @@ AIE.device(xcve2802) {
     ^dma1:
     AIE.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd3
     ^bd3:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd4
     ^bd4:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd5
     ^bd5:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd6
     ^bd6:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd7
     ^bd7:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd8
     ^bd8:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd9
     ^bd9:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd10
     ^bd10:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd11
     ^bd11:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd12
     ^bd12:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd13
     ^bd13:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd14
     ^bd14:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd15
     ^bd15:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd16
     ^bd16:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.end
   }
 }

--- a/test/dialect/AIE/memtiledma_channel4buffer.mlir
+++ b/test/dialect/AIE/memtiledma_channel4buffer.mlir
@@ -25,10 +25,10 @@ AIE.device(xcve2802) {
     ^dma1:
     AIE.dma_start("MM2S", 1, ^bd1, ^dma1)
     ^bd0:
-      AIE.dma_bd(<%buf1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf1 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd1:
-      AIE.dma_bd(<%buf2 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf2 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
       AIE.end

--- a/test/dialect/AIE/memtiledma_channel4lock.mlir
+++ b/test/dialect/AIE/memtiledma_channel4lock.mlir
@@ -27,11 +27,11 @@ AIE.device(xcve2802) {
     AIE.dma_start("MM2S", 1, ^bd1, ^dma1)
     ^bd0:
       AIE.use_lock(%lock1, "Acquire", 1)
-      AIE.dma_bd(<%buf1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf1 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd1:
       AIE.use_lock(%lock2, "Acquire", 1)
-      AIE.dma_bd(<%buf1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf1 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
       AIE.end

--- a/test/dialect/AIE/memtiledma_neighboraccess.mlir
+++ b/test/dialect/AIE/memtiledma_neighboraccess.mlir
@@ -27,19 +27,19 @@ AIE.device(xcve2802) {
     ^dma1:
     AIE.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf0 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf2 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf2 : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd15
     ^bd15:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd16
     ^bd16:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.end
   }
 }

--- a/test/dialect/AIE/nd-dma-oob.mlir
+++ b/test/dialect/AIE/nd-dma-oob.mlir
@@ -30,7 +30,7 @@ module @tutorial_2b {
             // attempt an access at index 128, which is OOB for a 128xi32 
             // memref.
             // expected-error@+1 {{Specified stepsize(s) and wrap(s) result in out of bounds access}}
-            AIE.dma_bd(<%buf14 : memref<128xi32>, 0, 128>, A, [<wrap = 2, step = 128>])
+            AIE.dma_bd(%buf14 : memref<128xi32>, 0, 128, [<wrap = 2, step = 128>])
             AIE.next_bd ^end
           ^end: 
             AIE.end

--- a/test/dialect/AIE/nd-dma-too-many-dims-1.mlir
+++ b/test/dialect/AIE/nd-dma-too-many-dims-1.mlir
@@ -21,7 +21,7 @@ module @tutorial_2b {
           %srcDma = AIE.dma_start("MM2S", 0, ^bd0, ^end)
           ^bd0:
             //expected-error@+1 {{Cannot give more than 4 dimensions}}
-            AIE.dma_bd(<%buf31 : memref<128xi32>, 0, 128>, A, [<wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>])
+            AIE.dma_bd(%buf31 : memref<128xi32>, 0, 128, [<wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>])
             AIE.next_bd ^end
           ^end: 
             AIE.end

--- a/test/dialect/AIE/nd-dma-too-many-dims-2.mlir
+++ b/test/dialect/AIE/nd-dma-too-many-dims-2.mlir
@@ -21,7 +21,7 @@ module @tutorial_2b {
           %srcDma = AIE.dma_start("MM2S", 0, ^bd0, ^end)
           ^bd0:
             //expected-error@+1 {{Cannot give more than 3 dimensions}}
-            AIE.dma_bd(<%buf33 : memref<128xi32>, 0, 128>, A, [<wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>])
+            AIE.dma_bd(%buf33 : memref<128xi32>, 0, 128, [<wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>, <wrap = 1, step = 1>])
             AIE.next_bd ^end
           ^end: 
             AIE.end

--- a/test/dialect/AIE/shimdma.mlir
+++ b/test/dialect/AIE/shimdma.mlir
@@ -23,52 +23,52 @@ AIE.device(xcvc1902) {
     ^dma1:
     AIE.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd3
     ^bd3:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd4
     ^bd4:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd5
     ^bd5:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd6
     ^bd6:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd7
     ^bd7:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd8
     ^bd8:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd9
     ^bd9:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd10
     ^bd10:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd11
     ^bd11:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd12
     ^bd12:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd13
     ^bd13:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd14
     ^bd14:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd15
     ^bd15:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.end
   }
 }

--- a/test/dialect/AIE/tiledma.mlir
+++ b/test/dialect/AIE/tiledma.mlir
@@ -23,52 +23,52 @@ AIE.device(xcvc1902) {
     ^dma1:
     AIE.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd1
     ^bd1:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd2
     ^bd2:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd3
     ^bd3:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd4
     ^bd4:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd5
     ^bd5:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd6
     ^bd6:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd7
     ^bd7:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd8
     ^bd8:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd9
     ^bd9:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd10
     ^bd10:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd11
     ^bd11:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd12
     ^bd12:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd13
     ^bd13:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd14
     ^bd14:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.next_bd ^bd15
     ^bd15:
-      AIE.dma_bd(<%buf : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf : memref<256xi32>, 0, 256)
       AIE.end
   }
 }

--- a/test/lower-to-standard/lower_dma.mlir
+++ b/test/lower-to-standard/lower_dma.mlir
@@ -41,7 +41,7 @@ module @example0 {
       %dmaSt0 = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l33_0, Acquire, 1)
-      AIE.dma_bd(<%buf33 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l33_0, Release, 0)
       AIE.next_bd ^end
     ^end:
@@ -52,7 +52,7 @@ module @example0 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l43_0, Acquire, 0)
-      AIE.dma_bd(<%buf43 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf43 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l43_0, Release, 1)
       AIE.next_bd ^end
     ^end:

--- a/test/merge-buffers/test_buffer_merge0.mlir
+++ b/test/merge-buffers/test_buffer_merge0.mlir
@@ -78,7 +78,7 @@ module @test_buffer_merge0 {
       %dmaSt = AIE.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l34_0, Acquire, 1)
-      AIE.dma_bd(<%buf34_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf34_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l34_0, Release, 0)
       AIE.next_bd ^end
     ^end:
@@ -89,7 +89,7 @@ module @test_buffer_merge0 {
       %dmaSt = AIE.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l32_0, Acquire, 0)
-      AIE.dma_bd(<%buf32_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf32_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l32_0, Release, 1)
       AIE.next_bd ^end
     ^end:

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
@@ -50,12 +50,12 @@
 // CHECK:       %[[dma0:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[CL]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[buf0_0]] : memref<i32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[buf0_0]] : memref<i32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[PL]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[CL]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[buf0_1:.*]] : memref<i32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[buf0_1:.*]] : memref<i32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[PL]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -65,17 +65,17 @@
 // CHECK:       %[[dma1:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:       AIE.use_lock(%[[C_PL]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[buf1_0:.*]] : memref<i32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[buf1_0:.*]] : memref<i32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[C_CL]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[C_PL]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[buf1_1]] : memref<i32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[buf1_1]] : memref<i32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[C_CL]], Release, 1)
 // CHECK:       AIE.next_bd ^bb3
 // CHECK:     ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[C_PL]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[buf1_2]] : memref<i32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[buf1_2]] : memref<i32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[C_CL]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -153,7 +153,7 @@
 // the stream, then move on to bb2.
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[fifo0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_buff_0]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_buff_0]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_prod_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 
@@ -161,7 +161,7 @@
 // go back to bb1. Ping-pong.
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[fifo0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_buff_1]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_buff_1]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_prod_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 
@@ -182,22 +182,22 @@
 // things through the stream:
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_0]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_0]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_1]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_1]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb3
 // CHECK:     ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_2]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_2]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb4
 // CHECK:     ^bb4:  // pred: ^bb3
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_3]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_3]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 
@@ -206,22 +206,22 @@
 // CHECK:       %[[VAL_26:.*]] = AIE.dma_start(MM2S, 0, ^bb6, ^bb10)
 // CHECK:     ^bb6:  // 2 preds: ^bb5, ^bb9
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_0]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_0]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb7
 // CHECK:     ^bb7:  // pred: ^bb6
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_1]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_1]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb8
 // CHECK:     ^bb8:  // pred: ^bb7
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_2]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_2]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb9
 // CHECK:     ^bb9:  // pred: ^bb8
 // CHECK:       AIE.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo0_cons_buff_3]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo0_cons_buff_3]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb6
 // CHECK:     ^bb10:  // pred: ^bb5
@@ -242,22 +242,22 @@
 // CHECK:       %[[dma2:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo1_cons_buff_0]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo1_cons_buff_0]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo1_cons_buff_1]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo1_cons_buff_1]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb3
 // CHECK:     ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo1_cons_buff_2]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo1_cons_buff_2]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb4
 // CHECK:     ^bb4:  // pred: ^bb3
 // CHECK:       AIE.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo1_cons_buff_3]] : memref<1xi32>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo1_cons_buff_3]] : memref<1xi32>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb5:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
@@ -137,7 +137,7 @@
 // CHECK:       %11 = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       AIE.use_lock(%[[fifo_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo_buff_0]] : memref<i64>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo_buff_0]] : memref<i64>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo_prod_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb2:  // pred: ^bb0
@@ -147,7 +147,7 @@
 // CHECK:       %11 = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       AIE.use_lock(%[[fifo_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[fifo_cons_buff_0]] : memref<i64>, 0, 1>, A)
+// CHECK:       AIE.dma_bd(%[[fifo_cons_buff_0]] : memref<i64>, 0, 1)
 // CHECK:       AIE.use_lock(%[[fifo_cons_cons_lock]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb2:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE1.mlir
@@ -39,12 +39,12 @@
 // CHECK:       AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:       AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[VAL_10]], Acquire, 1)
-// CHECK:       AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_10]], Release, 0)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -54,12 +54,12 @@
 // CHECK:       AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:       AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:       AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/base_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE2.mlir
@@ -37,12 +37,12 @@
 // CHECK:       AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -52,12 +52,12 @@
 // CHECK:       AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:       AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:       AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_test.mlir
@@ -173,12 +173,12 @@
 // CHECK:             %[[VAL_65:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_31]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_29]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_29]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_31]], Release, 0)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_32]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_30]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_30]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_32]], Release, 0)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -188,12 +188,12 @@
 // CHECK:             %[[VAL_67:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_8]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -203,17 +203,17 @@
 // CHECK:             %[[VAL_69:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_12]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_13]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_13]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_14]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_11]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_11]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_14]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0
@@ -223,22 +223,22 @@
 // CHECK:             %[[VAL_71:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_19]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_15]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_15]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_20]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_16]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_16]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_21]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_22]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
@@ -248,17 +248,17 @@
 // CHECK:             %[[VAL_73:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_26]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_23]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_23]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_26]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_27]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_24]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_24]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_27]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_28]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_25]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_25]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_28]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -37,7 +37,7 @@
 // CHECK:             %[[VAL_14:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_11]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_12]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 0)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -47,24 +47,24 @@
 // CHECK:             %[[VAL_16:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_10]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_17:.*]] = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_10]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 0)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -74,12 +74,12 @@
 // CHECK:             %[[VAL_19:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -65,12 +65,12 @@
 // CHECK:             %[[VAL_32:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_13]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_11]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_11]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_13]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -80,74 +80,74 @@
 // CHECK:             %[[VAL_34:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb8)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb7
 // CHECK:             AIE.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_14]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_14]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_15]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_15]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_16]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_16]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb6:  // pred: ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_19]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_19]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:             AIE.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_20]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_20]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb8:  // pred: ^bb0
 // CHECK:             %[[VAL_35:.*]] = AIE.dma_start(MM2S, 0, ^bb9, ^bb16)
 // CHECK:           ^bb9:  // 2 preds: ^bb8, ^bb15
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_14]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_14]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb10
 // CHECK:           ^bb10:  // pred: ^bb9
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_15]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_15]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb11
 // CHECK:           ^bb11:  // pred: ^bb10
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_16]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_16]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb12
 // CHECK:           ^bb12:  // pred: ^bb11
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb13
 // CHECK:           ^bb13:  // pred: ^bb12
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb14
 // CHECK:           ^bb14:  // pred: ^bb13
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_19]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_19]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb15
 // CHECK:           ^bb15:  // pred: ^bb14
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_20]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_20]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb9
 // CHECK:           ^bb16:  // pred: ^bb8
@@ -157,22 +157,22 @@
 // CHECK:             %[[VAL_37:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<3000xi32>, 0, 3000>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<3000xi32>, 0, 3000)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -38,7 +38,7 @@
 // CHECK:             %[[VAL_15:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_13]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_13]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -48,24 +48,24 @@
 // CHECK:             %[[VAL_17:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_18:.*]] = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -75,12 +75,12 @@
 // CHECK:             %[[VAL_20:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -37,12 +37,12 @@
 // CHECK:             %[[VAL_15:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -52,24 +52,24 @@
 // CHECK:             %[[VAL_17:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_18:.*]] = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -80,7 +80,7 @@
 // CHECK:             %[[VAL_20:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_3]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_13]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_13]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -56,24 +56,24 @@
 // CHECK:             %[[VAL_28:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_21]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_21]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_24]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_22]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_22]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_24]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_29:.*]] = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_24]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_21]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_21]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_23]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_24]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_22]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_22]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_23]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -83,24 +83,24 @@
 // CHECK:             %[[VAL_31:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_12]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_13]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_13]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_32:.*]] = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -110,29 +110,29 @@
 // CHECK:             %[[VAL_34:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_16]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_16]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0
 // CHECK:             %[[VAL_35:.*]] = AIE.dma_start(S2MM, 1, ^bb5, ^bb7)
 // CHECK:           ^bb5:  // 2 preds: ^bb4, ^bb6
 // CHECK:             AIE.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb6:  // pred: ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb7:  // pred: ^bb4

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -54,7 +54,7 @@
 // CHECK:             %[[VAL_25:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_23]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_23]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -64,48 +64,48 @@
 // CHECK:             %[[VAL_27:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_19]], AcquireGreaterEqual, 3)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_20]], Release, 3)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_19]], AcquireGreaterEqual, 3)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<48xi32>, 0, 48>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<48xi32>, 0, 48)
 // CHECK:             AIE.use_lock(%[[VAL_20]], Release, 3)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_28:.*]] = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<48xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<48xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<48xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<48xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
 // CHECK:             %[[VAL_29:.*]] = AIE.dma_start(MM2S, 1, ^bb7, ^bb9)
 // CHECK:           ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:             AIE.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<48xi32>, 64, 20>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<48xi32>, 64, 20)
 // CHECK:             AIE.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             AIE.next_bd ^bb8
 // CHECK:           ^bb8:  // pred: ^bb7
 // CHECK:             AIE.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<48xi32>, 64, 20>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<48xi32>, 64, 20)
 // CHECK:             AIE.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb9:  // pred: ^bb6
 // CHECK:             %[[VAL_30:.*]] = AIE.dma_start(MM2S, 2, ^bb10, ^bb12)
 // CHECK:           ^bb10:  // 2 preds: ^bb9, ^bb11
 // CHECK:             AIE.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<48xi32>, 144, 12>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<48xi32>, 144, 12)
 // CHECK:             AIE.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             AIE.next_bd ^bb11
 // CHECK:           ^bb11:  // pred: ^bb10
 // CHECK:             AIE.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<48xi32>, 144, 12>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<48xi32>, 144, 12)
 // CHECK:             AIE.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             AIE.next_bd ^bb10
 // CHECK:           ^bb12:  // pred: ^bb9
@@ -115,12 +115,12 @@
 // CHECK:             %[[VAL_32:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_13]] : memref<4x4xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_13]] : memref<4x4xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_16]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_14]] : memref<4x4xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_14]] : memref<4x4xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_16]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -130,12 +130,12 @@
 // CHECK:             %[[VAL_34:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<20xi32>, 0, 20>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<20xi32>, 0, 20)
 // CHECK:             AIE.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<20xi32>, 0, 20>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<20xi32>, 0, 20)
 // CHECK:             AIE.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -145,12 +145,12 @@
 // CHECK:             %[[VAL_36:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<12xi32>, 0, 12>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<12xi32>, 0, 12)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<12xi32>, 0, 12>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<12xi32>, 0, 12)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -61,12 +61,12 @@
 // CHECK:             %[[VAL_30:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_27]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_24]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_24]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_26]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_27]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_25]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_25]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_26]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -76,60 +76,60 @@
 // CHECK:             %[[VAL_32:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<512xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<512xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<512xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<512xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_33:.*]] = AIE.dma_start(S2MM, 1, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<512xi8>, 128, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<512xi8>, 128, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<512xi8>, 128, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<512xi8>, 128, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
 // CHECK:             %[[VAL_34:.*]] = AIE.dma_start(S2MM, 2, ^bb7, ^bb9)
 // CHECK:           ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<512xi8>, 256, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<512xi8>, 256, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb8
 // CHECK:           ^bb8:  // pred: ^bb7
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<512xi8>, 256, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<512xi8>, 256, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb9:  // pred: ^bb6
 // CHECK:             %[[VAL_35:.*]] = AIE.dma_start(S2MM, 3, ^bb10, ^bb12)
 // CHECK:           ^bb10:  // 2 preds: ^bb9, ^bb11
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<512xi8>, 384, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<512xi8>, 384, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb11
 // CHECK:           ^bb11:  // pred: ^bb10
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<512xi8>, 384, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<512xi8>, 384, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb10
 // CHECK:           ^bb12:  // pred: ^bb9
 // CHECK:             %[[VAL_36:.*]] = AIE.dma_start(MM2S, 0, ^bb13, ^bb15)
 // CHECK:           ^bb13:  // 2 preds: ^bb12, ^bb14
 // CHECK:             AIE.use_lock(%[[VAL_11]], AcquireGreaterEqual, 4)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<512xi8>, 0, 512>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<512xi8>, 0, 512)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 4)
 // CHECK:             AIE.next_bd ^bb14
 // CHECK:           ^bb14:  // pred: ^bb13
 // CHECK:             AIE.use_lock(%[[VAL_11]], AcquireGreaterEqual, 4)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<512xi8>, 0, 512>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<512xi8>, 0, 512)
 // CHECK:             AIE.use_lock(%[[VAL_10]], Release, 4)
 // CHECK:             AIE.next_bd ^bb13
 // CHECK:           ^bb15:  // pred: ^bb12
@@ -139,12 +139,12 @@
 // CHECK:             %[[VAL_38:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_20]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_20]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_21]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_21]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -154,12 +154,12 @@
 // CHECK:             %[[VAL_40:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_16]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_16]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_18]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_17]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_17]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_18]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -169,12 +169,12 @@
 // CHECK:             %[[VAL_42:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_12]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_12]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_14]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_13]] : memref<128xi8>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_13]] : memref<128xi8>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_14]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -185,7 +185,7 @@
 // CHECK:             %[[VAL_44:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_28]] : memref<512xi8>, 0, 512>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_28]] : memref<512xi8>, 0, 512)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/matmul_test.mlir
+++ b/test/objectFifo-stateful-transform/matmul_test.mlir
@@ -89,36 +89,36 @@
 // CHECK:             %[[VAL_37:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_16]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_14]] : memref<16x8xi16>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_14]] : memref<16x8xi16>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_17]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_16]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_15]] : memref<16x8xi16>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_15]] : memref<16x8xi16>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_17]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_38:.*]] = AIE.dma_start(S2MM, 1, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<8x16xi16>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<8x16xi16>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<8x16xi16>, 0, 128>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<8x16xi16>, 0, 128)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
 // CHECK:             %[[VAL_39:.*]] = AIE.dma_start(MM2S, 0, ^bb7, ^bb9)
 // CHECK:           ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16x16xi16>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16x16xi16>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb8
 // CHECK:           ^bb8:  // pred: ^bb7
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<16x16xi16>, 0, 256>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<16x16xi16>, 0, 256)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb9:  // pred: ^bb6

--- a/test/objectFifo-stateful-transform/memTile_test.mlir
+++ b/test/objectFifo-stateful-transform/memTile_test.mlir
@@ -31,12 +31,12 @@
 // CHECK:             %[[VAL_11:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -46,12 +46,12 @@
 // CHECK:             %[[VAL_13:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_2]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -48,34 +48,34 @@
 // CHECK:       %[[VAL_26:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_2]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_2]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_3]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_3]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
 // CHECK:       %[[VAL_27:.*]] = AIE.dma_start(MM2S, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:       AIE.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 128, step = 2>])
+// CHECK:       AIE.dma_bd(%[[of1_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 128, step = 2>])
 // CHECK:       AIE.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:       AIE.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 128, step = 2>])
+// CHECK:       AIE.dma_bd(%[[of1_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 128, step = 2>])
 // CHECK:       AIE.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -85,22 +85,22 @@
 // CHECK:       %[[VAL_26:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buff_2]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buff_2]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buff_3]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buff_3]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
@@ -110,12 +110,12 @@
 // CHECK:       %[[VAL_26:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
@@ -56,24 +56,24 @@
 // CHECK:       %22 = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buf_0:.*]] : memref<256xi32>, 0, 128>, 0, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, 0, 128, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buf_1:.*]] : memref<256xi32>, 0, 128>, 0, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, 0, 128, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb4
 // CHECK:     ^bb6:  // pred: ^bb3
 // CHECK:       %23 = AIE.dma_start(MM2S, 1, ^bb7, ^bb9)
 // CHECK:     ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buf_0:.*]] : memref<256xi32>, 512, 128>, 0, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, 512, 128, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb8
 // CHECK:     ^bb8:  // pred: ^bb7
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buf_1:.*]] : memref<256xi32>, 512, 128>, 0, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, 512, 128, [<wrap = 4, step = 64>, <wrap = 2, step = 4>, <wrap = 8, step = 8>, <wrap = 4, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb7
 // CHECK:     ^bb9:  // pred: ^bb6

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
@@ -44,12 +44,12 @@
 // CHECK:       %21 = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock:.*]], AcquireGreaterEqual, 2)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buf_0:.*]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock:.*]], Release, 2)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of0_cons_prod_lock:.*]], AcquireGreaterEqual, 2)
-// CHECK:       AIE.dma_bd(<%[[of0_cons_buf_1:.*]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of0_cons_cons_lock:.*]], Release, 2)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -83,12 +83,12 @@
 // CHECK:       %21 = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[of1_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_cons_buf_0:.*]] : memref<128xi32>, 0, 128>, A)
+// CHECK:       AIE.dma_bd(%[[of1_cons_buf_0:.*]] : memref<128xi32>, 0, 128)
 // CHECK:       AIE.use_lock(%[[of1_cons_cons_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of1_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_cons_buf_1:.*]] : memref<128xi32>, 0, 128>, A)
+// CHECK:       AIE.dma_bd(%[[of1_cons_buf_1:.*]] : memref<128xi32>, 0, 128)
 // CHECK:       AIE.use_lock(%[[of1_cons_cons_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -98,12 +98,12 @@
 // CHECK:       %21 = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[of2_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of2_cons_buf_0:.*]] : memref<128xi32>, 0, 128>, A)
+// CHECK:       AIE.dma_bd(%[[of2_cons_buf_0:.*]] : memref<128xi32>, 0, 128)
 // CHECK:       AIE.use_lock(%[[of2_cons_cons_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of2_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of2_cons_buf_1:.*]] : memref<128xi32>, 0, 128>, A)
+// CHECK:       AIE.dma_bd(%[[of2_cons_buf_1:.*]] : memref<128xi32>, 0, 128)
 // CHECK:       AIE.use_lock(%[[of2_cons_cons_lock:.*]], Release, 1)
 // CHECK:       AIE.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -62,34 +62,34 @@
 // CHECK:       %[[VAL_44:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_2]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_2]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       AIE.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_buff_3]] : memref<256xi32>, 0, 256>, A, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_buff_3]] : memref<256xi32>, 0, 256, [<wrap = 16, step = 1>, <wrap = 16, step = 16>, <wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
 // CHECK:       %[[VAL_45:.*]] = AIE.dma_start(MM2S, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:       AIE.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 128, step = 2>])
+// CHECK:       AIE.dma_bd(%[[of1_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 128, step = 2>])
 // CHECK:       AIE.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:       AIE.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 128, step = 2>])
+// CHECK:       AIE.dma_bd(%[[of1_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 128, step = 2>])
 // CHECK:       AIE.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -99,22 +99,22 @@
 // CHECK:       %[[VAL_44:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_0_cons_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_0_cons_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_0_cons_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_0_cons_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_0_cons_buff_2]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_0_cons_buff_2]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       AIE.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_0_cons_buff_3]] : memref<256xi32>, 0, 256>, A, [<wrap = 1, step = 1>])
+// CHECK:       AIE.dma_bd(%[[of0_0_cons_buff_3]] : memref<256xi32>, 0, 256, [<wrap = 1, step = 1>])
 // CHECK:       AIE.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
@@ -124,34 +124,34 @@
 // CHECK:       %[[VAL_44:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       AIE.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_1_cons_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 3, step = 4>])
+// CHECK:       AIE.dma_bd(%[[of0_1_cons_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 3, step = 4>])
 // CHECK:       AIE.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_1_cons_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 3, step = 4>])
+// CHECK:       AIE.dma_bd(%[[of0_1_cons_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 3, step = 4>])
 // CHECK:       AIE.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       AIE.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_1_cons_buff_2]] : memref<256xi32>, 0, 256>, A, [<wrap = 3, step = 4>])
+// CHECK:       AIE.dma_bd(%[[of0_1_cons_buff_2]] : memref<256xi32>, 0, 256, [<wrap = 3, step = 4>])
 // CHECK:       AIE.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       AIE.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of0_1_cons_buff_3]] : memref<256xi32>, 0, 256>, A, [<wrap = 3, step = 4>])
+// CHECK:       AIE.dma_bd(%[[of0_1_cons_buff_3]] : memref<256xi32>, 0, 256, [<wrap = 3, step = 4>])
 // CHECK:       AIE.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
 // CHECK:       %[[VAL_45:.*]] = AIE.dma_start(S2MM, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:       AIE.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:       AIE.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -161,12 +161,12 @@
 // CHECK:       %[[VAL_44:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[of3_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of3_buff_0]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of3_buff_0]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of3_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of3_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of3_buff_1]] : memref<256xi32>, 0, 256>, A)
+// CHECK:       AIE.dma_bd(%[[of3_buff_1]] : memref<256xi32>, 0, 256)
 // CHECK:       AIE.use_lock(%[[of3_prod_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -176,12 +176,12 @@
 // CHECK:       %[[VAL_44:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       AIE.use_lock(%[[of3_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of3_cons_buff_0]] : memref<256xi32>, 0, 256>, A, [<wrap = 9, step = 9>])
+// CHECK:       AIE.dma_bd(%[[of3_cons_buff_0]] : memref<256xi32>, 0, 256, [<wrap = 9, step = 9>])
 // CHECK:       AIE.use_lock(%[[of3_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       AIE.use_lock(%[[of3_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       AIE.dma_bd(<%[[of3_cons_buff_1]] : memref<256xi32>, 0, 256>, A, [<wrap = 9, step = 9>])
+// CHECK:       AIE.dma_bd(%[[of3_cons_buff_1]] : memref<256xi32>, 0, 256, [<wrap = 9, step = 9>])
 // CHECK:       AIE.use_lock(%[[of3_cons_cons_lock]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
@@ -63,12 +63,12 @@
 // CHECK:             %[[VAL_24:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -78,12 +78,12 @@
 // CHECK:             %[[VAL_26:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_2]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
@@ -75,12 +75,12 @@
 // CHECK:             %[[VAL_28:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_12]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_12]], Release, 0)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_13]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_11]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_11]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_13]], Release, 0)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -90,22 +90,22 @@
 // CHECK:             %[[VAL_30:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_2]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_8]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
@@ -64,12 +64,12 @@
 // CHECK:             %[[VAL_24:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -79,12 +79,12 @@
 // CHECK:             %[[VAL_26:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_2]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -45,7 +45,7 @@
 // CHECK:             %[[VAL_17:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<64xi32>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<64xi32>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -55,17 +55,17 @@
 // CHECK:             %[[VAL_19:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_2]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -43,7 +43,7 @@
 // CHECK:             %[[VAL_17:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<64xi32>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<64xi32>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -53,17 +53,17 @@
 // CHECK:             %[[VAL_19:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_2]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -36,14 +36,14 @@
 // CHECK:             %[[VAL_17:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_13]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_14]] : memref<64xi32>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_14]] : memref<64xi32>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
 // CHECK:             %[[VAL_18:.*]] = AIE.dma_start(S2MM, 0, ^bb3, ^bb4)
 // CHECK:           ^bb3:  // 2 preds: ^bb2, ^bb3
 // CHECK:             AIE.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_15]] : memref<64xi32>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_15]] : memref<64xi32>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:             AIE.next_bd ^bb3
 // CHECK:           ^bb4:  // pred: ^bb2
@@ -54,24 +54,24 @@
 // CHECK:             %[[VAL_20:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_21:.*]] = AIE.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -40,7 +40,7 @@
 // CHECK:             %[[VAL_20:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_18]] : memref<64xi32>, 0, 64>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_18]] : memref<64xi32>, 0, 64)
 // CHECK:             AIE.use_lock(%[[VAL_16]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -50,12 +50,12 @@
 // CHECK:             %[[VAL_22:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_4]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_5]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -65,12 +65,12 @@
 // CHECK:             %[[VAL_24:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_8]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_9]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -80,12 +80,12 @@
 // CHECK:             %[[VAL_26:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_12]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_13]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_13]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/tileDMA_test.mlir
@@ -53,31 +53,31 @@
 // CHECK:             %[[VAL_24:.*]] = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_11]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_10]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_11]], Release, 0)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_13]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_12]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_13]], Release, 0)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_25:.*]] = AIE.dma_start(S2MM, 0, ^bb4, ^bb5)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:             AIE.use_lock(%[[VAL_15]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_14]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_14]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             AIE.next_bd ^bb4
 // CHECK:           ^bb5:  // pred: ^bb3
 // CHECK:             %[[VAL_26:.*]] = AIE.dma_start(MM2S, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:             AIE.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_6]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             AIE.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:             AIE.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:             AIE.dma_bd(<%[[VAL_7]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:             AIE.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -87,12 +87,12 @@
 // CHECK:             %[[VAL_28:.*]] = AIE.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             AIE.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_2]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             AIE.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             AIE.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             AIE.dma_bd(<%[[VAL_3]] : memref<16xi32>, 0, 16>, A)
+// CHECK:             AIE.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:             AIE.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             AIE.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -137,19 +137,19 @@ module @tileDMA_channels {
             %dma1 = AIE.dma_start(MM2S, 0, ^bb1, ^bb3)
         ^bb1:
             AIE.use_lock(%lock0, Acquire, 1)
-            AIE.dma_bd(<%buff0 : memref<16xi32>, 0, 16>, A)
+            AIE.dma_bd(%buff0 : memref<16xi32>, 0, 16)
             AIE.use_lock(%lock0, Release, 0)
             AIE.next_bd ^bb2
         ^bb2:
             AIE.use_lock(%lock1, Acquire, 1)
-            AIE.dma_bd(<%buff1 : memref<16xi32>, 0, 16>, A)
+            AIE.dma_bd(%buff1 : memref<16xi32>, 0, 16)
             AIE.use_lock(%lock1, Release, 0)
             AIE.next_bd ^bb1
         ^bb3:
             %dma2 = AIE.dma_start(S2MM, 0, ^bb4, ^bb5)
         ^bb4:
             AIE.use_lock(%lock2, Acquire, 0)
-            AIE.dma_bd(<%buff2 : memref<16xi32>, 0, 16>, A)
+            AIE.dma_bd(%buff2 : memref<16xi32>, 0, 16)
             AIE.use_lock(%lock2, Release, 1)
             AIE.next_bd ^bb4
         ^bb5:

--- a/test/unit_tests/aie/05_tiledma/aie.mlir
+++ b/test/unit_tests/aie/05_tiledma/aie.mlir
@@ -66,7 +66,7 @@ module @test05_tiledma {
     %dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock13_5, "Acquire", 1)
-      AIE.dma_bd(<%buf13_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf13_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock13_5, "Release", 0)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -77,7 +77,7 @@ module @test05_tiledma {
     %dma0 = AIE.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock33_6, "Acquire", 0)
-      AIE.dma_bd(<%buf33_0: memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33_0: memref<256xi32>, 0, 256)
       AIE.use_lock(%lock33_6, "Release", 1)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:

--- a/test/unit_tests/aie/08_stream_broadcast/aie.mlir
+++ b/test/unit_tests/aie/08_stream_broadcast/aie.mlir
@@ -60,7 +60,7 @@ module @test08_stream_broadcast {
     %dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock13_5, "Acquire", 1)
-      AIE.dma_bd(<%buf13_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf13_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock13_5, "Release", 0)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -97,7 +97,7 @@ module @test08_stream_broadcast {
     %dma0 = AIE.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock32_6, "Acquire", 0)
-      AIE.dma_bd(<%buf32_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf32_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock32_6, "Release", 1)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -132,7 +132,7 @@ module @test08_stream_broadcast {
     %dma0 = AIE.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock33_6, "Acquire", 0)
-      AIE.dma_bd(<%buf33_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock33_6, "Release", 1)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -167,7 +167,7 @@ module @test08_stream_broadcast {
     %dma0 = AIE.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%lock34_6, "Acquire", 0)
-      AIE.dma_bd(<%buf34_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf34_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock34_6, "Release", 1)
       AIE.next_bd ^end // point to the next BD, or termination
     ^end:

--- a/test/unit_tests/aie/09_simple_shim_dma/aie.mlir
+++ b/test/unit_tests/aie/09_simple_shim_dma/aie.mlir
@@ -32,7 +32,7 @@ module @test09_simple_shim_dma {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -51,12 +51,12 @@ module @test09_simple_shim_dma {
       %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l72_0, "Acquire", 0)
-      AIE.dma_bd(<%buf72_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l72_0, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%l72_1, "Acquire", 0)
-      AIE.dma_bd(<%buf72_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l72_1, "Release", 1)
       AIE.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/14_stream_packet/aie.mlir
+++ b/test/unit_tests/aie/14_stream_packet/aie.mlir
@@ -53,7 +53,7 @@ module @test14_stream_packet {
     ^bd0:
       AIE.use_lock(%l73, "Acquire", 0)
       AIE.dma_bd_packet(0x5, 0xD)
-      AIE.dma_bd(<%buf73 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf73 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l73, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -65,7 +65,7 @@ module @test14_stream_packet {
     ^bd0:
       AIE.use_lock(%l71, "Acquire", 0)
       AIE.dma_bd_packet(0x4, 0xC)
-      AIE.dma_bd(<%buf71 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf71 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l71, "Release", 1)
       AIE.next_bd ^end
     ^end:
@@ -85,12 +85,12 @@ module @test14_stream_packet {
     //  %srcDma1 = AIE.dma_start("S2MM", 1, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%l62, "Acquire", 0)
-      AIE.dma_bd(<%buf62 : memref<512xi32>, 0, 512>, A)
+      AIE.dma_bd(%buf62 : memref<512xi32>, 0, 512)
       AIE.use_lock(%l62, "Release", 1)
       AIE.next_bd ^end
     //^bd1:
     //  AIE.use_lock(%l62_1, "Acquire", 0)
-    //  AIE.dma_bd(<%buf62_1 : memref<256xi32>, 0, 256>, A)
+    //  AIE.dma_bd(%buf62_1 : memref<256xi32>, 0, 256)
     //  AIE.use_lock(%l62_1, "Release", 1)
     //  AIE.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/17_shim_dma_with_core/aie.mlir
+++ b/test/unit_tests/aie/17_shim_dma_with_core/aie.mlir
@@ -81,22 +81,22 @@ module @test17_shim_dma_with_core{
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_ping : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_pong : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_ping : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_pong : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -128,12 +128,12 @@ module @test17_shim_dma_with_core{
       AIE.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_in : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%lock2, Acquire, 1)
-      AIE.dma_bd(<%buffer_out : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock2, Release, 0)
       AIE.next_bd ^bd1
     ^end:

--- a/test/unit_tests/aie/18_simple_shim_dma_routed/aie.mlir
+++ b/test/unit_tests/aie/18_simple_shim_dma_routed/aie.mlir
@@ -24,7 +24,7 @@ module @test18_simple_shim_dma_routed {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -43,12 +43,12 @@ module @test18_simple_shim_dma_routed {
       %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l72_0, "Acquire", 0)
-      AIE.dma_bd(<%buf72_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l72_0, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%l72_1, "Acquire", 0)
-      AIE.dma_bd(<%buf72_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l72_1, "Release", 1)
       AIE.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/19_shim_dma_with_core_routed/aie.mlir
+++ b/test/unit_tests/aie/19_shim_dma_with_core_routed/aie.mlir
@@ -79,22 +79,22 @@ module @test19_shim_dma_with_core_routed{
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_ping : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_pong : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_ping : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_pong : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -119,12 +119,12 @@ module @test19_shim_dma_with_core_routed{
       AIE.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_in : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%lock2, Acquire, 1)
-      AIE.dma_bd(<%buffer_out : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock2, Release, 0)
       AIE.next_bd ^bd1
     ^end:

--- a/test/unit_tests/aie/20_shim_dma_broadcast/aie.mlir
+++ b/test/unit_tests/aie/20_shim_dma_broadcast/aie.mlir
@@ -24,7 +24,7 @@ module @test20_shim_dma_broadcast {
 
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^end:
@@ -43,12 +43,12 @@ module @test20_shim_dma_broadcast {
       %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l72_0, "Acquire", 0)
-      AIE.dma_bd(<%buf72_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l72_0, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%l72_1, "Acquire", 0)
-      AIE.dma_bd(<%buf72_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l72_1, "Release", 1)
       AIE.next_bd ^bd0
     ^end:
@@ -67,12 +67,12 @@ module @test20_shim_dma_broadcast {
       %srcDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.use_lock(%l73_0, "Acquire", 0)
-      AIE.dma_bd(<%buf73_0 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf73_0 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l73_0, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%l73_1, "Acquire", 0)
-      AIE.dma_bd(<%buf73_1 : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf73_1 : memref<256xi32>, 0, 256)
       AIE.use_lock(%l73_1, "Release", 1)
       AIE.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/21_shim_dma_packet/aie.mlir
+++ b/test/unit_tests/aie/21_shim_dma_packet/aie.mlir
@@ -34,7 +34,7 @@ module @kernel_gemm  {
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.use_lock(%5, Acquire, 1)
     AIE.dma_bd_packet(0, 2)
-    AIE.dma_bd(<%6 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%6 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%5, Release, 0)
     AIE.next_bd ^bb1
   ^bb2:  // pred: ^bb0
@@ -64,14 +64,14 @@ module @kernel_gemm  {
     %43 = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.use_lock(%13, Acquire, 0)
-    AIE.dma_bd(<%16 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%16 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%13, Release, 1)
     AIE.next_bd ^bb1
   ^bb2:  // pred: ^bb0
     %44 = AIE.dma_start(MM2S, 0, ^bb3, ^bb4)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.use_lock(%11, Acquire, 1)
-    AIE.dma_bd(<%15 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%15 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%11, Release, 0)
     AIE.next_bd ^bb3
   ^bb4:  // pred: ^bb2
@@ -79,7 +79,7 @@ module @kernel_gemm  {
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.use_lock(%12, Acquire, 1)
     AIE.dma_bd_packet(0, 3)
-    AIE.dma_bd(<%14 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%14 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%12, Release, 0)
     AIE.next_bd ^bb5
   ^bb6:  // pred: ^bb4
@@ -134,7 +134,7 @@ module @kernel_gemm  {
     %43 = AIE.dma_start(S2MM, 0, ^bb1, ^bb2)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.use_lock(%22, Acquire, 0)
-    AIE.dma_bd(<%31 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%31 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%22, Release, 1)
     AIE.next_bd ^bb1
   ^bb2:  // pred: ^bb0
@@ -142,20 +142,20 @@ module @kernel_gemm  {
   ^bb3:  // 2 preds: ^bb2, ^bb4
     AIE.use_lock(%24, Acquire, 0)
     AIE.dma_bd_packet(0, 2)
-    AIE.dma_bd(<%29 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%29 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%24, Release, 1)
     AIE.next_bd ^bb4
   ^bb4:  // pred: ^bb3
     AIE.use_lock(%23, Acquire, 0)
     AIE.dma_bd_packet(0, 3)
-    AIE.dma_bd(<%30 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%30 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%23, Release, 1)
     AIE.next_bd ^bb3
   ^bb5:  // pred: ^bb2
     %45 = AIE.dma_start(MM2S, 0, ^bb6, ^bb7)
   ^bb6:  // 2 preds: ^bb5, ^bb6
     AIE.use_lock(%25, Acquire, 1)
-    AIE.dma_bd(<%26 : memref<32x32xi32>, 0, 1024>, A)
+    AIE.dma_bd(%26 : memref<32x32xi32>, 0, 1024)
     AIE.use_lock(%25, Release, 0)
     AIE.next_bd ^bb6
   ^bb7:  // pred: ^bb5

--- a/test/unit_tests/aie/23_broadcast_packet/aie.mlir
+++ b/test/unit_tests/aie/23_broadcast_packet/aie.mlir
@@ -47,13 +47,13 @@ module @test23_broadcast_packet {
     ^bd4:
       AIE.use_lock(%lock72_4, "Acquire", 1)
       AIE.dma_bd_packet(0x0, 0x0)
-      AIE.dma_bd(<%buf72_0 : memref<1024xi32>, 0, 1024>, A)
+      AIE.dma_bd(%buf72_0 : memref<1024xi32>, 0, 1024)
       AIE.use_lock(%lock72_4, "Release", 0)
       AIE.next_bd ^bd5
     ^bd5:
       AIE.use_lock(%lock72_5, "Acquire", 1)
       AIE.dma_bd_packet(0x1, 0x1)
-      AIE.dma_bd(<%buf72_1 : memref<1024xi32>, 0, 1024>, A)
+      AIE.dma_bd(%buf72_1 : memref<1024xi32>, 0, 1024)
       AIE.use_lock(%lock72_5, "Release", 0)
       AIE.next_bd ^bd4
     ^end:
@@ -65,7 +65,7 @@ module @test23_broadcast_packet {
   AIE.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     AIE.use_lock(%lock63_0, Acquire, 0)
-    AIE.dma_bd(<%buf63_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf63_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock63_0, Release, 1)
     AIE.next_bd ^bd0
   ^end:
@@ -78,7 +78,7 @@ module @test23_broadcast_packet {
   AIE.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     AIE.use_lock(%lock64_0, Acquire, 0)
-    AIE.dma_bd(<%buf64_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf64_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock64_0, Release, 1)
     AIE.next_bd ^bd0
   ^end:
@@ -91,7 +91,7 @@ module @test23_broadcast_packet {
   AIE.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     AIE.use_lock(%lock73_0, Acquire, 0)
-    AIE.dma_bd(<%buf73_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf73_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock73_0, Release, 1)
     AIE.next_bd ^bd0
   ^end:
@@ -104,7 +104,7 @@ module @test23_broadcast_packet {
   AIE.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     AIE.use_lock(%lock74_0, Acquire, 0)
-    AIE.dma_bd(<%buf74_0 : memref<1024xi32>, 0, 1024>, A)
+    AIE.dma_bd(%buf74_0 : memref<1024xi32>, 0, 1024)
     AIE.use_lock(%lock74_0, Release, 1)
     AIE.next_bd ^bd0
   ^end:

--- a/test/unit_tests/aie/23_packet_biShim/aie.mlir
+++ b/test/unit_tests/aie/23_packet_biShim/aie.mlir
@@ -28,13 +28,13 @@ module @aie_module  {
     %dstDma = AIE.dma_start("MM2S", 0, ^bb3, ^end)
   ^bb2:
     AIE.use_lock(%10, Acquire, 0)
-    AIE.dma_bd(<%11 : memref<256xi32>, 0, 256>, A)
+    AIE.dma_bd(%11 : memref<256xi32>, 0, 256)
     AIE.use_lock(%10, Release, 1)
     AIE.next_bd ^bb2
   ^bb3:
     AIE.use_lock(%10, Acquire, 1)
     AIE.dma_bd_packet(0x6, 10)
-    AIE.dma_bd(<%11 : memref<256xi32>, 0, 256>, A)
+    AIE.dma_bd(%11 : memref<256xi32>, 0, 256)
     AIE.next_bd ^bb3
   ^end:
     AIE.end
@@ -47,12 +47,12 @@ module @aie_module  {
   ^bb0:
     AIE.use_lock(%lock1, Acquire, 1)
     AIE.dma_bd_packet(0x2, 3)
-    AIE.dma_bd(<%buf_i : memref<256xi32>, 0, 256>, A)
+    AIE.dma_bd(%buf_i : memref<256xi32>, 0, 256)
     AIE.use_lock(%lock1, Release, 0)
     AIE.next_bd ^bb0
   ^bb1:
     AIE.use_lock(%lock2, Acquire, 0)
-    AIE.dma_bd(<%buf_o : memref<257xi32>, 0, 257>, A)
+    AIE.dma_bd(%buf_o : memref<257xi32>, 0, 257)
     AIE.use_lock(%lock2, Release, 1)
     AIE.next_bd ^bb1
   ^end:

--- a/test/unit_tests/aie/29_aie2_nd_dma_even_odd/aie.mlir
+++ b/test/unit_tests/aie/29_aie2_nd_dma_even_odd/aie.mlir
@@ -83,7 +83,7 @@ module @tutorial_2b {
           ^bd0:
             AIE.use_lock(%lock14_done, "AcquireGreaterEqual", 1)
                                                              ////////// new //////////
-            AIE.dma_bd(<%buf14 : memref<128xi32>, 0, 128>, A, [<wrap = 8, step = 16>, <wrap = 2, step = 1>, <wrap = 8, step = 2>])
+            AIE.dma_bd(%buf14 : memref<128xi32>, 0, 128, [<wrap = 8, step = 16>, <wrap = 2, step = 1>, <wrap = 8, step = 2>])
                                                             // w, s    w, s    w,  s
                                                             // dim 2,  dim 1,  dim 0
             AIE.use_lock(%lock14_sent, "Release", 1)
@@ -96,7 +96,7 @@ module @tutorial_2b {
           %dstDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
           ^bd0:
             AIE.use_lock(%lock34_wait, "AcquireGreaterEqual", 1)
-            AIE.dma_bd(<%buf34 : memref<128xi32>, 0, 128>, A)
+            AIE.dma_bd(%buf34 : memref<128xi32>, 0, 128)
             AIE.use_lock(%lock34_recv, "Release", 1)
             AIE.next_bd ^end
           ^end:

--- a/test/unit_tests/aie/30_aie2_nd_dma_transpose_repeat/aie.mlir
+++ b/test/unit_tests/aie/30_aie2_nd_dma_transpose_repeat/aie.mlir
@@ -62,7 +62,7 @@ module @tutorial_2b {
           ^bd0:
             AIE.use_lock(%lock14_done, "AcquireGreaterEqual", 1)
                                                              ////////// new //////////
-            AIE.dma_bd(<%buf14 : memref<128xi32>, 0, 128>, A, [<wrap = 2, step = 1>, <wrap = 8, step = 1>, <wrap = 8, step = 8>])
+            AIE.dma_bd(%buf14 : memref<128xi32>, 0, 128, [<wrap = 2, step = 1>, <wrap = 8, step = 1>, <wrap = 8, step = 8>])
                                                             // w, s    w, s    w,  s
                                                             // dim 2,  dim 1,  dim 0
             AIE.use_lock(%lock14_sent, "Release", 1)
@@ -75,7 +75,7 @@ module @tutorial_2b {
           %dstDma = AIE.dma_start("S2MM", 0, ^bd0, ^end)
           ^bd0:
             AIE.use_lock(%lock34_wait, "AcquireGreaterEqual", 1)
-            AIE.dma_bd(<%buf34 : memref<128xi32>, 0, 128>, A)
+            AIE.dma_bd(%buf34 : memref<128xi32>, 0, 128)
             AIE.use_lock(%lock34_recv, "Release", 1)
             AIE.next_bd ^end
           ^end:

--- a/test/unit_tests/aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/aie2/05_shim_dma_core_function/aie.mlir
@@ -68,22 +68,22 @@ module @test_chess_05_shim_dma_core_function {
         %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_ping : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_a_ping : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_pong : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_a_pong : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^bd0
       ^bd2:
         AIE.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_b_ping : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_b_ping : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_b_write, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_b_pong : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_b_pong : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_b_write, Release, 1)
         AIE.next_bd ^bd2
       ^end:
@@ -109,12 +109,12 @@ module @test_chess_05_shim_dma_core_function {
         AIE.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         AIE.use_lock(%lock1_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buffer_in : memref<32 x i32>, 0, 32>, A)
+        AIE.dma_bd(%buffer_in : memref<32 x i32>, 0, 32)
         AIE.use_lock(%lock1_write, Release, 1)
         AIE.next_bd ^bd0
       ^bd1:
         AIE.use_lock(%lock2_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buffer_out : memref<32 x i32>, 0, 32>, A)
+        AIE.dma_bd(%buffer_out : memref<32 x i32>, 0, 32)
         AIE.use_lock(%lock2_read, Release, 1)
         AIE.next_bd ^bd1
       ^end:

--- a/test/unit_tests/aie2/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/aie2/07_shim_dma_core_function_with_loop/aie.mlir
@@ -69,22 +69,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_a_ping, "Acquire", 0)
-        AIE.dma_bd(<%buf_a_ping : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_a_ping, "Release", 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_a_pong, "Acquire", 0)
-        AIE.dma_bd(<%buf_a_pong : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_a_pong, "Release", 1)
         AIE.next_bd ^bd0
       ^bd2:
         AIE.use_lock(%lock_b_ping, "Acquire", 1)
-        AIE.dma_bd(<%buf_b_ping : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_b_ping, "Release", 0)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_b_pong, "Acquire", 1)
-        AIE.dma_bd(<%buf_b_pong : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_b_pong, "Release", 0)
         AIE.next_bd ^bd2
       ^end:
@@ -116,12 +116,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         AIE.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         AIE.use_lock(%lock1, Acquire, 1)
-        AIE.dma_bd(<%buffer_in : memref<512 x i32>, 0, 512>, A)
+        AIE.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
         AIE.use_lock(%lock1, Release, 0)
         AIE.next_bd ^bd0
       ^bd1:
         AIE.use_lock(%lock2, Acquire, 1)
-        AIE.dma_bd(<%buffer_out : memref<512 x i32>, 0, 512>, A)
+        AIE.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
         AIE.use_lock(%lock2, Release, 0)
         AIE.next_bd ^bd1
       ^end:

--- a/test/unit_tests/aie2/08_tile_locks/aie.mlir
+++ b/test/unit_tests/aie2/08_tile_locks/aie.mlir
@@ -67,22 +67,22 @@ module @test_chess_08_tile_locks {
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 4, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 4, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^end
       ^bd2:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 8, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 8, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 12, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 12, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/unit_tests/aie2/09_memtile_locks/aie.mlir
+++ b/test/unit_tests/aie2/09_memtile_locks/aie.mlir
@@ -56,7 +56,7 @@ module @test_chess_08_tile_locks {
          %srcDma = AIE.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         AIE.use_lock(%lock_d2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 0, 2>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 0, 2)
         AIE.use_lock(%lock_s2, Release, 1)
         AIE.next_bd ^end
       ^end:
@@ -69,22 +69,22 @@ module @test_chess_08_tile_locks {
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_w : memref<256xi32>, 0, 2>, A)
+        AIE.dma_bd(%buf_w : memref<256xi32>, 0, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_w : memref<256xi32>, 4, 2>, A)
+        AIE.dma_bd(%buf_w : memref<256xi32>, 4, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^end
       ^bd2:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 8, 2>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 8, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 12, 2>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 12, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
@@ -42,22 +42,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_ping : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_pong : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_a_pong : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_ping : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_b_ping : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_pong : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_b_pong : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -81,12 +81,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       AIE.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_in : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%lock2, Acquire, 1)
-      AIE.dma_bd(<%buffer_out : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock2, Release, 0)
       AIE.next_bd ^bd1
     ^end:

--- a/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
@@ -67,22 +67,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_ping : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_pong : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_a_pong : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_ping : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_b_ping : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_pong : memref<256xi32>, 0, 256>, A)
+      AIE.dma_bd(%buf_b_pong : memref<256xi32>, 0, 256)
       AIE.use_lock(%lock_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -106,12 +106,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       AIE.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_in : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%lock2, Acquire, 1)
-      AIE.dma_bd(<%buffer_out : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock2, Release, 0)
       AIE.next_bd ^bd1
     ^end:

--- a/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
@@ -73,22 +73,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.use_lock(%lock_a_ping, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_ping : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_a_ping, "Release", 1)
       AIE.next_bd ^bd1
     ^bd1:
       AIE.use_lock(%lock_a_pong, "Acquire", 0)
-      AIE.dma_bd(<%buf_a_pong : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_a_pong, "Release", 1)
       AIE.next_bd ^bd0
     ^bd2:
       AIE.use_lock(%lock_b_ping, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_ping : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_b_ping, "Release", 0)
       AIE.next_bd ^bd3
     ^bd3:
       AIE.use_lock(%lock_b_pong, "Acquire", 1)
-      AIE.dma_bd(<%buf_b_pong : memref<64xi32>, 0, 64>, A)
+      AIE.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
       AIE.use_lock(%lock_b_pong, "Release", 0)
       AIE.next_bd ^bd2
     ^end:
@@ -112,12 +112,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       AIE.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.use_lock(%lock1, Acquire, 1)
-      AIE.dma_bd(<%buffer_in : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock1, Release, 0)
       AIE.next_bd ^bd0
     ^bd1:
       AIE.use_lock(%lock2, Acquire, 1)
-      AIE.dma_bd(<%buffer_out : memref<512 x i32>, 0, 512>, A)
+      AIE.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
       AIE.use_lock(%lock2, Release, 0)
       AIE.next_bd ^bd1
     ^end:

--- a/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
@@ -62,22 +62,22 @@ module @test_chess_08_tile_locks {
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_e, Acquire, 0)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 2)
         AIE.use_lock(%lock_e, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_l, Acquire, 0)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 4, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 4, 2)
         AIE.use_lock(%lock_l, Release, 1)
         AIE.next_bd ^end
       ^bd2:
         AIE.use_lock(%lock_n, Acquire, 0)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 8, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 8, 2)
         AIE.use_lock(%lock_n, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_s, Acquire, 0)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 12, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 12, 2)
         AIE.use_lock(%lock_s, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
@@ -48,22 +48,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_ping : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_a_ping : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_pong : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_a_pong : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^bd0
       ^bd2:
         AIE.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_b_ping : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_b_ping : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_b_write, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_b_pong : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_b_pong : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_b_write, Release, 1)
         AIE.next_bd ^bd2
       ^end:
@@ -89,12 +89,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         AIE.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         AIE.use_lock(%lock1_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buffer_in : memref<32 x i32>, 0, 32>, A)
+        AIE.dma_bd(%buffer_in : memref<32 x i32>, 0, 32)
         AIE.use_lock(%lock1_write, Release, 1)
         AIE.next_bd ^bd0
       ^bd1:
         AIE.use_lock(%lock2_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buffer_out : memref<32 x i32>, 0, 32>, A)
+        AIE.dma_bd(%buffer_out : memref<32 x i32>, 0, 32)
         AIE.use_lock(%lock2_read, Release, 1)
         AIE.next_bd ^bd1
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
@@ -71,22 +71,22 @@ module @test_chess_05_shim_dma_core_function {
         %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_ping : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_a_ping : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_a_pong : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_a_pong : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_a_read, Release, 1)
         AIE.next_bd ^bd0
       ^bd2:
         AIE.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_b_ping : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_b_ping : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_b_write, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_b_pong : memref<16xi32>, 0, 16>, A)
+        AIE.dma_bd(%buf_b_pong : memref<16xi32>, 0, 16)
         AIE.use_lock(%lock_b_write, Release, 1)
         AIE.next_bd ^bd2
       ^end:
@@ -112,12 +112,12 @@ module @test_chess_05_shim_dma_core_function {
         AIE.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         AIE.use_lock(%lock1_read, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buffer_in : memref<32 x i32>, 0, 32>, A)
+        AIE.dma_bd(%buffer_in : memref<32 x i32>, 0, 32)
         AIE.use_lock(%lock1_write, Release, 1)
         AIE.next_bd ^bd0
       ^bd1:
         AIE.use_lock(%lock2_write, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buffer_out : memref<32 x i32>, 0, 32>, A)
+        AIE.dma_bd(%buffer_out : memref<32 x i32>, 0, 32)
         AIE.use_lock(%lock2_read, Release, 1)
         AIE.next_bd ^bd1
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
@@ -72,22 +72,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         %dstDma = AIE.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_a_ping, "Acquire", 0)
-        AIE.dma_bd(<%buf_a_ping : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_a_ping, "Release", 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_a_pong, "Acquire", 0)
-        AIE.dma_bd(<%buf_a_pong : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_a_pong, "Release", 1)
         AIE.next_bd ^bd0
       ^bd2:
         AIE.use_lock(%lock_b_ping, "Acquire", 1)
-        AIE.dma_bd(<%buf_b_ping : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_b_ping, "Release", 0)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_b_pong, "Acquire", 1)
-        AIE.dma_bd(<%buf_b_pong : memref<64xi32>, 0, 64>, A)
+        AIE.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
         AIE.use_lock(%lock_b_pong, "Release", 0)
         AIE.next_bd ^bd2
       ^end:
@@ -119,12 +119,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         AIE.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         AIE.use_lock(%lock1, Acquire, 1)
-        AIE.dma_bd(<%buffer_in : memref<512 x i32>, 0, 512>, A)
+        AIE.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
         AIE.use_lock(%lock1, Release, 0)
         AIE.next_bd ^bd0
       ^bd1:
         AIE.use_lock(%lock2, Acquire, 1)
-        AIE.dma_bd(<%buffer_out : memref<512 x i32>, 0, 512>, A)
+        AIE.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
         AIE.use_lock(%lock2, Release, 0)
         AIE.next_bd ^bd1
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
@@ -69,22 +69,22 @@ module @test_chess_08_tile_locks {
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 0, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 0, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 4, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 4, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^end
       ^bd2:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 8, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 8, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_l : memref<256xi32>, 12, 2>, A)
+        AIE.dma_bd(%buf_l : memref<256xi32>, 12, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
@@ -58,7 +58,7 @@ module @test_chess_08_tile_locks {
          %srcDma = AIE.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         AIE.use_lock(%lock_d2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 0, 2>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 0, 2)
         AIE.use_lock(%lock_s2, Release, 1)
         AIE.next_bd ^end
       ^end:
@@ -71,22 +71,22 @@ module @test_chess_08_tile_locks {
         %dstDma = AIE.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_w : memref<256xi32>, 0, 2>, A)
+        AIE.dma_bd(%buf_w : memref<256xi32>, 0, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^bd1
       ^bd1:
         AIE.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_w : memref<256xi32>, 4, 2>, A)
+        AIE.dma_bd(%buf_w : memref<256xi32>, 4, 2)
         AIE.use_lock(%lock_d1, Release, 1)
         AIE.next_bd ^end
       ^bd2:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 8, 2>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 8, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^bd3
       ^bd3:
         AIE.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        AIE.dma_bd(<%buf_e : memref<256xi32>, 12, 2>, A)
+        AIE.dma_bd(%buf_e : memref<256xi32>, 12, 2)
         AIE.use_lock(%lock_d2, Release, 1)
         AIE.next_bd ^end
       ^end:

--- a/tutorials/tutorial-4/flow/README.md
+++ b/tutorials/tutorial-4/flow/README.md
@@ -54,7 +54,7 @@ There are 2 tile DMAs connected to the local switchbox, each with a read and wri
     %dma1 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
     ^bd0:
         AIE.use_lock(%lock14_6, "Acquire", 1)
-        AIE.dma_bd(<%buf14: memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf14: memref<256xi32>, 0, 256)
         AIE.use_lock(%lock14_6, "Release", 0)
         AIE.next_bd ^end
     ^end:
@@ -105,22 +105,22 @@ In a common scenario where we may declare 2x DMAs (1x MM2S, 1x S2MM), each with 
         %dma2 = AIE.dma_start("S2MM", 0, ^bd3, ^end)
     ^bd0:
         AIE.use_lock(%lock14_6, "Acquire", 0)
-        AIE.dma_bd(<%buf14_1: memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf14_1: memref<256xi32>, 0, 256)
         AIE.use_lock(%lock14_6, "Release", 1)
         AIE.next_bd ^bd1
     ^bd1:
         AIE.use_lock(%lock14_7, "Acquire", 0)
-        AIE.dma_bd(<%buf14_2: memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf14_2: memref<256xi32>, 0, 256)
         AIE.use_lock(%lock14_7, "Release", 1)
         AIE.next_bd ^bd0
     ^bd3:
         AIE.use_lock(%lock14_10, "Acquire", 0)
-        AIE.dma_bd(<%buf14_3: memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf14_3: memref<256xi32>, 0, 256)
         AIE.use_lock(%lock14_10, "Release", 1)
         AIE.next_bd ^bd4
     ^bd4:
         AIE.use_lock(%lock14_11, "Acquire", 0)
-        AIE.dma_bd(<%buf14_4: memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf14_4: memref<256xi32>, 0, 256)
         AIE.use_lock(%lock14_11, "Release", 1)
         AIE.next_bd ^bd3
     ^end:

--- a/tutorials/tutorial-4/flow/aie.mlir
+++ b/tutorials/tutorial-4/flow/aie.mlir
@@ -57,7 +57,7 @@ module @tutorial_4 {
         AIE.dma_start("MM2S", 0, ^bd0, ^end)
         ^bd0:
             AIE.use_lock(%lock14_6, Acquire, 1)
-            AIE.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock14_6, Release, 0)
             AIE.next_bd ^end
         ^end:
@@ -102,7 +102,7 @@ module @tutorial_4 {
             // 0   - offset of transfer
             // 256 - length of transfer
             // 0   - A/B mode enable (default is disabled)
-            AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock34_7, Release, 1)
             AIE.next_bd ^end
         ^end:

--- a/tutorials/tutorial-4/flow/answers/aie_q5.mlir
+++ b/tutorials/tutorial-4/flow/answers/aie_q5.mlir
@@ -56,7 +56,7 @@ module @tutorial_4 {
         AIE.dma_start("MM2S", 0, ^bd0, ^end)
         ^bd0:
             AIE.use_lock(%lock14_6, Acquire, 1)
-            AIE.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock14_6, Release, 0)
             AIE.next_bd ^bd0
         ^end:
@@ -97,7 +97,7 @@ module @tutorial_4 {
             // 0   - offset of transfer
             // 256 - length of transfer
             // 0   - A/B mode enable (default is disabled)
-            AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock34_7, Release, 1)
             AIE.next_bd ^bd0
         ^end:

--- a/tutorials/tutorial-4/switchbox/aie.mlir
+++ b/tutorials/tutorial-4/switchbox/aie.mlir
@@ -61,7 +61,7 @@ module @tutorial_4 {
         AIE.dma_start("MM2S", 0, ^bd0, ^end)
         ^bd0:
             AIE.use_lock(%lock14_6, Acquire, 1)
-            AIE.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock14_6, Release, 0)
             AIE.next_bd ^end
         ^end:
@@ -104,7 +104,7 @@ module @tutorial_4 {
             // 0   - offset of transfer
             // 256 - length of transfer
             // 0   - A/B mode enable (default is disabled)
-            AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock34_7, Release, 1)
             AIE.next_bd ^end
         ^end:

--- a/tutorials/tutorial-5/flow/aie.mlir
+++ b/tutorials/tutorial-5/flow/aie.mlir
@@ -53,12 +53,12 @@ module @tutorial_5 {
         ^bd1:
             // Lock used to allow host to start transfer
             AIE.use_lock(%lock70_in, "Acquire", 1)
-            AIE.dma_bd(<%ext_buf70_in : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%ext_buf70_in : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock70_in, "Release", 0)
             AIE.next_bd ^end
         ^bd2:
             AIE.use_lock(%lock70_out, "Acquire", 1)
-            AIE.dma_bd(<%ext_buf70_out : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%ext_buf70_out : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock70_out, "Release", 0)
             AIE.next_bd ^end
         ^end:
@@ -103,12 +103,12 @@ module @tutorial_5 {
             // 0   - offset of transfer
             // 256 - length of transfer
             // 0   - A/B mode enable (default is disabled)
-            AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock34_in, "Release", 1)
             AIE.next_bd ^end
         ^bd1:
             AIE.use_lock(%lock34_out, "Acquire", 1)
-            AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock34_out, "Release", 0)
             AIE.next_bd ^end
         ^end:

--- a/tutorials/tutorial-6/README.md
+++ b/tutorials/tutorial-6/README.md
@@ -64,7 +64,7 @@ An example of this inside a BD definition would be:
     ^bd0:
         AIE.use_lock(%lock14_6, Acquire, 1)
         AIE.dma_bd_packet(0x4, 0xD) 
-        AIE.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+        AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
         AIE.use_lock(%lock14_6, Release, 0)
         cf.br ^end
 ```

--- a/tutorials/tutorial-6/aie.mlir
+++ b/tutorials/tutorial-6/aie.mlir
@@ -67,7 +67,7 @@ module @tutorial_6 {
                 // 0x4 - packet type, arbitary value
                 // 0xD - packet ID, arbitary value but used for routing
                 AIE.dma_bd_packet(0x4, 0xD)
-                AIE.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+                AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
                 AIE.use_lock(%lock14_6, Release, 0)
                 AIE.next_bd ^end
             ^end:
@@ -100,7 +100,7 @@ module @tutorial_6 {
             ^bd0:
                 AIE.use_lock(%lock34_7, Acquire, 0)
                 // Packets headers are dropped so no need to define packet behavior here
-                AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+                AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
                 AIE.use_lock(%lock34_7, Release, 1)
                 AIE.next_bd ^end
             ^end:

--- a/tutorials/tutorial-7/flow/aie.mlir
+++ b/tutorials/tutorial-7/flow/aie.mlir
@@ -76,7 +76,7 @@ module @tutorial_7 {
             // 0x4 - packet type, arbitary value
             // 0xD - packet ID, arbitary value but used for routing
             AIE.dma_bd_packet(0x4, 0xD)
-            AIE.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock14_6, Release, 0)
             AIE.next_bd ^end
         ^end:
@@ -111,7 +111,7 @@ module @tutorial_7 {
         ^bd0:
             AIE.use_lock(%lock34_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock34_7, Release, 1)
             AIE.next_bd ^end
         ^end:
@@ -146,7 +146,7 @@ module @tutorial_7 {
         ^bd0:
             AIE.use_lock(%lock35_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            AIE.dma_bd(<%buf35 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf35 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock35_7, Release, 1)
             AIE.next_bd ^end
         ^end:

--- a/tutorials/tutorial-7/switchbox/aie.mlir
+++ b/tutorials/tutorial-7/switchbox/aie.mlir
@@ -76,7 +76,7 @@ module @tutorial_7 {
             // 0x4 - packet type, arbitary value
             // 0xD - packet ID, arbitary value but used for routing
             AIE.dma_bd_packet(0x4, 0xD)
-            AIE.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock14_6, Release, 0)
             AIE.next_bd ^end
         ^end:
@@ -111,7 +111,7 @@ module @tutorial_7 {
         ^bd0:
             AIE.use_lock(%lock34_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            AIE.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock34_7, Release, 1)
             AIE.next_bd ^end
         ^end:
@@ -146,7 +146,7 @@ module @tutorial_7 {
         ^bd0:
             AIE.use_lock(%lock35_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            AIE.dma_bd(<%buf35 : memref<256xi32>, 0, 256>, A)
+            AIE.dma_bd(%buf35 : memref<256xi32>, 0, 256)
             AIE.use_lock(%lock35_7, Release, 1)
             AIE.next_bd ^end
         ^end:


### PR DESCRIPTION
This PR removes the buffer type from `dma_bd` op. Assembly changes from 

```mlir
AIE.dma_bd(<%buf0 : memref<256xi32>, 0, 256>, A)
```
(note the `A` was introduced in https://github.com/Xilinx/mlir-aie/pull/879)

to

```mlir
AIE.dma_bd(%buf0 : memref<256xi32>, 0, 256)
```

Similarly for `dma_bd`s that have dimensions.


Note this PR is based off the other PR https://github.comNo/Xilinx/mlir-aie/pull/879 which renames that attribute to `DMABuffer` but it can land independently (i.e., I'll just close the other one and change the base here to main).