### PR TITLE
Various fixes for Vitis 2023.2 and Ubuntu 23.10 on RyzenAI

### DIFF
--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -48,13 +48,13 @@ jobs:
           dotnet: true
           haskell: true
           large-packages: true
-          swap-storage: false 
+          swap-storage: false
 
       - name: Docker prune
         shell: bash
         run: |
           docker system prune -a -f
-          
+
       - uses: uraimo/run-on-arch-action@v2.5.0
         name: Run commands
         id: runcmd
@@ -66,41 +66,41 @@ jobs:
             --mac-address ${{ secrets.XILINX_MAC }}
           run: |
             ls -l /opt/Xilinx/Vitis/2023.2/
-            
+
             # this is the inverse of `base64 -w 1000000 Xilinx.lic`
             # the -w ("wrap after 1000000 cols") is so that there are no spaces in the XILINX_LIC env var
             echo -n "${{ secrets.XILINX_LIC }}" | base64 --decode > ~/.Xilinx/Xilinx.lic
-            
+
             cd /
             git clone https://github.com/Xilinx/mlir-aie.git
             cd /mlir-aie
-            
+
             git checkout ${{ github.head_ref }}
             if [ x"${{ inputs.AIE_COMMIT }}" != x"" ]; then
               git reset --hard ${{ inputs.AIE_COMMIT }}
             fi
-            
+
             git submodule update --init --recursive
-            
+
             apt install python3.10-venv
             python -m venv aie-venv
             source aie-venv/bin/activate
             pip install -r python/requirements.txt
-            
+
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
             pip -q download mlir==$VERSION \
               -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
             unzip -q mlir-*.whl
             find mlir -exec touch -a -m -t 201108231405.14 {} \;
-            
+
             # don't delete the space in the sed
             pushd cmake/modulesXilinx && sed -i.bak 's/		VITIS_VPP//g' FindVitis.cmake && popd
-            
+
             mkdir build && cd build
             export PATH=/opt/Xilinx/Vitis/2023.2/bin:/opt/Xilinx/Vitis/2023.2/aietools/bin:$PATH
             cmake .. -G Ninja \
               -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-              -DVITIS_ROOT=/opt/Xilinx/Vitis/2023.2/ \
+              -DVITIS_ROOT=/opt/Xilinx/Vitis/2023.2 \
               -DVitis_VERSION_MAJOR=2023 \
               -DVitis_VERSION_MINOR=2 \
               -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
@@ -112,14 +112,14 @@ jobs:
               -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_INSTALL_PREFIX=install 
-            
+              -DCMAKE_INSTALL_PREFIX=install
+
             ninja
-            
+
             if [ x"${{ inputs.LIT_FILTER }}" == x"" ]; then
               export LIT_FILTER="${{ inputs.LIT_FILTER }}"
             fi
-            
+
             # filter out CODirect until I put bootgen into the image
             export LIT_OPTS="-sv --timeout 600 -j1 --filter-out Targets/AIEGenerateCDODirect"
             ninja check-aie

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -6,7 +6,22 @@ on:
       - main
       - test-ryzen-ai
   pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab by
+  # selecting CI and then "Run workflow" menu on the right branch
+  # and clicking on "launch_tmate_terminal_for_debug".
+  # Unfortunately this works only for the default branch.
+  # So you can either
+  # - change the default branch of the PR on the GitHub repository owning the PR
+  #   and launching in Actions tab;
+  # - or edit directly the step below which runs tmate and push to the
+  #   PR, ignoring the manual workflow launch.
   workflow_dispatch:
+      launch_tmate_terminal_for_debug:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 defaults:
   run:
@@ -31,15 +46,84 @@ jobs:
 
     steps:
 
+      - name: Display environment variables
+        run: env
+
+      - name: User and group ids
+        run: id -a
+
+      - name: Execution context information
+        # Display a lot of information to help further development
+        # https://docs.github.com/en/actions/learn-github-actions/variables
+        # https://docs.github.com/en/enterprise-cloud@latest/actions/learn-github-actions/contexts
+        # The problem is that echo-ing directly "${{ toJSON(github) }}"
+        # in the shell is not escaped and for example '&' breaks
+        # things or can lead to server-side script injection. :-(
+        # So, use environment setting and display the environment
+        # variable in the shell between "" to avoid unsafe
+        # interpretation.
+        env:
+          execution_context_var_github: ${{ toJSON(github) }}
+          execution_context_var_env: ${{ toJSON(env) }}
+          execution_context_var_vars: ${{ toJSON(vars) }}
+          execution_context_var_job: ${{ toJSON(job) }}
+          execution_context_var_steps: ${{ toJSON(steps) }}
+          execution_context_var_runner: ${{ toJSON(runner) }}
+          execution_context_var_strategy: ${{ toJSON(strategy) }}
+          execution_context_var_matrix: ${{ toJSON(matrix) }}
+          execution_context_var_needs: ${{ toJSON(needs) }}
+          execution_context_var_inputs: ${{ toJSON(inputs) }}
+        run: |
+          echo "::group::github context"
+          echo "$execution_context_var_github"
+          echo "::endgroup::"
+          echo "::group::env context"
+          echo "$execution_context_var_env"
+          echo "::endgroup::"
+          echo "::group::vars context"
+          echo "$execution_context_var_vars"
+          echo "::endgroup::"
+          echo "::group::job context"
+          echo "$execution_context_var_job"
+          echo "::endgroup::"
+          echo "::group::steps context"
+          echo "$execution_context_var_steps"
+          echo "::endgroup::"
+          echo "::group::runner context"
+          echo "$execution_context_var_runner"
+          echo "::endgroup::"
+          echo "::group::strategy context"
+          echo "$execution_context_var_strategy"
+          echo "::endgroup::"
+          echo "::group::matrix context"
+          echo "$execution_context_var_matrix"
+          echo "::endgroup::"
+          echo "::group::needs context"
+          echo "$execution_context_var_needs"
+          echo "::endgroup::"
+          echo "::group::inputs context"
+          echo "$execution_context_var_inputs"
+          echo "::endgroup::"
+
       - uses: actions/checkout@v3
         with:
           submodules: "true"
 
