### PR TITLE
refactor dma_memcpy_nd to use `OffsetSizeAndStrideOpInterface`

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -92,21 +92,13 @@ jobs:
             echo "FIXES=true" | tee $GITHUB_OUTPUT
           fi
 
-      - name: Post clang-tidy requests
+      - name: Upload clang-tidy fixes
         if: ${{ steps.clang-tidy-fixes.outputs.FIXES }}
-        env:
-          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          PULL_REQUEST_ID="$(jq "if (.issue.number != null) then .issue.number else .number end" < "$GITHUB_EVENT_PATH")"
-          echo $PULL_REQUEST_ID
-          
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}  python utils/git/clang_tidy_pr.py \
-          --clang-tidy-fixes fixes.yml \
-          --pull-request-id "$PULL_REQUEST_ID" \
-          --repository "$GITHUB_REPOSITORY" \
-          --repository-root "$PWD" \
-          --request-changes "false" \
-          --suggestions-per-comment 10
+        uses: actions/upload-artifact@v3
+        with:
+          path: fixes.yml
+          name: clang-tidy-fixes.yml
+
 
   formatting:
 

--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -47,8 +47,32 @@ struct HasValidDMAChannels
 class TileOp;
 } // namespace xilinx::AIE
 
+namespace xilinx::AIE {
+mlir::LogicalResult
+verifyOffsetSizeAndStrideOp(mlir::OffsetSizeAndStrideOpInterface op);
+} // namespace xilinx::AIE
+
 /// Include the generated interface declarations.
 #include "aie/Dialect/AIE/IR/AIEInterfaces.h.inc"
+
+namespace xilinx::AIE {
+mlir::LogicalResult
+myVerifyOffsetSizeAndStrideOp(mlir::OffsetSizeAndStrideOpInterface op);
+template <typename ConcreteOp>
+struct MyOffsetSizeAndStrideOpInterfaceTrait
+    : public ::mlir::detail::OffsetSizeAndStrideOpInterfaceTrait<ConcreteOp> {
+  static ::mlir::LogicalResult verifyTrait(::mlir::Operation *op) {
+    return myVerifyOffsetSizeAndStrideOp(
+        ::mlir::cast<::mlir::OffsetSizeAndStrideOpInterface>(op));
+  }
+};
+
+struct MyOffsetSizeAndStrideOpInterface
+    : ::mlir::OffsetSizeAndStrideOpInterface {
+  template <typename ConcreteOp>
+  struct Trait : public MyOffsetSizeAndStrideOpInterfaceTrait<ConcreteOp> {};
+};
+} // namespace xilinx::AIE
 
 // Include dialect declarations such as parseAttributes, parseType
 #include "aie/Dialect/AIE/IR/AIEDialect.h.inc"

--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -133,5 +133,12 @@ def AIETarget : OpInterface<"AIETarget"> {
   ];
 }
 
+// def OffloadingTranslationAttrTrait :
+//    NativeTrait<"OffloadingTranslationAttrTrait", ""> {
+//   let cppNamespace = "::mlir::gpu";
+// }
+
+def MyOffsetSizeAndStrideOpInterface: OpInterfaceTrait<"::xilinx::AIE::MyOffsetSizeAndStrideOpInterface"> {
+}
 
 #endif // AIE_INTERFACES

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -469,9 +469,9 @@ def AIE_IpuDmaMemcpyNdOp: AIEX_Op<"ipu.dma_memcpy_nd", []> {
         I32Attr:$y,
         AnyMemRef:$memref,
         // NOTE: these are in reverse order: offset3, offset2, ...
-        ConfinedAttr<I32ArrayAttr, [ArrayCount<4>]>:$offsets,
-        ConfinedAttr<I32ArrayAttr, [ArrayCount<4>]>:$lengths,
-        ConfinedAttr<I32ArrayAttr, [ArrayCount<3>]>:$strides,
+        ConfinedAttr<DenseI32ArrayAttr, [DenseArrayCount<4>]>:$offsets,
+        ConfinedAttr<DenseI32ArrayAttr, [DenseArrayCount<4>]>:$lengths,
+        ConfinedAttr<DenseI32ArrayAttr, [DenseArrayCount<3>]>:$strides,
         FlatSymbolRefAttr:$metadata,
         I32Attr:$id
   );

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -19,6 +19,7 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 
 def AIEX_Dialect : Dialect {
   let name = "aiex";
@@ -462,26 +463,48 @@ def AIE_SelectOp: AIEX_Op<"select", []>, Results<(outs Index)> {
   ];
 }
 
-def AIE_IpuDmaMemcpyNdOp: AIEX_Op<"ipu.dma_memcpy_nd", []> {
+def AIE_IpuDmaMemcpyNdOp: AIEX_Op<"ipu.dma_memcpy_nd", [
+    AttrSizedOperandSegments,
+    OffsetSizeAndStrideOpInterface,
+    DeclareOpInterfaceMethods<OffsetSizeAndStrideOpInterface, ["getSizes", "getStaticSizes"]>,
+  ]> {
   let summary = "half dma operator";
-  let arguments = (
-    ins I32Attr:$x,
-        I32Attr:$y,
-        AnyMemRef:$memref,
-        // NOTE: these are in reverse order: offset3, offset2, ...
-        ConfinedAttr<DenseI32ArrayAttr, [DenseArrayCount<4>]>:$offsets,
-        ConfinedAttr<DenseI32ArrayAttr, [DenseArrayCount<4>]>:$lengths,
-        ConfinedAttr<DenseI32ArrayAttr, [DenseArrayCount<3>]>:$strides,
-        FlatSymbolRefAttr:$metadata,
-        I32Attr:$id
-  );
-  let assemblyFormat = [{
-    `(` $x `,` $y `,` $memref `:` type($memref) `)` attr-dict
-  }];
-  let hasVerifier = 1;
+
   let description = [{
     nd half dma operator
   }];
+
+  let arguments = (
+    ins IndexAttr:$x,
+        IndexAttr:$y,
+        AnyMemRef:$memref,
+        // NOTE: these are in reverse order: offset3, offset2, ...
+        Variadic<Index>:$offsets,
+        Variadic<Index>:$wraps,
+        Variadic<Index>:$strides,
+        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_offsets,
+        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_wraps,
+        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<3>]>:$static_strides,
+        FlatSymbolRefAttr:$metadata,
+        IndexAttr:$id
+  );
+
+  let assemblyFormat = [{
+    $x `,` $y `,` $memref ``
+    custom<DynamicIndexList>($offsets, $static_offsets)
+    custom<DynamicIndexList>($wraps, $static_wraps)
+    custom<DynamicIndexList>($strides, $static_strides)
+    attr-dict `:` type($memref)
+  }];
+
+  let extraClassDefinition = [{
+    ::mlir::OperandRange $cppClass::getSizes() { return getWraps(); }
+    ::llvm::ArrayRef<int64_t> $cppClass::getStaticSizes() { return getStaticWraps(); }
+    unsigned $cppClass::getOffsetSizeAndStrideStartOperandIndex() { return 1; }
+    std::array<unsigned, 3> $cppClass::getArrayAttrMaxRanks() { return {4, 4, 3}; }
+  }];
+
+  let hasVerifier = 1;
 }
 
 // Write RTP

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -12,6 +12,7 @@
 #define AIEX_OPS
 
 include "aie/Dialect/AIE/IR/AIEAttrs.td"
+include "aie/Dialect/AIE/IR/AIEInterfaces.td"
 
 include "mlir/IR/OpBase.td"
 include "mlir/IR/AttrTypeBase.td"
