### PR TITLE
Sort CMake configuration options and update actions/checkout

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -102,28 +102,32 @@ jobs:
           mkdir build_assert
           cd build_assert
 
+          # Please keep the options sorted so it is easier to compare
           cmake .. \
             -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
-            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
-            -DCMAKE_C_VISIBILITY_PRESET=hidden \
-            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
             -DAIE_COMPILER=NONE \
-            -DAIE_LINKER=NONE \
-            -DAIE_ENABLE_PYTHON_PASSES=OFF \
             -DAIE_ENABLE_AIRBIN=OFF \
+            -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_LINKER=NONE \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_VISIBILITY_PRESET=hidden \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
+            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
             -DHOST_COMPILER=NONE \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_ENABLE_RTTI=ON \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
-            -DLLVM_USE_LINKER=lld \
             -DLLVM_EXTERNAL_LIT=$(which lit) \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DLLVM_USE_LINKER=lld \
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
 
           ninja
           ninja check-aie
@@ -138,27 +142,31 @@ jobs:
           mkdir build_release
           cd build_release
 
+          # Please keep the options sorted so it is easier to compare
           cmake .. \
             -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
-            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
-            -DCMAKE_C_VISIBILITY_PRESET=hidden \
-            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
             -DAIE_COMPILER=NONE \
-            -DAIE_LINKER=NONE \
-            -DAIE_ENABLE_PYTHON_PASSES=OFF \
             -DAIE_ENABLE_AIRBIN=OFF \
+            -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_LINKER=NONE \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_VISIBILITY_PRESET=hidden \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
+            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
             -DHOST_COMPILER=NONE \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_ENABLE_ASSERTIONS=OFF \
             -DLLVM_ENABLE_RTTI=ON \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
+            -DLLVM_EXTERNAL_LIT=$(which lit) \
             -DLLVM_USE_LINKER=lld \
-            -DLLVM_EXTERNAL_LIT=$(which lit)
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
 
           ninja
           ninja check-aie

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -39,7 +39,7 @@ jobs:
       # Clone the repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get the project repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          
+
           pip install -r python/requirements.txt
 
       - name: Install packages
@@ -80,7 +80,7 @@ jobs:
       - name: Get MLIR
         id: mlir-wheels
         run: |
-          
+
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
           pip -q download mlir==$VERSION \
             -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
@@ -98,10 +98,10 @@ jobs:
       - name: Build and test (Assert)
         if: matrix.build_type == 'Assert'
         run: |
-          
+
           mkdir build_assert
           cd build_assert
-          
+
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
@@ -124,7 +124,7 @@ jobs:
             -DLLVM_USE_LINKER=lld \
             -DLLVM_EXTERNAL_LIT=$(which lit) \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          
+
           ninja
           ninja check-aie
           ninja check-tutorials
@@ -134,10 +134,10 @@ jobs:
       - name: Build and test (Release)
         if: matrix.build_type == 'Release'
         run: |
-          
+
           mkdir build_release
           cd build_release
-          
+
           cmake .. \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -159,7 +159,7 @@ jobs:
             -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_USE_LINKER=lld \
             -DLLVM_EXTERNAL_LIT=$(which lit)
-          
+
           ninja
           ninja check-aie
           ninja check-tutorials

--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -48,13 +48,13 @@ jobs:
           dotnet: true
           haskell: true
           large-packages: true
-          swap-storage: false 
+          swap-storage: false
 
       - name: Docker prune
         shell: bash
         run: |
           docker system prune -a -f
-          
+
       - uses: uraimo/run-on-arch-action@v2.5.0
         name: Run commands
         id: runcmd
@@ -66,60 +66,61 @@ jobs:
             --mac-address ${{ secrets.XILINX_MAC }}
           run: |
             ls -l /opt/Xilinx/Vitis/2023.2/