+      # Launch an ssh session via a proxy server if there is a need
+      # for debug. This seems to live for 35 min max
+      # https://github.com/mxschmitt/action-tmate
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        # To run this, launch it manually on the default branch and
+        # click on "launch_tmate_terminal_for_debug"
+        if: github.event_name == 'workflow_dispatch'
+                && inputs.launch_tmate_terminal_for_debug
+
       - name: Run commands
         run: |
-          
+
           pip cache purge
-        
+
           python -m venv aie-venv
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
@@ -55,7 +139,7 @@ jobs:
           # That means wheels have file with time stamps in the future which makes ninja loop
           # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
           find mlir -exec touch -a -m -t 201108231405.14 {} \;
-          
+
           mkdir build
           pushd build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ list(FIND AIE_RUNTIME_TARGETS "aarch64" indexAarch64)
 if(NOT DEFINED SysrootAarch64
    AND DEFINED VITIS_ROOT
    AND ${indexAarch64} GREATER -1)
-  set(Sysroot ${VITIS_ROOT}/gnu/aarch64/lin/aarch64-linux/aarch64-xilinx-linux/)
+  set(Sysroot ${VITIS_ROOT}/gnu/aarch64/lin/aarch64-linux/aarch64-xilinx-linux)
   if(AIE_RUNTIME_TEST_TARGET STREQUAL "aarch64")
     set(LIBCXX_VERSION "11.2.0")
     set(extraAieCcFlags

--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -28,6 +28,7 @@ def parse_args(args=None):
         help="directory used for temporary file storage",
     )
     parser.add_argument(
+        "--verbose",
         "-v",
         dest="verbose",
         default=False,

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -659,7 +659,7 @@ class FlowRunner:
                     ],
                 )
 
