### PR TITLE
Faster Matrix Multiplication Verification

### DIFF
--- a/reference_designs/ipu-xrt/matrix_multiplication.h
+++ b/reference_designs/ipu-xrt/matrix_multiplication.h
@@ -1,0 +1,254 @@
+//===- matrix_multiplication.h ----------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// This file contains common helper functions for the matrix multiplication
+// host code, such as verifying and printing matrices.
+
+#ifndef MATRIX_MULTIPLICATION_H
+#define MATRIX_MULTIPLICATION_H
+
+#include <cmath>
+#include <boost/program_options.hpp>
+
+namespace matmul_common {
+
+namespace po = boost::program_options;
+
+// --------------------------------------------------------------------------
+// Command Line Argument Handling
+// --------------------------------------------------------------------------
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name)
+{
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+void add_default_options(po::options_description &desc)
+{
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+}
+
+void parse_options(int argc, const char *argv[], po::options_description &desc, po::variables_map &vm)
+{
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      std::exit(1);
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    std::exit(1);
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+}
+
+// --------------------------------------------------------------------------
+// AIE Specifics
+// --------------------------------------------------------------------------
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+
+// --------------------------------------------------------------------------
+// Matrix / Float / Math 
+// --------------------------------------------------------------------------
+
+static inline std::int16_t random_int16_t() {
+  return std::int16_t(rand() % 0x10000);
+}
+
+static inline std::bfloat16_t random_bfloat16_t() {
+  return std::bfloat16_t((float)(rand()) / (float)(RAND_MAX));
+}
+
+template <typename Tin, typename Tout>
+void matmul_naive(int M, int N, int K,
+                  const std::vector<Tin> A, const std::vector<Tin> B, std::vector<Tout> &C) {
+  for (int row = 0; row < M; row++) {
+    for (int col = 0; col < N; col++) {
+      float running_sum = 0;
+      for (int k = 0; k < K; k++) {
+        running_sum += float(A[row * K + k]) * float(B[k * N + col]);
+      }
+      C[row * N + col] = Tout(running_sum);
+    }
+  }
+}
+
+template <typename Tin, typename Tout>
+void matmul(int M, int N, int K, 
+            const std::vector<Tin> A, const std::vector<Tin> B, std::vector<Tout> &C) {
+  // A is an  MxK matrix
+  // B is a   KxN matrix
+  // C is the MxN output matrix, assumed to be zeroed out
+
+  constexpr int K_block_size = 64;
+  const int n_K_blocks = K / K_block_size;
+
+  const Tin *B_origin = B.data();  /* Avoid a calls to B.data() within the loop 
+                                      with this const variable. B does not get
+                                      resized, so the pointer remains valid. */
+
+  const Tin *A_base = A.data(); /* Points to start of current row of A, 
+                                   monotonically increasing by K. */
+  const Tin *B_base = B_origin; /* Points to start of current column of B; 
+                                   increases by 1 in each inner loop, resets
+                                   to B_origin (0) at the start of a new row
+                                   (outer loop). */
+
+  const Tin  *A_ptr = A_base;
+  const Tin  *B_ptr = B_base;
+        Tout *C_ptr = C.data(); /* Monotonically increasing by 1. */
+
+  for       (int row = 0; row < M;            row++) {
+    for     (int col = 0; col < N;            col++) {
+      A_ptr = A_base;
+      B_ptr = B_base;
+      float running_sum = 0;
+      for   (int k   = 0; k   < n_K_blocks;   k++  ) {
+        for (int i   = 0; i   < K_block_size; i++  ) {
+          running_sum += float(*A_ptr) * float(*B_ptr);
+          A_ptr += 1; // Advance to right neighbor; next value in this row
+          B_ptr += N; // Advance to bottom neighbor; next value in this column
+        }
+      }
+      *C_ptr  = Tout(running_sum);
+      C_ptr  += 1;
+      B_base += 1; /* Next iteration: same row of A (A_base unchanged), 
+                      next column of B (B_base increases by 1) */
+    }
+    A_base += K; // Advance to next row of A
+    B_base  = B_origin; /* Next row of A means we need to restart at the first
+                           column of B. */ 
+  }
+
+}
+
+// nearly_equal function adapted from Stack Overflow, License CC BY-SA 4.0
+// Original author: P-Gn
+// Source: https://stackoverflow.com/a/32334103
+bool nearly_equal(
+  float a, float b,
+  float epsilon = 128 * FLT_EPSILON, float abs_th = FLT_MIN)
+  // those defaults are arbitrary and could be removed
+{
+  assert(std::numeric_limits<float>::epsilon() <= epsilon);
+  assert(epsilon < 1.f);
+
+  if (a == b) return true;
+
+  auto diff = std::abs(a-b);
+  auto norm = std::min((std::abs(a) + std::abs(b)), std::numeric_limits<float>::max());
+  // or even faster: std::min(std::abs(a + b), std::numeric_limits<float>::max());
+  // keeping this commented out until I update figures below
+  return diff < std::max(abs_th, epsilon * norm);
+}
+
+template<typename T> 
+void print_matrix(const std::vector<T> matrix,
+                  int n_cols,
+                  int n_printable_rows = 10,
+                  int n_printable_cols = 10,
+                  std::ostream &ostream = std::cout,
+                  const char col_sep[] = "  ",
+                  const char elide_sym[] = " ... ",
+                  int w = -1)
+{
+  assert(matrix.size() % n_cols == 0);
+
+  auto maxima = std::minmax_element(matrix.begin(), matrix.end());
+  T max_val = std::max(*maxima.first, std::abs(*maxima.second));
+  size_t n_digits = log10(max_val);
+  if(w == -1) {
+    w = n_digits;
+  }
+  int n_rows = matrix.size() / n_cols;
+
+  n_printable_rows = std::min(n_rows, n_printable_rows);
+  n_printable_cols = std::min(n_cols, n_printable_cols);
+
+  const bool elide_rows = n_printable_rows < n_rows;
+  const bool elide_cols = n_printable_cols < n_cols;
+
+  if(elide_rows || elide_cols) {
+    w = std::max((int)w, (int)strlen(elide_sym));
+  }
+
+  w += 3; // for decimal point and two decimal digits
+  ostream << std::fixed << std::setprecision(2);
+
+  #define print_row(what) \
+    for(int col = 0; col < n_printable_cols/2; col++) { \
+      ostream << std::right << std::setw(w) << (what); \
+      ostream << std::setw(0) << col_sep; \
+    } \
+    if(elide_cols) { \
+      ostream << std::setw(0) << elide_sym; \
+    } \
+    for(int col = n_printable_cols/2+1; col < n_printable_cols; col++) { \
+      ostream << std::right << std::setw(w) << (what); \
+      ostream << std::setw(0) << col_sep; \
+    }
+
+  for(int row = 0; row < n_printable_rows/2; row++) {
+    print_row(matrix[row*n_rows + col]);
+    ostream << std::endl;
+  }
+  if(elide_rows) {
+    print_row(elide_sym);
+    ostream << std::endl;
+  }
+  for(int row = n_printable_rows/2+1; row < n_printable_rows; row++) {
+    print_row(matrix[row*n_rows + col]);
+    ostream << std::endl;
+  }
+
+  #undef print_row
+}
+
+}
+
+#endif

