### PR TITLE
Implement `aie-assign-bd-ids` pass

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -90,14 +90,3 @@ CheckOptions:
     value:           camelBack
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack
-  # Ours
-  - key:             readability-identifier-naming.GlobalConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.LocalConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.StaticConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.ConstantCase
-    value:           UPPER_CASE
-  - key:             readability-identifier-naming.ConstexprVariableCase
-    value:           UPPER_CASE

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -822,7 +822,10 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
     ins AnyMemRef:$buffer,
         OptionalAttr<AIEI32Attr>:$offset,
         OptionalAttr<AIEI32Attr>:$len,
-        OptionalAttr<BDDimLayoutArrayAttr>:$dimensions
+        OptionalAttr<BDDimLayoutArrayAttr>:$dimensions,
+        OptionalAttr<AIEI32Attr>:$bd_id,
+        // should never be assigned by user...
+        OptionalAttr<AIEI32Attr>:$next_bd_id
   );
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.h
@@ -42,7 +42,8 @@ createAIEObjectFifoStatefulTransformPass();
 std::unique_ptr<mlir::OperationPass<DeviceOp>>
 createAIEObjectFifoRegisterProcessPass();
 std::unique_ptr<mlir::OperationPass<DeviceOp>> createAIELowerCascadeFlowsPass();
-std::unique_ptr<mlir::OperationPass<DeviceOp>> createAIEAssignBufferDescriptorIDsPass();
+std::unique_ptr<mlir::OperationPass<DeviceOp>>
+createAIEAssignBufferDescriptorIDsPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.h
@@ -42,6 +42,7 @@ createAIEObjectFifoStatefulTransformPass();
 std::unique_ptr<mlir::OperationPass<DeviceOp>>
 createAIEObjectFifoRegisterProcessPass();
 std::unique_ptr<mlir::OperationPass<DeviceOp>> createAIELowerCascadeFlowsPass();
+std::unique_ptr<mlir::OperationPass<DeviceOp>> createAIEAssignBufferDescriptorIDsPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -99,6 +99,11 @@ def AIELocalizeLocks : Pass<"aie-localize-locks", "DeviceOp"> {
   let constructor = "xilinx::AIE::createAIELocalizeLocksPass()";
 }
 