-            
+
             # this is the inverse of `base64 -w 1000000 Xilinx.lic`
             # the -w ("wrap after 1000000 cols") is so that there are no spaces in the XILINX_LIC env var
             echo -n "${{ secrets.XILINX_LIC }}" | base64 --decode > ~/.Xilinx/Xilinx.lic
-            
+
             cd /
             git clone https://github.com/Xilinx/mlir-aie.git
             cd /mlir-aie
-            
+
             git checkout ${{ github.head_ref }}
             if [ x"${{ inputs.AIE_COMMIT }}" != x"" ]; then
               git reset --hard ${{ inputs.AIE_COMMIT }}
             fi
-            
+
             git submodule update --init --recursive
-            
+
             apt install python3.10-venv
             python -m venv aie-venv
             source aie-venv/bin/activate
             pip install -r python/requirements.txt
-            
+
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
             pip -q download mlir==$VERSION \
               -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
             unzip -q mlir-*.whl
             find mlir -exec touch -a -m -t 201108231405.14 {} \;
-            
+
             # don't delete the space in the sed
             pushd cmake/modulesXilinx && sed -i.bak 's/		VITIS_VPP//g' FindVitis.cmake && popd
-            
+
             mkdir build && cd build
             export PATH=/opt/Xilinx/Vitis/2023.2/bin:/opt/Xilinx/Vitis/2023.2/aietools/bin:$PATH
+            # Please keep the options sorted so it is easier to compare
             cmake .. -G Ninja \
-              -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-              -DVITIS_ROOT=/opt/Xilinx/Vitis/2023.2/ \
-              -DVitis_VERSION_MAJOR=2023 \
-              -DVitis_VERSION_MINOR=2 \
-              -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-              -DLLVM_EXTERNAL_LIT=$(which lit) \
               -DAIE_INCLUDE_INTEGRATION_TESTS=OFF \
               -DAIE_ENABLE_PYTHON_PASSES=OFF \
               -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
               -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+              -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
               -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_INSTALL_PREFIX=install 
-            
+              -DCMAKE_INSTALL_PREFIX=install \
+              -DLLVM_EXTERNAL_LIT=$(which lit) \
+              -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
+              -DVITIS_ROOT=/opt/Xilinx/Vitis/2023.2 \
+              -DVitis_VERSION_MAJOR=2023 \
+              -DVitis_VERSION_MINOR=2
+
             ninja
-            
+
             if [ x"${{ inputs.LIT_FILTER }}" == x"" ]; then
               export LIT_FILTER="${{ inputs.LIT_FILTER }}"
             fi
-            
+
             # filter out CODirect until I put bootgen into the image
             export LIT_OPTS="-sv --timeout 600 -j1 --filter-out Targets/AIEGenerateCDODirect"
             ninja check-aie

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -68,7 +68,7 @@ jobs:
       # Clone the repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get the project repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          
+
           pip install -r python/requirements.txt
 
       - name: Setup Cpp
@@ -103,7 +103,7 @@ jobs:
       - name: Get MLIR
         id: mlir-wheels
         run: |
-          
+
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
           if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF"]; then
             WHEEL=mlir_no_rtti
@@ -117,16 +117,16 @@ jobs:
       # Build the repo test target in release mode to build and test.
       - name: Build and test
         run: |
-          
+
           mkdir build_release
           cd build_release
-          
+
           if [ x"${{ contains(matrix.OS, 'windows') }}" == x"true" ]; then
             LLVM_EXTERNAL_LIT="$(where lit)"
           else
             LLVM_EXTERNAL_LIT="$(which lit)"
           fi
-          
+
           cmake .. \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -145,7 +145,7 @@ jobs:
             -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
             -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_EXTERNAL_LIT="$LLVM_EXTERNAL_LIT"
-          
+
           ninja
           # tests hang/fail on windows
           if [ x"${{ contains(matrix.OS, 'windows') }}" == x"false" ]; then

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -127,24 +127,26 @@ jobs:
             LLVM_EXTERNAL_LIT="$(which lit)"
           fi
 
