### PR TITLE
Reduce concurrency in integration tests to reduce memory usage

### DIFF
--- a/test/Integration/Dialect/AIEVec/64x32x64xbf16_4x8x4_packed_gemm/gemm-64x32x64-bf16.mlir
+++ b/test/Integration/Dialect/AIEVec/64x32x64xbf16_4x8x4_packed_gemm/gemm-64x32x64-bf16.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml" -lower-affine -canonicalize -cse | aie-translate --aieml -aievec-to-cpp -o gen_aie.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %S/kernel.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c %S/kernel.cc -o kernel.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/kernel.cc.o
 // RUN: cp -r %S/data . && xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" | FileCheck %s
 
 #map = affine_map<(d0, d1, d2) -> (d0, d2)>

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i16/kernel.mlir
@@ -1,7 +1,9 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml" | aie-translate -aieml=true -aievec-to-cpp -o kernel.tmp.cc
 // RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 -c kernel.cc -o kernel.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 -c %S/helplib.cc -o helplib.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 ./work/kernel.cc.o ./work/helplib.cc.o %S/main.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
 
 func.func private @printv32xi16(%v : vector<32xi16>)

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i32/kernel.mlir
@@ -1,7 +1,9 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml" | aie-translate -aieml=true -aievec-to-cpp -o kernel.tmp.cc
 // RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 -c kernel.cc -o kernel.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 -c %S/helplib.cc -o helplib.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 ./work/kernel.cc.o ./work/helplib.cc.o %S/main.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
 
 func.func private @printv16xi32(%v : vector<16xi32>)

--- a/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/ml_unaligned_read/i8/kernel.mlir
@@ -1,7 +1,9 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aieml" | aie-translate -aieml=true -aievec-to-cpp -o kernel.tmp.cc
 // RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 -c kernel.cc -o kernel.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 -c %S/helplib.cc -o helplib.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=20 ./work/kernel.cc.o ./work/helplib.cc.o %S/main.cc
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
 
 func.func private @printv64xi8(%v : vector<64xi8>)

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i16/kernel.mlir
@@ -1,7 +1,9 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -convert-vector-to-aievec | aie-translate -aievec-to-cpp -o kernel.tmp.cc
 // RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
-// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 -c kernel.cc -o kernel.cc.o
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 -c %S/helplib.cc -o helplib.cc.o
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 ./work/kernel.cc.o ./work/helplib.cc.o %S/main.cc
 // RUN: xca_udm_dbg -qf -T -P %aietools/data/versal_prod/lib -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
 
 func.func private @printv16xi16(%v : vector<16xi16>)

--- a/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/kernel.mlir
+++ b/test/Integration/Dialect/AIEVec/v1_unaligned_read/i32/kernel.mlir
@@ -1,7 +1,9 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s -convert-vector-to-aievec | aie-translate -aievec-to-cpp -o kernel.tmp.cc
 // RUN: echo "#include <cstdint>" > kernel.cc && cat kernel.tmp.cc >> kernel.cc
-// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 kernel.cc %S/helplib.cc %S/main.cc
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 -c kernel.cc -o kernel.cc.o
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 -c %S/helplib.cc -o helplib.cc.o
+// RUN: xchesscc_wrapper aie -f -g +s +w work +o work -I%S -I. -I%aietools/include -D__AIENGINE__ -D__AIEARCH__=10 ./work/kernel.cc.o ./work/helplib.cc.o %S/main.cc
 // RUN: xca_udm_dbg -qf -T -P %aietools/data/versal_prod/lib -t "%S/../../profiling.tcl ./work/a.out" | FileCheck %s
 
 func.func private @printv8xi32(%v : vector<8xi32>)