-            cmd = ["clang++", "-std=c++11"]
+            cmd = ["clang++", "-std=c++17"]
             if opts.host_target:
                 cmd += ["--target=" + opts.host_target]
                 if (

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -685,7 +685,14 @@ class FlowRunner:
                 # force using '/usr/lib,include/gcc'
                 if opts.host_target == "aarch64-linux-gnu":
                     cmd += [f"--gcc-toolchain={opts.sysroot}/usr"]
-
+                    # It looks like the G++ distribution is non standard, so add
+                    # an explicit handling of C++ library.
+                    # Perhaps related to https://discourse.llvm.org/t/add-gcc-install-dir-deprecate-gcc-toolchain-and-remove-gcc-install-prefix/65091/23
+                    cxx_include = glob.glob(f"{opts.sysroot}/usr/include/c++/*.*.*")[0]
+                    triple = os.path.basename(opts.sysroot)
+                    cmd += [f"-I{cxx_include}", f"-I{cxx_include}/{triple}"]
+                    gcc_lib = glob.glob(f"{opts.sysroot}/usr/lib/{triple}/*.*.*")[0]
+                    cmd += [f"-B{gcc_lib}", f"-L{gcc_lib}"]
             install_path = aie.compiler.aiecc.configure.install_path()
 
             # Setting everything up if linking against HSA

--- a/test/Integration/julia_by_lines/aie.mlir
+++ b/test/Integration/julia_by_lines/aie.mlir
@@ -10,7 +10,7 @@
 
 // REQUIRES: peano
 // RUN: %PEANO_INSTALL_DIR/bin/clang++ -O2 --target=aie -c -I/usr/include/aie %S/kernel.cpp
-// RUN: %PYTHON aiecc.py --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/ %host_runtime_lib%/test_library.cpp %S/test.cpp %S/kernel.cpp -lstdc++ -o test.elf
+// RUN: %PYTHON aiecc.py %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_libg %S/test.cpp %S/kernel.cpp -lstdc++ -o test.elf
 // RUN: %run_on_board ./test.elf
 
 module @test {

--- a/test/aiecc/simple.mlir
+++ b/test/aiecc/simple.mlir
@@ -8,12 +8,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %PYTHON aiecc.py --compile --xchesscc --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
-// RUN: %PYTHON aiecc.py --compile --no-xchesscc --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
-// RUN: %PYTHON aiecc.py --no-compile --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
-// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --xchesscc -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
-// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --no-xchesscc -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
-// RUN: %PYTHON aiecc.py --no-unified --no-compile --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %PYTHON aiecc.py --compile --xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %PYTHON aiecc.py --compile --no-xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
+// RUN: %PYTHON aiecc.py --no-compile --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --no-xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
+// RUN: %PYTHON aiecc.py --no-unified --no-compile --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
 
 // Note that llc determines the architecture from the llvm IR.
 

--- a/test/aiecc/simple_aie2.mlir
+++ b/test/aiecc/simple_aie2.mlir
@@ -1,4 +1,4 @@
-//===- simple.mlir ---------------------------------------------*- MLIR -*-===//
+//===- simple_aie2.mlir ----------------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,12 +8,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %PYTHON aiecc.py --compile --xchesscc --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
-// RUN: %PYTHON aiecc.py --compile --no-xchesscc --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
-// RUN: %PYTHON aiecc.py --no-compile --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
-// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --xchesscc -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
-// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --no-xchesscc -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
-// RUN: %PYTHON aiecc.py --no-unified --no-compile --no-link -nv --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib% %host_runtime_lib%/test_library.cpp %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %PYTHON aiecc.py --compile --xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %PYTHON aiecc.py --compile --no-xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
+// RUN: %PYTHON aiecc.py --no-compile --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
+// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %PYTHON aiecc.py --no-unified --compile --no-link --no-xchesscc -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
+// RUN: %PYTHON aiecc.py --no-unified --no-compile --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE
 
 // Note that llc determines the architecture from the llvm IR.
 // XCHESSCC-NOT: {{^[^ ]*llc}}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -86,7 +86,7 @@ if config.xrt_lib_dir:
                     print("\tmodel:", aie_model)
                 config.available_features.add("ryzen_ai")
                 run_on_ipu = (
-                    f"sudo --preserve-env flock /tmp/ipu.lock {config.aie_src_root}/utils/run_on_ipu.sh"
+                    f"flock /tmp/ipu.lock {config.aie_src_root}/utils/run_on_ipu.sh"
                 )
     except:
         print("Failed to run xbutil")

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -86,7 +86,7 @@ if config.xrt_lib_dir:
                     print("\tmodel:", aie_model)
                 config.available_features.add("ryzen_ai")
                 run_on_ipu = (
-                    f"flock /tmp/ipu.lock {config.aie_src_root}/utils/run_on_ipu.sh"
+                    f"sudo --preserve-env flock /tmp/ipu.lock {config.aie_src_root}/utils/run_on_ipu.sh"
                 )
     except:
         print("Failed to run xbutil")

--- a/tutorials/tutorial-1/aie.mlir
+++ b/tutorials/tutorial-1/aie.mlir
@@ -8,23 +8,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/ %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-1.exe
+// aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-1.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S tutorial-1.exe
 // RUN: %run_on_board ./tutorial-1.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_1 {
 
     // Declare tile object of the AIE class located at position col 1, row 4
     %tile14 = aie.tile(1, 4)
 
-    // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-    // size 256 deep x int32 wide. By default, the address of 
-    // this buffer begins after the stack (1024 Bytes offset) and 
+    // Declare buffer for tile(1, 4) with symbolic name "a14" and
+    // size 256 deep x int32 wide. By default, the address of
+    // this buffer begins after the stack (1024 Bytes offset) and
     // all subsequent buffers are allocated one after another in memory.
     %buf = aie.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
 

--- a/tutorials/tutorial-1/answers/aie_q5.mlir
+++ b/tutorials/tutorial-1/answers/aie_q5.mlir
@@ -10,20 +10,20 @@
 
 // REQUIRES: valid_xchess_license
 // XFAIL: *
-// RUN: aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/../test.cpp -o tutorial-1.exe
+// RUN: aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/../test.cpp -o tutorial-1.exe
 // RUN: %run_on_board ./tutorial-1.exe
 
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_1 {
 
     // Declare tile object of the AIE class located at position col 1, row 4
     %tile14 = aie.tile(1, 4)
 
-    // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-    // size 256 deep x int32 wide. By default, the address of 
-    // this buffer begins after the stack (1024 Bytes offset) and 
+    // Declare buffer for tile(1, 4) with symbolic name "a14" and
+    // size 256 deep x int32 wide. By default, the address of
+    // this buffer begins after the stack (1024 Bytes offset) and
     // all subsequent buffers are allocated one after another in memory.
     %buf = aie.buffer(%tile14) { sym_name = "a14" } : memref<8192xi32>
 

--- a/tutorials/tutorial-1/answers/aie_q6.mlir
+++ b/tutorials/tutorial-1/answers/aie_q6.mlir
@@ -10,11 +10,11 @@
 
 // REQUIRES: valid_xchess_license
 // XFAIL: *
-// RUN: aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/../test.cpp -o tutorial-1.exe
+// RUN: aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/../test.cpp -o tutorial-1.exe
 // RUN: %run_on_board ./tutorial-1.exe
 
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_1 {
 
@@ -22,9 +22,9 @@ module @tutorial_1 {
     %tile14 = aie.tile(1, 4)
     %tile24 = aie.tile(2, 4)
 
-    // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-    // size 256 deep x int32 wide. By default, the address of 
-    // this buffer begins after the stack (1024 Bytes offset) and 
+    // Declare buffer for tile(1, 4) with symbolic name "a14" and
+    // size 256 deep x int32 wide. By default, the address of
+    // this buffer begins after the stack (1024 Bytes offset) and
     // all subsequent buffers are allocated one after another in memory.
     %buf = aie.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
     %buf2 = aie.buffer(%tile24) { sym_name = "a24" } : memref<8192xi32>

--- a/tutorials/tutorial-2/tutorial-2a/aie.mlir
+++ b/tutorials/tutorial-2/tutorial-2a/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-2a.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-2a.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
@@ -16,20 +16,20 @@
 // RUN: make -C %S clean
 
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_2a {
 
     // Declare tile object of the AIE class located at position col 1, row 4
     %tile14 = aie.tile(1, 4)
 
-    // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-    // size 256 deep x int32 wide. By default, the address of 
-    // this buffer begins after the stack (1024 Bytes offset) and 
+    // Declare buffer for tile(1, 4) with symbolic name "a14" and
+    // size 256 deep x int32 wide. By default, the address of
+    // this buffer begins after the stack (1024 Bytes offset) and
     // all subsequent buffers are allocated one after another in memory.
     %buf = aie.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
 
-    // Declare a lock 0 associated with tile(1,4) with a 
+    // Declare a lock 0 associated with tile(1,4) with a
     // symbolic name "lock14_0" which can be used by access functions
     // in the generated host API (aie.mlir.prj/aie_inc.cpp)
     %lock14_0 = aie.lock(%tile14, 0) { sym_name = "lock14_0" }
@@ -47,7 +47,7 @@ module @tutorial_2a {
         // Release acquired lock at end of program.
         // This can be used by host to mark beginning/end of a program or
         // when the host is trying to determine when the program is done
-        // by acquiring this lock (with value 1). 
+        // by acquiring this lock (with value 1).
         aie.use_lock(%lock14_0, "Release", 1)
         aie.end
     }

--- a/tutorials/tutorial-2/tutorial-2b/aie.mlir
+++ b/tutorials/tutorial-2/tutorial-2b/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-2b.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-2b.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
@@ -16,22 +16,22 @@
 // RUN: make -C %S clean
 
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_2b {
-    
+
     // Declare the target device
     aie.device(xcvc1902) {
         // Declare tile object of the AIE class located at position col 1, row 4
         %tile14 = aie.tile(1, 4)
 
-        // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-        // size 256 deep x int32 wide. By default, the address of 
-        // this buffer begins after the stack (1024 Bytes offset) and 
+        // Declare buffer for tile(1, 4) with symbolic name "a14" and
+        // size 256 deep x int32 wide. By default, the address of
+        // this buffer begins after the stack (1024 Bytes offset) and
         // all subsequent buffers are allocated one after another in memory.
         %buf = aie.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
 
-        // Declare a lock 0 associated with tile(1,4) with a 
+        // Declare a lock 0 associated with tile(1,4) with a
         // symbolic name "lock14_0" which can be used by access functions
         // in the generated API (aie.mlir.prj/aie_inc.cpp)
         %lock14_0 = aie.lock(%tile14, 0) { sym_name = "lock14_0" }
@@ -49,7 +49,7 @@ module @tutorial_2b {
             // Release acquired lock at end of program.
             // This can be used by host to mark beginning/end of a program or
             // when the host is trying to determine when the program is done
-            // by acquiring this lock (with value 1). 
+            // by acquiring this lock (with value 1).
             aie.use_lock(%lock14_0, "Release", 1)
             aie.end
         }

--- a/tutorials/tutorial-2/tutorial-2c/aie.mlir
+++ b/tutorials/tutorial-2/tutorial-2c/aie.mlir
@@ -8,27 +8,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-2c.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-2c.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-2c.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_2c {
 
     // Declare tile object of the AIE class located at position col 1, row 4
     %tile14 = aie.tile(1, 4)
 
-    // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-    // size 256 deep x int32 wide. By default, the address of 
-    // this buffer begins after the stack (1024 Bytes offset) and 
+    // Declare buffer for tile(1, 4) with symbolic name "a14" and
+    // size 256 deep x int32 wide. By default, the address of
+    // this buffer begins after the stack (1024 Bytes offset) and
     // all subsequent buffers are allocated one after another in memory.
     %buf = aie.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
 
-    // Declare a lock 0 associated with tile(1,4) with a 
+    // Declare a lock 0 associated with tile(1,4) with a
     // symbolic name "lock14_0" which can be used by access functions
     // in the generated API (aie.mlir.prj/aie_inc.cpp)
     %lock14_0 = aie.lock(%tile14, 0) { sym_name = "lock14_0" }
@@ -46,7 +46,7 @@ module @tutorial_2c {
         // Release acquired lock at end of program.
         // This can be used by host to mark beginning/end of a program or
         // when the host is trying to determine when the program is done
-        // by acquiring this lock (with value 1). 
+        // by acquiring this lock (with value 1).
         aie.use_lock(%lock14_0, "Release", 1)
         aie.end
     }

--- a/tutorials/tutorial-3/aie.mlir
+++ b/tutorials/tutorial-3/aie.mlir
@@ -8,14 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-3.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-3.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-3.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_3 {
 
@@ -39,13 +39,13 @@ module @tutorial_3 {
         // Locks init value is Release 0, so this will always succeed first
         aie.use_lock(%lock24_1, "Acquire", 0)
 
-		%val = arith.constant 14 : i32 
-		%idx = arith.constant 3 : index 
-		memref.store %val, %buf[%idx] : memref<256xi32> 
+		%val = arith.constant 14 : i32
+		%idx = arith.constant 3 : index
+		memref.store %val, %buf[%idx] : memref<256xi32>
 
         aie.use_lock(%lock24_1, "Release", 1)
         aie.end
-    } 
+    }
 
     // Define core algorithm for tile(2,4) which reads value set by tile(1,4)
     // buf[5] = buf[3] + 100
@@ -57,10 +57,10 @@ module @tutorial_3 {
 
 		%idx1 = arith.constant 3 : index
 		%d1   = memref.load %buf[%idx1] : memref<256xi32>
-		%c1   = arith.constant 100 : i32 
+		%c1   = arith.constant 100 : i32
 		%d2   = arith.addi %d1, %c1 : i32
 		%idx2 = arith.constant 5 : index
-		memref.store %d2, %buf[%idx2] : memref<256xi32> 
+		memref.store %d2, %buf[%idx2] : memref<256xi32>
 
         // This release means our 2nd core is done
         aie.use_lock(%lock24_2, "Release", 1)

--- a/tutorials/tutorial-4/aie.mlir
+++ b/tutorials/tutorial-4/aie.mlir
@@ -8,14 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-4.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-4.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-4.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_4 {
     aie.device(xcvc1902) {
@@ -38,24 +38,24 @@ module @tutorial_4 {
         %core14 = aie.core(%tile14) {
             // Acquire a subview with one object from the object FIFO.
             // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
-            // This core acquires objects as a Producer: this impacts the acquire value of the lock 
+            // This core acquires objects as a Producer: this impacts the acquire value of the lock
             // that is generated through the object FIFO lowering.
             %inputSubview = aie.objectfifo.acquire @of (Produce, 1) : !aie.objectfifosubview<memref<256xi32>>
-            
+
             // Access the first, and only, element of the subview.
             %input = aie.objectfifo.subview.access %inputSubview[0] : !aie.objectfifosubview<memref<256xi32>> -> memref<256xi32>
 
-            %val = arith.constant 14 : i32 
-            %idx = arith.constant 3 : index 
-            memref.store %val, %input[%idx] : memref<256xi32> 
-            
+            %val = arith.constant 14 : i32
+            %idx = arith.constant 3 : index
+            memref.store %val, %input[%idx] : memref<256xi32>
+
             // Release the previously acquired object.
             // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
-            // This core releases objects as a Producer: this impacts the release value of the lock 
+            // This core releases objects as a Producer: this impacts the release value of the lock
             // that is generated through the object FIFO lowering.
             aie.objectfifo.release @of (Produce, 1)
             aie.end
-        } 
+        }
 
         // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
         // buf[5] = buf[3] + 100
@@ -68,11 +68,11 @@ module @tutorial_4 {
 
             %idx1 = arith.constant 3 : index
             %d1   = memref.load %input[%idx1] : memref<256xi32>
-            %c1   = arith.constant 100 : i32 
+            %c1   = arith.constant 100 : i32
             %d2   = arith.addi %d1, %c1 : i32
             %idx2 = arith.constant 5 : index
-            memref.store %d2, %input[%idx2] : memref<256xi32> 
-            
+            memref.store %d2, %input[%idx2] : memref<256xi32>
+
             aie.objectfifo.release @of (Consume, 1)
 
             // This release means our 2nd core is done

--- a/tutorials/tutorial-4/flow/answers/aie_q5.mlir
+++ b/tutorials/tutorial-4/flow/answers/aie_q5.mlir
@@ -10,11 +10,11 @@
 
 // REQUIRES: valid_xchess_license
 // XFAIL: *
-// RUN: aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/ %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/../test.cpp -o tutorial-4.exe
+// RUN: aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/../test.cpp -o tutorial-4.exe
 // RUN: %run_on_board ./tutorial-4.exe
 
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_4 {
 
@@ -43,9 +43,9 @@ module @tutorial_4 {
         // Locks init value is Release 0, so this will always succeed first
         aie.use_lock(%lock14_6, "Acquire", 0)
 
-		%val = arith.constant 14 : i32 
-		%idx = arith.constant 3 : index 
-		memref.store %val, %buf14[%idx] : memref<256xi32> 
+		%val = arith.constant 14 : i32
+		%idx = arith.constant 3 : index
+		memref.store %val, %buf14[%idx] : memref<256xi32>
 
         // Release lock to 1 so tile(2,4) can acquire and begin processing
         aie.use_lock(%lock14_6, "Release", 1)
@@ -61,9 +61,9 @@ module @tutorial_4 {
             aie.next_bd ^bd0
         ^end:
             aie.end
-    }    
+    }
 
- 
+
     // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
     // buf[5] = buf[3] + 100
     %core34 = aie.core(%tile34) {
@@ -72,10 +72,10 @@ module @tutorial_4 {
 
         %idx1 = arith.constant 3 : index
         %d1   = memref.load %buf34[%idx1] : memref<256xi32>
-        %c1   = arith.constant 100 : i32 
+        %c1   = arith.constant 100 : i32
         %d2   = arith.addi %d1, %c1 : i32
 		%idx2 = arith.constant 5 : index
-		memref.store %d2, %buf34[%idx2] : memref<256xi32> 
+		memref.store %d2, %buf34[%idx2] : memref<256xi32>
 
         // This release doesn't do much in our example but mimics ping-pong
         aie.use_lock(%lock34_7, "Release", 0)
@@ -86,7 +86,7 @@ module @tutorial_4 {
     %mem34 = aie.mem(%tile34) {
         // sequence of DMAs declaration and buffer descriptors (bd)
         // ^bd0 - first label/ bd definition to set
-        // ^end - next label/ bd definition to set 
+        // ^end - next label/ bd definition to set
         // (here, that is aie.end to indicate no more)
         aie.dma_start("S2MM", 1, ^bd0, ^end)
         ^bd0:
@@ -102,6 +102,6 @@ module @tutorial_4 {
             aie.next_bd ^bd0
         ^end:
             aie.end
-    }    
+    }
 
 }

--- a/tutorials/tutorial-5/aie.mlir
+++ b/tutorials/tutorial-5/aie.mlir
@@ -8,14 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-5.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-5.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-5.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_5 {
     aie.device(xcvc1902) {
@@ -49,32 +49,32 @@ module @tutorial_5 {
         %core34 = aie.core(%tile34) {
             // Acquire a subview with one object from each object FIFO.
             // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
-            // This core acquires objects both as a Consumer of one object FIFO and as a Producer of another: 
+            // This core acquires objects both as a Consumer of one object FIFO and as a Producer of another:
             // this impacts the acquire values of the locks that are generated through the object FIFO lowering
             %inputSubview = aie.objectfifo.acquire @of_in (Consume, 1) : !aie.objectfifosubview<memref<256xi32>>
             %outputSubview = aie.objectfifo.acquire @of_out (Produce, 1) : !aie.objectfifosubview<memref<256xi32>>
-            
+
             // Access the first, and only, element of each subview.
             %input = aie.objectfifo.subview.access %inputSubview[0] : !aie.objectfifosubview<memref<256xi32>> -> memref<256xi32>
             %output = aie.objectfifo.subview.access %outputSubview[0] : !aie.objectfifosubview<memref<256xi32>> -> memref<256xi32>
 
             %idx1 = arith.constant 3 : index
             %d1   = memref.load %input[%idx1] : memref<256xi32>
-            %c1   = arith.constant 100 : i32 
+            %c1   = arith.constant 100 : i32
             %d2   = arith.addi %d1, %c1 : i32
             %idx2 = arith.constant 5 : index
             memref.store %d2, %input[%idx2] : memref<256xi32>
 
-            memref.store %d1, %output[%idx1] : memref<256xi32> 
-            memref.store %d2, %output[%idx2] : memref<256xi32>  
-            
+            memref.store %d1, %output[%idx1] : memref<256xi32>
+            memref.store %d2, %output[%idx2] : memref<256xi32>
+
             // Release the previously acquired objects.
             // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
-            // This core releases objects both as a Consumer of one object FIFO and as a Producer of another: 
+            // This core releases objects both as a Consumer of one object FIFO and as a Producer of another:
             // this impacts the release values of the locks that are generated through the object FIFO lowering.
             aie.objectfifo.release @of_in (Consume, 1)
             aie.objectfifo.release @of_out (Produce, 1)
             aie.end
-        } 
+        }
     }
 }

--- a/tutorials/tutorial-6/aie.mlir
+++ b/tutorials/tutorial-6/aie.mlir
@@ -8,14 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-6.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-6.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-6.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_6 {
 
@@ -50,9 +50,9 @@ module @tutorial_6 {
             // Locks init value is Release 0, so this will always succeed first
             aie.use_lock(%lock14_6, "Acquire", 0)
 
-            %val = arith.constant 14 : i32 
-            %idx = arith.constant 3 : index 
-            memref.store %val, %buf14[%idx] : memref<256xi32> 
+            %val = arith.constant 14 : i32
+            %idx = arith.constant 3 : index
+            memref.store %val, %buf14[%idx] : memref<256xi32>
 
             // Release lock to 1 so tile(2,4) can acquire and begin processing
             aie.use_lock(%lock14_6, "Release", 1)
@@ -72,9 +72,9 @@ module @tutorial_6 {
                 aie.next_bd ^end
             ^end:
                 aie.end
-        }    
+        }
 
-     
+
         // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
         // buf[5] = buf[3] + 100
         %core34 = aie.core(%tile34) {
@@ -84,10 +84,10 @@ module @tutorial_6 {
 
             %idx1 = arith.constant 3 : index
             %d1   = memref.load %buf34[%idx1] : memref<256xi32>
-            %c1   = arith.constant 100 : i32 
+            %c1   = arith.constant 100 : i32
             %d2   = arith.addi %d1, %c1 : i32
             %idx2 = arith.constant 5 : index
-            memref.store %d2, %buf34[%idx2] : memref<256xi32> 
+            memref.store %d2, %buf34[%idx2] : memref<256xi32>
 
             aie.use_lock(%lock34_7, "Release", 0)
             aie.use_lock(%lock34_8, "Release", 1)
@@ -105,6 +105,6 @@ module @tutorial_6 {
                 aie.next_bd ^end
             ^end:
                 aie.end
-        }    
+        }
     }
 }

--- a/tutorials/tutorial-7/aie.mlir
+++ b/tutorials/tutorial-7/aie.mlir
@@ -8,14 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-7.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-7.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-7.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_7 {
 
@@ -43,24 +43,24 @@ module @tutorial_7 {
         %core14 = aie.core(%tile14) {
             // Acquire a subview with one object from the object FIFO.
             // This is equivalent to acquiring an AIE lock before accessing an AIE buffer.
-            // This core acquires objects as a Producer: this impacts the acquire value of the lock 
+            // This core acquires objects as a Producer: this impacts the acquire value of the lock
             // that is generated through the object FIFO lowering.
             %inputSubview = aie.objectfifo.acquire @of (Produce, 1) : !aie.objectfifosubview<memref<256xi32>>
-            
+
             // Access the first, and only, element of the subview.
             %input = aie.objectfifo.subview.access %inputSubview[0] : !aie.objectfifosubview<memref<256xi32>> -> memref<256xi32>
 
-            %val = arith.constant 14 : i32 
-            %idx = arith.constant 3 : index 
-            memref.store %val, %input[%idx] : memref<256xi32> 
-            
+            %val = arith.constant 14 : i32
+            %idx = arith.constant 3 : index
+            memref.store %val, %input[%idx] : memref<256xi32>
+
             // Release the previously acquired object.
             // This is equivalent to releasing an AIE lock after accessing an AIE buffer.
-            // This core releases objects as a Producer: this impacts the release value of the lock 
+            // This core releases objects as a Producer: this impacts the release value of the lock
             // that is generated through the object FIFO lowering.
             aie.objectfifo.release @of (Produce, 1)
             aie.end
-        } 
+        }
 
         // Define core algorithm for tile(3,4) which reads value set by tile(1,4)
         // buf[5] = buf[3] + 100
@@ -73,11 +73,11 @@ module @tutorial_7 {
 
             %idx1 = arith.constant 3 : index
             %d1   = memref.load %input[%idx1] : memref<256xi32>
-            %c1   = arith.constant 100 : i32 
+            %c1   = arith.constant 100 : i32
             %d2   = arith.addi %d1, %c1 : i32
             %idx2 = arith.constant 5 : index
-            memref.store %d2, %input[%idx2] : memref<256xi32> 
-            
+            memref.store %d2, %input[%idx2] : memref<256xi32>
+
             aie.objectfifo.release @of (Consume, 1)
 
             // This release means our 2nd core is done
@@ -96,11 +96,11 @@ module @tutorial_7 {
 
             %idx1 = arith.constant 3 : index
             %d1   = memref.load %input[%idx1] : memref<256xi32>
-            %c1   = arith.constant 100 : i32 
+            %c1   = arith.constant 100 : i32
             %d2   = arith.addi %d1, %c1 : i32
             %idx2 = arith.constant 5 : index
-            memref.store %d2, %input[%idx2] : memref<256xi32> 
-            
+            memref.store %d2, %input[%idx2] : memref<256xi32>
+
             aie.objectfifo.release @of (Consume, 1)
 
             // This release means our 2nd core is done

--- a/tutorials/tutorial-8/aie.mlir
+++ b/tutorials/tutorial-8/aie.mlir
@@ -8,14 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-8.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-8.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-8.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_8 {
 
@@ -42,7 +42,7 @@ module @tutorial_8 {
         // Locks init value is Release 0, so this will always succeed first
         // aie.use_lock(%lock13_1, "Acquire", 0)
 
-		// %val = arith.constant 14 : i384 
+		// %val = arith.constant 14 : i384
         // aie.putCascade(%val : i384)
 
         func.call @extern_kernel1() : () -> ()
@@ -62,10 +62,10 @@ module @tutorial_8 {
 
         // %cas1 = aie.get_cascade() : i384
         // %d1   = arith.trunci %cas1 : i384 to i32
-        // %c1   = arith.constant 100 : i32 
+        // %c1   = arith.constant 100 : i32
         // %d2   = arith.addi %d1, %c1 : i32
 		// %idx2 = arith.constant 5 : index
-		// memref.store %d2, %buf[%idx2] : memref<256xi32> 
+		// memref.store %d2, %buf[%idx2] : memref<256xi32>
 
         func.call @extern_kernel2(%buf) : (memref<256xi32>) -> ()
 

--- a/tutorials/tutorial-8/answers/aie.mlir
+++ b/tutorials/tutorial-8/answers/aie.mlir
@@ -8,15 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-8.exe
+// aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-8.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S 
+// RUN: make -C %S
 // RUN: %run_on_board ./tutorial-8_q3.exe
 // RUN: make -C %S clean
 
 
-// Declare this MLIR module. A wrapper that can contain all 
+// Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
 module @tutorial_8 {
 
@@ -43,9 +43,9 @@ module @tutorial_8 {
         // Locks init value is Release 0, so this will always succeed first
         aie.use_lock(%lock14_1, "Acquire", 0)
 
-		// %val = arith.constant 13 : i384 
-		// //%idx = arith.constant 3 : index 
-		// //memref.store %val, %buf[%idx] : memref<256xi32> 
+		// %val = arith.constant 13 : i384
+		// //%idx = arith.constant 3 : index
+		// //memref.store %val, %buf[%idx] : memref<256xi32>
         // aie.putCascade(%val : i384)
 
         func.call @extern_kernel2(%buf) : (memref<256xi32>) -> ()
@@ -64,10 +64,10 @@ module @tutorial_8 {
         //%d1   = memref.load %buf[%idx1] : memref<256xi32>
         // %cas1 = aie.get_cascade() : i384
         // %d1   = arith.trunci %cas1 : i384 to i32
-        // %c1   = arith.constant 100 : i32 
+        // %c1   = arith.constant 100 : i32
         // %d2   = arith.addi %d1, %c1 : i32
 		// %idx2 = arith.constant 5 : index
-		// memref.store %d2, %buf[%idx2] : memref<256xi32> 
+		// memref.store %d2, %buf[%idx2] : memref<256xi32>
 
         func.call @extern_kernel1() : () -> ()
 

--- a/tutorials/tutorial-9/aie.mlir
+++ b/tutorials/tutorial-9/aie.mlir
@@ -8,32 +8,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-9.exe
+// aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-9.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-9.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_9 {
 
     // Declare tile object of the AIE class located at position col 1, row 4
     %tile14 = aie.tile(1, 4)
 
-    // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-    // size 256 deep x int32 wide. By default, the address of 
-    // this buffer begins after the stack (1024 Bytes offset) and 
+    // Declare buffer for tile(1, 4) with symbolic name "a14" and
+    // size 256 deep x int32 wide. By default, the address of
+    // this buffer begins after the stack (1024 Bytes offset) and
     // all subsequent buffers are allocated one after another in memory.
     %buf = aie.buffer(%tile14) { sym_name = "a14" } : memref<256xi32>
 
-    // Declare a lock 0 associated with tile(1,4) with a 
+    // Declare a lock 0 associated with tile(1,4) with a
     // symbolic name "lock14_0" which can be used by access functions
     // in the generated API (aie.mlir.prj/aie_inc.cpp)
     %lock14_0 = aie.lock(%tile14, 0) { sym_name = "lock14_0" }
 
-    // declare kernel function name "extern_kernel" with one positional 
+    // declare kernel function name "extern_kernel" with one positional
     // function argument, in this case mapped to a memref
     func.func private @extern_kernel(%b: memref<256xi32>) -> ()
 
@@ -49,7 +49,7 @@ module @tutorial_9 {
         // Release acquired lock at end of program.
         // This can be used by host to mark beginning/end of a program or
         // when the host is trying to determine when the program is done
-        // by acquiring this lock (with value 1). 
+        // by acquiring this lock (with value 1).
         aie.use_lock(%lock14_0, "Release", 1)
         aie.end
     } { link_with="kernel.o" } // indicate kernel object name used by this core

--- a/tutorials/tutorial-9/answers/aie_matmul.mlir
+++ b/tutorials/tutorial-9/answers/aie_matmul.mlir
@@ -8,35 +8,35 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j4 --sysroot=%VITIS_SYSROOT% --host-target=aarch64-linux-gnu %s -I%host_runtime_lib%/  %extraAieCcFlags% %host_runtime_lib%/test_library.cpp %S/test.cpp -o tutorial-9.exe
+// aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-9.exe
 
 // REQUIRES: valid_xchess_license
 // RUN: make -C %S
 // RUN: %run_on_board ./tutorial-9.exe
 // RUN: make -C %S clean
 
-// Declare this MLIR module. A block encapsulates all 
+// Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design
 module @tutorial_9 {
 
     // Declare tile object of the AIE class located at position col 1, row 4
     %tile14 = aie.tile(1, 4)
 
-    // Declare buffer for tile(1, 4) with symbolic name "a14" and 
-    // size 256 deep x int32 wide. By default, the address of 
-    // this buffer begins after the stack (1024 Bytes offset) and 
+    // Declare buffer for tile(1, 4) with symbolic name "a14" and
+    // size 256 deep x int32 wide. By default, the address of
+    // this buffer begins after the stack (1024 Bytes offset) and
     // all subsequent buffers are allocated one after another in memory.
     %bufa   = aie.buffer(%tile14) { sym_name = "a14" }   : memref<32xi32>
     %bufb   = aie.buffer(%tile14) { sym_name = "b14" }   : memref<32xi32>
     %bufacc = aie.buffer(%tile14) { sym_name = "acc14" } : memref<32xi32>
     %bufc   = aie.buffer(%tile14) { sym_name = "c14" }   : memref<32xi32>
 
-    // Declare a lock 0 associated with tile(1,4) with a 
+    // Declare a lock 0 associated with tile(1,4) with a
     // symbolic name "lock14_0" which can be used by access functions
     // in the generated API (aie.mlir.prj/aie_inc.cpp)
     %lock14_0 = aie.lock(%tile14, 0) { sym_name = "lock14_0" }
 
-    // declare kernel function name "extern_kernel" with one positional 
+    // declare kernel function name "extern_kernel" with one positional
     // function argument, in this case mapped to a memref
     func.func private @extern_kernel(%a: memref<32xi32>, %b: memref<32xi32>, %acc: memref<32xi32>, %c: memref<32xi32>) -> ()
 
@@ -52,7 +52,7 @@ module @tutorial_9 {
         // Release acquired lock at end of program.
         // This can be used by host to mark beginning/end of a program or
         // when the host is trying to determine when the program is done
-        // by acquiring this lock (with value 1). 
+        // by acquiring this lock (with value 1).
         aie.use_lock(%lock14_0, "Release", 1)
         aie.end
     } { link_with="kernel_matmul.o" } // indicate kernel object name used by this core

--- a/utils/run_on_ipu.sh
+++ b/utils/run_on_ipu.sh
@@ -3,7 +3,22 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# Execute a command while pre-staging for AIE driver some .xclbin firmware and
+# clean up the firmware stage after execution.
+# This script assumes that the path of one xclbin
+# appears in the argument list
+
+# Old AIE driver
+# Where the device driver finds the firmware to be loaded.
 FIRMWARE_DIR=/lib/firmware/amdipu/1502
+# The AIE device model
+NPU_DEVICE=Phoenix
+if [[ -d /lib/firmware/amdnpu/1502_00 ]]; then
+  # New AIE driver naming and firmware location starting with Linux 6.8
+  FIRMWARE_DIR=/lib/firmware/amdnpu/1502_00
+  NPU_DEVICE=NPU1
+fi
+
 XRT_DIR=/opt/xilinx/xrt
 source $XRT_DIR/setup.sh
 
@@ -25,20 +40,25 @@ if [ x"$1" == x"--clean-xclbin" ]; then
 fi
 
 XCLBIN_FN=""
+# Analyze all the command arguments to find some .xclbin
 for f in "$@"; do
   if [ -f "$f" ]; then
     filename=$(basename "$f")
     extension="${f##*.}"
     if [ x"$extension" = x"xclbin" ]; then
       XCLBIN_FN="$filename"
-      $XRT_DIR/amdxdna/setup_xclbin_firmware.sh -dev Phoenix -xclbin $XCLBIN_FN
+      # Stage the .xclbin to be loaded by the command execution later
+      $XRT_DIR/amdxdna/setup_xclbin_firmware.sh -dev $NPU_DEVICE -xclbin $XCLBIN_FN
+      break
     fi
   fi
 done
 
+# Execute the commands and its arguments
 "$@"
 err=$?
 
+# TODO: use setup_xclbin_firmware.sh -clean instead
 if [ x"$XCLBIN_FN" != x"" ]; then
   rm_xclbin $XCLBIN_FN
 fi

--- a/utils/run_on_ipu.sh
+++ b/utils/run_on_ipu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# (c) Copyright 2023 Advanced Micro Devices, Inc.
+# (c) Copyright 2023-2024 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Execute a command while pre-staging for AIE driver some .xclbin firmware and
@@ -9,12 +9,14 @@
 # appears in the argument list
 
 # Old AIE driver
+linux_driver_version=""
 # Where the device driver finds the firmware to be loaded.
 FIRMWARE_DIR=/lib/firmware/amdipu/1502
 # The AIE device model
 NPU_DEVICE=Phoenix
 if [[ -d /lib/firmware/amdnpu/1502_00 ]]; then
   # New AIE driver naming and firmware location starting with Linux 6.8
+  linux_driver_version="6.8"
   FIRMWARE_DIR=/lib/firmware/amdnpu/1502_00
   NPU_DEVICE=NPU1
 fi
@@ -22,12 +24,46 @@ fi
 XRT_DIR=/opt/xilinx/xrt
 source $XRT_DIR/setup.sh
 
+# Get the UUID of the XCLBIN, used by the Linux kernel driver to access it
+xclbin_uuid() {
+  local xclbin_file_name=$1
+  local uuid=$($XRT_DIR/bin/xclbinutil --info -i $xclbin_file_name \
+                 | grep 'UUID (xclbin)' | awk '{print $3}')
+  echo "$uuid"
+}
+
+# Install the XCLBIN file so it can be consumed by the Linux kernel driver
+stage_xclbin() {
+  local npu_device=$1
+  local xclbin_file_name=$2
+  if [[ $linux_driver_version ]]; then
+    # There is a bug in the device driver which prevent loading an XCLBIN if it
+    # is accessed through a symbolic link which is not owned by root. So just
+    # skip the symbolic link installed by the official XDNA XRT staging script
+    # and do some manual work instead
+    cp -a $xclbin_file_name \
+       $FIRMWARE_DIR/$(xclbin_uuid $xclbin_file_name).xclbin
+  else
+    # Use the official XDNA XRT staging script which requires running as root
+    $XRT_DIR/amdxdna/setup_xclbin_firmware.sh \
+      -dev $npu_device -xclbin $xclbin_file_name
+  fi
+}
+
+# Unstage the XCLBIN file
 rm_xclbin() {
-  XCLBIN_FN=$1
+  local XCLBIN_FN=$1
   if [ -f "$XCLBIN_FN" ] && [ x"${XCLBIN_FN##*.}" == x"xclbin" ]; then
-    UUID=$($XRT_DIR/bin/xclbinutil --info -i $XCLBIN_FN | grep 'UUID (xclbin)' | awk '{print $3}')
-    rm -rf "$(readlink -f $FIRMWARE_DIR/$UUID.xclbin)"
-    unlink $FIRMWARE_DIR/$UUID.xclbin
+    local UUID=$(xclbin_uuid $XCLBIN_FN)
+    if [[ $linux_driver_version ]]; then
+      # Remove the XCLBIN file
+      rm $FIRMWARE_DIR/$UUID.xclbin
+    else
+      # Remove the XCLBIN file pointed by the link
+      rm -rf "$(readlink -f $FIRMWARE_DIR/$UUID.xclbin)"
+      # Remove the link
+      unlink $FIRMWARE_DIR/$UUID.xclbin
+    fi
   fi
 
   # -xtype l tests for links that are broken (it is the opposite of -type)
@@ -48,7 +84,7 @@ for f in "$@"; do
     if [ x"$extension" = x"xclbin" ]; then
       XCLBIN_FN="$filename"
       # Stage the .xclbin to be loaded by the command execution later
-      $XRT_DIR/amdxdna/setup_xclbin_firmware.sh -dev $NPU_DEVICE -xclbin $XCLBIN_FN
+      stage_xclbin $NPU_DEVICE $XCLBIN_FN
       break
     fi
   fi


### PR DESCRIPTION
Have mlir-aie working on my laptop running Ubuntu 23.10 and latest Linux 6.8 kernel.
Also fix VCK190 AIE1 tests to compile with Vitis 2023.2.
Can run the CI without being root with latest XDNA driver.