@@ -19,7 +20,6 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/Interfaces/ViewLikeInterface.td"
 
 def AIEX_Dialect : Dialect {
   let name = "aiex";
@@ -465,8 +465,7 @@ def AIE_SelectOp: AIEX_Op<"select", []>, Results<(outs Index)> {
 
 def AIE_IpuDmaMemcpyNdOp: AIEX_Op<"ipu.dma_memcpy_nd", [
     AttrSizedOperandSegments,
-    OffsetSizeAndStrideOpInterface,
-    DeclareOpInterfaceMethods<OffsetSizeAndStrideOpInterface, ["getSizes", "getStaticSizes"]>,
+    MyOffsetSizeAndStrideOpInterface
   ]> {
   let summary = "half dma operator";
 
@@ -475,31 +474,38 @@ def AIE_IpuDmaMemcpyNdOp: AIEX_Op<"ipu.dma_memcpy_nd", [
   }];
 
   let arguments = (
-    ins IndexAttr:$x,
-        IndexAttr:$y,
+    ins I64Attr:$x,
+        I64Attr:$y,
         AnyMemRef:$memref,
         // NOTE: these are in reverse order: offset3, offset2, ...
-        Variadic<Index>:$offsets,
-        Variadic<Index>:$wraps,
-        Variadic<Index>:$strides,
+        Variadic<I64>:$offsets,
+        Variadic<I64>:$lengths,
+        Variadic<I64>:$strides,
         ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_offsets,
-        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_wraps,
+        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_lengths,
         ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<3>]>:$static_strides,
         FlatSymbolRefAttr:$metadata,
-        IndexAttr:$id
+        I64Attr:$id
   );
 
   let assemblyFormat = [{
-    $x `,` $y `,` $memref ``
-    custom<DynamicIndexList>($offsets, $static_offsets)
-    custom<DynamicIndexList>($wraps, $static_wraps)
-    custom<DynamicIndexList>($strides, $static_strides)
+    `(` $x `,` $y `,` $memref ``
+    custom<DynamicIndexList>($offsets, $static_offsets) ``
+    custom<DynamicIndexList>($lengths, $static_lengths) ``
+    custom<DynamicIndexList>($strides, $static_strides) `)`
     attr-dict `:` type($memref)
   }];
 
+  let extraClassDeclaration = [{
+    ::mlir::OperandRange getSizes();
+    ::llvm::ArrayRef<int64_t> getStaticSizes();
+    static unsigned getOffsetSizeAndStrideStartOperandIndex();
+    static std::array<unsigned, 3> getArrayAttrMaxRanks();
+  }];
+
   let extraClassDefinition = [{
-    ::mlir::OperandRange $cppClass::getSizes() { return getWraps(); }
-    ::llvm::ArrayRef<int64_t> $cppClass::getStaticSizes() { return getStaticWraps(); }
+    ::mlir::OperandRange $cppClass::getSizes() { return getLengths(); }
+    ::llvm::ArrayRef<int64_t> $cppClass::getStaticSizes() { return getStaticLengths(); }
     unsigned $cppClass::getOffsetSizeAndStrideStartOperandIndex() { return 1; }
     std::array<unsigned, 3> $cppClass::getArrayAttrMaxRanks() { return {4, 4, 3}; }
   }];

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -465,33 +465,18 @@ def AIE_SelectOp: AIEX_Op<"select", []>, Results<(outs Index)> {
 def AIE_IpuDmaMemcpyNdOp: AIEX_Op<"ipu.dma_memcpy_nd", []> {
   let summary = "half dma operator";
   let arguments = (
-    ins I32:$x,
-        I32:$y,
+    ins I32Attr:$x,
+        I32Attr:$y,
         AnyMemRef:$memref,
-        I32:$offset3,
-        I32:$offset2,
-        I32:$offset1,
-        I32:$offset0,
-        I32:$length3,
-        I32:$length2,
-        I32:$length1,
-        I32:$length0,
-        I32:$stride3,
-        I32:$stride2,
-        I32:$stride1,
+        // NOTE: these are in reverse order: offset3, offset2, ...
+        ConfinedAttr<I32ArrayAttr, [ArrayCount<4>]>:$offsets,
+        ConfinedAttr<I32ArrayAttr, [ArrayCount<4>]>:$lengths,
+        ConfinedAttr<I32ArrayAttr, [ArrayCount<3>]>:$strides,
         FlatSymbolRefAttr:$metadata,
         I32Attr:$id
   );
-  let results = (outs );
   let assemblyFormat = [{
-    `(` $x `,`$y `,`$memref
-    `[` $offset3`,`$offset2`,`$offset1`,`$offset0 `]`
-    `[` $length3`,`$length2`,`$length1`,`$length0 `]`
-    `[` $stride3`,`$stride2`,`$stride1 `]` `)` attr-dict `:`
-    `(` type($x)`,`type($y)`,`type($memref)`,`
-    `[` type($offset3)`,`type($offset2)`,`type($offset1)`,` type($offset0) `]` `,`
-    `[` type($length3)`,`type($length2)`,`type($length1)`,` type($length0) `]` `,`
-    `[` type($stride3)`,`type($stride2)`,`type($stride1) `]` `)`
+    `(` $x `,` $y `,` $memref `:` type($memref) `)` attr-dict
   }];
   let hasVerifier = 1;
   let description = [{

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -68,16 +68,16 @@ LogicalResult AIEX::IpuDmaMemcpyNdOp::verify() {
   MemRefType buffer = getMemref().getType();
   if (!buffer.getElementType().isInteger(32))
     return emitOpError("must be used with memref type i32.");
-  llvm::SmallVector<int32_t> strides(getStrides().rbegin(),
-                                     getStrides().rend());
-  llvm::SmallVector<int32_t> lengths(getLengths().rbegin(),
-                                     getLengths().rend());
+  llvm::SmallVector<int32_t> strides(getStaticStrides().rbegin(),
+                                     getStaticStrides().rend());
+  llvm::SmallVector<int32_t> wraps(getStaticWraps().rbegin(),
+                                   getStaticWraps().rend());
 
-  if (lengths[3] > 64)
+  if (wraps[3] > 64)
     return emitOpError("Length 3 exceeds the [1:64] range.");
-  if (strides[1] && lengths[1] > 0x3FF)
+  if (strides[1] && wraps[1] > 0x3FF)
     return emitOpError("Length 1 exceeds the [0:1023] range.");
-  if (strides[0] && lengths[0] > 0x3FF)
+  if (strides[0] && wraps[0] > 0x3FF)
     return emitOpError("Length 0 exceeds the [0:1023] range.");
   if (strides[2] > 0x100000)
     return emitOpError("Stride 3 exceeds the [1:1M] range.");

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -68,29 +68,11 @@ LogicalResult AIEX::IpuDmaMemcpyNdOp::verify() {
   MemRefType buffer = getMemref().getType();
   if (!buffer.getElementType().isInteger(32))
     return emitOpError("must be used with memref type i32.");
-  uint32_t strides[3]{0, 0, 0};
-  uint32_t lengths[4]{0, 0, 0, 0};
-  if (auto constOp = getStride3().getDefiningOp<arith::ConstantIntOp>()) {
-    strides[2] = static_cast<uint32_t>(constOp.value());
-  }
-  if (auto constOp = getStride2().getDefiningOp<arith::ConstantIntOp>()) {
-    strides[1] = static_cast<uint32_t>(constOp.value());
-  }
-  if (auto constOp = getStride1().getDefiningOp<arith::ConstantIntOp>()) {
-    strides[0] = static_cast<uint32_t>(constOp.value());
-  }
-  if (auto constOp = getLength3().getDefiningOp<arith::ConstantIntOp>()) {
-    lengths[3] = static_cast<uint32_t>(constOp.value());
-  }
-  if (auto constOp = getLength2().getDefiningOp<arith::ConstantIntOp>()) {
-    lengths[2] = static_cast<uint32_t>(constOp.value());
-  }
-  if (auto constOp = getLength1().getDefiningOp<arith::ConstantIntOp>()) {
-    lengths[1] = static_cast<uint32_t>(constOp.value());
-  }
-  if (auto constOp = getLength0().getDefiningOp<arith::ConstantIntOp>()) {
-    lengths[0] = static_cast<uint32_t>(constOp.value());
-  }
+  llvm::SmallVector<uint32_t> strides(
+      llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(getStrides())));
+  llvm::SmallVector<uint32_t> lengths(
+      llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(getLengths())));
+
   if (lengths[3] > 64)
     return emitOpError("Length 3 exceeds the [1:64] range.");
   if (strides[1] && lengths[1] > 0x3FF)

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -68,10 +68,27 @@ LogicalResult AIEX::IpuDmaMemcpyNdOp::verify() {
   MemRefType buffer = getMemref().getType();
   if (!buffer.getElementType().isInteger(32))
     return emitOpError("must be used with memref type i32.");
-  llvm::SmallVector<int64_t> strides(getStaticStrides().rbegin(),
-                                     getStaticStrides().rend());
-  llvm::SmallVector<int64_t> lengths(getStaticLengths().rbegin(),
-                                   getStaticLengths().rend());
+  if (!llvm::all_of(getMixedStrides(), [](OpFoldResult s) {
+        return getConstantIntValue(s).has_value();
+      }))
+    llvm::report_fatal_error("Only constant strides currently supported.");
+  if (!llvm::all_of(getMixedSizes(), [](OpFoldResult s) {
+        return getConstantIntValue(s).has_value();
+      }))
+    llvm::report_fatal_error("Only constant lengths currently supported.");
+  if (!llvm::all_of(getMixedOffsets(), [](OpFoldResult s) {
+        return getConstantIntValue(s).has_value();
+      }))
+    llvm::report_fatal_error("Only constant offsets currently supported.");
+
+  llvm::SmallVector<int64_t, 3> strides =
+      llvm::map_to_vector(llvm::reverse(getMixedStrides()), [](OpFoldResult s) {
+        return getConstantIntValue(s).value();
+      });
+  llvm::SmallVector<int64_t, 4> lengths =
+      llvm::map_to_vector(llvm::reverse(getMixedSizes()), [](OpFoldResult s) {
+        return getConstantIntValue(s).value();
+      });
 
   if (lengths[3] > 64)
     return emitOpError("Length 3 exceeds the [1:64] range.");

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -68,10 +68,10 @@ LogicalResult AIEX::IpuDmaMemcpyNdOp::verify() {
   MemRefType buffer = getMemref().getType();
   if (!buffer.getElementType().isInteger(32))
     return emitOpError("must be used with memref type i32.");
-  llvm::SmallVector<uint32_t> strides(
-      llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(getStrides())));
-  llvm::SmallVector<uint32_t> lengths(
-      llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(getLengths())));
+  llvm::SmallVector<int32_t> strides(getStrides().rbegin(),
+                                     getStrides().rend());
+  llvm::SmallVector<int32_t> lengths(getLengths().rbegin(),
+                                     getLengths().rend());
 
   if (lengths[3] > 64)
     return emitOpError("Length 3 exceeds the [1:64] range.");

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -68,16 +68,16 @@ LogicalResult AIEX::IpuDmaMemcpyNdOp::verify() {
   MemRefType buffer = getMemref().getType();
   if (!buffer.getElementType().isInteger(32))
     return emitOpError("must be used with memref type i32.");
-  llvm::SmallVector<int32_t> strides(getStaticStrides().rbegin(),
+  llvm::SmallVector<int64_t> strides(getStaticStrides().rbegin(),
                                      getStaticStrides().rend());
-  llvm::SmallVector<int32_t> wraps(getStaticWraps().rbegin(),
-                                   getStaticWraps().rend());
+  llvm::SmallVector<int64_t> lengths(getStaticLengths().rbegin(),
+                                   getStaticLengths().rend());
 
-  if (wraps[3] > 64)
+  if (lengths[3] > 64)
     return emitOpError("Length 3 exceeds the [1:64] range.");
-  if (strides[1] && wraps[1] > 0x3FF)
+  if (strides[1] && lengths[1] > 0x3FF)
     return emitOpError("Length 1 exceeds the [0:1023] range.");
-  if (strides[0] && wraps[0] > 0x3FF)
+  if (strides[0] && lengths[0] > 0x3FF)
     return emitOpError("Length 0 exceeds the [0:1023] range.");
   if (strides[2] > 0x100000)
     return emitOpError("Stride 3 exceeds the [1:1M] range.");

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
@@ -194,12 +194,12 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
     auto issue_token = BoolAttr::get(ctx, false);
     auto repeat_count = zero;
 
-    SmallVector<uint32_t, 4> offsets(
-        llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(op.getOffsets())));
-    SmallVector<uint32_t, 4> lengths(
-        llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(op.getLengths())));
-    SmallVector<uint32_t, 3> strides(
-        llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(op.getStrides())));
+    SmallVector<int32_t, 4> offsets(op.getOffsets().rbegin(),
+                                    op.getOffsets().rend());
+    SmallVector<int32_t, 4> lengths(op.getLengths().rbegin(),
+                                    op.getLengths().rend());
+    SmallVector<int32_t, 3> strides(op.getStrides().rbegin(),
+                                    op.getStrides().rend());
 
     // column
     column = IntegerAttr::get(i32ty, col);
@@ -224,9 +224,9 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
     bd_id = IntegerAttr::get(i32ty, op.getId());
 
     // buffer_length
-    uint32_t repeat_length = 0;
-    for (uint32_t index_3d = 0; index_3d < lengths[2]; index_3d++)
-      for (uint32_t index_2d = 0; index_2d < lengths[1]; index_2d++)
+    int32_t repeat_length = 0;
+    for (int32_t index_3d = 0; index_3d < lengths[2]; index_3d++)
+      for (int32_t index_2d = 0; index_2d < lengths[1]; index_2d++)
         repeat_length += lengths[0];
     buffer_length = IntegerAttr::get(i32ty, repeat_length);
 

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
@@ -194,32 +194,12 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
     auto issue_token = BoolAttr::get(ctx, false);
     auto repeat_count = zero;
 
-    SmallVector<uint32_t, 4> offsets(4, 0);
-    SmallVector<uint32_t, 4> lengths(4, 1);
-    SmallVector<uint32_t, 3> strides(3, 0);
-
-    if (auto c = op.getOffset0().getDefiningOp<arith::ConstantIntOp>())
-      offsets[0] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getOffset1().getDefiningOp<arith::ConstantIntOp>())
-      offsets[1] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getOffset2().getDefiningOp<arith::ConstantIntOp>())
-      offsets[2] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getOffset3().getDefiningOp<arith::ConstantIntOp>())
-      offsets[3] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getLength0().getDefiningOp<arith::ConstantIntOp>())
-      lengths[0] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getLength1().getDefiningOp<arith::ConstantIntOp>())
-      lengths[1] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getLength2().getDefiningOp<arith::ConstantIntOp>())
-      lengths[2] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getLength3().getDefiningOp<arith::ConstantIntOp>())
-      lengths[3] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getStride1().getDefiningOp<arith::ConstantIntOp>())
-      strides[0] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getStride2().getDefiningOp<arith::ConstantIntOp>())
-      strides[1] = static_cast<uint32_t>(c.value());
-    if (auto c = op.getStride3().getDefiningOp<arith::ConstantIntOp>())
-      strides[2] = static_cast<uint32_t>(c.value());
+    SmallVector<uint32_t, 4> offsets(
+        llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(op.getOffsets())));
+    SmallVector<uint32_t, 4> lengths(
+        llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(op.getLengths())));
+    SmallVector<uint32_t, 3> strides(
+        llvm::reverse(extractFromIntegerArrayAttr<uint32_t>(op.getStrides())));
 
     // column
     column = IntegerAttr::get(i32ty, col);

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
@@ -194,12 +194,15 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
     auto issue_token = BoolAttr::get(ctx, false);
     auto repeat_count = zero;
 
-    SmallVector<int64_t, 4> offsets(op.getStaticOffsets().rbegin(),
-                                    op.getStaticOffsets().rend());
-    SmallVector<int64_t, 4> lengths(op.getStaticLengths().rbegin(),
-                                  op.getStaticLengths().rend());
-    SmallVector<int64_t, 3> strides(op.getStaticStrides().rbegin(),
-                                    op.getStaticStrides().rend());
+    llvm::SmallVector<int64_t, 3> strides = llvm::map_to_vector(
+        llvm::reverse(op.getMixedStrides()),
+        [](OpFoldResult s) { return getConstantIntValue(s).value(); });
+    llvm::SmallVector<int64_t, 4> lengths = llvm::map_to_vector(
+        llvm::reverse(op.getMixedSizes()),
+        [](OpFoldResult s) { return getConstantIntValue(s).value(); });
+    llvm::SmallVector<int64_t, 4> offsets = llvm::map_to_vector(
+        llvm::reverse(op.getMixedOffsets()),
+        [](OpFoldResult s) { return getConstantIntValue(s).value(); });
 
     // column
     column = IntegerAttr::get(i32ty, col);

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
@@ -196,8 +196,8 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
 
     SmallVector<int64_t, 4> offsets(op.getStaticOffsets().rbegin(),
                                     op.getStaticOffsets().rend());
-    SmallVector<int64_t, 4> wraps(op.getStaticWraps().rbegin(),
-                                  op.getStaticWraps().rend());
+    SmallVector<int64_t, 4> lengths(op.getStaticLengths().rbegin(),
+                                  op.getStaticLengths().rend());
     SmallVector<int64_t, 3> strides(op.getStaticStrides().rbegin(),
                                     op.getStaticStrides().rend());
 
@@ -225,9 +225,9 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
 
     // buffer_length
     int32_t repeat_length = 0;
-    for (int32_t index_3d = 0; index_3d < wraps[2]; index_3d++)
-      for (int32_t index_2d = 0; index_2d < wraps[1]; index_2d++)
-        repeat_length += wraps[0];
+    for (int32_t index_3d = 0; index_3d < lengths[2]; index_3d++)
+      for (int32_t index_2d = 0; index_2d < lengths[1]; index_2d++)
+        repeat_length += lengths[0];
     buffer_length = IntegerAttr::get(i32ty, repeat_length);
 
     // buffer_offset
@@ -253,14 +253,14 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
 
     // d0_wrap
     if (strides[0])
-      d0_wrap = IntegerAttr::get(i32ty, wraps[0]);
+      d0_wrap = IntegerAttr::get(i32ty, lengths[0]);
 
     // d0_stepsize
     d0_stepsize = IntegerAttr::get(i32ty, 0);
 
     // d1_wrap
     if (strides[1])
-      d1_wrap = IntegerAttr::get(i32ty, wraps[1]);
+      d1_wrap = IntegerAttr::get(i32ty, lengths[1]);
 
     // d1_stepsize
     if (strides[0])
@@ -274,7 +274,7 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
 
     // iteration_wrap
     if (strides[2])
-      iteration_wrap = IntegerAttr::get(i32ty, wraps[3] - 1);
+      iteration_wrap = IntegerAttr::get(i32ty, lengths[3] - 1);
 
     // iteration_stepsize
     if (strides[2])
@@ -302,7 +302,7 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
     // lock_acq_id
 
     // repeat_count
-    repeat_count = IntegerAttr::get(i32ty, wraps[3] - 1);
+    repeat_count = IntegerAttr::get(i32ty, lengths[3] - 1);
 
     // issue_token
     if (!isMM2S)

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -28,26 +28,17 @@ class IpuDmaMemcpyNd(IpuDmaMemcpyNdOp):
             lengths = [0] * 4
         if offsets is None:
             offsets = [0] * 4
-        symMetadata = FlatSymbolRefAttr.get(metadata)
         x = 0
         y = 0
         super().__init__(
-            metadata=symMetadata,
+            metadata=metadata,
             id=bd_id,
             x=x,
             y=y,
             memref=mem,
-            offset3=offsets[0],
-            offset2=offsets[1],
-            offset1=offsets[2],
-            offset0=offsets[3],
-            length3=lengths[0],
-            length2=lengths[1],
-            length1=lengths[2],
-            length0=lengths[3],
-            stride3=strides[0],
-            stride2=strides[1],
-            stride1=strides[2],
+            offsets=offsets,
+            lengths=lengths,
+            strides=strides,
         )
 
 

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -63,5 +63,4 @@ class IpuDmaMemcpyNd(IpuDmaMemcpyNdOp):
         )
 
 
-ipu_dma_memcpy_nd_ = ipu_dma_memcpy_nd
 ipu_dma_memcpy_nd = IpuDmaMemcpyNd

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -29,37 +29,25 @@ class IpuDmaMemcpyNd(IpuDmaMemcpyNdOp):
         if offsets is None:
             offsets = [0] * 4
         symMetadata = FlatSymbolRefAttr.get(metadata)
-        iTy = IntegerType.get_signless(32)
         x = 0
         y = 0
