### PR TITLE
Fix test compilation by adding missing <cfloat> header

### DIFF
--- a/runtime_lib/test_lib/test_utils.h
+++ b/runtime_lib/test_lib/test_utils.h
@@ -14,6 +14,7 @@
 #define _TEST_UTILS_H_
 
 #include <boost/program_options.hpp>
+#include <cfloat>
 #include <cmath>
 #include <cstdint>
 #include <fstream>


### PR DESCRIPTION
This fixes:
```
In file included from `/home/rkeryell/Xilinx/Projects/AIE/ACDC/mlir-aie/programming_examples/vision/edge_detect/../../../runtime_lib/test_lib/test_utils.cpp:13`:
/home/rkeryell/Xilinx/Projects/AIE/ACDC/mlir-aie/programming_examples/vision/edge_detect/../../../runtime_lib/test_lib/test_utils.h:62:59: error: use of undeclared identifier 'FLT_EPSILON'
   62 | bool nearly_equal(float a, float b, float epsilon = 128 * FLT_EPSILON,
      |                                                           ^
/home/rkeryell/Xilinx/Projects/AIE/ACDC/mlir-aie/programming_examples/vision/edge_detect/../../../runtime_lib/test_lib/test_utils.h:63:34: error: use of undeclared identifier 'FLT_MIN'
   63 |                   float abs_th = FLT_MIN);
```