### PR TITLE
[aievec] Fix matmul to llvm for int types

### DIFF
--- a/test/Conversion/AIEVecToLLVM/matmul.mlir
+++ b/test/Conversion/AIEVecToLLVM/matmul.mlir
@@ -42,6 +42,8 @@ func.func @matmul(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
 // CHECK-LABEL: llvm.func @llvm.aie2.I512.I512.ACC1024.acc32.mac.conf(
 // CHECK-SAME:    vector<64xi8>, vector<16xi32>, vector<16xi64>, i32)
 // CHECK-SAME:      -> vector<16xi64>
+// CHECK-LABEL: llvm.func @llvm.aie2.set.I512.I256(vector<8xi32>, i32) ->
+// CHECK-SAME:  vector<16xi32>
 // CHECK-LABEL: @matmul
 // CHECK-SAME: %[[A:.*]]: vector<4x8xi8>
 // CHECK-SAME: %[[B:.*]]: vector<8x8xi8>
@@ -52,7 +54,11 @@ func.func @matmul(%A : vector<4x8xi8>, %B : vector<8x8xi8>,
 // CHECK-SAME:                      vector<8x8xi8> to vector<64xi8>
 // CHECK:      %[[FC:.*]] = vector.shape_cast %[[C]] :
 // CHECK-SAME:                      vector<4x8xi32> to vector<32xi32>
-// CHECK:      %[[BCA:.*]] = llvm.bitcast %[[FA]] : vector<32xi8> to vector<64xi8>
+// CHECK:      %[[IFA2512b:.*]] = llvm.bitcast %[[FA]] : vector<32xi8> to vector<8xi32>
+// CHECK:      %[[C0I32:.*]] = arith.constant 0 : i32
+// CHECK:      %[[IFA:.*]] = llvm.call @llvm.aie2.set.I512.I256(%[[IFA2512b]],
+// CHECK-SAME:               %[[C0I32]]) : (vector<8xi32>, i32) -> vector<16xi32>
+// CHECK:      %[[BCA:.*]] = llvm.bitcast %[[IFA]] : vector<16xi32> to vector<64xi8>
 // CHECK:      %[[BCB:.*]] = llvm.bitcast %[[FB]] : vector<64xi8> to vector<16xi32>
 // CHECK:      %[[BCC:.*]] = llvm.bitcast %[[FC]] : vector<32xi32> to vector<16xi64>
 // CHECK:      %[[CONF:.*]] = arith.constant 776 : i32
@@ -78,6 +84,10 @@ func.func @matmul(%A : vector<4x2xi32>, %B : vector<2x4xi16>,
 // CHECK-LABEL: llvm.func @llvm.aie2.I512.I512.ACC1024.acc64.mac.conf(
 // CHECK-SAME:    vector<64xi8>, vector<16xi32>, vector<16xi64>, i32)
 // CHECK-SAME:      -> vector<16xi64>
+// CHECK-LABEL: llvm.func @llvm.aie2.set.I512.I128(vector<4xi32>) ->
+// CHECK-SAME:    vector<16xi32>
+// CHECK-LABEL: llvm.func @llvm.aie2.set.I512.I256(vector<8xi32>, i32) ->
+// CHECK-SAME:    vector<16xi32>
 // CHECK-LABEL: @matmul
 // CHECK-SAME: %[[A:.*]]: vector<4x2xi32>
 // CHECK-SAME: %[[B:.*]]: vector<2x4xi16>
@@ -88,8 +98,20 @@ func.func @matmul(%A : vector<4x2xi32>, %B : vector<2x4xi16>,
 // CHECK-SAME:                      vector<2x4xi16> to vector<8xi16>
 // CHECK:      %[[FC:.*]] = vector.shape_cast %[[C]] :
 // CHECK-SAME:                      vector<4x4xi64> to vector<16xi64>
-// CHECK:      %[[BCA:.*]] = llvm.bitcast %[[FA]] : vector<8xi32> to vector<64xi8>
-// CHECK:      %[[BCB:.*]] = llvm.bitcast %[[FB]] : vector<8xi16> to vector<16xi32>
+// CHECK:      %[[IFA2512b:.*]] = llvm.bitcast %[[FA]] : vector<8xi32> to
+// CHECK-SAME:                      vector<8xi32>
+// CHECK:      %[[C0I32:.*]] = arith.constant 0 : i32
+// CHECK:      %[[IFA:.*]] = llvm.call @llvm.aie2.set.I512.I256(%[[IFA2512b]],
+// CHECK-SAME:                      %[[C0I32]]) : (vector<8xi32>, i32) ->
+// CHECK-SAME:                      vector<16xi32>
+// CHECK:      %[[BCA:.*]] = llvm.bitcast %[[IFA]] : vector<16xi32> to
+// CHECK-SAME:                      vector<64xi8>
+// CHECK:      %[[IFB2512b:.*]] = llvm.bitcast %[[FB]] : vector<8xi16> to
+// CHECK-SAME:                      vector<4xi32>
+// CHECK:      %[[IFB:.*]] = llvm.call @llvm.aie2.set.I512.I128(%[[IFB2512b]]) :
+// CHECK-SAME:                      (vector<4xi32>) -> vector<16xi32>
+// CHECK:      %[[BCB:.*]] = llvm.bitcast %[[IFB]] : vector<16xi32> to
+// CHECK-SAME:                      vector<16xi32>
 // CHECK:      %[[BCC:.*]] = llvm.bitcast %[[FC]] : vector<16xi64> to vector<16xi64>
 // CHECK:      %[[CONF:.*]] = arith.constant 770 : i32
 // CHECK:      %[[RACC:.*]] =


### PR DESCRIPTION
This is a temporary solution, as a reference, while the AIEVec -> LLVM IR conversion is re-architected and re-implemented.