### PR TITLE
find/handle locks and buffers everywhere

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
@@ -47,8 +47,7 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
     DenseMap<TileOp, TileLockOps> tileToLocks;
 
     // Construct data structure storing locks by tile.
-    for (LockOp lockOp : device.getOps<LockOp>()) {
-
+    device.walk<WalkOrder::PreOrder>([&](LockOp lockOp) {
       TileOp tileOp = lockOp.getTileOp();
       if (lockOp.getLockID().has_value()) {
         auto lockID = lockOp.getLockID().value();
@@ -73,7 +72,7 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
         else
           iter->second.unassigned.push_back(lockOp);
       }
-    }
+    });
 
     // IR mutation: assign locks to all unassigned lock ops.
     for (auto [tileOp, locks] : tileToLocks) {

--- a/test/ipu-xrt/add_256_using_dma_op_no_double_buffering/aie.mlir
+++ b/test/ipu-xrt/add_256_using_dma_op_no_double_buffering/aie.mlir
@@ -15,11 +15,6 @@ module {
     %buffer_0_2 = aie.buffer(%tile_0_2) : memref<16xi32>
     %buffer_0_2_1 = aie.buffer(%tile_0_2) : memref<16xi32>
 
-    %lock_0_1_0 = aie.lock(%tile_0_1, 0) {init = 1 : i32}
-    %lock_0_1_1 = aie.lock(%tile_0_1, 1) {init = 0 : i32}
-    %lock_0_1_2 = aie.lock(%tile_0_1, 2) {init = 1 : i32}
-    %lock_0_1_3 = aie.lock(%tile_0_1, 3) {init = 0 : i32}
-    
     %lock_0_2_0 = aie.lock(%tile_0_2, 0) {init = 1 : i32}
     %lock_0_2_1 = aie.lock(%tile_0_2, 1) {init = 0 : i32}
     %lock_0_2_2 = aie.lock(%tile_0_2, 2) {init = 1 : i32}
@@ -50,10 +45,14 @@ module {
       aie.end
     }
 
-    %buffer_0_1 = aie.buffer(%tile_0_1) : memref<16xi32>
-    %buffer_0_1_0 = aie.buffer(%tile_0_1) : memref<16xi32>
-
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %buffer_0_1 = aie.buffer(%tile_0_1) : memref<16xi32>
+      %buffer_0_1_0 = aie.buffer(%tile_0_1) : memref<16xi32>
+      %lock_0_1_0 = aie.lock(%tile_0_1, 0) {init = 1 : i32}
+      %lock_0_1_1 = aie.lock(%tile_0_1, 1) {init = 0 : i32}
+      %lock_0_1_2 = aie.lock(%tile_0_1, 2) {init = 1 : i32}
+      %lock_0_1_3 = aie.lock(%tile_0_1, 3) {init = 0 : i32}
+
       // forward
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%lock_0_1_0, AcquireGreaterEqual, 1)

--- a/test/ipu-xrt/add_314_using_dma_op/aie.mlir
+++ b/test/ipu-xrt/add_314_using_dma_op/aie.mlir
@@ -15,20 +15,10 @@ module {
     %tile_0_1 = aie.tile(0, 1)
     %tile_0_2 = aie.tile(0, 2)
 
-    %objFifo_in0_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_0"} : memref<16xi32>
-    %objFifo_in0_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_1"} : memref<16xi32>
-    %objFifo_out0_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_0"} : memref<16xi32>
-    %objFifo_out0_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_1"} : memref<16xi32>
-
     %objFifo_in1_cons_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_0"} : memref<8xi32>
     %objFifo_in1_cons_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_1"} : memref<8xi32>
     %objFifo_out1_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_0"} : memref<8xi32>
     %objFifo_out1_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_1"} : memref<8xi32>
-
-    %objFifo_in0_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in0_cons_prod_lock"}
-    %objFifo_in0_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "objFifo_in0_cons_cons_lock"}
-    %objFifo_out0_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out0_prod_lock"}
-    %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_lock"}
 
     %objFifo_in1_cons_prod_lock = aie.lock(%tile_0_2, 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock"}
     %objFifo_in1_cons_cons_lock = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock"}
@@ -82,6 +72,14 @@ module {
     }
 
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %objFifo_in0_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_0"} : memref<16xi32>
+      %objFifo_in0_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_1"} : memref<16xi32>
+      %objFifo_out0_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_0"} : memref<16xi32>
+      %objFifo_out0_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_1"} : memref<16xi32>
+      %objFifo_in0_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in0_cons_prod_lock"}
+      %objFifo_in0_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "objFifo_in0_cons_cons_lock"}
+      %objFifo_out0_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out0_prod_lock"}
+      %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_lock"}
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
         aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>)

