### PR TITLE
offset, len, and stride in words not bytes (or 32b)

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -133,12 +133,7 @@ def AIETarget : OpInterface<"AIETarget"> {
   ];
 }
 
-// def OffloadingTranslationAttrTrait :
-//    NativeTrait<"OffloadingTranslationAttrTrait", ""> {
-//   let cppNamespace = "::mlir::gpu";
-// }
-
-def MyOffsetSizeAndStrideOpInterface: OpInterfaceTrait<"::xilinx::AIE::MyOffsetSizeAndStrideOpInterface"> {
-}
+// Don't delete - see AIEDialect::myVerifyOffsetSizeAndStrideOp
+def MyOffsetSizeAndStrideOpInterface: OpInterfaceTrait<"::xilinx::AIE::MyOffsetSizeAndStrideOpInterface"> {}
 
 #endif // AIE_INTERFACES

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -745,44 +745,66 @@ def AIE_DMABDPACKETOp: AIE_Op<"dma_bd_packet", []> {
   }];
 }
 
-def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
-  let summary = "Declare a dma block descriptor op";
+def AIE_DMABDOp: AIE_Op<"dma_bd", [
+    ParentOneOf<["MemOp", "MemTileDMAOp", "ShimDMAOp", "DMAOp"]>,
+  ]> {
+  let summary = "Declare a dma buffer descriptor op";
   let description = [{
-    This operation describes a block descriptor for DMA operations. In particular, it specifies
-    what buffer addresss to use, the transfer length, and the buffer type (A or B).
+    This operation describes a buffer descriptor for DMA operations. In particular, it specifies
+    what buffer to use, and optionally:
 
-    This operation must be used in an MLIR block that lives inside a MemOp's region.
-    The block descriptor specifies what lock to use and the buffer configuration.
+        1. the offset into the buffer;
+        2. the transfer length;
+        3. the sizes and strides for n-d tensor addressing (described below);
+        4. the "bd_id" with which to associate the buffer descriptor (most often left empty).
+
+    `offset`, `len`, `size`s and `stride`s are all denominated in 32 bits; e.g., transferring the whole of
+    `memref<512xi32>` means `len == 512`, while transferring the whole of `memref<512xi16>` means `len == 1024`.
+
+    `dma_bd` ops must appear in their own bbs (basic blocks) and such bbs can (optionally) include `use_lock`
+    operations (specifying an "acquire" and a "release" lock; see the `use_lock` operation) and subsequent bds in
+    a "chain" of bds (using `next_bd` as a "jump" to the next bb which contains a `dma_bd`).
 
     Example:
     ```
       // this defines a BD that uses lock %lck0 and buffer %buf0
       ^bd5:
         aie.use_lock(%lck, "Acquire", 0)
-        aie.dma_bd(<$buf0 : memref<512xi32>, 0, 512>, 1)
+        // transfer the first 32 elements of the memref
+        aie.dma_bd(<$buf0 : memref<128xi32>, 0, 32)
         aie.use_lock(%lck, "Release", 1)
-        br ^bd6 // point to the next Block, which is also a different Block Descriptor
+        aie.next_bd ^bd6 // point to the next bb, which describes the next buffer descriptor
+      ^bd6:
+        aie.use_lock(%lck, "Acquire", 1)
+        // transfer the last 32 elements of the memref
+        aie.dma_bd(<$buf1 : memref<128xi32>, 96, 32)
+        aie.use_lock(%lck, "Release", 0)
+        aie.next_bd ^end
 
       ...
 
       // this defines a BD that does not use any lock
       ^bd8:
-        aie.dma_bd(<$buf1 : memref<64xi32>, 0, 64>, 0)
+        aie.dma_bd(<$buf2 : memref<64xi32>, 0, 64)
     ```
-    A DMA channel in a Memory Module can process one block descriptor after another by chaining them.
-    There are 16 block descriptors per Memory Module. They are shared by four DMA channels.
+
+    ## Background/context:
+
+    A DMA channel in a Memory Module can process one buffer descriptor after another by chaining them.
+    There are 16 buffer descriptors per Core memory module and 48 buffer descriptors per Memtile memory module.
+    They are shared by four DMA channels (or 12).
 
     ## DMA Data Layout Transformations on AIE-ML Devices
 
     AIE-ML devices can apply data layout transformations at the buffer
     descriptor level. These transformation are described by strides and sizes in up to three dimensions (four
     dimensions on memtiles). Strides and sizes can be supplied to the `dma_bd`
-    through an optional argument, an array of tuples `<size, stride>`.
+    through an optional argument, an array of "tuple-like" attributes `bd_dim_layout<size, stride>`.
 
-    The first element of this array gives the _highest-dimension_ stride and
-    size, the last element of the array gives the lowest-dimension.
+    The first element of this array gives the outer-most dimension's stride and
+    size, the last element of the array gives the inner-most dimension's stride and size.
 
-    Strides are always expressed in units of `i32`s; this is an architectural
+    Sizes and strides are always expressed in units of 32 bits; this is an architectural
     requirement, as data is moved by the DMA at this fundamental size.
 
     We can model the access pattern strides and sizes generate by a series of
@@ -824,7 +846,9 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
 
   let arguments = (
     ins AnyMemRef:$buffer,
-        OptionalAttr<AIEI32Attr>:$offset,
+        // in words (multiples of 32b) not bytes
+        DefaultValuedAttr<AIEI32Attr, "0">:$offset,
+        // in words (multiples of 32b) not bytes
         OptionalAttr<AIEI32Attr>:$len,
         OptionalAttr<BDDimLayoutArrayAttr>:$dimensions,
         OptionalAttr<AIEI32Attr>:$bd_id,
@@ -840,8 +864,16 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
 
   let extraClassDeclaration = [{
     BufferOp getBufferOp();
-    int getOffsetValue() { return getOffset().value_or(0); }
-    int getLenValue() { return getLen().value_or(getBuffer().getType().getNumElements()); }
+    int32_t getBufferElementTypeWidthInBytes() {
+      return getBuffer().getType().getElementTypeBitWidth() / 8;
+    }
+    int32_t getLenIn32bWords() {
+      if (std::optional<int32_t> len = getLen())
+        return len.value() * getBufferElementTypeWidthInBytes() / 4;
+      else
+        return getBuffer().getType().getNumElements() * getBufferElementTypeWidthInBytes() / 4;
+    }
+    int32_t getOffsetIn32bWords() { return getOffset() * getBufferElementTypeWidthInBytes() / 4; }
   }];
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -758,7 +758,7 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
         3. the sizes and strides for n-d tensor addressing (described below);
         4. the "bd_id" with which to associate the buffer descriptor (most often left empty).
 
-    `offset`, `len`, `size`s and `stride`s are all denominated in 32 bit words; e.g., transferring the whole of
+    `offset`, `len`, `size`s and `stride`s are all denominated in element width; e.g., transferring the whole of
     `memref<512xi32>` means `len == 512`, while transferring the whole of `memref<512xi16>` means `len == 256`.
 
     `dma_bd` ops must appear in their own BBs (basic blocks) and such BBs can (optionally) include `use_lock`
@@ -846,9 +846,9 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
 
   let arguments = (
     ins AnyMemRef:$buffer,
-        // in words (multiples of 32b) not bytes
+        // in words (multiples of element width) not bytes
         DefaultValuedOptionalAttr<AIEI32Attr, "0">:$offset,
-        // in words (multiples of 32b) not bytes
+        // in words (multiples of element width) not bytes
         OptionalAttr<AIEI32Attr>:$len,
         OptionalAttr<BDDimLayoutArrayAttr>:$dimensions,
         OptionalAttr<AIEI32Attr>:$bd_id,

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -867,13 +867,13 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
     int32_t getBufferElementTypeWidthInBytes() {
       return getBuffer().getType().getElementTypeBitWidth() / 8;
     }
-    int32_t getLenIn32bWords() {
+    int32_t getLenInBytes() {
       if (std::optional<int32_t> len = getLen(); len.has_value())
-        return len.value() * getBufferElementTypeWidthInBytes() / 4;
+        return len.value() * getBufferElementTypeWidthInBytes();
       else
-        return getBuffer().getType().getNumElements() * getBufferElementTypeWidthInBytes() / 4;
+        return getBuffer().getType().getNumElements() * getBufferElementTypeWidthInBytes();
     }
-    int32_t getOffsetIn32bWords() { return getOffset() * getBufferElementTypeWidthInBytes() / 4; }
+    int32_t getOffsetInBytes() { return getOffset() * getBufferElementTypeWidthInBytes(); }
   }];
 
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -758,12 +758,12 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
         3. the sizes and strides for n-d tensor addressing (described below);
         4. the "bd_id" with which to associate the buffer descriptor (most often left empty).
 
-    `offset`, `len`, `size`s and `stride`s are all denominated in 32 bits; e.g., transferring the whole of
-    `memref<512xi32>` means `len == 512`, while transferring the whole of `memref<512xi16>` means `len == 1024`.
+    `offset`, `len`, `size`s and `stride`s are all denominated in 32 bit words; e.g., transferring the whole of
+    `memref<512xi32>` means `len == 512`, while transferring the whole of `memref<512xi16>` means `len == 256`.
 
-    `dma_bd` ops must appear in their own bbs (basic blocks) and such bbs can (optionally) include `use_lock`
-    operations (specifying an "acquire" and a "release" lock; see the `use_lock` operation) and subsequent bds in
-    a "chain" of bds (using `next_bd` as a "jump" to the next bb which contains a `dma_bd`).
+    `dma_bd` ops must appear in their own BBs (basic blocks) and such BBs can (optionally) include `use_lock`
+    operations (specifying an "acquire" and a "release" lock; see the `use_lock` operation) and subsequent BDs in
+    a "chain" of BDs (using `next_bd` as a "jump" to the next BB which contains a `dma_bd`).
 
     Example:
     ```
@@ -868,7 +868,7 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
       return getBuffer().getType().getElementTypeBitWidth() / 8;
     }
     int32_t getLenIn32bWords() {
-      if (std::optional<int32_t> len = getLen())
+      if (std::optional<int32_t> len = getLen(); len.has_value())
         return len.value() * getBufferElementTypeWidthInBytes() / 4;
       else
         return getBuffer().getType().getNumElements() * getBufferElementTypeWidthInBytes() / 4;

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -847,7 +847,7 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
   let arguments = (
     ins AnyMemRef:$buffer,
         // in words (multiples of 32b) not bytes
-        DefaultValuedAttr<AIEI32Attr, "0">:$offset,
+        DefaultValuedOptionalAttr<AIEI32Attr, "0">:$offset,
         // in words (multiples of 32b) not bytes
         OptionalAttr<AIEI32Attr>:$len,
         OptionalAttr<BDDimLayoutArrayAttr>:$dimensions,

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -845,18 +845,14 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
     ## Important gotcha regarding strides
 
     All strides are expressed in multiples of the element width (just like `len` and `offset`)
-    **with the caveat that the inner-most dimension's stride must be a multiple of 32b**.
-    I.e., `(stride_0 * element_width) % 32 == 0`. For example, if you are striding a `memref<512xi16>`,
-    `stride_0` cannot be 1 (or 3, or 5, ...). The reason for this requirement is stream access to DMA memory is 32b
-    aligned (and thus, for the `memref<512xi16>` example, a stride of 1 would require 16b, half-word, access, which isn't possible).
-
+    **with the caveat that the inner-most dimension's stride must be 1**.
   }];
 
   let arguments = (
     ins AnyMemRef:$buffer,
-        // in words (multiples of element width) not bytes
+        // in multiples of element width (not bytes)
         DefaultValuedOptionalAttr<AIEI32Attr, "0">:$offset,
-        // in words (multiples of element width) not bytes
+        // in multiples of element width (not bytes)
         OptionalAttr<AIEI32Attr>:$len,
         OptionalAttr<BDDimLayoutArrayAttr>:$dimensions,
         OptionalAttr<AIEI32Attr>:$bd_id,

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -759,7 +759,10 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
         4. the "bd_id" with which to associate the buffer descriptor (most often left empty).
 
     `offset`, `len`, `size`s and `stride`s are all denominated in element width; e.g., transferring the whole of
-    `memref<512xi32>` means `len == 512`, while transferring the whole of `memref<512xi16>` means `len == 256`.
+    `memref<512xi32>` means `len == 512`, and also while transferring the whole of `memref<512xi16>`, `len == 512`.
+
+    The only caveat to this "everything-is-in-terms-of-element-width" rule is regarding the inner-most dimension's stride
+    (see [Important gotcha regarding strides](#important-gotcha-regarding-strides) below).
 
     `dma_bd` ops must appear in their own BBs (basic blocks) and such BBs can (optionally) include `use_lock`
     operations (specifying an "acquire" and a "release" lock; see the `use_lock` operation) and subsequent BDs in
@@ -803,10 +806,6 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
 
     The first element of this array gives the outer-most dimension's stride and
     size, the last element of the array gives the inner-most dimension's stride and size.
-
-    Sizes and strides are always expressed in units of 32 bits; this is an architectural
-    requirement, as data is moved by the DMA at this fundamental size.
-
     We can model the access pattern strides and sizes generate by a series of
     nested loops. In general, a set of strides and sizes like this...
 
@@ -842,6 +841,15 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
         for(int k = 0; k < 8 /*size_0*/; k++)
           // access/store element at/to index (i * 16 /*stride_2*/ + j * 1 /*stride_1*/ + k * 2 /*stride_0*/)
     ```
+
+    ## Important gotcha regarding strides
+
+    All strides are expressed in multiples of the element width (just like `len` and `offset`)
+    **with the caveat that the inner-most dimension's stride must be a multiple of 32b**.
+    I.e., `(stride_0 * element_width) % 32 == 0`. For example, if you are striding a `memref<512xi16>`,
+    `stride_0` cannot be 1 (or 3, or 5, ...). The reason for this requirement is stream access to DMA memory is 32b
+    aligned (and thus, for the `memref<512xi16>` example, a stride of 1 would require 16b, half-word, access, which isn't possible).
+
   }];
 
   let arguments = (

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1545,11 +1545,45 @@ LogicalResult DMABDOp::verify() {
   if (!isa<BufferOp, ExternalBufferOp>(getBuffer().getDefiningOp()))
     return emitOpError(
         "BDs only support BufferOp or ExternalBufferOp operands.");
+
+  int32_t lenInBytes;
+  if (std::optional<int32_t> len = getLen())
+    lenInBytes = *len * getBufferElementTypeWidthInBytes();
+  else
+    lenInBytes = getBuffer().getType().getNumElements() *
+                 getBufferElementTypeWidthInBytes();
+  if (lenInBytes % 4)
+    return emitOpError("transfer length must be multiple of 4B (32b)");
+
   if (auto memOp = getOperation()->getParentOfType<MemOp>()) {
     if (auto bufferOp = getBufferOp();
         bufferOp.getTileOp().colIndex() != memOp.colIndex() ||
         bufferOp.getTileOp().rowIndex() != memOp.rowIndex())
-      return emitOpError("can only access a buffer in the same tile.");
+      return emitOpError(
+          "Core tile DMAs can only access a buffer in the same tile.");
+    if (std::optional<int32_t> bdId = getBdId(); *bdId > 15)
+      return emitOpError("Core tile DMAs have at most 16 buffer descriptors");
+    if (std::optional<int32_t> nextBdId = getNextBdId(); *nextBdId > 15)
+      return emitOpError("Core tile DMAs have at most 16 buffer descriptors");
+  } else if (getOperation()->getParentOfType<ShimDMAOp>()) {
+    if (!isa<ExternalBufferOp>(getBuffer().getDefiningOp()))
+      return emitOpError("Shim tile DMAs can only access external buffers");
+    if (std::optional<int32_t> bdId = getBdId(); *bdId > 15)
+      return emitOpError("Shim tile DMAs have at most 16 buffer descriptors");
+    if (std::optional<int32_t> nextBdId = getNextBdId(); *nextBdId > 15)
+      return emitOpError("Shim tile DMAs have at most 16 buffer descriptors");
+  } else {
+    assert(getOperation()->getParentOfType<MemTileDMAOp>() &&
+           "expected MemTileDMAOp parent");
+    if (auto bufferOp = getBufferOp();
+        bufferOp.getTileOp().rowIndex() != memOp.rowIndex() ||
+        std::abs(bufferOp.getTileOp().colIndex() - memOp.colIndex()) > 1)
+      return emitOpError("Mem tile DMAs can only access adjacent mem tiles");
+    // TODO(max): check even channel -> <24; odd channel -> > 24
+    if (std::optional<int32_t> bdId = getBdId(); *bdId > 47)
+      return emitOpError("Memtile DMAs have at most 48 buffer descriptors");
+    if (std::optional<int32_t> nextBdId = getNextBdId(); *nextBdId > 47)
+      return emitOpError("Memtile DMAs have at most 48 buffer descriptors");
   }
 
   // The following checks only apply if non-default strides/wraps are defined.

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1548,13 +1548,7 @@ LogicalResult DMABDOp::verify() {
     return emitOpError(
         "BDs only support BufferOp or ExternalBufferOp operands.");
 
-  int32_t lenInBytes;
-  if (std::optional<int32_t> len = getLen(); len.has_value())
-    lenInBytes = *len * getBufferElementTypeWidthInBytes();
-  else
-    lenInBytes = getBuffer().getType().getNumElements() *
-                 getBufferElementTypeWidthInBytes();
-  if (lenInBytes % 4)
+  if (getLenInBytes() % 4)
     return emitOpError("transfer length must be multiple of 4B (32b)");
 
   if (getOperation()->getParentOfType<MemOp>()) {

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -359,12 +359,10 @@ void AIEDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "aie/Dialect/AIE/IR/AIEAttrs.cpp.inc"
-
       >();
   addOperations<
 #define GET_OP_LIST
 #include "aie/Dialect/AIE/IR/AIEOps.cpp.inc"
-
       >();
   addInterfaces<AIEInlinerInterface, AIEDialectFoldInterface>();
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -359,10 +359,12 @@ void AIEDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "aie/Dialect/AIE/IR/AIEAttrs.cpp.inc"
+
       >();
   addOperations<
 #define GET_OP_LIST
 #include "aie/Dialect/AIE/IR/AIEOps.cpp.inc"
+
       >();
   addInterfaces<AIEInlinerInterface, AIEDialectFoldInterface>();
 }
@@ -1623,10 +1625,11 @@ LogicalResult DMABDOp::verify() {
                            << std::to_string(buffer.getNumElements()) << ".";
     // If the bd_dim_layout array is "full" (len 4 for memtiles, len 3
     // otherwise), we check to make sure that the inner-most dim's stride is
-    // a multiple of 32/element_width (since the stream of stream width
-    // restrictions is that the inner-most stride is 32b). For example, for an
-    // i16 element width, stride must be k * (32 / 16) = k * 2, which means we
-    // stride 2*k i16 elements in the inner-most dimension.
+    // a multiple of 32/element_width (because of stream width restrictions that
+    // require the inner-most stride is >=32b). For example, for an i16 element
+    // width, stride must be k * (32 / 16) = k * 2, which means we stride 2*k
+    // i16 elements in the inner-most dimension.
+    //
     // See 3.7.1.2 Limitations of Address Generation in the spec
     // Note, in the context of compression this is no longer valid
     // (See 3.10.1.1 Limitations).

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -204,14 +204,6 @@ struct AIEObjectFifoStatefulTransformPass
     return !hasSharedMemory || atLeastOneConsumerWantsTransform;
   }
 
-  /// Function to multiply all dimensions of a memref.
-  int64_t getMemrefTypeSize(MemRefType memref) {
-    int64_t size = 1;
-    for (auto dim : memref.getShape())
-      size *= dim;
-    return size;
-  }
-
   /// Function to retrieve ObjectFifoLinkOp of ObjectFifoCreateOp,
   /// if it belongs to one.
   std::optional<ObjectFifoLinkOp> getOptionalLinkOp(ObjectFifoCreateOp op) {
@@ -325,14 +317,14 @@ struct AIEObjectFifoStatefulTransformPass
                               .getElemType()
                               .cast<AIEObjectFifoType>();
         auto elemInType = fifoInType.getElementType().cast<MemRefType>();
-        int inSize = getMemrefTypeSize(elemInType);
+        int inSize = elemInType.getNumElements();
 
         auto fifoOutType = linkOp->getOutputObjectFifos()[0]
                                .getElemType()
                                .cast<AIEObjectFifoType>();
         auto elemOutType = fifoOutType.getElementType().cast<MemRefType>();
 
-        if (int outSize = getMemrefTypeSize(elemOutType); inSize >= outSize) {
+        if (int outSize = elemOutType.getNumElements(); inSize >= outSize) {
           if (op.name() != fifoIn.name())
             return;
         } else {
@@ -474,11 +466,10 @@ struct AIEObjectFifoStatefulTransformPass
 
     int acqNum = 1;
     int relNum = 1;
-    int offset = 0;
 
     auto fifo = op.getElemType().cast<AIEObjectFifoType>();
     auto elemType = fifo.getElementType().cast<MemRefType>();
-    int len = getMemrefTypeSize(elemType);
+    int len = elemType.getNumElements();
 
     // search for the buffers/locks (based on if this objFifo has a link)
     ObjectFifoCreateOp target = op;
@@ -539,8 +530,8 @@ struct AIEObjectFifoStatefulTransformPass
 
       builder.setInsertionPointToStart(curr);
       createBdBlock<BufferOp>(builder, target, lockMode, acqNum, relNum,
-                              buffersPerFifo[target][blockIndex], offset, len,
-                              channelDir, blockIndex, succ, dims);
+                              buffersPerFifo[target][blockIndex], /*offset*/ 0,
+                              len, channelDir, blockIndex, succ, dims);
       curr = succ;
       blockIndex++;
     }
@@ -558,7 +549,6 @@ struct AIEObjectFifoStatefulTransformPass
 
     int acqNum = 1;
     int relNum = 1;
-    int offset = 0;
 
     // search for ShimDMAOp
     Operation *producerDMA = nullptr;
@@ -612,12 +602,12 @@ struct AIEObjectFifoStatefulTransformPass
         succ = builder.createBlock(endBlock);
 
       MemRefType buffer = externalBuffersPerFifo[op][blockIndex].getType();
-      int len = getMemrefTypeSize(buffer);
+      int len = buffer.getNumElements();
       builder.setInsertionPointToStart(curr);
       createBdBlock<ExternalBufferOp>(builder, op, lockMode, acqNum, relNum,
                                       externalBuffersPerFifo[op][blockIndex],
-                                      offset, len, channelDir, blockIndex, succ,
-                                      dims);
+                                      /*offset*/ 0, len, channelDir, blockIndex,
+                                      succ, dims);
       curr = succ;
       blockIndex++;
     }
@@ -633,11 +623,9 @@ struct AIEObjectFifoStatefulTransformPass
     if (numBlocks == 0)
       return;
 
-    int offset = 0;
     auto fifo = op.getElemType().cast<AIEObjectFifoType>();
     auto elemType = fifo.getElementType().cast<MemRefType>();
-    int lenOut = getMemrefTypeSize(elemType);
-    int bytes = elemType.getElementTypeBitWidth() / 8;
+    int lenOut = elemType.getNumElements();
     int acqNum = 1;
     int relNum = 1;
 
@@ -663,7 +651,7 @@ struct AIEObjectFifoStatefulTransformPass
               auto elemType = fifoType.getElementType().cast<MemRefType>();
               if (fifoIn.name() == op.name())
                 break;
-              extraOffset += getMemrefTypeSize(elemType);
+              extraOffset += elemType.getNumElements();
             }
           }
         } else if (linkOp->isDistribute()) {
@@ -678,7 +666,7 @@ struct AIEObjectFifoStatefulTransformPass
               auto elemType = fifoType.getElementType().cast<MemRefType>();
               if (fifoOut.name() == op.name())
                 break;
-              extraOffset += getMemrefTypeSize(elemType);
+              extraOffset += elemType.getNumElements();
             }
           }
         } else {
@@ -686,7 +674,7 @@ struct AIEObjectFifoStatefulTransformPass
             auto targetFifo = target.getElemType().cast<AIEObjectFifoType>();
             auto targetElemType =
                 targetFifo.getElementType().cast<MemRefType>();
-            lenOut = getMemrefTypeSize(targetElemType);
+            lenOut = targetElemType.getNumElements();
           }
         }
 