+          # Please keep the options sorted so it is easier to compare
           cmake .. \
             -G Ninja \
+            -DAIE_COMPILER=NONE \
+            -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_LINKER=NONE \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_VISIBILITY_PRESET=hidden \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
             -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
             -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
-            -DCMAKE_C_VISIBILITY_PRESET=hidden \
-            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
-            -DAIE_COMPILER=NONE \
-            -DAIE_LINKER=NONE \
-            -DAIE_ENABLE_PYTHON_PASSES=OFF \
             -DHOST_COMPILER=NONE \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_ENABLE_ASSERTIONS=${{ matrix.ENABLE_ASSERTIONS }} \
             -DLLVM_ENABLE_RTTI=${{ matrix.ENABLE_RTTI }} \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
-            -DLLVM_EXTERNAL_LIT="$LLVM_EXTERNAL_LIT"
+            -DLLVM_EXTERNAL_LIT="$LLVM_EXTERNAL_LIT" \
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
 
           ninja
           # tests hang/fail on windows

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -103,27 +103,31 @@ jobs:
           mkdir build_assert
           cd build_assert
 
+          # Please keep the options sorted so it is easier to compare
           cmake .. \
             -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
-            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
-            -DCMAKE_C_VISIBILITY_PRESET=hidden \
-            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
             -DAIE_COMPILER=NONE \
-            -DAIE_LINKER=NONE \
             -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_LINKER=NONE \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_VISIBILITY_PRESET=hidden \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
+            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
             -DHOST_COMPILER=NONE \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_ENABLE_RTTI=ON \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
-            -DLLVM_USE_LINKER=lld \
             -DLLVM_EXTERNAL_LIT=$(which lit) \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DLLVM_USE_LINKER=lld \
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
 
           ninja
           ninja check-aie
@@ -140,24 +144,27 @@ jobs:
 
           cmake .. \
             -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
-            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
-            -DCMAKE_C_VISIBILITY_PRESET=hidden \
-            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
             -DAIE_COMPILER=NONE \
-            -DAIE_LINKER=NONE \
             -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_LINKER=NONE \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_VISIBILITY_PRESET=hidden \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
+            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
             -DHOST_COMPILER=NONE \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_ENABLE_ASSERTIONS=OFF \
             -DLLVM_ENABLE_RTTI=ON \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
+            -DLLVM_EXTERNAL_LIT=$(which lit) \
             -DLLVM_USE_LINKER=lld \
-            -DLLVM_EXTERNAL_LIT=$(which lit)
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
 
           ninja
           ninja check-aie

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -40,7 +40,7 @@ jobs:
       # Clone the repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get the project repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Python packages
         run: |
-          
+
           pip install -r python/requirements.txt
 
       - name: Install packages
@@ -81,7 +81,7 @@ jobs:
       - name: Get MLIR
         id: mlir-wheels
         run: |
-          
+
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
           pip -q download mlir==$VERSION \
             -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
@@ -99,10 +99,10 @@ jobs:
       - name: Build and test (Assert)
         if: matrix.build_type == 'Assert'
         run: |
-          
+
           mkdir build_assert
           cd build_assert
-          
+
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=Debug \
@@ -124,7 +124,7 @@ jobs:
             -DLLVM_USE_LINKER=lld \
             -DLLVM_EXTERNAL_LIT=$(which lit) \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          
+
           ninja
           ninja check-aie
           ninja check-tutorials
@@ -134,10 +134,10 @@ jobs:
       - name: Build and test (Release)
         if: matrix.build_type == 'Release'
         run: |
-          
+
           mkdir build_release
           cd build_release
-          
+
           cmake .. \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -158,7 +158,7 @@ jobs:
             -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_USE_LINKER=lld \
             -DLLVM_EXTERNAL_LIT=$(which lit)
