### PR TITLE
add address attribute to `BufferOp`

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -253,7 +253,7 @@ void printObjectFifoConsumerTiles(mlir::OpAsmPrinter &printer,
                                   mlir::Operation *op, mlir::OperandRange tiles,
                                   mlir::Attribute dimensions);
 
-uint64_t getBufferBaseAddress(mlir::Operation *bufOp);
+int32_t getBufferBaseAddress(mlir::Operation *bufOp);
 
 } // namespace xilinx::AIE
 

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1162,7 +1162,8 @@ def AIE_BufferOp: AIE_Op<"buffer", [
 
   let arguments = (
     ins Index:$tile,
-    OptionalAttr<StrAttr>:$sym_name
+    OptionalAttr<StrAttr>:$sym_name,
+    OptionalAttr<AIEI64Attr>:$address
   );
 
   let results = (outs AnyMemRef:$buffer);
@@ -1182,14 +1183,6 @@ def AIE_BufferOp: AIE_Op<"buffer", [
       emitOpError("does not have '")
           << mlir::SymbolTable::getSymbolAttrName() << "' attribute specified";
       llvm::report_fatal_error("couldn't get name");
-    }
-
-    // Return the address of this buffer
-    int64_t address() {
-      if (auto attr = getOperation()->getAttrOfType<mlir::IntegerAttr>("address"))
-        return attr.getInt();
-      emitOpError("does not have 'address' attribute specified");
-      llvm::report_fatal_error("couldn't address");
     }
 
     // Return the number of bytes that need to be allocated for this buffer.

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1163,7 +1163,7 @@ def AIE_BufferOp: AIE_Op<"buffer", [
   let arguments = (
     ins Index:$tile,
     OptionalAttr<StrAttr>:$sym_name,
-    OptionalAttr<AIEI64Attr>:$address
+    OptionalAttr<AIEI32Attr>:$address
   );
 
   let results = (outs AnyMemRef:$buffer);

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1191,7 +1191,7 @@ LogicalResult BufferOp::verify() {
 
 // FIXME: make address assignment for buffers explicit and move this function to
 // an interface
-uint64_t xilinx::AIE::getBufferBaseAddress(Operation *bufOp) {
+int32_t xilinx::AIE::getBufferBaseAddress(Operation *bufOp) {
   if (auto buf = dyn_cast<BufferOp>(bufOp)) {
     assert(buf.getAddress().has_value() && "buffer must have address assigned");
     return buf.getAddress().value();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1192,8 +1192,10 @@ LogicalResult BufferOp::verify() {
 // FIXME: make address assignment for buffers explicit and move this function to
 // an interface
 uint64_t xilinx::AIE::getBufferBaseAddress(Operation *bufOp) {
-  if (auto buf = dyn_cast<BufferOp>(bufOp))
-    return buf.address();
+  if (auto buf = dyn_cast<BufferOp>(bufOp)) {
+    assert(buf.getAddress().has_value() && "buffer must have address assigned");
+    return buf.getAddress().value();
+  }
   if (isa_and_nonnull<ExternalBufferOp>(bufOp))
     llvm::report_fatal_error(
         "External buffer addresses are assigned at runtime.");

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -100,9 +100,12 @@ struct AIEAssignBufferAddressesPass
         else
           error << "(no stack allocated)\n";
 
-        for (auto buffer : buffers)
-          printbuffer(buffer.name(), buffer.address(),
+        for (auto buffer : buffers) {
+          assert(buffer.getAddress().has_value() &&
+                 "buffer must have address assigned");
+          printbuffer(buffer.name(), buffer.getAddress().value(),
                       buffer.getAllocationSize());
+        }
         return signalPassFailure();
       }
     }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -385,7 +385,8 @@ struct AIEObjectFifoStatefulTransformPass
         auto buff = builder.create<BufferOp>(
             builder.getUnknownLoc(), elemType, creation_tile,
             builder.getStringAttr(op.name().str() + "_buff_" +
-                                  std::to_string(of_elem_index)));
+                                  std::to_string(of_elem_index)),
+            nullptr);
         buffers.push_back(buff);
       }
       of_elem_index++;

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -124,7 +124,7 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
           assert(t && "Unsupported type!");
           coreBufTypes.push_back({t, i});
           BufferOp buf = builder.create<BufferOp>(builder.getUnknownLoc(), t,
-                                                  tile, nullptr);
+                                                  tile, nullptr, nullptr);
           buffers[callOperands[i]] = buf;
           operand.replaceAllUsesWith(buf.getResult());
         }

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
@@ -43,8 +43,11 @@ struct RtpToIpuPattern : OpConversionPattern<IpuWriteRTPOp> {
 
     if (auto buffer = device.lookupSymbol<AIE::BufferOp>(op.getBufferSymName()))
       if (AIE::TileOp tile = buffer.getTileOp();
-          tile.colIndex() == c && tile.rowIndex() == r)
-        rtp_buffer_addr = static_cast<uint32_t>(buffer.address());
+          tile.colIndex() == c && tile.rowIndex() == r) {
+        assert(buffer.getAddress().has_value() &&
+               "buffer must have address assigned");
+        rtp_buffer_addr = static_cast<uint32_t>(buffer.getAddress().value());
+      }
 
     if (rtp_buffer_addr == UINT_MAX)
       return op.emitOpError("RTP buffer address cannot be found. Has an RTP "

--- a/lib/Targets/AIETargetCDO.cpp
+++ b/lib/Targets/AIETargetCDO.cpp
@@ -337,8 +337,10 @@ mlir::LogicalResult AIETranslateToCDO(ModuleOp m, raw_ostream &output) {
         foundBd = true;
         ShapedType bufferType =
             op.getBuffer().getType().cast<::mlir::MemRefType>();
-        BaseAddrA =
-            cast<AIE::BufferOp>(op.getBuffer().getDefiningOp()).address();
+        auto bufferOp = cast<AIE::BufferOp>(op.getBuffer().getDefiningOp());
+        assert(bufferOp.getAddress().has_value() &&
+               "buffer needs to have an address");
+        BaseAddrA = bufferOp.getAddress().value();
         lenA = op.getLenValue();
         bytesA = bufferType.getElementTypeBitWidth() / 8;
         offsetA = op.getOffsetValue();
@@ -518,8 +520,10 @@ mlir::LogicalResult AIETranslateToCDO(ModuleOp m, raw_ostream &output) {
         foundBd = true;
         ShapedType bufferType =
             op.getBuffer().getType().cast<::mlir::MemRefType>();
-        BaseAddrA =
-            cast<AIE::BufferOp>(op.getBuffer().getDefiningOp()).address();
+        auto bufferOp = cast<AIE::BufferOp>(op.getBuffer().getDefiningOp());
+        assert(bufferOp.getAddress().has_value() &&
+               "buffer op must have address assigned");
+        BaseAddrA = bufferOp.getAddress().value();
         lenA = op.getLenValue();
         bytesA = bufferType.getElementTypeBitWidth() / 8;
         offsetA = op.getOffsetValue();

--- a/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
@@ -32,8 +32,8 @@ module @test_xaie2 {
  aie.device(xcvc1902) {
   %t33 = aie.tile(3, 3)
 
-  %buf33_0 = aie.buffer(%t33) { address = 0x1000, sym_name = "buff33_0" }: memref<256xi32>
-  %buf33_1 = aie.buffer(%t33) { address = 0x1400, sym_name = "buff33_1" }: memref<16xi32>
+  %buf33_0 = aie.buffer(%t33) { address = 0x1000 : i32, sym_name = "buff33_0" }: memref<256xi32>
+  %buf33_1 = aie.buffer(%t33) { address = 0x1400 : i32, sym_name = "buff33_1" }: memref<16xi32>
 
   %l33_0 = aie.lock(%t33, 0)
   %l33_1 = aie.lock(%t33, 1)

--- a/test/Targets/AIEGenerateXAIE/test_xaie3.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie3.mlir
@@ -19,7 +19,7 @@ module @test_xaie3 {
   %t33 = aie.tile(3, 3)
   %t44 = aie.tile(4, 4)
 
-  %buf33_0 = aie.buffer(%t33) { address = 0, sym_name = "buf33_0" }: memref<256xi32>
+  %buf33_0 = aie.buffer(%t33) { address = 0 : i32, sym_name = "buf33_0" }: memref<256xi32>
 
   %l33_0 = aie.lock(%t33, 0)
 

--- a/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
@@ -35,8 +35,8 @@ module @test_xaie3 {
   %t33 = aie.tile(3, 3)
   %t44 = aie.tile(4, 4)
 
-  %buf33_0 = aie.buffer(%t33) {address = 0x1000, sym_name = "buf33_0" } : memref<256xi32>
-  %buf33_1 = aie.buffer(%t33) {address = 0x1400, sym_name = "buf33_1" } : memref<256xi32>
+  %buf33_0 = aie.buffer(%t33) {address = 0x1000 : i32, sym_name = "buf33_0" } : memref<256xi32>
+  %buf33_1 = aie.buffer(%t33) {address = 0x1400 : i32, sym_name = "buf33_1" } : memref<256xi32>
 
   %l33_0 = aie.lock(%t33, 0)
   %l33_1 = aie.lock(%t33, 1)

--- a/test/generate-mmap/test_mmap0.mlir
+++ b/test/generate-mmap/test_mmap0.mlir
@@ -123,13 +123,13 @@ module @test_mmap0 {
   %t43 = aie.tile(4, 3)
   %t45 = aie.tile(4, 5)
 
-  %buf44_0 = aie.buffer(%t44) { sym_name = "a", address = 0x0 } : memref<4xi32>
-  %buf44_1 = aie.buffer(%t44) { sym_name = "b", address = 0x10  } : memref<16xi32>
-  %buf44_2 = aie.buffer(%t44) { sym_name = "c", address = 0x50 } : memref<256xi32>
-  %buf34_0 = aie.buffer(%t34) { sym_name = "x", address = 0x0 } : memref<8xi32>
-  %buf54_0 = aie.buffer(%t54) { sym_name = "y", address = 0x0 } : memref<8xi32>
-  %buf43_0 = aie.buffer(%t43) { sym_name = "z", address = 0x0 } : memref<8xi32>
-  %buf45_0 = aie.buffer(%t45) { sym_name = "t", address = 0x0 } : memref<8xi32>
+  %buf44_0 = aie.buffer(%t44) { sym_name = "a", address = 0x0 : i32 } : memref<4xi32>
+  %buf44_1 = aie.buffer(%t44) { sym_name = "b", address = 0x10 : i32  } : memref<16xi32>
+  %buf44_2 = aie.buffer(%t44) { sym_name = "c", address = 0x50 : i32 } : memref<256xi32>
+  %buf34_0 = aie.buffer(%t34) { sym_name = "x", address = 0x0 : i32 } : memref<8xi32>
+  %buf54_0 = aie.buffer(%t54) { sym_name = "y", address = 0x0 : i32 } : memref<8xi32>
+  %buf43_0 = aie.buffer(%t43) { sym_name = "z", address = 0x0 : i32 } : memref<8xi32>
+  %buf45_0 = aie.buffer(%t45) { sym_name = "t", address = 0x0 : i32 } : memref<8xi32>
 
   aie.core(%t44) {
     aie.end

--- a/test/generate-mmap/test_mmap1.mlir
+++ b/test/generate-mmap/test_mmap1.mlir
@@ -29,7 +29,7 @@ module @test_mmap1 {
   %t33 = aie.tile(3, 3) // Different row
   %t35 = aie.tile(3, 5) // Different row
 
-  %buf34_0 = aie.buffer(%t34) { sym_name = "a", address = 0x0 } : memref<4xi32>
+  %buf34_0 = aie.buffer(%t34) { sym_name = "a", address = 0x0 : i32 } : memref<4xi32>
  }
 }
 

--- a/test/generate-mmap/test_mmap2.mlir
+++ b/test/generate-mmap/test_mmap2.mlir
@@ -29,7 +29,7 @@ module @test_mmap1 {
   %tsouth = aie.tile(3, 2) // Different row
   %tnorth = aie.tile(3, 4) // Different row
 
-  %bufsame = aie.buffer(%tsame) { sym_name = "a", address = 0x0 } : memref<4xi32>
+  %bufsame = aie.buffer(%tsame) { sym_name = "a", address = 0x0 : i32 } : memref<4xi32>
  }
 }
 

--- a/test/generate-mmap/test_mmap3.mlir
+++ b/test/generate-mmap/test_mmap3.mlir
@@ -25,10 +25,10 @@ module @test_mmap1 {
   %tsouth = aie.tile(3, 3) // Different row
   %tnorth = aie.tile(3, 5) // Different row
 
-  %bufsame = aie.buffer(%tsame) { sym_name = "same", address = 0x0 } : memref<4xi32>
-  %bufeast = aie.buffer(%teast) { sym_name = "east", address = 0x0 } : memref<4xi32>
-  %bufwest = aie.buffer(%twest) { sym_name = "west", address = 0x0 } : memref<4xi32>
-  %bufsouth = aie.buffer(%tsouth) { sym_name = "south", address = 0x0 } : memref<4xi32>
-  %bufnorth = aie.buffer(%tnorth) { sym_name = "north", address = 0x0 } : memref<4xi32>
+  %bufsame = aie.buffer(%tsame) { sym_name = "same", address = 0x0 : i32 } : memref<4xi32>
+  %bufeast = aie.buffer(%teast) { sym_name = "east", address = 0x0 : i32 } : memref<4xi32>
+  %bufwest = aie.buffer(%twest) { sym_name = "west", address = 0x0 : i32 } : memref<4xi32>
+  %bufsouth = aie.buffer(%tsouth) { sym_name = "south", address = 0x0 : i32 } : memref<4xi32>
+  %bufnorth = aie.buffer(%tnorth) { sym_name = "north", address = 0x0 : i32 } : memref<4xi32>
  }
 }

--- a/test/generate-mmap/test_mmap4.mlir
+++ b/test/generate-mmap/test_mmap4.mlir
@@ -25,10 +25,10 @@ module @test_mmap1 {
   %tsouth = aie.tile(2, 3) // Different row
   %tnorth = aie.tile(2, 5) // Different row
 
-  %bufsame = aie.buffer(%tsame) { sym_name = "same", address = 0x0 } : memref<4xi32>
-  %bufeast = aie.buffer(%teast) { sym_name = "east", address = 0x0 } : memref<4xi32>
-  %bufwest = aie.buffer(%twest) { sym_name = "west", address = 0x0 } : memref<4xi32>
-  %bufsouth = aie.buffer(%tsouth) { sym_name = "south", address = 0x0 } : memref<4xi32>
-  %bufnorth = aie.buffer(%tnorth) { sym_name = "north", address = 0x0 } : memref<4xi32>
+  %bufsame = aie.buffer(%tsame) { sym_name = "same", address = 0x0 : i32 } : memref<4xi32>
+  %bufeast = aie.buffer(%teast) { sym_name = "east", address = 0x0 : i32 } : memref<4xi32>
+  %bufwest = aie.buffer(%twest) { sym_name = "west", address = 0x0 : i32 } : memref<4xi32>
+  %bufsouth = aie.buffer(%tsouth) { sym_name = "south", address = 0x0 : i32 } : memref<4xi32>
+  %bufnorth = aie.buffer(%tnorth) { sym_name = "north", address = 0x0 : i32 } : memref<4xi32>
  }
 }

--- a/test/generate-mmap/test_mmap5.mlir
+++ b/test/generate-mmap/test_mmap5.mlir
@@ -25,10 +25,10 @@ module @test_mmap1 {
   %tsouth = aie.tile(3, 2) // Different row
   %tnorth = aie.tile(3, 4) // Different row
 
-  %bufsame = aie.buffer(%tsame) { sym_name = "same", address = 0x0 } : memref<4xi32>
-  %bufeast = aie.buffer(%teast) { sym_name = "east", address = 0x0 } : memref<4xi32>
-  %bufwest = aie.buffer(%twest) { sym_name = "west", address = 0x0 } : memref<4xi32>
-  %bufsouth = aie.buffer(%tsouth) { sym_name = "south", address = 0x0 } : memref<4xi32>
-  %bufnorth = aie.buffer(%tnorth) { sym_name = "north", address = 0x0 } : memref<4xi32>
+  %bufsame = aie.buffer(%tsame) { sym_name = "same", address = 0x0 : i32 } : memref<4xi32>
+  %bufeast = aie.buffer(%teast) { sym_name = "east", address = 0x0 : i32 } : memref<4xi32>
+  %bufwest = aie.buffer(%twest) { sym_name = "west", address = 0x0 : i32 } : memref<4xi32>
+  %bufsouth = aie.buffer(%tsouth) { sym_name = "south", address = 0x0 : i32 } : memref<4xi32>
+  %bufnorth = aie.buffer(%tnorth) { sym_name = "north", address = 0x0 : i32 } : memref<4xi32>
  }
 }

--- a/test/unit_tests/aie/00_itsalive/aie.mlir
+++ b/test/unit_tests/aie/00_itsalive/aie.mlir
@@ -14,7 +14,7 @@
 module @test00_itsalive {
   %tile12 = aie.tile(1, 2)
 
-  %buf12_0 = aie.buffer(%tile12) { sym_name = "a", address = 0 } : memref<256xi32>
+  %buf12_0 = aie.buffer(%tile12) { sym_name = "a", address = 0 : i32 } : memref<256xi32>
 
   %core12 = aie.core(%tile12) {
     %val1 = arith.constant 1 : i32

--- a/test/unit_tests/aie2/00_itsalive/aie.mlir
+++ b/test/unit_tests/aie2/00_itsalive/aie.mlir
@@ -15,7 +15,7 @@ module @test00_itsalive {
   aie.device(xcve2802) {
     %tile12 = aie.tile(1, 3)
 
-    %buf12_0 = aie.buffer(%tile12) { sym_name = "a", address = 0 } : memref<256xi32>
+    %buf12_0 = aie.buffer(%tile12) { sym_name = "a", address = 0 : i32 } : memref<256xi32>
 
     %core12 = aie.core(%tile12) {
       %val1 = arith.constant 1 : i32

--- a/test/unit_tests/chess_compiler_tests/00_itsalive/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/00_itsalive/aie.mlir
@@ -20,7 +20,7 @@
 module @test00_itsalive {
   %tile12 = aie.tile(1, 2)
 
-  %buf12_0 = aie.buffer(%tile12) { sym_name = "a", address = 0 } : memref<256xi32>
+  %buf12_0 = aie.buffer(%tile12) { sym_name = "a", address = 0 : i32 } : memref<256xi32>
 
   %core12 = aie.core(%tile12) {
     %val1 = arith.constant 1 : i32


### PR DESCRIPTION
This PR adds `address` as an explicit attribute of `BufferOp` instead of depending on string matching/insertion. Please let's not do this anymore and use named, explicit attributes for such things from now on. And if you know elsewhere this is done, can you please patch/PR them (or at least file issues and assign to me).

Also, this attribute (`address`) is variously used as a signed and unsigned integer. We need to make a decision on this and stick to it. So shall it be signed or unsigned? In light of https://github.com/Xilinx/mlir-aie/pull/723, I vote signed.