-        intX = arith.ConstantOp(iTy, IntegerAttr.get(iTy, x))
-        intY = arith.ConstantOp(iTy, IntegerAttr.get(iTy, y))
-        valueOffsets = []
-        valueLengths = []
-        valueStrides = []
-        for i in offsets:
-            valueOffsets.append(arith.ConstantOp(iTy, IntegerAttr.get(iTy, i)))
-        for i in lengths:
-            valueLengths.append(arith.ConstantOp(iTy, IntegerAttr.get(iTy, i)))
-        for i in strides:
-            valueStrides.append(arith.ConstantOp(iTy, IntegerAttr.get(iTy, i)))
         super().__init__(
             metadata=symMetadata,
             id=bd_id,
-            x=intX,
-            y=intY,
+            x=x,
+            y=y,
             memref=mem,
-            offset3=valueOffsets[0],
-            offset2=valueOffsets[1],
-            offset1=valueOffsets[2],
-            offset0=valueOffsets[3],
-            length3=valueLengths[0],
-            length2=valueLengths[1],
-            length1=valueLengths[2],
-            length0=valueLengths[3],
-            stride3=valueStrides[0],
-            stride2=valueStrides[1],
-            stride1=valueStrides[2],
+            offset3=offsets[0],
+            offset2=offsets[1],
+            offset1=offsets[2],
+            offset0=offsets[3],
+            length3=lengths[0],
+            length2=lengths[1],
+            length1=lengths[2],
+            length0=lengths[3],
+            stride3=strides[0],
+            stride2=strides[1],
+            stride1=strides[2],
         )
 
 

--- a/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
@@ -221,7 +221,6 @@ def my_matmul():
                     ipu_sync(column=0, row=0, direction=0, channel=0)
 
     print(ctx.module)
-    print(ctx.module.operation.verify())
 
 
 my_matmul()

--- a/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
@@ -221,6 +221,7 @@ def my_matmul():
                     ipu_sync(column=0, row=0, direction=0, channel=0)
 
     print(ctx.module)
