### PR TITLE
remove aie_cdo_error_handling.bin from cdo backend

### DIFF
--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -437,11 +437,6 @@ struct AIEControl {
     TRY_XAIE_API_FATAL_ERROR(XAie_UpdateNpiAddr, &devInst, NPI_ADDR);
   }
 
-  LogicalResult addErrorHandlingToCDO() {
-    TRY_XAIE_API_LOGICAL_RESULT(XAie_ErrorHandlingInit, &devInst);
-    return success();
-  }
-
   LogicalResult addAieElfToCDO(uint8_t col, uint8_t row,
                                const StringRef elfPath, bool aieSim) {
     // loadSym: Load symbols from .map file. This argument is not used when
@@ -721,12 +716,6 @@ LogicalResult generateCDOBinariesSeparately(AIEControl &ctl,
                                             const StringRef workDirPath,
                                             DeviceOp &targetOp, bool aieSim,
                                             bool enableCores) {
-  if (failed(generateCDOBinary(
-          (llvm::Twine(workDirPath) + std::string(1, ps) +
-           "aie_cdo_error_handling.bin")
-              .str(),
-          std::bind(&AIEControl::addErrorHandlingToCDO, ctl))))
-    return failure();
 
   if (!targetOp.getOps<CoreOp>().empty() &&
       failed(generateCDOBinary(
@@ -759,8 +748,6 @@ LogicalResult generateCDOUnified(AIEControl &ctl, const StringRef workDirPath,
   return generateCDOBinary(
       (llvm::Twine(workDirPath) + std::string(1, ps) + "aie_cdo.bin").str(),
       [&ctl, &targetOp, &workDirPath, &aieSim, &enableCores] {
-        if (failed(ctl.addErrorHandlingToCDO()))
-          return failure();
         if (!targetOp.getOps<CoreOp>().empty() &&
             failed(ctl.addAieElfsToCDO(targetOp, workDirPath, aieSim)))
           return failure();

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -267,7 +267,6 @@ def emit_design_bif(root_path, has_cores=True, enable_cores=True):
           {{
             name=aie_image, id=0x1c000000
             {{ type=cdo
-               file={root_path}/aie_cdo_error_handling.bin
                {elf_file}
                file={root_path}/aie_cdo_init.bin
                {enable_file}

--- a/tools/aie2xclbin/XCLBinGen.cpp
+++ b/tools/aie2xclbin/XCLBinGen.cpp
@@ -527,8 +527,6 @@ static LogicalResult generateXCLBin(MLIRContext *context, ModuleOp moduleOp,
                        << "\t{\n"
                        << "\t\tname=aie_image, id=0x1c000000\n"
                        << "\t\t{ type=cdo\n"
-                       << "\t\t  file=" << TK.TempDir
-                       << "/aie_cdo_error_handling.bin\n"
                        << "\t\t  file=" << TK.TempDir << "/aie_cdo_elfs.bin\n"
                        << "\t\t  file=" << TK.TempDir << "/aie_cdo_init.bin\n"
                        << "\t\t  file=" << TK.TempDir << "/aie_cdo_enable.bin\n"


### PR DESCRIPTION
Remove `aie_cdo_error_handling.bin` from CDO generation. This seems to resolve the problem noted in https://github.com/Xilinx/mlir-aie/issues/1484. This error handling setup was cut-and-paste from an early example, is not directly used by mlir-aie as far as I can tell, and apparently can't work on windows anyway.