--- a/test/Integration/Dialect/TOSA/bf16_abs_v16/bf16_abs.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_abs_v16/bf16_abs.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_abs_v32/bf16_abs.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_abs_v32/bf16_abs.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_cast_float/bf16_cast_float.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_cast_float/bf16_cast_float.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_ceil_v16/bf16_ceil.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_ceil_v16/bf16_ceil.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_ceil_v32/bf16_ceil.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_ceil_v32/bf16_ceil.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_erf_v16/bf16_erf.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_erf_v16/bf16_erf.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"
 // RUN: clang++ %S/dut_ref.cc -o dut_ref

--- a/test/Integration/Dialect/TOSA/bf16_erf_v32/bf16_erf.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_erf_v32/bf16_erf.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out"
 // RUN: clang++ %S/dut_ref.cc -o dut_ref

--- a/test/Integration/Dialect/TOSA/bf16_floor_v16/bf16_floor.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_floor_v16/bf16_floor.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_floor_v32/bf16_floor.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_floor_v32/bf16_floor.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_neg/bf16_neg.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_neg/bf16_neg.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_sigmoid_v16bf16/bf16_sigmoid.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_sigmoid_v16bf16/bf16_sigmoid.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_sigmoid_v32bf16/bf16_sigmoid.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_sigmoid_v32bf16/bf16_sigmoid.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16_tanh/bf16_tanh.mlir
+++ b/test/Integration/Dialect/TOSA/bf16_tanh/bf16_tanh.mlir
@@ -1,6 +1,8 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 %aie_runtime_lib%/AIE2/lut_based_ops.cpp -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c %aie_runtime_lib%/AIE2/lut_based_ops.cpp -o lut_based_ops.cpp.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c %S/testbench.cc -o testbench.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. ./work/lut_based_ops.cpp.o ./work/testbench.cc.o dut.cc
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/bf16xbf16_add_elem/bf16xbf16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_add_elem/bf16xbf16_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem/bf16xbf16_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem/bf16xbf16_mul_elem.mlir
@@ -6,7 +6,8 @@
 // RUN: aie-opt %s %tosa-to-linalg% -o %t/linalg.mlir >& aie-opt.stdout
 // RUN: aie-opt %t/linalg.mlir %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1/bf16xbf16_mul_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1/bf16xbf16_mul_elem_2d_broadcast_1d_unit_dim.mlir