--- a/test/ipu-xrt/add_one_using_dma/aie.mlir
+++ b/test/ipu-xrt/add_one_using_dma/aie.mlir
@@ -21,25 +21,10 @@ module {
     %tile_0_1 = aie.tile(0, 1)
     %tile_0_2 = aie.tile(0, 2)
 
-    %objFifo_in0_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_0"} : memref<16xi32>
-    %objFifo_in0_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_1"} : memref<16xi32>
-    %objFifo_out0_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_0"} : memref<16xi32>
-    %objFifo_out0_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_1"} : memref<16xi32>
-
     %objFifo_in1_cons_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_0"} : memref<8xi32>
     %objFifo_in1_cons_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_1"} : memref<8xi32>
     %objFifo_out1_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_0"} : memref<8xi32>
     %objFifo_out1_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_1"} : memref<8xi32>
-
-    %objFifo_in0_prod_lock = aie.lock(%tile_0_0, 0) {init = 0 : i32, sym_name = "objFifo_in0_prod_lock"}
-    %objFifo_in0_cons_lock = aie.lock(%tile_0_0, 1) {init = 0 : i32, sym_name = "objFifo_in0_cons_lock"}
-    %objFifo_out0_cons_prod_lock = aie.lock(%tile_0_0, 2) {init = 0 : i32, sym_name = "objFifo_out0_cons_prod_lock"}
-    %objFifo_out0_cons_cons_lock = aie.lock(%tile_0_0, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_cons_lock"}
-
-    %objFifo_in0_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in0_cons_prod_lock"}
-    %objFifo_in0_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "objFifo_in0_cons_cons_lock"}
-    %objFifo_out0_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out0_prod_lock"}
-    %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_lock"}
 
     %objFifo_in1_cons_prod_lock = aie.lock(%tile_0_2, 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock"}
     %objFifo_in1_cons_cons_lock = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock"}
@@ -98,6 +83,15 @@ module {
     }
 
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %objFifo_in0_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_0"} : memref<16xi32>
+      %objFifo_in0_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in0_cons_buff_1"} : memref<16xi32>
+      %objFifo_out0_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_0"} : memref<16xi32>
+      %objFifo_out0_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out0_buff_1"} : memref<16xi32>
+
+      %objFifo_in0_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in0_cons_prod_lock"}
+      %objFifo_in0_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "objFifo_in0_cons_cons_lock"}
+      %objFifo_out0_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out0_prod_lock"}
+      %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_lock"}
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -30,31 +30,12 @@ module {
     %tile_0_1 = aie.tile(0, 1)
     %tile_0_2 = aie.tile(0, 2)
 
-    %inA_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "inA_cons_buff_0"} : memref<64x32xi16>
-    %inA_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "inA_cons_buff_1"} : memref<64x32xi16>
-    %inB_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "inB_cons_buff_0"} : memref<32x64xi16>
-    %inB_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "inB_cons_buff_1"} : memref<32x64xi16>
-
     %memA_cons_buff_0 = aie.buffer(%tile_0_2) {sym_name = "memA_cons_buff_0"} : memref<64x32xi16>
     %memA_cons_buff_1 = aie.buffer(%tile_0_2) {sym_name = "memA_cons_buff_1"} : memref<64x32xi16>
     %memB_cons_buff_0 = aie.buffer(%tile_0_2) {sym_name = "memB_cons_buff_0"} : memref<32x64xi16>
     %memB_cons_buff_1 = aie.buffer(%tile_0_2) {sym_name = "memB_cons_buff_1"} : memref<32x64xi16>
     %memC_buff_0 = aie.buffer(%tile_0_2) {sym_name = "memC_buff_0"} : memref<64x64xi16>
     %memC_buff_1 = aie.buffer(%tile_0_2) {sym_name = "memC_buff_1"} : memref<64x64xi16>