+    print(ctx.module.operation.verify())
 
 
 my_matmul()

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_1080.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_1080.mlir
@@ -47,12 +47,14 @@ module @passThroughLine_aie2 {
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<518400xi32>, %arg1 : memref<1xi32>, %out : memref<518400xi32>) {
-            // %tileheight = arith.constant 1080  : i32
-            //%tilewidth  = arith.constant 480 : i32  // in 32b words so tileWidth/4
+            %c0 = arith.constant 0 : i32
+            %c1 = arith.constant 1 : i32
+            %tileheight = arith.constant 1080  : i32
+            %tilewidth  = arith.constant 480 : i32  // in 32b words so tileWidth/4
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<518400xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 1080  : i32, 480  : i32], strides = [0 : i32, 0 : i32, 480  : i32],  metadata = @inOF, id = 1 : i32 }
-            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<518400xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 1080  : i32, 480  : i32], strides = [0 : i32, 0 : i32, 480  : i32],  metadata = @outOF, id = 0 : i32 }
+            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<518400xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<518400xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_1080.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_1080.mlir
@@ -47,14 +47,14 @@ module @passThroughLine_aie2 {
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<518400xi32>, %arg1 : memref<1xi32>, %out : memref<518400xi32>) {
-            %c0 = arith.constant 0 : i32
-            %c1 = arith.constant 1 : i32
-            %tileheight = arith.constant 1080  : i32
-            %tilewidth  = arith.constant 480 : i32  // in 32b words so tileWidth/4
+            %c0 = arith.constant 0 : i64
+            %c1 = arith.constant 1 : i64
+            %tileheight = arith.constant 1080  : i64
+            %tilewidth  = arith.constant 480 : i64  // in 32b words so tileWidth/4
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<518400xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<518400xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i64 } : memref<518400xi32>
+            aiex.ipu.dma_memcpy_nd (0, 0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i64 } : memref<518400xi32>
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_1080.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_1080.mlir
@@ -51,8 +51,8 @@ module @passThroughLine_aie2 {
             //%tilewidth  = arith.constant 480 : i32  // in 32b words so tileWidth/4
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<518400xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1080  : i32, 480  : i32], strides = [0 : i32, 0 : i32, 480  : i32],  metadata = @inOF, id = 1 : i32 }
-            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<518400xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1080  : i32, 480  : i32], strides = [0 : i32, 0 : i32, 480  : i32],  metadata = @outOF, id = 0 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<518400xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 1080  : i32, 480  : i32], strides = [0 : i32, 0 : i32, 480  : i32],  metadata = @inOF, id = 1 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<518400xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 1080  : i32, 480  : i32], strides = [0 : i32, 0 : i32, 480  : i32],  metadata = @outOF, id = 0 : i32 }
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
@@ -47,17 +47,15 @@ module @passThroughLine_aie2 {
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<2073600xi32>, %arg1 : memref<1xi32>, %out : memref<2073600xi32>) {
-            %c0 = arith.constant 0 : i32
-            %c1 = arith.constant 1 : i32
-            %tileheight = arith.constant 1080  : i32
-            %tilewidth  = arith.constant 1920 : i32  // in 32b words so tileWidth/4
-            %totalLenRGBA = arith.constant 2073600 : i32
+            %c0 = arith.constant 0 : i64
+            %c1 = arith.constant 1 : i64
+            %tileheight = arith.constant 1080  : i64
+            %tilewidth  = arith.constant 1920 : i64  // in 32b words so tileWidth/4
+            %totalLenRGBA = arith.constant 2073600 : i64
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            //aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            //aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @inOF, id = 1 : i64 } : memref<2073600xi32>
+            aiex.ipu.dma_memcpy_nd (0, 0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @outOF, id = 0 : i64 } : memref<2073600xi32>
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
@@ -20,8 +20,8 @@ module @passThroughLine_aie2 {
         %tile00 = aie.tile(0, 0)
         %tile02 = aie.tile(0, 2)
 
-        aie.objectFifo @inOF(%tile00, {%tile02}, 2 : i32) : !aie.objectFifo<memref<7680xui8>>
-        aie.objectFifo @outOF(%tile02, {%tile00}, 2 : i32) : !aie.objectFifo<memref<7680xui8>>
+        aie.objectfifo @inOF(%tile00, {%tile02}, 2 : i32) : !aie.objectfifo<memref<7680xui8>>
+        aie.objectfifo @outOF(%tile02, {%tile00}, 2 : i32) : !aie.objectfifo<memref<7680xui8>>
        
         // Define the algorithm for the core of tile(0,2) 
         %core02 = aie.core(%tile02) {
@@ -31,33 +31,25 @@ module @passThroughLine_aie2 {
             %tilewidth  = arith.constant 7680 : i32
             
             scf.for %iter = %c0 to %tileheight step %c1 { 
-                // Acquire objectFifos and get subviews
-                %subviewIn = aie.objectFifo.acquire @inOF(Consume, 1) : !aie.objectFifoSubview<memref<7680xui8>>
-                %elemIn = aie.objectFifo.subview.access %subviewIn[0] : !aie.objectFifoSubview<memref<7680xui8>> -> memref<7680xui8>
-                %subviewOut = aie.objectFifo.acquire @outOF(Produce, 1) : !aie.objectFifoSubview<memref<7680xui8>>
-                %elemOut = aie.objectFifo.subview.access %subviewOut[0] : !aie.objectFifoSubview<memref<7680xui8>> -> memref<7680xui8>
+                // Acquire objectfifos and get subviews
+                %subviewIn = aie.objectfifo.acquire @inOF(Consume, 1) : !aie.objectfifosubview<memref<7680xui8>>
+                %elemIn = aie.objectfifo.subview.access %subviewIn[0] : !aie.objectfifosubview<memref<7680xui8>> -> memref<7680xui8>
+                %subviewOut = aie.objectfifo.acquire @outOF(Produce, 1) : !aie.objectfifosubview<memref<7680xui8>>
+                %elemOut = aie.objectfifo.subview.access %subviewOut[0] : !aie.objectfifosubview<memref<7680xui8>> -> memref<7680xui8>
 
                 func.call @passThroughLine(%elemIn, %elemOut, %tilewidth) : (memref<7680xui8>, memref<7680xui8>, i32) -> ()
 
-                // Release objectFifos
-                aie.objectFifo.release @inOF(Consume, 1)
-                aie.objectFifo.release @outOF(Produce, 1)
+                // Release objectfifos
+                aie.objectfifo.release @inOF(Consume, 1)
+                aie.objectfifo.release @outOF(Produce, 1)
             }
             aie.end
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<2073600xi32>, %arg1 : memref<1xi32>, %out : memref<2073600xi32>) {
-            %c0 = arith.constant 0 : i32
-            %c1 = arith.constant 1 : i32
-            %tileheight = arith.constant 1080  : i32
-            %tilewidth  = arith.constant 1920 : i32  // in 32b words so tileWidth/4
-            %totalLenRGBA = arith.constant 2073600 : i32
-
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            //aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            //aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<2073600xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 2073600 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @inOF, id = 1 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<2073600xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 2073600 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @outOF, id = 0 : i32 }
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
@@ -48,8 +48,8 @@ module @passThroughLine_aie2 {
 
         func.func @sequence(%in : memref<2073600xi32>, %arg1 : memref<1xi32>, %out : memref<2073600xi32>) {
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<2073600xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 2073600 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @inOF, id = 1 : i32 }
-            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<2073600xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 2073600 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @outOF, id = 0 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<2073600xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 2073600>, strides = array<i32: 0, 0, 0>,  metadata = @inOF, id = 1 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<2073600xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 2073600>, strides = array<i32: 0, 0, 0>,  metadata = @outOF, id = 0 : i32 }
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_8k.mlir
@@ -47,9 +47,17 @@ module @passThroughLine_aie2 {
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<2073600xi32>, %arg1 : memref<1xi32>, %out : memref<2073600xi32>) {
+            %c0 = arith.constant 0 : i32
+            %c1 = arith.constant 1 : i32
+            %tileheight = arith.constant 1080  : i32
+            %tilewidth  = arith.constant 1920 : i32  // in 32b words so tileWidth/4
+            %totalLenRGBA = arith.constant 2073600 : i32
+
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<2073600xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 2073600>, strides = array<i32: 0, 0, 0>,  metadata = @inOF, id = 1 : i32 }
-            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<2073600xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 2073600>, strides = array<i32: 0, 0, 0>,  metadata = @outOF, id = 0 : i32 }
+            //aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            //aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<2073600xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
@@ -20,8 +20,8 @@ module @passThroughLine_aie2 {
         %tile00 = aie.tile(0, 0)
         %tile02 = aie.tile(0, 2)
 
-        aie.objectFifo @inOF(%tile00, {%tile02}, 2 : i32) : !aie.objectFifo<memref<512xui8>>
-        aie.objectFifo @outOF(%tile02, {%tile00}, 2 : i32) : !aie.objectFifo<memref<512xui8>>
+        aie.objectfifo @inOF(%tile00, {%tile02}, 2 : i32) : !aie.objectfifo<memref<512xui8>>
+        aie.objectfifo @outOF(%tile02, {%tile00}, 2 : i32) : !aie.objectfifo<memref<512xui8>>
        
         // Define the algorithm for the core of tile(0,2) 
         %core02 = aie.core(%tile02) {
@@ -31,30 +31,28 @@ module @passThroughLine_aie2 {
             %tilewidth  = arith.constant 512 : i32
             
             scf.for %iter = %c0 to %tileheight step %c1 { 
-                // Acquire objectFifos and get subviews
-                %subviewIn = aie.objectFifo.acquire @inOF(Consume, 1) : !aie.objectFifoSubview<memref<512xui8>>
-                %elemIn = aie.objectFifo.subview.access %subviewIn[0] : !aie.objectFifoSubview<memref<512xui8>> -> memref<512xui8>
-                %subviewOut = aie.objectFifo.acquire @outOF(Produce, 1) : !aie.objectFifoSubview<memref<512xui8>>
-                %elemOut = aie.objectFifo.subview.access %subviewOut[0] : !aie.objectFifoSubview<memref<512xui8>> -> memref<512xui8>
+                // Acquire objectfifos and get subviews
+                %subviewIn = aie.objectfifo.acquire @inOF(Consume, 1) : !aie.objectfifosubview<memref<512xui8>>
+                %elemIn = aie.objectfifo.subview.access %subviewIn[0] : !aie.objectfifosubview<memref<512xui8>> -> memref<512xui8>
+                %subviewOut = aie.objectfifo.acquire @outOF(Produce, 1) : !aie.objectfifosubview<memref<512xui8>>
+                %elemOut = aie.objectfifo.subview.access %subviewOut[0] : !aie.objectfifosubview<memref<512xui8>> -> memref<512xui8>
 
                 func.call @passThroughLine(%elemIn, %elemOut, %tilewidth) : (memref<512xui8>, memref<512xui8>, i32) -> ()
 
-                // Release objectFifos
-                aie.objectFifo.release @inOF(Consume, 1)
-                aie.objectFifo.release @outOF(Produce, 1)
+                // Release objectfifos
+                aie.objectfifo.release @inOF(Consume, 1)
+                aie.objectfifo.release @outOF(Produce, 1)
             }
             aie.end
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<1152xi32>, %arg1 : memref<1xi32>, %out : memref<1152xi32>) {
-            %c0 = arith.constant 0 : i32
-            %c1 = arith.constant 1 : i32
-            %tileheight = arith.constant 9  : i32
-            %tilewidth  = arith.constant 128 : i32  // in 32b words so tileWidth/4
+            // %tileheight = arith.constant 9  : i32
+            // %tilewidth  : i32  = arith.constant 128 : i32  // in 32b words so tileWidth/4
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<1152xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<1152xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1152xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @inOF, id = 1 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<1152xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @outOF, id = 0 : i32 }
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
@@ -47,12 +47,14 @@ module @passThroughLine_aie2 {
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<1152xi32>, %arg1 : memref<1xi32>, %out : memref<1152xi32>) {
-            // %tileheight = arith.constant 9  : i32
-            // %tilewidth  : i32  = arith.constant 128 : i32  // in 32b words so tileWidth/4
+            %c0 = arith.constant 0 : i32
+            %c1 = arith.constant 1 : i32
+            %tileheight = arith.constant 9  : i32
+            %tilewidth  = arith.constant 128 : i32  // in 32b words so tileWidth/4
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1152xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @inOF, id = 1 : i32 }
-            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<1152xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @outOF, id = 0 : i32 }
+            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<1152xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<1152xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
@@ -51,8 +51,8 @@ module @passThroughLine_aie2 {
             // %tilewidth  : i32  = arith.constant 128 : i32  // in 32b words so tileWidth/4
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1152xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @inOF, id = 1 : i32 }
-            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<1152xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @outOF, id = 0 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1152xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @inOF, id = 1 : i32 }
+            aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<1152xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = [1 : i32, 1 : i32, 9  : i32, 128  : i32], strides = [0 : i32, 0 : i32, 128  : i32],  metadata = @outOF, id = 0 : i32 }
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
+++ b/reference_designs/ipu-xrt/vision_pipelines/passthrough/aie2_lineBased_8b_tiny.mlir
@@ -47,14 +47,14 @@ module @passThroughLine_aie2 {
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
         func.func @sequence(%in : memref<1152xi32>, %arg1 : memref<1xi32>, %out : memref<1152xi32>) {
-            %c0 = arith.constant 0 : i32
-            %c1 = arith.constant 1 : i32
-            %tileheight = arith.constant 9  : i32
-            %tilewidth  = arith.constant 128 : i32  // in 32b words so tileWidth/4
+            %c0 = arith.constant 0 : i64
+            %c1 = arith.constant 1 : i64
+            %tileheight = arith.constant 9  : i64
+            %tilewidth  = arith.constant 128 : i64  // in 32b words so tileWidth/4
 
             //dma_memcpy_nd ([offset in 32b words][length in 32b words][stride in 32b words])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i32 } : (i32, i32, memref<1152xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-            aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i32 } : (i32, i32, memref<1152xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+            aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @inOF, id = 1 : i64 } : memref<1152xi32>
+            aiex.ipu.dma_memcpy_nd (0, 0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth]) { metadata = @outOF, id = 0 : i64 } : memref<1152xi32>
             aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
             return
         }

--- a/reference_designs/lit.cfg.py
+++ b/reference_designs/lit.cfg.py
@@ -196,7 +196,11 @@ if config.enable_chess_tests:
             print(
                 "WARNING: no valid xchess license that is required by some of the lit tests"
             )
-
+    elif os.getenv("XILINXD_LICENSE_FILE") is not None:
+        print("Chess license found")
+        llvm_config.with_environment(
+            "XILINXD_LICENSE_FILE", os.getenv("XILINXD_LICENSE_FILE")
+        )
     else:
         print("Chess not found")
 

--- a/reference_designs/lit.cfg.py
+++ b/reference_designs/lit.cfg.py
@@ -82,6 +82,7 @@ config.substitutions.append(("%XRT_DIR", config.xrt_dir))
 
 opencv_flags = ""
 if config.opencv_include_dir and config.opencv_libs:
+    print("opencv found")
     config.available_features.add("opencv")
     opencv_flags = opencv_flags + " -I" + config.opencv_include_dir
     if config.opencv_lib_dir:
@@ -89,6 +90,7 @@ if config.opencv_include_dir and config.opencv_libs:
     libs = config.opencv_libs.split(";")
     opencv_flags = opencv_flags + " " + " ".join(["-l" + l for l in libs])
 else:
+    print("opencv not found")
     opencv_flags = ""
 config.substitutions.append(("%opencv_flags", opencv_flags))
 

--- a/test/Conversion/DmaToIpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToIpu/aiert_insts.mlir
@@ -17,8 +17,8 @@ module {
     memref.global "public" @of_toMem : memref<32xi32>
     memref.global "public" @of_fromMem : memref<32xi32>
     func.func @sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 32 : i32], strides = [0 : i32, 0 : i32, 0 : i32], metadata = @of_toMem, id = 1 : i32 }
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<4x2x8xi32>) { offsets = [0 : i32, 2 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 2 : i32, 2 : i32, 8 : i32], strides = [0 : i32, 16 : i32, 8 : i32], metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 32>, strides = array<i32: 0, 0, 0>, metadata = @of_toMem, id = 1 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<4x2x8xi32>) { offsets = array<i32: 0, 2, 0, 0>, lengths = array<i32: 1, 2, 2, 8>, strides = array<i32: 0, 16, 8>, metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToIpu/aiert_insts.mlir
@@ -17,8 +17,15 @@ module {
     memref.global "public" @of_toMem : memref<32xi32>
     memref.global "public" @of_fromMem : memref<32xi32>
     func.func @sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 32>, strides = array<i32: 0, 0, 0>, metadata = @of_toMem, id = 1 : i32 }
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<4x2x8xi32>) { offsets = array<i32: 0, 2, 0, 0>, lengths = array<i32: 1, 2, 2, 8>, strides = array<i32: 0, 16, 8>, metadata = @of_fromMem, id = 0 : i32 }
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %c4 = arith.constant 4 : i32
+      %c8 = arith.constant 8 : i32
+      %c16 = arith.constant 16 : i32
+      %c32 = arith.constant 32 : i32
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0]) { metadata = @of_toMem, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<4x2x8xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToIpu/aiert_insts.mlir
@@ -17,15 +17,17 @@ module {
     memref.global "public" @of_toMem : memref<32xi32>
     memref.global "public" @of_fromMem : memref<32xi32>
     func.func @sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c2 = arith.constant 2 : i32
-      %c4 = arith.constant 4 : i32
-      %c8 = arith.constant 8 : i32
-      %c16 = arith.constant 16 : i32
-      %c32 = arith.constant 32 : i32
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0]) { metadata = @of_toMem, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<4x2x8xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c2 = arith.constant 2 : i64
+      %c4 = arith.constant 4 : i64
+      %c8 = arith.constant 8 : i64
+      %c16 = arith.constant 16 : i64
+      %c32 = arith.constant 32 : i64
+      aiex.ipu.dma_memcpy_nd(0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0]) { metadata = @of_toMem, id = 1 : i64 } : memref<64xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i64 } : memref<4x2x8xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %out[0,0,0,0][1,1,1,32][0,0,0]) { metadata = @of_toMem, id = 1 : i64 } : memref<64xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %in[0,2,0,0][1,2,2,8][0,16,8]) { metadata = @of_fromMem, id = 0 : i64 } : memref<4x2x8xi32>
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToIpu/aiert_insts.mlir
@@ -26,8 +26,6 @@ module {
       %c32 = arith.constant 32 : i64
       aiex.ipu.dma_memcpy_nd(0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0]) { metadata = @of_toMem, id = 1 : i64 } : memref<64xi32>
       aiex.ipu.dma_memcpy_nd(0, 0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i64 } : memref<4x2x8xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %out[0,0,0,0][1,1,1,32][0,0,0]) { metadata = @of_toMem, id = 1 : i64 } : memref<64xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %in[0,2,0,0][1,2,2,8][0,16,8]) { metadata = @of_fromMem, id = 0 : i64 } : memref<4x2x8xi32>
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToIpu/aiert_insts.mlir
@@ -17,15 +17,8 @@ module {
     memref.global "public" @of_toMem : memref<32xi32>
     memref.global "public" @of_fromMem : memref<32xi32>
     func.func @sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c2 = arith.constant 2 : i32
-      %c4 = arith.constant 4 : i32
-      %c8 = arith.constant 8 : i32
-      %c16 = arith.constant 16 : i32
-      %c32 = arith.constant 32 : i32
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0]) { metadata = @of_toMem, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<4x2x8xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 32 : i32], strides = [0 : i32, 0 : i32, 0 : i32], metadata = @of_toMem, id = 1 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<4x2x8xi32>) { offsets = [0 : i32, 2 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 2 : i32, 2 : i32, 8 : i32], strides = [0 : i32, 16 : i32, 8 : i32], metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/dma_to_ipu.mlir
+++ b/test/Conversion/DmaToIpu/dma_to_ipu.mlir
@@ -22,12 +22,8 @@ aie.device(ipu) {
   memref.global "public" @toMem : memref<16xi32>
   memref.global "public" @fromMem : memref<16xi32>
   func.func @test0(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-    %c16_i32 = arith.constant 16 : i32
-    %c64_i32 = arith.constant 64 : i32
-    %c0_i32 = arith.constant 0 : i32
-    %c1_i32 = arith.constant 1 : i32
-    aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @toMem, id = 1 : i32 } : (i32, i32, memref<16xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-    aiex.ipu.dma_memcpy_nd(%c0_i32, %c1_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c16_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @fromMem, id = 0 : i32 } : (i32, i32, memref<16xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+    aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<16xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 16 : i32, 16 : i32], strides = [0 : i32, 0 : i32, 64 : i32],  metadata = @toMem, id = 1 : i32 }
+    aiex.ipu.dma_memcpy_nd(0, 1, %arg1 : memref<16xi32>) { offsets = [0 : i32, 0 : i32, 16 : i32, 16 : i32], lengths = [1 : i32, 1 : i32, 16 : i32, 16 : i32], strides = [0 : i32, 0 : i32, 64 : i32],  metadata = @fromMem, id = 0 : i32 }
     return
   }
   aie.shim_dma_allocation @fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/dma_to_ipu.mlir
+++ b/test/Conversion/DmaToIpu/dma_to_ipu.mlir
@@ -26,8 +26,8 @@ aie.device(ipu) {
     %c64_i64 = arith.constant 64 : i64
     %c0_i64 = arith.constant 0 : i64
     %c1_i64 = arith.constant 1 : i64
-    aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
-    aiex.ipu.dma_memcpy_nd(0, 1, %arg1[%c0_i32, %c0_i32, %c0_i32, %c16_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
+    aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c16_i64, %c16_i64][%c0_i64, %c0_i64, %c64_i64]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+    aiex.ipu.dma_memcpy_nd(0, 1, %arg1[%c0_i64, %c0_i64, %c0_i64, %c16_i64][%c1_i64, %c1_i64, %c16_i64, %c16_i64][%c0_i64, %c0_i64, %c64_i64]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
     return
   }
   aie.shim_dma_allocation @fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/dma_to_ipu.mlir
+++ b/test/Conversion/DmaToIpu/dma_to_ipu.mlir
@@ -22,12 +22,12 @@ aie.device(ipu) {
   memref.global "public" @toMem : memref<16xi32>
   memref.global "public" @fromMem : memref<16xi32>
   func.func @test0(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-    %c16_i32 = arith.constant 16 : i32
-    %c64_i32 = arith.constant 64 : i32
-    %c0_i32 = arith.constant 0 : i32
-    %c1_i32 = arith.constant 1 : i32
-    aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @toMem, id = 1 : i32 } : (i32, i32, memref<16xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-    aiex.ipu.dma_memcpy_nd(%c0_i32, %c1_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c16_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @fromMem, id = 0 : i32 } : (i32, i32, memref<16xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+    %c16_i64 = arith.constant 16 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+    aiex.ipu.dma_memcpy_nd(0, 1, %arg1[%c0_i32, %c0_i32, %c0_i32, %c16_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
     return
   }
   aie.shim_dma_allocation @fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/dma_to_ipu.mlir
+++ b/test/Conversion/DmaToIpu/dma_to_ipu.mlir
@@ -22,8 +22,12 @@ aie.device(ipu) {
   memref.global "public" @toMem : memref<16xi32>
   memref.global "public" @fromMem : memref<16xi32>
   func.func @test0(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-    aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<16xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 16, 16>, strides = array<i32: 0, 0, 64>,  metadata = @toMem, id = 1 : i32 }
-    aiex.ipu.dma_memcpy_nd(0, 1, %arg1 : memref<16xi32>) { offsets = array<i32: 0, 0, 16, 16>, lengths = array<i32: 1, 1, 16, 16>, strides = array<i32: 0, 0, 64>,  metadata = @fromMem, id = 0 : i32 }
+    %c16_i32 = arith.constant 16 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @toMem, id = 1 : i32 } : (i32, i32, memref<16xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+    aiex.ipu.dma_memcpy_nd(%c0_i32, %c1_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c16_i32][%c1_i32, %c1_i32, %c16_i32, %c16_i32][%c0_i32, %c0_i32, %c64_i32]) { metadata = @fromMem, id = 0 : i32 } : (i32, i32, memref<16xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
     return
   }
   aie.shim_dma_allocation @fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToIpu/dma_to_ipu.mlir
+++ b/test/Conversion/DmaToIpu/dma_to_ipu.mlir
@@ -22,8 +22,8 @@ aie.device(ipu) {
   memref.global "public" @toMem : memref<16xi32>
   memref.global "public" @fromMem : memref<16xi32>
   func.func @test0(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-    aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<16xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 16 : i32, 16 : i32], strides = [0 : i32, 0 : i32, 64 : i32],  metadata = @toMem, id = 1 : i32 }
-    aiex.ipu.dma_memcpy_nd(0, 1, %arg1 : memref<16xi32>) { offsets = [0 : i32, 0 : i32, 16 : i32, 16 : i32], lengths = [1 : i32, 1 : i32, 16 : i32, 16 : i32], strides = [0 : i32, 0 : i32, 64 : i32],  metadata = @fromMem, id = 0 : i32 }
+    aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<16xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 16, 16>, strides = array<i32: 0, 0, 64>,  metadata = @toMem, id = 1 : i32 }
+    aiex.ipu.dma_memcpy_nd(0, 1, %arg1 : memref<16xi32>) { offsets = array<i32: 0, 0, 16, 16>, lengths = array<i32: 1, 1, 16, 16>, strides = array<i32: 0, 0, 64>,  metadata = @fromMem, id = 0 : i32 }
     return
   }
   aie.shim_dma_allocation @fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_length.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_length.mlir
@@ -13,8 +13,12 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi32>, %buf : memref<32xi32>, %out : memref<1920x1080xi32>) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c1920 = arith.constant 1920 : i32
+      %c1080 = arith.constant 1080 : i32
       // expected-error@+1 {{Length 0 exceeds the [0:1023] range}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1080, 1920>, strides = array<i32: 0, 0, 1920>,  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<1920x1080xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_length.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_length.mlir
@@ -14,7 +14,7 @@ module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi32>, %buf : memref<32xi32>, %out : memref<1920x1080xi32>) {
       // expected-error@+1 {{Length 0 exceeds the [0:1023] range}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1080 : i32, 1920 : i32], strides = [0 : i32, 0 : i32, 1920 : i32],  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1080, 1920>, strides = array<i32: 0, 0, 1920>,  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_length.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_length.mlir
@@ -13,12 +13,8 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi32>, %buf : memref<32xi32>, %out : memref<1920x1080xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c1920 = arith.constant 1920 : i32
-      %c1080 = arith.constant 1080 : i32
       // expected-error@+1 {{Length 0 exceeds the [0:1023] range}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<1920x1080xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1080 : i32, 1920 : i32], strides = [0 : i32, 0 : i32, 1920 : i32],  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_length.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_length.mlir
@@ -13,12 +13,12 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi32>, %buf : memref<32xi32>, %out : memref<1920x1080xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c1920 = arith.constant 1920 : i32
-      %c1080 = arith.constant 1080 : i32
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c1920 = arith.constant 1920 : i64
+      %c1080 = arith.constant 1080 : i64
       // expected-error@+1 {{Length 0 exceeds the [0:1023] range}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<1920x1080xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i64 } : memref<1920x1080xi32>
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
@@ -13,16 +13,8 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c2 = arith.constant 2 : i32
-      %c4 = arith.constant 4 : i32
-      %c8 = arith.constant 8 : i32
-      %c16 = arith.constant 16 : i32
-      %c32 = arith.constant 32 : i32
-      %c128 = arith.constant 128 : i32
       // expected-error@+1 {{Length 3 exceeds the [1:64] range}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c128,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<128x4x2x8xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<128x4x2x8xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [128 : i32, 2 : i32, 2 : i32, 8 : i32], strides = [0 : i32, 16 : i32, 8 : i32],  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
@@ -13,8 +13,16 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %c4 = arith.constant 4 : i32
+      %c8 = arith.constant 8 : i32
+      %c16 = arith.constant 16 : i32
+      %c32 = arith.constant 32 : i32
+      %c128 = arith.constant 128 : i32
       // expected-error@+1 {{Length 3 exceeds the [1:64] range}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<128x4x2x8xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 128, 2, 2, 8>, strides = array<i32: 0, 16, 8>,  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c128,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<128x4x2x8xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
@@ -13,16 +13,16 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c2 = arith.constant 2 : i32
-      %c4 = arith.constant 4 : i32
-      %c8 = arith.constant 8 : i32
-      %c16 = arith.constant 16 : i32
-      %c32 = arith.constant 32 : i32
-      %c128 = arith.constant 128 : i32
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c2 = arith.constant 2 : i64
+      %c4 = arith.constant 4 : i64
+      %c8 = arith.constant 8 : i64
+      %c16 = arith.constant 16 : i64
+      %c32 = arith.constant 32 : i64
+      %c128 = arith.constant 128 : i64
       // expected-error@+1 {{Length 3 exceeds the [1:64] range}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c128,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<128x4x2x8xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c128,%c2,%c2,%c8][%c0,%c16,%c8]) { metadata = @of_fromMem, id = 0 : i64 } : memref<128x4x2x8xi32>
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_repeat.mlir
@@ -14,7 +14,7 @@ module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       // expected-error@+1 {{Length 3 exceeds the [1:64] range}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<128x4x2x8xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [128 : i32, 2 : i32, 2 : i32, 8 : i32], strides = [0 : i32, 16 : i32, 8 : i32],  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<128x4x2x8xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 128, 2, 2, 8>, strides = array<i32: 0, 16, 8>,  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_stride.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_stride.mlir
@@ -13,12 +13,12 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<8388608xi32>, %buf : memref<32xi32>, %out : memref<8388608xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c2 = arith.constant 2 : i32
-      %c2097152 = arith.constant 2097152 : i32
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c2 = arith.constant 2 : i64
+      %c2097152 = arith.constant 2097152 : i64
       // expected-error@+1 {{Stride 1 exceeds the [1:1M] range}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2][%c0,%c0,%c2097152]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<8388608xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2][%c0,%c0,%c2097152]) { metadata = @of_fromMem, id = 0 : i64 } : memref<8388608xi32>
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_stride.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_stride.mlir
@@ -13,12 +13,8 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<8388608xi32>, %buf : memref<32xi32>, %out : memref<8388608xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c2 = arith.constant 2 : i32
-      %c2097152 = arith.constant 2097152 : i32
       // expected-error@+1 {{Stride 1 exceeds the [1:1M] range}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2][%c0,%c0,%c2097152]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<8388608xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<8388608xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 2 : i32, 2 : i32], strides = [0 : i32, 0 : i32, 2097152 : i32],  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_stride.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_stride.mlir
@@ -14,7 +14,7 @@ module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<8388608xi32>, %buf : memref<32xi32>, %out : memref<8388608xi32>) {
       // expected-error@+1 {{Stride 1 exceeds the [1:1M] range}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<8388608xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 2 : i32, 2 : i32], strides = [0 : i32, 0 : i32, 2097152 : i32],  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<8388608xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 2, 2>, strides = array<i32: 0, 0, 2097152>,  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_stride.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_stride.mlir
@@ -13,8 +13,12 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<8388608xi32>, %buf : memref<32xi32>, %out : memref<8388608xi32>) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : i32
+      %c2097152 = arith.constant 2097152 : i32
       // expected-error@+1 {{Stride 1 exceeds the [1:1M] range}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<8388608xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 2, 2>, strides = array<i32: 0, 0, 2097152>,  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2][%c0,%c0,%c2097152]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<8388608xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_type.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_type.mlir
@@ -13,12 +13,12 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi8>, %buf : memref<32xi32>, %out : memref<1920x1080xi8>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c1920 = arith.constant 1920 : i32
-      %c1080 = arith.constant 1080 : i32
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c1920 = arith.constant 1920 : i64
+      %c1080 = arith.constant 1080 : i64
       // expected-error@+1 {{must be used with memref type i32.}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<1920x1080xi8>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i64 } : memref<1920x1080xi8>
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_type.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_type.mlir
@@ -14,7 +14,7 @@ module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi8>, %buf : memref<32xi32>, %out : memref<1920x1080xi8>) {
       // expected-error@+1 {{must be used with memref type i32.}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi8>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1080 : i32, 1920 : i32], strides = [0 : i32, 0 : i32, 1920 : i32],  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi8>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1080, 1920>, strides = array<i32: 0, 0, 1920>,  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_type.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_type.mlir
@@ -13,12 +13,8 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi8>, %buf : memref<32xi32>, %out : memref<1920x1080xi8>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c1920 = arith.constant 1920 : i32
-      %c1080 = arith.constant 1080 : i32
       // expected-error@+1 {{must be used with memref type i32.}}
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<1920x1080xi8>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi8>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1080 : i32, 1920 : i32], strides = [0 : i32, 0 : i32, 1920 : i32],  metadata = @of_fromMem, id = 0 : i32 }
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/dialect/AIEX/bad_ipu_nd_type.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_type.mlir
@@ -13,8 +13,12 @@
 module {
   aie.device(ipu) {
     func.func @sequence(%in : memref<1920x1080xi8>, %buf : memref<32xi32>, %out : memref<1920x1080xi8>) {
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c1920 = arith.constant 1920 : i32
+      %c1080 = arith.constant 1080 : i32
       // expected-error@+1 {{must be used with memref type i32.}}
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<1920x1080xi8>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1080, 1920>, strides = array<i32: 0, 0, 1920>,  metadata = @of_fromMem, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i32 } : (i32, i32, memref<1920x1080xi8>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/ipu-xrt/add_one_objFifo/aie.mlir
+++ b/test/ipu-xrt/add_one_objFifo/aie.mlir
@@ -41,11 +41,11 @@ module {
       aie.end
     }
     func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c64 = arith.constant 64 : i32
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c64 = arith.constant 64 : i64
+      aiex.ipu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
+      aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
       return
     }

--- a/test/ipu-xrt/add_one_objFifo/aie.mlir
+++ b/test/ipu-xrt/add_one_objFifo/aie.mlir
@@ -41,8 +41,8 @@ module {
       aie.end
     }
     func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32,1 : i32,1 : i32,64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], metadata = @objFifo_out0, id = 1 : i32 }
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32,1 : i32,1 : i32,64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], metadata = @objFifo_in0, id = 0 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, metadata = @objFifo_out0, id = 1 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, metadata = @objFifo_in0, id = 0 : i32 }
       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
       return
     }

