### PR TITLE
Fix ipu_sync for multicore in matrix vector ref design

### DIFF
--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
@@ -20,7 +20,7 @@ def my_matmul():
     word_size_in = 2
     word_size_out = 4
 
-    n_cores = 3
+    n_cores = 1
 
     A_sz_in_i32s = M * K * word_size_in // 4
     B_sz_in_i32s = K * word_size_in // 4

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
@@ -13,14 +13,14 @@ from aie.dialects.scf import *
 
 
 def my_matmul():
-    M = 512
-    K = 512
+    M = 288
+    K = 288
     m = 32
     k = 32
     word_size_in = 2
     word_size_out = 4
 
-    n_cores = 2
+    n_cores = 3
 
     A_sz_in_i32s = M * K * word_size_in // 4
     B_sz_in_i32s = K * word_size_in // 4

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
@@ -13,14 +13,14 @@ from aie.dialects.scf import *
 
 
 def my_matmul():
-    M = 288
-    K = 288
+    M = 512
+    K = 512
     m = 32
     k = 32
     word_size_in = 2
     word_size_out = 4
 
-    n_cores = 1
+    n_cores = 2
 
     A_sz_in_i32s = M * K * word_size_in // 4
     B_sz_in_i32s = K * word_size_in // 4

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
@@ -13,14 +13,14 @@ from aie.dialects.scf import *
 
 
 def my_matmul():
-    M = 288
-    K = 288
+    M = 512
+    K = 512
     m = 32
     k = 32
     word_size_in = 2
     word_size_out = 4
 
-    n_cores = 1
+    n_cores = 2
 
     A_sz_in_i32s = M * K * word_size_in // 4
     B_sz_in_i32s = K * word_size_in // 4
@@ -198,7 +198,8 @@ def my_matmul():
                         strides=[0, 0, 0],
                     )
 
-                ipu_sync(column=0, row=0, direction=0, channel=0)
+                for i in range(n_cores):
+                    ipu_sync(column=i, row=0, direction=0, channel=0)
 
     print(ctx.module)
 

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
@@ -25,8 +25,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-constexpr int m = 288;
-constexpr int k = 288;
+constexpr int m = 512;
+constexpr int k = 512;
 
 constexpr int aVolume = m * k;
 constexpr int bVolume = k;
@@ -204,8 +204,11 @@ int main(int argc, const char *argv[]) {
 
   if (verbosity >= 1)
     std::cout << "Running Kernel.\n";
+
+  auto start = std::chrono::system_clock::now();
   auto run = kernel(boInstr, instrV.size(), boA, boB, boC);
   run.wait();
+  auto stop = std::chrono::system_clock::now();
 
   boC.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
 
@@ -218,6 +221,13 @@ int main(int argc, const char *argv[]) {
   for (uint32_t i = 0; i < cVolume; i++)
     outputRef0.push_back(0);
   matvec(aVec, bVec, outputRef0);
+
+  std::cout << std::endl
+            << "NPU matmul time: "
+            << std::chrono::duration_cast<std::chrono::microseconds>((stop -
+                                                                     start))
+                   .count()
+            << "us." << std::endl;
 
   const float absTol = std::abs(0.1);
   for (uint32_t i = 0; i < cVolume; i++) {

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
@@ -224,8 +224,8 @@ int main(int argc, const char *argv[]) {
 
   std::cout << std::endl
             << "NPU matmul time: "
-            << std::chrono::duration_cast<std::chrono::microseconds>((stop -
-                                                                     start))
+            << std::chrono::duration_cast<std::chrono::microseconds>(
+                   (stop - start))
                    .count()
             << "us." << std::endl;
 

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
@@ -25,8 +25,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-constexpr int m = 288;
-constexpr int k = 288;
+constexpr int m = 512;
+constexpr int k = 512;
 
 constexpr int aVolume = m * k;
 constexpr int bVolume = k;

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/test.cpp
@@ -25,8 +25,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-constexpr int m = 512;
-constexpr int k = 512;
+constexpr int m = 288;
+constexpr int k = 288;
 
 constexpr int aVolume = m * k;
 constexpr int bVolume = k;


### PR DESCRIPTION
@jgmelber In the multicore matrix vector reference design, I believe every shim connection requires its own sync to make sure all output data is properly returned?