### PR TITLE
Cleanup calls to dyn_cast

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1327,7 +1327,7 @@ def AIE_UseLockOp: AIE_Op<"use_lock", []> {
       return 1;
     }
     LockOp getLockOp() {
-      return llvm::cast<xilinx::AIE::LockOp>(getLock().getDefiningOp());
+      return llvm::dyn_cast<xilinx::AIE::LockOp>(getLock().getDefiningOp());
     }
   }];
 }
@@ -1743,11 +1743,11 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
   let extraClassDeclaration = [{
     int size(int index = 0) {
       if (llvm::isa<mlir::ArrayAttr>(getElemNumber()))
-        return llvm::cast<mlir::IntegerAttr>(
-                   llvm::cast<mlir::ArrayAttr>(getElemNumber())[index])
+        return llvm::dyn_cast<mlir::IntegerAttr>(
+                   llvm::dyn_cast<mlir::ArrayAttr>(getElemNumber())[index])
             .getInt();
       else
-        return llvm::cast<mlir::IntegerAttr>(getElemNumber()).getInt();
+        return llvm::dyn_cast<mlir::IntegerAttr>(getElemNumber()).getInt();
     }
 
     TileOp getProducerTileOp();

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1743,11 +1743,11 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
   let extraClassDeclaration = [{
     int size(int index = 0) {
       if (llvm::isa<mlir::ArrayAttr>(getElemNumber()))
-        return llvm::dyn_cast<mlir::IntegerAttr>(
-                   llvm::dyn_cast<mlir::ArrayAttr>(getElemNumber())[index])
+        return llvm::cast<mlir::IntegerAttr>(
+                   llvm::cast<mlir::ArrayAttr>(getElemNumber())[index])
             .getInt();
       else
-        return llvm::dyn_cast<mlir::IntegerAttr>(getElemNumber()).getInt();
+        return llvm::cast<mlir::IntegerAttr>(getElemNumber()).getInt();
     }
 
     TileOp getProducerTileOp();

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1327,7 +1327,7 @@ def AIE_UseLockOp: AIE_Op<"use_lock", []> {
       return 1;
     }
     LockOp getLockOp() {
-      return llvm::dyn_cast<xilinx::AIE::LockOp>(getLock().getDefiningOp());
+      return llvm::cast<xilinx::AIE::LockOp>(getLock().getDefiningOp());
     }
   }];
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -486,9 +486,9 @@ static void printObjectFifoInitValues(OpAsmPrinter &p, ObjectFifoCreateOp op,
                                       Attribute initValues) {
   if (op.getInitValues()) {
     p << "= [";
-    int depth = llvm::dyn_cast<mlir::IntegerAttr>(numElem).getInt();
+    int depth = llvm::cast<mlir::IntegerAttr>(numElem).getInt();
     for (int i = 0; i < depth; i++) {
-      p.printStrippedAttrOrType(llvm::dyn_cast<mlir::ArrayAttr>(initValues)[i]);
+      p.printStrippedAttrOrType(llvm::cast<mlir::ArrayAttr>(initValues)[i]);
       if (i < depth - 1) {
         p << ", ";
       }
@@ -522,7 +522,7 @@ static ParseResult parseObjectFifoInitValues(OpAsmParser &parser,
   if (parser.parseAttribute(initValues, tensorType))
     return failure();
   for (int i = 0; i < depth; i++) {
-    auto initialValues = llvm::dyn_cast<mlir::ArrayAttr>(initValues);
+    auto initialValues = llvm::cast<mlir::ArrayAttr>(initValues);
     if ((int)initialValues.size() != depth)
       return parser.emitError(parser.getNameLoc())
              << "initial values should initialize all objects";
@@ -1946,9 +1946,9 @@ static LogicalResult FoldDMAStartOp(DMAStartOp op, PatternRewriter &rewriter) {
   }
 
   // Repeating BD chains detected. Erasing repetitions.
-  auto lastBDTerm = dyn_cast<NextBDOp>(reachable.back()->getTerminator());
+  auto lastBDTerm = cast<NextBDOp>(reachable.back()->getTerminator());
   auto lastUniqueBDTerm =
-      dyn_cast<NextBDOp>(uniquePattern.back()->getTerminator());
+      cast<NextBDOp>(uniquePattern.back()->getTerminator());
   lastUniqueBDTerm.setSuccessor(lastBDTerm.getSuccessor());
 
   return success();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1947,8 +1947,7 @@ static LogicalResult FoldDMAStartOp(DMAStartOp op, PatternRewriter &rewriter) {
 
   // Repeating BD chains detected. Erasing repetitions.
   auto lastBDTerm = cast<NextBDOp>(reachable.back()->getTerminator());
-  auto lastUniqueBDTerm =
-      cast<NextBDOp>(uniquePattern.back()->getTerminator());
+  auto lastUniqueBDTerm = cast<NextBDOp>(uniquePattern.back()->getTerminator());
   lastUniqueBDTerm.setSuccessor(lastBDTerm.getSuccessor());
 
   return success();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -229,7 +229,7 @@ static TileElement getParentTileElement(Operation *op) {
       return element;
     parent = parent->getParentOp();
   }
-  return llvm::dyn_cast<TileElement>(parent);
+  return llvm::cast<TileElement>(parent);
 }
 
 namespace {
@@ -680,10 +680,10 @@ std::vector<ObjectFifoCreateOp> ObjectFifoLinkOp::getInputObjectFifos() {
   while ((parent = parent->getParentOp())) {
     if (parent->hasTrait<OpTrait::SymbolTable>()) {
       for (auto sym : getFifoIns()) {
-        auto name = dyn_cast<FlatSymbolRefAttr>(sym);
+        auto name = cast<FlatSymbolRefAttr>(sym);
         if (auto *st = SymbolTable::lookupSymbolIn(parent, name);
             isa_and_nonnull<ObjectFifoCreateOp>(st))
-          inputObjFifos.push_back(dyn_cast<ObjectFifoCreateOp>(st));
+          inputObjFifos.push_back(cast<ObjectFifoCreateOp>(st));
       }
     }
   }
@@ -696,10 +696,10 @@ std::vector<ObjectFifoCreateOp> ObjectFifoLinkOp::getOutputObjectFifos() {
   while ((parent = parent->getParentOp())) {
     if (parent->hasTrait<OpTrait::SymbolTable>()) {
       for (auto sym : getFifoOuts()) {
-        auto name = dyn_cast<FlatSymbolRefAttr>(sym);
-        if (auto *st = mlir::SymbolTable::lookupSymbolIn(parent, name);
+        auto name = cast<FlatSymbolRefAttr>(sym);
+        if (auto *st = SymbolTable::lookupSymbolIn(parent, name);
             isa_and_nonnull<ObjectFifoCreateOp>(st))
-          outputObjFifos.push_back(dyn_cast<ObjectFifoCreateOp>(st));
+          outputObjFifos.push_back(cast<ObjectFifoCreateOp>(st));
       }
     }
   }
@@ -774,7 +774,7 @@ ObjectFifoCreateOp ObjectFifoRegisterExternalBuffersOp::getObjectFifo() {
     if (parent->hasTrait<OpTrait::SymbolTable>()) {
       if (auto *st = SymbolTable::lookupSymbolIn(parent, getObjFifoName());
           isa_and_nonnull<ObjectFifoCreateOp>(st))
-        return dyn_cast<ObjectFifoCreateOp>(st);
+        return cast<ObjectFifoCreateOp>(st);
     }
   }
   return {};
@@ -831,7 +831,7 @@ ObjectFifoCreateOp ObjectFifoAcquireOp::getObjectFifo() {
     if (parent->hasTrait<OpTrait::SymbolTable>()) {
       if (auto *st = SymbolTable::lookupSymbolIn(parent, getObjFifoName());
           isa_and_nonnull<ObjectFifoCreateOp>(st))
-        return dyn_cast<ObjectFifoCreateOp>(st);
+        return cast<ObjectFifoCreateOp>(st);
     }
   }
   return {};
@@ -878,7 +878,7 @@ ObjectFifoCreateOp ObjectFifoReleaseOp::getObjectFifo() {
     if (parent->hasTrait<OpTrait::SymbolTable>()) {
       if (auto *st = SymbolTable::lookupSymbolIn(parent, getObjFifoName());
           isa_and_nonnull<ObjectFifoCreateOp>(st))
-        return dyn_cast<ObjectFifoCreateOp>(st);
+        return cast<ObjectFifoCreateOp>(st);
     }
   }
   return {};
@@ -929,7 +929,7 @@ ObjectFifoCreateOp ObjectFifoRegisterProcessOp::getObjectFifo() {
     if (parent->hasTrait<OpTrait::SymbolTable>()) {
       if (auto *st = SymbolTable::lookupSymbolIn(parent, getObjFifoName());
           isa_and_nonnull<ObjectFifoCreateOp>(st))
-        return dyn_cast<ObjectFifoCreateOp>(st);
+        return cast<ObjectFifoCreateOp>(st);
     }
   }
   return {};
@@ -2045,7 +2045,7 @@ LogicalResult SwitchboxOp::verify() {
 
       int arbiter = -1;
       for (auto val : connectOp.getAmsels()) {
-        auto amsel = dyn_cast<AMSelOp>(val.getDefiningOp());
+        auto amsel = cast<AMSelOp>(val.getDefiningOp());
         if (arbiter != -1 && arbiter != amsel.arbiterIndex())
           return connectOp.emitOpError(
               "a master port can only be tied to one arbiter");
@@ -2064,7 +2064,7 @@ LogicalResult SwitchboxOp::verify() {
       std::vector<PacketRulesOp> slvs;
       for (auto *user : amselOp.getResult().getUsers()) {
         if (auto s = dyn_cast<PacketRuleOp>(user)) {
-          auto pktRules = dyn_cast<PacketRulesOp>(s->getParentOp());
+          auto pktRules = cast<PacketRulesOp>(s->getParentOp());
           slvs.push_back(pktRules);
         } else if (auto m = dyn_cast<MasterSetOp>(user))
           mstrs.push_back(m);
@@ -2171,7 +2171,7 @@ struct AcquireReleaseOneStateInDMABlock {
 struct AccessesLocalLocks {
   static LogicalResult verifyTrait(Operation *op) {
     if (auto memOp = op->getParentOfType<MemOp>()) {
-      auto useLock = dyn_cast<UseLockOp>(op);
+      auto useLock = cast<UseLockOp>(op);
       if (auto lock = useLock.getLockOp();
           lock.getTileOp().colIndex() != memOp.colIndex() ||
           lock.getTileOp().rowIndex() != memOp.rowIndex())

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -229,7 +229,7 @@ static TileElement getParentTileElement(Operation *op) {
       return element;
     parent = parent->getParentOp();
   }
-  return llvm::cast<TileElement>(parent);
+  return llvm::dyn_cast<TileElement>(parent);
 }
 
 namespace {

--- a/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp
+++ b/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp
@@ -33,7 +33,7 @@ struct AIELocalizeLocksPass : AIELocalizeLocksBase<AIELocalizeLocksPass> {
       // Collect the locks used in this core.
       const auto &targetModel = getTargetModel(coreOp);
 
-      auto thisTile = dyn_cast<TileOp>(coreOp.getTile().getDefiningOp());
+      auto thisTile = cast<TileOp>(coreOp.getTile().getDefiningOp());
       int col = thisTile.colIndex();
       int row = thisTile.rowIndex();
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -108,7 +108,7 @@ struct AIEObjectFifoRegisterProcessPass
       builder.setInsertionPoint(device.getBody()->getTerminator());
       ObjectFifoCreateOp objFifo = registerOp.getObjectFifo();
       auto elementType =
-          llvm::dyn_cast<AIEObjectFifoType>(objFifo.getElemType())
+          llvm::cast<AIEObjectFifoType>(objFifo.getElemType())
               .getElementType();
 
       if (consumersPerFifo.find(objFifo) == consumersPerFifo.end()) {

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -146,7 +146,7 @@ struct AIEObjectFifoRegisterProcessPass
         builder.create<EndOp>(builder.getUnknownLoc());
         builder.setInsertionPointToStart(&block);
       } else {
-        CoreOp coreOp = llvm::dyn_cast<CoreOp>(op);
+        CoreOp coreOp = llvm::cast<CoreOp>(op);
         Region &r = coreOp.getBody();
         Block &endBlock = r.back();
         builder.setInsertionPointToStart(&endBlock);

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -108,7 +108,7 @@ struct AIEObjectFifoRegisterProcessPass
       builder.setInsertionPoint(device.getBody()->getTerminator());
       ObjectFifoCreateOp objFifo = registerOp.getObjectFifo();
       auto elementType =
-          llvm::cast<AIEObjectFifoType>(objFifo.getElemType())
+          llvm::dyn_cast<AIEObjectFifoType>(objFifo.getElemType())
               .getElementType();
 
       if (consumersPerFifo.find(objFifo) == consumersPerFifo.end()) {

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -594,7 +594,7 @@ struct AIEObjectFifoStatefulTransformPass
 
     TileOp creation_tile;
     auto consumerTileOp =
-        dyn_cast<TileOp>(op.getConsumerTiles()[0].getDefiningOp());
+        cast<TileOp>(op.getConsumerTiles()[0].getDefiningOp());
     if (share_direction == 0 || share_direction == -1)
       creation_tile = op.getProducerTileOp();
     else
@@ -1764,7 +1764,7 @@ struct AIEObjectFifoStatefulTransformPass
       }
 
       for (auto consumerTile : createOp.getConsumerTiles()) {
-        auto consumerTileOp = dyn_cast<TileOp>(consumerTile.getDefiningOp());
+        auto consumerTileOp = cast<TileOp>(consumerTile.getDefiningOp());
 
         if (isa<ArrayAttr>(createOp.getElemNumber())) {
           // +1 to account for 1st depth (producer)
@@ -1841,7 +1841,7 @@ struct AIEObjectFifoStatefulTransformPass
       // loop unrolling pass
       objectFifoTiles.insert(createOp.getProducerTileOp());
       for (auto consumerTile : createOp.getConsumerTiles()) {
-        auto consumerTileOp = dyn_cast<TileOp>(consumerTile.getDefiningOp());
+        auto consumerTileOp = cast<TileOp>(consumerTile.getDefiningOp());
         objectFifoTiles.insert(consumerTileOp);
       }
 

--- a/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
@@ -881,14 +881,14 @@ ConcatOp::inferReturnTypes(MLIRContext *, std::optional<Location>,
                              adaptor.getSources().end());
   unsigned totalLength = 0;
   for (auto source : srcs) {
-    VectorType type = llvm::dyn_cast<VectorType>(source.getType());
+    VectorType type = llvm::cast<VectorType>(source.getType());
     assert(type.getRank() == 1 &&
            "only rank 1 vectors currently supported by concat");
     totalLength += type.getDimSize(0);
   }
   inferredReturnTypes.push_back(VectorType::get(
       {totalLength},
-      llvm::dyn_cast<VectorType>(srcs[0].getType()).getElementType()));
+      llvm::cast<VectorType>(srcs[0].getType()).getElementType()));
   return success();
 }
 

--- a/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
+++ b/lib/Dialect/AIEVec/Transforms/AIEVectorize.cpp
@@ -2179,9 +2179,9 @@ static void fuseMulFMAOpsForInt16(Operation *Op, VectState *state) {
   // lhs of current FMAOp should be an upd operation with 512-bit vector width.
   // For AIE-ML, we can directly load 512 bits vectors. Thus, we can delete the
   // upd operation with index 1.
-  auto lUpdOp = dyn_cast<aievec::UPDOp>(lhs.getDefiningOp());
+  auto lUpdOp = cast<aievec::UPDOp>(lhs.getDefiningOp());
   if (lUpdOp.getIndex() == 1) {
-    auto lUpdOp0 = dyn_cast<aievec::UPDOp>(lUpdOp.getVector().getDefiningOp());
+    auto lUpdOp0 = cast<aievec::UPDOp>(lUpdOp.getVector().getDefiningOp());
     lUpdOp->replaceAllUsesWith(lUpdOp0);
     lUpdOp->erase();
   }
@@ -2189,7 +2189,7 @@ static void fuseMulFMAOpsForInt16(Operation *Op, VectState *state) {
   // 2. Deal with the rhs:
   // Since vector size of current FMAOp rhs is 256 bits, we need to generate a
   // concat op to make the vector size to 512 bits.
-  auto rUpdOp = dyn_cast<aievec::UPDOp>(curOp->getOperand(1).getDefiningOp());
+  auto rUpdOp = cast<aievec::UPDOp>(curOp->getOperand(1).getDefiningOp());
   state->builder.setInsertionPointAfter(rUpdOp);
   AIEVecAttributes rstat = getOperandVecStats(curOp, state, 1);
   assert(rstat.vecSizeInBits % 256 == 0);

--- a/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
+++ b/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
@@ -267,7 +267,7 @@ struct LongestConvMACChainAnalysis {
              isa<aievec::ExtOp>(opBwdSlices[sliceSz - 1]))) {
           convMacRhs = opBwdSlices[sliceSz - 3]->getOperand(0);
           convMacBcastIdx =
-              dyn_cast<aievec::BroadcastOp>(opBwdSlices[sliceSz - 2]).getIdx();
+              cast<aievec::BroadcastOp>(opBwdSlices[sliceSz - 2]).getIdx();
           return true;
         }
       }

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -427,7 +427,7 @@ generateAIEVecOpsForReductionOp(ConversionPatternRewriter &rewriter,
          "shiftIndex must be power of 2");
 
   Location loc = srcOp.getLoc();
-  auto vType = dyn_cast<VectorType>(curValue.getType());
+  auto vType = cast<VectorType>(curValue.getType());
   Type scalarType = vType.getElementType();
   Type vecType = curValue.getType();
   DstOpTy curOp = nullptr;
@@ -1522,7 +1522,7 @@ struct LowerVectorCmpOpToAIEVecCmpOp : OpConversionPattern<SrcOpTy> {
     if (!aieCmpOp)
       return failure();
 
-    VectorType resultType = dyn_cast<VectorType>(srcOp.getResult().getType());
+    VectorType resultType = cast<VectorType>(srcOp.getResult().getType());
     // Convert vector i1 type to unsigned interger type by built-in unrealized
     // conversion cast op.
     rewriter.replaceOpWithNewOp<UnrealizedConversionCastOp>(
@@ -1782,7 +1782,7 @@ struct LowerVectorReductionAddBfloat16Op
     Location loc = srcOp.getLoc();
     Type accType = getVectorOpDestType(vType, /*AIE2 =*/true);
     unsigned accWidth =
-        dyn_cast<VectorType>(accType).getElementType().getIntOrFloatBitWidth();
+        cast<VectorType>(accType).getElementType().getIntOrFloatBitWidth();
 
     auto upsOp =
         rewriter.create<aievec::UPSOp>(loc, accType, srcOp.getVector());
@@ -2363,8 +2363,8 @@ struct LowerExtOpPattern : OpConversionPattern<SrcOpTy> {
   LogicalResult
   matchAndRewrite(SrcOpTy extOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    VectorType srcType = dyn_cast<VectorType>(extOp.getIn().getType());
-    VectorType dstType = dyn_cast<VectorType>(extOp.getOut().getType());
+    VectorType srcType = cast<VectorType>(extOp.getIn().getType());
+    VectorType dstType = cast<VectorType>(extOp.getOut().getType());
 
     auto accType = getVectorOpDestType(srcType, /*AIE2 =*/true);
     auto upsOp =
@@ -2394,8 +2394,8 @@ struct LowerTruncOpPattern : OpConversionPattern<SrcOpTy> {
   LogicalResult
   matchAndRewrite(SrcOpTy truncOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    VectorType srcType = dyn_cast<VectorType>(truncOp.getIn().getType());
-    VectorType dstType = dyn_cast<VectorType>(truncOp.getOut().getType());
+    VectorType srcType = cast<VectorType>(truncOp.getIn().getType());
+    VectorType dstType = cast<VectorType>(truncOp.getOut().getType());
     Type scalarType = srcType.getElementType();
     unsigned elWidth = scalarType.getIntOrFloatBitWidth();
 

--- a/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
@@ -56,8 +56,7 @@ struct AIEBroadcastPacketPass
       Region &r = broadcastpacket.getPorts();
       Block &b = r.front();
       Port sourcePort = broadcastpacket.port();
-      TileOp srcTile =
-          cast<TileOp>(broadcastpacket.getTile().getDefiningOp());
+      TileOp srcTile = cast<TileOp>(broadcastpacket.getTile().getDefiningOp());
 
       for (Operation &Op : b.getOperations()) {
         if (BPIDOp bpid = dyn_cast<BPIDOp>(Op)) {
@@ -74,8 +73,7 @@ struct AIEBroadcastPacketPass
                                          sourcePort.bundle, sourcePort.channel);
           for (Operation &op : b_bpid.getOperations()) {
             if (BPDestOp bpdest = dyn_cast<BPDestOp>(op)) {
-              TileOp destTile =
-                  cast<TileOp>(bpdest.getTile().getDefiningOp());
+              TileOp destTile = cast<TileOp>(bpdest.getTile().getDefiningOp());
               Port destPort = bpdest.port();
               builder.setInsertionPointToEnd(b_pkFlow);
               builder.create<PacketDestOp>(builder.getUnknownLoc(), destTile,

--- a/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
@@ -57,7 +57,7 @@ struct AIEBroadcastPacketPass
       Block &b = r.front();
       Port sourcePort = broadcastpacket.port();
       TileOp srcTile =
-          dyn_cast<TileOp>(broadcastpacket.getTile().getDefiningOp());
+          cast<TileOp>(broadcastpacket.getTile().getDefiningOp());
 
       for (Operation &Op : b.getOperations()) {
         if (BPIDOp bpid = dyn_cast<BPIDOp>(Op)) {
@@ -75,7 +75,7 @@ struct AIEBroadcastPacketPass
           for (Operation &op : b_bpid.getOperations()) {
             if (BPDestOp bpdest = dyn_cast<BPDestOp>(op)) {
               TileOp destTile =
-                  dyn_cast<TileOp>(bpdest.getTile().getDefiningOp());
+                  cast<TileOp>(bpdest.getTile().getDefiningOp());
               Port destPort = bpdest.port();
               builder.setInsertionPointToEnd(b_pkFlow);
               builder.create<PacketDestOp>(builder.getUnknownLoc(), destTile,

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -105,7 +105,7 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
         tiles[{colIndex, rowIndex}] = tile;
       }
       Operation *tileOp = tiles[{colIndex, rowIndex}];
-      TileOp tile = dyn_cast<TileOp>(tileOp);
+      TileOp tile = cast<TileOp>(tileOp);
       builder.setInsertionPointAfter(tileOp);
 
       // create MemOp
@@ -218,8 +218,8 @@ struct AIECreateCoresPass : public AIECreateCoresBase<AIECreateCoresPass> {
     // DenseMap<Value, int> destChannel;
     // for (auto op : device.getOps<MemcpyOp>()) {
     //   builder.setInsertionPoint(op);
-    //   TileOp srcTile = dyn_cast<TileOp>(op.srcTile().getDefiningOp());
-    //   TileOp dstTile = dyn_cast<TileOp>(op.dstTile().getDefiningOp());
+    //   TileOp srcTile = cast<TileOp>(op.srcTile().getDefiningOp());
+    //   TileOp dstTile = cast<TileOp>(op.dstTile().getDefiningOp());
     //   // TODO: perhaps a better approach is to not assert here, but rather
     //   have a subsequent pass
     //   // that legally relocates the ports

--- a/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
@@ -188,7 +188,7 @@ struct AIECreateLocksPass : public AIECreateLocksBase<AIECreateLocksPass> {
       assert(tileOp &&
              "Sorry, the lock users of this chain do not have a common lock");
 
-      TileOp tile = dyn_cast<TileOp>(tileOp);
+      TileOp tile = cast<TileOp>(tileOp);
       int lockID = getLockID(locks, tileOp);
       assert(lockID >= 0 && "No more locks to allocate!");
       LLVM_DEBUG(llvm::dbgs() << "Shared tile \n"; tileOp->print(llvm::dbgs()));

--- a/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
@@ -218,25 +218,25 @@ struct AIEHerdRoutingPass : AIEHerdRoutingBase<AIEHerdRoutingPass> {
       routeOps.push_back(routeOp);
 
       auto sourceHerds =
-          dyn_cast<SelectOp>(routeOp.getSourceHerds().getDefiningOp());
+          cast<SelectOp>(routeOp.getSourceHerds().getDefiningOp());
       auto destHerds =
-          dyn_cast<SelectOp>(routeOp.getDestHerds().getDefiningOp());
+          cast<SelectOp>(routeOp.getDestHerds().getDefiningOp());
       WireBundle sourceBundle = routeOp.getSourceBundle();
       WireBundle destBundle = routeOp.getDestBundle();
       int sourceChannel = routeOp.getSourceChannelValue();
       int destChannel = routeOp.getDestChannelValue();
 
       HerdOp sourceHerd =
-          dyn_cast<HerdOp>(sourceHerds.getStartHerd().getDefiningOp());
+          cast<HerdOp>(sourceHerds.getStartHerd().getDefiningOp());
       IterOp sourceIterX =
-          dyn_cast<IterOp>(sourceHerds.getIterX().getDefiningOp());
+          cast<IterOp>(sourceHerds.getIterX().getDefiningOp());
       IterOp sourceIterY =
-          dyn_cast<IterOp>(sourceHerds.getIterY().getDefiningOp());
+          cast<IterOp>(sourceHerds.getIterY().getDefiningOp());
 
       HerdOp destHerd =
-          dyn_cast<HerdOp>(destHerds.getStartHerd().getDefiningOp());
-      IterOp destIterX = dyn_cast<IterOp>(destHerds.getIterX().getDefiningOp());
-      IterOp destIterY = dyn_cast<IterOp>(destHerds.getIterY().getDefiningOp());
+          cast<HerdOp>(destHerds.getStartHerd().getDefiningOp());
+      IterOp destIterX = cast<IterOp>(destHerds.getIterX().getDefiningOp());
+      IterOp destIterY = cast<IterOp>(destHerds.getIterY().getDefiningOp());
 
       int sourceStartX = sourceIterX.getStartValue();
       int sourceEndX = sourceIterX.getEndValue();
@@ -294,7 +294,7 @@ struct AIEHerdRoutingPass : AIEHerdRoutingBase<AIEHerdRoutingPass> {
       int x = swboxCfg.first.second.col;
       int y = swboxCfg.first.second.row;
       auto connects = swboxCfg.second;
-      HerdOp herd = dyn_cast<HerdOp>(herdOp);
+      HerdOp herd = cast<HerdOp>(herdOp);
 
       builder.setInsertionPoint(device.getBody()->getTerminator());
 

--- a/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
@@ -219,8 +219,7 @@ struct AIEHerdRoutingPass : AIEHerdRoutingBase<AIEHerdRoutingPass> {
 
       auto sourceHerds =
           cast<SelectOp>(routeOp.getSourceHerds().getDefiningOp());
-      auto destHerds =
-          cast<SelectOp>(routeOp.getDestHerds().getDefiningOp());
+      auto destHerds = cast<SelectOp>(routeOp.getDestHerds().getDefiningOp());
       WireBundle sourceBundle = routeOp.getSourceBundle();
       WireBundle destBundle = routeOp.getDestBundle();
       int sourceChannel = routeOp.getSourceChannelValue();
@@ -228,13 +227,10 @@ struct AIEHerdRoutingPass : AIEHerdRoutingBase<AIEHerdRoutingPass> {
 
       HerdOp sourceHerd =
           cast<HerdOp>(sourceHerds.getStartHerd().getDefiningOp());
-      IterOp sourceIterX =
-          cast<IterOp>(sourceHerds.getIterX().getDefiningOp());
-      IterOp sourceIterY =
-          cast<IterOp>(sourceHerds.getIterY().getDefiningOp());
+      IterOp sourceIterX = cast<IterOp>(sourceHerds.getIterX().getDefiningOp());
+      IterOp sourceIterY = cast<IterOp>(sourceHerds.getIterY().getDefiningOp());
 
-      HerdOp destHerd =
-          cast<HerdOp>(destHerds.getStartHerd().getDefiningOp());
+      HerdOp destHerd = cast<HerdOp>(destHerds.getStartHerd().getDefiningOp());
       IterOp destIterX = cast<IterOp>(destHerds.getIterX().getDefiningOp());
       IterOp destIterY = cast<IterOp>(destHerds.getIterY().getDefiningOp());
 

--- a/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
@@ -29,10 +29,10 @@ using namespace xilinx::AIE;
 using namespace xilinx::AIEX;
 
 static TileOp srcTileOp(xilinx::AIEX::MemcpyOp op) {
-  return llvm::cast<xilinx::AIE::TileOp>(op.getSrcTile().getDefiningOp());
+  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.getSrcTile().getDefiningOp());
 }
 static TileOp dstTileOp(xilinx::AIEX::MemcpyOp op) {
-  return llvm::cast<xilinx::AIE::TileOp>(op.getDstTile().getDefiningOp());
+  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.getDstTile().getDefiningOp());
 }
 
 struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {

--- a/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
@@ -29,10 +29,10 @@ using namespace xilinx::AIE;
 using namespace xilinx::AIEX;
 
 static TileOp srcTileOp(xilinx::AIEX::MemcpyOp op) {
-  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.getSrcTile().getDefiningOp());
+  return llvm::cast<xilinx::AIE::TileOp>(op.getSrcTile().getDefiningOp());
 }
 static TileOp dstTileOp(xilinx::AIEX::MemcpyOp op) {
-  return llvm::dyn_cast<xilinx::AIE::TileOp>(op.getDstTile().getDefiningOp());
+  return llvm::cast<xilinx::AIE::TileOp>(op.getDstTile().getDefiningOp());
 }
 
 struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
@@ -113,8 +113,8 @@ struct AIELowerMemcpyPass : public AIELowerMemcpyBase<AIELowerMemcpyPass> {
     DenseMap<Value, int> destChannel;
     for (auto op : device.getOps<MemcpyOp>()) {
       builder.setInsertionPoint(op);
-      TileOp srcTile = dyn_cast<TileOp>(op.getSrcTile().getDefiningOp());
-      TileOp dstTile = dyn_cast<TileOp>(op.getDstTile().getDefiningOp());
+      TileOp srcTile = cast<TileOp>(op.getSrcTile().getDefiningOp());
+      TileOp dstTile = cast<TileOp>(op.getDstTile().getDefiningOp());
       // TODO: perhaps a better approach is to not assert here, but rather have
       // a subsequent pass that legally relocates the ports
       assert(destChannel[op.getDstTile()] <= 2 &&

--- a/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
@@ -55,11 +55,11 @@ struct AIELowerMulticastPass : public AIEMulticastBase<AIELowerMulticastPass> {
       Region &r = multicast.getPorts();
       Block &b = r.front();
       Port sourcePort = multicast.port();
-      TileOp srcTile = dyn_cast<TileOp>(multicast.getTile().getDefiningOp());
+      TileOp srcTile = cast<TileOp>(multicast.getTile().getDefiningOp());
       for (Operation &Op : b.getOperations()) {
         if (MultiDestOp multiDest = dyn_cast<MultiDestOp>(Op)) {
           TileOp destTile =
-              dyn_cast<TileOp>(multiDest.getTile().getDefiningOp());
+              cast<TileOp>(multiDest.getTile().getDefiningOp());
           Port destPort = multiDest.port();
           builder.create<FlowOp>(builder.getUnknownLoc(), srcTile,
                                  sourcePort.bundle, sourcePort.channel,

--- a/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
@@ -58,8 +58,7 @@ struct AIELowerMulticastPass : public AIEMulticastBase<AIELowerMulticastPass> {
       TileOp srcTile = cast<TileOp>(multicast.getTile().getDefiningOp());
       for (Operation &Op : b.getOperations()) {
         if (MultiDestOp multiDest = dyn_cast<MultiDestOp>(Op)) {
-          TileOp destTile =
-              cast<TileOp>(multiDest.getTile().getDefiningOp());
+          TileOp destTile = cast<TileOp>(multiDest.getTile().getDefiningOp());
           Port destPort = multiDest.port();
           builder.create<FlowOp>(builder.getUnknownLoc(), srcTile,
                                  sourcePort.bundle, sourcePort.channel,

--- a/lib/Targets/AIEFlowsToJSON.cpp
+++ b/lib/Targets/AIEFlowsToJSON.cpp
@@ -63,11 +63,11 @@ void translateSwitchboxes(DeviceOp targetOp, raw_ostream &output) {
     Block &b = r.front();
     for (Operation &Op : b.getOperations()) {
       if (auto pktSource = dyn_cast<PacketSourceOp>(Op)) {
-        TileOp source = dyn_cast<TileOp>(pktSource.getTile().getDefiningOp());
+        TileOp source = cast<TileOp>(pktSource.getTile().getDefiningOp());
         TileID srcID = {source.colIndex(), source.rowIndex()};
         sourceCounts[srcID]++;
       } else if (auto pktDest = dyn_cast<PacketDestOp>(Op)) {
-        TileOp dest = dyn_cast<TileOp>(pktDest.getTile().getDefiningOp());
+        TileOp dest = cast<TileOp>(pktDest.getTile().getDefiningOp());
         TileID dstID = {dest.colIndex(), dest.rowIndex()};
         destinationCounts[dstID]++;
       }

--- a/lib/Targets/AIETargetAirbin.cpp
+++ b/lib/Targets/AIETargetAirbin.cpp
@@ -658,7 +658,7 @@ static void configureDMAs(DeviceOp &targetOp) {
       std::optional<int> lockID = std::nullopt;
 
       for (auto op : block.getOps<UseLockOp>()) {
-        LockOp lock = dyn_cast<LockOp>(op.getLock().getDefiningOp());
+        LockOp lock = cast<LockOp>(op.getLock().getDefiningOp());
         lockID = lock.getLockIDValue();
         if (op.acquire()) {
           acqEnable = ENABLE;
@@ -906,7 +906,7 @@ static void configureSwitchBoxes(DeviceOp &targetOp) {
           auto mask = 0u;
           int arbiter = -1;
           for (auto val : connectOp.getAmsels()) {
-            auto amsel = dyn_cast<AMSelOp>(val.getDefiningOp());
+            auto amsel = cast<AMSelOp>(val.getDefiningOp());
             arbiter = amsel.arbiterIndex();
             int msel = amsel.getMselValue();
             mask |= 1u << msel;
@@ -931,7 +931,7 @@ static void configureSwitchBoxes(DeviceOp &targetOp) {
       int slot = 0;
       Block &block = connectOp.getRules().front();
       for (auto slotOp : block.getOps<PacketRuleOp>()) {
-        AMSelOp amselOp = dyn_cast<AMSelOp>(slotOp.getAmsel().getDefiningOp());
+        AMSelOp amselOp = cast<AMSelOp>(slotOp.getAmsel().getDefiningOp());
         int arbiter = amselOp.arbiterIndex();
         int msel = amselOp.getMselValue();
 

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -2841,8 +2841,8 @@ StringRef CppEmitter::getMemRefDimParam(Value memref, unsigned index) {
 /// associated with it
 bool CppEmitter::isMemRefDimParam(Value memref, unsigned index) {
   assert([&] {
-    auto type = llvm::dyn_cast<MemRefType>(memref.getType());
-    if (!(type && type.isDynamicDim(index))) {
+    auto type = llvm::cast<MemRefType>(memref.getType());
+    if (!type.isDynamicDim(index)) {
       printf("the dimension size at index is not dynamic\n");
       return false;
     }


### PR DESCRIPTION
Cleanup unchecked calls to `llvm::dyn_cast` by replacing them with `llvm::cast`