### PR TITLE
Add chess support to aie2xclbin

### DIFF
--- a/test/ipu-xrt/matrix_multiplication_using_dma/run-a2x.lit
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/run-a2x.lit
@@ -1,0 +1,11 @@
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+//
+// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/mm.cc -o ./mm.o
+// RUN: aie2xclbin --use-chess --xclbin-name=aie2.xclbin --ipu-insts-name=insts2.txt --tmpdir=aie2xclbin.prj -v %S/aie.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_ipu ./test.exe -x aie2.xclbin -k MLIR_AIE -i insts2.txt | FileCheck %s
+// CHECK: PASS!
+

--- a/tools/aie2xclbin/XCLBinGen.cpp
+++ b/tools/aie2xclbin/XCLBinGen.cpp
@@ -606,18 +606,6 @@ static LogicalResult generateUnifiedObject(MLIRContext *context,
       llvmModule->print(llvmirStream, nullptr);
     }
 
-    // SmallString<64> chesshackedFile(TK.TempDir);
-    // sys::path::append(chesshackedFile, "input.chesshacked.ll");
-
-    // {
-    //   auto chesshackOutput = openOutputFile(chesshackedFile, &errorMessage);
-    //   if (!chesshackOutput) {
-    //     return moduleOp.emitOpError(errorMessage);
-    //   }
-    //   chesshackOutput->os() << chesshack(llvmirString);
-    //   chesshackOutput->keep();
-    // }
-
     SmallString<64> chesslinkedFile(TK.TempDir);
     sys::path::append(chesslinkedFile, "input.chesslinked.ll");
     SmallString<64> llvmLinkBin(TK.PeanoDir);

--- a/tools/aie2xclbin/XCLBinGen.cpp
+++ b/tools/aie2xclbin/XCLBinGen.cpp
@@ -133,14 +133,12 @@ int runTool(StringRef Program, ArrayRef<std::string> Args, bool Verbose,
   if (Verbose) {
     llvm::outs() << "Run:";
     if (Env) {
-      for (auto &s : *Env) {
+      for (auto &s : *Env)
         llvm::outs() << " " << s;
-      }
     }
     llvm::outs() << " " << Program;
-    for (auto &s : Args) {
+    for (auto &s : Args)
       llvm::outs() << " " << s;
-    }
     llvm::outs() << "\n";
   }
   std::string err_msg;
@@ -233,9 +231,8 @@ static LogicalResult generateCoreElfFiles(ModuleOp moduleOp,
         std::regex r("^_include _file (.*)", std::regex::multiline);
         auto begin = std::sregex_iterator(bcfFile.begin(), bcfFile.end(), r);
         auto end = std::sregex_iterator();
-        for (std::sregex_iterator i = begin; i != end; ++i) {
+        for (std::sregex_iterator i = begin; i != end; ++i)
           extractedIncludes.push_back(i->str(1));
-        }
       }
 
       SmallString<64> chessWrapperBin(TK.InstallDir);
@@ -253,9 +250,8 @@ static LogicalResult generateCoreElfFiles(ModuleOp moduleOp,
                                      std::string(elfFile),
                                      "-f",
                                      std::string(objFile)};
-      for (const auto &inc : extractedIncludes) {
+      for (const auto &inc : extractedIncludes)
         flags.push_back(inc);
-      }
 
       if (runTool(chessWrapperBin, flags, TK.Verbose) != 0) {
         coreOp.emitOpError("Failed to link with xbridge");
@@ -569,9 +565,8 @@ static std::string chesshack(const std::string &input) {
       {"memory(argmem: write, inaccessiblemem: write)",
        "inaccessiblemem_or_argmemonly writeonly"},
   };
-  for (const auto &pair : substitutions) {
+  for (const auto &pair : substitutions)
     result = std::regex_replace(result, std::regex(pair.first), pair.second);
-  }
   return result;
 }
 

--- a/tools/aie2xclbin/XCLBinGen.h
+++ b/tools/aie2xclbin/XCLBinGen.h
@@ -30,6 +30,7 @@ struct XCLBinGenConfig {
   std::string XCLBinKernelName;
   std::string XCLBinKernelID;
   std::string XCLBinInstanceName;
+  bool UseChess = false;
 };
 
 void findVitis(XCLBinGenConfig &TK);

--- a/tools/aie2xclbin/aie2xclbin.cpp
+++ b/tools/aie2xclbin/aie2xclbin.cpp
@@ -104,9 +104,8 @@ int main(int argc, char *argv[]) {
 
   findVitis(TK);
 
-  if (Verbose) {
+  if (Verbose)
     llvm::dbgs() << "\nCompiling " << FileName << "\n";
-  }
 
   if (InstallDir.size()) {
     TK.InstallDir = InstallDir;
@@ -120,17 +119,17 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  if (TmpDir.size()) {
+  if (TmpDir.size())
     TK.TempDir = TmpDir.getValue();
-  } else {
+  else
     TK.TempDir = FileName + ".prj";
-  }
+
   std::error_code err;
   SmallString<64> tmpDir(TK.TempDir);
   err = sys::fs::make_absolute(tmpDir);
-  if (err) {
+  if (err)
     llvm::errs() << "Failed to make absolute path: " << err.message() << "\n";
-  }
+
   TK.TempDir = std::string(tmpDir);
 
   err = sys::fs::create_directories(TK.TempDir);
@@ -140,9 +139,8 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  if (Verbose) {
+  if (Verbose)
     llvm::errs() << "Created temporary directory " << TK.TempDir << "\n";
-  }
 
   MLIRContext ctx;
   ParserConfig pcfg(&ctx);
@@ -163,14 +161,12 @@ int main(int argc, char *argv[]) {
   OwningOpRef<ModuleOp> owning =
       parseSourceFile<ModuleOp>(FileName, srcMgr, pcfg);
 
-  if (!owning) {
+  if (!owning)
     return 1;
-  }
 
   if (failed(aie2xclbin(&ctx, *owning, TK, IPUInstsName.getValue(),
-                        XCLBinName.getValue()))) {
+                        XCLBinName.getValue())))
     return 1;
-  }
 
   return 0;
 }

