### PR TITLE
[aievec] Add option to separate LLVM IR and C++ targets

### DIFF
--- a/include/aie/Dialect/AIEVec/Pipelines/Passes.h
+++ b/include/aie/Dialect/AIEVec/Pipelines/Passes.h
@@ -22,6 +22,10 @@ enum class AIEArch {
   AIE,    // Original AIE
   AIE_ML, // ML/V2 version of AIE
 };
+enum class TargetBackend {
+  CPP,    // Convert to aievec targeting C++ backend
+  LLVMIR, // Convert to aievec targeting LLVM IR backend
+};
 } // namespace xilinx
 
 namespace xilinx {
@@ -37,6 +41,12 @@ struct CanonicalizeVectorForAIEVecOptions
       llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
+  PassOptions::Option<std::string> targetBackend{
+      *this, "target-backend",
+      llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
+                     "will determine the aievec operations used to convert "
+                     "from vector dialect."),
+      llvm::cl::init("cpp")};
 };
 
 /// Options for the "lower-vector-to-aievec" pipeline.
@@ -47,6 +57,12 @@ struct LowerVectorToAIEVecOptions
       llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
+  PassOptions::Option<std::string> targetBackend{
+      *this, "target-backend",
+      llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
+                     "will determine the aievec operations used to convert "
+                     "from vector dialect."),
+      llvm::cl::init("cpp")};
 };
 
 /// Options for the "optimize-aievec" pipeline.
@@ -57,6 +73,12 @@ struct OptimizeAIEVecOptions
       llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
+  PassOptions::Option<std::string> targetBackend{
+      *this, "target-backend",
+      llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
+                     "will determine the aievec operations used to convert "
+                     "from vector dialect."),
+      llvm::cl::init("cpp")};
   PassOptions::Option<unsigned> shiftParam{
       *this, "shift",
       llvm::cl::desc("Shift parameter for rounding and saturation"),
@@ -87,13 +109,22 @@ struct ConvertVectorToAIEVecOptions
       llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
+  PassOptions::Option<std::string> targetBackend{
+      *this, "target-backend",
+      llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
+                     "will determine the aievec operations used to convert "
+                     "from vector dialect."),
+      llvm::cl::init("cpp")};
 
   mlir::LogicalResult parseFromString(mlir::StringRef options) {
     auto res = PassPipelineOptions::parseFromString(options);
     if (!failed(res)) {
       lowerOptions.aieTarget = aieTarget;
+      lowerOptions.targetBackend = targetBackend;
       canonicalizeOptions.aieTarget = aieTarget;
+      canonicalizeOptions.targetBackend = targetBackend;
       optimizeOptions.aieTarget = aieTarget;
+      optimizeOptions.targetBackend = targetBackend;
       optimizeOptions.shiftParam = shiftParam;
     }
     return res;

--- a/lib/Dialect/AIEVec/Transforms/ConvertVectorToAIEVec.cpp
+++ b/lib/Dialect/AIEVec/Transforms/ConvertVectorToAIEVec.cpp
@@ -114,7 +114,7 @@ void xilinx::aievec::buildConvertVectorToAIEVec(
   buildCanonicalizeVectorForAIEVec(
       pm, options.getCanonicalizeVectorForAIEVecOptions());
   // NOTE: At this stage, all the Vector code in the IR can be mapped
-  // HOTE: to AIEVec operations.
+  // NOTE: to AIEVec operations.
 
   //============================================================================
   // Vector to AIEVec lowering: Vector to AIEVec conversion.

--- a/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
+++ b/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
@@ -16,7 +16,7 @@
 #include "aie/Dialect/AIEVec/AIEVecUtils.h"
 #include "aie/Dialect/AIEVec/Analysis/Passes.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecOps.h"
-
+#include "aie/Dialect/AIEVec/Pipelines/Passes.h"
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -511,8 +511,11 @@ struct FoldMulAddChainToConvOpPattern
   unsigned shiftParam;
 };
 
+namespace xilinx::aievec {
+
 void configureAIEVecConvOpTransformationLegalizations(ConversionTarget &target,
-                                                      AnalysisManager &am) {
+                                                      AnalysisManager &am,
+                                                      TargetBackend backend) {
   LongestConvMACChainAnalysis::am = &am;
   target.addLegalDialect<AIEVecDialect>();
   target.addLegalDialect<arith::ArithDialect>();
@@ -524,7 +527,8 @@ void configureAIEVecConvOpTransformationLegalizations(ConversionTarget &target,
 
 void populateAIEVecConvOpTransformationPatterns(RewritePatternSet &patterns,
                                                 AnalysisManager &am,
-                                                unsigned shiftParam) {
+                                                unsigned shiftParam,
+                                                TargetBackend backend) {
   patterns.add<FoldMulAddChainToConvOpPattern>(patterns.getContext(), am,
                                                shiftParam);
 }
@@ -602,6 +606,8 @@ struct AIEVecConvAnalysis : public AIEVecConvAnalysisBase<AIEVecConvAnalysis> {
   }
 };
 
-std::unique_ptr<Pass> xilinx::aievec::createAIEVecConvolutionAnalysisPass() {
+std::unique_ptr<Pass> createAIEVecConvolutionAnalysisPass() {
   return std::make_unique<AIEVecConvAnalysis>();
 }
+
+} // namespace xilinx::aievec

--- a/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.h
+++ b/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.h
@@ -12,6 +12,11 @@
 #include "mlir/Pass/AnalysisManager.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+namespace xilinx {
+
+enum class TargetBackend;
+
+namespace aievec {
 //===----------------------------------------------------------------------===//
 // This is the implementation of the folding pass from mul add chain
 // to AIEVec convolution operations, compatible with the AIE-ML architecture.
@@ -19,12 +24,16 @@
 
 // Configure the legalizations for aievec conv op transformation
 void configureAIEVecConvOpTransformationLegalizations(
-    mlir::ConversionTarget &target, mlir::AnalysisManager &am);
+    mlir::ConversionTarget &target, mlir::AnalysisManager &am,
+    TargetBackend backend);
 
 // Populate the conversion pattern by FoldMulAddChainToConvOpPattern, which
 // folds a mul add chain into mul_conv and mac_conv.
 void populateAIEVecConvOpTransformationPatterns(
     mlir::RewritePatternSet &patterns, mlir::AnalysisManager &am,
-    unsigned shiftParam);
+    unsigned shiftParam, TargetBackend backend);
+
+} // namespace aievec
+} // namespace xilinx
 
 #endif // FOLDMULADDCHAINTOCONVOP_H


### PR DESCRIPTION
In order to support two different translation targets, we need slightly different conversion patterns depending on whether our backend will be LLVM IR or C++. In most cases, there won't be a need to differentiate, but for the few that will be different, this patch adds the option.