-          
+
           ninja
           ninja check-aie
           ninja check-tutorials

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -60,21 +60,22 @@ jobs:
           pushd build
 
           export PATH=/opt/Xilinx/Vitis/2023.2/bin:/opt/Xilinx/Vitis/2023.2/aietools/bin:$PATH
+          # Please keep the options sorted so it is easier to compare
           cmake .. -G Ninja \
-            -DPython3_EXECUTABLE=$(which python) \
-            -DCMAKE_INSTALL_PREFIX=$PWD/../mlir_aie \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DLLVM_EXTERNAL_LIT=$(which lit) \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DXRT_ROOT=/opt/xilinx/xrt \
             -DAIE_ENABLE_PYTHON_PASSES=OFF \
             -DAIE_ENABLE_XRT_PYTHON_BINDINGS=ON \
-            -DAIE_INCLUDE_INTEGRATION_TESTS=OFF
+            -DAIE_INCLUDE_INTEGRATION_TESTS=OFF \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_INSTALL_PREFIX=$PWD/../mlir_aie \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DLLVM_EXTERNAL_LIT=$(which lit) \
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
+            -DPython3_EXECUTABLE=$(which python) \
+            -DXRT_ROOT=/opt/xilinx/xrt
 
           ninja install
 

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -31,15 +31,15 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "true"
 
       - name: Run commands
         run: |
-          
+
           pip cache purge
-        
+
           python -m venv aie-venv
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
@@ -55,7 +55,7 @@ jobs:
           # That means wheels have file with time stamps in the future which makes ninja loop
           # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
           find mlir -exec touch -a -m -t 201108231405.14 {} \;
-          
+
           mkdir build
           pushd build
 

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -7,11 +7,11 @@ on:
   schedule:
     # At 04:00. (see https://crontab.guru)
     - cron: '0 4 * * *'
-    
+
 defaults:
   run:
     shell: bash
-    
+
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
@@ -35,7 +35,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: "true"
 
@@ -45,9 +45,9 @@ jobs:
 
       - name: Build mlir-aie distro
         run: |
-          
+
           pip cache purge
-          
+
           python -m venv aie-venv
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
@@ -60,7 +60,7 @@ jobs:
           # That means wheels have file with time stamps in the future which makes ninja loop
           # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
           find mlir -exec touch -a -m -t 201108231405.14 {} \;
-          
+
           export PATH=/opt/Xilinx/Vitis/2023.2/bin:/opt/Xilinx/Vitis/2023.2/aietools/bin:$PATH
           export MLIR_INSTALL_ABS_PATH=$PWD/mlir
           export MLIR_AIE_SOURCE_DIR=$PWD
@@ -69,14 +69,14 @@ jobs:
           export XRT_ROOT=/opt/xilinx/xrt
           export AIE_PROJECT_COMMIT=$(git rev-parse --short HEAD)
           export DATETIME=$(date +"%Y%m%d%H")
-          
+
           pushd utils/mlir_aie_wheels
-          
+
           pip install wheel auditwheel patchelf importlib_metadata
           CIBW_ARCHS=x86_64 pip wheel . -v -w $WHEELHOUSE_DIR --no-build-isolation
-          
+
           popd
-          
+
           auditwheel repair -w $WHEELHOUSE_DIR/repaired_wheel $WHEELHOUSE_DIR/mlir_aie-*.whl --plat manylinux_2_35_x86_64 --exclude libcdo_driver.so --exclude libmlir_float16_utils.so
           WHL_FN=$(ls $WHEELHOUSE_DIR/repaired_wheel/mlir_aie*whl)
           mv "$WHL_FN" "`echo $WHL_FN | sed "s/cp310-cp310/py3-none/"`"
@@ -120,7 +120,7 @@ jobs:
 
     steps:
       - name: Get the project repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -148,15 +148,15 @@ jobs:
           # That means wheels have file with time stamps in the future which makes ninja loop
           # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
           find mlir -exec touch -a -m -t 201108231405.14 {} \;