@@ -748,8 +736,9 @@ struct AIEObjectFifoStatefulTransformPass
         succ = builder.createBlock(endBlock);
 
       builder.setInsertionPointToStart(curr);
+      int offset = 0;
       if (isDistribute || isJoin)
-        offset = extraOffset * bytes;
+        offset = extraOffset;
       createBdBlock<BufferOp>(builder, target, lockMode, acqNum, relNum,
                               buffersPerFifo[target][blockIndex], offset,
                               lenOut, channelDir, blockIndex, succ, dims);

--- a/lib/Targets/AIETargetAirbin.cpp
+++ b/lib/Targets/AIETargetAirbin.cpp
@@ -598,9 +598,9 @@ static BDInfo getBDInfo(Block &block) {
     assert(op.getBufferOp().getAddress().has_value() &&
            "buffer op should have address");
     bdInfo.baseAddrA = op.getBufferOp().getAddress().value();
-    bdInfo.lenA = op.getLenIn32bWords() * 4;
+    bdInfo.lenA = op.getLenInBytes();
     bdInfo.bytesA = op.getBufferElementTypeWidthInBytes();
-    bdInfo.offsetA = op.getOffset() * 4;
+    bdInfo.offsetA = op.getOffsetInBytes();
     bdInfo.bufA = "XAIEDMA_TILE_BD_ADDRA";
     bdInfo.hasA = true;
   }

