### PR TITLE
Fix for unused variable errors

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
+++ b/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
@@ -245,7 +245,7 @@ struct LongestConvMACChainAnalysis {
       opBwdSlices.insert(mulOpOperand);
 
       LLVM_DEBUG(llvm::dbgs() << "opBwdSlices = [\n");
-      for (auto op : opBwdSlices) {
+      for ([[maybe_unused]] auto op : opBwdSlices) {
         LLVM_DEBUG(llvm::dbgs() << *op << "\n");
       }
       LLVM_DEBUG(llvm::dbgs() << "]\n");

--- a/lib/Dialect/AIEX/Utils/AIETokenAnalysis.cpp
+++ b/lib/Dialect/AIEX/Utils/AIETokenAnalysis.cpp
@@ -64,7 +64,7 @@ void xilinx::AIEX::TokenAnalysis::runAnalysis() {
   for (const auto &map : tokenAcqMap) {
     StringRef tokenName = map.first;
     for (auto Op : map.second) {
-      bool isReleased = false;
+      [[maybe_unused]] bool isReleased = false;
       if (auto op = dyn_cast<MemcpyOp>(Op))
         isReleased = true;
 


### PR DESCRIPTION
I got unused variable errors after https://github.com/Xilinx/mlir-aie/pull/1079. Not sure why this isn't catched in CI?

cc @makslevental @jsetoain 


