### PR TITLE
DCE AIETargetCDODirect

### DIFF
--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -602,23 +602,7 @@ struct AIEControl {
         auto slvPortNum = 0;
         auto mstrPortNum = 0;
         TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_StrmConnCctEnable, &devInst,
-                                tileLoc, CTRL, slvPortNum, SOUTH, mstrPortNum);
-        // configure DMA_<S2MM/MM2S>_<chNum>_Ctrl register
-        assert(targetOp.getDevice() == AIEDevice::ipu &&
-               "Only IPU currently supported");
-        if (col != 0)
-          for (int chNum = 0; chNum <= 1; ++chNum) {
-            XAie_DmaChannelDesc dmaChannelDescInst;
-            TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_DmaChannelDescInit,
-                                    &devInst, &dmaChannelDescInst, tileLoc);
-            auto controllerId = 0;
-            TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_DmaChannelSetControllerId,
-                                    &dmaChannelDescInst, controllerId);
-            TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_DmaWriteChannel, &devInst,
-                                    &dmaChannelDescInst, tileLoc, chNum,
-                                    DMA_S2MM);
-          }
-
+                                tileLoc, CTRL, slvPortNum, SOUTH, mstrPortNum)
         TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_AieToPlIntfEnable, &devInst,
                                 tileLoc, /*PortNum*/ 0, PLIF_WIDTH_32);
       }

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -602,7 +602,7 @@ struct AIEControl {
         auto slvPortNum = 0;
         auto mstrPortNum = 0;
         TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_StrmConnCctEnable, &devInst,
-                                tileLoc, CTRL, slvPortNum, SOUTH, mstrPortNum)
+                                tileLoc, CTRL, slvPortNum, SOUTH, mstrPortNum);
         TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_AieToPlIntfEnable, &devInst,
                                 tileLoc, /*PortNum*/ 0, PLIF_WIDTH_32);
       }

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -603,8 +603,6 @@ struct AIEControl {
         auto mstrPortNum = 0;
         TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_StrmConnCctEnable, &devInst,
                                 tileLoc, CTRL, slvPortNum, SOUTH, mstrPortNum);
-        TRY_XAIE_API_EMIT_ERROR(switchboxOp, XAie_AieToPlIntfEnable, &devInst,
-                                tileLoc, /*PortNum*/ 0, PLIF_WIDTH_32);
       }
 
       Block &b = switchboxOp.getConnections().front();


### PR DESCRIPTION
The removed code here seemingly has no effect nor do I understand its intent since on IPU these configs would be overwritten by direct programming by ipu instructions.