### PR TITLE
[aie2xclbin] Options to configure pass managers for debug support 

### DIFF
--- a/tools/aie2xclbin/XCLBinGen.cpp
+++ b/tools/aie2xclbin/XCLBinGen.cpp
@@ -48,6 +48,30 @@ using namespace llvm;
 using namespace mlir;
 using namespace xilinx;
 
+namespace {
+
+// Apply the pass manager specific options of the XCLBinGenConfig to the pass
+// manager. These control when (if ever) and what IR gets printed between
+// passes, and whether the pass manager uses multi-theading.
+void applyConfigToPassManager(XCLBinGenConfig &TK, PassManager &pm) {
+
+  pm.getContext()->disableMultithreading(TK.DisableThreading);
+
+  bool printBefore = TK.PrintIRBeforeAll;
+  auto shouldPrintBeforePass = [printBefore](Pass *, Operation *) {
+    return printBefore;
+  };
+
+  bool printAfter = TK.PrintIRAfterAll;
+  auto shouldPrintAfterPass = [printAfter](Pass *, Operation *) {
+    return printAfter;
+  };
+
+  pm.enableIRPrinting(shouldPrintBeforePass, shouldPrintAfterPass,
+                      TK.PrintIRModuleScope);
+}
+} // namespace
+
 void xilinx::findVitis(XCLBinGenConfig &TK) {
   const char *env_vitis = ::getenv("VITIS");
   if (env_vitis == nullptr) {
@@ -298,6 +322,8 @@ static LogicalResult generateCDO(MLIRContext *context, ModuleOp moduleOp,
   // This corresponds to `process_host_cgen`, which is listed as host
   // compilation in aiecc.py... not sure we need this.
   PassManager passManager(context, ModuleOp::getOperationName());
+  applyConfigToPassManager(TK, passManager);
+
   passManager.addNestedPass<AIE::DeviceOp>(AIE::createAIEPathfinderPass());
   passManager.addNestedPass<AIE::DeviceOp>(
       AIEX::createAIEBroadcastPacketPass());
@@ -555,6 +581,8 @@ static LogicalResult generateUnifiedObject(MLIRContext *context,
                                            XCLBinGenConfig &TK,
                                            const std::string &outputFile) {
   PassManager pm(context, moduleOp.getOperationName());
+  applyConfigToPassManager(TK, pm);
+
   pm.addNestedPass<AIE::DeviceOp>(AIE::createAIELocalizeLocksPass());
   pm.addNestedPass<AIE::DeviceOp>(AIE::createAIENormalizeAddressSpacesPass());
   pm.addPass(AIE::createAIECoreToStandardPass());
@@ -705,6 +733,8 @@ LogicalResult xilinx::aie2xclbin(MLIRContext *ctx, ModuleOp moduleOp,
                                  XCLBinGenConfig &TK, StringRef OutputIPU,
                                  StringRef OutputXCLBin) {
   PassManager pm(ctx, moduleOp.getOperationName());
+  applyConfigToPassManager(TK, pm);
+
   addAIELoweringPasses(pm);
 
   if (TK.Verbose) {
@@ -730,6 +760,8 @@ LogicalResult xilinx::aie2xclbin(MLIRContext *ctx, ModuleOp moduleOp,
   // generateIPUInstructions
   {
     PassManager pm(ctx, moduleOp.getOperationName());
+    applyConfigToPassManager(TK, pm);
+
     pm.addNestedPass<AIE::DeviceOp>(AIEX::createAIEDmaToIpuPass());
     ModuleOp copy = moduleOp.clone();
     if (failed(pm.run(copy)))

--- a/tools/aie2xclbin/XCLBinGen.h
+++ b/tools/aie2xclbin/XCLBinGen.h
@@ -31,6 +31,10 @@ struct XCLBinGenConfig {
   std::string XCLBinKernelID;
   std::string XCLBinInstanceName;
   bool UseChess = false;
+  bool DisableThreading = false;
+  bool PrintIRAfterAll = false;
+  bool PrintIRBeforeAll = false;
+  bool PrintIRModuleScope = false;
 };
 
 void findVitis(XCLBinGenConfig &TK);

--- a/tools/aie2xclbin/aie2xclbin.cpp
+++ b/tools/aie2xclbin/aie2xclbin.cpp
@@ -49,41 +49,77 @@ using namespace xilinx;
 
 cl::OptionCategory AIE2XCLBinCat("AIE To XCLBin Options",
                                  "Options specific to the aie2xclbin tool");
+
 cl::opt<std::string> FileName(cl::Positional, cl::desc("<input mlir>"),
                               cl::Required, cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string>
     TmpDir("tmpdir", cl::desc("Directory used for temporary file storage"),
            cl::cat(AIE2XCLBinCat));
+
 cl::opt<bool> Verbose("v", cl::desc("Trace commands as they are executed"),
                       cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string>
     Peano("peano", cl::desc("Root directory where peano compiler is installed"),
           cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string>
     HostArch("host-target", cl::desc("Target architecture of the host program"),
              cl::init(HOST_ARCHITECTURE), cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string>
     IPUInstsName("ipu-insts-name",
                  cl::desc("Output instructions filename for IPU target"),
                  cl::init("ipu_insts.txt"), cl::cat(AIE2XCLBinCat));
+
+cl::opt<bool>
+    PrintIRAfterAll("print-ir-after-all",
+                    cl::desc("Configure all pass managers in lowering from aie "
+                             "to xclbin to print IR after all passes"),
+                    cl::init(false), cl::cat(AIE2XCLBinCat));
+
+cl::opt<bool>
+    PrintIRBeforeAll("print-ir-before-all",
+                     cl::desc("Configure all pass managers in lowering from "
+                              "aie to xclbin to print IR before all passes"),
+                     cl::init(false), cl::cat(AIE2XCLBinCat));
+
+cl::opt<bool>
+    DisableThreading("disable-threading",
+                     cl::desc("Configure all pass managers in lowering from "
+                              "aie to xclbin to disable multithreading"),
+                     cl::init(false), cl::cat(AIE2XCLBinCat));
+
+cl::opt<bool> PrintIRModuleScope(
+    "print-ir-module-scope",
+    cl::desc("Configure all pass managers in lowering from aie to xclbin to "
+             "print IR at the module scope"),
+    cl::init(false), cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string>
     XCLBinName("xclbin-name",
                cl::desc("Output xclbin filename for CDO/XCLBIN target"),
                cl::init("final.xclbin"), cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string> XCLBinKernelName("xclbin-kernel-name",
                                       cl::desc("Kernel name in xclbin file"),
                                       cl::init("MLIR_AIE"),
                                       cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string>
     XCLBinInstanceName("xclbin-instance-name",
                        cl::desc("Instance name in xclbin metadata"),
                        cl::init("MLIRAIEV1"), cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string> XCLBinKernelID("xclbin-kernel-id",
                                     cl::desc("Kernel id in xclbin file"),
                                     cl::init("0x901"), cl::cat(AIE2XCLBinCat));
+
 cl::opt<std::string> InstallDir("install-dir",
                                 cl::desc("Root of mlir-aie installation"),
                                 cl::cat(AIE2XCLBinCat));
+
 cl::opt<bool> UseChess("use-chess",
                        cl::desc("Use chess compiler instead of peano"),
                        cl::cat(AIE2XCLBinCat));
@@ -101,6 +137,10 @@ int main(int argc, char *argv[]) {
   TK.XCLBinKernelID = XCLBinKernelID;
   TK.XCLBinInstanceName = XCLBinInstanceName;
   TK.UseChess = UseChess;
+  TK.DisableThreading = DisableThreading;
+  TK.PrintIRAfterAll = PrintIRAfterAll;
+  TK.PrintIRBeforeAll = PrintIRBeforeAll;
+  TK.PrintIRModuleScope = PrintIRModuleScope;
 
   findVitis(TK);
 


### PR DESCRIPTION
This PR adds command line options: 

print-ir-before-all
print-ir-after-all
print-ir-module-scope
disable-threading

to aie2xclbin. 

Motivation: When running via iree-amd-aie, failures in aie2xclbin don't provide much in the way of diagnostics. If this lands, I will extend iree-amd-aie's call to aie2xclbin to optionally dump IR. 