+def AIEAssignBufferDescriptorIDs : Pass<"aie-assign-bd-ids", "DeviceOp"> {
+  let summary = "Assign bd ids to aie.dma_bd ops.";
+  let constructor = "xilinx::AIE::createAIEAssignBufferDescriptorIDsPass()";
+}
+
 def AIENormalizeAddressSpaces : Pass<"aie-normalize-address-spaces", "DeviceOp"> {
   let summary = "Remove non-default address spaces";
   let description = [{

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -359,12 +359,10 @@ void AIEDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "aie/Dialect/AIE/IR/AIEAttrs.cpp.inc"
-
       >();
   addOperations<
 #define GET_OP_LIST
 #include "aie/Dialect/AIE/IR/AIEOps.cpp.inc"
-
       >();
   addInterfaces<AIEInlinerInterface, AIEDialectFoldInterface>();
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -359,10 +359,12 @@ void AIEDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "aie/Dialect/AIE/IR/AIEAttrs.cpp.inc"
+
       >();
   addOperations<
 #define GET_OP_LIST
 #include "aie/Dialect/AIE/IR/AIEOps.cpp.inc"
+
       >();
   addInterfaces<AIEInlinerInterface, AIEDialectFoldInterface>();
 }
@@ -1514,9 +1516,22 @@ LogicalResult MemTileDMAOp::verify() {
 LogicalResult DMAOp::verify() {
   auto *parentOp = getOperation()->getParentOp();
   if (parentOp->getRegion(0).getBlocks().size() > 1)
-    return emitOpError("DMA op can only appear in single block region");
+    return emitOpError("DMAOp can only appear in single block region");
   if (!parentOp->getRegion(0).getOps<DMAStartOp>().empty())
-    return emitOpError("DMA op is not compatible with DMAStart ops");
+    return emitOpError("DMAOp is not compatible with DMAStart ops");
+  auto bdRegions = getBds();
+  for (auto &bdRegion : bdRegions) {
+    if (!bdRegion.hasOneBlock())
+      return emitOpError("DMAOp regions must have only one block");
+    auto bds = llvm::to_vector_of<DMABDOp>(bdRegion.front().getOps<DMABDOp>());
+    if (bds.size() != 1)
+      return emitOpError("DMAOp regions/blocks must have exactly one DMABDOp");
+    auto useLocks =
+        llvm::to_vector_of<UseLockOp>(bdRegion.front().getOps<UseLockOp>());
+    if (useLocks.size() != 2)
+      return emitOpError(
+          "DMAOp regions/blocks must have exactly two UseLock ops");
+  }
   return success();
 }
 

--- a/lib/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.cpp
@@ -1,0 +1,174 @@
+//===- AIEAssignBufferDescriptorIDs.cpp
+//---------------------------------------*- C++
+//-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
+
+#include "mlir/Pass/Pass.h"
+
+#define DEBUG_TYPE "aie-assign-bd-ids"
+#define EVEN_BD_ID_START 0
+#define ODD_BD_ID_START 24
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIE;
+
+struct BdNumGenerator {
+  BdNumGenerator(int col, int row, const AIETargetModel &targetModel)
+      : col(col), row(row), isMemTile(targetModel.isMemTile(col, row)) {}
+
+  int32_t nextBDNum(int channelIndex) {
+    int32_t bdId = isMemTile && channelIndex & 1 ? oddBdId++ : evenBdId++;
+    while (bdIdAlreadyAssigned(bdId))
+      bdId = isMemTile && channelIndex & 1 ? oddBdId++ : evenBdId++;
+    assignBdId(bdId);
+    return bdId;
+  }
+
+  void assignBdId(int32_t bdId) {
+    assert(!alreadyAssigned.count(bdId) && "bdId has already been assigned");
+    alreadyAssigned.insert(bdId);
+  }
+
+  bool bdIdAlreadyAssigned(int32_t bdId) { return alreadyAssigned.count(bdId); }
+
+  int col;
+  int row;
+  int oddBdId = ODD_BD_ID_START;
+  int evenBdId = EVEN_BD_ID_START;
+  bool isMemTile;
+  std::set<int32_t> alreadyAssigned;
+};
+
+struct AIEAssignBufferDescriptorIDsPass
+    : AIEAssignBufferDescriptorIDsBase<AIEAssignBufferDescriptorIDsPass> {
+  void runOnOperation() override {
+    DeviceOp targetOp = getOperation();
+    const AIETargetModel &targetModel = targetOp.getTargetModel();
+
+    auto memOps = llvm::to_vector_of<TileElement>(targetOp.getOps<MemOp>());
+    llvm::append_range(memOps, targetOp.getOps<MemTileDMAOp>());
+    llvm::append_range(memOps, targetOp.getOps<ShimDMAOp>());
+    for (TileElement memOp : memOps) {
+      int col = memOp.getTileID().col;
+      int row = memOp.getTileID().row;
+      BdNumGenerator gen(col, row, targetModel);
+
+      auto dmaOps = llvm::to_vector_of<DMAOp>(
+          memOp.getOperation()->getRegion(0).getOps<DMAOp>());
+      if (!dmaOps.empty()) {
+        for (auto dmaOp : dmaOps) {
+          auto bdRegions = dmaOp.getBds();
+          for (auto &bdRegion : bdRegions) {
+            auto &block = bdRegion.getBlocks().front();
+            DMABDOp bd = *block.getOps<DMABDOp>().begin();
+            if (bd.getBdId().has_value())
+              gen.assignBdId(bd.getBdId().value());
+            else
+              bd.setBdId(gen.nextBDNum(dmaOp.getChannelIndex()));
+          }
+        }
+      } else {
+        DenseMap<Block *, int> blockChannelMap;
+        // Associate with each block the channel index specified by the
+        // dma_start
+        for (Block &block : memOp.getOperation()->getRegion(0))
+          for (auto op : block.getOps<DMAStartOp>()) {
+            int chNum = op.getChannelIndex();
+            blockChannelMap[&block] = chNum;
+            Block *dest = op.getDest();
+            while (dest) {
+              blockChannelMap[dest] = chNum;
+              if (dest->hasNoSuccessors())
+                break;
+              dest = dest->getSuccessors()[0];
+              if (blockChannelMap.contains(dest))
+                dest = nullptr;
+            }
+          }
+
+        for (Block &block : memOp.getOperation()->getRegion(0)) {
+          if (block.getOps<DMABDOp>().empty())
+            continue;
+          assert(blockChannelMap.count(&block));
+          DMABDOp bd = (*block.getOps<DMABDOp>().begin());
+          if (bd.getBdId().has_value())
+            gen.assignBdId(bd.getBdId().value());
+          else
+            bd.setBdId(gen.nextBDNum(blockChannelMap[&block]));
+        }
+      }
+    }
+    for (TileElement memOp : memOps) {
+      auto dmaOps = llvm::to_vector_of<DMAOp>(
+          memOp.getOperation()->getRegion(0).getOps<DMAOp>());
+      if (!dmaOps.empty())
+        for (auto dmaOp : dmaOps) {
+          auto bdRegions = dmaOp.getBds();
+          for (auto *bdRegionIt = bdRegions.begin();
+               bdRegionIt != bdRegions.end();) {
+            auto &block = bdRegionIt->getBlocks().front();
+            DMABDOp bd = *block.getOps<DMABDOp>().begin();
+            std::optional<int> nextBdNum;
+            if (++bdRegionIt != bdRegions.end())
+              nextBdNum =
+                  (*bdRegionIt->getBlocks().front().getOps<DMABDOp>().begin())
+                      .getBdId();
+            else if (dmaOp.getLoop())
+              nextBdNum = (*bdRegions.front()
+                                .getBlocks()
+                                .front()
+                                .getOps<DMABDOp>()
+                                .begin())
+                              .getBdId();
+            bd.setNextBdId(nextBdNum);
+          }
+        }
+      else {
+        DenseMap<Block *, int> blockBdNumMap;
+        for (Block &block : memOp.getOperation()->getRegion(0)) {
+          if (block.getOps<DMABDOp>().empty())
+            continue;
+          DMABDOp bd = *block.getOps<DMABDOp>().begin();
+          assert(bd.getBdId().has_value() &&
+                 "DMABDOp should have bd_id assigned by now");
+          blockBdNumMap[&block] = bd.getBdId().value();
+        }
+
+        for (Block &block : memOp.getOperation()->getRegion(0)) {
+          if (block.getOps<DMABDOp>().empty())
+            continue;
+          DMABDOp bd = *block.getOps<DMABDOp>().begin();
+          std::optional<int> nextBdNum;
+          if (block.getNumSuccessors()) {
+            assert(llvm::range_size(block.getSuccessors()) == 1 &&
+                   "should have only one successor block");
+            Block *nextBlock = block.getSuccessor(0);
+            if (!blockBdNumMap.contains(nextBlock))
+              assert(nextBlock->getOperations().size() == 1 &&
+                     isa<EndOp>(nextBlock->getOperations().front()) &&
+                     "bb that's not in blockMap can only have aie.end");
+            else
+              nextBdNum = blockBdNumMap[nextBlock];
+            bd.setNextBdId(nextBdNum);
+          }
+        }
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<DeviceOp>>
+AIE::createAIEAssignBufferDescriptorIDsPass() {
+  return std::make_unique<AIEAssignBufferDescriptorIDsPass>();
+}

--- a/lib/Dialect/AIE/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIE/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@
 add_mlir_dialect_library(
   AIETransforms
   AIEAssignBuffers.cpp
+  AIEAssignBufferDescriptorIDs.cpp
   AIEAssignLockIDs.cpp
   AIEFindFlows.cpp
   AIEPathFinder.cpp

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -357,8 +357,7 @@ LogicalResult pushToBdQueueAndEnable(XAie_DevInst &devInst, Operation &op,
   return success();
 };
 
-LogicalResult
-configureLocksinBdAndBdInBlockAnd(XAie_DevInst &devInst, Block &block,
+LogicalResult configureLocksAndBd(XAie_DevInst &devInst, Block &block,
                                   XAie_LocType tileLoc,
                                   const AIETargetModel &targetModel) {
   DMABDOp bd = *block.getOps<DMABDOp>().begin();
@@ -509,16 +508,15 @@ struct AIEControl {
         for (auto dmaOp : dmaOps)
           for (auto &bdRegion : dmaOp.getBds()) {
             Block &block = bdRegion.getBlocks().front();
-            if (failed(configureLocksinBdAndBdInBlockAnd(devInst, block,
-                                                         tileLoc, targetModel)))
+            if (failed(
+                    configureLocksAndBd(devInst, block, tileLoc, targetModel)))
               return failure();
           }
       } else {
         for (Block &block : memOp.getOperation()->getRegion(0)) {
           if (block.getOps<DMABDOp>().empty())
             continue;
-          if (failed(configureLocksinBdAndBdInBlockAnd(devInst, block, tileLoc,
-                                                       targetModel)))
+          if (failed(configureLocksAndBd(devInst, block, tileLoc, targetModel)))
             return failure();
         }
       }

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -197,8 +197,7 @@ namespace xilinx::AIE {
 LogicalResult configureLocksInBdBlock(XAie_DmaDesc &dmaTileBd, Block &block,
                                       const AIETargetModel &targetModel,
                                       XAie_LocType &tileLoc) {
-  assert(!block.getOps<UseLockOp>().empty() &&
-         "expected use_lock op in bb with dma_db op");
+  LLVM_DEBUG(llvm::dbgs() << "\nstart configuring bds\n");
   std::optional<int> acqValue, relValue, acqLockId, relLockId;
   bool acqEn;
   // switch (lock->getAc)
@@ -249,8 +248,6 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
                                  const AIETargetModel &targetModel,
                                  XAie_LocType &tileLoc, int bdNum,
                                  std::optional<int> nextBdNum) {
-  assert(!block.getOps<DMABDOp>().empty() && "expected bd ops in block");
-
   std::optional<int> packetType;
   std::optional<int> packetID;
   auto maybePacketOps = block.getOps<DMABDPACKETOp>();
@@ -262,9 +259,22 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
     packetID = packetOp.getPacketID();
   }
 
+  auto bdOp = *block.getOps<DMABDOp>().begin();
+
+  if (targetModel.isShimNOCTile(tileLoc.Col, tileLoc.Row)) {
+    // write them out like this so they show up with names in debug prints
+    size_t smid = 0;
+    size_t burstLen = 16; // (10):BLEN=16 (256Byte) (corresponds to
+                          // 0x800000000 from targetipu)
+    size_t qOs = 0;
+    size_t cache = 0;
+    size_t secure = 0;
+    TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAxi, &dmaTileBd, smid, burstLen,
+                            qOs, cache, secure);
+  }
+
   // deref here because this is a const iter and the various getters below
   // aren't const (even though they probably should be...)
-  auto bdOp = *block.getOps<DMABDOp>().begin();
   // StringRef FifoMode = disable; // FIXME: when to enable FIFO mode?
   ShapedType bufferType = bdOp.getBuffer().getType().cast<::mlir::MemRefType>();
   int bytes = bufferType.getElementTypeBitWidth() / 8;
@@ -278,22 +288,11 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
   }
 
   std::optional<llvm::ArrayRef<BDDimLayoutAttr>> dims = bdOp.getDimensions();
+  int lenInBytes = bdOp.getLenValue() * bytes;
+  int basePlusOffset = baseAddr + bdOp.getOffsetValue();
   if (!dims) {
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAddrLen, &dmaTileBd,
-                            baseAddr + bdOp.getOffsetValue(),
-                            bdOp.getLenValue() * bytes);
-    if (targetModel.isShimNOCTile(tileLoc.Col, tileLoc.Row)) {
-      // write them out like this so they show up with names in debug prints
-      size_t smid = 0;
-      size_t burstLen = 16; // (10):BLEN=16 (256Byte) (corresponds to
-                            // 0x800000000 from targetipu)
-      size_t qOs = 0;
-      size_t cache = 0;
-      size_t secure = 0;
-      TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAxi, &dmaTileBd, smid, burstLen,
-                              qOs, cache, secure);
-    }
-
+                            basePlusOffset, lenInBytes);
   } else {
     XAie_DmaTensor dmaTileBdTensor = {};
     dmaTileBdTensor.NumDim = dims->size();
@@ -315,8 +314,7 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
     // TODO: Probably need special handling for NOC
     // TODO: Might need to adjust step sizes / wraps by -1
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetMultiDimAddr, &dmaTileBd,
-                            &dmaTileBdTensor, baseAddr + bdOp.getOffsetValue(),
-                            bdOp.getLenValue() * bytes);
+                            &dmaTileBdTensor, basePlusOffset, lenInBytes);
   }
 
   if (nextBdNum) {
@@ -338,6 +336,44 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
   TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaEnableBd, &dmaTileBd);
   TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaWriteBd, &devInst, &dmaTileBd, tileLoc,
                           bdNum);
+  LLVM_DEBUG(llvm::dbgs() << "\nend configuring bds\n");
+  return success();
+};
+
+LogicalResult pushToBdQueueAndEnable(XAie_DevInst &devInst, Operation &op,
+                                     XAie_LocType &tileLoc, int chNum,
+                                     const DMAChannelDir &channelDir, int bdNum,
+                                     int repeatCount) {
+  XAie_DmaDirection direction =
+      channelDir == DMAChannelDir::S2MM ? DMA_S2MM : DMA_MM2S;
+  auto enTokenIssue = tileLoc.Row == 0 && direction == DMA_S2MM;
+  // in english repeat_count==0 means "do it once" and don't repeat but
+  // libxaie treats repeat_count=1 as do it once.
+  repeatCount += 1;
+  TRY_XAIE_API_EMIT_ERROR(op, XAie_DmaChannelSetStartQueue, &devInst, tileLoc,
+                          chNum, direction, bdNum, repeatCount, enTokenIssue);
+  TRY_XAIE_API_EMIT_ERROR(op, XAie_DmaChannelEnable, &devInst, tileLoc, chNum,
+                          direction);
+  return success();
+};
+
+LogicalResult
+configureLocksinBdAndBdInBlockAnd(XAie_DevInst &devInst, Block &block,
+                                  XAie_LocType tileLoc,
+                                  const AIETargetModel &targetModel) {
+  DMABDOp bd = *block.getOps<DMABDOp>().begin();
+  assert(bd.getBdId().has_value() &&
+         "DMABDOp must have assigned bd_id; did you forget to run "
+         "aie-assign-bd-ids?");
+  XAie_DmaDesc dmaTileBd;
+  TRY_XAIE_API_EMIT_ERROR(bd, XAie_DmaDescInit, &devInst, &dmaTileBd, tileLoc);
+  if (!block.getOps<UseLockOp>().empty() &&
+      failed(configureLocksInBdBlock(dmaTileBd, block, targetModel, tileLoc)))
+    return failure();
+  if (!block.getOps<DMABDOp>().empty() &&
+      failed(configureBdInBlock(devInst, dmaTileBd, block, targetModel, tileLoc,
+                                bd.getBdId().value(), bd.getNextBdId())))
+    return failure();
   return success();
 };
 
@@ -456,136 +492,33 @@ struct AIEControl {
                    << "lock op missing either id or init" << lockOp << "\n");
     });
 
