### PR TITLE
Allow f32 type in AIEX::IpuDmaMemcpyNdOp::verify()

### DIFF
--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -66,8 +66,8 @@ LogicalResult AIEX::BroadcastPacketOp::verify() {
 
 LogicalResult AIEX::IpuDmaMemcpyNdOp::verify() {
   MemRefType buffer = getMemref().getType();
-  if (!buffer.getElementType().isInteger(32))
-    return emitOpError("must be used with memref type i32.");
+  if (buffer.getElementTypeBitWidth() != 32)
+    return emitOpError("must be used with memref type with element width 32.");
   if (!llvm::all_of(getMixedStrides(), [](OpFoldResult s) {
         return getConstantIntValue(s).has_value();
       }))

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp
@@ -246,7 +246,10 @@ struct DmaToIpuPattern : OpConversionPattern<IpuDmaMemcpyNdOp> {
     MemRefType my_memref = op.getMemref().getType();
     auto shape = my_memref.getShape();
     size_t R = shape.size();
-    size_t S = my_memref.getElementType().getIntOrFloatBitWidth() / 8;
+    size_t el_bit_width = my_memref.getElementTypeBitWidth();
+    assert(el_bit_width % 8 == 0 &&
+           "Expected Memref element bitwidth to be multiple of 8.");
+    size_t S = el_bit_width / 8;
     for (size_t i = 0; i < R; i++) {
       offset += offsets[i] * stride * S;
       stride *= shape[R - i - 1];

--- a/test/dialect/AIEX/bad_ipu_nd_type.mlir
+++ b/test/dialect/AIEX/bad_ipu_nd_type.mlir
@@ -17,7 +17,7 @@ module {
       %c1 = arith.constant 1 : i64
       %c1920 = arith.constant 1920 : i64
       %c1080 = arith.constant 1080 : i64
-      // expected-error@+1 {{must be used with memref type i32.}}
+      // expected-error@+1 {{must be used with memref type with element width 32.}}
       aiex.ipu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920]) { metadata = @of_fromMem, id = 0 : i64 } : memref<1920x1080xi8>
       return
     }


### PR DESCRIPTION
f32 type work with the current flow so no reason to fail them in the verifier.