--- a/lib/Targets/AIETargetAirbin.cpp
+++ b/lib/Targets/AIETargetAirbin.cpp
@@ -81,7 +81,7 @@ static constexpr auto ME_SS_SLAVE_SLOT_BASE = 0x3F200u;
 /*
   Tile DMA
 */
-static constexpr auto ME_DMA_BD_COUNT = 16;
+static constexpr auto ME_DMA_BD_COUNT = 48;
 static constexpr auto ME_DMA_BD_SIZE = 0x20;
 
 struct MERegDMABD {
@@ -595,14 +595,12 @@ static BDInfo getBDInfo(Block &block) {
   BDInfo bdInfo;
   for (auto op : block.getOps<DMABDOp>()) {
     bdInfo.foundBD = true;
-    auto bufferType = op.getBuffer().getType().cast<::mlir::MemRefType>();
-
     assert(op.getBufferOp().getAddress().has_value() &&
            "buffer op should have address");
     bdInfo.baseAddrA = op.getBufferOp().getAddress().value();
-    bdInfo.lenA = op.getLenValue();
-    bdInfo.bytesA = bufferType.getElementTypeBitWidth() / 8u;
-    bdInfo.offsetA = op.getOffsetValue();
+    bdInfo.lenA = op.getLenIn32bWords() * 4;
+    bdInfo.bytesA = op.getBufferElementTypeWidthInBytes();
+    bdInfo.offsetA = op.getOffset() * 4;
     bdInfo.bufA = "XAIEDMA_TILE_BD_ADDRA";
     bdInfo.hasA = true;
   }

--- a/lib/Targets/AIETargetAirbin.cpp
+++ b/lib/Targets/AIETargetAirbin.cpp
@@ -81,7 +81,7 @@ static constexpr auto ME_SS_SLAVE_SLOT_BASE = 0x3F200u;
 /*
   Tile DMA
 */
-static constexpr auto ME_DMA_BD_COUNT = 48;
+static constexpr auto ME_DMA_BD_COUNT = 16;
 static constexpr auto ME_DMA_BD_SIZE = 0x20;
 
 struct MERegDMABD {

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -285,13 +285,13 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
   }
 
   std::optional<llvm::ArrayRef<BDDimLayoutAttr>> dims = bdOp.getDimensions();
-  int lenIn32bWords = bdOp.getLenIn32bWords();
-  int basePlusOffsetInBytes = baseAddr + (bdOp.getOffsetIn32bWords() * 4);
+  int lenInBytes = bdOp.getLenInBytes();
+  int basePlusOffsetInBytes = baseAddr + bdOp.getOffsetInBytes();
   if (basePlusOffsetInBytes % 4)
     return bdOp.emitOpError("bd address must be 4B (32b) aligned");
   if (!dims) {
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAddrLen, &dmaTileBd,
-                            basePlusOffsetInBytes, lenIn32bWords);
+                            basePlusOffsetInBytes, lenInBytes);
   } else {
     XAie_DmaTensor dmaTileBdTensor = {};
     dmaTileBdTensor.NumDim = dims->size();
@@ -310,7 +310,7 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
     }
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetMultiDimAddr, &dmaTileBd,
                             &dmaTileBdTensor, basePlusOffsetInBytes,
-                            lenIn32bWords);
+                            lenInBytes);
   }
 
   if (nextBdId) {

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -299,7 +299,7 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
         calloc(dims->size(), sizeof(XAie_DmaDimDesc)));
     if (!dmaTileBdTensor.Dim)
       return bdOp.emitError("couldn't allocate array of XAie_DmaDimDesc");
-    // libxaie denominates these in 32b
+    // libxaie requires stride in multiples of 32b
     double elementWidthIn32bWords =
         static_cast<double>(bdOp.getBufferElementTypeWidthInBytes()) / 4.0;
     for (size_t i = 0; i < dims->size(); i++) {

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -273,26 +273,25 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
                             qOs, cache, secure);
   }
 
-  // deref here because this is a const iter and the various getters below
-  // aren't const (even though they probably should be...)
   // StringRef FifoMode = disable; // FIXME: when to enable FIFO mode?
-  ShapedType bufferType = bdOp.getBuffer().getType().cast<::mlir::MemRefType>();
-  int bytes = bufferType.getElementTypeBitWidth() / 8;
   int baseAddr = 0;
   if (!targetModel.isShimNOCTile(tileLoc.Col, tileLoc.Row)) {
     auto bufferOp = cast<AIE::BufferOp>(bdOp.getBuffer().getDefiningOp());
-    assert(bufferOp.getAddress().has_value() && "buffer must have address");
+    if (!bufferOp.getAddress())
+      return bufferOp.emitError("buffer must have address assigned");
     baseAddr = bufferOp.getAddress().value();
     if (targetModel.isMemTile(tileLoc.Col, tileLoc.Row))
       baseAddr += BASE_ADDR_A_INCR;
   }
 
   std::optional<llvm::ArrayRef<BDDimLayoutAttr>> dims = bdOp.getDimensions();
-  int lenInBytes = bdOp.getLenValue() * bytes;
-  int basePlusOffset = baseAddr + bdOp.getOffsetValue();
+  int lenIn32bWords = bdOp.getLenIn32bWords();
+  int basePlusOffsetInBytes = baseAddr + (bdOp.getOffsetIn32bWords() * 4);
+  if (basePlusOffsetInBytes % 4)
+    return bdOp.emitOpError("bd address must be 4B (32b) aligned");
   if (!dims) {
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAddrLen, &dmaTileBd,
-                            basePlusOffset, lenInBytes);
+                            basePlusOffsetInBytes, lenIn32bWords);
   } else {
     XAie_DmaTensor dmaTileBdTensor = {};
     dmaTileBdTensor.NumDim = dims->size();
@@ -300,21 +299,18 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
         calloc(dims->size(), sizeof(XAie_DmaDimDesc)));
     if (!dmaTileBdTensor.Dim)
       return bdOp.emitError("couldn't allocate array of XAie_DmaDimDesc");
-    // TODO(max): rethink this?
     for (size_t i = 0; i < dims->size(); i++) {
       // Pass down dimensions in reverse order; in the MLIR, this allows
       // us to specify step sizes/wraps in the same order as we would
       // access a multi-dim C array, with the highest dimension first.
       int j = dims->size() - i - 1;
       // Assume AIE-ML architecture; we assert this above
-      // TODO(max): no we don't
       dmaTileBdTensor.Dim[j].AieMlDimDesc = {dims.value()[i].getStride(),
                                              dims.value()[i].getSize()};
     }
-    // TODO: Probably need special handling for NOC
-    // TODO: Might need to adjust step sizes / wraps by -1
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetMultiDimAddr, &dmaTileBd,
-                            &dmaTileBdTensor, basePlusOffset, lenInBytes);
+                            &dmaTileBdTensor, basePlusOffsetInBytes,
+                            lenIn32bWords);
   }
 
   if (nextBdId) {
@@ -324,8 +320,9 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
   }
 
   if (packetID) {
-    assert(packetType && "must have packetType with packetID");
-    if (bdOp.getLenValue() == 0)
+    if (!packetType)
+      bdOp.emitError("must have packetType with packetID");
+    if (bdOp.getLen() == 0)
       return bdOp.emitOpError(
           "For MM2S channels, if Buffer_Length=0 then Enable_Packet must be "
           "set to 0, otherwise behavior is undefined (3.7.8 arch spec)");

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -299,13 +299,17 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
         calloc(dims->size(), sizeof(XAie_DmaDimDesc)));
     if (!dmaTileBdTensor.Dim)
       return bdOp.emitError("couldn't allocate array of XAie_DmaDimDesc");
