### PR TITLE
Weight expand reference design

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #  -DAIE_RUNTIME_TARGETS: list of targets (x86_64,aarch64) to build runtime libs for, default: x86_64; cross compilation for aarch64 against default Vitis Sysroot
 #  -DAIE_RUNTIME_TEST_TARGET: runtime test target (x86_64 or aarch64) used for running unit test and tutorials, default x86_64
 
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.23)
 
 set(TOOLCHAINFILES_PATH ${CMAKE_SOURCE_DIR}/cmake/modulesXilinx)
 
@@ -243,6 +243,7 @@ endif()
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(aie_runtime_lib)
+add_subdirectory(aie_kernels)
 add_subdirectory(tools)
 add_subdirectory(runtime_lib)
 

--- a/aie_kernels/CMakeLists.txt
+++ b/aie_kernels/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Xilinx Inc.
+
+# Stuff into the build area:
+add_custom_target(aie-kernels ALL)
+
+function(add_aie_kernels arch)
+  if(DEFINED VITIS_ROOT)
+    if(EXISTS "${PROJECT_SOURCE_DIR}/tools/chess-clang/xchesscc_wrapper")
+        add_custom_target(${arch}_kernels ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/mm.o)
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mm.o
+                      COMMAND ${PROJECT_SOURCE_DIR}/tools/chess-clang/xchesscc_wrapper ${arch} -I ${VITIS_ROOT}/aietools/include -c ${CMAKE_CURRENT_SOURCE_DIR}/mm.cc -o ${CMAKE_CURRENT_BINARY_DIR}/mm.o
+                      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mm.cc)
+        add_dependencies(aie-kernels ${arch}_kernels)
+    
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mm.o DESTINATION ${CMAKE_INSTALL_PREFIX}/aie_kernels/)
+    else()
+      message(STATUS "Could not find xchesscc_wrapper inside mlir-aie's build directory")
+    endif()
+  else()
+      message(STATUS "Tool 'xchesscc' not found. Skipping compilation of microkernel .o files.")
+  endif()
+
+endfunction()
+
+add_aie_kernels(AIE2)

