### PR TITLE
[aievec] to-llvm flow for aievec.ext op

### DIFF
--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -185,6 +185,24 @@ def ExtI256I512IntrOp :
     Arguments<(ins VectorOfLengthAndType<[16], [I32]>:$src,
                    I32:$idx)>;
 
+def ExtI512I1024IntrOp :
+    AIEVec2_IntrOp<"ext.I512.I1024",
+        [TypeIs<"res", VectorOfLengthAndType<[16], [I32]>>]>,
+    Arguments<(ins VectorOfLengthAndType<[32], [I32]>:$src,
+                   I32:$idx)>;
+
+def ExtI256I1024IntrOp :
+    AIEVec2_IntrOp<"ext.I256.I1024",
+        [TypeIs<"res", VectorOfLengthAndType<[8], [I32]>>]>,
+    Arguments<(ins VectorOfLengthAndType<[32], [I32]>:$src,
+                   I32:$idx)>;
+
+def ExtI128I512IntrOp :
+    AIEVec2_IntrOp<"extract.I128.I512",
+        [TypeIs<"res", VectorOfLengthAndType<[4], [I32]>>]>,
+    Arguments<(ins VectorOfLengthAndType<[16], [I32]>:$src,
+                   I32:$idx)>;
+  
 // ----- CONCAT ----- 
 
 def ConcatI512I256IntrOp :

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -1300,7 +1300,8 @@ public:
               rewriter, loc, operands,
               {VectorType::get({32}, rewriter.getI32Type()),
                rewriter.getI32Type()}));
-    } else if (resultVectorSize == 128 && srcVectorSize == 512) {
+      // TODO: handle below case
+      // } else if (resultVectorSize == 128 && srcVectorSize == 512) {
       // Special case
     } else {
       op.emitWarning() << "aievec.ext with " << srcVectorSize

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -1257,26 +1257,65 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
 
+    Value src = adaptor.getSource();
+    VectorType srcType = cast<VectorType>(src.getType());
+    Type srcScalarType = srcType.getElementType();
+    unsigned srcBitWidth = srcScalarType.getIntOrFloatBitWidth();
+    int srcLanes = getVectorLaneSize(srcType);
+    int srcVectorSize = srcBitWidth * srcLanes;
+
+    Value result = op.getResult();
+    VectorType resultType = cast<VectorType>(result.getType());
+    Type resultScaTy = resultType.getElementType();
+    unsigned resultBitWidth = resultScaTy.getIntOrFloatBitWidth();
+    int resultLanes = getVectorLaneSize(resultType);
+    int resultVectorSize = resultBitWidth * resultLanes;
+
     // create constant for index
     auto indexCst = rewriter.create<LLVM::ConstantOp>(
-        loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(0));
-    if (op.getIndex() == 1) {
-      indexCst = rewriter.create<LLVM::ConstantOp>(
-          loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(1));
-    }
+        loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(op.getIndex()));
 
     // create xllvm intrinsic
     SmallVector<Value> operands({adaptor.getSource(), indexCst});
-    auto extOp = rewriter.create<xllvm::ExtI256I512IntrOp>(
-        loc, VectorType::get({8}, rewriter.getI32Type()),
-        forceCastOperandsToSignature(
-            rewriter, loc, operands,
-            {VectorType::get({16}, rewriter.getI32Type()),
-             rewriter.getI32Type()}));
+    Value extOp = nullptr;
+    // Integer types
+    if (resultVectorSize == 256 && srcVectorSize == 512) {
+      extOp = rewriter.create<xllvm::ExtI256I512IntrOp>(
+          loc, VectorType::get({8}, rewriter.getI32Type()),
+          forceCastOperandsToSignature(
+              rewriter, loc, operands,
+              {VectorType::get({16}, rewriter.getI32Type()),
+               rewriter.getI32Type()}));
+    } else if (resultVectorSize == 512 && srcVectorSize == 1024) {
+      extOp = rewriter.create<xllvm::ExtI512I1024IntrOp>(
+          loc, VectorType::get({16}, rewriter.getI32Type()),
+          forceCastOperandsToSignature(
+              rewriter, loc, operands,
+              {VectorType::get({32}, rewriter.getI32Type()),
+               rewriter.getI32Type()}));
+    } else if (resultVectorSize == 256 && srcVectorSize == 1024) {
+      extOp = rewriter.create<xllvm::ExtI256I1024IntrOp>(
+          loc, VectorType::get({8}, rewriter.getI32Type()),
+          forceCastOperandsToSignature(
+              rewriter, loc, operands,
+              {VectorType::get({32}, rewriter.getI32Type()),
+               rewriter.getI32Type()}));
+    } else if (resultVectorSize == 128 && srcVectorSize == 512) {
+      // Special case
+    } else {
+      op.emitWarning() << "aievec.ext with " << srcVectorSize
+                       << "-bit source, and " << resultVectorSize
+                       << "-bit result is not supported.\n";
+      return failure();
+    }
 
     // create bitcast for result
