### PR TITLE
Disable programming_examples/ml/resnet/layers_conv2_x

### DIFF
--- a/programming_examples/ml/resnet/layers_conv2_x/run_makefile.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_makefile.lit
@@ -1,7 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess, torch
+// This test is disabled due to random failures on gihub CI
+// REQUIRES: ryzen_ai, chess, torch, has_random_failures
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 


### PR DESCRIPTION
Disable test because it causes too many CI failures