-    %memC_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "memC_cons_buff_0"} : memref<64x64xi16>
-    %memC_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "memC_cons_buff_1"} : memref<64x64xi16>
-
-    %inA_cons_lock = aie.lock(%tile_0_0, 1) {init = 0 : i32, sym_name = "inA_cons_lock"}
-    %inA_prod_lock = aie.lock(%tile_0_0, 0) {init = 0 : i32, sym_name = "inA_prod_lock"}
-    %inB_cons_lock = aie.lock(%tile_0_0, 3) {init = 0 : i32, sym_name = "inB_cons_lock"}
-    %inB_prod_lock = aie.lock(%tile_0_0, 2) {init = 0 : i32, sym_name = "inB_prod_lock"}
-
-    %inA_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "inA_cons_cons_lock"}
-    %inA_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32, sym_name = "inA_cons_prod_lock"}
-    %inB_cons_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "inB_cons_cons_lock"}
-    %inB_cons_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32, sym_name = "inB_cons_prod_lock"}
-    %outC_cons_cons_lock = aie.lock(%tile_0_0, 5) {init = 0 : i32, sym_name = "outC_cons_cons_lock"}
-    %outC_cons_prod_lock = aie.lock(%tile_0_0, 4) {init = 0 : i32, sym_name = "outC_cons_prod_lock"}
 
     %memA_cons_cons_lock = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "memA_cons_cons_lock"}
     %memA_cons_prod_lock = aie.lock(%tile_0_2, 0) {init = 2 : i32, sym_name = "memA_cons_prod_lock"}
@@ -118,7 +99,9 @@ module {
       }
       aie.end
     } {link_with = "mm.o"}
+
     aie.shim_dma_allocation @inA(MM2S, 0, 0)
+
     func.func @sequence(%arg0: memref<8192xi32>, %arg1: memref<8192xi32>, %arg2: memref<8192xi32>) {
       %c2048_i64 = arith.constant 2048 : i64
       %c16_i64 = arith.constant 16 : i64
@@ -136,7 +119,18 @@ module {
       aiex.ipu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       return
     }
+
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %inA_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "inA_cons_buff_0"} : memref<64x32xi16>
+      %inA_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "inA_cons_buff_1"} : memref<64x32xi16>
+      %inB_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "inB_cons_buff_0"} : memref<32x64xi16>
+      %inB_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "inB_cons_buff_1"} : memref<32x64xi16>
+      %memC_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "memC_cons_buff_0"} : memref<64x64xi16>
+      %memC_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "memC_cons_buff_1"} : memref<64x64xi16>
+      %inA_cons_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32, sym_name = "inA_cons_prod_lock"}
+      %inA_cons_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "inA_cons_cons_lock"}
+      %inB_cons_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "inB_cons_cons_lock"}
+      %inB_cons_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32, sym_name = "inB_cons_prod_lock"}
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%inA_cons_prod_lock, AcquireGreaterEqual)


### PR DESCRIPTION
This PR extends buffer address and lock id assignment:

- both passes now look for buffers/locks everywhere in a device instead of just in the region (i.e. `device.walk<WalkOrder::PreOrder>`). The point/value is to declutter the main region of buffers/locks that only play in one tile (e.g. managing data passthrough in a memtile).

