### PR TITLE
VCK5000 Test Fix

### DIFF
--- a/programming_examples/basic/vector_vector_add/README.md
+++ b/programming_examples/basic/vector_vector_add/README.md
@@ -10,7 +10,7 @@
 
 # <ins>Vector Vector Add</ins>
 
-A simple binary operator, which uses a single AIE core to add two vectors together.  The overall vector size in this design is `1024` and it processed by the core in smaller sub tiles of size `16`.  It shows how simple it can be to just feed data into the AIEs using the Object FIFO abstraction, and drain the results back to external memory.  This reference design can be run on either a Ryzen™ AI NPU or a VCK5000. 
+A simple binary operator, which uses a single AIE core to add two vectors together.  The overall vector size in this design is `256` and it processed by the core in smaller sub tiles of size `16`.  It shows how simple it can be to just feed data into the AIEs using the Object FIFO abstraction, and drain the results back to external memory.  This reference design can be run on either a Ryzen™ AI NPU or a VCK5000. 
 
 The kernel executes on AIE tile (`col`, 2). Both input vectors are brought into the tile from Shim tile (`col`, 0). The value of `col` is dependent on whether the application is targeting NPU or VCK5000. The AIE tile performs the summation operations and the Shim tile brings the data back out to external memory.
 

--- a/programming_examples/basic/vector_vector_add/aie2.py
+++ b/programming_examples/basic/vector_vector_add/aie2.py
@@ -17,7 +17,7 @@ import sys
 
 
 def my_vector_add():
-    N = 1024
+    N = 256
     n = 16
     N_div_n = N // n
 

--- a/programming_examples/basic/vector_vector_add/test.cpp
+++ b/programming_examples/basic/vector_vector_add/test.cpp
@@ -40,8 +40,8 @@ int main(int argc, const char *argv[]) {
   int n_warmup_iterations = vm["warmup"].as<int>();
   int trace_size = vm["trace_sz"].as<int>();
 
-  constexpr int IN_SIZE = 1024;
-  constexpr int OUT_SIZE = 1024;
+  constexpr int IN_SIZE = 256;
+  constexpr int OUT_SIZE = 256;
 
   // Load instruction sequence
   std::vector<uint32_t> instr_v =

--- a/programming_examples/basic/vector_vector_add/test_vck5000.cpp
+++ b/programming_examples/basic/vector_vector_add/test_vck5000.cpp
@@ -30,7 +30,7 @@
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 
-constexpr int DMA_COUNT = 64;
+constexpr int DMA_COUNT = 256;
 
 void hsa_check_status(const std::string func_name, hsa_status_t status) {
   if (status != HSA_STATUS_SUCCESS) {

--- a/programming_examples/basic/vector_vector_mul/README.md
+++ b/programming_examples/basic/vector_vector_mul/README.md
@@ -10,7 +10,7 @@
 
 # <ins>Vector Vector Multiply</ins>
 
-A simple binary operator, which uses a single AIE core to multiply two vectors together.  The overall vector size in this design is `1024` and it processed by the core in smaller sub tiles of size `16`.  It shows how simple it can be to just feed data into the AIEs using the ObjectFIFO abstraction, and drain the results back to external memory.  This reference design can be run on either a Ryzen™ AI NPU or a VCK5000. 
+A simple binary operator, which uses a single AIE core to multiply two vectors together.  The overall vector size in this design is `256` and it processed by the core in smaller sub tiles of size `16`.  It shows how simple it can be to just feed data into the AIEs using the ObjectFIFO abstraction, and drain the results back to external memory.  This reference design can be run on either a Ryzen™ AI NPU or a VCK5000. 
 
 The kernel executes on AIE tile (`col`, 2). Both input vectors are brought into the tile from Shim tile (`col`, 0). The value of `col` is dependent on whether the application is targeting NPU or VCK5000. The AIE tile performs the multiplication operations and the Shim tile brings the data back out to external memory.
 

--- a/programming_examples/basic/vector_vector_mul/aie2.py
+++ b/programming_examples/basic/vector_vector_mul/aie2.py
@@ -17,7 +17,7 @@ import sys
 
 
 def my_vector_mul():
-    N = 1024
+    N = 256
     n = 16
     N_div_n = N // n
 

--- a/programming_examples/basic/vector_vector_mul/test.cpp
+++ b/programming_examples/basic/vector_vector_mul/test.cpp
@@ -40,8 +40,8 @@ int main(int argc, const char *argv[]) {
   int n_warmup_iterations = vm["warmup"].as<int>();
   int trace_size = vm["trace_sz"].as<int>();
 
-  constexpr int IN_SIZE = 1024;
-  constexpr int OUT_SIZE = 1024;
+  constexpr int IN_SIZE = 256;
+  constexpr int OUT_SIZE = 256;
 
   // Load instruction sequence
   std::vector<uint32_t> instr_v =

--- a/programming_examples/basic/vector_vector_mul/test_vck5000.cpp
+++ b/programming_examples/basic/vector_vector_mul/test_vck5000.cpp
@@ -30,7 +30,7 @@
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
 
-constexpr int DMA_COUNT = 64;
+constexpr int DMA_COUNT = 256;
 
 void hsa_check_status(const std::string func_name, hsa_status_t status) {
   if (status != HSA_STATUS_SUCCESS) {


### PR DESCRIPTION
For some reason the lengths of 1024 in these tests seem to be deadlocking the interconnect. Need to investigate more but in the meantime making the input buffers smaller.