### PR TITLE
Adding the full LLVM hash to ./utils/clone-llvm.sh and then slicing it for the WHEEL_VERSION

### DIFF
--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -13,9 +13,9 @@
 ##===----------------------------------------------------------------------===##
 
 # The LLVM commit to use.
-LLVM_PROJECT_COMMIT=5cfc7b33
+LLVM_PROJECT_COMMIT=5cfc7b3342ce4de0bbe182b38baa8a71fc83f8f8
 DATETIME=2023122517
-WHEEL_VERSION=18.0.0.$DATETIME+$LLVM_PROJECT_COMMIT
+WHEEL_VERSION=18.0.0.$DATETIME+${LLVM_PROJECT_COMMIT:0:8}
 ############################################################################################
 # The way to bump `LLVM_PROJECT_COMMIT`
 #   1. Find the hash you want (`git rev-parse --short=8 HEAD` or just copy paste from github);


### PR DESCRIPTION
Without this change, just running `./utils/clone-llvm.sh` fails because `git fetch --depth=1` requires a full commit hash.