-    auto pushToBdQueueAndEnable =
-        [this](Operation &op, XAie_LocType &tileLoc, int chNum,
-               const DMAChannelDir &channelDir, int bdNum,
-               int repeatCount) -> LogicalResult {
-      XAie_DmaDirection direction =
-          channelDir == DMAChannelDir::S2MM ? DMA_S2MM : DMA_MM2S;
-      auto enTokenIssue = tileLoc.Row == 0 && direction == DMA_S2MM;
-      // in english repeat_count==0 means "do it once" and don't repeat but
-      // libxaie treats repeat_count=1 as do it once.
-      repeatCount += 1;
-      TRY_XAIE_API_EMIT_ERROR(op, XAie_DmaChannelSetStartQueue, &devInst,
-                              tileLoc, chNum, direction, bdNum, repeatCount,
-                              enTokenIssue);
-      TRY_XAIE_API_EMIT_ERROR(op, XAie_DmaChannelEnable, &devInst, tileLoc,
-                              chNum, direction);
-      return success();
-    };
-
     const AIETargetModel &targetModel = targetOp.getTargetModel();
-    auto isMemTileOddBd = [&targetModel](int col, int row, int channelIndex) {
-      return targetModel.isMemTile(col, row) && channelIndex & 1;
-    };
+
     auto memOps = llvm::to_vector_of<TileElement>(targetOp.getOps<MemOp>());
     llvm::append_range(memOps, targetOp.getOps<MemTileDMAOp>());
     llvm::append_range(memOps, targetOp.getOps<ShimDMAOp>());
     for (TileElement memOp : memOps) {
       int col = memOp.getTileID().col;
       int row = memOp.getTileID().row;
-      auto tileLoc = XAie_TileLoc(col, row);
-      DenseMap<Block *, int> blockBdNumMap;
+      XAie_LocType tileLoc = XAie_TileLoc(col, row);
 
       // handle DMA ops separately
       auto dmaOps = llvm::to_vector_of<DMAOp>(
           memOp.getOperation()->getRegion(0).getOps<DMAOp>());
       if (!dmaOps.empty()) {
-        int oddBdNum = ODD_BD_NUM_START;
-        int evenBdNum = EVEN_BD_NUM_START;
-        for (auto dmaOp : dmaOps) {
-          auto bdRegions = dmaOp.getBds();
-          for (auto *bdRegionIt = bdRegions.begin();
-               bdRegionIt != bdRegions.end();) {
-            auto &block = bdRegionIt->getBlocks().front();
-            blockBdNumMap[&block] =
-                isMemTileOddBd(col, row, dmaOp.getChannelIndex()) ? oddBdNum++
-                                                                  : evenBdNum++;
-            std::optional<int> nextBdNum;
-            if (++bdRegionIt != bdRegions.end()) {
-              nextBdNum = isMemTileOddBd(col, row, dmaOp.getChannelIndex())
-                              ? oddBdNum
-                              : evenBdNum;
-            } else if (dmaOp.getLoop()) {
-              assert(blockBdNumMap.contains(
-                  &bdRegions.front().getBlocks().front()));
-              nextBdNum = blockBdNumMap[&bdRegions.front().getBlocks().front()];
-            }
-            assert(blockBdNumMap.contains(&block));
-            XAie_DmaDesc dmaTileBd;
-            TRY_XAIE_API_EMIT_ERROR(dmaOp, XAie_DmaDescInit, &devInst,
-                                    &dmaTileBd, tileLoc);
-            if (!block.getOps<UseLockOp>().empty() &&
-                failed(configureLocksInBdBlock(dmaTileBd, block, targetModel,
-                                               tileLoc)))
-              return failure();
-            if (!block.getOps<DMABDOp>().empty() &&
-                failed(configureBdInBlock(devInst, dmaTileBd, block,
-                                          targetModel, tileLoc,
-                                          blockBdNumMap[&block], nextBdNum)))
+        for (auto dmaOp : dmaOps)
+          for (auto &bdRegion : dmaOp.getBds()) {
+            Block &block = bdRegion.getBlocks().front();
+            if (failed(configureLocksinBdAndBdInBlockAnd(devInst, block,
+                                                         tileLoc, targetModel)))
               return failure();
           }
-        }
       } else {
-        DenseMap<Block *, int> blockChannelMap;
-        // Assign each block a BD number
-        for (Block &block : memOp.getOperation()->getRegion(0))
-          for (auto op : block.getOps<DMAStartOp>()) {
-            int chNum = op.getChannelIndex();
-            blockChannelMap[&block] = chNum;
-            Block *dest = op.getDest();
-            while (dest) {
-              blockChannelMap[dest] = chNum;
-              if (dest->hasNoSuccessors())
-                break;
-              dest = dest->getSuccessors()[0];
-              if (blockChannelMap.contains(dest))
-                dest = nullptr;
-            }
-          }
-
-        // Assign each block a BD number
-        int evenBdNum = EVEN_BD_NUM_START;
-        int oddBdNum = ODD_BD_NUM_START;
         for (Block &block : memOp.getOperation()->getRegion(0)) {
           if (block.getOps<DMABDOp>().empty())
             continue;
-          assert(blockChannelMap.count(&block));
-          if (isMemTileOddBd(col, row, blockChannelMap[&block]))
-            blockBdNumMap[&block] = oddBdNum++;
-          else
-            blockBdNumMap[&block] = evenBdNum++;
-        }
-
-        for (Block &block : memOp.getOperation()->getRegion(0)) {
-          if (block.getOps<DMABDOp>().empty())
-            continue;
-          assert(blockBdNumMap.contains(&block));
-          int bdNum = blockBdNumMap[&block];
-
-          std::optional<int> nextBdNum;
-          if (block.getNumSuccessors()) {
-            assert(llvm::range_size(block.getSuccessors()) == 1 &&
-                   "should have only one successor block");
-            Block *nextBlock = block.getSuccessor(0);
-            if (!blockBdNumMap.contains(nextBlock))
-              assert(nextBlock->getOperations().size() == 1 &&
-                     isa<EndOp>(nextBlock->getOperations().front()) &&
-                     "bb that's not in blockMap can only have aie.end");
-            else
-              nextBdNum = blockBdNumMap[nextBlock];
-          }
-
-          XAie_DmaDesc dmaTileBd;
-          TRY_XAIE_API_EMIT_ERROR(memOp, XAie_DmaDescInit, &devInst, &dmaTileBd,
-                                  tileLoc);
-          if (!block.getOps<UseLockOp>().empty() &&
-              failed(configureLocksInBdBlock(dmaTileBd, block, targetModel,
-                                             tileLoc)))
-            return failure();
-          if (!block.getOps<DMABDOp>().empty() &&
-              failed(configureBdInBlock(devInst, dmaTileBd, block, targetModel,
-                                        tileLoc, bdNum, nextBdNum)))
+          if (failed(configureLocksinBdAndBdInBlockAnd(devInst, block, tileLoc,
+                                                       targetModel)))
             return failure();
         }
       }
@@ -593,23 +526,22 @@ struct AIEControl {
       if (!dmaOps.empty())
         for (auto dmaOp : dmaOps) {
           auto &block = dmaOp.getBds().front().getBlocks().front();
-          assert(blockBdNumMap.contains(&block));
+          DMABDOp bd = *block.getOps<DMABDOp>().begin();
           if (failed(pushToBdQueueAndEnable(
-                  *dmaOp.getOperation(), tileLoc, dmaOp.getChannelIndex(),
-                  dmaOp.getChannelDir(), blockBdNumMap[&block],
-                  dmaOp.getRepeatCount())))
+                  devInst, *dmaOp.getOperation(), tileLoc,
+                  dmaOp.getChannelIndex(), dmaOp.getChannelDir(),
+                  bd.getBdId().value(), dmaOp.getRepeatCount())))
             return failure();
         }
       else
         for (Block &block : memOp.getOperation()->getRegion(0)) {
           for (auto op : block.getOps<DMAStartOp>()) {
-            assert(blockBdNumMap.contains(op.getDest()));
-            int bdNum = blockBdNumMap[op.getDest()];
+            DMABDOp bd = *op.getDest()->getOps<DMABDOp>().begin();
             int chNum = op.getChannelIndex();
             auto channelDir = op.getChannelDir();
-            if (failed(pushToBdQueueAndEnable(*op.getOperation(), tileLoc,
-                                              chNum, channelDir, bdNum,
-                                              op.getRepeatCount())))
+            if (failed(pushToBdQueueAndEnable(
+                    devInst, *bd.getOperation(), tileLoc, chNum, channelDir,
+                    bd.getBdId().value(), op.getRepeatCount())))
               return failure();
           }
         }

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -23,7 +23,6 @@ from textwrap import dedent
 import time
 
 from aie.extras.runtime.passes import Pipeline