@@ -6,7 +6,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1/bf16xbf16_mul_elem_2d_broadcast_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1/bf16xbf16_mul_elem_2d_broadcast_scalar.mlir
@@ -6,7 +6,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_mul_elem_16x1024_broadcast_1024/bf16xbf16_mul_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sel/bf16xbf16_sel.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sel/bf16xbf16_sel.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem/bf16xbf16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem/bf16xbf16_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1/bf16xbf16_sub_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1/bf16xbf16_sub_elem_2d_broadcast_1d_unit_dim.mlir
@@ -6,7 +6,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1/bf16xbf16_sub_elem_2d_broadcast_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1/bf16xbf16_sub_elem_2d_broadcast_scalar.mlir
@@ -6,7 +6,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_16x1024_broadcast_1024/bf16xbf16_sub_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_dyn_size/bf16xbf16_sub_elem_dyn_size.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_dyn_size/bf16xbf16_sub_elem_dyn_size.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_dyn_size_2d/bf16xbf16_sub_elem_dyn_size_2d.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xbf16_sub_elem_dyn_size_2d/bf16xbf16_sub_elem_dyn_size_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/bf16xfloat_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/bf16xfloat_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/floatxbf16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_add_elem/floatxbf16_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/bf16xfloat_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/bf16xfloat_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/floatxbf16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/bf16xfloat_sub_elem/floatxbf16_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/float_abs_v16/float_abs.mlir
+++ b/test/Integration/Dialect/TOSA/float_abs_v16/float_abs.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I%aie_runtime_lib%/AIE2 -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/float_cast_bf16/float_cast_bf16.mlir
+++ b/test/Integration/Dialect/TOSA/float_cast_bf16/float_cast_bf16.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/float_neg/float_neg.mlir
+++ b/test/Integration/Dialect/TOSA/float_neg/float_neg.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/floatxfloat_add_elem/floatxfloat_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_add_elem/floatxfloat_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/floatxfloat_sel/floatxfloat_sel.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sel/floatxfloat_sel.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem/floatxfloat_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem/floatxfloat_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1/floatxfloat_sub_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1/floatxfloat_sub_elem_2d_broadcast_1d_unit_dim.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1/floatxfloat_sub_elem_2d_broadcast_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1/floatxfloat_sub_elem_2d_broadcast_scalar.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/floatxfloat_sub_elem_16x1024_broadcast_1024/floatxfloat_sub_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16_abs_v32/i16_abs.mlir
+++ b/test/Integration/Dialect/TOSA/i16_abs_v32/i16_abs.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_arithmetic_right_shift/i16_arithmetic_right_shift.mlir
+++ b/test/Integration/Dialect/TOSA/i16_arithmetic_right_shift/i16_arithmetic_right_shift.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_bitwise_and/i16_bitwise_and.mlir
+++ b/test/Integration/Dialect/TOSA/i16_bitwise_and/i16_bitwise_and.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_bitwise_not/i16_bitwise_not.mlir
+++ b/test/Integration/Dialect/TOSA/i16_bitwise_not/i16_bitwise_not.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_bitwise_or/i16_bitwise_or.mlir
+++ b/test/Integration/Dialect/TOSA/i16_bitwise_or/i16_bitwise_or.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_bitwise_xor/i16_bitwise_xor.mlir
+++ b/test/Integration/Dialect/TOSA/i16_bitwise_xor/i16_bitwise_xor.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_cast_i32/i16_cast_i32.mlir
+++ b/test/Integration/Dialect/TOSA/i16_cast_i32/i16_cast_i32.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_cast_i8/i16_cast_i8.mlir
+++ b/test/Integration/Dialect/TOSA/i16_cast_i8/i16_cast_i8.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16_neg/i16_neg.mlir
+++ b/test/Integration/Dialect/TOSA/i16_neg/i16_neg.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i16xi16_add_elem/i16xi16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_add_elem/i16xi16_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem/i16xi16_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem/i16xi16_mul_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1/i16xi16_mul_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1/i16xi16_mul_elem_2d_broadcast_1d_unit_dim.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1/i16xi16_mul_elem_2d_broadcast_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1/i16xi16_mul_elem_2d_broadcast_scalar.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_16x1024_broadcast_1024/i16xi16_mul_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/i16xi16_mul_elem_i32.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_mul_elem_i32/i16xi16_mul_elem_i32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_sel/i16xi16_sel.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sel/i16xi16_sel.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem/i16xi16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem/i16xi16_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1/i16xi16_sub_elem_2d_broadcast_1d_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1/i16xi16_sub_elem_2d_broadcast_1d_scalar.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1/i16xi16_sub_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1/i16xi16_sub_elem_2d_broadcast_1d_unit_dim.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi16_sub_elem_16x1024_broadcast_1024/i16xi16_sub_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i16xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i16xi32_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i32xi16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_add_elem_v16/i32xi16_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_add_elem_v32/i16xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_add_elem_v32/i16xi32_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i16xi32_mul_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i32xi16_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_mul_elem/i32xi16_mul_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i16xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i16xi32_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i32xi16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v16/i32xi16_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v32/i16xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i16xi32_sub_elem_v32/i16xi32_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32_abs_v16/i32_abs.mlir
+++ b/test/Integration/Dialect/TOSA/i32_abs_v16/i32_abs.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_arithmetic_right_shift/i32_arithmetic_right_shift.mlir
+++ b/test/Integration/Dialect/TOSA/i32_arithmetic_right_shift/i32_arithmetic_right_shift.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_bitwise_and/i32_bitwise_and.mlir
+++ b/test/Integration/Dialect/TOSA/i32_bitwise_and/i32_bitwise_and.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_bitwise_not/i32_bitwise_not.mlir
+++ b/test/Integration/Dialect/TOSA/i32_bitwise_not/i32_bitwise_not.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_bitwise_or/i32_bitwise_or.mlir
+++ b/test/Integration/Dialect/TOSA/i32_bitwise_or/i32_bitwise_or.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_bitwise_xor/i32_bitwise_xor.mlir
+++ b/test/Integration/Dialect/TOSA/i32_bitwise_xor/i32_bitwise_xor.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_cast_i16/i32_cast_i16.mlir
+++ b/test/Integration/Dialect/TOSA/i32_cast_i16/i32_cast_i16.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_cast_i8/i32_cast_i8.mlir
+++ b/test/Integration/Dialect/TOSA/i32_cast_i8/i32_cast_i8.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32_neg/i32_neg.mlir
+++ b/test/Integration/Dialect/TOSA/i32_neg/i32_neg.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i32xi32_add_elem/i32xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_add_elem/i32xi32_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem/i32xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem/i32xi32_mul_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1/i32xi32_mul_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1/i32xi32_mul_elem_2d_broadcast_1d_unit_dim.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1/i32xi32_mul_elem_2d_broadcast_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1/i32xi32_mul_elem_2d_broadcast_scalar.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_mul_elem_16x1024_broadcast_1024/i32xi32_mul_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sel/i32xi32_sel.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sel/i32xi32_sel.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem/i32xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem/i32xi32_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_1d_unit_dim_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_1d_unit_dim_v16.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_1d_unit_dim_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_1d_unit_dim_v32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_scalar_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_scalar_v16.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_scalar_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1/i32xi32_sub_elem_2d_broadcast_scalar_v32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_reshape_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_reshape_v16.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_reshape_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_reshape_v32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v16.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_1d_v32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_2d_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_2d_v16.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_2d_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i32xi32_sub_elem_16x1024_broadcast_1024/i32xi32_sub_elem_2d_broadcast_2d_v32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8_abs_v64/i8_abs.mlir
+++ b/test/Integration/Dialect/TOSA/i8_abs_v64/i8_abs.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_arithmetic_right_shift/i8_arithmetic_right_shift.mlir
+++ b/test/Integration/Dialect/TOSA/i8_arithmetic_right_shift/i8_arithmetic_right_shift.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_bitwise_and/i8_bitwise_and.mlir
+++ b/test/Integration/Dialect/TOSA/i8_bitwise_and/i8_bitwise_and.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_bitwise_not/i8_bitwise_not.mlir
+++ b/test/Integration/Dialect/TOSA/i8_bitwise_not/i8_bitwise_not.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_bitwise_or/i8_bitwise_or.mlir
+++ b/test/Integration/Dialect/TOSA/i8_bitwise_or/i8_bitwise_or.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_bitwise_xor/i8_bitwise_xor.mlir
+++ b/test/Integration/Dialect/TOSA/i8_bitwise_xor/i8_bitwise_xor.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_cast_i16/i8_cast_i16.mlir
+++ b/test/Integration/Dialect/TOSA/i8_cast_i16/i8_cast_i16.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_cast_i32/i8_cast_i32.mlir
+++ b/test/Integration/Dialect/TOSA/i8_cast_i32/i8_cast_i32.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I %aietools/include -D__AIEARCH__=20 -D__AIENGINE__ -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8_neg/i8_neg.mlir
+++ b/test/Integration/Dialect/TOSA/i8_neg/i8_neg.mlir
@@ -1,6 +1,7 @@
 // REQUIRES: valid_xchess_license
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
-// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc ./work/dut.cc.o
 // RUN: mkdir -p data
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s

