### PR TITLE
[aievec] Make accum. materialization optional for matmul

### DIFF
--- a/test/Conversion/VectorToAIEVec/test-contract.mlir
+++ b/test/Conversion/VectorToAIEVec/test-contract.mlir
@@ -1,4 +1,5 @@
 // RUN: aie-opt %s -convert-vector-to-aievec=aie-target=aieml | FileCheck %s
+// RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml target-backend=llvmir" | FileCheck %s --check-prefix=CHECK-LLVM
 
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -13,6 +14,14 @@
 // CHECK-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
 // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xf32>, vector<4x4xf32>
 // CHECK:        return %[[R]] : vector<4x4xf32>
+
+// CHECK-LLVM-LABEL: func.func @contractbf16bf16f32(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
+// CHECK-LLVM:        return %[[MM]] : vector<4x4xf32>
 func.func @contractbf16bf16f32(%A : vector<4x8xbf16>,
                                %B : vector<8x4xbf16>,
                                %C : vector<4x4xf32>) -> vector<4x4xf32> {
@@ -32,6 +41,14 @@ func.func @contractbf16bf16f32(%A : vector<4x8xbf16>,
 // CHECK-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
 // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x8xi32>, vector<4x8xi32>
 // CHECK:        return %[[R]] : vector<4x8xi32>
+
+// CHECK-LLVM-LABEL: func.func @contracti16i8i32(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contracti16i8i32(%A : vector<4x4xi16>,
                             %B : vector<4x8xi8>,
                             %C : vector<4x8xi32>) -> vector<4x8xi32> {
@@ -52,6 +69,14 @@ func.func @contracti16i8i32(%A : vector<4x4xi16>,
 // CHECK-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
 // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xi64>, vector<4x4xi64>
 // CHECK:        return %[[R]] : vector<4x4xi64>
+
+// CHECK-LLVM-LABEL: func.func @contracti32i16i64(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+// CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
 func.func @contracti32i16i64(%A : vector<4x2xi32>,
                              %B : vector<2x4xi16>,
                              %C : vector<4x4xi64>) -> vector<4x4xi64> {
@@ -72,6 +97,14 @@ func.func @contracti32i16i64(%A : vector<4x2xi32>,
 // CHECK-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
 // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xf32>, vector<4x4xf32>
 // CHECK:        return %[[R]] : vector<4x4xf32>
+
+// CHECK-LLVM-LABEL: func.func @contractf32f32f32(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
+// CHECK-LLVM:        return %[[MM]] : vector<4x4xf32>
 func.func @contractf32f32f32(%A : vector<4x8xbf16>,
                              %B : vector<8x4xbf16>,
                              %C : vector<4x4xf32>) -> vector<4x4xf32> {
@@ -93,6 +126,14 @@ func.func @contractf32f32f32(%A : vector<4x8xbf16>,
 // CHECK-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
 // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x8xi32>, vector<4x8xi32>
 // CHECK:        return %[[R]] : vector<4x8xi32>
+
+// CHECK-LLVM-LABEL: func.func @contracti32i32i32(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+// CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
 func.func @contracti32i32i32(%A : vector<4x4xi16>,
                              %B : vector<4x8xi8>,
                              %C : vector<4x8xi32>) -> vector<4x8xi32> {
@@ -114,6 +155,14 @@ func.func @contracti32i32i32(%A : vector<4x4xi16>,
 // CHECK-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
 // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xi64>, vector<4x4xi64>
 // CHECK:        return %[[R]] : vector<4x4xi64>
+
+// CHECK-LLVM-LABEL: func.func @contracti64i64i64(
+// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
+// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
+// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
+// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+// CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+// CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
 func.func @contracti64i64i64(%A : vector<4x2xi32>,
                              %B : vector<2x4xi16>,
                              %C : vector<4x4xi64>) -> vector<4x4xi64> {


### PR DESCRIPTION
When lowering to LLVM IR, we don't need to make transfers between the accumulator and regular bank registers explicit.