### PR TITLE
Pin wheels version in quick setup

### DIFF
--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -33,6 +33,10 @@ if [[ $WSL_DISTRO_NAME == "" ]]; then
 else
   echo "Environment is WSL"
 fi
+if ! hash python3.10; then
+   echo "This script requires python3.10"
+   return 1
+fi
 if ! hash virtualenv; then
   echo "virtualenv is not installed"
   return 1

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -33,12 +33,6 @@ if [[ $WSL_DISTRO_NAME == "" ]]; then
 else
   echo "Environment is WSL"
 fi
-if ! hash python3.8; then
-  echo "This script requires python3.8"
-  echo "https://linuxgenie.net/how-to-install-python-3-8-on-ubuntu-22-04/"
-  echo "Don't forget python3.8-distutils!"
-  return 1
-fi
 if ! hash virtualenv; then
   echo "virtualenv is not installed"
   return 1
@@ -47,7 +41,6 @@ if ! hash unzip; then
   echo "unzip is not installed"
   return 1
 fi
-alias python3=python3.8
 # if an install is already present, remove it to start from a clean slate
 rm -rf ironenv
 rm -rf my_install
@@ -64,9 +57,11 @@ if test -f "$VPP"; then
   AIETOOLS="`dirname $VPP`/../aietools"
   mkdir -p my_install
   pushd my_install
-  pip download mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
+  # pip download mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
+  wget -q --show-progress https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024022716+9fb02d7-py3-none-manylinux_2_35_x86_64.whl
   unzip -q mlir_aie-*_x86_64.whl
-  pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
+  # pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
+  wget -q --show-progress https://github.com/Xilinx/mlir-aie/releases/download/mlir-distro/mlir-19.0.0.2024022520+641d160a-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   unzip -q mlir-*_x86_64.whl
   pip install https://github.com/makslevental/mlir-python-extras/archive/d84f05582adb2eed07145dabce1e03e13d0e29a6.zip
   rm -rf mlir*.whl


### PR DESCRIPTION
Initially manually pin wheels to a particular verified version in the quick setup script. Future work to use actions to update the script after automatic verification. 