### PR TITLE
[wip] adjust target model to support 5x4

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -233,7 +233,7 @@ typedef struct DMAChannel {
   }
 } DMAChannel;
 
-const AIETargetModel &getTargetModel(mlir::Operation *op);
+std::shared_ptr<AIETargetModel> getTargetModel(mlir::Operation *op);
 
 mlir::ParseResult
 parseObjectFifoProducerTile(mlir::OpAsmParser &parser,

--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -28,13 +28,13 @@ def HasValidDMAChannels : NativeOpTrait<"HasValidDMAChannels"> {
   string cppNamespace = "::xilinx::AIE";
 }
 
-def PredIsCoreTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isCoreTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+def PredIsCoreTile : CPred<"xilinx::AIE::getTargetModel(&$_op)->isCoreTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
                                                                        "llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
-def PredIsMemTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isMemTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+def PredIsMemTile : CPred<"xilinx::AIE::getTargetModel(&$_op)->isMemTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
                                                                        "llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
-def PredIsShimNOCTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isShimNOCTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+def PredIsShimNOCTile : CPred<"xilinx::AIE::getTargetModel(&$_op)->isShimNOCTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
                                                                         "llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
-def PredIsShimPLTile : CPred<"xilinx::AIE::getTargetModel(&$_op).isShimPLTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
+def PredIsShimPLTile : CPred<"xilinx::AIE::getTargetModel(&$_op)->isShimPLTile(llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().col,"
                                                                         "llvm::cast<xilinx::AIE::TileElement>($_op).getTileID().row)">;
 
 def IsCoreTile : PredOpTrait<"op exists in a core tile", PredIsCoreTile>;
@@ -117,20 +117,6 @@ def TileElement : OpInterface<"TileElement", [
                                     std::to_string(getTileID().row));
     }
   }];