--- a/aie_kernels/mm.cc
+++ b/aie_kernels/mm.cc
@@ -1,0 +1,62 @@
+//===- mm.cc ----------------------------------------------000---*- C++ -*-===//
+//
+//  THIS IS WIP AND HAS BEEN TAKEN AND MODIFIED FROM MLIR-AIE.
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#define __AIENGINE__ 2
+#define NOCPP
+#define __AIEARCH__ 20
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#define REL_WRITE 0
+#define REL_READ 1
+
+#include <aie_api/aie.hpp>
+
+template <typename T_in, typename T_out, int M, int K, int N>
+void matmul_scalar(T_in *a, unsigned offsetA, T_in *b, unsigned offsetB,
+                   T_out *c, unsigned offsetC) {
+  event0();
+  for (int row = 0; row < M; row++) {
+    for (int col = 0; col < N; col++) {
+      T_out running_sum = 0;
+      for (int i = 0; i < K; i++) {
+        running_sum += a[offsetA + row * K + i] * b[offsetB + i * N + col];
+      }
+      c[offsetC + row * N + col] += running_sum;
+    }
+  }
+  event1();
+}
+
+extern "C" {
+
+#define combos(X)                                                              \
+  X(int16, i16, int16, i16, 4, 4, 4)                                           \
+  X(int32, i32, int32, i32, 4, 4, 4)                                           \
+  X(bfloat16, bf16, bfloat16, bf16, 4, 8, 4)                                   \
+  X(bfloat16, bf16, float, f32, 4, 8, 4)
+
+#define matmul_scalar_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out, \
+                             r, s, t)                                          \
+  void matmul_scalar_##mlir_type_in##_##mlir_type_out(                         \
+      ctype_in *a_in, unsigned offsetA, ctype_in *b_in, unsigned offsetB,      \
+      ctype_out *c_out, unsigned offsetC) {                                    \
+    matmul_scalar<ctype_in, ctype_out, 4, 4, 4>(a_in, offsetA, b_in, offsetB,  \
+                                                c_out, offsetC);               \
+  }
+
+combos(matmul_scalar_c_func)
+
+} // extern "C"

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -631,8 +631,6 @@ def AIE_PacketRuleOp: AIE_Op<"rule", [HasParent<"PacketRulesOp">]> {
 
 
 def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndOp">]> {
-  let arguments = (ins AIEI8Attr:$ID);
-  let regions = (region AnyRegion:$ports);
   let summary = "Packet switched flow";
   let description = [{
     A logical packet-switched flow between tiles.  During place and
@@ -648,6 +646,12 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
       }
     ```
   }];
+
+  let arguments = (
+    ins AIEI8Attr:$ID,
+        OptionalAttr<BoolAttr>:$keep_pkt_header
+  );
+  let regions = (region AnyRegion:$ports);
 
   let assemblyFormat = [{ `(` $ID `)` regions attr-dict }];
   let hasVerifier = 1;

--- a/include/aie/Dialect/AIEVec/IR/CMakeLists.txt
+++ b/include/aie/Dialect/AIEVec/IR/CMakeLists.txt
@@ -8,7 +8,3 @@
 add_mlir_dialect(AIEVecOps aievec)
 add_mlir_doc(AIEVecOps AIEVecDialect ./ -gen-dialect-doc -dialect=aievec)
 
-set(LLVM_TARGET_DEFINITIONS AIEVecLLVMIntrOp.td)
-mlir_tablegen(AIEVecConversions.inc -gen-llvmir-conversions)
-add_public_tablegen_target(MLIRAIEVecConversionsIncGen)
-

--- a/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEFindFlows.cpp
@@ -248,8 +248,8 @@ static void findFlowsFrom(TileOp op, ConnectivityAnalysis &analysis,
                                   destOp->getResult(0), destPort.bundle,
                                   destPort.channel);
         } else {
-          auto flowOp =
-              rewriter.create<PacketFlowOp>(Op->getLoc(), maskValue.value);
+          auto flowOp = rewriter.create<PacketFlowOp>(Op->getLoc(),
+                                                      maskValue.value, nullptr);
           PacketFlowOp::ensureTerminator(flowOp.getPorts(), rewriter,
                                          Op->getLoc());
           OpBuilder::InsertPoint ip = rewriter.saveInsertionPoint();

--- a/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
@@ -65,8 +65,8 @@ struct AIEBroadcastPacketPass
           Block &b_bpid = r_bpid.front();
           int flowID = bpid.IDInt();
           builder.setInsertionPointAfter(broadcastpacket);
-          PacketFlowOp pkFlow =
-              builder.create<PacketFlowOp>(builder.getUnknownLoc(), flowID);
+          PacketFlowOp pkFlow = builder.create<PacketFlowOp>(
+              builder.getUnknownLoc(), flowID, nullptr);
           Region &r_pkFlow = pkFlow.getPorts();
           Block *b_pkFlow = builder.createBlock(&r_pkFlow);
           builder.setInsertionPointToStart(b_pkFlow);

--- a/programming_guide/README.md
+++ b/programming_guide/README.md
@@ -1,0 +1,56 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// 
+//===----------------------------------------------------------------------===//-->
+
+# <ins>MLIR-AIE Programming Guide</ins>
+
+MLIR-AIE is an MLIR-based representation for AI Engine design. It provides a foundation from which complex and performant AI Engine designs can be defined and is supported by simulation and hardware impelemenation infrastructure. To better understand how AI Engine designs are defined at the MLIR level, it is recommended that you spend some time going through the [tutorial course](../tutorials/). However, this programming guide is intended to lead you through a higher level abstraction (python) of the underlying MLIR-AIE framework and provide design examples and programming tips to allow users to build designs directly. Keep in mind also that MLIR-AIE is a foundational layer in a AI Engine software development framework and while this guide provides a programmer's view for using AI Engines, it also serves as a lower layer for higher abstraction MLIR layers such as [MLIR-AIR](https://github.com/Xilinx/mlir-air).
+
+## Outline
+<details><summary><a href="./section-1">Section 1 - Basic AI Engine building blocks (tiles and buffers)</a></summary>
+
+* Introduce AI Engine building blocks with references to Tutorial material
+* Give example of python binded MLIR source for defining tiles and buffers
+</details>
+<details><summary><a href="./section-2">Section 2- My First Program</a></summary>
+
+* Introduce example of first simple program (Bias Add)
+* Illustrate how built-in simulation of single core design
+</details>
+<details><summary><a href="./section-3">Section 3 - Data Movement (objectfifos)</a></summary>
+
+* Introduce topic of objectfifos and how they abstract connections between objects in the AIE array
+* Point to more detailed objectfifo material in Tutorial
+* Introduce key objectfifo connection patterns (link/ broadcast, join/ distribute)
+</details>
+<details><summary><a href="./section-4">Section 4 - Vector programming & Peformance Measurement</a></summary>
+
+* Discuss topic of vector programming at the kernel level
+* Introduce performance measurement (trace) and how we measure cycle count and efficiency
+* Vector Scalar design example
+</details>
+<details><summary><a href="./section-5">Section 5 - Example Vector Designs</a></summary>
+
+* Introduce additional vector design examples with exercises to measure performance on each
+    * Eltwise Unary ReLU
+    * Eltwise Unary e^x
+    * Eltwise Binary: Vector Addition
+    * Eltwise Binary: Vector Multiplication
+</details>
+<details><summary><a href="./section-6">Section 6 - Larger Example Designs</a></summary>
+
+* Introduce larger design examples with performance measured over multiple cores
+    * GEMM
+    * CONV2D
+    * Edge Detect
+    * Resnet
+</details>
+
+
+

--- a/programming_guide/section-1/README.md
+++ b/programming_guide/section-1/README.md
@@ -1,0 +1,17 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// 
+//===----------------------------------------------------------------------===//-->
+
+# <ins>Section 1 - Basic AI Engine building blocks (tiles and buffers)</ins>
+
+* Introduce AI Engine building blocks with references to Tutorial material
+* Give example of python binded MLIR source for defining tiles and buffers
+
+
+

--- a/programming_guide/section-2/README.md
+++ b/programming_guide/section-2/README.md
@@ -1,0 +1,14 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// 
+//===----------------------------------------------------------------------===//-->
+
+# <ins>Section 2- My First Program</ins>
+
+* Introduce example of first simple program (Bias Add)
+* Illustrate how built-in simulation of single core design

--- a/programming_guide/section-3/README.md
+++ b/programming_guide/section-3/README.md
@@ -1,0 +1,15 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// 
+//===----------------------------------------------------------------------===//-->
+
+# <ins>Section 3 - Data Movement (objectfifos)</ins>
+
+* Introduce topic of objectfifos and how they abstract connections between objects in the AIE array
+* Point to more detailed objectfifo material in Tutorial
+* Introduce key objectfifo connection patterns (link/ broadcast, join/ distribute)

--- a/programming_guide/section-4/README.md
+++ b/programming_guide/section-4/README.md
@@ -1,0 +1,15 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// 
+//===----------------------------------------------------------------------===//-->
+
+# <ins>Section 4 - Vector programming & Peformance Measurement</ins>
+
+* Discuss topic of vector programming at the kernel level
+* Introduce performance measurement (trace) and how we measure cycle count and efficiency
+* Vector Scalar design example

--- a/programming_guide/section-5/README.md
+++ b/programming_guide/section-5/README.md
@@ -1,0 +1,17 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// 
+//===----------------------------------------------------------------------===//-->
+
+# <ins>Section 5 - Example Vector Designs</ins>
+
+* Introduce additional vector design examples with exercises to measure performance on each
+    * Eltwise Unary ReLU
+    * Eltwise Unary e^x
+    * Eltwise Binary: Vector Addition
+    * Eltwise Binary: Vector Multiplication

--- a/programming_guide/section-6/README.md
+++ b/programming_guide/section-6/README.md
@@ -1,0 +1,20 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+// 
+//===----------------------------------------------------------------------===//-->
+
+# <ins>Section 6 - Larger Example Designs</ins>
+
+* Introduce larger design examples with performance measured over multiple cores
+    * GEMM
+    * CONV2D
+    * Edge Detect
+    * Resnet
+
+
+

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -276,9 +276,17 @@ class packetflow(PacketFlowOp):
     """Specialize PacketFlowOp class constructor to take python integers"""
 
     def __init__(
-        self, pkt_id, source, source_port, source_channel, dest, dest_port, dest_channel
+        self,
+        pkt_id,
+        source,
+        source_port,
+        source_channel,
+        dest,
+        dest_port,
+        dest_channel,
+        keep_pkt_header: Optional[bool] = None,
     ):
-        super().__init__(ID=pkt_id)
+        super().__init__(ID=pkt_id, keep_pkt_header=keep_pkt_header)
         bb = Block.create_at_start(self.ports)
         with InsertionPoint(bb):
             src = PacketSourceOp(source, source_port, source_channel)

--- a/reference_designs/ipu-xrt/eltwise_add/CMakeLists.txt
+++ b/reference_designs/ipu-xrt/eltwise_add/CMakeLists.txt
@@ -1,0 +1,68 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+# parameters
+# -DBOOST_ROOT: Path to Boost install
+# -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
+# -DXRT_LIB_DIR: Path to xrt_coreutil.lib
+# -DTARGET_NAME: Target name to be built
+
+# cmake needs this line
+cmake_minimum_required(VERSION 3.1)
+
+find_program(WSL NAMES powershell.exe)
+
+if (NOT WSL)
+    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
+    set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
+    set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
+else()
+    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
+    set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
+    set(XRT_LIB_DIR C:/Technical/xrtIPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
+endif()
+
+set(TARGET_NAME test CACHE STRING "Target to be built")
+
+SET (ProjectName ${TARGET_NAME})
+SET (currentTarget ${TARGET_NAME})
+
+if ( WSL )
+	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
+endif ()
+
+project(${ProjectName})
+
+# Find packages
+find_package(Boost REQUIRED)
+
+add_executable(${currentTarget}
+    test.cpp
+)
+
+target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
+
+target_include_directories (${currentTarget} PUBLIC 
+    ${XRT_INC_DIR}
+    ${Boost_INCLUDE_DIRS}
+)
+
+target_link_directories(${currentTarget} PUBLIC
+    ${XRT_LIB_DIR}
+    ${Boost_LIBRARY_DIRS}
+)
+
+if (NOT WSL)
+    target_link_libraries(${currentTarget} PUBLIC
+        xrt_coreutil
+        boost_program_options
+        boost_filesystem
+    )
+else()
+    target_link_libraries(${currentTarget} PUBLIC
+        xrt_coreutil
+    )
+endif()

--- a/reference_designs/ipu-xrt/eltwise_add/Makefile
+++ b/reference_designs/ipu-xrt/eltwise_add/Makefile
@@ -1,0 +1,50 @@
+##===- Makefile -----------------------------------------------------------===##
+# 
+# This file licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# 
+##===----------------------------------------------------------------------===##
+
+include ../makefile-common
+
+targetname = eltwiseAdd
+
+all: build/final.xclbin build/insts.txt
+
+build/%.o: %.cc
+	mkdir -p ${@D}
+	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -DBIT_WIDTH=8 -c $(<:%=../%) -o ${@F}
+
+build/aie.mlir: aie2.py
+	mkdir -p ${@D}
+	python3 $< > $@
+
+build/final.xclbin: build/aie.mlir build/add.o
+	mkdir -p ${@D}
+	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+				--aie-generate-ipu --ipu-insts-name=insts.txt $(<:%=../%)
+
+${targetname}.exe: test.cpp
+	rm -rf _build
+	mkdir -p _build
+	cd _build && ${powershell} cmake -E env CXXFLAGS="-std=c++23" cmake .. -D CMAKE_C_COMPILER=gcc-13 -D CMAKE_CXX_COMPILER=g++-13 -DTARGET_NAME=${targetname}
+	cd _build && ${powershell} cmake --build . --config Release
+ifeq "${powershell}" "powershell.exe"
+	cp _build/${targetname}.exe $@
+else
+	cp _build/${targetname} $@ 
+endif
+
+run: ${targetname}.exe build/final.xclbin build/insts.txt 
+	${powershell} ./$< -x build/final.xclbin -i build/insts.txt -k MLIR_AIE
+
+trace:
+	../../utils/parse_eventIR.py --filename trace.txt --mlir build/aie.mlir --colshift 1 > parse_eventIR_vs.json
+
+clean_trace:
+	rm -rf tmpTrace trace.txt
+
+clean: clean_trace
+	rm -rf build _build ${targetname}.exe
+

--- a/reference_designs/ipu-xrt/eltwise_add/add.cc
+++ b/reference_designs/ipu-xrt/eltwise_add/add.cc
@@ -1,0 +1,63 @@
+//===- scale.cc -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#define __AIENGINE__ 2
+#define NOCPP
+#define __AIEARCH__ 20
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#include <aie_api/aie.hpp>
+
+template <typename T_in, typename T_out, const int N>
+void eltwise_add(T_in *a, T_in *b, T_out *c) {
+  for (int i = 0; i < N; i++) {
+    c[i] = a[i]+b[i];
+  }
+}
+
+template <typename T_in, typename T_out, const int N>
+void eltwise_vadd(T_in *a, T_in *b, T_out *c) {
+
+  constexpr int vec_factor = 16;
+  event0();
+  T_in *__restrict pA1 = a;
+  T_in *__restrict pB1 = b;
+  T_out *__restrict pC1 = c;
+  const int F = N / vec_factor;
+  for (int i = 0; i < F; i++)
+    chess_prepare_for_pipelining chess_loop_range(16, ) {
+      aie::vector<T_in, vec_factor> A0 = aie::load_v<vec_factor>(pA1);
+      pA1 += vec_factor;
+      aie::vector<T_in, vec_factor> B0 = aie::load_v<vec_factor>(pB1);
+      pB1 += vec_factor;
+      aie::vector<T_out, vec_factor> cout = aie::add(A0, B0);
+      aie::store_v(pC1,cout);
+      pC1 += vec_factor;
+    }
+  event1();
+
+}
+
+
+extern "C" {
+
+void eltwise_add_bf16_scalar(bfloat16 *a_in, bfloat16 *b_in, bfloat16 *c_out) {
+  eltwise_add<bfloat16, bfloat16, 1024>(a_in, b_in, c_out);
+}
+
+void eltwise_add_bf16_vector(bfloat16 *a_in, bfloat16 *b_in, bfloat16 *c_out) {
+  eltwise_vadd<bfloat16, bfloat16, 1024>(a_in, b_in, c_out);
+}
+
+} // extern "C"

--- a/reference_designs/ipu-xrt/eltwise_add/aie2.py
+++ b/reference_designs/ipu-xrt/eltwise_add/aie2.py
@@ -1,0 +1,146 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 AMD Inc.
+
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.dialects.scf import *
+from aie.extras.context import mlir_mod_ctx
+
+
+def my_eltwise_add():
+
+
+    word_size_in = 2
+    N = 65536
+    N_in_bytes = N * word_size_in 
+
+    A_sz_in_i32s = N_in_bytes // 4
+    B_sz_in_i32s = N_in_bytes // 4
+    C_sz_in_i32s = N_in_bytes // 4
+
+    # Tile sizes
+    n = 1024
+    N_div_n = N // n
+
+    n_cores = 2
+    tiles = N_div_n // n_cores
+    buffer_depth = 2
+
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.ipu)
+        def device_body():
+            memRef_ty = T.memref(n, T.bf16())
+
+            # Type used in the tile memory
+            memRef_A_ty = T.memref(n, T.bf16())
+            memRef_B_ty = T.memref(n, T.bf16())
+            memRef_C_ty = T.memref(n, T.bf16())
+
+            # Type used in the memory tile which aggregates across the 4 cores
+            memRef_A_MT_ty = T.memref(n*n_cores, T.bf16())
+            memRef_B_MT_ty = T.memref(n*n_cores, T.bf16())
+            memRef_C_MT_ty = T.memref(n*n_cores, T.bf16())
+
+            # AIE Core Function declarations
+
+            eltwise_add_bf16_scalar = external_func(
+                "eltwise_add_bf16_scalar", inputs=[memRef_ty, memRef_ty, memRef_ty]
+            )
+            eltwise_add_bf16_vector = external_func(
+                "eltwise_add_bf16_vector", inputs=[memRef_ty, memRef_ty, memRef_ty]
+            )
+            #elwise_int32 = external_func("scale_int32", inputs=[memRef_ty, memRef_ty])
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+
+            MemTile = tile(0, 1)
+            cores = [tile(0,2+i) for i in range(n_cores)]
+
+            inA_fifo_names = [f"memA{i}" for i in range(n_cores)]
+            inB_fifo_names = [f"memB{i}" for i in range(n_cores)]
+            outC_fifo_names = [f"memC{i}" for i in range(n_cores)]
+
+            inA_fifos = {}
+            inB_fifos = {}
+            outC_fifos = {}
+
+            # AIE-array data movement with object fifos
+            # Input A
+            inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, memRef_A_MT_ty)
+            for i in range(n_cores):
+                inA_fifos[inA_fifo_names[i]] = object_fifo(
+                    inA_fifo_names[i],
+                    MemTile,
+                    cores[i],
+                    buffer_depth,
+                    memRef_A_ty
+                )
+            object_fifo_link(inA, inA_fifo_names)
+
+            # Input B
+            inB = object_fifo("inB", ShimTile, MemTile, buffer_depth, memRef_B_MT_ty)
+            for i in range(n_cores):
+                inB_fifos[inB_fifo_names[i]] = object_fifo(
+                    inB_fifo_names[i],
+                    MemTile,
+                    cores[i],
+                    buffer_depth,
+                    memRef_B_ty
+                )
+            object_fifo_link(inB, inB_fifo_names[0:n_cores])
+
+            # Output C
+            for i in range(n_cores):
+                outC_fifos[outC_fifo_names[i]] = object_fifo(
+                    outC_fifo_names[i], cores[i], MemTile, buffer_depth, memRef_C_ty
+                )
+            outC = object_fifo(
+                "outC",
+                MemTile,
+                ShimTile,
+                buffer_depth,
+                memRef_C_MT_ty
+            )
+            object_fifo_link(outC_fifo_names[0:n_cores], outC)
+
+            # Set up compute tiles
+            for i in range(n_cores):
+                # Compute tile i
+                @core(cores[i], "add.o")
+                def core_body():
+                    for _ in for_(0xFFFFFFFF):
+                        for _ in for_(tiles):
+                            elem_out = outC_fifos[outC_fifo_names[i]].acquire(ObjectFifoPort.Produce, 1)
+                            elem_in_a = inA_fifos[inA_fifo_names[i]].acquire(ObjectFifoPort.Consume, 1)
+                            elem_in_b = inB_fifos[inB_fifo_names[i]].acquire(ObjectFifoPort.Consume, 1)
+
+                            call(eltwise_add_bf16_vector, [elem_in_a, elem_in_b, elem_out])
+                            inA_fifos[inA_fifo_names[i]].release(ObjectFifoPort.Consume, 1)
+                            inB_fifos[inB_fifo_names[i]].release(ObjectFifoPort.Consume, 1)
+                            outC_fifos[outC_fifo_names[i]].release(ObjectFifoPort.Produce, 1)
+                            yield_([])
+                        yield_([])
+
+            # To/from AIE-array data movement
+            tensor_ty = T.memref(N, T.i32())
+
+            @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+            def sequence(A, B, C):
+
+                ipu_dma_memcpy_nd(metadata="outC", bd_id=0, mem=C, sizes=[1, 1, 1, C_sz_in_i32s])
+                ipu_dma_memcpy_nd(metadata="inA", bd_id=1, mem=A, sizes=[1, 1, 1, A_sz_in_i32s])
+                ipu_dma_memcpy_nd(metadata="inB", bd_id=2, mem=B, sizes=[1, 1, 1, B_sz_in_i32s])
+                ipu_sync(column=0, row=0, direction=0, channel=0)
+
+    print(ctx.module)
+
+
+my_eltwise_add()

--- a/reference_designs/ipu-xrt/eltwise_add/test.cpp
+++ b/reference_designs/ipu-xrt/eltwise_add/test.cpp
@@ -1,0 +1,266 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <bits/stdc++.h>
+#include <boost/program_options.hpp>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <stdfloat>
+
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+constexpr bool VERIFY = true;
+
+constexpr int IN_SIZE = 65536;
+constexpr int OUT_SIZE = IN_SIZE;
+
+namespace po = boost::program_options;
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+static inline std::bfloat16_t random_bfloat16_t() {
+  // Random numbers should NOT be uniformly between 0 and 1, because that
+  // would make the matrix product AB always close to 1.
+  return std::bfloat16_t(4.0 * (float)rand() / (float)(RAND_MAX));
+}
+
+bool nearly_equal(std::bfloat16_t a, std::bfloat16_t b) {
+  std::bfloat16_t diff = fabs(a-b);
+  if ((diff/a) < 0.01)
+    return true;
+  else
+    return false;
+}
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  po::options_description desc("Allowed options");
+
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    return 1;
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+
+  std::vector<uint32_t> instr_v =
+      load_instr_sequence(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(0));
+  auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(std::bfloat16_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(2));
+  auto bo_inB = xrt::bo(device, IN_SIZE * sizeof(std::bfloat16_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(std::bfloat16_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  std::bfloat16_t *bufA = bo_inA.map<std::bfloat16_t *>();
+  std::vector<std::bfloat16_t> AVec(IN_SIZE);
+  for (int i = 0; i < IN_SIZE; i++)
+    AVec[i] = random_bfloat16_t();
+  memcpy(bufA, AVec.data(), (AVec.size() * sizeof(std::bfloat16_t)));
+
+  std::bfloat16_t *bufB = bo_inB.map<std::bfloat16_t *>();
+  std::vector<std::bfloat16_t> BVec(IN_SIZE);
+  for (int i = 0; i < IN_SIZE; i++)
+    BVec[i] = random_bfloat16_t();
+  memcpy(bufB, BVec.data(), (BVec.size() * sizeof(std::bfloat16_t)));
+
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_inA.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_inB.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+
+  int sticky_errors = 0;
+
+  unsigned num_iter = 256;
+  float npu_time_total = 0;
+  float npu_time_min = 9999999;
+  float npu_time_max = 0;
+  for (unsigned iter = 0; iter < num_iter; iter++) {
+
+    if (verbosity >= 1)
+      std::cout << "Running Kernel.\n";
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    auto run = kernel(bo_instr, instr_v.size(), bo_inA, bo_inB, bo_out);
+    run.wait();
+    auto stop = std::chrono::high_resolution_clock::now();
+
+    bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    std::bfloat16_t *bufOut = bo_out.map<std::bfloat16_t *>();
+
+    int errors = 0;
+
+    if (VERIFY) {
+      if (verbosity >= 1) {
+        std::cout << "Verifying results ..." << std::endl;
+      }
+      for (uint32_t i = 0; i < IN_SIZE; i++) {
+        std::bfloat16_t ref = AVec[i] + BVec[i];
+        if (!nearly_equal(*(bufOut + i),ref)) {
+          std::cout << "Error in " << i << " output " << *(bufOut + i) << " != " << ref << " actual " << AVec[i] << " + " << BVec[i] 
+                    << std::endl;
+          errors++;
+          sticky_errors++;
+        } else {
+          if (verbosity >= 2)
+            std::cout << "Correct " << i << " output " << *(bufOut + i) << " == " << ref
+                      << std::endl;
+        }
+      }
+    } else {
+      if (verbosity >= 1)
+        std::cout << "WARNING: vector-scalar results not verified." << std::endl;
+    }
+
+    float npu_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
+            .count();
+
+    npu_time_total += npu_time;
+    npu_time_min = (npu_time < npu_time_min) ? npu_time : npu_time_min;
+    npu_time_max = (npu_time > npu_time_max) ? npu_time : npu_time_max;
+
+
+    if (VERIFY && !errors) {
+      std::cout << iter << ": pass!\n";
+    } else {
+      std::cout << iter << ": fail! " << errors << " errors\n";
+    }
+  }
+
+  std::cout << "Avg NPU exec time: " << npu_time_total / num_iter << "us."
+            << std::endl;
+  std::cout <<"Min NPU matmul time: " << npu_time_min << "us." << std::endl;
+  std::cout << "Max NPU matmul time: " << npu_time_max << "us." << std::endl;
+  
+  if (VERIFY && !sticky_errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nFAIL.\n\n";
+    return 1;
+  }
+
+
+}

--- a/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
+++ b/reference_designs/ipu-xrt/matrix_multiplication_array/aie2.py
@@ -38,7 +38,7 @@ def my_matmul():
     M_div_m_div_n_rows = M // (m * n_rows)
     K_div_k = K // k
     N_div_n = N // n
-    tiles = M_div_m * N_div_n // n_rows
+    tiles = M_div_m * N_div_n // n_cores
     N_div_n_div_n_cols = N_div_n // n_cols
 
     # Matrix A: MxK, submatrices a: mxk
@@ -64,8 +64,8 @@ def my_matmul():
 
         @device(AIEDevice.ipu)
         def device_body():
-            memRef_inA_ty = T.memref(m * k * n_rows, T.bf16())
-            memRef_inB_ty = T.memref(k * n * 1, T.bf16())
+            memRef_inA_ty = T.memref(m * k, T.bf16())
+            memRef_inB_ty = T.memref(k * n, T.bf16())
             memRef_outC_ty = T.memref(m * n * n_rows, T.bf16())
             memRef_A_ty = T.memref(m, k, T.bf16())
             memRef_B_ty = T.memref(k, n, T.bf16())

--- a/reference_designs/ipu-xrt/vector_scalar/Makefile
+++ b/reference_designs/ipu-xrt/vector_scalar/Makefile
@@ -39,5 +39,12 @@ endif
 run: ${targetname}.exe build/final.xclbin build/insts.txt 
 	${powershell} ./$< -x build/final.xclbin -i build/insts.txt -k MLIR_AIE
 
-clean:
+trace:
+	../../utils/parse_eventIR.py --filename trace.txt --mlir build/aie.mlir --colshift 1 > parse_eventIR_vs.json
+
+clean_trace:
+	rm -rf tmpTrace trace.txt
+
+clean: clean_trace
 	rm -rf build _build ${targetname}.exe
+

--- a/reference_designs/ipu-xrt/vector_scalar/Makefile
+++ b/reference_designs/ipu-xrt/vector_scalar/Makefile
@@ -39,12 +39,5 @@ endif
 run: ${targetname}.exe build/final.xclbin build/insts.txt 
 	${powershell} ./$< -x build/final.xclbin -i build/insts.txt -k MLIR_AIE
 
-trace:
-	../../utils/parse_eventIR.py --filename trace.txt --mlir build/aie.mlir --colshift 1 > parse_eventIR_vs.json
-
-clean_trace:
-	rm -rf tmpTrace trace.txt
-
-clean: clean_trace
+clean:
 	rm -rf build _build ${targetname}.exe
-

--- a/reference_designs/ipu-xrt/vector_scalar/aie2.py
+++ b/reference_designs/ipu-xrt/vector_scalar/aie2.py
@@ -15,10 +15,15 @@ from aie.extras.context import mlir_mod_ctx
 
 def my_vector_scalar():
     N = 4096
+    N_in_bytes = N * 4
     n = 1024
     N_div_n = N // n
 
     buffer_depth = 2
+
+    vectorized = True
+    enable_tracing = False
+    trace_size = 8192
 
     with mlir_mod_ctx() as ctx:
 
@@ -27,15 +32,24 @@ def my_vector_scalar():
             memRef_ty = T.memref(n, T.i32())
 
             # AIE Core Function declarations
+
+            scale_scalar_int32 = external_func(
+                "scale_scalar_int32", inputs=[memRef_ty, memRef_ty]
+            )
             scale_int32 = external_func("scale_int32", inputs=[memRef_ty, memRef_ty])
 
             # Tile declarations
             ShimTile = tile(0, 0)
-            ComputeTile2 = tile(0, 2)
+            compute_tile2_col, compute_tile2_row = 0, 2
+            ComputeTile2 = tile(compute_tile2_col, compute_tile2_row)
 
             # AIE-array data movement with object fifos
             of_in = object_fifo("in", ShimTile, ComputeTile2, buffer_depth, memRef_ty)
             of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, memRef_ty)
+
+            # Set up a circuit-switched flow from core to shim for tracing information
+            if enable_tracing:
+                flow(ComputeTile2, WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
 
             # Set up compute tiles
 
@@ -48,7 +62,10 @@ def my_vector_scalar():
                     for _ in for_(N_div_n):
                         elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
                         elem_in = of_in.acquire(ObjectFifoPort.Consume, 1)
-                        call(scale_int32, [elem_in, elem_out])
+                        if vectorized:
+                            call(scale_int32, [elem_in, elem_out])
+                        else:
+                            call(scale_scalar_int32, [elem_in, elem_out])
                         of_in.release(ObjectFifoPort.Consume, 1)
                         of_out.release(ObjectFifoPort.Produce, 1)
                         yield_([])
@@ -59,6 +76,87 @@ def my_vector_scalar():
 
             @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
             def sequence(A, B, C):
+
+                # Configure tracing, see https://github.com/Xilinx/mlir-aie/blob/resnet/docs/Tracing.md
+                if enable_tracing:
+                    # 0x340D0: Trace Control 0
+                    #          0xAABB---C
+                    #            AA        <- Event to stop trace capture
+                    #              BB      <- Event to start trace capture
+                    #                   C  <- Trace mode, 00=event=time, 01=event-PC, 10=execution
+                    # Configure so that "Event 1" (always true) causes tracing to start
+                    ipu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340D0,
+                        value=0x00010000,
+                    )
+                    # 0x340D4: Trace Control 1
+                    ipu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340D4,
+                        value=0x00000000,
+                    )
+                    # 0x340E0: Trace Event Group 1  (Which events to trace)
+                    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
+                    ipu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340E0,
+                        value=0x4B222125,
+                    )
+                    # 0x340E4: Trace Event Group 2  (Which events to trace)
+                    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
+                    ipu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340E4,
+                        value=0x2D2C1A4F,
+                    )
+
+                    ipu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x3FF00,
+                        value=0x00000121,
+                    )
+
+                    # Configure a buffer descriptor to write tracing information that has been routed into this shim tile
+                    # out to host DDR memory
+                    trace_bd_id = 13  # use BD 13 for writing trace output from compute tile to DDR host memory
+                    output_size = N_in_bytes
+                    ipu_writebd_shimtile(
+                        bd_id=trace_bd_id,
+                        buffer_length=trace_size,
+                        buffer_offset=output_size,
+                        enable_packet=0,
+                        out_of_order_id=0,
+                        packet_id=0,
+                        packet_type=0,
+                        column=0,
+                        column_num=1,
+                        d0_size=0,
+                        d0_stride=0,
+                        d1_size=0,
+                        d1_stride=0,
+                        d2_stride=0,
+                        ddr_id=2,
+                        iteration_current=0,
+                        iteration_size=0,
+                        iteration_stride=0,
+                        lock_acq_enable=0,
+                        lock_acq_id=0,
+                        lock_acq_val=0,
+                        lock_rel_id=0,
+                        lock_rel_val=0,
+                        next_bd=0,
+                        use_next_bd=0,
+                        valid_bd=1,
+                    )
+                    # Set start BD to our shim bd_Id (3)
+                    ipu_write32(column=0, row=0, address=0x1D20C, value=trace_bd_id)
+
                 ipu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
                 ipu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])
                 ipu_sync(column=0, row=0, direction=0, channel=0)

--- a/reference_designs/ipu-xrt/vector_scalar/aie2.py
+++ b/reference_designs/ipu-xrt/vector_scalar/aie2.py
@@ -15,15 +15,10 @@ from aie.extras.context import mlir_mod_ctx
 
 def my_vector_scalar():
     N = 4096
-    N_in_bytes = N * 4
     n = 1024
     N_div_n = N // n
 
     buffer_depth = 2
-
-    vectorized = True
-    enable_tracing = False
-    trace_size = 8192
 
     with mlir_mod_ctx() as ctx:
 
@@ -32,24 +27,15 @@ def my_vector_scalar():
             memRef_ty = T.memref(n, T.i32())
 
             # AIE Core Function declarations
-
-            scale_scalar_int32 = external_func(
-                "scale_scalar_int32", inputs=[memRef_ty, memRef_ty]
-            )
             scale_int32 = external_func("scale_int32", inputs=[memRef_ty, memRef_ty])
 
             # Tile declarations
             ShimTile = tile(0, 0)
-            compute_tile2_col, compute_tile2_row = 0, 2
-            ComputeTile2 = tile(compute_tile2_col, compute_tile2_row)
+            ComputeTile2 = tile(0, 2)
 
             # AIE-array data movement with object fifos
             of_in = object_fifo("in", ShimTile, ComputeTile2, buffer_depth, memRef_ty)
             of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, memRef_ty)
-
-            # Set up a circuit-switched flow from core to shim for tracing information
-            if enable_tracing:
-                flow(ComputeTile2, WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
 
             # Set up compute tiles
 
@@ -62,10 +48,7 @@ def my_vector_scalar():
                     for _ in for_(N_div_n):
                         elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
                         elem_in = of_in.acquire(ObjectFifoPort.Consume, 1)
-                        if vectorized:
-                            call(scale_int32, [elem_in, elem_out])
-                        else:
-                            call(scale_scalar_int32, [elem_in, elem_out])
+                        call(scale_int32, [elem_in, elem_out])
                         of_in.release(ObjectFifoPort.Consume, 1)
                         of_out.release(ObjectFifoPort.Produce, 1)
                         yield_([])
@@ -76,87 +59,6 @@ def my_vector_scalar():
 
             @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
             def sequence(A, B, C):
-
-                # Configure tracing, see https://github.com/Xilinx/mlir-aie/blob/resnet/docs/Tracing.md
-                if enable_tracing:
-                    # 0x340D0: Trace Control 0
-                    #          0xAABB---C
-                    #            AA        <- Event to stop trace capture
-                    #              BB      <- Event to start trace capture
-                    #                   C  <- Trace mode, 00=event=time, 01=event-PC, 10=execution
-                    # Configure so that "Event 1" (always true) causes tracing to start
-                    ipu_write32(
-                        column=compute_tile2_col,
-                        row=compute_tile2_row,
-                        address=0x340D0,
-                        value=0x00010000,
-                    )
-                    # 0x340D4: Trace Control 1
-                    ipu_write32(
-                        column=compute_tile2_col,
-                        row=compute_tile2_row,
-                        address=0x340D4,
-                        value=0x00000000,
-                    )
-                    # 0x340E0: Trace Event Group 1  (Which events to trace)
-                    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
-                    ipu_write32(
-                        column=compute_tile2_col,
-                        row=compute_tile2_row,
-                        address=0x340E0,
-                        value=0x4B222125,
-                    )
-                    # 0x340E4: Trace Event Group 2  (Which events to trace)
-                    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
-                    ipu_write32(
-                        column=compute_tile2_col,
-                        row=compute_tile2_row,
-                        address=0x340E4,
-                        value=0x2D2C1A4F,
-                    )
-
-                    ipu_write32(
-                        column=compute_tile2_col,
-                        row=compute_tile2_row,
-                        address=0x3FF00,
-                        value=0x00000121,
-                    )
-
-                    # Configure a buffer descriptor to write tracing information that has been routed into this shim tile
-                    # out to host DDR memory
-                    trace_bd_id = 13  # use BD 13 for writing trace output from compute tile to DDR host memory
-                    output_size = N_in_bytes
-                    ipu_writebd_shimtile(
-                        bd_id=trace_bd_id,
-                        buffer_length=trace_size,
-                        buffer_offset=output_size,
-                        enable_packet=0,
-                        out_of_order_id=0,
-                        packet_id=0,
-                        packet_type=0,
-                        column=0,
-                        column_num=1,
-                        d0_size=0,
-                        d0_stride=0,
-                        d1_size=0,
-                        d1_stride=0,
-                        d2_stride=0,
-                        ddr_id=2,
-                        iteration_current=0,
-                        iteration_size=0,
-                        iteration_stride=0,
-                        lock_acq_enable=0,
-                        lock_acq_id=0,
-                        lock_acq_val=0,
-                        lock_rel_id=0,
-                        lock_rel_val=0,
-                        next_bd=0,
-                        use_next_bd=0,
-                        valid_bd=1,
-                    )
-                    # Set start BD to our shim bd_Id (3)
-                    ipu_write32(column=0, row=0, address=0x1D20C, value=trace_bd_id)
-
                 ipu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
                 ipu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])
                 ipu_sync(column=0, row=0, direction=0, channel=0)

--- a/reference_designs/ipu-xrt/vector_scalar/scale.cc
+++ b/reference_designs/ipu-xrt/vector_scalar/scale.cc
@@ -22,7 +22,7 @@
 
 #include <aie_api/aie.hpp>
 
-template <typename T_in, typename T_out, int N>
+template <typename T_in, typename T_out, const int N>
 void scale(T_in *a, T_out *c, T_in factor) {
   event0();
   for (int i = 0; i < N; i++) {
@@ -31,9 +31,32 @@ void scale(T_in *a, T_out *c, T_in factor) {
   event1();
 }
 
+// Assume factor is at least 16
+template <typename T_in, typename T_out, const int N>
+void scale_vectorized(T_in *a, T_out *c, T_in factor) {
+  constexpr int vec_factor = 16;
+  event0();
+  T_in *__restrict pA1 = a;
+  T_out *__restrict pC1 = c;
+  const int F = N / vec_factor;
+  for (int i = 0; i < F; i++)
+    chess_prepare_for_pipelining chess_loop_range(16, ) {
+      aie::vector<T_in, vec_factor> A0 = aie::load_v<vec_factor>(pA1);
+      pA1 += vec_factor;
+      aie::accum<acc64, vec_factor> cout = aie::mul(A0, factor);
+      aie::store_v(pC1, cout.to_vector<T_out>(0));
+      pC1 += vec_factor;
+    }
+  event1();
+}
+
 extern "C" {
 
 void scale_int32(int32_t *a_in, int32_t *c_out) {
+  scale_vectorized<int32_t, int32_t, 1024>(a_in, c_out, 3);
+}
+
+void scale_scalar_int32(int32_t *a_in, int32_t *c_out) {
   scale<int32_t, int32_t, 1024>(a_in, c_out, 3);
 }
 

--- a/reference_designs/ipu-xrt/vector_scalar/scale.cc
+++ b/reference_designs/ipu-xrt/vector_scalar/scale.cc
@@ -22,7 +22,7 @@
 
 #include <aie_api/aie.hpp>
 
-template <typename T_in, typename T_out, const int N>
+template <typename T_in, typename T_out, int N>
 void scale(T_in *a, T_out *c, T_in factor) {
   event0();
   for (int i = 0; i < N; i++) {
@@ -31,32 +31,9 @@ void scale(T_in *a, T_out *c, T_in factor) {
   event1();
 }
 
-// Assume factor is at least 16
-template <typename T_in, typename T_out, const int N>
-void scale_vectorized(T_in *a, T_out *c, T_in factor) {
-  constexpr int vec_factor = 16;
-  event0();
-  T_in *__restrict pA1 = a;
-  T_out *__restrict pC1 = c;
-  const int F = N / vec_factor;
-  for (int i = 0; i < F; i++)
-    chess_prepare_for_pipelining chess_loop_range(16, ) {
-      aie::vector<T_in, vec_factor> A0 = aie::load_v<vec_factor>(pA1);
-      pA1 += vec_factor;
-      aie::accum<acc64, vec_factor> cout = aie::mul(A0, factor);
-      aie::store_v(pC1, cout.to_vector<T_out>(0));
-      pC1 += vec_factor;
-    }
-  event1();
-}
-
 extern "C" {
 
 void scale_int32(int32_t *a_in, int32_t *c_out) {
-  scale_vectorized<int32_t, int32_t, 1024>(a_in, c_out, 3);
-}
-
-void scale_scalar_int32(int32_t *a_in, int32_t *c_out) {
   scale<int32_t, int32_t, 1024>(a_in, c_out, 3);
 }
 

--- a/reference_designs/ipu-xrt/vector_scalar/test.cpp
+++ b/reference_designs/ipu-xrt/vector_scalar/test.cpp
@@ -8,9 +8,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <bits/stdc++.h>
 #include <boost/program_options.hpp>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <ctime>
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -21,8 +24,13 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
+constexpr bool VERIFY = true;
+constexpr bool ENABLE_TRACING = false;
+constexpr int TRACE_SIZE = 8192;
+
 constexpr int IN_SIZE = 4096;
-constexpr int OUT_SIZE = 4096;
+constexpr int OUT_SIZE = ENABLE_TRACING ? IN_SIZE + TRACE_SIZE / 4 : IN_SIZE;
+// constexpr int OUT_SIZE = 4096;
 
 namespace po = boost::program_options;
 
@@ -54,10 +62,26 @@ std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
   return instr_v;
 }
 
+void write_out_trace(uint32_t *bufOut, std::string path) {
+  std::ofstream fout(path);
+  uint32_t *traceOut =
+      (uint32_t *)((char *)bufOut + sizeof(uint32_t) * IN_SIZE);
+  for (int i = 0; i < TRACE_SIZE / sizeof(traceOut[0]); i++) {
+    fout << std::setfill('0') << std::setw(8) << std::hex << (int)traceOut[i];
+    fout << std::endl;
+  }
+}
+
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
   po::options_description desc("Allowed options");
+  if (ENABLE_TRACING) {
+    desc.add_options()("trace,t",
+                       po::value<std::string>()->default_value("trace.txt"),
+                       "where to store trace output");
+  }
+
   desc.add_options()("help,h", "produce help message")(
       "xclbin,x", po::value<std::string>()->required(),
       "the input xclbin path")(
@@ -68,6 +92,11 @@ int main(int argc, const char *argv[]) {
       "instr,i", po::value<std::string>()->required(),
       "path of file containing userspace instructions to be sent to the LX6");
   po::variables_map vm;
+  if (ENABLE_TRACING) {
+    desc.add_options()("trace,t",
+                       po::value<std::string>()->default_value("trace.txt"),
+                       "where to store trace output");
+  }
 
   try {
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -168,19 +197,31 @@ int main(int argc, const char *argv[]) {
 
   int errors = 0;
 
-  for (uint32_t i = 0; i < OUT_SIZE; i++) {
-    uint32_t ref = (i + 1) * 3;
-    if (*(bufOut + i) != ref) {
-      std::cout << "Error in output " << *(bufOut + i) << " != " << ref
-                << std::endl;
-      errors++;
-    } else {
-      std::cout << "Correct output " << *(bufOut + i) << " == " << ref
-                << std::endl;
+  if (VERIFY) {
+    if (verbosity >= 1) {
+      std::cout << "Verifying results ..." << std::endl;
     }
+    for (uint32_t i = 0; i < IN_SIZE; i++) {
+      uint32_t ref = (i + 1) * 3;
+      if (*(bufOut + i) != ref) {
+        std::cout << "Error in output " << *(bufOut + i) << " != " << ref
+                  << std::endl;
+        errors++;
+      } else {
+        std::cout << "Correct output " << *(bufOut + i) << " == " << ref
+                  << std::endl;
+      }
+    }
+  } else {
+    if (verbosity >= 1)
+      std::cout << "WARNING: vector-scalar results not verified." << std::endl;
   }
 
-  if (!errors) {
+  if (ENABLE_TRACING) {
+    write_out_trace(bufOut, vm["trace"].as<std::string>());
+  }
+
+  if (VERIFY && !errors) {
     std::cout << "\nPASS!\n\n";
     return 0;
   } else {

--- a/reference_designs/ipu-xrt/weight_expand/CMakeLists.txt
+++ b/reference_designs/ipu-xrt/weight_expand/CMakeLists.txt
@@ -1,0 +1,68 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 Advanced Micro Devices, Inc.
+
+# parameters
+# -DBOOST_ROOT: Path to Boost install
+# -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
+# -DXRT_LIB_DIR: Path to xrt_coreutil.lib
+# -DTARGET_NAME: Target name to be built
+
+# cmake needs this line
+cmake_minimum_required(VERSION 3.1)
+
+find_program(WSL NAMES powershell.exe)
+
+if (NOT WSL)
+    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
+    set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
+    set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
+else()
+    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
+    set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
+    set(XRT_LIB_DIR C:/Technical/xrtIPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
+endif()
+
+set(TARGET_NAME test CACHE STRING "Target to be built")
+
+SET (ProjectName ${TARGET_NAME})
+SET (currentTarget ${TARGET_NAME})
+
+if ( WSL )
+	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
+endif ()
+
+project(${ProjectName})
+
+# Find packages
+find_package(Boost REQUIRED)
+
+add_executable(${currentTarget}
+    test.cpp
+)
+
+target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
+
+target_include_directories (${currentTarget} PUBLIC 
+    ${XRT_INC_DIR}
+    ${Boost_INCLUDE_DIRS}
+)
+
+target_link_directories(${currentTarget} PUBLIC
+    ${XRT_LIB_DIR}
+    ${Boost_LIBRARY_DIRS}
+)
+
+if (NOT WSL)
+    target_link_libraries(${currentTarget} PUBLIC
+        xrt_coreutil
+        boost_program_options
+        boost_filesystem
+    )
+else()
+    target_link_libraries(${currentTarget} PUBLIC
+        xrt_coreutil
+    )
+endif()

--- a/reference_designs/ipu-xrt/weight_expand/Makefile
+++ b/reference_designs/ipu-xrt/weight_expand/Makefile
@@ -1,0 +1,50 @@
+##===- Makefile -----------------------------------------------------------===##
+# 
+# This file licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# 
+##===----------------------------------------------------------------------===##
+
+include ../makefile-common
+
+targetname = eltwiseAdd
+
+all: build/final.xclbin build/insts.txt
+
+build/%.o: %.cc
+	mkdir -p ${@D}
+	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -DBIT_WIDTH=8 -c $(<:%=../%) -o ${@F}
+
+build/aie.mlir: aie2.py
+	mkdir -p ${@D}
+	python3 $< > $@
+
+build/final.xclbin: build/aie.mlir build/expand.o
+	mkdir -p ${@D}
+	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+				--aie-generate-ipu --ipu-insts-name=insts.txt $(<:%=../%)
+
+${targetname}.exe: test.cpp
+	rm -rf _build
+	mkdir -p _build
+	cd _build && ${powershell} cmake -E env CXXFLAGS="-std=c++23" cmake .. -D CMAKE_C_COMPILER=gcc-13 -D CMAKE_CXX_COMPILER=g++-13 -DTARGET_NAME=${targetname}
+	cd _build && ${powershell} cmake --build . --config Release
+ifeq "${powershell}" "powershell.exe"
+	cp _build/${targetname}.exe $@
+else
+	cp _build/${targetname} $@ 
+endif
+
+run: ${targetname}.exe build/final.xclbin build/insts.txt 
+	${powershell} ./$< -x build/final.xclbin -i build/insts.txt -k MLIR_AIE
+
+trace:
+	../../utils/parse_eventIR.py --filename trace.txt --mlir build/aie.mlir --colshift 1 > parse_eventIR_vs.json
+
+clean_trace:
+	rm -rf tmpTrace trace.txt
+
+clean: clean_trace
+	rm -rf build _build ${targetname}.exe
+

--- a/reference_designs/ipu-xrt/weight_expand/aie2.py
+++ b/reference_designs/ipu-xrt/weight_expand/aie2.py
@@ -1,0 +1,96 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 AMD Inc.
+
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.dialects.scf import *
+from aie.extras.context import mlir_mod_ctx
+
+
+def my_expand():
+
+    SF_BLOCK_SIZE = 32
+    word_size_in = 2
+    sf_word_size_in = 2
+    N = 65536
+
+    N_in_bytes = (N // word_size_in) + (N/SF_BLOCK_SIZE)*sf_word_size_in 
+
+    A_sz_in_i32s = (N // 8) + (N // SF_BLOCK_SIZE) // 2     # They are 4 bits per element, we need to add on the scale factors later though
+    B_sz_in_i32s = N // 2      # Returning 16 bits at the moment
+
+    # Tile sizes
+    n = 1024
+    block_size = 32
+    sf_size = n // block_size
+
+    input_buffer_size_bytes = (n // 2)   + (sf_size * 2)   # They are bfloat16 sfs after the private values
+    output_buffer_size_bytes = (n * 2)                     # The unscaled values
+
+
+    N_div_n = N // n
+
+    n_cores = 1
+    tiles = N_div_n // n_cores
+    buffer_depth = 2
+
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.ipu)
+        def device_body():
+            memRef_i_ty = T.memref(input_buffer_size_bytes, T.i8())          # Just think of the input as a raw byte buffer
+            memRef_o_ty = T.memref(output_buffer_size_bytes, T.i8())         # For now
+
+            # AIE Core Function declarations
+
+            expand_int4_to_bfloat16 = external_func(
+                "expand_int4_to_bfloat16", inputs=[memRef_i_ty, memRef_o_ty]
+            )
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+
+            MemTile = tile(0, 1)
+            core0    = tile(0,2)
+
+            # AIE-array data movement with object fifos
+            # Input
+            inA = object_fifo("inA", ShimTile, core0, buffer_depth, memRef_i_ty)
+
+            # Output B
+            outB = object_fifo("outB", core0, ShimTile, buffer_depth, memRef_o_ty)
+
+            # Set up compute tiles
+            @core(core0, "expand.o")
+            def core_body():
+                for _ in for_(0xFFFFFFFF):
+                    for _ in for_(tiles):
+                        elem_out = outB.acquire(ObjectFifoPort.Produce, 1)
+                        elem_in  = inA.acquire(ObjectFifoPort.Consume, 1)
+
+                        call(expand_int4_to_bfloat16, [elem_in, elem_out])
+                        inA.release(ObjectFifoPort.Consume, 1)
+                        outB.release(ObjectFifoPort.Produce, 1)
+                        yield_([])
+                    yield_([])
+
+            # To/from AIE-array data movement
+            tensor_ty = T.memref(N, T.i32())
+
+            @FuncOp.from_py_func(tensor_ty, tensor_ty)
+            def sequence(A, C):
+
+                ipu_dma_memcpy_nd(metadata="outB", bd_id=0, mem=C, sizes=[1, 1, 1, B_sz_in_i32s])
+                ipu_dma_memcpy_nd(metadata="inA", bd_id=1, mem=A, sizes=[1, 1, 1, A_sz_in_i32s])
+                ipu_sync(column=0, row=0, direction=0, channel=0)
+
+    print(ctx.module)
+
+
+my_expand()

--- a/reference_designs/ipu-xrt/weight_expand/expand.cc
+++ b/reference_designs/ipu-xrt/weight_expand/expand.cc
@@ -1,0 +1,77 @@
+//===- scale.cc -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#define __AIENGINE__ 2
+#define NOCPP
+#define __AIEARCH__ 20
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <type_traits>
+
+#include <aie_api/aie.hpp>
+
+template <typename T_in, typename T_sf, typename T_out, const int N>
+void expand(T_in *in, T_out *out) {
+
+  /*
+  out[0] = 0x0;
+  out[1] = 0x1;
+  out[2] = 0x2;
+  out[3] = 0x3;
+*/
+  constexpr int vec_factor = 32;
+  constexpr int sf_vec_factor = 8;
+
+  event0();
+  T_in *__restrict pI = in;
+  T_in *__restrict pSFb = in + N/2;             // The scale factors are after the integer values
+  T_sf *__restrict pSF = (T_sf *)pSFb;          // But we only advance by the number of bytes not elements
+  T_out *__restrict pO = out;
+  const int F = N / vec_factor;
+
+
+  for (int i = 0; i < F; i++)
+       chess_prepare_for_pipelining chess_loop_range(16, ) {
+    aie::vector<T_in, vec_factor> I0 = aie::load_v<vec_factor>(pI);  // For example <int4, 32>
+    pI += vec_factor/2;  // Try this
+
+    // Should really do this outside the loop
+    aie::vector<T_sf, sf_vec_factor> sfV = aie::load_v<sf_vec_factor>(pSF);  // For example <bfloat16, 16>
+    if ((i % sf_vec_factor) == (sf_vec_factor - 1))
+      pSF += sf_vec_factor;
+
+    bfloat16 sf = sfV[i % sf_vec_factor];
+    
+    aie::vector<bfloat16, vec_factor> sf_broadcast = aie::broadcast(sf);
+
+    // Upsize these to 8 bits -> 16 -> bfloat16
+    aie::vector<int8, vec_factor>  asInt8 = aie::unpack(I0);
+    aie::vector<int16, vec_factor>  asInt16 = aie::unpack(asInt8);
+    aie::vector<bfloat16, vec_factor>  as_bf16 = aie::to_float<bfloat16>(asInt16, 0);
+    aie::vector<bfloat16, vec_factor>  scaled_bf16 = aie::mul(as_bf16, sf_broadcast);
+
+    aie::store_v(pO,scaled_bf16);
+    pO += vec_factor;
+  }
+  event1();
+
+}
+
+
+extern "C" {
+
+void expand_int4_to_bfloat16(int4 *a_in, bfloat16 *c_out) {
+  expand<int4, bfloat16, bfloat16, 1024>(a_in, c_out);
+}
+
+
+} // extern "C"

--- a/reference_designs/ipu-xrt/weight_expand/test.cpp
+++ b/reference_designs/ipu-xrt/weight_expand/test.cpp
@@ -1,0 +1,310 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <bits/stdc++.h>
+#include <boost/program_options.hpp>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <stdfloat>
+
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+constexpr bool VERIFY = true;
+
+constexpr int TEST_SIZE = 65536;
+constexpr int TILE_SIZE = 1024;
+constexpr int NUM_TILES = TEST_SIZE / TILE_SIZE;
+
+constexpr int SF_BLOCK_SIZE = 32;
+
+constexpr int TOTAL_TILE_SIZE = (TILE_SIZE/2) + (TILE_SIZE/SF_BLOCK_SIZE)*2;
+
+constexpr int IN_SIZE = (TEST_SIZE / 2) + (TEST_SIZE / SF_BLOCK_SIZE)*2;   
+constexpr int OUT_SIZE = TEST_SIZE * 2;                                      
+
+namespace po = boost::program_options;
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+static inline std::bfloat16_t random_bfloat16_t() {
+  // Random numbers should NOT be uniformly between 0 and 1, because that
+  // would make the matrix product AB always close to 1.
+  return std::bfloat16_t(4.0 * (float)rand() / (float)(RAND_MAX));
+}
+
+bool nearly_equal(std::bfloat16_t a, std::bfloat16_t b) {
+  std::bfloat16_t diff = fabs(a-b);
+  if ((diff/a) < 0.01)
+    return true;
+  else
+    return false;
+}
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  po::options_description desc("Allowed options");
+
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    return 1;
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+
+  std::vector<uint32_t> instr_v =
+      load_instr_sequence(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(0));
+  auto bo_in = xrt::bo(device, IN_SIZE * sizeof(char),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(2));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(char),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  char *bufA = bo_in.map<char *>();
+  std::vector<char> AVec(IN_SIZE);
+
+  std::vector<std::int8_t> A_private;
+  std::vector<std::bfloat16_t> A_sf;
+
+  for (int t=0;t<NUM_TILES;t++) {
+    for (int pr=0;pr<TILE_SIZE/2;pr++) {
+        std::int8_t lower = (rand()) & 0xf;
+        std::int8_t upper = (rand()) & 0xf;
+        AVec[t*TOTAL_TILE_SIZE + pr] = ((upper) << 4) + lower;
+        A_private.push_back(lower);
+        A_private.push_back(upper);
+        if (verbosity >= 2) {
+          if (t==0) std::cout << std::hex << (t*TOTAL_TILE_SIZE + pr) << " : " <<((upper << 4) + lower) << std::dec << std::endl;
+        }
+    }
+    for (int isf=0;isf<TILE_SIZE/SF_BLOCK_SIZE;isf++) {
+      std::bfloat16_t sf = std::bfloat16_t(4.0 * (float)rand() / (float)(RAND_MAX));
+      std::uint16_t bits = *((std::uint16_t *)&sf);
+      std::int8_t upper = (std::int8_t)(bits >> 8);
+      std::int8_t lower = (std::int8_t)(bits & 0x00ff);
+      AVec[t*TOTAL_TILE_SIZE + TILE_SIZE/2 + isf*2]  = lower;
+      AVec[t*TOTAL_TILE_SIZE + TILE_SIZE/2 + isf*2+1] = upper;
+      A_sf.push_back(sf);
+      if (verbosity >= 2) {
+        if (t==0) std::cout << std::hex << (t*TOTAL_TILE_SIZE + TILE_SIZE/2 + isf*2) << " and +1 :" << sf << std::dec << std::endl;
+      }
+    }
+  }
+
+  memcpy(bufA, AVec.data(), (AVec.size() * sizeof(char)));
+
+  if (verbosity >= 2) 
+    std::cout << "Pre run values in  " << std::hex << int(bufA[0]) << ", " << int(bufA[1]) << ", " << int(bufA[2]) << std::dec << std::endl;
+
+
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_in.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+
+  int sticky_errors = 0;
+
+  unsigned num_iter = 16;
+  float npu_time_total = 0;
+  float npu_time_min = 9999999;
+  float npu_time_max = 0;
+  for (unsigned iter = 0; iter < num_iter; iter++) {
+
+    if (verbosity >= 1)
+      std::cout << "Running Kernel.\n";
+
+    auto start = std::chrono::high_resolution_clock::now();
+
+    auto run = kernel(bo_instr, instr_v.size(), bo_in, bo_out);
+    run.wait();
+    auto stop = std::chrono::high_resolution_clock::now();
+
+    bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+    std::bfloat16_t *bufOut = bo_out.map<std::bfloat16_t *>();
+
+    int errors = 0;
+
+    if (verbosity >= 2) {
+      std::cout << "First values in  " << std::hex << int(bufA[0]) << ", " << int(bufA[1]) << ", " << int(bufA[2]) << std::dec << std::endl;
+      std::cout << "First sf values in  " << std::hex << int(bufA[512]) << ", " << int(bufA[513]) << ", " << int(bufA[514]) << ", " << int(bufA[515]) << std::dec << std::endl;
+      std::cout << "First values out " << std::hex << bufOut[0] << ", " << bufOut[1] << ", " << bufOut[2] << ", " << bufOut[3] << std::dec << std::endl;
+      std::cout << "Second values out " << std::hex << bufOut[32] << ", " << bufOut[33] << ", " << bufOut[34] << ", " << bufOut[35] << std::dec << std::endl;
+  
+      std::cout << "Reference values " << std::hex << A_private[0] << ", " << A_private[1] << std::dec << std::endl;
+      std::cout << "Reference sfs    " << A_sf[0] << ", " << A_sf[1] << std::endl;
+    }
+    float npu_time =
+        std::chrono::duration_cast<std::chrono::microseconds>(stop - start)
+            .count();
+
+    npu_time_total += npu_time;
+    npu_time_min = (npu_time < npu_time_min) ? npu_time : npu_time_min;
+    npu_time_max = (npu_time > npu_time_max) ? npu_time : npu_time_max;
+
+
+    if (VERIFY) {
+      for (int t=0;t<NUM_TILES;t++) {
+        for (int pr=0;pr<TILE_SIZE;pr++) {
+          std::bfloat16_t sf = A_sf[t*SF_BLOCK_SIZE + pr/SF_BLOCK_SIZE];
+          int val = (int)(A_private[t*TILE_SIZE + pr]);
+          if (val >= 8)
+            val = (val & 0x7) - 8;  // Two's complement, but threes a crowd
+          std::bfloat16_t scaled = sf * val;
+
+          std::bfloat16_t from_AIE = bufOut[(t*TILE_SIZE)+pr];
+
+          // These will not exactly match
+          // The default rounding mode in AIE2 is to truncate, so we will get off by one errors.
+          std::uint16_t from_AIE_raw = *reinterpret_cast<std::uint16_t *>(&from_AIE);
+          std::uint16_t scaled_raw = *reinterpret_cast<std::uint16_t *>(&scaled);
+
+          std::bfloat16_t abs_diff = fabs(from_AIE-scaled);
+          if ((abs_diff/fabs(from_AIE)) > 0.01) {
+            std::cout <<  "Tile " << t << ":" << pr << " From AIE " << std::setprecision(12) << from_AIE << " ref " << std::setprecision(12) << scaled << " from " << std::setprecision(12) << sf << "*" << std::hex << val << std::dec << std::endl;
+            std::cout <<  "Tile " << t << ":" << pr << " From AIE " << std::hex << from_AIE_raw << " ref " << scaled_raw << " from " << *reinterpret_cast<std::uint16_t *>(&sf) << "*" << val << std::dec << std::endl;
+            errors ++;
+          }
+        }
+      }
+    }
+
+
+    if (VERIFY && !errors) {
+      std::cout << iter << ": pass!\n";
+    } else {
+      std::cout << iter << ": fail! " << errors << " errors\n";
+    }
+  }
+
+  std::cout << "Avg NPU exec time: " << npu_time_total / num_iter << "us."
+            << std::endl;
+  std::cout <<"Min NPU matmul time: " << npu_time_min << "us." << std::endl;
+  std::cout << "Max NPU matmul time: " << npu_time_max << "us." << std::endl;
+  
+  if (VERIFY && !sticky_errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nFAIL.\n\n";
+    return 1;
+  }
+
+
+}

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -22,6 +22,8 @@ from aie.dialects.aie import (
     objectfifo_subview_access,
     tile,
     cascade_flow,
+    WireBundle,
+    packetflow,
 )
 from aie.ir import InsertionPoint, Block, TypeAttr
 from aie.extras.context import mlir_mod_ctx
@@ -221,6 +223,27 @@ def cascadeFlowOp():
     t0 = tile(col=1, row=3)
     t1 = tile(col=2, row=3)
     cascade_flow(t0, t1)
+
+
+# CHECK-LABEL: packetFlowOp
+# CHECK: %[[VAL_0:.*]] = aie.tile(1, 3)
+# CHECK: aie.packet_flow(16) {
+# CHECK:   aie.packet_source<%[[VAL_0]], Core : 0>
+# CHECK:   aie.packet_dest<%[[VAL_0]], Core : 0>
+# CHECK: } {keep_pkt_header = true}
+@construct_and_print_module
+def packetFlowOp():
+    t0 = tile(col=1, row=3)
+    packetflow(
+        pkt_id=0x10,
+        source=t0,
+        source_port=WireBundle.Core,
+        source_channel=0,
+        dest=t0,
+        dest_port=WireBundle.Core,
+        dest_channel=0,
+        keep_pkt_header=True,
+    )
 
 
 # CHECK-LABEL: test_module_context

--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -13,8 +13,8 @@
 ##===----------------------------------------------------------------------===##
 
 # The LLVM commit to use.
-LLVM_PROJECT_COMMIT=800de14fab136f8e17c04cc783e0f8f2b305333b
-DATETIME=2024030308
+LLVM_PROJECT_COMMIT=60dda1fc6ef82c5d7fe54000e6c0a21e7bafdeb5
+DATETIME=2024031100
 WHEEL_VERSION=19.0.0.$DATETIME+${LLVM_PROJECT_COMMIT:0:8}
 
 ############################################################################################

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -62,7 +62,7 @@ if test -f "$VPP"; then
   mkdir -p my_install
   pushd my_install
   # pip download mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
-  wget -q --show-progress https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024030613+315a9f3-py3-none-manylinux_2_35_x86_64.whl 
+  wget -q --show-progress https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024030621+5164b34-py3-none-manylinux_2_35_x86_64.whl 
   unzip -q mlir_aie-*_x86_64.whl
   # pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
   wget -q --show-progress https://github.com/Xilinx/mlir-aie/releases/download/mlir-distro/mlir-19.0.0.2024030308+800de14f-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl 


### PR DESCRIPTION
This is another reference example for expanding 4 bits weights with a bfloat16 scale factor shared across 32 elements.  This is suitable for accelerating vector/matrix multiplication by allowing us to read compressed weights from memory and then expand them to the compute data type (in this case bfloat16)