--- a/reference_designs/ipu-xrt/matrix_multiplication/test.cpp
+++ b/reference_designs/ipu-xrt/matrix_multiplication/test.cpp
@@ -23,6 +23,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
+#include "../matrix_multiplication.h"
+
 constexpr int M = 256;
 constexpr int K = 256;
 constexpr int N = 256;
@@ -47,55 +49,6 @@ constexpr int OUT_SIZE = C_SIZE + (ENABLE_TRACING ? TRACE_SIZE : 0);
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
-
-static inline std::int16_t random_int16_t() {
-  return ((std::int16_t)rand() % 0x10000);
-}
-
-static inline std::bfloat16_t random_bfloat16_t() {
-  return ((std::bfloat16_t)rand() / (std::bfloat16_t)INT_MAX);
-}
-
-template <typename Tin, typename Tout>
-void matmul(std::vector<Tin> a, std::vector<Tin> b, std::vector<Tout> &c) {
-  for (int row = 0; row < M; row++) {
-    for (int col = 0; col < N; col++) {
-      Tout running_sum = 0;
-      for (int i = 0; i < K; i++) {
-        running_sum += Tout(a[row * K + i] * b[i * N + col]);
-      }
-      c[row * N + col] += running_sum;
-    }
-  }
-}
-
 void write_out_trace(char *bufOut, std::string path) {
   std::ofstream fout(path);
   uint32_t *traceOut =
@@ -110,43 +63,20 @@ int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
   po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+  matmul_common::add_default_options(desc);
   if (ENABLE_TRACING) {
     desc.add_options()("trace,t",
                        po::value<std::string>()->default_value("trace.txt"),
                        "where to store trace output");
   }
-  po::variables_map vm;
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-
-  std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
-
+  matmul_common::parse_options(argc, argv, desc, vm);
   int verbosity = vm["verbosity"].as<int>();
+
+  srand(time(NULL));
+
+  std::vector<uint32_t> instr_v = matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 
@@ -203,21 +133,23 @@ int main(int argc, const char *argv[]) {
 
   if (verbosity >= 1)
     std::cout << "Writing data into buffer objects.\n";
-  srand(static_cast<unsigned>(time(0)));
   A_DATATYPE *bufA = bo_a.map<A_DATATYPE *>();
-  std::vector<A_DATATYPE> AVec;
-  for (int i = 0; i < A_VOLUME; i++)
-    AVec.push_back(random_bfloat16_t());
+  std::vector<A_DATATYPE> AVec(A_VOLUME);
+  for (int i = 0; i < A_VOLUME; i++) {
+    AVec[i] = matmul_common::random_bfloat16_t();
+  }
   memcpy(bufA, AVec.data(), (AVec.size() * sizeof(A_DATATYPE)));
   B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
-  std::vector<B_DATATYPE> BVec;
-  for (int i = 0; i < B_VOLUME; i++)
-    BVec.push_back(random_bfloat16_t());
+  std::vector<B_DATATYPE> BVec(B_VOLUME);
+  for (int i = 0; i < B_VOLUME; i++) {
+    BVec[i] = matmul_common::random_bfloat16_t();
+  }
   memcpy(bufB, BVec.data(), (BVec.size() * sizeof(B_DATATYPE)));
 
   // Initialize outputs; bufOut is results matrix plus tracing info
   char *bufOut = bo_out.map<char *>();
   memset(bufOut, 0, OUT_SIZE);
+  std::vector<C_DATATYPE> CVec(C_VOLUME);
 
   // Instruction buffer for DMA configuration
   void *bufInstr = bo_instr.map<void *>();
@@ -239,25 +171,26 @@ int main(int argc, const char *argv[]) {
 
   // Reinterpret first C_VOLUME bytes of bufOut as our output C_DATATYPE C
   // matrix
-  C_DATATYPE *COut = (C_DATATYPE *)bufOut;
+  memcpy(CVec.data(), bufOut, (CVec.size() * sizeof(C_DATATYPE)));
 
   int errors = 0;
-  int max_errors = 100;
+  int max_printable_errors = 100;
 
+  std::vector<C_DATATYPE> CVecRef(C_VOLUME);
   if (VERIFY) {
-    std::vector<C_DATATYPE> output_ref0;
-    for (uint32_t i = 0; i < C_VOLUME; i++)
-      output_ref0.push_back(0);
-    matmul(AVec, BVec, output_ref0);
+    const float absTol = 0.5;
+    const float relTol = 0.5;
+    matmul_common::matmul(M, N, K, AVec, BVec, CVecRef);
 
-    const C_DATATYPE absTol = std::abs(0.1);
-    for (uint32_t i = 0; i < C_VOLUME; i++) {
-      if (std::abs(COut[i] - output_ref0[i]) > absTol) {
-        errors++;
-        if (errors < max_errors) {
-          std::cout << "\nerror, id " << i << " expected "
-                    << std::to_string(output_ref0[i]) << ", got "
-                    << std::to_string(COut[i]) << "\n";
+    for(int row = 0; row < M; row++) {
+      for(int col = 0; col < N; col++) {
+        if(!matmul_common::nearly_equal(CVecRef[row*N+col], CVec[row*N+col], relTol, absTol)) {
+          errors++;
+          if (errors < max_printable_errors) {
+            std::cout << "\nerror, row " << row << ", col " << col << ", expected "
+                      << std::to_string(CVecRef[row*N+col]) << ", got "
+                      << std::to_string(CVec[row*N+col]) << "\n";
+          }
         }
       }
     }

--- a/reference_designs/ipu-xrt/matrix_multiplication_array/Makefile
+++ b/reference_designs/ipu-xrt/matrix_multiplication_array/Makefile
@@ -8,9 +8,9 @@
 
 include ../makefile-common
 
-M?=256
-K?=256
-N?=256
+M?=512
+K?=512
+N?=512
 
 m?=64
 k?=64
@@ -51,7 +51,7 @@ build/final.xclbin: build/aie.mlir build/mm.o
 	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
 				--aie-generate-ipu --ipu-insts-name=insts.txt $(<:%=../%)
 
-${targetname}.exe: test.cpp
+${targetname}.exe: test.cpp ../matrix_multiplication.h
 	rm -rf _build
 	mkdir -p _build
 	cd _build && ${powershell} cmake -E env CXXFLAGS="-std=c++23" cmake .. -D CMAKE_C_COMPILER=gcc-13 -D CMAKE_CXX_COMPILER=g++-13 -DTARGET_NAME=${targetname}

--- a/reference_designs/ipu-xrt/matrix_multiplication_array/test.cpp
+++ b/reference_designs/ipu-xrt/matrix_multiplication_array/test.cpp
@@ -24,6 +24,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
+#include "../matrix_multiplication.h"
+
 constexpr int M = 512;
 constexpr int K = 512;
 constexpr int N = 512;
@@ -44,94 +46,19 @@ constexpr bool VERIFY = true;
 
 namespace po = boost::program_options;
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
-
-static inline std::int16_t random_int16_t() {
-  return ((std::int16_t)rand() % 0x10000);
-}
-
-static inline std::bfloat16_t random_bfloat16_t() {
-  // std::default_random_engine gen;
-  // std::uniform_real_distribution<float> distribution(0.0, 1.0);
-  // return std::bfloat16_t(distribution(gen));
-  return std::bfloat16_t(1.0);
-}
-
-template <typename Tin, typename Tout>
-void matmul(std::vector<Tin> a, std::vector<Tin> b, std::vector<Tout> &c) {
-  for (int row = 0; row < M; row++) {
-    for (int col = 0; col < N; col++) {
-      float running_sum = 0;
-      for (int i = 0; i < K; i++) {
-        running_sum += float(a[row * K + i]) * float(b[i * N + col]);
-      }
-      c[row * N + col] = Tout(running_sum);
-    }
-  }
-}
 
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
   po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
   po::variables_map vm;
-
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
-
-  std::vector<uint32_t> instr_v =
-      load_instr_sequence(vm["instr"].as<std::string>());
-
+  matmul_common::add_default_options(desc);
+  matmul_common::parse_options(argc, argv, desc, vm);
   int verbosity = vm["verbosity"].as<int>();
+
+  srand(time(NULL));
+
+  std::vector<uint32_t> instr_v = matmul_common::load_instr_sequence(vm["instr"].as<std::string>());
   if (verbosity >= 1)
     std::cout << "Sequence instr count: " << instr_v.size() << "\n";
 
@@ -188,19 +115,19 @@ int main(int argc, const char *argv[]) {
     std::cout << "Writing data into buffer objects.\n";
   srand(static_cast<unsigned>(time(0)));
   A_DATATYPE *bufA = bo_a.map<A_DATATYPE *>();
-  std::vector<A_DATATYPE> AVec;
-  for (int i = 0; i < A_VOLUME; i++)
-    AVec.push_back(random_bfloat16_t());
+  std::vector<A_DATATYPE> AVec(A_VOLUME);
+  for (int i = 0; i < A_VOLUME; i++) {
+    AVec[i] = matmul_common::random_bfloat16_t();
+  }
   memcpy(bufA, AVec.data(), (AVec.size() * sizeof(A_DATATYPE)));
   B_DATATYPE *bufB = bo_b.map<B_DATATYPE *>();
-  std::vector<B_DATATYPE> BVec;
-  for (int i = 0; i < B_VOLUME; i++)
-    BVec.push_back(random_bfloat16_t());
+  std::vector<B_DATATYPE> BVec(B_VOLUME);
+  for (int i = 0; i < B_VOLUME; i++) {
+    BVec[i] = matmul_common::random_bfloat16_t();
+  }
   memcpy(bufB, BVec.data(), (BVec.size() * sizeof(B_DATATYPE)));
   C_DATATYPE *bufC = bo_c.map<C_DATATYPE *>();
-  std::vector<C_DATATYPE> CVec;
-  for (int i = 0; i < C_VOLUME; i++)
-    CVec.push_back(0);
+  std::vector<C_DATATYPE> CVec(C_VOLUME);
   memcpy(bufC, CVec.data(), (CVec.size() * sizeof(C_DATATYPE)));
 
   void *bufInstr = bo_instr.map<void *>();
@@ -219,33 +146,34 @@ int main(int argc, const char *argv[]) {
   auto stop = std::chrono::high_resolution_clock::now();
 
   bo_c.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-
-  C_DATATYPE *bufOut = bo_c.map<C_DATATYPE *>();
+  memcpy(CVec.data(), bufC, (CVec.size() * sizeof(C_DATATYPE)));
 
   int errors = 0;
-  int max_errors = 100;
-
+  int max_printable_errors = 500;
+  std::vector<C_DATATYPE> CVecRef(C_VOLUME);
   if (VERIFY) {
-    std::vector<C_DATATYPE> output_ref0;
-    for (uint32_t i = 0; i < C_VOLUME; i++)
-      output_ref0.push_back(K);
-    // matmul(AVec, BVec, output_ref0);
+    matmul_common::matmul(M, N, K, AVec, BVec, CVecRef);
 
-    const float absTol = std::abs(0.1);
+    const float absTol = 0.5;
+    const float relTol = 0.5;
     for (int row = 0; row < M; row++) {
       for (int col = 0; col < N; col++) {
-        if (std::abs((float)bufOut[row * N + col] -
-                     (float)output_ref0[row * N + col]) > absTol) {
+        if(!matmul_common::nearly_equal(CVecRef[row*N+col], CVec[row*N+col], relTol, absTol)) {
           errors++;
-          if (errors < max_errors) {
-            std::cout << "\nerror, row: " << row << " col: " << col
-                      << " expected "
-                      << std::to_string((float)output_ref0[row * N + col])
+          if (errors < max_printable_errors) {
+            std::cout << "Error in row " << row << ", col " << col << ". "
+                      << "Expected "
+                      << std::setw(4) << (float)CVecRef[row * N + col]
                       << ", got "
-                      << std::to_string((float)bufOut[row * N + col]) << "\n";
+                      << std::setw(4) << (float)CVec[row * N + col] 
+                      << "." << std::endl;
           }
         }
       }
+    }
+
+    if (errors >= max_printable_errors) {
+      std::cout << "...and " << std::setw(0) << errors << " further errors." << std::endl;
     }
   }
 
@@ -262,8 +190,12 @@ int main(int argc, const char *argv[]) {
     std::cout << "\nPASS!\n\n";
     return 0;
   } else {
-    std::cout << "\nerror count: " << errors << "\n\n";
-    std::cout << "\nfailed.\n\n";
+    std::cout << std::endl << "Reference:" << std::endl;
+    matmul_common::print_matrix(CVecRef, N);
+    std::cout << std::endl << "Output:" << std::endl;
+    matmul_common::print_matrix(CVec, N);
+    std::cout << "\nError count: " << errors << "\n\n";
+    std::cout << "\nFailed.\n\n";
     return 1;
   }
 }


### PR DESCRIPTION
 - New `matmul` reference computation that should be faster. Verified correct for 512x512x512. When compiled, it uses SIMD instructions on my machine:
![image](https://github.com/Xilinx/mlir-aie/assets/557998/c4b2f627-ec6a-452b-a03e-5b622279a09d)
- Proper floating point comparison adapted from a source online
- Remove some duplicated code. This is just a start, there's still a lot of duplicated stuff, which has already started to diverge.