-    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                 extOp);
+    if (op.getResult().getType() != extOp.getType()) {
+      rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
+                                                   extOp);
+    } else {
+      rewriter.replaceOp(op, extOp);
+    }
 
     return success();
   }

--- a/test/Conversion/AIEVecToLLVM/test-ext.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-ext.mlir
@@ -1,12 +1,12 @@
 // RUN: aie-opt %s -split-input-file -convert-aievec-to-llvm -cse | FileCheck %s
 
-func.func @i8_ext(%arg0 : vector<64xi8>) -> (vector<32xi8>, vector<32xi8>) {
+func.func @v32i8_ext_v64i8(%arg0 : vector<64xi8>) -> (vector<32xi8>, vector<32xi8>) {
   %0 = aievec.ext %arg0 {index = 0 : i8} : vector<64xi8>, vector<32xi8>
   %1 = aievec.ext %arg0 {index = 1 : i8} : vector<64xi8>, vector<32xi8>
   return %0, %1 : vector<32xi8>, vector<32xi8>
 }
 
-// CHECK-LABEL: @i8_ext
+// CHECK-LABEL: @v32i8_ext_v64i8
 // CHECK-SAME: %[[ARG0:.*]]: vector<64xi8>
 // CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<64xi8> to vector<16xi32>
@@ -23,13 +23,188 @@ func.func @i8_ext(%arg0 : vector<64xi8>) -> (vector<32xi8>, vector<32xi8>) {
 
 // -----
 
-func.func @bf16_ext(%arg0 : vector<32xbf16>) -> (vector<16xbf16>, vector<16xbf16>) {
+func.func @v64i8_ext_v128i8(%arg0 : vector<128xi8>) -> (vector<64xi8>, vector<64xi8>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<128xi8>, vector<64xi8>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<128xi8>, vector<64xi8>
+  return %0, %1 : vector<64xi8>, vector<64xi8>
+}
+
+// CHECK-LABEL: @v64i8_ext_v128i8
+// CHECK-SAME: %[[ARG0:.*]]: vector<128xi8>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<128xi8> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<16xi32> to vector<64xi8>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<16xi32> to vector<64xi8>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<64xi8>, vector<64xi8>
+
+// -----
+
+func.func @v32i8_ext_v128i8(%arg0 : vector<128xi8>) -> (vector<32xi8>, vector<32xi8>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<128xi8>, vector<32xi8>
+  %1 = aievec.ext %arg0 {index = 3 : i8} : vector<128xi8>, vector<32xi8>
+  return %0, %1 : vector<32xi8>, vector<32xi8>
+}
+
+// CHECK-LABEL: @v32i8_ext_v128i8
+// CHECK-SAME: %[[ARG0:.*]]: vector<128xi8>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<128xi8> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<8xi32> to vector<32xi8>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<8xi32> to vector<32xi8>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<32xi8>, vector<32xi8>
+
+// -----
+
+func.func @v16i16_ext_v32i16(%arg0 : vector<32xi16>) -> (vector<16xi16>, vector<16xi16>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<32xi16>, vector<16xi16>
+  return %0, %1 : vector<16xi16>, vector<16xi16>
+}
+
+// CHECK-LABEL: @v16i16_ext_v32i16
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xi16>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<32xi16> to vector<16xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I512"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<16xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<8xi32> to vector<16xi16>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I512"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<16xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<8xi32> to vector<16xi16>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<16xi16>, vector<16xi16>
+
+// -----
+
+func.func @v32i16_ext_v64i16(%arg0 : vector<64xi16>) -> (vector<32xi16>, vector<32xi16>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<64xi16>, vector<32xi16>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<64xi16>, vector<32xi16>
+  return %0, %1 : vector<32xi16>, vector<32xi16>
+}
+
+// CHECK-LABEL: @v32i16_ext_v64i16
+// CHECK-SAME: %[[ARG0:.*]]: vector<64xi16>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<64xi16> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<16xi32> to vector<32xi16>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<16xi32> to vector<32xi16>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<32xi16>, vector<32xi16>
+
+// -----
+
+func.func @v16i16_ext_v64i16(%arg0 : vector<64xi16>) -> (vector<16xi16>, vector<16xi16>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<64xi16>, vector<16xi16>
+  %1 = aievec.ext %arg0 {index = 3 : i8} : vector<64xi16>, vector<16xi16>
+  return %0, %1 : vector<16xi16>, vector<16xi16>
+}
+
+// CHECK-LABEL: @v16i16_ext_v64i16
+// CHECK-SAME: %[[ARG0:.*]]: vector<64xi16>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<64xi16> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<8xi32> to vector<16xi16>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<8xi32> to vector<16xi16>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<16xi16>, vector<16xi16>
+
+// -----
+
+func.func @v8i32_ext_v16i32(%arg0 : vector<16xi32>) -> (vector<8xi32>, vector<8xi32>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<16xi32>, vector<8xi32>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<16xi32>, vector<8xi32>
+  return %0, %1 : vector<8xi32>, vector<8xi32>
+}
+
+// CHECK-LABEL: @v8i32_ext_v16i32
+// CHECK-SAME: %[[ARG0:.*]]: vector<16xi32>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I512"(
+// CHECK-SAME: %[[ARG0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<16xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I512"(
+// CHECK-SAME: %[[ARG0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<16xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: return %[[EXT0]], %[[EXT1]] : vector<8xi32>, vector<8xi32>
+
+// -----
+
+func.func @v16i32_ext_v32i32(%arg0 : vector<32xi32>) -> (vector<16xi32>, vector<16xi32>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<32xi32>, vector<16xi32>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<32xi32>, vector<16xi32>
+  return %0, %1 : vector<16xi32>, vector<16xi32>
+}
+
+// CHECK-LABEL: @v16i32_ext_v32i32
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xi32>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[ARG0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[ARG0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: return %[[EXT0]], %[[EXT1]] : vector<16xi32>, vector<16xi32>
+
+// -----
+
+func.func @v8i32_ext_v32i32(%arg0 : vector<32xi32>) -> (vector<8xi32>, vector<8xi32>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<32xi32>, vector<8xi32>
+  %1 = aievec.ext %arg0 {index = 3 : i8} : vector<32xi32>, vector<8xi32>
+  return %0, %1 : vector<8xi32>, vector<8xi32>
+}
+
+// CHECK-LABEL: @v8i32_ext_v32i32
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xi32>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[ARG0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(3 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[ARG0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: return %[[EXT0]], %[[EXT1]] : vector<8xi32>, vector<8xi32>
+
+// -----
+
+func.func @v16bf16_ext_v32bf16(%arg0 : vector<32xbf16>) -> (vector<16xbf16>, vector<16xbf16>) {
   %0 = aievec.ext %arg0 {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
   %1 = aievec.ext %arg0 {index = 1 : i8} : vector<32xbf16>, vector<16xbf16>
   return %0, %1 : vector<16xbf16>, vector<16xbf16>
 }
 
-// CHECK-LABEL: @bf16_ext
+// CHECK-LABEL: @v16bf16_ext_v32bf16
 // CHECK-SAME: %[[ARG0:.*]]: vector<32xbf16>
 // CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<32xbf16> to vector<16xi32>
@@ -43,3 +218,118 @@ func.func @bf16_ext(%arg0 : vector<32xbf16>) -> (vector<16xbf16>, vector<16xbf16
 // CHECK-SAME: (vector<16xi32>, i32) -> vector<8xi32>
 // CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<8xi32> to vector<16xbf16>
 // CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<16xbf16>, vector<16xbf16>
+
+// -----
+
+func.func @v32bf16_ext_v64bf16(%arg0 : vector<64xbf16>) -> (vector<32xbf16>, vector<32xbf16>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<64xbf16>, vector<32xbf16>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<64xbf16>, vector<32xbf16>
+  return %0, %1 : vector<32xbf16>, vector<32xbf16>
+}
+
+// CHECK-LABEL: @v32bf16_ext_v64bf16
+// CHECK-SAME: %[[ARG0:.*]]: vector<64xbf16>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<64xbf16> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<16xi32> to vector<32xbf16>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<16xi32> to vector<32xbf16>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<32xbf16>, vector<32xbf16>
+
+// -----
+
+func.func @v16bf16_ext_v64bf16(%arg0 : vector<64xbf16>) -> (vector<16xbf16>, vector<16xbf16>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<64xbf16>, vector<16xbf16>
+  %1 = aievec.ext %arg0 {index = 2 : i8} : vector<64xbf16>, vector<16xbf16>
+  return %0, %1 : vector<16xbf16>, vector<16xbf16>
+}
+
+// CHECK-LABEL: @v16bf16_ext_v64bf16
+// CHECK-SAME: %[[ARG0:.*]]: vector<64xbf16>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<64xbf16> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<8xi32> to vector<16xbf16>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<8xi32> to vector<16xbf16>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<16xbf16>, vector<16xbf16>
+
+// -----
+
+func.func @v8f32_ext_v16f32(%arg0 : vector<16xf32>) -> (vector<8xf32>, vector<8xf32>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<16xf32>, vector<8xf32>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<16xf32>, vector<8xf32>
+  return %0, %1 : vector<8xf32>, vector<8xf32>
+}
+
+// CHECK-LABEL: @v8f32_ext_v16f32
+// CHECK-SAME: %[[ARG0:.*]]: vector<16xf32>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<16xf32> to vector<16xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I512"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<16xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<8xi32> to vector<8xf32>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I512"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<16xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<8xi32> to vector<8xf32>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<8xf32>, vector<8xf32>
+
+// -----
+
+func.func @v16f32_ext_v32f32(%arg0 : vector<32xf32>) -> (vector<16xf32>, vector<16xf32>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<32xf32>, vector<16xf32>
+  %1 = aievec.ext %arg0 {index = 1 : i8} : vector<32xf32>, vector<16xf32>
+  return %0, %1 : vector<16xf32>, vector<16xf32>
+}
+
+// CHECK-LABEL: @v16f32_ext_v32f32
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xf32>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<32xf32> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<16xi32> to vector<16xf32>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I512.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<16xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<16xi32> to vector<16xf32>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<16xf32>, vector<16xf32>
+
+// -----
+
+func.func @v8f32_ext_v32f32(%arg0 : vector<32xf32>) -> (vector<8xf32>, vector<8xf32>) {
+  %0 = aievec.ext %arg0 {index = 0 : i8} : vector<32xf32>, vector<8xf32>
+  %1 = aievec.ext %arg0 {index = 2 : i8} : vector<32xf32>, vector<8xf32>
+  return %0, %1 : vector<8xf32>, vector<8xf32>
+}
+
+// CHECK-LABEL: @v8f32_ext_v32f32
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xf32>
+// CHECK: %[[CST0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[ARG0]] : vector<32xf32> to vector<32xi32>
+// CHECK-NEXT: %[[EXT0:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST0]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES0:.*]] = llvm.bitcast %[[EXT0]] : vector<8xi32> to vector<8xf32>
+// CHECK-NEXT: %[[CST1:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT: %[[EXT1:.*]] = "xllvm.intr.aie2.ext.I256.I1024"(
+// CHECK-SAME: %[[BITCAST0]], %[[CST1]]) : 
+// CHECK-SAME: (vector<32xi32>, i32) -> vector<8xi32>
+// CHECK-NEXT: %[[RES1:.*]] = llvm.bitcast %[[EXT1]] : vector<8xi32> to vector<8xf32>
+// CHECK-NEXT: return %[[RES0]], %[[RES1]] : vector<8xf32>, vector<8xf32>

--- a/test/Target/LLVMIR/aievec.mlir
+++ b/test/Target/LLVMIR/aievec.mlir
@@ -242,7 +242,7 @@ llvm.func @ext_i256_i1024(%v : vector<32xi32>, %idx : i32) -> vector<8xi32> {
 
 // CHECK-LABEL: define <4 x i32> @ext_i128_i512
 llvm.func @ext_i128_i512(%v : vector<16xi32>, %idx : i32) -> vector<4xi32> {
-    // CHECK: call <4 x i32> @llvm.aie2.ext.I128.I512(
+    // CHECK: call <4 x i32> @llvm.aie2.extract.I128.I512(
     // CHECK-SAME: <16 x i32> %{{[0-9]+}}, i32 %{{[0-9]+}})
     %1 = "xllvm.intr.aie2.extract.I128.I512"(%v, %idx) : 
                                         (vector<16xi32>, i32) -> vector<4xi32>

--- a/test/Target/LLVMIR/aievec.mlir
+++ b/test/Target/LLVMIR/aievec.mlir
@@ -222,6 +222,33 @@ llvm.func @ext_i256_i512(%v : vector<16xi32>, %idx : i32) -> vector<8xi32> {
     llvm.return %1 : vector<8xi32>
 }
 
+// CHECK-LABEL: define <16 x i32> @ext_i512_i1024
+llvm.func @ext_i512_i1024(%v : vector<32xi32>, %idx : i32) -> vector<16xi32> {
+    // CHECK: call <16 x i32> @llvm.aie2.ext.I512.I1024(
+    // CHECK-SAME: <32 x i32> %{{[0-9]+}}, i32 %{{[0-9]+}})
+    %1 = "xllvm.intr.aie2.ext.I512.I1024"(%v, %idx) : 
+                                        (vector<32xi32>, i32) -> vector<16xi32>
+    llvm.return %1 : vector<16xi32>
+}
+
+// CHECK-LABEL: define <8 x i32> @ext_i256_i1024
+llvm.func @ext_i256_i1024(%v : vector<32xi32>, %idx : i32) -> vector<8xi32> {
+    // CHECK: call <8 x i32> @llvm.aie2.ext.I256.I1024(
+    // CHECK-SAME: <32 x i32> %{{[0-9]+}}, i32 %{{[0-9]+}})
+    %1 = "xllvm.intr.aie2.ext.I256.I1024"(%v, %idx) : 
+                                        (vector<32xi32>, i32) -> vector<8xi32>
+    llvm.return %1 : vector<8xi32>
+}
+
+// CHECK-LABEL: define <4 x i32> @ext_i128_i512
+llvm.func @ext_i128_i512(%v : vector<16xi32>, %idx : i32) -> vector<4xi32> {
+    // CHECK: call <4 x i32> @llvm.aie2.ext.I128.I512(
+    // CHECK-SAME: <16 x i32> %{{[0-9]+}}, i32 %{{[0-9]+}})
+    %1 = "xllvm.intr.aie2.extract.I128.I512"(%v, %idx) : 
+                                        (vector<16xi32>, i32) -> vector<4xi32>
+    llvm.return %1 : vector<4xi32>
+}
+
 // ----- CONCAT ----- 
 
 // CHECK-LABEL: define <16 x i32> @concat_i512_i256


### PR DESCRIPTION
This PR add the support for aievec.ext op going through the to-llvm flow.

Changes:
- Add ext intrinsic ops to XLLVM dialect.
- Add aievec-to-llvm conversion pattern/tests for the aievec.ext op.
- Add test for translating to external llvm.