### PR TITLE
rename `aie-*.whl` to `aie_python_bindings`

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -173,18 +173,18 @@ jobs:
           
           popd
           
-          auditwheel repair -w $WHEELHOUSE_DIR/repaired_wheel $WHEELHOUSE_DIR/aie-*whl --plat manylinux_2_35_x86_64
+          auditwheel repair -w $WHEELHOUSE_DIR/repaired_wheel $WHEELHOUSE_DIR/aie_python_bindings-*whl --plat manylinux_2_35_x86_64
 
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
-          path: wheelhouse/repaired_wheel/aie-*.whl
+          path: wheelhouse/repaired_wheel/aie_python_bindings-*.whl
           name: ryzen_ai_wheel
 
       - name: Release current commit
         uses: ncipollo/release-action@v1.12.0
         with:
-          artifacts: wheelhouse/repaired_wheel/aie-*.whl
+          artifacts: wheelhouse/repaired_wheel/aie_python_bindings-*.whl
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && 'latest-wheels' || 'dev-wheels' }}
           name: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && 'latest-wheels' || 'dev-wheels' }}

--- a/utils/mlir_aie_wheels/python_bindings/setup.py
+++ b/utils/mlir_aie_wheels/python_bindings/setup.py
@@ -203,7 +203,7 @@ version = f"{release_version}.{datetime}+{commit_hash}"
 setup(
     version=os.getenv("MLIR_AIE_WHEEL_VERSION", version),
     author="",
-    name="aie",
+    name="aie-python-bindings",
     include_package_data=True,
     long_description_content_type="text/markdown",
     ext_modules=[CMakeExtension("_aie", sourcedir=Path(__file__).parent.absolute())],


### PR DESCRIPTION
This avoids the need for `--no-index` when doing `pip install aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels` (which blocks install since it remove access to the generic pypi index which has eg setuptools).