-          
+
           unzip -q mlir_aie-*.whl
           find mlir_aie -exec touch -a -m -t 201108231405.14 {} \;
-          
+
           python -m venv aie-venv
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
           source aie-venv/bin/activate
-          
+
           export MLIR_INSTALL_ABS_PATH=$PWD/mlir
           export MLIR_AIE_INSTALL_ABS_PATH=$PWD/mlir_aie
           export WHEELHOUSE_DIR=$PWD/wheelhouse
@@ -165,17 +165,17 @@ jobs:
           export XRT_ROOT=/opt/xilinx/xrt
           export AIE_PROJECT_COMMIT=$(git rev-parse --short HEAD)
           export DATETIME=$(date +"%Y%m%d%H")
-          
+
           cp python/requirements.txt utils/mlir_aie_wheels/python_bindings
           cp python/aie-python-extras-req.txt utils/mlir_aie_wheels/python_bindings
-          
+
           pushd utils/mlir_aie_wheels/python_bindings
-          
+
           pip install wheel auditwheel patchelf
           CIBW_ARCHS=x86_64 pip wheel . -v -w $WHEELHOUSE_DIR --no-build-isolation
-          
+
           popd
-          
+
           auditwheel repair -w $WHEELHOUSE_DIR/repaired_wheel $WHEELHOUSE_DIR/aie_python_bindings-*whl --plat manylinux_2_35_x86_64
 
       - uses: geekyeggo/delete-artifact@v4

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -23,7 +23,7 @@ jobs:
       # Clone the repo and its submodules. Do shallow clone to save clone
       # time.
       - name: Get the project repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -58,7 +58,7 @@ jobs:
       - name: Get MLIR
         id: mlir-wheels
         run: |
-          
+
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
           pip -q download mlir==$VERSION \
             -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
@@ -71,10 +71,10 @@ jobs:
       # Build the repo test target in release mode to build and test.
       - name: Build Docs
         run: |
-          
+
           mkdir build_release
           pushd build_release
-          
+
           cmake .. \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=OFF \

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -75,16 +75,17 @@ jobs:
           mkdir build_release
           pushd build_release
 
+          # Please keep the options sorted so it is easier to compare
           cmake .. \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_ENABLE_ASSERTIONS=OFF \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
-            -DLLVM_USE_LINKER=lld \
-            -DAIE_INCLUDE_DOCS=ON \
             -DAIE_ENABLE_PYTHON_PASSES=OFF \