-
 # this is inside the aie-python-extras (shared) namespace package
 from aie.extras.util import find_ops
 import aiofiles
@@ -44,6 +43,7 @@ INPUT_WITH_ADDRESSES_PIPELINE = (
         "aie.device",
         Pipeline()
         .add_pass("aie-assign-lock-ids")
+        .add_pass("aie-assign-bd-ids")
         .add_pass("aie-register-objectFifos")
         .add_pass("aie-objectFifo-stateful-transform")
         .add_pass("aie-lower-cascade-flows")

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -23,6 +23,7 @@ from textwrap import dedent
 import time
 
 from aie.extras.runtime.passes import Pipeline
+
 # this is inside the aie-python-extras (shared) namespace package
 from aie.extras.util import find_ops
 import aiofiles

--- a/python/compiler/util.py
+++ b/python/compiler/util.py
@@ -309,7 +309,9 @@ def compile_with_vectorization(
 ):
     debug = debug or xaie_debug or cdo_debug
     input_with_addresses = run_pipeline(
-        mod_aie, INPUT_WITH_ADDRESSES_PIPELINE, enable_ir_printing=debug
+        mod_aie,
+        Pipeline().convert_linalg_to_affine_loops() + INPUT_WITH_ADDRESSES_PIPELINE,
+        enable_ir_printing=debug,
     )
 
     aievec_cpp = translate_aie_vec_to_cpp(mod_aievec.operation, aieml=True)
@@ -367,7 +369,9 @@ def compile_with_vectorization(
 
     input_physical = run_pipeline(
         mod_aie,
-        CREATE_PATH_FINDER_FLOWS + INPUT_WITH_ADDRESSES_PIPELINE,
+        CREATE_PATH_FINDER_FLOWS
+        + Pipeline().convert_linalg_to_affine_loops()
+        + INPUT_WITH_ADDRESSES_PIPELINE,
         enable_ir_printing=debug,
     )
     with _global_debug(debug):

--- a/test/Passes/assign-bd-ids/basic.mlir
+++ b/test/Passes/assign-bd-ids/basic.mlir
@@ -1,0 +1,157 @@
+//===- basic.mlir ----------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-assign-bd-ids --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   aie.device(ipu) {
+// CHECK:  %[[VAL_0:.*]] = aie.tile(0, 0)
+// CHECK:  %[[VAL_1:.*]] = aie.tile(0, 1)
+// CHECK:  %[[VAL_2:.*]] = aie.tile(0, 2)
+// CHECK:  %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "double_buffer"} : memref<32xi32>
+// CHECK:  %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) : memref<32xi32>
+// CHECK:  %[[VAL_5:.*]] = aie.lock(%[[VAL_2]]) {init = 1 : i32, sym_name = "lock_X"}
+// CHECK:  %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "lock_Y"}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 0 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 2 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 2 : i32, next_bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 3 : i32, next_bd_id = 4 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 4 : i32, next_bd_id = 5 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 5 : i32, next_bd_id = 3 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 24 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 25 : i32}
+
+module {
+  aie.device(ipu) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    %double_buffer = aie.buffer(%tile_0_2) {sym_name = "double_buffer"} : memref<32xi32>
+    %buffer_0_1 = aie.buffer(%tile_0_1) : memref<32xi32>
+    %lock_X = aie.lock(%tile_0_2) {init = 1 : i32, sym_name = "lock_X"}
+    %lock_Y = aie.lock(%tile_0_2) {init = 0 : i32, sym_name = "lock_Y"}
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %player_a = aie.dma(S2MM, 0) {sym_name = "player_a"} [{
+        aie.use_lock(%lock_Y, Acquire, 0)
+        aie.dma_bd(%double_buffer : memref<32xi32>, 0)
+        aie.use_lock(%lock_Y, Release, 0)
+      }, {
+        aie.use_lock(%lock_X, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>)
+        aie.use_lock(%lock_X, Release, -1)
+      }, {
+        aie.use_lock(%lock_Y, Acquire) {acq_en = false}
+        aie.dma_bd(%double_buffer : memref<32xi32>)
+        aie.use_lock(%lock_Y, Release, 1)
+      }]
+      %player_b = aie.dma(S2MM, 1) {sym_name = "player_b"} [{
+        aie.use_lock(%lock_Y, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>, 0)
+        aie.use_lock(%lock_Y, Release, 0)
+      }, {
+        aie.use_lock(%lock_X, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>)
+        aie.use_lock(%lock_X, Release, -1)
+      }, {
+        aie.use_lock(%lock_Y, Acquire) {acq_en = false}
+        aie.dma_bd(%double_buffer : memref<32xi32>)
+        aie.use_lock(%lock_Y, Release, -1)
+      }]
+      aie.end
+    }
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %0 = aie.dma(S2MM, 0) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      %1 = aie.dma(MM2S, 0) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_0, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1, Release)
+      }]
+      %lock_0_1_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_2 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %2 = aie.dma(S2MM, 1) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_1, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1_2, Release)
+      }]
+      %3 = aie.dma(MM2S, 1) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_2, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1_1, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL:   aie.device(xcve2302) {
+// CHECK:  %[[VAL_0:.*]] = aie.tile(2, 1)
+// CHECK:  %[[VAL_1:.*]] = aie.buffer(%[[VAL_0]]) {address = 8192 : i32, sym_name = "in"} : memref<16xi32>
+// CHECK:  %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {address = 1824 : i32, sym_name = "out"} : memref<16xi32>
+// CHECK:  %[[VAL_8:.*]] = aie.memtile_dma(%[[VAL_0]]) {
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) {bd_id = 0 : i32, next_bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 16) {bd_id = 24 : i32, next_bd_id = 24 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 25 : i32, next_bd_id = 25 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 1 : i32, next_bd_id = 1 : i32}
+
+module @aie_module  {
+  aie.device(xcve2302) {
+    %t01 = aie.tile(2, 1)
+    %buf01_0 = aie.buffer(%t01) { address = 8192 : i32, sym_name = "in" } : memref<16xi32>
+    %buf01_1 = aie.buffer(%t01) { address = 1824 : i32, sym_name = "out" } : memref<16xi32>
+
+    %l01_0 = aie.lock(%t01, 0) { init = 1 : i32 }
+    %l01_1 = aie.lock(%t01, 1)
+    %l01_2 = aie.lock(%t01, 2) { init = 1 : i32 }
+    %l01_3 = aie.lock(%t01, 3)
+
+    %m01 = aie.memtile_dma(%t01) {
+        %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^dma0)
+      ^dma0:
+        %memSrcDma = aie.dma_start(MM2S, 1, ^bd1, ^dma1)
+      ^dma1:
+        %memDstDma = aie.dma_start(S2MM, 1, ^bd2, ^dma2)
+      ^dma2:
+        %dstDma = aie.dma_start(MM2S, 0, ^bd3, ^end)
+      ^bd0:
+        aie.use_lock(%l01_0, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>])
+        aie.use_lock(%l01_1, "Release", 1)
+        aie.next_bd ^bd0
+      ^bd1:
+        aie.use_lock(%l01_1, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
+        aie.use_lock(%l01_0, "Release", 1)
+        aie.next_bd ^bd1
+      ^bd2:
+        aie.use_lock(%l01_2, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+        aie.use_lock(%l01_3, "Release", 1)
+        aie.next_bd ^bd2
+      ^bd3:
+        aie.use_lock(%l01_3, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+        aie.use_lock(%l01_2, "Release", 1)
+        aie.next_bd ^bd3
+      ^end:
+        aie.end
+    }
+  }
+}
+
+

--- a/test/Passes/assign-bd-ids/basic.mlir
+++ b/test/Passes/assign-bd-ids/basic.mlir
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2022 Xilinx Inc.
+// (c) Copyright 2024 Advanced Micro Devices Inc.
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/Passes/assign-bd-ids/user_assigned.mlir
+++ b/test/Passes/assign-bd-ids/user_assigned.mlir
@@ -1,0 +1,239 @@
+//===- basic.mlir ----------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-assign-bd-ids --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL:   aie.device(ipu) {
+// CHECK:  %[[VAL_0:.*]] = aie.tile(0, 0)
+// CHECK:  %[[VAL_1:.*]] = aie.tile(0, 1)
+// CHECK:  %[[VAL_2:.*]] = aie.tile(0, 2)
+// CHECK:  %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "double_buffer"} : memref<32xi32>
+// CHECK:  %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) : memref<32xi32>
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 0 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 2 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 2 : i32, next_bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 3 : i32, next_bd_id = 4 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 4 : i32, next_bd_id = 5 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 5 : i32, next_bd_id = 3 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 24 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 25 : i32}
+
+module {
+  aie.device(ipu) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    %double_buffer = aie.buffer(%tile_0_2) {sym_name = "double_buffer"} : memref<32xi32>
+    %buffer_0_1 = aie.buffer(%tile_0_1) : memref<32xi32>
+    %lock_X = aie.lock(%tile_0_2) {init = 1 : i32, sym_name = "lock_X"}
+    %lock_Y = aie.lock(%tile_0_2) {init = 0 : i32, sym_name = "lock_Y"}
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %player_a = aie.dma(S2MM, 0) {sym_name = "player_a"} [{
+        aie.use_lock(%lock_Y, Acquire, 0)
+        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 0 : i32}
+        aie.use_lock(%lock_Y, Release, 0)
+      }, {
+        aie.use_lock(%lock_X, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 1 : i32}
+        aie.use_lock(%lock_X, Release, -1)
+      }, {
+        aie.use_lock(%lock_Y, Acquire) {acq_en = false}
+        aie.dma_bd(%double_buffer : memref<32xi32>)
+        aie.use_lock(%lock_Y, Release, 1)
+      }]
+      %player_b = aie.dma(S2MM, 1) {sym_name = "player_b"} [{
+        aie.use_lock(%lock_Y, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>, 0)
+        aie.use_lock(%lock_Y, Release, 0)
+      }, {
+        aie.use_lock(%lock_X, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 4 : i32}
+        aie.use_lock(%lock_X, Release, -1)
+      }, {
+        aie.use_lock(%lock_Y, Acquire) {acq_en = false}
+        aie.dma_bd(%double_buffer : memref<32xi32>)
+        aie.use_lock(%lock_Y, Release, -1)
+      }]
+      aie.end
+    }
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %0 = aie.dma(S2MM, 0) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      %1 = aie.dma(MM2S, 0) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_0, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1, Release)
+      }]
+      %lock_0_1_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_2 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %2 = aie.dma(S2MM, 1) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_1, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>) {bd_id = 24 : i32}
+        aie.use_lock(%lock_0_1_2, Release)
+      }]
+      %3 = aie.dma(MM2S, 1) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_2, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1_1, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL:   aie.device(xcve2302) {
+// CHECK:  %[[VAL_0:.*]] = aie.tile(2, 1)
+// CHECK:  %[[VAL_1:.*]] = aie.buffer(%[[VAL_0]]) {address = 8192 : i32, sym_name = "in"} : memref<16xi32>
+// CHECK:  %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {address = 1824 : i32, sym_name = "out"} : memref<16xi32>
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) {bd_id = 0 : i32, next_bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 16) {bd_id = 24 : i32, next_bd_id = 24 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 25 : i32, next_bd_id = 25 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 1 : i32, next_bd_id = 1 : i32}
+
+module @aie_module  {
+  aie.device(xcve2302) {
+    %t01 = aie.tile(2, 1)
+    %buf01_0 = aie.buffer(%t01) { address = 8192 : i32, sym_name = "in" } : memref<16xi32>
+    %buf01_1 = aie.buffer(%t01) { address = 1824 : i32, sym_name = "out" } : memref<16xi32>
+
+    %l01_0 = aie.lock(%t01, 0) { init = 1 : i32 }
+    %l01_1 = aie.lock(%t01, 1)
+    %l01_2 = aie.lock(%t01, 2) { init = 1 : i32 }
+    %l01_3 = aie.lock(%t01, 3)
+
+    %m01 = aie.memtile_dma(%t01) {
+        %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^dma0)
+      ^dma0:
+        %memSrcDma = aie.dma_start(MM2S, 1, ^bd1, ^dma1)
+      ^dma1:
+        %memDstDma = aie.dma_start(S2MM, 1, ^bd2, ^dma2)
+      ^dma2:
+        %dstDma = aie.dma_start(MM2S, 0, ^bd3, ^end)
+      ^bd0:
+        aie.use_lock(%l01_0, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>])
+        aie.use_lock(%l01_1, "Release", 1)
+        aie.next_bd ^bd0
+      ^bd1:
+        aie.use_lock(%l01_1, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 16) {bd_id = 24 : i32}
+        aie.use_lock(%l01_0, "Release", 1)
+        aie.next_bd ^bd1
+      ^bd2:
+        aie.use_lock(%l01_2, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+        aie.use_lock(%l01_3, "Release", 1)
+        aie.next_bd ^bd2
+      ^bd3:
+        aie.use_lock(%l01_3, "AcquireGreaterEqual", 1)
+        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16) {bd_id = 1 : i32}
+        aie.use_lock(%l01_2, "Release", 1)
+        aie.next_bd ^bd3
+      ^end:
+        aie.end
+    }
+  }
+}
+
+// -----
+
+// CHECK-LABEL:   aie.device(ipu) {
+// CHECK:  %[[VAL_0:.*]] = aie.tile(0, 0)
+// CHECK:  %[[VAL_1:.*]] = aie.tile(0, 1)
+// CHECK:  %[[VAL_2:.*]] = aie.tile(0, 2)
+// CHECK:  %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "double_buffer"} : memref<32xi32>
+// CHECK:  %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) : memref<32xi32>
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 5 : i32, next_bd_id = 4 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 4 : i32, next_bd_id = 3 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 3 : i32, next_bd_id = 5 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 2 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 0 : i32, next_bd_id = 2 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 24 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 25 : i32}
+
+module {
+  aie.device(ipu) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    %double_buffer = aie.buffer(%tile_0_2) {sym_name = "double_buffer"} : memref<32xi32>
+    %buffer_0_1 = aie.buffer(%tile_0_1) : memref<32xi32>
+    %lock_X = aie.lock(%tile_0_2) {init = 1 : i32, sym_name = "lock_X"}
+    %lock_Y = aie.lock(%tile_0_2) {init = 0 : i32, sym_name = "lock_Y"}
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %player_a = aie.dma(S2MM, 0) {sym_name = "player_a"} [{
+        aie.use_lock(%lock_Y, Acquire, 0)
+        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 5 : i32}
+        aie.use_lock(%lock_Y, Release, 0)
+      }, {
+        aie.use_lock(%lock_X, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 4 : i32}
+        aie.use_lock(%lock_X, Release, -1)
+      }, {
+        aie.use_lock(%lock_Y, Acquire) {acq_en = false}
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 3 : i32}
+        aie.use_lock(%lock_Y, Release, 1)
+      }]
+      %player_b = aie.dma(S2MM, 1) {sym_name = "player_b"} [{
+        aie.use_lock(%lock_Y, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 2 : i32}
+        aie.use_lock(%lock_Y, Release, 0)
+      }, {
+        aie.use_lock(%lock_X, Acquire, 1)
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 1 : i32}
+        aie.use_lock(%lock_X, Release, -1)
+      }, {
+        aie.use_lock(%lock_Y, Acquire) {acq_en = false}
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 0 : i32}
+        aie.use_lock(%lock_Y, Release, -1)
+      }]
+      aie.end
+    }
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %0 = aie.dma(S2MM, 0) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      %1 = aie.dma(MM2S, 0) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_0, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1, Release)
+      }]
+      %lock_0_1_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_2 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %2 = aie.dma(S2MM, 1) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_1, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>) {bd_id = 24 : i32}
+        aie.use_lock(%lock_0_1_2, Release)
+      }]
+      %3 = aie.dma(MM2S, 1) {loop = false, repeat_count = 10 : i32} [{
+        aie.use_lock(%lock_0_1_2, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>)
+        aie.use_lock(%lock_0_1_1, Release)
+      }]
+      aie.end
+    }
+  }
+}

