### PR TITLE
use test_utils for vision examples argparsing

### DIFF
--- a/programming_examples/vision/color_detect/test.cpp
+++ b/programming_examples/vision/color_detect/test.cpp
@@ -80,27 +80,7 @@ int main(int argc, const char *argv[]) {
                                        "optional video input file name");
   po::variables_map vm;
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  try {
-    test_utils::check_arg_file_exists(vm, "xclbin");
-    test_utils::check_arg_file_exists(vm, "instr");
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    return 1;
-  }
+  test_utils::parse_options(argc, argv, desc, vm);
 
   std::cout << "Running colorDetect for resolution: " << testImageWidth << "x"
             << testImageHeight << std::endl;

--- a/programming_examples/vision/color_threshold/test.cpp
+++ b/programming_examples/vision/color_threshold/test.cpp
@@ -66,22 +66,7 @@ int main(int argc, const char *argv[]) {
       "path of file containing userspace instructions to be sent to the LX6");
   po::variables_map vm;
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
+  test_utils::parse_options(argc, argv, desc, vm);
 
   /*
    ****************************************************************************

--- a/programming_examples/vision/edge_detect/test.cpp
+++ b/programming_examples/vision/edge_detect/test.cpp
@@ -80,27 +80,7 @@ int main(int argc, const char *argv[]) {
                                        "optional video input file name");
   po::variables_map vm;
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  try {
-    test_utils::check_arg_file_exists(vm, "xclbin");
-    test_utils::check_arg_file_exists(vm, "instr");
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    return 1;
-  }
+  test_utils::parse_options(argc, argv, desc, vm);
 
   std::cout << "Running edgeDetect for resolution: " << testImageWidth << "x"
             << testImageHeight << std::endl;

--- a/programming_examples/vision/vision_passthrough/test.cpp
+++ b/programming_examples/vision/vision_passthrough/test.cpp
@@ -48,26 +48,7 @@ int main(int argc, const char *argv[]) {
       "path of file containing userspace instructions to be sent to the LX6");
   po::variables_map vm;
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  try {
-    test_utils::check_arg_file_exists(vm, "xclbin");
-    test_utils::check_arg_file_exists(vm, "instr");
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-  }
+  test_utils::parse_options(argc, argv, desc, vm);
 
   // Read the input image or generate random one if no input file argument
   // provided


### PR DESCRIPTION
I think this was a merge fail from https://github.com/Xilinx/mlir-aie/tree/asplos/programming_examples/vision to `main`