+    // libxaie denominates these in 32b
+    uint16_t elementWidthIn32bWords =
+        bdOp.getBufferElementTypeWidthInBytes() / 4;
     for (size_t i = 0; i < dims->size(); i++) {
       // Pass down dimensions in reverse order; in the MLIR, this allows
       // us to specify step sizes/wraps in the same order as we would
       // access a multi-dim C array, with the highest dimension first.
       int j = dims->size() - i - 1;
       // Assume AIE-ML architecture; we assert this above
-      dmaTileBdTensor.Dim[j].AieMlDimDesc = {dims.value()[i].getStride(),
+      dmaTileBdTensor.Dim[j].AieMlDimDesc = {dims.value()[i].getStride() *
+                                                 elementWidthIn32bWords,
                                              dims.value()[i].getSize()};
     }
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetMultiDimAddr, &dmaTileBd,

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -300,17 +300,18 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
     if (!dmaTileBdTensor.Dim)
       return bdOp.emitError("couldn't allocate array of XAie_DmaDimDesc");
     // libxaie denominates these in 32b
-    uint16_t elementWidthIn32bWords =
-        bdOp.getBufferElementTypeWidthInBytes() / 4;
+    double elementWidthIn32bWords =
+        static_cast<double>(bdOp.getBufferElementTypeWidthInBytes()) / 4.0;
     for (size_t i = 0; i < dims->size(); i++) {
       // Pass down dimensions in reverse order; in the MLIR, this allows
       // us to specify step sizes/wraps in the same order as we would
       // access a multi-dim C array, with the highest dimension first.
       int j = dims->size() - i - 1;
       // Assume AIE-ML architecture; we assert this above
-      dmaTileBdTensor.Dim[j].AieMlDimDesc = {dims.value()[i].getStride() *
-                                                 elementWidthIn32bWords,
-                                             dims.value()[i].getSize()};
+      dmaTileBdTensor.Dim[j].AieMlDimDesc = {
+          static_cast<uint32_t>(dims.value()[i].getStride() *
+                                elementWidthIn32bWords),
+          dims.value()[i].getSize()};
     }
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetMultiDimAddr, &dmaTileBd,
                             &dmaTileBdTensor, basePlusOffsetInBytes,

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -287,8 +287,6 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
   std::optional<llvm::ArrayRef<BDDimLayoutAttr>> dims = bdOp.getDimensions();
   int lenInBytes = bdOp.getLenInBytes();
   int basePlusOffsetInBytes = baseAddr + bdOp.getOffsetInBytes();
-  if (basePlusOffsetInBytes % 4)
-    return bdOp.emitOpError("bd address must be 4B (32b) aligned");
   if (!dims) {
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAddrLen, &dmaTileBd,
                             basePlusOffsetInBytes, lenInBytes);
@@ -319,7 +317,6 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
                                      elementWidthIn32bWords);
       }
       stride = stride > 0 ? stride : 1;
-      std::cerr << "stride: " << stride << "\n";
       // Assume AIE-ML architecture (ie use AieMlDimDesc instead of AieDimDesc);
       // asserted in AIETranslateToCDODirect).
       dmaTileBdTensor.Dim[j].AieMlDimDesc = {stride, size};

--- a/lib/Targets/AIETargetShared.cpp
+++ b/lib/Targets/AIETargetShared.cpp
@@ -87,7 +87,9 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
                                     ArrayRef<BDDimLayoutAttr> dims, int col,
                                     int row, int bdNum, int baseAddrA,
                                     int offsetA, int lenA,
+                                    int elementWidthInBytes,
                                     const char *errorRetval) {
+  uint16_t elementWidthIn32bWords = elementWidthInBytes / 4;
   std::string tensor = tileDMATensorStr(col, row, bdNum);
   output << "XAie_DmaTensor " << tensor << " = {};\n";
   output << tensor << ".NumDim = " << std::to_string(ndims) << ";\n";
@@ -105,7 +107,8 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
     int j = ndims - i - 1;
     // Assume AIE-ML architecture; we assert this above
     output << tensor << ".Dim[" << std::to_string(j) << "].AieMlDimDesc"
-           << " = { /* StepSize */ " << std::to_string(dims[i].getStride())
+           << " = { /* StepSize */ "
+           << std::to_string(dims[i].getStride() * elementWidthIn32bWords)
            << ", /* Size */ " << std::to_string(dims[i].getSize()) << "};\n";
   }
   if ((baseAddrA + offsetA) % 4)

--- a/lib/Targets/AIETargetShared.cpp
+++ b/lib/Targets/AIETargetShared.cpp
@@ -86,7 +86,7 @@ static std::string tileDMATensorStr(int col, int row, int bdNum) {
 void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
                                     ArrayRef<BDDimLayoutAttr> dims, int col,
                                     int row, int bdNum, int baseAddrA,
-                                    int offsetA, int lenA, int bytesA,
+                                    int offsetA, int lenA,
                                     const char *errorRetval) {
   std::string tensor = tileDMATensorStr(col, row, bdNum);
   output << "XAie_DmaTensor " << tensor << " = {};\n";
@@ -108,11 +108,13 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
            << " = { /* StepSize */ " << std::to_string(dims[i].getStride())
            << ", /* Size */ " << std::to_string(dims[i].getSize()) << "};\n";
   }
+  if ((baseAddrA + offsetA) % 4)
+    llvm::report_fatal_error("bd address must be 4B (32b) aligned");
   output << "__mlir_aie_try(XAie_DmaSetMultiDimAddr("
          << tileDMAInstRefStr(col, row, bdNum) << ", "
          << "&" << tensor << ", "
          << "0x" << llvm::utohexstr(baseAddrA + offsetA) << ", "
-         << " /* len */ " << lenA << " * " << bytesA << "));\n";
+         << " /* len */ " << lenA << "));\n";
   // TODO: Probably need special handling for NOC
   // TODO: Might need to adjust strides / sizes by -1
 }

--- a/lib/Targets/AIETargetShared.cpp
+++ b/lib/Targets/AIETargetShared.cpp
@@ -108,7 +108,7 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
     // Pass down dimensions in reverse order; in the MLIR, this allows us
     // to specify strides/sizes in the same order as we would access a
     // multi-dim C array, with the highest dimension first.
-    int j = ndims - i - 1;
+    int j = dims.size() - i - 1;
     if (j > 0) {
       stride =
           static_cast<uint32_t>(dims[i].getStride() * elementWidthIn32bWords);
@@ -123,11 +123,6 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
            << " = { /* Stride */ " << std::to_string(stride) << ", /* Size */ "
            << std::to_string(size) << "};\n";
   }
-  for (int i = dims.size(); i < ndims; i++) {
-    int j = ndims - i - 1;
-    output << tensor << ".Dim[" << std::to_string(j) << "].AieMlDimDesc"
-           << " = { /* Stride */ 1, /* Size */ 0};\n";
-  }
   if ((baseAddrA + offsetA) % 4)
     llvm::report_fatal_error("bd address must be 4B (32b) aligned");
   output << "__mlir_aie_try(XAie_DmaSetMultiDimAddr("
@@ -135,8 +130,6 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
          << "&" << tensor << ", "
          << "0x" << llvm::utohexstr(baseAddrA + offsetA) << ", "
          << " /* len */ " << lenA << "));\n";
-  // TODO: Probably need special handling for NOC
-  // TODO: Might need to adjust strides / sizes by -1
 }
 
 } // namespace xilinx::AIE

--- a/lib/Targets/AIETargetShared.cpp
+++ b/lib/Targets/AIETargetShared.cpp
@@ -89,6 +89,7 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
                                     int offsetA, int lenA,
                                     int elementWidthInBytes,
                                     const char *errorRetval) {
+  // libxaie requires stride in multiples of 32b
   double elementWidthIn32bWords =
       static_cast<double>(elementWidthInBytes) / 4.0;
   std::string tensor = tileDMATensorStr(col, row, bdNum);

--- a/lib/Targets/AIETargetShared.cpp
+++ b/lib/Targets/AIETargetShared.cpp
@@ -89,7 +89,8 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
                                     int offsetA, int lenA,
                                     int elementWidthInBytes,
                                     const char *errorRetval) {
-  uint16_t elementWidthIn32bWords = elementWidthInBytes / 4;
+  double elementWidthIn32bWords =
+      static_cast<double>(elementWidthInBytes) / 4.0;
   std::string tensor = tileDMATensorStr(col, row, bdNum);
   output << "XAie_DmaTensor " << tensor << " = {};\n";
   output << tensor << ".NumDim = " << std::to_string(ndims) << ";\n";
@@ -108,7 +109,8 @@ void generateXAieDmaSetMultiDimAddr(raw_ostream &output, int ndims,
     // Assume AIE-ML architecture; we assert this above
     output << tensor << ".Dim[" << std::to_string(j) << "].AieMlDimDesc"
            << " = { /* StepSize */ "
-           << std::to_string(dims[i].getStride() * elementWidthIn32bWords)
+           << std::to_string(static_cast<uint32_t>(dims[i].getStride() *
+                                                   elementWidthIn32bWords))
            << ", /* Size */ " << std::to_string(dims[i].getSize()) << "};\n";
   }
   if ((baseAddrA + offsetA) % 4)

--- a/lib/Targets/AIETargetShared.h
+++ b/lib/Targets/AIETargetShared.h
@@ -34,7 +34,7 @@ std::string packetStr(int id, int type);
 void generateXAieDmaSetMultiDimAddr(llvm::raw_ostream &output, int ndims,
                                     llvm::ArrayRef<BDDimLayoutAttr> dims,
                                     int col, int row, int bdNum, int baseAddrA,
-                                    int offsetA, int lenA, int bytesA,
+                                    int offsetA, int lenA,
                                     const char *errorRet);
 
 } // namespace AIE

--- a/lib/Targets/AIETargetShared.h
+++ b/lib/Targets/AIETargetShared.h
@@ -35,6 +35,7 @@ void generateXAieDmaSetMultiDimAddr(llvm::raw_ostream &output, int ndims,
                                     llvm::ArrayRef<BDDimLayoutAttr> dims,
                                     int col, int row, int bdNum, int baseAddrA,
                                     int offsetA, int lenA,
+                                    int elementWidthInBytes,
                                     const char *errorRet);
 
 } // namespace AIE

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -91,6 +91,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
     int lenA = 0;
     int offsetA = 0;
     int BaseAddrA = 0;
+    int elementWidthInBytes = 0;
     int ndims = 0;
     ArrayRef<BDDimLayoutAttr> dims;
     //      StringRef FifoMode = disable; // FIXME: when to enable FIFO mode?
@@ -116,6 +117,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
 
       lenA = op.getLenInBytes();
       offsetA = op.getOffsetInBytes();
+      elementWidthInBytes = op.getBufferElementTypeWidthInBytes();
       if ((BaseAddrA + offsetA) % 4)
         return op.emitOpError("bd address must be 4B (32b) aligned");
 
@@ -216,7 +218,8 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
         }
       } else
         generateXAieDmaSetMultiDimAddr(output, ndims, dims, col, row, bdNum,
-                                       BaseAddrA, offsetA, lenA, "1");
+                                       BaseAddrA, offsetA, lenA,
+                                       elementWidthInBytes, "1");
 
       if (block.getNumSuccessors() > 0) {
         Block *nextBlock = block.getSuccessors()[0]; // should have only one

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -118,9 +118,6 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
       lenA = op.getLenInBytes();
       offsetA = op.getOffsetInBytes();
       elementWidthInBytes = op.getBufferElementTypeWidthInBytes();
-      if ((BaseAddrA + offsetA) % 4)
-        return op.emitOpError("bd address must be 4B (32b) aligned");
-
       if (op.getDimensions()) {
         dims = *op.getDimensions();
         ndims = dims.size();

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -114,8 +114,8 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
         }
       }
 
