### PR TITLE
[aievec] Remove unused build targets

### DIFF
--- a/include/aie/Dialect/AIEVec/IR/CMakeLists.txt
+++ b/include/aie/Dialect/AIEVec/IR/CMakeLists.txt
@@ -8,7 +8,3 @@
 add_mlir_dialect(AIEVecOps aievec)
 add_mlir_doc(AIEVecOps AIEVecDialect ./ -gen-dialect-doc -dialect=aievec)
 
-set(LLVM_TARGET_DEFINITIONS AIEVecLLVMIntrOp.td)
-mlir_tablegen(AIEVecConversions.inc -gen-llvmir-conversions)
-add_public_tablegen_target(MLIRAIEVecConversionsIncGen)
-


### PR DESCRIPTION
Missed these when splitting off xllvm dialect.