-            -DLLVM_EXTERNAL_LIT=$(which lit)
+            -DAIE_INCLUDE_DOCS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
+            -DLLVM_ENABLE_ASSERTIONS=OFF \
+            -DLLVM_EXTERNAL_LIT=$(which lit) \
+            -DLLVM_USE_LINKER=lld \
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
           make docs
           popd
           cp -r docs/* build_release/docs

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -39,14 +39,14 @@ jobs:
 
       - name: Install Python packages
         run: |
-          
+
           pip install cmake==3.27.9 numpy psutil pybind11 rich pkginfo lit PyYAML requests
           pip install -r python/requirements.txt
 
       - name: Get MLIR
         id: mlir-wheels
         run: |
-          
+
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
           pip -q download mlir==$VERSION \
             -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
@@ -54,10 +54,10 @@ jobs:
 
       - name: Prepare compile_commands.json
         run: |
-          
+
           mkdir build
           pushd build
-          
+
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -79,9 +79,9 @@ jobs:
             -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_EXTERNAL_LIT=$(which lit) \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          
+
           ninja aie-headers mlir-headers
-          
+
           popd
 
       - name: Analyze
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Get the project repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -188,7 +188,7 @@ jobs:
 
     steps:
       - name: Get the project repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: "true"
@@ -216,7 +216,7 @@ jobs:
       - name: Get MLIR
         id: mlir-wheels
         run: |
-          
+
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
           pip -q download mlir==$VERSION \
             -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
@@ -236,10 +236,10 @@ jobs:
       - name: Build and generate coverage (Release)
         if: steps.changed-files.outputs.changed-files != ''
         run: |
-          
+
           mkdir build_release
           cd build_release
-          
+
           cmake .. \
             -GNinja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -265,9 +265,9 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
             -DBUILD_INSTRUMENTED_COVERAGE=ON \
             -DINSTRUMENTED_COVERAGE_FILES="${{ steps.changed-files.outputs.changed-files }}"
-          
+
           ninja && ninja generate-aie-coverage-report
-          
+
           cat /home/runner/work/mlir-aie/mlir-aie/build_release/report/summary.txt
 
       - name: Format coverage report
@@ -292,4 +292,3 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-path: /home/runner/work/mlir-aie/mlir-aie/build_release/report/index.html
           edit-mode: replace
-

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -58,27 +58,28 @@ jobs:
           mkdir build
           pushd build
 
+          # Please keep the options sorted so it is easier to compare
           cmake .. \
             -GNinja \
+            -DAIE_COMPILER=NONE \
+            -DAIE_ENABLE_AIRBIN=OFF \
+            -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_LINKER=NONE \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_C_VISIBILITY_PRESET=hidden \
             -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_MODULE_PATH=`pwd`/../cmake/modulesXilinx \
             -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
             -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
-            -DCMAKE_C_VISIBILITY_PRESET=hidden \
-            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
-            -DAIE_COMPILER=NONE \
-            -DAIE_LINKER=NONE \
-            -DAIE_ENABLE_PYTHON_PASSES=OFF \
-            -DAIE_ENABLE_AIRBIN=OFF \
             -DHOST_COMPILER=NONE \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_ENABLE_RTTI=ON \
-            -DCMAKE_MODULE_PATH=`pwd`/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_EXTERNAL_LIT=$(which lit) \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
 
           ninja aie-headers mlir-headers
 
@@ -240,31 +241,35 @@ jobs:
           mkdir build_release
           cd build_release
 
+          # Please keep the options sorted so it is easier to compare
           cmake .. \
             -GNinja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
-            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
-            -DCMAKE_C_VISIBILITY_PRESET=hidden \
-            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
             -DAIE_COMPILER=NONE \
-            -DAIE_LINKER=NONE \
-            -DAIE_ENABLE_PYTHON_PASSES=OFF \
             -DAIE_ENABLE_AIRBIN=OFF \
+            -DAIE_ENABLE_PYTHON_PASSES=OFF \
+            -DAIE_LINKER=NONE \
+            -DBUILD_INSTRUMENTED_COVERAGE=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_VISIBILITY_PRESET=hidden \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
+            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
+            -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
+            -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+            -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \
             -DHOST_COMPILER=NONE \
+            -DINSTRUMENTED_COVERAGE_FILES="${{steps.changed-files.outputs.changed-files }}" \
+            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
             -DLLVM_ENABLE_ASSERTIONS=OFF \
             -DLLVM_ENABLE_RTTI=ON \
-            -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
-            -DLLVM_USE_LINKER=lld \
             -DLLVM_EXTERNAL_LIT=$(which lit) \
-            \
-            -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
-            -DBUILD_INSTRUMENTED_COVERAGE=ON \
-            -DINSTRUMENTED_COVERAGE_FILES="${{ steps.changed-files.outputs.changed-files }}"
+            -DLLVM_USE_LINKER=lld \
+            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir
 
           ninja && ninja generate-aie-coverage-report
 


### PR DESCRIPTION
This allows easier comparisons between the various CI configurations.
Use latest GitHub actions/checkout@v4
This fixes some deprecation warnings about old NodeJS.
Also fix some trailing space issues by side effect.