### PR TITLE
Unified `DMAOp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # MLIR-based AI Engine toolchain
 
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Xilinx/mlir-aie/buildAndTest.yml?branch=main)
+[![Build and Test](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTest.yml/badge.svg)](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTest.yml)
+
+[![Build and Test across Python versions](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestPythons.yml/badge.svg)](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestPythons.yml)
+
+[![Build and Test with AIE tools](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestAieTools.yml/badge.svg)](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestAieTools.yml)
+
+[![Build and Test with AIE tools on Ryzen AI](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestRyzenAI.yml/badge.svg)](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestRyzenAI.yml)
+
+[![Compile across platforms](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestMulti.yml/badge.svg)](https://github.com/Xilinx/mlir-aie/actions/workflows/buildAndTestMulti.yml)
+
 ![GitHub Pull Requests](https://img.shields.io/github/issues-pr-raw/Xilinx/mlir-aie)
 
 ![](https://mlir.llvm.org//mlir-logo.png)

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -887,6 +887,25 @@ def AIE_DMAStartOp: AIE_Op<"dma_start", [
   }];
 }
 
+def AIE_DMAOp: AIE_Op<"dma", [
+    ParentOneOf<["MemOp", "MemTileDMAOp", "mlir::func::FuncOp", "ShimDMAOp"]>,
+    NoTerminator,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]>, Results<(outs I1:$valid)> {
+
+  let summary = "An op to describe a set of DMA operations.";
+
+  let arguments = (
+    ins DMAChannelDir:$channelDir,
+        ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$channelIndex
+  );
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    `(` $channelDir `,` $channelIndex `)` regions attr-dict
+  }];
+}
+
+
 // MemOps are not actually Callable, but we want to inline code into them, so we have to
 // implement CallableOpInterface
 def AIE_MemOp: AIE_Op<"mem", [

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -888,7 +888,7 @@ def AIE_DMAStartOp: AIE_Op<"dma_start", [
 }
 
 def AIE_DMAOp: AIE_Op<"dma", [
-    ParentOneOf<["MemOp", "MemTileDMAOp", "mlir::func::FuncOp", "ShimDMAOp"]>,
+    ParentOneOf<["MemOp", "MemTileDMAOp", "ShimDMAOp"]>,
     NoTerminator,
     DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]>, Results<(outs I1:$valid)> {
@@ -903,6 +903,7 @@ def AIE_DMAOp: AIE_Op<"dma", [
   let assemblyFormat = [{
     `(` $channelDir `,` $channelIndex `)` regions attr-dict
   }];
+  let hasVerifier = 1;
 }
 
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1349,6 +1349,19 @@ LogicalResult MemTileDMAOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// DMAOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult DMAOp::verify() {
+  auto *parentOp = getOperation()->getParentOp();
+  if (parentOp->getRegion(0).getBlocks().size() > 1)
+    return emitOpError("DMA op can only appear in single block region");
+  if (!parentOp->getRegion(0).getOps<DMAStartOp>().empty())
+    return emitOpError("DMA op is not compatible with DMAStart ops");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // DMABDOp
 //===----------------------------------------------------------------------===//
 

--- a/test/Targets/AIEGenerateCDODirect/dma_op.mlir
+++ b/test/Targets/AIEGenerateCDODirect/dma_op.mlir
@@ -10,12 +10,11 @@
 
 // REQUIRES: ryzen_ai
 
-// RUN: aie-translate --aie-generate-cdo-direct %S/dma_op.mlir --cdo-axi-debug 2>&1 | FileCheck %s
+// RUN: aie-translate --aie-generate-cdo-direct %s --cdo-axi-debug 2>&1 | FileCheck %s
 
 // CHECK: Generating: {{.*}}aie_cdo_error_handling.bin
-// CHECK: Generating: {{.*}}aie_cdo_elfs.bin
 // CHECK: Generating: {{.*}}aie_cdo_init.bin
-// CHECK: Generating: {{.*}}aie_cdo_enable.bin
+
 module {
   aie.device(ipu) {
     %tile_0_1 = aie.tile(0, 1)
@@ -98,4 +97,3 @@ module {
     }
   }
 }
-

--- a/test/dialect/AIE/bad_dma_op.mlir
+++ b/test/dialect/AIE/bad_dma_op.mlir
@@ -1,0 +1,34 @@
+//===- dma_op.mlir --------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aie-opt %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'aie.dma' op DMA op can only appear in single block region
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %objFifo_in0_cons_buff_0 = aie.buffer(%tile_0_1) {address = 0 : i32} : memref<16xi32>
+    %objFifo_in0_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32}
+    %objFifo_in0_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32}
+
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+    ^bb0:
+      aie.dma(S2MM, 0) {
+        aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
+      }
+      aie.next_bd ^bb1
+    ^bb1:
+      aie.end
+    }
+
+  }
+}

--- a/test/dialect/AIE/dma_op.mlir
+++ b/test/dialect/AIE/dma_op.mlir
@@ -1,0 +1,101 @@
+//===- dma_op.mlir --------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: ryzen_ai
+
+// RUN: aie-translate --aie-generate-cdo-direct %S/dma_op.mlir --cdo-axi-debug 2>&1 | FileCheck %s
+
+// CHECK: Generating: {{.*}}aie_cdo_error_handling.bin
+// CHECK: Generating: {{.*}}aie_cdo_elfs.bin
+// CHECK: Generating: {{.*}}aie_cdo_init.bin
+// CHECK: Generating: {{.*}}aie_cdo_enable.bin
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+
+    %objFifo_in0_cons_buff_0 = aie.buffer(%tile_0_1) {address = 0 : i32} : memref<16xi32>
+    %objFifo_in0_cons_buff_1 = aie.buffer(%tile_0_1) {address = 64 : i32} : memref<16xi32>
+    %objFifo_out0_buff_0 = aie.buffer(%tile_0_1) {address = 128 : i32} : memref<16xi32>
+    %objFifo_out0_buff_1 = aie.buffer(%tile_0_1) {address = 192 : i32} : memref<16xi32>
+
+    %objFifo_in1_cons_buff_0 = aie.buffer(%tile_0_2) {address = 0 : i32} : memref<8xi32>
+    %objFifo_in1_cons_buff_1 = aie.buffer(%tile_0_2) {address = 32 : i32} : memref<8xi32>
+    %objFifo_out1_buff_0 = aie.buffer(%tile_0_2) {address = 64 : i32} : memref<8xi32>
+    %objFifo_out1_buff_1 = aie.buffer(%tile_0_2) {address = 96 : i32} : memref<8xi32>
+
+    %objFifo_in0_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32}
+    %objFifo_in0_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32}
+    %objFifo_out0_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32}
+    %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32}
+
+    %objFifo_in1_cons_prod_lock = aie.lock(%tile_0_2, 0) {init = 2 : i32}
+    %objFifo_in1_cons_cons_lock = aie.lock(%tile_0_2, 1) {init = 0 : i32}
+    %objFifo_out1_prod_lock = aie.lock(%tile_0_2, 2) {init = 2 : i32}
+    %objFifo_out1_cons_lock = aie.lock(%tile_0_2, 3) {init = 0 : i32}
+
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      aie.dma(S2MM, 0) {
+        aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
+        aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
+      }
+      aie.dma(MM2S, 0) {
+        aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
+        aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
+      }
+      aie.dma(MM2S, 0) {
+        aie.use_lock(%objFifo_out0_cons_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_out0_buff_0 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_out0_prod_lock, Release, 1)
+        aie.use_lock(%objFifo_out0_cons_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_out0_buff_1 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_out0_prod_lock, Release, 1)
+      }
+      aie.dma(S2MM, 1) {
+        aie.use_lock(%objFifo_out0_prod_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_out0_buff_0 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_out0_cons_lock, Release, 1)
+        aie.use_lock(%objFifo_out0_prod_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_out0_buff_1 : memref<16xi32>, 0, 16)
+        aie.use_lock(%objFifo_out0_cons_lock, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      aie.dma(S2MM, 0) {
+        aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_in1_cons_buff_0 : memref<8xi32>, 0, 8)
+        aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
+        aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_in1_cons_buff_1 : memref<8xi32>, 0, 8)
+        aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
+      }
+      aie.dma(MM2S, 0) {
+        aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_out1_buff_0 : memref<8xi32>, 0, 8)
+        aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
+        aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
+        aie.dma_bd(%objFifo_out1_buff_1 : memref<8xi32>, 0, 8)
+        aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
+      }
+      aie.end
+    }
+  }
+}
+


### PR DESCRIPTION
This PR introduces `aie.dma` which is a single region (single block) op that encompasses both `aie.dma_start` and then dma instructions (such as `use_lock` and `dma_bd`). It looks like this:

```mlir
      aie.dma(S2MM, 0) {
        aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16)
        aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
        aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, 0, 16)
        aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
      }
```

This PR also uses the previous PR https://github.com/Xilinx/mlir-aie/pull/913 to lower/translate these ops to the CDO backend.