--- a/test/ipu-xrt/add_one_objFifo/aie.mlir
+++ b/test/ipu-xrt/add_one_objFifo/aie.mlir
@@ -41,11 +41,8 @@ module {
       aie.end
     }
     func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      %c0 = arith.constant 0 : i32
-      %c1 = arith.constant 1 : i32
-      %c64 = arith.constant 64 : i32
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32,1 : i32,1 : i32,64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], metadata = @objFifo_out0, id = 1 : i32 }
+      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32,1 : i32,1 : i32,64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], metadata = @objFifo_in0, id = 0 : i32 }
       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
       return
     }

--- a/test/ipu-xrt/add_one_objFifo/aie.mlir
+++ b/test/ipu-xrt/add_one_objFifo/aie.mlir
@@ -41,8 +41,11 @@ module {
       aie.end
     }
     func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, metadata = @objFifo_out0, id = 1 : i32 }
-      aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, metadata = @objFifo_in0, id = 0 : i32 }
+      %c0 = arith.constant 0 : i32
+      %c1 = arith.constant 1 : i32
+      %c64 = arith.constant 64 : i32
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+      aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
       return
     }

--- a/test/ipu-xrt/add_one_using_dma/aie.mlir
+++ b/test/ipu-xrt/add_one_using_dma/aie.mlir
@@ -88,8 +88,11 @@ module {
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
     func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, id = 0 : i32, metadata = @objFifo_in0}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, id = 1 : i32, metadata = @objFifo_out0}
+      %c0_i32 = arith.constant 0 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %c64_i32 = arith.constant 64 : i32
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/add_one_using_dma/aie.mlir
+++ b/test/ipu-xrt/add_one_using_dma/aie.mlir
@@ -88,11 +88,8 @@ module {
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
     func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-      %c0_i32 = arith.constant 0 : i32
-      %c1_i32 = arith.constant 1 : i32
-      %c64_i32 = arith.constant 64 : i32
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @objFifo_in0}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @objFifo_out0}
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/add_one_using_dma/aie.mlir
+++ b/test/ipu-xrt/add_one_using_dma/aie.mlir
@@ -91,8 +91,8 @@ module {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c64_i64 = arith.constant 64 : i64
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : memref<64xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : memref<64xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64]) {id = 1 : i64, metadata = @objFifo_out0} : memref<64xi32>
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/add_one_using_dma/aie.mlir
+++ b/test/ipu-xrt/add_one_using_dma/aie.mlir
@@ -88,11 +88,11 @@ module {
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
     func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-      %c0_i32 = arith.constant 0 : i32
-      %c1_i32 = arith.constant 1 : i32
-      %c64_i32 = arith.constant 64 : i32
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c64_i64 = arith.constant 64 : i64
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : memref<64xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : memref<64xi32>
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/add_one_using_dma/aie.mlir
+++ b/test/ipu-xrt/add_one_using_dma/aie.mlir
@@ -88,8 +88,8 @@ module {
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
     func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @objFifo_in0}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @objFifo_out0}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, id = 0 : i32, metadata = @objFifo_in0}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 64>, strides = array<i32: 0, 0, 0>, id = 1 : i32, metadata = @objFifo_out0}
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -120,19 +120,19 @@ module {
     } {link_with = "mm.o"}
     aie.shim_dma_allocation @inA(MM2S, 0, 0)
     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-      %c2048_i32 = arith.constant 2048 : i32
-      %c16_i32 = arith.constant 16 : i32
-      %c4_i32 = arith.constant 4 : i32
-      %c0_i32 = arith.constant 0 : i32
-      %c2_i32 = arith.constant 2 : i32
-      %c64_i32 = arith.constant 64 : i32
-      %c32_i32 = arith.constant 32 : i32
-      %c4096_i32 = arith.constant 4096 : i32
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i32, metadata = @outC} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      %c2048_i64 = arith.constant 2048 : i64
+      %c16_i64 = arith.constant 16 : i64
+      %c4_i64 = arith.constant 4 : i64
+      %c0_i64 = arith.constant 0 : i64
+      %c2_i64 = arith.constant 2 : i64
+      %c64_i64 = arith.constant 64 : i64
+      %c32_i64 = arith.constant 32 : i64
+      %c4096_i64 = arith.constant 4096 : i64
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i64, metadata = @outC} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i64, metadata = @inA} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i64, metadata = @inB} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i64, metadata = @inA} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i64, metadata = @inB} : memref<8192xi32>
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -120,11 +120,11 @@ module {
     } {link_with = "mm.o"}
     aie.shim_dma_allocation @inA(MM2S, 0, 0)
     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 2 : i32, 64 : i32, 32 : i32], strides = [4096 : i32, 32 : i32, 64 : i32], id = 0 : i32, metadata = @outC}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 1 : i32, metadata = @inA}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 2 : i32, metadata = @inB}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 4096 : i32, 4096 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 3 : i32, metadata = @inA}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 4 : i32, metadata = @inB}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 2, 64, 32>, strides = array<i32: 4096, 32, 64>, id = 0 : i32, metadata = @outC}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 4, 64, 16>, strides = array<i32: 0, 16, 64>, id = 1 : i32, metadata = @inA}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 4, 32, 32>, strides = array<i32: 32, 2048, 64>, id = 2 : i32, metadata = @inB}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = array<i32: 0, 0, 4096, 4096>, lengths = array<i32: 2, 4, 64, 16>, strides = array<i32: 0, 16, 64>, id = 3 : i32, metadata = @inA}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 4, 32, 32>, strides = array<i32: 32, 2048, 64>, id = 4 : i32, metadata = @inB}
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -120,19 +120,11 @@ module {
     } {link_with = "mm.o"}
     aie.shim_dma_allocation @inA(MM2S, 0, 0)
     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-      %c2048_i32 = arith.constant 2048 : i32