--- a/tools/aie2xclbin/aie2xclbin.cpp
+++ b/tools/aie2xclbin/aie2xclbin.cpp
@@ -54,7 +54,8 @@ cl::opt<std::string> FileName(cl::Positional, cl::desc("<input mlir>"),
 cl::opt<std::string>
     TmpDir("tmpdir", cl::desc("Directory used for temporary file storage"),
            cl::cat(AIE2XCLBinCat));
-cl::opt<bool> Verbose("v", cl::desc("Trace commands as they are executed"));
+cl::opt<bool> Verbose("v", cl::desc("Trace commands as they are executed"),
+                      cl::cat(AIE2XCLBinCat));
 cl::opt<std::string>
     Peano("peano", cl::desc("Root directory where peano compiler is installed"),
           cl::Required, cl::cat(AIE2XCLBinCat));
@@ -83,6 +84,9 @@ cl::opt<std::string> XCLBinKernelID("xclbin-kernel-id",
 cl::opt<std::string> InstallDir("install-dir",
                                 cl::desc("Root of mlir-aie installation"),
                                 cl::cat(AIE2XCLBinCat));
+cl::opt<bool> UseChess("use-chess",
+                       cl::desc("Use chess compiler instead of peano"),
+                       cl::cat(AIE2XCLBinCat));
 
 int main(int argc, char *argv[]) {
   registerAsmPrinterCLOptions();
@@ -96,6 +100,7 @@ int main(int argc, char *argv[]) {
   TK.XCLBinKernelName = XCLBinKernelName;
   TK.XCLBinKernelID = XCLBinKernelID;
   TK.XCLBinInstanceName = XCLBinInstanceName;
+  TK.UseChess = UseChess;
 
   findVitis(TK);
 

--- a/tools/aie2xclbin/aie2xclbin.cpp
+++ b/tools/aie2xclbin/aie2xclbin.cpp
@@ -58,7 +58,7 @@ cl::opt<bool> Verbose("v", cl::desc("Trace commands as they are executed"),
                       cl::cat(AIE2XCLBinCat));
 cl::opt<std::string>
     Peano("peano", cl::desc("Root directory where peano compiler is installed"),
-          cl::Required, cl::cat(AIE2XCLBinCat));
+          cl::cat(AIE2XCLBinCat));
 cl::opt<std::string>
     HostArch("host-target", cl::desc("Target architecture of the host program"),
              cl::init(HOST_ARCHITECTURE), cl::cat(AIE2XCLBinCat));
@@ -115,8 +115,8 @@ int main(int argc, char *argv[]) {
     TK.InstallDir = sys::path::parent_path(sys::path::parent_path(argv[0]));
   }
   TK.PeanoDir = Peano.getValue();
-  if (!sys::fs::is_directory(TK.PeanoDir)) {
-    llvm::errs() << "Peano path " << TK.PeanoDir << " is invalid\n";
+  if (!TK.UseChess && !sys::fs::is_directory(TK.PeanoDir)) {
+    llvm::errs() << "Peano path \"" << TK.PeanoDir << "\" is invalid\n";
     return 1;
   }
 


### PR DESCRIPTION
This copies the pile of hacks from aiecc.py to use the Vitis chess compiler with aie2xclbin (thereby allowing IREE to use chess).