### PR TITLE
Bump required cmake (3.21 -> 3.23) to get OpenSSL::applink fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #  -DAIE_RUNTIME_TARGETS: list of targets (x86_64,aarch64) to build runtime libs for, default: x86_64; cross compilation for aarch64 against default Vitis Sysroot
 #  -DAIE_RUNTIME_TEST_TARGET: runtime test target (x86_64 or aarch64) used for running unit test and tutorials, default x86_64
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.23)
 
 set(TOOLCHAINFILES_PATH ${CMAKE_SOURCE_DIR}/cmake/modulesXilinx)
 


### PR DESCRIPTION
Without this change I get:

```
CMake Error at tools/bootgen/CMakeLists.txt:147 (add_executable):
  Target "bootgen" links to target "OpenSSL::applink" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?
  ```
  when I run 
  
  ```
  ./utils/build-mlir-aie.sh llvm/build
  ```
  
 I don't know what bootgen, or "applink" is. 
 
  