-      %c16_i32 = arith.constant 16 : i32
-      %c4_i32 = arith.constant 4 : i32
-      %c0_i32 = arith.constant 0 : i32
-      %c2_i32 = arith.constant 2 : i32
-      %c64_i32 = arith.constant 64 : i32
-      %c32_i32 = arith.constant 32 : i32
-      %c4096_i32 = arith.constant 4096 : i32
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i32, metadata = @outC} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 2 : i32, 64 : i32, 32 : i32], strides = [4096 : i32, 32 : i32, 64 : i32], id = 0 : i32, metadata = @outC}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 1 : i32, metadata = @inA}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 2 : i32, metadata = @inB}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 4096 : i32, 4096 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 3 : i32, metadata = @inA}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 4 : i32, metadata = @inB}
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -120,11 +120,19 @@ module {
     } {link_with = "mm.o"}
     aie.shim_dma_allocation @inA(MM2S, 0, 0)
     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 2, 64, 32>, strides = array<i32: 4096, 32, 64>, id = 0 : i32, metadata = @outC}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 4, 64, 16>, strides = array<i32: 0, 16, 64>, id = 1 : i32, metadata = @inA}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 4, 32, 32>, strides = array<i32: 32, 2048, 64>, id = 2 : i32, metadata = @inB}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = array<i32: 0, 0, 4096, 4096>, lengths = array<i32: 2, 4, 64, 16>, strides = array<i32: 0, 16, 64>, id = 3 : i32, metadata = @inA}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 2, 4, 32, 32>, strides = array<i32: 32, 2048, 64>, id = 4 : i32, metadata = @inB}
+      %c2048_i32 = arith.constant 2048 : i32
+      %c16_i32 = arith.constant 16 : i32
+      %c4_i32 = arith.constant 4 : i32
+      %c0_i32 = arith.constant 0 : i32
+      %c2_i32 = arith.constant 2 : i32
+      %c64_i32 = arith.constant 64 : i32
+      %c32_i32 = arith.constant 32 : i32
+      %c4096_i32 = arith.constant 4096 : i32
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i32, metadata = @outC} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -128,11 +128,11 @@ module {
       %c64_i64 = arith.constant 64 : i64
       %c32_i64 = arith.constant 32 : i64
       %c4096_i64 = arith.constant 4096 : i64
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i64, metadata = @outC} : memref<8192xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i64, metadata = @inA} : memref<8192xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i64, metadata = @inB} : memref<8192xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i64, metadata = @inA} : memref<8192xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i64, metadata = @inB} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c2_i64, %c2_i64, %c64_i64, %c32_i64] [%c4096_i64, %c32_i64, %c64_i64]) {id = 0 : i64, metadata = @outC} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c2_i64, %c4_i64, %c64_i64, %c16_i64] [%c0_i64, %c16_i64, %c64_i64]) {id = 1 : i64, metadata = @inA} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c2_i64, %c4_i64, %c32_i64, %c32_i64] [%c32_i64, %c2048_i64, %c64_i64]) {id = 2 : i64, metadata = @inB} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c4096_i64] [%c2_i64, %c4_i64, %c64_i64, %c16_i64] [%c0_i64, %c16_i64, %c64_i64]) {id = 3 : i64, metadata = @inA} : memref<8192xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c2_i64, %c4_i64, %c32_i64, %c32_i64] [%c32_i64, %c2048_i64, %c64_i64]) {id = 4 : i64, metadata = @inB} : memref<8192xi32>
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
+++ b/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
@@ -63,8 +63,8 @@ module {
     aie.shim_dma_allocation @in(MM2S, 0, 0)
 
     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @out}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @in}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 4096>, strides = array<i32: 0, 0, 0>, id = 0 : i32, metadata = @out}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 4096>, strides = array<i32: 0, 0, 0>, id = 1 : i32, metadata = @in}
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
+++ b/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
@@ -63,11 +63,8 @@ module {
     aie.shim_dma_allocation @in(MM2S, 0, 0)
 
     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-      %c0_i32 = arith.constant 0 : i32
-      %c1_i32 = arith.constant 1 : i32
-      %c4096_i32 = arith.constant 4096 : i32
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @out} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @in} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @out}
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @in}
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
+++ b/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
@@ -63,8 +63,11 @@ module {
     aie.shim_dma_allocation @in(MM2S, 0, 0)
 
     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 4096>, strides = array<i32: 0, 0, 0>, id = 0 : i32, metadata = @out}
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) { offsets = array<i32: 0, 0, 0, 0>, lengths = array<i32: 1, 1, 1, 4096>, strides = array<i32: 0, 0, 0>, id = 1 : i32, metadata = @in}
+      %c0_i32 = arith.constant 0 : i32
+      %c1_i32 = arith.constant 1 : i32
+      %c4096_i32 = arith.constant 4096 : i32
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @out} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @in} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
+++ b/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
@@ -66,8 +66,8 @@ module {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c4096_i64 = arith.constant 4096 : i64
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i64, metadata = @out} : memref<4096xi32>
-      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i64, metadata = @in} : memref<4096xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c4096_i64] [%c0_i64, %c0_i64, %c0_i64]) {id = 0 : i64, metadata = @out} : memref<4096xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c4096_i64] [%c0_i64, %c0_i64, %c0_i64]) {id = 1 : i64, metadata = @in} : memref<4096xi32>
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
+++ b/test/ipu-xrt/vector_scalar_using_dma/aie.mlir
@@ -63,11 +63,11 @@ module {
     aie.shim_dma_allocation @in(MM2S, 0, 0)
 
     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-      %c0_i32 = arith.constant 0 : i32
-      %c1_i32 = arith.constant 1 : i32
-      %c4096_i32 = arith.constant 4096 : i32
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @out} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @in} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c4096_i64 = arith.constant 4096 : i64
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i64, metadata = @out} : memref<4096xi32>
+      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i64, metadata = @in} : memref<4096xi32>
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }

--- a/test/python/e2e/e2e_ipu.py
+++ b/test/python/e2e/e2e_ipu.py
@@ -226,28 +226,24 @@ def add_one_using_dma(module):
             arg1: T.memref(32, T.i32()),
             arg2: T.memref(64, T.i32()),
         ):
-            c0_i32 = arith.constant(0)
-            c1_i32 = arith.constant(1)
-            c64_i32 = arith.constant(64)
-
             ipu_dma_memcpy_nd_(
-                c0_i32,
-                c0_i32,
+                0,
+                0,
                 arg0,
-                *[c0_i32, c0_i32, c0_i32, c0_i32],
-                *[c1_i32, c1_i32, c1_i32, c64_i32],
-                *[c0_i32, c0_i32, c0_i32],
+                [0, 0, 0, 0],
+                [1, 1, 1, 64],
+                [0, 0, 0],
                 metadata="objFifo_in0",
                 id=0,
             )
 
             ipu_dma_memcpy_nd_(
-                c0_i32,
-                c0_i32,
+                0,
+                0,
                 arg2,
-                *[c0_i32, c0_i32, c0_i32, c0_i32],
-                *[c1_i32, c1_i32, c1_i32, c64_i32],
-                *[c0_i32, c0_i32, c0_i32],
+                [0, 0, 0, 0],
+                [1, 1, 1, 64],
+                [0, 0, 0],
                 metadata="objFifo_out0",
                 id=1,
             )

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -90,8 +90,8 @@ Release = LockAction.Release
 # CHECK:       aie.end
 # CHECK:     } {link_with = "scale.o"}
 # CHECK:     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], metadata = @out, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], metadata = @in, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 1, 4096>, metadata = @out, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 1, 4096>, metadata = @in, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -201,11 +201,11 @@ def my_vector_scalar(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "mm.o"}
 # CHECK:     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) {id = 0 : i32, lengths = [2 : i32, 2 : i32, 64 : i32, 32 : i32], metadata = @outC, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [4096 : i32, 32 : i32, 64 : i32]}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 1 : i32, lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], metadata = @inA, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 16 : i32, 64 : i32]}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 2 : i32, lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], metadata = @inB, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [32 : i32, 2048 : i32, 64 : i32]}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 3 : i32, lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], metadata = @inA, offsets = [0 : i32, 0 : i32, 0 : i32, 4096 : i32], strides = [0 : i32, 16 : i32, 64 : i32]}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 4 : i32, lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], metadata = @inB, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [32 : i32, 2048 : i32, 64 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) {id = 0 : i32, lengths = array<i32: 2, 2, 64, 32>, metadata = @outC, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 4096, 32, 64>}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 1 : i32, lengths = array<i32: 2, 4, 64, 16>, metadata = @inA, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 16, 64>}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 2 : i32, lengths = array<i32: 2, 4, 32, 32>, metadata = @inB, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 32, 2048, 64>}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 3 : i32, lengths = array<i32: 2, 4, 64, 16>, metadata = @inA, offsets = array<i32: 0, 0, 0, 4096>, strides = array<i32: 0, 16, 64>}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 4 : i32, lengths = array<i32: 2, 4, 32, 32>, metadata = @inB, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 32, 2048, 64>}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -523,8 +523,8 @@ def my_matmul(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "combined_gray2rgba_addWeighted.a"}
 # CHECK:     func.func @sequence(%arg0: memref<2304xi32>, %arg1: memref<2304xi32>, %arg2: memref<2304xi32>) {
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<2304xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], metadata = @outOF_L2L3, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 64 : i32]}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<2304xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], metadata = @inOF_L3L2, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 64 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<2304xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 36, 64>, metadata = @outOF_L2L3, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 64>}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<2304xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 36, 64>, metadata = @inOF_L3L2, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 64>}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -888,8 +888,8 @@ def edge_detect(module):
 #       aie.end
 #     }
 #     func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-#       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @out0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
-#       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @in0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
+#       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @out0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
+#       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @in0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
 #       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
 #       return
 #     }
@@ -1649,8 +1649,8 @@ def my_passthrough(module):
 # CHECK:    }
 # CHECK:    aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 # CHECK:    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @objFifo_in0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @objFifo_out0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @objFifo_in0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @objFifo_out0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
 # CHECK:      aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:      return
 # CHECK:    }

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -93,8 +93,8 @@ Release = LockAction.Release
 # CHECK:       %c0_i32 = arith.constant 0 : i32
 # CHECK:       %c1_i32 = arith.constant 1 : i32
 # CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @out} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @in} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i64, metadata = @out} : memref<4096xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i64, metadata = @in} : memref<4096xi32>
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -212,11 +212,11 @@ def my_vector_scalar(module):
 # CHECK:       %c64_i32 = arith.constant 64 : i32
 # CHECK:       %c32_i32 = arith.constant 32 : i32
 # CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i32, metadata = @outC} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i64, metadata = @outC} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i64, metadata = @inA} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i64, metadata = @inB} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i64, metadata = @inA} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i64, metadata = @inB} : memref<8192xi32>
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -538,8 +538,8 @@ def my_matmul(module):
 # CHECK:       %c1_i32 = arith.constant 1 : i32
 # CHECK:       %c36_i32 = arith.constant 36 : i32
 # CHECK:       %c64_i32 = arith.constant 64 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 0 : i32, metadata = @outOF_L2L3} : (i32, i32, memref<2304xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 1 : i32, metadata = @inOF_L3L2} : (i32, i32, memref<2304xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 0 : i64, metadata = @outOF_L2L3} : memref<2304xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 1 : i64, metadata = @inOF_L3L2} : memref<2304xi32>
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -906,8 +906,8 @@ def edge_detect(module):
 #       %c0 = arith.constant 0 : i32
 #       %c1 = arith.constant 1 : i32
 #       %c64 = arith.constant 64 : i32
-#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
+#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
 #       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
 #       return
 #     }
@@ -1670,8 +1670,8 @@ def my_passthrough(module):
 # CHECK:      %c0_i32 = arith.constant 0 : i32
 # CHECK:      %c1_i32 = arith.constant 1 : i32
 # CHECK:      %c64_i32 = arith.constant 64 : i32
-# CHECK:      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i64, metadata = @objFifo_out0} : memref<64xi32>
 # CHECK:      aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:      return
 # CHECK:    }

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -93,8 +93,8 @@ Release = LockAction.Release
 # CHECK:       %c0_i32 = arith.constant 0 : i32
 # CHECK:       %c1_i32 = arith.constant 1 : i32
 # CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @out} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @in} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @out}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @in}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -212,11 +212,11 @@ def my_vector_scalar(module):
 # CHECK:       %c64_i32 = arith.constant 64 : i32
 # CHECK:       %c32_i32 = arith.constant 32 : i32
 # CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i32, metadata = @outC} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 2 : i32, 64 : i32, 32 : i32], strides = [4096 : i32, 32 : i32, 64 : i32], id = 0 : i32, metadata = @outC}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 1 : i32, metadata = @inA}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 2 : i32, metadata = @inB}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 4096 : i32, 4096 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 3 : i32, metadata = @inA}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 4 : i32, metadata = @inB}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -538,8 +538,8 @@ def my_matmul(module):
 # CHECK:       %c1_i32 = arith.constant 1 : i32
 # CHECK:       %c36_i32 = arith.constant 36 : i32
 # CHECK:       %c64_i32 = arith.constant 64 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 0 : i32, metadata = @outOF_L2L3} : (i32, i32, memref<2304xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 1 : i32, metadata = @inOF_L3L2} : (i32, i32, memref<2304xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<2304xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 64 : i32], id = 0 : i32, metadata = @outOF_L2L3}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<2304xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 64 : i32], id = 1 : i32, metadata = @inOF_L3L2}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -906,8 +906,8 @@ def edge_detect(module):
 #       %c0 = arith.constant 0 : i32
 #       %c1 = arith.constant 1 : i32
 #       %c64 = arith.constant 64 : i32
-#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
-#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+#       aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @objFifo_out0, id = 1 : i32 }
+#       aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @objFifo_in0, id = 0 : i32 }
 #       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
 #       return
 #     }
@@ -1670,8 +1670,8 @@ def my_passthrough(module):
 # CHECK:      %c0_i32 = arith.constant 0 : i32
 # CHECK:      %c1_i32 = arith.constant 1 : i32
 # CHECK:      %c64_i32 = arith.constant 64 : i32
-# CHECK:      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
-# CHECK:      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @objFifo_in0}
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @objFifo_out0}
 # CHECK:      aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:      return
 # CHECK:    }

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -46,7 +46,7 @@ from aie.dialects.aie import (
     translate_mlir_to_llvmir,
     use_lock,
 )