-}
-
-def AIETarget : OpInterface<"AIETarget"> {
-  let description = [{
-    Interface for operations that model an array of AIEngine cores.
-  }];
-  let cppNamespace = "::xilinx::AIE";
-  let methods = [
-    InterfaceMethod<[{
-        Return the target model describing the characteristics of how this operation will be implemented.
-      }],
-      "const ::xilinx::AIE::AIETargetModel&", "getTargetModel", (ins )
-    >
-  ];
 }
 
 // Don't delete - see AIEDialect::myVerifyOffsetSizeAndStrideOp

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -55,10 +55,13 @@ def AIE_DeviceOp: AIE_Op<"device", [
     ```
   }];
 
-  let arguments = (ins AIEDevice:$device);
+  let arguments = (
+    ins AIEDevice:$device,
+    DefaultValuedOptionalAttr<BoolAttr, "true">:$virtualized
+  );
   let regions = (region AnyRegion:$body_region);
   let assemblyFormat = [{
-    `(` $device `)` regions attr-dict
+    `(` $device (`,` `virtualized` `=` $virtualized^)? `)` regions attr-dict
   }];
   let extraClassDeclaration = [{
     std::shared_ptr<xilinx::AIE::AIETargetModel> getTargetModel();

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -27,7 +27,7 @@ class AIE_Op<string mnemonic, list<Trait> traits = []> :
 
 
 def AIE_DeviceOp: AIE_Op<"device", [
-    AIETarget, HasParent<"mlir::ModuleOp">,
+    HasParent<"mlir::ModuleOp">,
     SymbolTable, SingleBlock, NoTerminator, IsolatedFromAbove
   ]> {
   let summary = "Define an AIE design targetting a complete device";
@@ -61,7 +61,7 @@ def AIE_DeviceOp: AIE_Op<"device", [
     `(` $device `)` regions attr-dict
   }];
   let extraClassDeclaration = [{
-    const xilinx::AIE::AIETargetModel &getTargetModel();
+    std::shared_ptr<xilinx::AIE::AIETargetModel> getTargetModel();
   }];
   let hasVerifier = 1;
 }

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -204,7 +204,7 @@ public:
 
 class AIE1TargetModel : public AIETargetModel {
 public:
-  AIE1TargetModel() = default;
+  using AIETargetModel::AIETargetModel;
 
   bool isCoreTile(int col, int row) const override { return row > 0; }
   bool isMemTile(int col, int row) const override { return false; }
@@ -268,7 +268,7 @@ public:
 
 class AIE2TargetModel : public AIETargetModel {
 public:
-  AIE2TargetModel() = default;
+  using AIETargetModel::AIETargetModel;
 
   AIEArch getTargetArch() const override;
 
@@ -325,7 +325,7 @@ class VC1902TargetModel : public AIE1TargetModel {
       2, 3, 6, 7, 10, 11, 18, 19, 26, 27, 34, 35, 42, 43, 46, 47};
 
 public:
-  VC1902TargetModel() = default;
+  using AIE1TargetModel::AIE1TargetModel;
 
   int columns() const override { return 50; }
 
@@ -348,7 +348,7 @@ class VE2302TargetModel : public AIE2TargetModel {
   llvm::SmallDenseSet<unsigned, 8> nocColumns = {2, 3, 6, 7, 10, 11};
 
 public:
-  VE2302TargetModel() = default;
+  using AIE2TargetModel::AIE2TargetModel;
 
   int columns() const override { return 17; }
 
@@ -400,7 +400,7 @@ class VE2802TargetModel : public AIE2TargetModel {
                                                   22, 23, 30, 31, 34, 35};
 
 public:
-  VE2802TargetModel() = default;
+  using AIE2TargetModel::AIE2TargetModel;
 
   int columns() const override { return 38; }
 
@@ -454,7 +454,7 @@ class IPUTargetModel : public AIE2TargetModel {
   llvm::SmallDenseSet<unsigned, 16> nocColumns = {0, 1, 2, 3};
 
 public:
-  IPUTargetModel() = default;
+  using AIE2TargetModel::AIE2TargetModel;
 
   int columns() const override { return 5; }
 

--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -193,7 +193,7 @@ public:
   // https://lld.llvm.org/missingkeyfunction
   virtual ~Router() = default;
   virtual void initialize(int maxCol, int maxRow,
-                          const AIETargetModel &targetModel) = 0;
+                          std::shared_ptr<AIETargetModel> targetModel) = 0;
   virtual void addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
                        Port dstPort) = 0;
   virtual bool addFixedConnection(ConnectOp connectOp) = 0;
@@ -206,7 +206,7 @@ class Pathfinder : public Router {
 public:
   Pathfinder() = default;
   void initialize(int maxCol, int maxRow,
-                  const AIETargetModel &targetModel) override;
+                  std::shared_ptr<AIETargetModel> targetModel) override;
   void addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
                Port dstPort) override;
   bool addFixedConnection(ConnectOp connectOp) override;

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -352,10 +352,12 @@ void AIEDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "aie/Dialect/AIE/IR/AIEAttrs.cpp.inc"
+
       >();
   addOperations<
 #define GET_OP_LIST
 #include "aie/Dialect/AIE/IR/AIEOps.cpp.inc"
+
       >();
   addInterfaces<AIEInlinerInterface, AIEDialectFoldInterface>();
 }
@@ -969,16 +971,17 @@ LogicalResult GetCascadeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 std::shared_ptr<AIETargetModel> DeviceOp::getTargetModel() {
+  bool virtualized = getVirtualized();
   switch (getDevice()) {
   case AIEDevice::xcve2302:
-    return std::make_shared<VE2302TargetModel>();
+    return std::make_shared<VE2302TargetModel>(virtualized);
   case AIEDevice::xcve2802:
-    return std::make_shared<VE2802TargetModel>();
+    return std::make_shared<VE2802TargetModel>(virtualized);
   case AIEDevice::ipu:
-    return std::make_shared<IPUTargetModel>();
+    return std::make_shared<IPUTargetModel>(virtualized);
   case AIEDevice::xcvc1902:
   default:
-    return std::make_shared<VC1902TargetModel>();
+    return std::make_shared<VC1902TargetModel>(virtualized);
   }
 }
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -101,20 +101,13 @@ LogicalResult myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
   return success();
 }
 
-static VC1902TargetModel VC1902model;
-static VE2302TargetModel VE2302model;
-static VE2802TargetModel VE2802model;
-static IPUTargetModel IPUmodel;
-
-const AIETargetModel &getTargetModel(Operation *op) {
-  if (auto t = dyn_cast<AIETarget>(op))
+std::shared_ptr<AIETargetModel> getTargetModel(Operation *op) {
+  if (auto t = llvm::dyn_cast<DeviceOp>(op))
     return t.getTargetModel();
-  if (auto t = op->getParentOfType<AIETarget>())
+  if (auto t = op->getParentOfType<DeviceOp>())
     return t.getTargetModel();
 
-  // For backward compatibility, return a basic device model compatible with
-  // the VCK190
-  return VC1902model;
+  return std::make_shared<VC1902TargetModel>();
 }
 
 // Walk the operation hierarchy until we find a containing TileElement.
@@ -134,7 +127,7 @@ struct UsesAreAccessable {
     auto thisElement = cast<TileElement>(op);
     auto thisID = thisElement.getTileID();
     auto users = op->getResult(0).getUsers();
-    const auto &targetModel = getTargetModel(op);
+    std::shared_ptr<AIETargetModel> targetModel = getTargetModel(op);
     for (auto *user : users) {
       // AIE.useLock may be used in a device to set the lock's default value
       // Allow in a toplevel module for backward compatibility
@@ -143,8 +136,8 @@ struct UsesAreAccessable {
       if (auto element = getParentTileElement(user)) {
 
         auto tileID = element.getTileID();
-        if (!targetModel.isLegalMemAffinity(tileID.col, tileID.row, thisID.col,
-                                            thisID.row))
+        if (!targetModel->isLegalMemAffinity(tileID.col, tileID.row, thisID.col,
+                                             thisID.row))
           return (op->emitOpError("in Column ")
                   << thisID.col << " and Row " << thisID.row
                   << " is accessed from an unreachable tile in Column "
@@ -394,9 +387,9 @@ struct HasSomeTerminator {
 template <typename ConcreteType>
 LogicalResult HasValidBDs<ConcreteType>::verifyTrait(Operation *op) {
   auto element = cast<ConcreteType>(op);
-  const auto &targetModel = getTargetModel(op);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(op);
   int bdMax =
-      targetModel.getNumBDs(element.getTileID().col, element.getTileID().row);
+      targetModel->getNumBDs(element.getTileID().col, element.getTileID().row);
 
   int bdNum = 0;
   for (auto &block : element.getBody()) {
@@ -876,14 +869,14 @@ LogicalResult CascadeFlowOp::verify() {
 
   if (src.isShimTile() || dst.isShimTile())
     return emitOpError("shimTile row has no cascade stream interface");
-  if (t.isMemTile(src.colIndex(), src.rowIndex()) ||
-      t.isMemTile(dst.colIndex(), dst.rowIndex()))
+  if (t->isMemTile(src.colIndex(), src.rowIndex()) ||
+      t->isMemTile(dst.colIndex(), dst.rowIndex()))
     return emitOpError("memTile row has no cascade stream interface");
 
-  if (!t.isSouth(src.getCol(), src.getRow(), dst.getCol(), dst.getRow()) &&
-      !t.isWest(src.getCol(), src.getRow(), dst.getCol(), dst.getRow()) &&
-      !t.isNorth(src.getCol(), src.getRow(), dst.getCol(), dst.getRow()) &&
-      !t.isEast(src.getCol(), src.getRow(), dst.getCol(), dst.getRow())) {
+  if (!t->isSouth(src.getCol(), src.getRow(), dst.getCol(), dst.getRow()) &&
+      !t->isWest(src.getCol(), src.getRow(), dst.getCol(), dst.getRow()) &&
+      !t->isNorth(src.getCol(), src.getRow(), dst.getCol(), dst.getRow()) &&
+      !t->isEast(src.getCol(), src.getRow(), dst.getCol(), dst.getRow())) {
     return emitOpError("tiles must be adjacent");
   }
   return success();
@@ -902,29 +895,29 @@ TileOp CascadeFlowOp::getDestTileOp() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ConfigureCascadeOp::verify() {
-  const auto &t = getTargetModel(*this);
+  std::shared_ptr<AIETargetModel> t = getTargetModel(*this);
   TileOp tile = cast<TileOp>(getTile().getDefiningOp());
   CascadeDir inputDir = getInputDir();
   CascadeDir outputDir = getOutputDir();
 
   if (tile.isShimTile())
     return emitOpError("shimTile row has no cascade stream interface");
-  if (t.isMemTile(tile.colIndex(), tile.rowIndex()))
+  if (t->isMemTile(tile.colIndex(), tile.rowIndex()))
     return emitOpError("memTile row has no cascade stream interface");
 
-  if (t.getTargetArch() == AIEArch::AIE2) {
+  if (t->getTargetArch() == AIEArch::AIE2) {
     if (inputDir == CascadeDir::South || inputDir == CascadeDir::East) {
       return emitOpError("input direction of cascade must be North or West on ")
-             << stringifyAIEArch(t.getTargetArch());
+             << stringifyAIEArch(t->getTargetArch());
     }
     if (outputDir == CascadeDir::North || outputDir == CascadeDir::West) {
       return emitOpError(
                  "output direction of cascade must be South or East on ")
-             << stringifyAIEArch(t.getTargetArch());
+             << stringifyAIEArch(t->getTargetArch());
     }
   } else {
     return emitOpError("cascade not supported in ")
-           << stringifyAIEArch(t.getTargetArch());
+           << stringifyAIEArch(t->getTargetArch());
   }
   return success();
 }
@@ -934,19 +927,19 @@ LogicalResult ConfigureCascadeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult PutCascadeOp::verify() {
-  const auto &targetModel = getTargetModel(*this);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
   Type type = getCascadeValue().getType();
   DataLayout dataLayout = DataLayout::closest(*this);
   auto bits = dataLayout.getTypeSizeInBits(type);
-  if (targetModel.getTargetArch() == AIEArch::AIE1) {
+  if (targetModel->getTargetArch() == AIEArch::AIE1) {
     if (bits != 384)
       return emitOpError("must be a 384-bit type");
-  } else if (targetModel.getTargetArch() == AIEArch::AIE2) {
+  } else if (targetModel->getTargetArch() == AIEArch::AIE2) {
     if (bits != 512)
       return emitOpError("must be a 512-bit type");
   } else
     return emitOpError("cascade not supported in ")
-           << stringifyAIEArch(targetModel.getTargetArch());
+           << stringifyAIEArch(targetModel->getTargetArch());
   return success();
 }
 
@@ -955,19 +948,19 @@ LogicalResult PutCascadeOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult GetCascadeOp::verify() {
-  const auto &targetModel = getTargetModel(*this);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
   Type type = getCascadeValue().getType();
   DataLayout dataLayout = DataLayout::closest(*this);
   auto bits = dataLayout.getTypeSizeInBits(type);
-  if (targetModel.getTargetArch() == AIEArch::AIE1) {
+  if (targetModel->getTargetArch() == AIEArch::AIE1) {
     if (bits != 384)
       return emitOpError("must be a 384-bit type");
-  } else if (targetModel.getTargetArch() == AIEArch::AIE2) {
+  } else if (targetModel->getTargetArch() == AIEArch::AIE2) {
     if (bits != 512)
       return emitOpError("must be a 512-bit type");
   } else
     return emitOpError("cascade not supported in ")
-           << stringifyAIEArch(targetModel.getTargetArch());
+           << stringifyAIEArch(targetModel->getTargetArch());
   return success();
 }
 
@@ -975,18 +968,18 @@ LogicalResult GetCascadeOp::verify() {
 // DeviceOp
 //===----------------------------------------------------------------------===//
 
-const AIETargetModel &DeviceOp::getTargetModel() {
+std::shared_ptr<AIETargetModel> DeviceOp::getTargetModel() {
   switch (getDevice()) {
-  case AIEDevice::xcvc1902:
-    return VC1902model;
   case AIEDevice::xcve2302:
-    return VE2302model;
+    return std::make_shared<VE2302TargetModel>();
   case AIEDevice::xcve2802:
-    return VE2802model;
+    return std::make_shared<VE2802TargetModel>();
   case AIEDevice::ipu:
-    return IPUmodel;
+    return std::make_shared<IPUTargetModel>();
+  case AIEDevice::xcvc1902:
+  default:
+    return std::make_shared<VC1902TargetModel>();
   }
-  return VC1902model;
 }
 
 LogicalResult DeviceOp::verify() { return success(); }
@@ -996,9 +989,9 @@ LogicalResult DeviceOp::verify() { return success(); }
 //===----------------------------------------------------------------------===//
 
 LogicalResult TileOp::verify() {
-  const auto &targetModel = getTargetModel(*this);
-  int columns = targetModel.columns();
-  int rows = targetModel.rows();
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  int columns = targetModel->columns();
+  int rows = targetModel->rows();
   if (colIndex() >= columns)
     return emitOpError("column index (")
            << colIndex()
@@ -1024,75 +1017,75 @@ LogicalResult TileOp::verify() {
 }
 
 size_t TileOp::getNumSourceConnections(WireBundle bundle) {
-  const auto &targetModel = getTargetModel(*this);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
   if (bundle == WireBundle::Core || bundle == WireBundle::DMA)
   // Note dest is correct here, since direction is reversed.
   {
     // Note dest is correct here, since direction is reversed.
-    if (targetModel.isShimNOCTile(getCol(), getRow()) ||
-        targetModel.isShimPLTile(getCol(), getRow()))
-      return targetModel.getNumDestShimMuxConnections(getCol(), getRow(),
-                                                      bundle);
-    return targetModel.getNumDestSwitchboxConnections(getCol(), getRow(),
-                                                      bundle);
+    if (targetModel->isShimNOCTile(getCol(), getRow()) ||
+        targetModel->isShimPLTile(getCol(), getRow()))
+      return targetModel->getNumDestShimMuxConnections(getCol(), getRow(),
+                                                       bundle);
+    return targetModel->getNumDestSwitchboxConnections(getCol(), getRow(),
+                                                       bundle);
   }
   return 0;
 }
 
 size_t TileOp::getNumDestConnections(WireBundle bundle) {
-  const auto &targetModel = getTargetModel(*this);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
   if (bundle == WireBundle::Core || bundle == WireBundle::DMA)
   // Note source is correct here, since direction is reversed.
   {
     // Note source is correct here, since direction is reversed.
-    if (targetModel.isShimNOCTile(getCol(), getRow()) ||
-        targetModel.isShimPLTile(getCol(), getRow()))
-      return targetModel.getNumDestShimMuxConnections(getCol(), getRow(),
-                                                      bundle);
-    return targetModel.getNumSourceSwitchboxConnections(getCol(), getRow(),
-                                                        bundle);
+    if (targetModel->isShimNOCTile(getCol(), getRow()) ||
+        targetModel->isShimPLTile(getCol(), getRow()))
+      return targetModel->getNumDestShimMuxConnections(getCol(), getRow(),
+                                                       bundle);
+    return targetModel->getNumSourceSwitchboxConnections(getCol(), getRow(),
+                                                         bundle);
   }
   return 0;
 }
 
 bool TileOp::isMemTile() {
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.isMemTile(getCol(), getRow());
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->isMemTile(getCol(), getRow());
 }
 
 bool TileOp::isShimNOCTile() {
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.isShimNOCTile(getCol(), getRow());
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->isShimNOCTile(getCol(), getRow());
 }
 
 bool TileOp::isShimPLTile() {
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.isShimPLTile(getCol(), getRow());
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->isShimPLTile(getCol(), getRow());
 }
 
 bool TileOp::isShimNOCorPLTile() {
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.isShimNOCorPLTile(getCol(), getRow());
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->isShimNOCorPLTile(getCol(), getRow());
 }
 
-bool isLegalMemtileConnection(const AIETargetModel &targetModel,
+bool isLegalMemtileConnection(std::shared_ptr<AIETargetModel> targetModel,
                               MasterSetOp masterOp, PacketRulesOp slaveOp) {
   auto srcBundle = masterOp.destPort().bundle;
   auto srcChan = masterOp.destPort().channel;
   auto dstBundle = slaveOp.sourcePort().bundle;
   auto dstChan = slaveOp.sourcePort().channel;
-  return targetModel.isLegalMemtileConnection(srcBundle, srcChan, dstBundle,
-                                              dstChan);
+  return targetModel->isLegalMemtileConnection(srcBundle, srcChan, dstBundle,
+                                               dstChan);
 }
 
-bool isLegalMemtileConnection(const AIETargetModel &targetModel,
+bool isLegalMemtileConnection(std::shared_ptr<AIETargetModel> targetModel,
                               ConnectOp connectOp) {
   auto srcBundle = connectOp.getSourceBundle();
   auto srcChan = connectOp.getSourceChannel();
   auto dstBundle = connectOp.getDestBundle();
   auto dstChan = connectOp.getDestChannel();
-  return targetModel.isLegalMemtileConnection(srcBundle, srcChan, dstBundle,
-                                              dstChan);
+  return targetModel->isLegalMemtileConnection(srcBundle, srcChan, dstBundle,
+                                               dstChan);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1152,16 +1145,16 @@ LogicalResult ShimMuxOp::verify() {
 
 size_t ShimMuxOp::getNumSourceConnections(WireBundle bundle) {
   auto tile = getTileOp();
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.getNumSourceShimMuxConnections(tile.getCol(),
-                                                    tile.getRow(), bundle);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->getNumSourceShimMuxConnections(tile.getCol(),
+                                                     tile.getRow(), bundle);
 }
 
 size_t ShimMuxOp::getNumDestConnections(WireBundle bundle) {
   auto tile = getTileOp();
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.getNumDestShimMuxConnections(tile.getCol(), tile.getRow(),
-                                                  bundle);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->getNumDestShimMuxConnections(tile.getCol(), tile.getRow(),
+                                                   bundle);
 }
 
 TileOp ShimMuxOp::getTileOp() {
@@ -1648,7 +1641,7 @@ LogicalResult SwitchboxOp::verify() {
   DenseSet<Port> sourceset;
   DenseSet<Port> destset;
   auto tile = getTileOp();
-  const auto &targetModel = getTargetModel(tile);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(tile);
   if (body.empty())
     return emitOpError("should have non-empty body");
   for (auto &ops : body.front()) {
@@ -1713,9 +1706,9 @@ LogicalResult SwitchboxOp::verify() {
         return connectOp.emitOpError("Trace port cannot be a destination");
 
       if (connectOp.getSourceBundle() == WireBundle::Trace &&
-          !targetModel.isValidTraceMaster(tile.getCol(), tile.getRow(),
-                                          connectOp.getDestBundle(),
-                                          connectOp.getDestChannel()))
+          !targetModel->isValidTraceMaster(tile.getCol(), tile.getRow(),
+                                           connectOp.getDestBundle(),
+                                           connectOp.getDestChannel()))
         return connectOp.emitOpError("illegal Trace destination");
 
     } else if (auto connectOp = dyn_cast<MasterSetOp>(ops)) {
@@ -1766,9 +1759,9 @@ LogicalResult SwitchboxOp::verify() {
           return connectOp.emitOpError("Trace port cannot be a destination");
         for (auto s : slvs) {
           if (s.sourcePort().bundle == WireBundle::Trace &&
-              !targetModel.isValidTraceMaster(tile.getCol(), tile.getRow(),
-                                              m.destPort().bundle,
-                                              m.destPort().channel))
+              !targetModel->isValidTraceMaster(tile.getCol(), tile.getRow(),
+                                               m.destPort().bundle,
+                                               m.destPort().channel))
             return amselOp.emitOpError("illegal Trace destination");
 
           // Memtile stream switch connection constraints
@@ -1819,10 +1812,10 @@ LogicalResult LockOp::verify() {
     return result;
 
   if (getLockID().has_value()) {
-    const auto &targetModel = getTargetModel(getTileOp());
+    std::shared_ptr<AIETargetModel> targetModel = getTargetModel(getTileOp());
     auto tileOp = getTileOp();
     if (int numLocks =
-            targetModel.getNumLocks(tileOp.getCol(), tileOp.getRow());
+            targetModel->getNumLocks(tileOp.getCol(), tileOp.getRow());
         getLockID().value() >= numLocks)
       return emitOpError("lock assigned invalid id (maximum is ")
              << numLocks - 1 << ")";
@@ -1886,8 +1879,8 @@ LogicalResult UseLockOp::verify() {
   if (llvm::isa_and_nonnull<DeviceOp, ModuleOp>((*this)->getParentOp()))
     return (*this)->emitOpError("must be used in a core or memory operation.");
 
-  const auto &targetModel = getTargetModel(*this);
-  if (targetModel.getTargetArch() == AIEArch::AIE1 && acquireGE())
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  if (targetModel->getTargetArch() == AIEArch::AIE1 && acquireGE())
     return (*this)->emitOpError(
         "AcquireGreaterEqual is not supported in AIE1.");
 
@@ -1897,7 +1890,7 @@ LogicalResult UseLockOp::verify() {
     if (!(*this)->getBlock())
       return (*this)->emitOpError("is not in a block.");
 
-    if (targetModel.getTargetArch() == AIEArch::AIE1 &&
+    if (targetModel->getTargetArch() == AIEArch::AIE1 &&
         UsesOneLockInDMABlock::verifyTrait(*this).failed())
       return (*this)->emitOpError(
           "used in a DMA block that have multiple locks.");
@@ -1931,16 +1924,16 @@ namespace xilinx::AIE {
 
 size_t SwitchboxOp::getNumSourceConnections(WireBundle bundle) {
   auto tile = getTileOp();
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.getNumSourceSwitchboxConnections(tile.getCol(),
-                                                      tile.getRow(), bundle);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->getNumSourceSwitchboxConnections(tile.getCol(),
+                                                       tile.getRow(), bundle);
 }
 
 size_t SwitchboxOp::getNumDestConnections(WireBundle bundle) {
   auto tile = getTileOp();
-  const auto &targetModel = getTargetModel(*this);
-  return targetModel.getNumDestSwitchboxConnections(tile.getCol(),
-                                                    tile.getRow(), bundle);
+  std::shared_ptr<AIETargetModel> targetModel = getTargetModel(*this);
+  return targetModel->getNumDestSwitchboxConnections(tile.getCol(),
+                                                     tile.getRow(), bundle);
 }
 
 WireBundle getConnectingBundle(WireBundle dir) {

--- a/lib/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.cpp
@@ -22,8 +22,8 @@ using namespace xilinx;
 using namespace xilinx::AIE;
 
 struct BdIdGenerator {
-  BdIdGenerator(int col, int row, const AIETargetModel &targetModel)
-      : col(col), row(row), isMemTile(targetModel.isMemTile(col, row)) {}
+  BdIdGenerator(int col, int row, std::shared_ptr<AIETargetModel> targetModel)
+      : col(col), row(row), isMemTile(targetModel->isMemTile(col, row)) {}
 
   int32_t nextBdId(int channelIndex) {
     int32_t bdId = isMemTile && channelIndex & 1 ? oddBdId++ : evenBdId++;
@@ -52,7 +52,7 @@ struct AIEAssignBufferDescriptorIDsPass
     : AIEAssignBufferDescriptorIDsBase<AIEAssignBufferDescriptorIDsPass> {
   void runOnOperation() override {
     DeviceOp targetOp = getOperation();
-    const AIETargetModel &targetModel = targetOp.getTargetModel();
+    std::shared_ptr<AIETargetModel> targetModel = targetOp.getTargetModel();
 
     auto memOps = llvm::to_vector_of<TileElement>(targetOp.getOps<MemOp>());
     llvm::append_range(memOps, targetOp.getOps<MemTileDMAOp>());

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -43,12 +43,12 @@ struct AIEAssignBufferAddressesPass
     });
 
     for (auto tile : device.getOps<TileOp>()) {
-      const auto &targetModel = getTargetModel(tile);
+      std::shared_ptr<AIETargetModel> targetModel = getTargetModel(tile);
       int maxDataMemorySize = 0;
       if (tile.isMemTile())
-        maxDataMemorySize = targetModel.getMemTileSize();
+        maxDataMemorySize = targetModel->getMemTileSize();
       else
-        maxDataMemorySize = targetModel.getLocalMemorySize();
+        maxDataMemorySize = targetModel->getLocalMemorySize();
       SmallVector<BufferOp, 4> buffers;
       // Collect all the buffers for this tile.
       device.walk<WalkOrder::PreOrder>([&](BufferOp buffer) {

--- a/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignLockIDs.cpp
@@ -77,7 +77,7 @@ struct AIEAssignLockIDsPass : AIEAssignLockIDsBase<AIEAssignLockIDsPass> {
     // IR mutation: assign locks to all unassigned lock ops.
     for (auto [tileOp, locks] : tileToLocks) {
       const auto locksPerTile =
-          getTargetModel(tileOp).getNumLocks(tileOp.getCol(), tileOp.getRow());
+          getTargetModel(tileOp)->getNumLocks(tileOp.getCol(), tileOp.getRow());
       uint32_t nextID = 0;
       for (auto lockOp : locks.unassigned) {
         while (nextID < locksPerTile &&

--- a/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
@@ -27,9 +27,9 @@ struct AIECanonicalizeDevicePass
 
     ModuleOp moduleOp = getOperation();
 
-    for (auto deviceOp : moduleOp.getOps<AIETarget>()) {
+    for (auto deviceOp : moduleOp.getOps<DeviceOp>()) {
       (void)deviceOp;
-      // We have a device..  Nothing to do.
+      // We have a device...  Nothing to do.
       return;
     }
 
@@ -39,8 +39,8 @@ struct AIECanonicalizeDevicePass
 
     Location location = builder.getUnknownLoc();
     auto deviceOp = builder.create<DeviceOp>(
-        location,
-        AIEDeviceAttr::get(builder.getContext(), AIEDevice::xcvc1902));
+        location, AIEDeviceAttr::get(builder.getContext(), AIEDevice::xcvc1902),
+        /*virtualized*/ builder.getBoolAttr(true));
 
     deviceOp.getRegion().takeBody(moduleOp.getBodyRegion());
     new (&moduleOp->getRegion(0)) Region(moduleOp);

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -284,14 +284,14 @@ void AIEPathfinderPass::runOnOperation() {
 
   // If the routing violates architecture-specific routing constraints, then
   // attempt to partially reroute.
-  const auto &targetModel = d.getTargetModel();
+  std::shared_ptr<AIETargetModel> targetModel = d.getTargetModel();
   std::vector<ConnectOp> problemConnects;
   d.walk([&](ConnectOp connect) {
     if (auto sw = connect->getParentOfType<SwitchboxOp>()) {
       // Constraint: memtile stream switch constraints
       if (auto tile = sw.getTileOp();
           tile.isMemTile() &&
-          !targetModel.isLegalMemtileConnection(
+          !targetModel->isLegalMemtileConnection(
               connect.getSourceBundle(), connect.getSourceChannel(),
               connect.getDestBundle(), connect.getDestChannel())) {
         problemConnects.push_back(connect);

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -274,7 +274,7 @@ struct AIEFindFlowsPass : public AIEFindFlowsBase<AIEFindFlowsPass> {
 
     DeviceOp d = getOperation();
     ConnectivityAnalysis analysis(d);
-    d.getTargetModel().validate();
+    d.getTargetModel()->validate();
 
     OpBuilder builder = OpBuilder::atBlockEnd(d.getBody());
     for (auto tile : d.getOps<TileOp>()) {

--- a/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
@@ -29,7 +29,7 @@ struct AIELowerCascadeFlowsPass
   }
   void runOnOperation() override {
     DeviceOp device = getOperation();
-    const auto &targetModel = device.getTargetModel();
+    std::shared_ptr<AIETargetModel> targetModel = device.getTargetModel();
     OpBuilder builder = OpBuilder::atBlockEnd(device.getBody());
 
     std::set<TileOp> tilesWithCascadeFlow;
@@ -44,12 +44,12 @@ struct AIELowerCascadeFlowsPass
       tilesWithCascadeFlow.insert(src);
       tilesWithCascadeFlow.insert(dst);
 
-      if (targetModel.isSouth(src.getCol(), src.getRow(), dst.getCol(),
-                              dst.getRow())) {
+      if (targetModel->isSouth(src.getCol(), src.getRow(), dst.getCol(),
+                               dst.getRow())) {
         cascadeInputsPerTile[dst] = WireBundle::North;
         cascadeOutputsPerTile[src] = WireBundle::South;
-      } else if (targetModel.isEast(src.getCol(), src.getRow(), dst.getCol(),
-                                    dst.getRow())) {
+      } else if (targetModel->isEast(src.getCol(), src.getRow(), dst.getCol(),
+                                     dst.getRow())) {
         cascadeInputsPerTile[dst] = WireBundle::West;
         cascadeOutputsPerTile[src] = WireBundle::East;
       } else {

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -151,7 +151,7 @@ ShimMuxOp DynamicTileAnalysis::getShimMux(OpBuilder &builder, int col) {
 }
 
 void Pathfinder::initialize(int maxCol, int maxRow,
-                            const AIETargetModel &targetModel) {
+                            std::shared_ptr<AIETargetModel> targetModel) {
   // make grid of switchboxes
   int id = 0;
   for (int row = 0; row <= maxRow; row++) {
@@ -163,7 +163,7 @@ void Pathfinder::initialize(int maxCol, int maxRow,
         SwitchboxNode &southernNeighbor = grid.at({col, row - 1});
         // get the number of outgoing connections on the south side - outgoing
         // because these correspond to rhs of a connect op
-        if (uint32_t maxCapacity = targetModel.getNumDestSwitchboxConnections(
+        if (uint32_t maxCapacity = targetModel->getNumDestSwitchboxConnections(
                 col, row, WireBundle::South)) {
           edges.emplace_back(thisNode, southernNeighbor, WireBundle::South,
                              maxCapacity);
@@ -173,8 +173,9 @@ void Pathfinder::initialize(int maxCol, int maxRow,
         // because they correspond to connections on the southside that are then
         // routed using internal connect ops through the switchbox (i.e., lhs of
         // connect ops)
-        if (uint32_t maxCapacity = targetModel.getNumSourceSwitchboxConnections(
-                col, row, WireBundle::South)) {
+        if (uint32_t maxCapacity =
+                targetModel->getNumSourceSwitchboxConnections(
+                    col, row, WireBundle::South)) {
           edges.emplace_back(southernNeighbor, thisNode, WireBundle::North,
                              maxCapacity);
           (void)graph.connect(southernNeighbor, thisNode, edges.back());
@@ -183,14 +184,15 @@ void Pathfinder::initialize(int maxCol, int maxRow,
 
       if (col > 0) { // if not in col 0 add channel to East/West
         SwitchboxNode &westernNeighbor = grid.at({col - 1, row});
-        if (uint32_t maxCapacity = targetModel.getNumDestSwitchboxConnections(
+        if (uint32_t maxCapacity = targetModel->getNumDestSwitchboxConnections(
                 col, row, WireBundle::West)) {
           edges.emplace_back(thisNode, westernNeighbor, WireBundle::West,
                              maxCapacity);
           (void)graph.connect(thisNode, westernNeighbor, edges.back());
         }
-        if (uint32_t maxCapacity = targetModel.getNumSourceSwitchboxConnections(
-                col, row, WireBundle::West)) {
+        if (uint32_t maxCapacity =
+                targetModel->getNumSourceSwitchboxConnections(
+                    col, row, WireBundle::West)) {
           edges.emplace_back(westernNeighbor, thisNode, WireBundle::East,
                              maxCapacity);
           (void)graph.connect(westernNeighbor, thisNode, edges.back());

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -106,8 +106,8 @@ LogicalResult AIEX::IpuDmaMemcpyNdOp::verify() {
 }
 
 LogicalResult AIEX::IpuShimTilePushQueueOp::verify() {
-  const auto &targetModel = AIE::getTargetModel(*this);
-  auto numBds = targetModel.getNumBDs(0, 0); // assume shim
+  std::shared_ptr<AIE::AIETargetModel> targetModel = AIE::getTargetModel(*this);
+  auto numBds = targetModel->getNumBDs(0, 0); // assume shim
   if (getBdId() > numBds)
     return emitOpError("BD ID exceeds the maximum ID.");
   if (getRepeatCount() > 255)
@@ -116,8 +116,8 @@ LogicalResult AIEX::IpuShimTilePushQueueOp::verify() {
 }
 
 LogicalResult AIEX::IpuWriteBdExShimTileOp::verify() {
-  const auto &targetModel = AIE::getTargetModel(*this);
-  auto numBds = targetModel.getNumBDs(0, 0); // assume shim
+  std::shared_ptr<AIE::AIETargetModel> targetModel = AIE::getTargetModel(*this);
+  auto numBds = targetModel->getNumBDs(0, 0); // assume shim
   if (getBdId() > numBds)
     return emitOpError("BD ID exceeds the maximum ID.");
   if (getD0Size() > 0x3FF)

--- a/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
@@ -118,9 +118,9 @@ struct Token2LockLowering : public OpConversionPattern<UseTokenOp> {
 static int getLockID(DenseMap<std::pair<Operation *, int>, int> &locks,
                      Operation *op) {
   auto tileOp = cast<TileOp>(op);
-  const auto &targetModel = xilinx::AIE::getTargetModel(op);
+  std::shared_ptr<AIETargetModel> targetModel = xilinx::AIE::getTargetModel(op);
   for (unsigned i = 0;
-       i < targetModel.getNumLocks(tileOp.getCol(), tileOp.getRow()); i++) {
+       i < targetModel->getNumLocks(tileOp.getCol(), tileOp.getRow()); i++) {
     int usageCnt = locks[std::make_pair(tileOp, i)];
     if (usageCnt == 0) {
       locks[std::make_pair(tileOp, i)] = 1;

--- a/lib/Dialect/AIEX/Utils/AIETokenAnalysis.cpp
+++ b/lib/Dialect/AIEX/Utils/AIETokenAnalysis.cpp
@@ -172,12 +172,13 @@ Operation *xilinx::AIEX::TokenAnalysis::getShareableTileOp(Operation *Op1,
   int col2 = coord2.col;
   int row2 = coord2.row;
 
-  const auto &targetModel = xilinx::AIE::getTargetModel(Op1);
+  std::shared_ptr<AIETargetModel> targetModel =
+      xilinx::AIE::getTargetModel(Op1);
 
   bool IsOp1ShareableMem =
-      IsOp1Mem && targetModel.isLegalMemAffinity(col2, row2, col1, row1);
+      IsOp1Mem && targetModel->isLegalMemAffinity(col2, row2, col1, row1);
   bool IsOp2ShareableMem =
-      IsOp2Mem && targetModel.isLegalMemAffinity(col1, row1, col2, row2);
+      IsOp2Mem && targetModel->isLegalMemAffinity(col1, row1, col2, row2);
 
   if (IsOp1ShareableMem)
     return tiles[coord1];
@@ -186,11 +187,11 @@ Operation *xilinx::AIEX::TokenAnalysis::getShareableTileOp(Operation *Op1,
 
   // both Op1 and Op2 are core ops
   if (!IsOp1Mem && !IsOp2Mem) {
-    bool IsS = targetModel.isSouth(col1, row1, col2, row2);
-    bool IsW = targetModel.isWest(col1, row1, col2, row2);
-    bool IsN = targetModel.isNorth(col1, row1, col2, row2);
-    bool IsE = targetModel.isEast(col1, row1, col2, row2);
-    bool IsInternal = targetModel.isInternal(col1, row1, col2, row2);
+    bool IsS = targetModel->isSouth(col1, row1, col2, row2);
+    bool IsW = targetModel->isWest(col1, row1, col2, row2);
+    bool IsN = targetModel->isNorth(col1, row1, col2, row2);
+    bool IsE = targetModel->isEast(col1, row1, col2, row2);
+    bool IsInternal = targetModel->isInternal(col1, row1, col2, row2);
     bool IsEvenRow = ((row1 % 2) == 0);
 
     // FIXME: This logic appears AIE1 specific.

--- a/lib/Targets/AIETargetAirbin.cpp
+++ b/lib/Targets/AIETargetAirbin.cpp
@@ -1060,8 +1060,9 @@ static void configureSwitchBoxes(DeviceOp &targetOp) {
 }
 
 static void configureCascade(DeviceOp &targetOp) {
-  const auto &target_model = xilinx::AIE::getTargetModel(targetOp);
-  if (target_model.getTargetArch() == AIEArch::AIE2) {
+  std::shared_ptr<AIETargetModel> target_model =
+      xilinx::AIE::getTargetModel(targetOp);
+  if (target_model->getTargetArch() == AIEArch::AIE2) {
     for (auto configOp : targetOp.getOps<ConfigureCascadeOp>()) {
       TileOp tile = cast<TileOp>(configOp.getTile().getDefiningOp());
       auto inputDir = stringifyCascadeDir(configOp.getInputDir()).upper();

--- a/lib/Targets/AIETargetSimulationFiles.cpp
+++ b/lib/Targets/AIETargetSimulationFiles.cpp
@@ -29,7 +29,7 @@ mlir::LogicalResult AIETranslateSCSimConfig(mlir::ModuleOp module,
   }
   AIEArch arch = AIEArch::AIE1;
   if (targetOp) {
-    arch = targetOp.getTargetModel().getTargetArch();
+    arch = targetOp.getTargetModel()->getTargetArch();
   }
 
   if (arch == AIEArch::AIE2) {
@@ -237,7 +237,7 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
   }
   AIEArch arch = AIEArch::AIE1;
   if (targetOp) {
-    arch = targetOp.getTargetModel().getTargetArch();
+    arch = targetOp.getTargetModel()->getTargetArch();
   }
 
   // Generate boilerplate header
@@ -297,7 +297,7 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
           // AIE2 - xcve2802
           std::to_string(col) << ","
              << std::to_string(
-                    row - targetOp.getTargetModel().getNumMemTileRows() - 1)
+                    row - targetOp.getTargetModel()->getNumMemTileRows() - 1)
              << ")\" "
              // CR coordinates ignores shim and 1 mem row, hence row-2
              // AIE2 - xcve2302
@@ -311,7 +311,7 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
           // TODO: does stream_util matter for sim?
           std::to_string(col) << ","
              << std::to_string(row -
-                               targetOp.getTargetModel().getNumMemTileRows())
+                               targetOp.getTargetModel()->getNumMemTileRows())
              << "\">\n";
 
     } else {
@@ -344,7 +344,7 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
   // For each ShimOp in the module, generate a <SHIM> section
   for (ShimDMAOp shimOp : targetOp.getOps<ShimDMAOp>()) {
     if (arch == AIEArch::AIE2) {
-      auto noc_label = (targetOp.getTargetModel().isShimNOCTile(
+      auto noc_label = (targetOp.getTargetModel()->isShimNOCTile(
                            shimOp.colIndex(), shimOp.rowIndex()))
                            ? "AIE_PL_NOC_SIM"
                            : "AIE_PL_SHIM";
@@ -379,8 +379,8 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
       int row = tileOp.rowIndex();
 
       // NOTE: row == 0 assumes shim always row 0
-      if (row == 0 ||
-          row > static_cast<int>(targetOp.getTargetModel().getNumMemTileRows()))
+      if (row == 0 || row > static_cast<int>(
+                                targetOp.getTargetModel()->getNumMemTileRows()))
         continue; // Skip regular tiles (handled above)
 
       output << "      <MEM name=\"MEM(" << std::to_string(col) << ", "

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -73,9 +73,10 @@ static std::string tileLockStr(StringRef id, StringRef val) {
 // a proper DMA-like interface
 // blockMap: A map that gives a unique bd ID assignment for every block.
 template <typename OpType>
-mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
-                                      const AIETargetModel &targetModel,
-                                      DenseMap<Block *, int> blockMap) {
+mlir::LogicalResult
+generateDMAConfig(OpType memOp, raw_ostream &output,
+                  std::shared_ptr<AIETargetModel> targetModel,
+                  DenseMap<Block *, int> blockMap) {
   StringRef enable = "XAIE_ENABLE";
   StringRef disable = "XAIE_DISABLE";
   StringRef deviceInstRef = "&(ctx->DevInst)"; // TODO
@@ -97,7 +98,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
     //      StringRef FifoMode = disable; // FIXME: when to enable FIFO mode?
     for (auto op : block.template getOps<DMABDOp>()) {
       foundBd = true;
-      if (!targetModel.isShimNOCTile(col, row)) {
+      if (!targetModel->isShimNOCTile(col, row)) {
         assert(op.getBufferOp().getAddress() &&
                "buffer must have address assigned");
         BaseAddrA = op.getBufferOp().getAddress().value();
@@ -105,13 +106,13 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
         int bufferRow = op.getBufferOp().getTileOp().rowIndex();
 
         // Memtile DMAs can access neighboring tiles.
-        if (targetModel.isMemTile(col, row)) {
-          if (targetModel.isWest(col, row, bufferCol, bufferRow))
+        if (targetModel->isMemTile(col, row)) {
+          if (targetModel->isWest(col, row, bufferCol, bufferRow))
             BaseAddrA += 0x0;
-          else if (targetModel.isInternal(col, row, bufferCol, bufferRow))
-            BaseAddrA += targetModel.getMemTileSize() * 1;
-          else if (targetModel.isEast(col, row, bufferCol, bufferRow))
-            BaseAddrA += targetModel.getMemTileSize() * 2;
+          else if (targetModel->isInternal(col, row, bufferCol, bufferRow))
+            BaseAddrA += targetModel->getMemTileSize() * 1;
+          else if (targetModel->isEast(col, row, bufferCol, bufferRow))
+            BaseAddrA += targetModel->getMemTileSize() * 2;
         }
       }
 
@@ -124,7 +125,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
       }
     }
 
-    if (0 != ndims && AIEArch::AIE2 != targetModel.getTargetArch())
+    if (0 != ndims && AIEArch::AIE2 != targetModel->getTargetArch())
       return memOp.emitOpError("DMA contains at least one multi-dimensional "
                                "buffer descriptor. This is currently only "
                                "supported for AIE-ML devices.");
@@ -138,13 +139,13 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
       int lockRow = lock.rowIndex();
       int lockID = lock.getLockIDValue();
       // Memtile DMAs can access neighboring tiles.
-      if (targetModel.isMemTile(col, row)) {
-        if (targetModel.isWest(col, row, lockCol, lockRow))
+      if (targetModel->isMemTile(col, row)) {
+        if (targetModel->isWest(col, row, lockCol, lockRow))
           lockID += 0;
-        else if (targetModel.isInternal(col, row, lockCol, lockRow))
-          lockID += targetModel.getNumLocks(lockCol, lockRow) * 1;
-        else if (targetModel.isEast(col, row, lockCol, lockRow))
-          lockID += targetModel.getNumLocks(lockCol, lockRow) * 2;
+        else if (targetModel->isInternal(col, row, lockCol, lockRow))
+          lockID += targetModel->getNumLocks(lockCol, lockRow) * 1;
+        else if (targetModel->isEast(col, row, lockCol, lockRow))
+          lockID += targetModel->getNumLocks(lockCol, lockRow) * 2;
       }
 
       if (op.acquire() || op.acquireGE()) {
@@ -192,7 +193,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
       }
 
       if (0 == ndims) {
-        if (targetModel.isShimNOCTile(col, row)) {
+        if (targetModel->isShimNOCTile(col, row)) {
           output << "__mlir_aie_try(XAie_DmaSetAddrLen("
                  << tileDMAInstRefStr(col, row, bdNum) << ", /* addrA */ "
                  << "mlir_aie_external_get_addr_myBuffer_" << col << row << "_"
@@ -252,8 +253,9 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
       int bdNum = blockMap[op.getDest()];
       StringRef dmaDir = stringifyDMAChannelDir(op.getChannelDir());
       int chNum = op.getChannelIndex();
-      const auto &target_model = xilinx::AIE::getTargetModel(op);
-      if (target_model.getTargetArch() == AIEArch::AIE1) {
+      std::shared_ptr<AIETargetModel> target_model =
+          xilinx::AIE::getTargetModel(op);
+      if (target_model->getTargetArch() == AIEArch::AIE1) {
         output << "__mlir_aie_try(XAie_DmaChannelPushBdToQueue("
                << deviceInstRef << ", " << tileLocStr(col, row) << ", "
                << "/* ChNum */" << chNum
@@ -300,7 +302,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   if (module.getOps<DeviceOp>().empty())
     return module.emitOpError("expected AIE.device operation at toplevel");
   DeviceOp targetOp = *(module.getOps<DeviceOp>().begin());
-  const auto &targetModel = targetOp.getTargetModel();
+  std::shared_ptr<AIETargetModel> targetModel = targetOp.getTargetModel();
 
   collectTiles(targetOp, tiles);
   collectBuffers(targetOp, buffers);
@@ -313,7 +315,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   output << "  aie_libxaie_ctx_t *ctx = new aie_libxaie_ctx_t;\n";
   output << "  if (!ctx)\n";
   output << "    return 0;\n";
-  auto arch = targetModel.getTargetArch();
+  auto arch = targetModel->getTargetArch();
   std::string AIE1_device("XAIE_DEV_GEN_AIE");
   std::string AIE2_device("XAIE_DEV_GEN_AIEML");
   std::string device;
@@ -337,20 +339,21 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
   output << "  ctx->AieConfigPtr.BaseAddr = 0x20000000000;\n";
   output << "  ctx->AieConfigPtr.ColShift = " << col_shift << ";\n";
   output << "  ctx->AieConfigPtr.RowShift = " << row_shift << ";\n";
-  output << "  ctx->AieConfigPtr.NumRows = " << targetModel.rows() << ";\n";
-  output << "  ctx->AieConfigPtr.NumCols = " << targetModel.columns() << ";\n";
+  output << "  ctx->AieConfigPtr.NumRows = " << targetModel->rows() << ";\n";
+  output << "  ctx->AieConfigPtr.NumCols = " << targetModel->columns() << ";\n";
   output << "  ctx->AieConfigPtr.ShimRowNum = 0;\n";
   output << "  ctx->AieConfigPtr.MemTileRowStart = 1;\n";
   output << "  ctx->AieConfigPtr.MemTileNumRows = "
-         << targetModel.getNumMemTileRows() << ";\n";
+         << targetModel->getNumMemTileRows() << ";\n";
   output << "  //  ctx->AieConfigPtr.ReservedRowStart = "
             "XAIE_RES_TILE_ROW_START;\n";
   output
       << "  //  ctx->AieConfigPtr.ReservedNumRows  = XAIE_RES_TILE_NUM_ROWS;\n";
   output << "  ctx->AieConfigPtr.AieTileRowStart = "
-         << (1 + targetModel.getNumMemTileRows()) << ";\n";
+         << (1 + targetModel->getNumMemTileRows()) << ";\n";
   output << "  ctx->AieConfigPtr.AieTileNumRows = "
-         << (targetModel.rows() - 1 - targetModel.getNumMemTileRows()) << ";\n";
+         << (targetModel->rows() - 1 - targetModel->getNumMemTileRows())
+         << ";\n";
   output << "  ctx->AieConfigPtr.PartProp = {0};\n";
   output << "  ctx->DevInst = {0};\n";
   output << "  return ctx;\n";
@@ -374,7 +377,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       output << "__mlir_aie_try(XAie_CoreDisable(" << deviceInstRef << ", "
              << tileLocStr(col, row) << "));\n";
       // Release locks
-      int numLocks = targetModel.getNumLocks(col, row);
+      int numLocks = targetModel->getNumLocks(col, row);
       output << "for (int l = 0; l < " << numLocks << "; ++l)\n"
              << "  __mlir_aie_try(XAie_LockRelease(" << deviceInstRef << ", "
              << tileLocStr(col, row) << ", XAie_LockInit(l, 0x0), 0));\n";
@@ -481,10 +484,10 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       for (auto op : block.getOps<DMAStartOp>()) {
         int chNum = op.getChannelIndex();
         channelMap[&block] = chNum;
-        auto dest = op.getDest();
+        auto *dest = op.getDest();
         while (dest) {
           channelMap[dest] = chNum;
-          if (dest->getSuccessors().size() < 1)
+          if (dest->getSuccessors().empty())
             break;
           dest = dest->getSuccessors()[0];
           if (channelMap.count(dest))

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -97,7 +97,7 @@ LogicalResult AIETranslateToTargetArch(ModuleOp module, raw_ostream &output) {
   AIEArch arch = AIEArch::AIE1;
   if (!module.getOps<DeviceOp>().empty()) {
     DeviceOp targetOp = *(module.getOps<DeviceOp>().begin());
-    arch = targetOp.getTargetModel().getTargetArch();
+    arch = targetOp.getTargetModel()->getTargetArch();
   }
   if (arch == AIEArch::AIE1)
     output << "AIE\n";
@@ -181,16 +181,17 @@ void registerAIETranslations() {
                 writeBufferMap(output, buf, offset);
           };
 
-          const auto &targetModel = xilinx::AIE::getTargetModel(srcTileOp);
+          std::shared_ptr<AIETargetModel> targetModel =
+              xilinx::AIE::getTargetModel(srcTileOp);
 
-          if (auto tile = targetModel.getMemSouth(srcCoord))
-            doBuffer(tile, targetModel.getMemSouthBaseAddress());
-          if (auto tile = targetModel.getMemWest(srcCoord))
-            doBuffer(tile, targetModel.getMemWestBaseAddress());
-          if (auto tile = targetModel.getMemNorth(srcCoord))
-            doBuffer(tile, targetModel.getMemNorthBaseAddress());
-          if (auto tile = targetModel.getMemEast(srcCoord))
-            doBuffer(tile, targetModel.getMemEastBaseAddress());
+          if (auto tile = targetModel->getMemSouth(srcCoord))
+            doBuffer(tile, targetModel->getMemSouthBaseAddress());
+          if (auto tile = targetModel->getMemWest(srcCoord))
+            doBuffer(tile, targetModel->getMemWestBaseAddress());
+          if (auto tile = targetModel->getMemNorth(srcCoord))
+            doBuffer(tile, targetModel->getMemNorthBaseAddress());
+          if (auto tile = targetModel->getMemEast(srcCoord))
+            doBuffer(tile, targetModel->getMemEastBaseAddress());
         }
         return success();
       },

--- a/python/RouterPass.cpp
+++ b/python/RouterPass.cpp
@@ -38,7 +38,7 @@ public:
   explicit PythonRouter(py::object router) : router(std::move(router)) {}
 
   void initialize(const int maxCol, const int maxRow,
-                  const AIETargetModel &targetModel) override {
+                  std::shared_ptr<AIETargetModel> targetModel) override {
     // Here we're copying a pointer to targetModel, which is a static somewhere.
     router.attr("initialize")(maxCol, maxRow, &targetModel);
   }

--- a/test/canonicalize-device/canonicalize-device.mlir
+++ b/test/canonicalize-device/canonicalize-device.mlir
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-canonicalize-device %s | FileCheck %s
-// CHECK: aie.device(xcvc1902) {
+// CHECK: aie.device(xcvc1902, virtualized = true) {
 // CHECK:   %[[T0:.*]] = aie.tile(0, 1)
 // CHECK:   %[[T1:.*]] = aie.tile(1, 2)
 // CHECK:   %[[T2:.*]] = aie.tile(0, 2)


### PR DESCRIPTION
This PR parameterizes `AIETargetModel` with a `bool virtualized`, which is then queried when checking `isShimNOCTile(col, row) || isShimPLTile(col, row)`. Note, I have only updated `IPUTargetModel` to the correct result because that is the only one I am familiar with (the rest fallback to `virtualized=true`, i.e., the current behavior).

Note, this PR touched a lot of lines only because the models were `static` prior and had to be updated to `shared_ptr`s.

fixes https://github.com/Xilinx/mlir-aie/issues/1094