-      lenA = op.getLenIn32bWords() * 4;
-      offsetA = op.getOffsetIn32bWords() * 4;
+      lenA = op.getLenInBytes();
+      offsetA = op.getOffsetInBytes();
       if ((BaseAddrA + offsetA) % 4)
         return op.emitOpError("bd address must be 4B (32b) aligned");
 
@@ -547,7 +547,7 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
           blockMap[&block] = bdNum;
           uint64_t offset = 0;
           for (auto op : block.getOps<DMABDOp>()) {
-            offset = op.getOffsetIn32bWords() * 4;
+            offset = op.getOffsetInBytes();
             auto buffer =
                 cast<ExternalBufferOp>(op.getBuffer().getDefiningOp());
 

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -123,7 +123,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
 
       if (op.getDimensions()) {
         dims = *op.getDimensions();
-        ndims = dims.size();
+        ndims = targetModel.isMemTile(col, row) ? 4 : 3;
       }
     }
 

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -123,7 +123,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
 
       if (op.getDimensions()) {
         dims = *op.getDimensions();
-        ndims = targetModel.isMemTile(col, row) ? 4 : 3;
+        ndims = dims.size();
       }
     }
 

--- a/lib/Targets/CMakeLists.txt
+++ b/lib/Targets/CMakeLists.txt
@@ -7,9 +7,7 @@
 
 add_subdirectory(AIEVecToCpp)
 