--- a/test/Integration/Dialect/TOSA/i8xi16_add_elem/i16xi8_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_add_elem/i16xi8_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi16_add_elem/i8xi16_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_add_elem/i8xi16_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/i8xi16_mul_elem_v16.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v16/i8xi16_mul_elem_v16.mlir
@@ -6,7 +6,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i16xi8_mul_elem_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i16xi8_mul_elem_v32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_mul_elem_v32/i8xi16_mul_elem_v32.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i16xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i16xi8_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i8xi16_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi16_sub_elem/i8xi16_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi32_add_elem/i32xi8_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_add_elem/i32xi8_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi32_add_elem/i8xi32_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_add_elem/i8xi32_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i32xi8_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i32xi8_mul_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_mul_elem/i8xi32_mul_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v16% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i32xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i32xi8_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i8xi32_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi32_sub_elem/i8xi32_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_add_elem/i8xi8_add_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_add_elem/i8xi8_add_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem/i8xi8_mul_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem/i8xi8_mul_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1/i8xi8_mul_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1/i8xi8_mul_elem_2d_broadcast_1d_unit_dim.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1/i8xi8_mul_elem_2d_broadcast_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1/i8xi8_mul_elem_2d_broadcast_scalar.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_16x1024_broadcast_1024/i8xi8_mul_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/i8xi8_mul_elem_i32.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_mul_elem_i32/i8xi8_mul_elem_i32.mlir
@@ -6,7 +6,8 @@
 // RUN: aie-opt %s %tosa-to-linalg% -o %t/linalg.mlir
 // RUN: aie-opt %t/linalg.mlir %linalg-to-vector-v32% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc >& xchesscc_wrapper.stdout
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o >& xchesscc_wrapper.stdout
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_sel/i8xi8_sel.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sel/i8xi8_sel.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem/i8xi8_sub_elem.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem/i8xi8_sub_elem.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1/i8xi8_sub_elem_2d_broadcast_1d_scalar.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1/i8xi8_sub_elem_2d_broadcast_1d_scalar.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1/i8xi8_sub_elem_2d_broadcast_1d_unit_dim.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1/i8xi8_sub_elem_2d_broadcast_1d_unit_dim.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_1d.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_1d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_1d_reshape.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_1d_reshape.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_2d.mlir
+++ b/test/Integration/Dialect/TOSA/i8xi8_sub_elem_16x1024_broadcast_1024/i8xi8_sub_elem_2d_broadcast_2d.mlir
@@ -5,7 +5,8 @@
 // RUN: mkdir -p %t/data
 // RUN: aie-opt %s %tosa-to-linalg% | aie-opt %linalg-to-vector-v64% --convert-vector-to-aievec="aie-target=aieml" -lower-affine -o %t/aievec.mlir
 // RUN: aie-translate %t/aievec.mlir -aieml=true --aievec-to-cpp -o %t/dut.cc
-// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc dut.cc
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. -c dut.cc -o dut.cc.o
+// RUN: cd %t; xchesscc_wrapper aie2 -f -g +s +w work +o work -I%S -I. %S/testbench.cc %t/work/dut.cc.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=%t/xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/Integration/julia_by_lines/kernel.h
+++ b/test/Integration/julia_by_lines/kernel.h
@@ -9,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <stdint.h>
-#include <stdio.h>
 
 extern "C" {
 void do_line(int32_t *a, float MinRe, float StepRe, float Im, int size);


### PR DESCRIPTION
Replace command lines like,
```
xchesscc_wrapper ... file1.cc file2.cc ..
```
with,
```
xchesscc_wrapper ... -c file1.cc -o file1.cc.o ..
xchesscc_wrapper ... -c file2.cc -o file2.cc.o ..
xchesscc_wrapper ... file1.cc.o file2.cc.o ..
```
because each source file on the xchesscc_wrapper command line gets compiled in parallel, and each of those jobs takes a lot of memory. Instead compile the source files sequentially so that the parallelism can be controlled by lit at a higher level.