-from aie.dialects.aiex import ipu_sync, ipu_dma_memcpy_nd, ipu_dma_memcpy_nd_
+from aie.dialects.aiex import ipu_sync, ipu_dma_memcpy_nd
 from aie.dialects.func import FuncOp
 from aie.dialects.scf import for_
 from aie.dialects.scf import yield_
@@ -90,11 +90,8 @@ Release = LockAction.Release
 # CHECK:       aie.end
 # CHECK:     } {link_with = "scale.o"}
 # CHECK:     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-# CHECK:       %c0_i32 = arith.constant 0 : i32
-# CHECK:       %c1_i32 = arith.constant 1 : i32
-# CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i64, metadata = @out} : memref<4096xi32>
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i64, metadata = @in} : memref<4096xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 1, 4096][0, 0, 0]) {id = 0 : i64, metadata = @out} : memref<4096xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 4096][0, 0, 0]) {id = 1 : i64, metadata = @in} : memref<4096xi32>
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -204,19 +201,11 @@ def my_vector_scalar(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "mm.o"}
 # CHECK:     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-# CHECK:       %c2048_i32 = arith.constant 2048 : i32
-# CHECK:       %c16_i32 = arith.constant 16 : i32
-# CHECK:       %c4_i32 = arith.constant 4 : i32
-# CHECK:       %c0_i32 = arith.constant 0 : i32
-# CHECK:       %c2_i32 = arith.constant 2 : i32
-# CHECK:       %c64_i32 = arith.constant 64 : i32
-# CHECK:       %c32_i32 = arith.constant 32 : i32
-# CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i64, metadata = @outC} : memref<8192xi32>
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i64, metadata = @inA} : memref<8192xi32>
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i64, metadata = @inB} : memref<8192xi32>
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i64, metadata = @inA} : memref<8192xi32>
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i64, metadata = @inB} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][2, 2, 64, 32][4096, 32, 64]) {id = 0 : i64, metadata = @outC} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][2, 4, 64, 16][0, 16, 64]) {id = 1 : i64, metadata = @inA} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][2, 4, 32, 32][32, 2048, 64]) {id = 2 : i64, metadata = @inB} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 4096][2, 4, 64, 16][0, 16, 64]) {id = 3 : i64, metadata = @inA} : memref<8192xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1[0, 0, 0, 0][2, 4, 32, 32][32, 2048, 64]) {id = 4 : i64, metadata = @inB} : memref<8192xi32>
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -534,12 +523,8 @@ def my_matmul(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "combined_gray2rgba_addWeighted.a"}
 # CHECK:     func.func @sequence(%arg0: memref<2304xi32>, %arg1: memref<2304xi32>, %arg2: memref<2304xi32>) {
-# CHECK:       %c0_i32 = arith.constant 0 : i32
-# CHECK:       %c1_i32 = arith.constant 1 : i32
-# CHECK:       %c36_i32 = arith.constant 36 : i32
-# CHECK:       %c64_i32 = arith.constant 64 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 0 : i64, metadata = @outOF_L2L3} : memref<2304xi32>
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 1 : i64, metadata = @inOF_L3L2} : memref<2304xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 36, 64][0, 0, 64]) {id = 0 : i64, metadata = @outOF_L2L3} : memref<2304xi32>
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 36, 64][0, 0, 64]) {id = 1 : i64, metadata = @inOF_L3L2} : memref<2304xi32>
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -1667,11 +1652,11 @@ def my_passthrough(module):
 # CHECK:    }
 # CHECK:    aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 # CHECK:    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-# CHECK:      %c0_i32 = arith.constant 0 : i32
-# CHECK:      %c1_i32 = arith.constant 1 : i32
-# CHECK:      %c64_i32 = arith.constant 64 : i32
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i64, metadata = @objFifo_out0} : memref<64xi32>
+# CHECK:      %c0_i64 = arith.constant 0 : i64
+# CHECK:      %c1_i64 = arith.constant 1 : i64
+# CHECK:      %c64_i64 = arith.constant 64 : i64
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64]) {id = 1 : i64, metadata = @objFifo_out0} : memref<64xi32>
 # CHECK:      aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:      return
 # CHECK:    }
@@ -1889,30 +1874,26 @@ def add_one_using_dma(module):
             arg1: T.memref(32, T.i32()),
             arg2: T.memref(64, T.i32()),
         ):
-            c0_i32 = arith.constant(0)
-            c1_i32 = arith.constant(1)
-            c64_i32 = arith.constant(64)
+            c0_i64 = arith.constant(0, T.i64())
+            c1_i64 = arith.constant(1, T.i64())
+            c64_i64 = arith.constant(64, T.i64())
 
-            ipu_dma_memcpy_nd_(
-                c0_i32,
-                c0_i32,
+            ipu_dma_memcpy_nd(
+                "objFifo_in0",
+                0,
                 arg0,
-                *[c0_i32, c0_i32, c0_i32, c0_i32],
-                *[c1_i32, c1_i32, c1_i32, c64_i32],
-                *[c0_i32, c0_i32, c0_i32],
-                metadata="objFifo_in0",
-                id=0,
+                [c0_i64, c0_i64, c0_i64, c0_i64],
+                [c1_i64, c1_i64, c1_i64, c64_i64],
+                [c0_i64, c0_i64, c0_i64],
             )
 
-            ipu_dma_memcpy_nd_(
-                c0_i32,
-                c0_i32,
+            ipu_dma_memcpy_nd(
+                "objFifo_out0",
+                1,
                 arg2,
-                *[c0_i32, c0_i32, c0_i32, c0_i32],
-                *[c1_i32, c1_i32, c1_i32, c64_i32],
-                *[c0_i32, c0_i32, c0_i32],
-                metadata="objFifo_out0",
-                id=1,
+                [c0_i64, c0_i64, c0_i64, c0_i64],
+                [c1_i64, c1_i64, c1_i64, c64_i64],
+                [c0_i64, c0_i64, c0_i64],
             )
             ipu_sync(channel=0, column=0, column_num=1, direction=0, row=0, row_num=1)
 

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -90,11 +90,8 @@ Release = LockAction.Release
 # CHECK:       aie.end
 # CHECK:     } {link_with = "scale.o"}
 # CHECK:     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-# CHECK:       %c0_i32 = arith.constant 0 : i32
-# CHECK:       %c1_i32 = arith.constant 1 : i32
-# CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @out}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @in}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], metadata = @out, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 4096 : i32], metadata = @in, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -204,19 +201,11 @@ def my_vector_scalar(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "mm.o"}
 # CHECK:     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-# CHECK:       %c2048_i32 = arith.constant 2048 : i32
-# CHECK:       %c16_i32 = arith.constant 16 : i32
-# CHECK:       %c4_i32 = arith.constant 4 : i32
-# CHECK:       %c0_i32 = arith.constant 0 : i32
-# CHECK:       %c2_i32 = arith.constant 2 : i32
-# CHECK:       %c64_i32 = arith.constant 64 : i32
-# CHECK:       %c32_i32 = arith.constant 32 : i32
-# CHECK:       %c4096_i32 = arith.constant 4096 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 2 : i32, 64 : i32, 32 : i32], strides = [4096 : i32, 32 : i32, 64 : i32], id = 0 : i32, metadata = @outC}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 1 : i32, metadata = @inA}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 2 : i32, metadata = @inB}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 4096 : i32, 4096 : i32], lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], strides = [0 : i32, 16 : i32, 64 : i32], id = 3 : i32, metadata = @inA}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], strides = [32 : i32, 2048 : i32, 64 : i32], id = 4 : i32, metadata = @inB}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) {id = 0 : i32, lengths = [2 : i32, 2 : i32, 64 : i32, 32 : i32], metadata = @outC, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [4096 : i32, 32 : i32, 64 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 1 : i32, lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], metadata = @inA, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 16 : i32, 64 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 2 : i32, lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], metadata = @inB, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [32 : i32, 2048 : i32, 64 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 3 : i32, lengths = [2 : i32, 4 : i32, 64 : i32, 16 : i32], metadata = @inA, offsets = [0 : i32, 0 : i32, 0 : i32, 4096 : i32], strides = [0 : i32, 16 : i32, 64 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 4 : i32, lengths = [2 : i32, 4 : i32, 32 : i32, 32 : i32], metadata = @inB, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [32 : i32, 2048 : i32, 64 : i32]}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -534,12 +523,8 @@ def my_matmul(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "combined_gray2rgba_addWeighted.a"}
 # CHECK:     func.func @sequence(%arg0: memref<2304xi32>, %arg1: memref<2304xi32>, %arg2: memref<2304xi32>) {
-# CHECK:       %c0_i32 = arith.constant 0 : i32
-# CHECK:       %c1_i32 = arith.constant 1 : i32
-# CHECK:       %c36_i32 = arith.constant 36 : i32
-# CHECK:       %c64_i32 = arith.constant 64 : i32
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<2304xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 64 : i32], id = 0 : i32, metadata = @outOF_L2L3}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<2304xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 64 : i32], id = 1 : i32, metadata = @inOF_L3L2}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<2304xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], metadata = @outOF_L2L3, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 64 : i32]}
+# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<2304xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 36 : i32, 64 : i32], metadata = @inOF_L3L2, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 64 : i32]}
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -903,11 +888,8 @@ def edge_detect(module):
 #       aie.end
 #     }
 #     func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-#       %c0 = arith.constant 0 : i32
-#       %c1 = arith.constant 1 : i32
-#       %c64 = arith.constant 64 : i32
-#       aiex.ipu.dma_memcpy_nd(0, 0, %out : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @objFifo_out0, id = 1 : i32 }
-#       aiex.ipu.dma_memcpy_nd(0, 0, %in : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32],  metadata = @objFifo_in0, id = 0 : i32 }
+#       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @out0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
+#       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @in0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
 #       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
 #       return
 #     }
@@ -1667,11 +1649,8 @@ def my_passthrough(module):
 # CHECK:    }
 # CHECK:    aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 # CHECK:    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-# CHECK:      %c0_i32 = arith.constant 0 : i32
-# CHECK:      %c1_i32 = arith.constant 1 : i32
-# CHECK:      %c64_i32 = arith.constant 64 : i32
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 0 : i32, metadata = @objFifo_in0}
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) { offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], strides = [0 : i32, 0 : i32, 0 : i32], id = 1 : i32, metadata = @objFifo_out0}
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 0 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @objFifo_in0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
+# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 1 : i32, lengths = [1 : i32, 1 : i32, 1 : i32, 64 : i32], metadata = @objFifo_out0, offsets = [0 : i32, 0 : i32, 0 : i32, 0 : i32], strides = [0 : i32, 0 : i32, 0 : i32]}
 # CHECK:      aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:      return
 # CHECK:    }
@@ -1889,28 +1868,24 @@ def add_one_using_dma(module):
             arg1: T.memref(32, T.i32()),
             arg2: T.memref(64, T.i32()),
         ):
-            c0_i32 = arith.constant(0)
-            c1_i32 = arith.constant(1)
-            c64_i32 = arith.constant(64)
-
             ipu_dma_memcpy_nd_(
-                c0_i32,
-                c0_i32,
+                0,
+                0,
                 arg0,
-                *[c0_i32, c0_i32, c0_i32, c0_i32],
-                *[c1_i32, c1_i32, c1_i32, c64_i32],
-                *[c0_i32, c0_i32, c0_i32],
+                [0, 0, 0, 0],
+                [1, 1, 1, 64],
+                [0, 0, 0],
                 metadata="objFifo_in0",
                 id=0,
             )
 
             ipu_dma_memcpy_nd_(
-                c0_i32,
-                c0_i32,
+                0,
+                0,
                 arg2,
-                *[c0_i32, c0_i32, c0_i32, c0_i32],
-                *[c1_i32, c1_i32, c1_i32, c64_i32],
-                *[c0_i32, c0_i32, c0_i32],
+                [0, 0, 0, 0],
+                [1, 1, 1, 64],
+                [0, 0, 0],
                 metadata="objFifo_out0",
                 id=1,
             )

--- a/test/python/ipu.py
+++ b/test/python/ipu.py
@@ -90,8 +90,11 @@ Release = LockAction.Release
 # CHECK:       aie.end
 # CHECK:     } {link_with = "scale.o"}
 # CHECK:     func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<4096xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 1, 4096>, metadata = @out, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<4096xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 1, 4096>, metadata = @in, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