-set(LLVM_OPTIONAL_SOURCES AIETargetAirbin.cpp)
-
-set(_sources
+add_mlir_library(AIETargets
   AIETargets.cpp
   AIETargetBCF.cpp
   AIETargetCDODirect.cpp
@@ -21,15 +19,8 @@ set(_sources
   ADFGenerateCppGraph.cpp
   AIEFlowsToJSON.cpp
   AIELLVMLink.cpp
-)
 
-if(AIE_ENABLE_AIRBIN)
-  list(APPEND _sources AIETargetAirbin.cpp)
-endif()
-
-add_mlir_library(AIETargets
-  ${_sources}
-
+  PARTIAL_SOURCES_INTENDED
   ENABLE_AGGREGATION
 
   ADDITIONAL_HEADER_DIRS
@@ -55,6 +46,26 @@ add_mlir_library(AIETargets
   ADF
 )
 
+if(AIE_ENABLE_AIRBIN)
+  add_mlir_library(AIETargetAirbin
+    AIETargetAirbin.cpp
+
+    PARTIAL_SOURCES_INTENDED
+
+    LINK_COMPONENTS
+    Support
+
+    LINK_LIBS PRIVATE
+    elf
+
+    LINK_LIBS PUBLIC
+    AIE
+    AIEX
+  )
+  target_link_libraries(AIETargets PUBLIC AIETargetAirbin)
+  target_compile_definitions(obj.AIETargets PRIVATE AIE_ENABLE_AIRBIN)
+endif()
+
 target_link_libraries(AIETargets PRIVATE xaienginecdo_static)
 add_dependencies(obj.AIETargets xaienginecdo_static xaienginecdo_static-headers)
 # for #include <elf.h>
@@ -62,7 +73,3 @@ set(BOOTGEN_SOURCE_DIR ${PROJECT_SOURCE_DIR}/third_party/bootgen)
 target_include_directories(AIETargets SYSTEM PRIVATE ${BOOTGEN_SOURCE_DIR})
 target_include_directories(obj.AIETargets SYSTEM PRIVATE ${BOOTGEN_SOURCE_DIR})
 
-if(AIE_ENABLE_AIRBIN)
-  target_link_libraries(AIETargets PRIVATE elf)
-  target_compile_definitions(obj.AIETargets PRIVATE AIE_ENABLE_AIRBIN)
-endif()

--- a/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
@@ -91,9 +91,9 @@ def my_matmul():
                 2,
                 memref_a_ty,
                 [
-                    (m // r, r * k * word_size_in // 2),
-                    (k // s, s * word_size_in // 2),
-                    (r, k * word_size_in // 2),
+                    (m // r, r * k),
+                    (k // s, s),
+                    (r, k),
                     (s * word_size_in // 4, 2),
                 ],
             )
@@ -108,9 +108,9 @@ def my_matmul():
                 2,
                 memref_b_ty,
                 [
-                    (k // s, s * n * word_size_in // 2),
-                    (n // t, t * word_size_in // 2),
-                    (s, n * word_size_in // 2),
+                    (k // s, s * n),
+                    (n // t, t),
+                    (s, n),
                     (t * word_size_in // 4, 2),
                 ],
             )

--- a/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
@@ -94,7 +94,7 @@ def my_matmul():
                     (m // r, r * k),
                     (k // s, s),
                     (r, k),
-                    (s * word_size_in // 4, 2),
+                    (s, 1),
                 ],
             )
             object_fifo_link(inA, memA)
@@ -111,7 +111,7 @@ def my_matmul():
                     (k // s, s * n),
                     (n // t, t),
                     (s, n),
-                    (t * word_size_in // 4, 2),
+                    (t, 1),
                 ],
             )
             object_fifo_link(inB, memB)
@@ -125,10 +125,10 @@ def my_matmul():
                 2,
                 memref_c_ty,
                 [
-                    (m // r, r * n * word_size_out // 2),
-                    (r, t * word_size_out // 2),
-                    (n // t, r * t * word_size_out // 2),
-                    (t * word_size_out // 4, 2),
+                    (m // r, r * n),
+                    (r, t),
+                    (n // t, r * t),
+                    (t, 1),
                 ],
             )
             object_fifo_link(memC, outC)

--- a/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication/aie2.py
@@ -91,10 +91,10 @@ def my_matmul():
                 2,
                 memref_a_ty,
                 [
-                    (m // r, r * k * word_size_in // 4),
-                    (k // s, s * word_size_in // 4),
-                    (r, k * word_size_in // 4),
-                    (s * word_size_in // 4, 1),
+                    (m // r, r * k * word_size_in // 2),
+                    (k // s, s * word_size_in // 2),
+                    (r, k * word_size_in // 2),
+                    (s * word_size_in // 4, 2),
                 ],
             )
             object_fifo_link(inA, memA)
@@ -108,10 +108,10 @@ def my_matmul():
                 2,
                 memref_b_ty,
                 [
-                    (k // s, s * n * word_size_in // 4),
-                    (n // t, t * word_size_in // 4),
-                    (s, n * word_size_in // 4),
-                    (t * word_size_in // 4, 1),
+                    (k // s, s * n * word_size_in // 2),
+                    (n // t, t * word_size_in // 2),
+                    (s, n * word_size_in // 2),
+                    (t * word_size_in // 4, 2),
                 ],
             )
             object_fifo_link(inB, memB)
@@ -125,10 +125,10 @@ def my_matmul():
                 2,
                 memref_c_ty,
                 [
-                    (m // r, r * n * word_size_out // 4),
-                    (r, t * word_size_out // 4),
-                    (n // t, r * t * word_size_out // 4),
-                    (t * word_size_out // 4, 1),
+                    (m // r, r * n * word_size_out // 2),
+                    (r, t * word_size_out // 2),
+                    (n // t, r * t * word_size_out // 2),
+                    (t * word_size_out // 4, 2),
                 ],
             )
             object_fifo_link(memC, outC)

--- a/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
@@ -197,10 +197,10 @@ def my_matmul(M=512, K=512, N=512):
                     2,
                     memRef_A_ty,
                     [
-                        (m // r, r * k * word_size_in // 4),
-                        (k // s, s * word_size_in // 4),
-                        (r, k * word_size_in // 4),
-                        (s * word_size_in // 4, 1),
+                        (m // r, r * k * word_size_in // 2),
+                        (k // s, s * word_size_in // 2),
+                        (r, k * word_size_in // 2),
+                        (s * word_size_in // 4, 2),
                     ],
                 )
                 object_fifo_link(inA_fifo_names[i], memA_fifo_names[i])
@@ -221,10 +221,10 @@ def my_matmul(M=512, K=512, N=512):
                     2,
                     memRef_B_ty,
                     [
-                        (k // s, s * n * word_size_in // 4),
-                        (n // t, t * word_size_in // 4),
-                        (s, n * word_size_in // 4),
-                        (t * word_size_in // 4, 1),
+                        (k // s, s * n * word_size_in // 2),
+                        (n // t, t * word_size_in // 2),
+                        (s, n * word_size_in // 2),
+                        (t * word_size_in // 4, 2),
                     ],
                 )
                 object_fifo_link(inB_fifo_names[i], memB_fifo_names[i])
@@ -246,10 +246,10 @@ def my_matmul(M=512, K=512, N=512):
                     2,
                     memRef_outC_ty,
                     [
-                        (m // r, r * n * word_size_out // 4),
-                        (r, t * word_size_out // 4),
-                        (n // t, r * t * word_size_out // 4),
-                        (t * word_size_out // 4, 1),
+                        (m // r, r * n * word_size_out // 2),
+                        (r, t * word_size_out // 2),
+                        (n // t, r * t * word_size_out // 2),
+                        (t * word_size_out // 4, 2),
                     ],
                 )
                 object_fifo_link(memC_fifo_names[i], outC_fifo_names[i])

--- a/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
@@ -200,7 +200,7 @@ def my_matmul(M=512, K=512, N=512):
                         (m // r, r * k),
                         (k // s, s),
                         (r, k),
-                        (s * word_size_in // 4, 2),
+                        (s, 1),
                     ],
                 )
                 object_fifo_link(inA_fifo_names[i], memA_fifo_names[i])
@@ -224,7 +224,7 @@ def my_matmul(M=512, K=512, N=512):
                         (k // s, s * n),
                         (n // t, t),
                         (s, n),
-                        (t * word_size_in // 4, 2),
+                        (t, 1),
                     ],
                 )
                 object_fifo_link(inB_fifo_names[i], memB_fifo_names[i])
@@ -246,10 +246,10 @@ def my_matmul(M=512, K=512, N=512):
                     2,
                     memRef_outC_ty,
                     [
-                        (m // r, r * n * word_size_out // 2),
-                        (r, t * word_size_out // 2),
-                        (n // t, r * t * word_size_out // 2),
-                        (t * word_size_out // 4, 2),
+                        (m // r, r * n),
+                        (r, t),
+                        (n // t, r * t),
+                        (t, 1),
                     ],
                 )
                 object_fifo_link(memC_fifo_names[i], outC_fifo_names[i])

--- a/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
@@ -197,9 +197,9 @@ def my_matmul(M=512, K=512, N=512):
                     2,
                     memRef_A_ty,
                     [
-                        (m // r, r * k * word_size_in // 2),
-                        (k // s, s * word_size_in // 2),
-                        (r, k * word_size_in // 2),
+                        (m // r, r * k),
+                        (k // s, s),
+                        (r, k),
                         (s * word_size_in // 4, 2),
                     ],
                 )
@@ -221,9 +221,9 @@ def my_matmul(M=512, K=512, N=512):
                     2,
                     memRef_B_ty,
                     [
-                        (k // s, s * n * word_size_in // 2),
-                        (n // t, t * word_size_in // 2),
-                        (s, n * word_size_in // 2),
+                        (k // s, s * n),
+                        (n // t, t),
+                        (s, n),
                         (t * word_size_in // 4, 2),
                     ],
                 )

--- a/reference_designs/ipu-xrt/matrix_multiplication_column/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication_column/aie2.py
@@ -105,7 +105,7 @@ def my_matmul():
                         (m // r, r * k),
                         (k // s, s),
                         (r, k),
-                        (s * word_size_in // 4, 2),
+                        (s, 1),
                     ],
                 )
             object_fifo_link(inA, inA_fifo_names[0:n_cores])
@@ -122,7 +122,7 @@ def my_matmul():
                     (k // s, s * n),
                     (n // t, t),
                     (s, n),
-                    (t * word_size_in // 4, 2),
+                    (t, 1),
                 ],
             )
             object_fifo_link(inB, [inB_fifo_names[0]])
@@ -139,10 +139,10 @@ def my_matmul():
                 2,
                 memRef_outC_ty,
                 [
-                    (m // r, r * n * word_size_out // 4),
-                    (r, t * word_size_out // 4),
-                    (n // t, r * t * word_size_out // 4),
-                    (t * word_size_out // 4, 1),
+                    (m // r, r * n),
+                    (r, t),
+                    (n // t, r * t),
+                    (t, 1),
                 ],
             )
             object_fifo_link(outC_fifo_names[0:n_cores], outC)

--- a/reference_designs/ipu-xrt/matrix_multiplication_column/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication_column/aie2.py
@@ -102,10 +102,10 @@ def my_matmul():
                     2,
                     memRef_A_ty,
                     [
-                        (m // r, r * k * word_size_in // 4),
-                        (k // s, s * word_size_in // 4),
-                        (r, k * word_size_in // 4),
-                        (s * word_size_in // 4, 1),
+                        (m // r, r * k * word_size_in // 2),
+                        (k // s, s * word_size_in // 2),
+                        (r, k * word_size_in // 2),
+                        (s * word_size_in // 4, 2),
                     ],
                 )
             object_fifo_link(inA, inA_fifo_names[0:n_cores])
@@ -119,10 +119,10 @@ def my_matmul():
                 2,
                 memRef_B_ty,
                 [
-                    (k // s, s * n * word_size_in // 4),
-                    (n // t, t * word_size_in // 4),
-                    (s, n * word_size_in // 4),
-                    (t * word_size_in // 4, 1),
+                    (k // s, s * n * word_size_in // 2),
+                    (n // t, t * word_size_in // 2),
+                    (s, n * word_size_in // 2),
+                    (t * word_size_in // 4, 2),
                 ],
             )
             object_fifo_link(inB, [inB_fifo_names[0]])

--- a/reference_designs/ipu-xrt/matrix_multiplication_column/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication_column/aie2.py
@@ -102,9 +102,9 @@ def my_matmul():
                     2,
                     memRef_A_ty,
                     [
-                        (m // r, r * k * word_size_in // 2),
-                        (k // s, s * word_size_in // 2),
-                        (r, k * word_size_in // 2),
+                        (m // r, r * k),
+                        (k // s, s),
+                        (r, k),
                         (s * word_size_in // 4, 2),
                     ],
                 )
@@ -119,9 +119,9 @@ def my_matmul():
                 2,
                 memRef_B_ty,
                 [
-                    (k // s, s * n * word_size_in // 2),
-                    (n // t, t * word_size_in // 2),
-                    (s, n * word_size_in // 2),
+                    (k // s, s * n),
+                    (n // t, t),
+                    (s, n),
                     (t * word_size_in // 4, 2),
                 ],
             )

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
@@ -103,9 +103,8 @@ def my_matmul():
                     2,
                     memRef_A_ty,
                     [
-                        (k_in_i32s, 2),
-                        (m, k_in_i32s * 2),
-                        (1, 2),
+                        (m, k),
+                        (k, 1),
                     ],
                 )
                 object_fifo_link(

--- a/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_vector_multiplication/aie2.py
@@ -103,9 +103,9 @@ def my_matmul():
                     2,
                     memRef_A_ty,
                     [
-                        (k_in_i32s, 1),
-                        (m, k_in_i32s),
-                        (1, 1),
+                        (k_in_i32s, 2),
+                        (m, k_in_i32s * 2),
+                        (1, 2),
                     ],
                 )
                 object_fifo_link(

--- a/test/Passes/assign-bd-ids/bad_bd_assignments.mlir
+++ b/test/Passes/assign-bd-ids/bad_bd_assignments.mlir
@@ -1,0 +1,128 @@
+//===- bad_bd_assignments.mlir.mlir ----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --verify-diagnostics --split-input-file %s
+
+module {
+  aie.device(ipu) {
+    %tile_0_2 = aie.tile(0, 2)
+    %double_buffer = aie.buffer(%tile_0_2) : memref<32xi32>
+    %lock_Y = aie.lock(%tile_0_2) {init = 0 : i32}
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %player_a = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_Y, Acquire, 0)
+        // expected-error@+1 {{'aie.dma_bd' op bdId attribute exceeds max: 15}}
+        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 16 : i32, next_bd_id = 1 : i32}
+        aie.use_lock(%lock_Y, Release, 0)
+      }]
+      aie.end
+    }
+  }
+}
+
+// -----
+
+module {
+  aie.device(ipu) {
+    %tile_0_2 = aie.tile(0, 2)
+    %double_buffer = aie.buffer(%tile_0_2) : memref<32xi32>
+    %lock_X = aie.lock(%tile_0_2) {init = 0 : i32}
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %player_a = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_X, Acquire, 1)
+        // expected-error@+1 {{'aie.dma_bd' op nextBdId attribute exceeds max: 15}}
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 16 : i32}
+        aie.use_lock(%lock_X, Release, -1)
+      }]
+      aie.end
+    }
+  }
+}
+
+// -----
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %buffer_0_1 = aie.buffer(%tile_0_1) : memref<32xi32>
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        // expected-error@+1 {{'aie.dma_bd' op bdId attribute exceeds max: 47}}
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>) {bd_id = 48 : i32, next_bd_id = 1 : i32}
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+// -----
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %buffer_0_1 = aie.buffer(%tile_0_1) : memref<32xi32>
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        // expected-error@+1 {{'aie.dma_bd' op nextBdId attribute exceeds max: 47}}
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 48 : i32}
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+
+// -----
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %buffer_0_1 = aie.buffer(%tile_0_1) : memref<32xi32>
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        // expected-error@+1 {{'aie.dma_bd' op nextBdId attribute exceeds max: 47}}
+        aie.dma_bd(%buffer_0_1 : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 48 : i32}
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+// -----
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %buffer_0_1 = aie.buffer(%tile_0_1) : memref<128xi16>
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        // expected-error@+1 {{'aie.dma_bd' op transfer length must be multiple of 4 (i.e., represent 4 byte aligned address)}}
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 0, 129)
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}

--- a/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
@@ -19,7 +19,7 @@
 // CHECK: dma_tile_2_1_bd_0_tensor.Dim[2].AieMlDimDesc = { /* StepSize */ 2, /* Size */ 3};
 // CHECK: dma_tile_2_1_bd_0_tensor.Dim[1].AieMlDimDesc = { /* StepSize */ 4, /* Size */ 2};
 // CHECK: dma_tile_2_1_bd_0_tensor.Dim[0].AieMlDimDesc = { /* StepSize */ 1, /* Size */ 1};
-// CHECK: __mlir_aie_try(XAie_DmaSetMultiDimAddr(&(dma_tile21_bd0), &dma_tile_2_1_bd_0_tensor, 0x82000,  /* len */ 128 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetMultiDimAddr(&(dma_tile21_bd0), &dma_tile_2_1_bd_0_tensor, 0x82000,  /* len */ 512));
 
 module @aie_module  {
  aie.device(xcve2302) {

--- a/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
@@ -15,10 +15,10 @@
 // CHECK: if(NULL == dma_tile_2_1_bd_0_tensor.Dim){
 // CHECK:   return 1;
 // CHECK: }
-// CHECK: dma_tile_2_1_bd_0_tensor.Dim[3].AieMlDimDesc = { /* StepSize */ 1, /* Size */ 2};
-// CHECK: dma_tile_2_1_bd_0_tensor.Dim[2].AieMlDimDesc = { /* StepSize */ 2, /* Size */ 3};
-// CHECK: dma_tile_2_1_bd_0_tensor.Dim[1].AieMlDimDesc = { /* StepSize */ 4, /* Size */ 2};
-// CHECK: dma_tile_2_1_bd_0_tensor.Dim[0].AieMlDimDesc = { /* StepSize */ 1, /* Size */ 1};
+// CHECK: dma_tile_2_1_bd_0_tensor.Dim[3].AieMlDimDesc = { /* Stride */ 1, /* Size */ 2};
+// CHECK: dma_tile_2_1_bd_0_tensor.Dim[2].AieMlDimDesc = { /* Stride */ 2, /* Size */ 3};
+// CHECK: dma_tile_2_1_bd_0_tensor.Dim[1].AieMlDimDesc = { /* Stride */ 4, /* Size */ 2};
+// CHECK: dma_tile_2_1_bd_0_tensor.Dim[0].AieMlDimDesc = { /* Stride */ 1, /* Size */ 1};
 // CHECK: __mlir_aie_try(XAie_DmaSetMultiDimAddr(&(dma_tile21_bd0), &dma_tile_2_1_bd_0_tensor, 0x82000,  /* len */ 512));
 
 module @aie_module  {

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA.mlir
@@ -13,7 +13,7 @@
 // CHECK: XAie_DmaDesc [[bd0:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(3,-1),XAie_LockInit(4,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]),  /* nextbd */ 0,  /* enableNextBd */ 0));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd0]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3),  /* bd */ 0));

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA2.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA2.mlir
@@ -14,7 +14,7 @@
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(3,-1),XAie_LockInit({{.*}},0)));
 // CHECK: [[bd0]].LockDesc.LockRelEn = XAIE_DISABLE;
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]),  /* nextbd */ 0,  /* enableNextBd */ 0));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd0]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3),  /* bd */ 0));

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA3.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA3.mlir
@@ -14,7 +14,7 @@
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd0]]), XAie_LockInit({{.*}},0),XAie_LockInit(4,1)));
 // CHECK: [[bd0]].LockDesc.LockAcqEn = XAIE_DISABLE;
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]),  /* nextbd */ 0,  /* enableNextBd */ 0));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd0]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3),  /* bd */ 0));

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA4.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA4.mlir
@@ -13,7 +13,7 @@
 // CHECK: XAie_DmaDesc [[bd0:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(3,-1),XAie_LockInit(4,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]),  /* nextbd */ 0,  /* enableNextBd */ 0));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd0]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,3),  /* bd */ 0));

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA_locks.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA_locks.mlir
@@ -13,7 +13,7 @@
 // CHECK: XAie_DmaDesc [[bd0:.*]];
 // CHECK: XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,4))
 // CHECK: XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(3,-1),XAie_LockInit(4,1))
-// CHECK: XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 256 * 4)
+// CHECK: XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x720,  /* len */ 1024)
 // CHECK: XAie_DmaSetNextBd(&([[bd0]]),  /* nextbd */ 1,  /* enableNextBd */ 1)
 // CHECK: XAie_DmaEnableBd(&([[bd0]]))
 // CHECK: XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(7,4),  /* bd */ 0)

--- a/test/Targets/AIEGenerateXAIE/memTileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/memTileDMA.mlir
@@ -14,25 +14,25 @@
 
 // CHECK: XAie_DmaDesc [[bd0:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(2,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x82000,  /* len */ 16 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]),  /* addrA */ 0x82000,  /* len */ 64));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]), {{.*}} 0, {{.*}} 1));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(2,1), {{.*}} 0));
 
 // CHECK: XAie_DmaDesc [[bd24:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd24]]), XAie_TileLoc(2,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd24]]),  /* addrA */ 0x82000,  /* len */ 16 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd24]]),  /* addrA */ 0x82000,  /* len */ 64));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd24]]), {{.*}} 24, {{.*}} 1));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd24]]), XAie_TileLoc(2,1), {{.*}} 24));
 
 // CHECK: XAie_DmaDesc [[bd25:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd25]]), XAie_TileLoc(2,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd25]]),  /* addrA */ 0x80720,  /* len */ 16 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd25]]),  /* addrA */ 0x80720,  /* len */ 64));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd25]]), {{.*}} 25, {{.*}} 1));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd25]]), XAie_TileLoc(2,1), {{.*}} 25));
 
 // CHECK: XAie_DmaDesc [[bd1:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(2,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]),  /* addrA */ 0x80720,  /* len */ 16 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]),  /* addrA */ 0x80720,  /* len */ 64));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd1]]), {{.*}} 1, {{.*}} 1));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(2,1), {{.*}} 1));
 

--- a/test/Targets/AIEGenerateXAIE/memTileDMA2.mlir
+++ b/test/Targets/AIEGenerateXAIE/memTileDMA2.mlir
@@ -14,7 +14,7 @@
 // CHECK: XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(2,1))
 // CHECK: XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(0,0),XAie_LockInit(0,1))
 // CHECK: [[bd0]].LockDesc.LockAcqEn = XAIE_DISABLE;
-// CHECK: XAie_DmaSetAddrLen(&([[bd0]]), /* addrA */ 0x0,  /* len */ 16 * 4)
+// CHECK: XAie_DmaSetAddrLen(&([[bd0]]), /* addrA */ 0x0,  /* len */ 64)
 // CHECK: XAie_DmaSetNextBd(&([[bd0]]),  /* nextbd */ 1,  /* enableNextBd */ 1)
 // CHECK: XAie_DmaEnableBd(&([[bd0]]))
 // CHECK: XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(2,1),  /* bd */ 0)
@@ -23,7 +23,7 @@
 // CHECK: XAie_DmaDescInit(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(2,1))
 // CHECK: XAie_DmaSetLock(&([[bd1]]), XAie_LockInit(0,0),XAie_LockInit(64,1))
 // CHECK: [[bd1]].LockDesc.LockAcqEn = XAIE_DISABLE;
-// CHECK: XAie_DmaSetAddrLen(&([[bd1]]), /* addrA */ 0x80000,  /* len */ 16 * 4)
+// CHECK: XAie_DmaSetAddrLen(&([[bd1]]), /* addrA */ 0x80000,  /* len */ 64)
 // CHECK: XAie_DmaSetNextBd(&([[bd1]]),  /* nextbd */ 2,  /* enableNextBd */ 1)
 // CHECK: XAie_DmaEnableBd(&([[bd1]]))
 // CHECK: XAie_DmaWriteBd(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(2,1),  /* bd */ 1)
@@ -32,7 +32,7 @@
 // CHECK: XAie_DmaDescInit(&(ctx->DevInst), &([[bd2]]), XAie_TileLoc(2,1))
 // CHECK: XAie_DmaSetLock(&([[bd2]]), XAie_LockInit(0,0),XAie_LockInit(128,1))
 // CHECK: [[bd2]].LockDesc.LockAcqEn = XAIE_DISABLE;
-// CHECK: XAie_DmaSetAddrLen(&([[bd2]]), /* addrA */ 0x100000,  /* len */ 16 * 4)
+// CHECK: XAie_DmaSetAddrLen(&([[bd2]]), /* addrA */ 0x100000,  /* len */ 64)
 // CHECK: XAie_DmaSetNextBd(&([[bd2]]),  /* nextbd */ 0,  /* enableNextBd */ 0)
 // CHECK: XAie_DmaEnableBd(&([[bd2]]))
 // CHECK: XAie_DmaWriteBd(&(ctx->DevInst), &([[bd2]]), XAie_TileLoc(2,1),  /* bd */ 2)

--- a/test/Targets/AIEGenerateXAIE/shim.mlir
+++ b/test/Targets/AIEGenerateXAIE/shim.mlir
@@ -14,14 +14,14 @@
 // CHECK: XAie_DmaDesc [[bd0:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(2,0)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(0,0),XAie_LockInit(0,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]), {{.*}} mlir_aie_external_get_addr_myBuffer_20_0(), {{.*}} 16 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]), {{.*}} mlir_aie_external_get_addr_myBuffer_20_0(), {{.*}} 64));
 // CHECK: __mlir_aie_try(XAie_DmaSetAxi(&([[bd0]]), {{.*}} 0, {{.*}} 4, {{.*}} 0, {{.*}} 0, {{.*}} XAIE_ENABLE));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]), {{.*}} 0, {{.*}} 1));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd0]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(2,0), {{.*}} 0));
 // CHECK: XAie_DmaDesc [[bd1:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(2,0)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]), {{.*}} mlir_aie_external_get_addr_myBuffer_20_1(), {{.*}} 4 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]), {{.*}} mlir_aie_external_get_addr_myBuffer_20_1(), {{.*}} 16));
 // CHECK: __mlir_aie_try(XAie_DmaSetAxi(&([[bd1]]), {{.*}} 0, {{.*}} 4, {{.*}} 0, {{.*}} 0, {{.*}} XAIE_ENABLE));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd1]]), {{.*}} 1, {{.*}} 1));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd1]])));

--- a/test/Targets/AIEGenerateXAIE/shim_dma_packet.mlir
+++ b/test/Targets/AIEGenerateXAIE/shim_dma_packet.mlir
@@ -14,7 +14,7 @@
 // CHECK: XAie_DmaDesc dma_tile70_bd0;
 // CHECK: XAie_DmaDescInit(&(ctx->DevInst), &(dma_tile70_bd0), XAie_TileLoc(7,0))
 // CHECK: XAie_DmaSetLock(&(dma_tile70_bd0), XAie_LockInit(0,1),XAie_LockInit(0,0))
-// CHECK: XAie_DmaSetAddrLen(&(dma_tile70_bd0), /* addrA */ mlir_aie_external_get_addr_myBuffer_70_0(),  /* len */ 1024 * 4)
+// CHECK: XAie_DmaSetAddrLen(&(dma_tile70_bd0), /* addrA */ mlir_aie_external_get_addr_myBuffer_70_0(),  /* len */ 4096)
 // CHECK: XAie_DmaSetAxi(&(dma_tile70_bd0), /* smid */ 0, /* burstlen */ 4, /* QoS */ 0, /* Cache */ 0, /* Secure */ XAIE_ENABLE)
 // CHECK: XAie_DmaSetNextBd(&(dma_tile70_bd0),  /* nextbd */ 0,  /* enableNextBd */ 1)
 // CHECK: XAie_DmaSetPkt(&(dma_tile70_bd0), XAie_PacketInit(2,0))

--- a/test/Targets/AIEGenerateXAIE/test_xaie1.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie1.mlir
@@ -13,7 +13,7 @@
 // CHECK: XAie_DmaDesc dma_tile33_bd0;
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &(dma_tile33_bd0), XAie_TileLoc(3,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&(dma_tile33_bd0), XAie_LockInit(0,0),XAie_LockInit(0,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&(dma_tile33_bd0), {{.*}} 0x1400, {{.*}} 256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&(dma_tile33_bd0), {{.*}} 0x1400, {{.*}} 1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&(dma_tile33_bd0), {{.*}} 0, {{.*}} 0));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&(dma_tile33_bd0)));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &(dma_tile33_bd0), XAie_TileLoc(3,3), {{.*}} 0));

--- a/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
@@ -14,14 +14,14 @@
 // CHECK: XAie_DmaDesc [[bd0:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(3,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(0,0),XAie_LockInit(0,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]), {{.*}}0x1000, {{.*}}256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]), {{.*}}0x1000, {{.*}}1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]), {{.*}}1, {{.*}}1));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd0]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(3,3), {{.*}}0));
 // CHECK: XAie_DmaDesc [[bd1:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(3,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd1]]), XAie_LockInit(0,0),XAie_LockInit(0,1)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]), {{.*}}0x1400, {{.*}}4 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]), {{.*}}0x1400, {{.*}}16));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd1]]), {{.*}}0, {{.*}}1));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd1]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(3,3), {{.*}}1));

--- a/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
@@ -14,14 +14,14 @@
 // CHECK: XAie_DmaDesc [[bd0:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(3,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd0]]), XAie_LockInit(0,1),XAie_LockInit(0,0)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]), {{.*}}0x1000, {{.*}}256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd0]]), {{.*}}0x1000, {{.*}}1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd0]]), {{.*}}0, {{.*}}0));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd0]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd0]]), XAie_TileLoc(3,3), {{.*}}0));
 // CHECK: XAie_DmaDesc [[bd1:.*]];
 // CHECK: __mlir_aie_try(XAie_DmaDescInit(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(3,3)));
 // CHECK: __mlir_aie_try(XAie_DmaSetLock(&([[bd1]]), XAie_LockInit(1,1),XAie_LockInit(1,0)));
-// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]), {{.*}}0x1400, {{.*}}256 * 4));
+// CHECK: __mlir_aie_try(XAie_DmaSetAddrLen(&([[bd1]]), {{.*}}0x1400, {{.*}}1024));
 // CHECK: __mlir_aie_try(XAie_DmaSetNextBd(&([[bd1]]), {{.*}}0, {{.*}}0));
 // CHECK: __mlir_aie_try(XAie_DmaEnableBd(&([[bd1]])));
 // CHECK: __mlir_aie_try(XAie_DmaWriteBd(&(ctx->DevInst), &([[bd1]]), XAie_TileLoc(3,3), {{.*}}1));

--- a/test/assign-buffer-addresses/bad_alignment.mlir
+++ b/test/assign-buffer-addresses/bad_alignment.mlir
@@ -1,0 +1,95 @@
+//===- bad_alignment.mlir --------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022 Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --verify-diagnostics --split-input-file %s
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %buffer_0_1 = aie.buffer(%tile_0_1) {address = 1 : i32} : memref<128xi16>
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        // expected-error@+1 {{'aie.dma_bd' op bd address must be 4 byte (32b) aligned; got base+offset: 1 (bytes)}}
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 0, 128)
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+// -----
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %buffer_0_1 = aie.buffer(%tile_0_1) {address = 1 : i32} : memref<128xi16>
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 3, 128)
+        // expected-error@above {{'aie.dma_bd' op bd address must be 4 byte (32b) aligned; got base+offset: 7 (bytes)}}
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+
+// -----
+
+// Technically this should be in a "positive test" but it makes more sense here
+// the "expected-above" in the previous test and the "expected-below" in the following test
+// prevent false-positives/false-negatives (I think).
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %buffer_0_1 = aie.buffer(%tile_0_1) {address = 2 : i32} : memref<128xi16>
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        // 2*6 + 2 = 8 bytes i.e., 4B aligned...
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 3, 128)
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}
+
+
+// -----
+
+module {
+  aie.device(ipu) {
+    %tile_0_1 = aie.tile(0, 1)
+    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+      %lock_0_1 = aie.lock(%tile_0_1) {init = 1 : i32}
+      %lock_0_1_0 = aie.lock(%tile_0_1) {init = 0 : i32}
+      %buffer_0_1 = aie.buffer(%tile_0_1) {address = 0 : i32} : memref<128xi16>
+      %0 = aie.dma(S2MM, 0) [{
+        aie.use_lock(%lock_0_1, AcquireGreaterEqual)
+        // expected-error@below {{'aie.dma_bd' op bd address must be 4 byte (32b) aligned; got base+offset: 6 (bytes)}}
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 3, 128)
+        aie.use_lock(%lock_0_1_0, Release)
+      }]
+      aie.end
+    }
+  }
+}

--- a/test/dialect/AIE/badtiledma2.mlir
+++ b/test/dialect/AIE/badtiledma2.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not %PYTHON aiecc.py %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}}'aie.dma_bd' op can only access a buffer in the same tile.
+// CHECK: error{{.*}}'aie.dma_bd' op Core tile DMAs can only access a buffer in the same tile.
 
 module @test {
     %t63 = aie.tile(6, 3)

--- a/test/dialect/AIE/nd-dma-bad-stride.mlir
+++ b/test/dialect/AIE/nd-dma-bad-stride.mlir
@@ -1,0 +1,31 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --verify-diagnostics %s
+
+module @tutorial_2b {
+  aie.device(xcve2802) {
+    %tile14 = aie.tile(1, 4)
+    %tile34 = aie.tile(3, 4)
+
+    aie.flow(%tile14, DMA : 0, %tile34, DMA : 0)
+    %buf14 = aie.buffer(%tile14) : memref<128xi16>
+    %lock14_done = aie.lock(%tile14, 0) { init = 0 : i32 }
+    %mem14 = aie.mem(%tile14) {
+      %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
+      ^bd0:
+        // expected-error@+1 {{'aie.dma_bd' op For <32b width datatypes, inner-most dim stride must be 1}}
+        aie.dma_bd(%buf14 : memref<128xi16>, 0, 128, [<size = 32, stride = 2>])
+        aie.next_bd ^end
+      ^end:
+        aie.end
+    }
+  }
+}

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -146,12 +146,12 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
     ^bb4:  // 2 preds: ^bb3, ^bb5
       aie.use_lock(%inA_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inA_cons_buff_0 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 128>, <size = 8, stride = 4>, <size = 4, stride = 32>, <size = 2, stride = 2>])
+      aie.dma_bd(%inA_cons_buff_0 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 128>, <size = 8, stride = 4>, <size = 4, stride = 32>, <size = 4, stride = 1>])
       aie.use_lock(%inA_cons_prod_lock, Release)
       aie.next_bd ^bb5
     ^bb5:  // pred: ^bb4
       aie.use_lock(%inA_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inA_cons_buff_1 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 128>, <size = 8, stride = 4>, <size = 4, stride = 32>, <size = 2, stride = 2>])
+      aie.dma_bd(%inA_cons_buff_1 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 128>, <size = 8, stride = 4>, <size = 4, stride = 32>, <size = 4, stride = 1>])
       aie.use_lock(%inA_cons_prod_lock, Release)
       aie.next_bd ^bb4
     ^bb6:  // pred: ^bb3
@@ -170,12 +170,12 @@ module {
       %3 = aie.dma_start(MM2S, 1, ^bb10, ^bb12)
     ^bb10:  // 2 preds: ^bb9, ^bb11
       aie.use_lock(%inB_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inB_cons_buff_0 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 256>, <size = 16, stride = 4>, <size = 4, stride = 64>, <size = 2, stride = 2>])
+      aie.dma_bd(%inB_cons_buff_0 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 256>, <size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>])
       aie.use_lock(%inB_cons_prod_lock, Release)
       aie.next_bd ^bb11
     ^bb11:  // pred: ^bb10
       aie.use_lock(%inB_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inB_cons_buff_1 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 256>, <size = 16, stride = 4>, <size = 4, stride = 64>, <size = 2, stride = 2>])
+      aie.dma_bd(%inB_cons_buff_1 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 256>, <size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>])
       aie.use_lock(%inB_cons_prod_lock, Release)
       aie.next_bd ^bb10
     ^bb12:  // pred: ^bb9
@@ -194,12 +194,12 @@ module {
       %5 = aie.dma_start(MM2S, 2, ^bb16, ^bb18)
     ^bb16:  // 2 preds: ^bb15, ^bb17
       aie.use_lock(%memC_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%memC_cons_buff_0 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 256>, <size = 4, stride = 4>, <size = 16, stride = 16>, <size = 2, stride = 2>])
+      aie.dma_bd(%memC_cons_buff_0 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 256>, <size = 4, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>])
       aie.use_lock(%memC_cons_prod_lock, Release)
       aie.next_bd ^bb17
     ^bb17:  // pred: ^bb16
       aie.use_lock(%memC_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%memC_cons_buff_1 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 256>, <size = 4, stride = 4>, <size = 16, stride = 16>, <size = 2, stride = 2>])
+      aie.dma_bd(%memC_cons_buff_1 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 256>, <size = 4, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>])
       aie.use_lock(%memC_cons_prod_lock, Release)
       aie.next_bd ^bb16
     ^bb18:  // pred: ^bb15

--- a/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
+++ b/test/ipu-xrt/matrix_multiplication_using_dma/aie.mlir
@@ -146,12 +146,12 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
     ^bb4:  // 2 preds: ^bb3, ^bb5
       aie.use_lock(%inA_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inA_cons_buff_0 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 64>, <size = 8, stride = 2>, <size = 4, stride = 16>, <size = 2, stride = 1>])
+      aie.dma_bd(%inA_cons_buff_0 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 128>, <size = 8, stride = 4>, <size = 4, stride = 32>, <size = 2, stride = 2>])
       aie.use_lock(%inA_cons_prod_lock, Release)
       aie.next_bd ^bb5
     ^bb5:  // pred: ^bb4
       aie.use_lock(%inA_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inA_cons_buff_1 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 64>, <size = 8, stride = 2>, <size = 4, stride = 16>, <size = 2, stride = 1>])
+      aie.dma_bd(%inA_cons_buff_1 : memref<64x32xi16>, 0, 2048, [<size = 16, stride = 128>, <size = 8, stride = 4>, <size = 4, stride = 32>, <size = 2, stride = 2>])
       aie.use_lock(%inA_cons_prod_lock, Release)
       aie.next_bd ^bb4
     ^bb6:  // pred: ^bb3
@@ -170,12 +170,12 @@ module {
       %3 = aie.dma_start(MM2S, 1, ^bb10, ^bb12)
     ^bb10:  // 2 preds: ^bb9, ^bb11
       aie.use_lock(%inB_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inB_cons_buff_0 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 128>, <size = 16, stride = 2>, <size = 4, stride = 32>, <size = 2, stride = 1>])
+      aie.dma_bd(%inB_cons_buff_0 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 256>, <size = 16, stride = 4>, <size = 4, stride = 64>, <size = 2, stride = 2>])
       aie.use_lock(%inB_cons_prod_lock, Release)
       aie.next_bd ^bb11
     ^bb11:  // pred: ^bb10
       aie.use_lock(%inB_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%inB_cons_buff_1 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 128>, <size = 16, stride = 2>, <size = 4, stride = 32>, <size = 2, stride = 1>])
+      aie.dma_bd(%inB_cons_buff_1 : memref<32x64xi16>, 0, 2048, [<size = 8, stride = 256>, <size = 16, stride = 4>, <size = 4, stride = 64>, <size = 2, stride = 2>])
       aie.use_lock(%inB_cons_prod_lock, Release)
       aie.next_bd ^bb10
     ^bb12:  // pred: ^bb9
@@ -194,12 +194,12 @@ module {
       %5 = aie.dma_start(MM2S, 2, ^bb16, ^bb18)
     ^bb16:  // 2 preds: ^bb15, ^bb17
       aie.use_lock(%memC_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%memC_cons_buff_0 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 128>, <size = 4, stride = 2>, <size = 16, stride = 8>, <size = 2, stride = 1>])
+      aie.dma_bd(%memC_cons_buff_0 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 256>, <size = 4, stride = 4>, <size = 16, stride = 16>, <size = 2, stride = 2>])
       aie.use_lock(%memC_cons_prod_lock, Release)
       aie.next_bd ^bb17
     ^bb17:  // pred: ^bb16
       aie.use_lock(%memC_cons_cons_lock, AcquireGreaterEqual)
-      aie.dma_bd(%memC_cons_buff_1 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 128>, <size = 4, stride = 2>, <size = 16, stride = 8>, <size = 2, stride = 1>])
+      aie.dma_bd(%memC_cons_buff_1 : memref<64x64xi16>, 0, 4096, [<size = 16, stride = 256>, <size = 4, stride = 4>, <size = 16, stride = 16>, <size = 2, stride = 2>])
       aie.use_lock(%memC_cons_prod_lock, Release)
       aie.next_bd ^bb16
     ^bb18:  // pred: ^bb15

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -88,24 +88,24 @@
 // CHECK:             %[[VAL_29:.*]] = aie.dma_start(MM2S, 1, ^bb7, ^bb9)
 // CHECK:           ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 64, 20)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 16, 20)
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb8
 // CHECK:           ^bb8:  // pred: ^bb7
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 64, 20)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 16, 20)
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb9:  // pred: ^bb6
 // CHECK:             %[[VAL_30:.*]] = aie.dma_start(MM2S, 2, ^bb10, ^bb12)
 // CHECK:           ^bb10:  // 2 preds: ^bb9, ^bb11
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 144, 12)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 36, 12)
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb11
 // CHECK:           ^bb11:  // pred: ^bb10
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 144, 12)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 36, 12)
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb10
 // CHECK:           ^bb12:  // pred: ^bb9


### PR DESCRIPTION
The PR changes `offset` and `len` on `dma_bd` to be denominated in **multiple of the element type width**, e.g., `memref<32xi16>` with `offset=4` and `len=8` will send **elements** 4 through 12 inclusive (3rd through 11th). 

The arithmetic to convert between the element type width and 32b alignments is now done in the op definition (~cf. `getLenIn32bWords` and `getOffsetIn32bWords`~ cf. `getLenInBytes` and `getOffsetInBytes` [the spec is in bits but libxaie is in bytes :shrug:]). 

Note, this PR does **not** update [AIEDmaToIpu::IpuDmaMemcpyNdOp](https://github.com/Xilinx/mlir-aie/blob/174398da1e140bcd9b4527aa0697ae3ec8c50e1d/lib/Dialect/AIEX/Transforms/AIEDmaToIpu.cpp#L249) because if I understand correctly, it's already treated in this way there (though I could be wrong - I am not familiar with that op).