--- a/test/Passes/assign-bd-ids/user_assigned.mlir
+++ b/test/Passes/assign-bd-ids/user_assigned.mlir
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2022 Xilinx Inc.
+// (c) Copyright 2024 Advanced Micro Devices Inc.
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/dialect/AIE/bad_dma_op.mlir
+++ b/test/dialect/AIE/bad_dma_op.mlir
@@ -10,7 +10,7 @@
 
 // RUN: not aie-opt %s 2>&1 | FileCheck %s
 
-// CHECK: error: 'aie.dma' op DMA op can only appear in single block region
+// CHECK: error: 'aie.dma' op DMAOp can only appear in single block region
 module {
   aie.device(ipu) {
     %tile_0_1 = aie.tile(0, 1)

--- a/tools/aie2xclbin/XCLBinGen.cpp
+++ b/tools/aie2xclbin/XCLBinGen.cpp
@@ -127,6 +127,7 @@ static void addAIELoweringPasses(OpPassManager &pm) {
   pm.addPass(AIE::createAIECanonicalizeDevicePass());
   OpPassManager &devicePM = pm.nest<AIE::DeviceOp>();
   devicePM.addPass(AIE::createAIEAssignLockIDsPass());
+  devicePM.addPass(AIE::createAIEAssignBufferDescriptorIDsPass());
   devicePM.addPass(AIE::createAIEObjectFifoRegisterProcessPass());
   devicePM.addPass(AIE::createAIEObjectFifoStatefulTransformPass());
   devicePM.addPass(AIEX::createAIEBroadcastPacketPass());


### PR DESCRIPTION
This PR factors out the "tree-walking interpreter" bd assignment loops buried inside of `AIETargetCDODirect` as a full-fledged pass that assigns `bd_id` and `next_bd_id` to `DMABDOp`. This greatly simplifies `AIETargetCDODirect` and enables compile stages prior to CDO emission to have knowledge of assigned bds (see https://github.com/Xilinx/mlir-aie/pull/1089). Note, the same exact logic exists in `AIETargetXAIEV2` and can be factored/removed in the same way, I'm just not 100% familiar with that path (nor do I have a VCK to test) so I leave that to someone else (there's no collision, the new attributes are just ignored).