+# CHECK:       %c0_i32 = arith.constant 0 : i32
+# CHECK:       %c1_i32 = arith.constant 1 : i32
+# CHECK:       %c4096_i32 = arith.constant 4096 : i32
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @out} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c4096_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @in} : (i32, i32, memref<4096xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -201,11 +204,19 @@ def my_vector_scalar(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "mm.o"}
 # CHECK:     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<8192xi32>) {id = 0 : i32, lengths = array<i32: 2, 2, 64, 32>, metadata = @outC, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 4096, 32, 64>}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 1 : i32, lengths = array<i32: 2, 4, 64, 16>, metadata = @inA, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 16, 64>}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 2 : i32, lengths = array<i32: 2, 4, 32, 32>, metadata = @inB, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 32, 2048, 64>}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<8192xi32>) {id = 3 : i32, lengths = array<i32: 2, 4, 64, 16>, metadata = @inA, offsets = array<i32: 0, 0, 0, 4096>, strides = array<i32: 0, 16, 64>}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg1 : memref<8192xi32>) {id = 4 : i32, lengths = array<i32: 2, 4, 32, 32>, metadata = @inB, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 32, 2048, 64>}
+# CHECK:       %c2048_i32 = arith.constant 2048 : i32
+# CHECK:       %c16_i32 = arith.constant 16 : i32
+# CHECK:       %c4_i32 = arith.constant 4 : i32
+# CHECK:       %c0_i32 = arith.constant 0 : i32
+# CHECK:       %c2_i32 = arith.constant 2 : i32
+# CHECK:       %c64_i32 = arith.constant 64 : i32
+# CHECK:       %c32_i32 = arith.constant 32 : i32
+# CHECK:       %c4096_i32 = arith.constant 4096 : i32
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c2_i32, %c64_i32, %c32_i32] [%c4096_i32, %c32_i32, %c64_i32]) {id = 0 : i32, metadata = @outC} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 1 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 2 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c4096_i32] [%c2_i32, %c4_i32, %c64_i32, %c16_i32] [%c0_i32, %c16_i32, %c64_i32]) {id = 3 : i32, metadata = @inA} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg1[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c2_i32, %c4_i32, %c32_i32, %c32_i32] [%c32_i32, %c2048_i32, %c64_i32]) {id = 4 : i32, metadata = @inB} : (i32, i32, memref<8192xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -523,8 +534,12 @@ def my_matmul(module):
 # CHECK:       aie.end
 # CHECK:     } {link_with = "combined_gray2rgba_addWeighted.a"}
 # CHECK:     func.func @sequence(%arg0: memref<2304xi32>, %arg1: memref<2304xi32>, %arg2: memref<2304xi32>) {
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<2304xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 36, 64>, metadata = @outOF_L2L3, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 64>}
-# CHECK:       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<2304xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 36, 64>, metadata = @inOF_L3L2, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 64>}
+# CHECK:       %c0_i32 = arith.constant 0 : i32
+# CHECK:       %c1_i32 = arith.constant 1 : i32
+# CHECK:       %c36_i32 = arith.constant 36 : i32
+# CHECK:       %c64_i32 = arith.constant 64 : i32
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 0 : i32, metadata = @outOF_L2L3} : (i32, i32, memref<2304xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:       aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c36_i32, %c64_i32] [%c0_i32, %c0_i32, %c64_i32]) {id = 1 : i32, metadata = @inOF_L3L2} : (i32, i32, memref<2304xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
 # CHECK:       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:       return
 # CHECK:     }
@@ -888,8 +903,11 @@ def edge_detect(module):
 #       aie.end
 #     }
 #     func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-#       aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @out0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
-#       aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @in0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
+#       %c0 = arith.constant 0 : i32
+#       %c1 = arith.constant 1 : i32
+#       %c64 = arith.constant 64 : i32
+#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_out0, id = 1 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
+#       aiex.ipu.dma_memcpy_nd (%c0, %c0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0]) { metadata = @objFifo_in0, id = 0 : i32 } : (i32, i32, memref<64xi32>, [i32,i32,i32,i32], [i32,i32,i32,i32], [i32,i32,i32])
 #       aiex.ipu.sync { column = 0 : i32, row = 0 : i32, direction = 0 : i32, channel = 0 : i32, column_num = 1 : i32, row_num = 1 : i32 }
 #       return
 #     }
@@ -1649,8 +1667,11 @@ def my_passthrough(module):
 # CHECK:    }
 # CHECK:    aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 # CHECK:    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg0 : memref<64xi32>) {id = 0 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @objFifo_in0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
-# CHECK:      aiex.ipu.dma_memcpy_nd(0, 0, %arg2 : memref<64xi32>) {id = 1 : i32, lengths = array<i32: 1, 1, 1, 64>, metadata = @objFifo_out0, offsets = array<i32: 0, 0, 0, 0>, strides = array<i32: 0, 0, 0>}
+# CHECK:      %c0_i32 = arith.constant 0 : i32
+# CHECK:      %c1_i32 = arith.constant 1 : i32
+# CHECK:      %c64_i32 = arith.constant 64 : i32
+# CHECK:      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg0[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 0 : i32, metadata = @objFifo_in0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
+# CHECK:      aiex.ipu.dma_memcpy_nd(%c0_i32, %c0_i32, %arg2[%c0_i32, %c0_i32, %c0_i32, %c0_i32] [%c1_i32, %c1_i32, %c1_i32, %c64_i32] [%c0_i32, %c0_i32, %c0_i32]) {id = 1 : i32, metadata = @objFifo_out0} : (i32, i32, memref<64xi32>, [i32, i32, i32, i32], [i32, i32, i32, i32], [i32, i32, i32])
 # CHECK:      aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 # CHECK:      return
 # CHECK:    }
@@ -1868,24 +1889,28 @@ def add_one_using_dma(module):
             arg1: T.memref(32, T.i32()),
             arg2: T.memref(64, T.i32()),
         ):
+            c0_i32 = arith.constant(0)
+            c1_i32 = arith.constant(1)
+            c64_i32 = arith.constant(64)
+
             ipu_dma_memcpy_nd_(
-                0,
-                0,
+                c0_i32,
+                c0_i32,
                 arg0,
-                [0, 0, 0, 0],
-                [1, 1, 1, 64],
-                [0, 0, 0],
+                *[c0_i32, c0_i32, c0_i32, c0_i32],
+                *[c1_i32, c1_i32, c1_i32, c64_i32],
+                *[c0_i32, c0_i32, c0_i32],
                 metadata="objFifo_in0",
                 id=0,
             )
 
             ipu_dma_memcpy_nd_(
-                0,
-                0,
+                c0_i32,
+                c0_i32,
                 arg2,
-                [0, 0, 0, 0],
-                [1, 1, 1, 64],
-                [0, 0, 0],
+                *[c0_i32, c0_i32, c0_i32, c0_i32],
+                *[c1_i32, c1_i32, c1_i32, c64_i32],
+                *[c0_i32, c0_i32, c0_i32],
                 metadata="objFifo_out0",
                 id=1,
             )


### PR DESCRIPTION
## TL;DR

This PR refactors `ipu.dma_memcpy_nd` to use [`OffsetSizeAndStrideOpInterface`](https://github.com/llvm/llvm-project/blob/1949fe90bfccaa13b4ecbce33de3123824b9a150/mlir/include/mlir/Interfaces/ViewLikeInterface.td#L33). This enables supporting both operands and attributes for `offsets`/`lengths`/`strides`. This means you can write IR like

```mlir
func.func @sequence(%arg0: memref<2304xi32>, %arg1: memref<2304xi32>, %arg2: memref<2304xi32>) {
  aiex.ipu.dma_memcpy_nd(0, 0, %arg2[0, 0, 0, 0][1, 1, 36, 64][0, 0, 64]) {id = 0 : i64, metadata = @outOF_L2L3} : memref<2304xi32>
  aiex.ipu.dma_memcpy_nd(0, 0, %arg0[0, 0, 0, 0][1, 1, 36, 64][0, 0, 64]) {id = 1 : i64, metadata = @inOF_L3L2} : memref<2304xi32>
  aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
  return
}
```

or

```mlir
func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
  %c0_i64 = arith.constant 0 : i64
  %c1_i64 = arith.constant 1 : i64
  %c64_i64 = arith.constant 64 : i64
  aiex.ipu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
  aiex.ipu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64]) {id = 1 : i64, metadata = @objFifo_out0} : memref<64xi32>
  aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
  return
}
```

and both will get munged to the same thing: an array of integers.

## Why

This simplifies the current cpp, which looks like this

```cpp
    SmallVector<uint32_t, 4> offsets(4, 0);
    SmallVector<uint32_t, 4> lengths(4, 1);
    SmallVector<uint32_t, 3> strides(3, 0);

    if (auto c = op.getOffset0().getDefiningOp<arith::ConstantIntOp>())
      offsets[0] = static_cast<uint32_t>(c.value());
    if (auto c = op.getOffset1().getDefiningOp<arith::ConstantIntOp>())
      offsets[1] = static_cast<uint32_t>(c.value());
    if (auto c = op.getOffset2().getDefiningOp<arith::ConstantIntOp>())
      offsets[2] = static_cast<uint32_t>(c.value());
    if (auto c = op.getOffset3().getDefiningOp<arith::ConstantIntOp>())
      offsets[3] = static_cast<uint32_t>(c.value());
    if (auto c = op.getLength0().getDefiningOp<arith::ConstantIntOp>())
      lengths[0] = static_cast<uint32_t>(c.value());
    if (auto c = op.getLength1().getDefiningOp<arith::ConstantIntOp>())
      lengths[1] = static_cast<uint32_t>(c.value());
    if (auto c = op.getLength2().getDefiningOp<arith::ConstantIntOp>())
      lengths[2] = static_cast<uint32_t>(c.value());
    if (auto c = op.getLength3().getDefiningOp<arith::ConstantIntOp>())
      lengths[3] = static_cast<uint32_t>(c.value());
    if (auto c = op.getStride1().getDefiningOp<arith::ConstantIntOp>())
      strides[0] = static_cast<uint32_t>(c.value());
    if (auto c = op.getStride2().getDefiningOp<arith::ConstantIntOp>())
      strides[1] = static_cast<uint32_t>(c.value());
    if (auto c = op.getStride3().getDefiningOp<arith::ConstantIntOp>())
      strides[2] = static_cast<uint32_t>(c.value());
```

to this

```cpp
    llvm::SmallVector<int64_t, 3> strides = llvm::map_to_vector(
        llvm::reverse(op.getMixedStrides()),
        [](OpFoldResult s) { return getConstantIntValue(s).value(); });
    llvm::SmallVector<int64_t, 4> lengths = llvm::map_to_vector(
        llvm::reverse(op.getMixedSizes()),
        [](OpFoldResult s) { return getConstantIntValue(s).value(); });
    llvm::SmallVector<int64_t, 4> offsets = llvm::map_to_vector(
        llvm::reverse(op.getMixedOffsets()),
        [](OpFoldResult s) { return getConstantIntValue(s).value(); });
```

and also the python bindings from this

```python
class IpuDmaMemcpyNd(IpuDmaMemcpyNdOp):
    """Specialize IpuDmaMemcpyNdOp class constructor to take python integers"""

    def __init__(self, metadata, bd_id, mem, offsets=None, lengths=None, strides=None):
        if strides is None:
            strides = [0] * 3
        if lengths is None:
            lengths = [0] * 4
        if offsets is None:
            offsets = [0] * 4
        symMetadata = FlatSymbolRefAttr.get(metadata)
        iTy = IntegerType.get_signless(32)
        x = 0
        y = 0
        intX = arith.ConstantOp(iTy, IntegerAttr.get(iTy, x))
        intY = arith.ConstantOp(iTy, IntegerAttr.get(iTy, y))
        valueOffsets = []
        valueLengths = []
        valueStrides = []
        for i in offsets:
            valueOffsets.append(arith.ConstantOp(iTy, IntegerAttr.get(iTy, i)))
        for i in lengths:
            valueLengths.append(arith.ConstantOp(iTy, IntegerAttr.get(iTy, i)))
        for i in strides:
            valueStrides.append(arith.ConstantOp(iTy, IntegerAttr.get(iTy, i)))
        super().__init__(
            metadata=symMetadata,
            id=bd_id,
            x=intX,
            y=intY,
            memref=mem,
            offset3=valueOffsets[0],
            offset2=valueOffsets[1],
            offset1=valueOffsets[2],
            offset0=valueOffsets[3],
            length3=valueLengths[0],
            length2=valueLengths[1],
            length1=valueLengths[2],
            length0=valueLengths[3],
            stride3=valueStrides[0],
            stride2=valueStrides[1],
            stride1=valueStrides[2],
        )
```

to this

```python
class IpuDmaMemcpyNd(IpuDmaMemcpyNdOp):
    """Specialize IpuDmaMemcpyNdOp class constructor to take python integers"""

    def __init__(
        self,
        metadata,
        bd_id,
        mem,
        offsets: MixedValues = None,
        lengths: MixedValues = None,
        strides: MixedValues = None,
    ):
        x = 0
        y = 0
        if offsets is None:
            offsets = [0] * 4
        if lengths is None:
            lengths = [0] * 4
        if strides is None:
            strides = [0] * 3
        dynamic_offsets, _packed_offsets, static_offsets = _dispatch_mixed_values(
            offsets
        )
        dynamic_lengths, _packed_lengths, static_lengths = _dispatch_mixed_values(
            lengths
        )
        dynamic_strides, _packed_strides, static_strides = _dispatch_mixed_values(
            strides
        )
        super().__init__(
            x,
            y,
            mem,
            dynamic_offsets,
            dynamic_lengths,
            dynamic_strides,
            static_offsets,
            static_lengths,
            static_strides,
            metadata,
            bd_id,
        )
```

## How

This would've been a simple matter of implementing `OffsetSizeAndStrideOpInterface` i.e.

```cpp
    ::mlir::OperandRange getSizes();
    ::llvm::ArrayRef<int64_t> getStaticSizes();
    static unsigned getOffsetSizeAndStrideStartOperandIndex();
    static std::array<unsigned, 3> getArrayAttrMaxRanks();
```

if it weren't for the fact that `OffsetSizeAndStrideOpInterface` [assumes/verifies/enforces](https://github.com/llvm/llvm-project/blob/1949fe90bfccaa13b4ecbce33de3123824b9a150/mlir/lib/Interfaces/ViewLikeInterface.cpp#L52-L58) `strides.rank == lengths.rank`. 

The workaround is some pretty "advanced" usage of interfaces that boils down to

1. Subclassing both `OffsetSizeAndStrideOpInterface` and `OffsetSizeAndStrideOpInterface::Trait` in C++ in order to override `OffsetSizeAndStrideOpInterface::Trait::verifyTrait` to skip the `strides.rank == lengths.rank` check. 
    - The reason you have to do this is because interface inheritance in tablegen just means appending traits, not subclassing, so you can't override trait methods in "subinterfaces".
2. Using [`OpInterfaceTrait`](https://github.com/llvm/llvm-project/blob/edae8f6ce29a980d83761f59f81b88167a0fd815/mlir/include/mlir/IR/Interfaces.td#L36) to expose the pure C++ interface to tablegen.
3. Using `i64` instead of `i32` indices (the interface requires either `index` or `i64` and `i64` seems more straightforward).

## N.B.

- Currently only `arith.constant` operands are supported (and this is verified). In the future, if we want to support fully dynamic operands, this will be straightforward.
- There is a stacked [PR](https://github.com/Xilinx/mlir-aie/pull/905) that chronologically predates the current version of this PR where I rename `lengths` -> `wraps` and `steps` -> `strides` on `dma_memcpy_nd` and `writebd_shimtile`. In light of this current version I propose we actually rename `lengths` -> `sizes` to completely align with `OffsetSizeAndStrideOpInterface`'s naming conventions.
- This PR also updates `objectFifo` -> `objectfifo` in `reference_designs/ipu-xrt/vision_pipelines` which wasn't being tested because OpenCV is not installed on the minisforum runner (i've tested them on my minisforum).