### PR TITLE
Remove xchesscc_wrapper parallelism

### DIFF
--- a/tools/chess-clang/xchesscc_wrapper
+++ b/tools/chess-clang/xchesscc_wrapper
@@ -48,4 +48,4 @@ export UNWRAPPED_XCHESSCC=$AIETOOLS/bin/unwrapped/lnx64.o/xchesscc
 export LD_LIBRARY_PATH=$AIETOOLS/lib/lnx64.o:$AIETOOLS/lnx64/tools/dot/lib:$LD_LIBRARY_PATH
 # Carefully crafted path so that we can inject other scripts into the chess path, namely chess-clang
 export PATH=$DIR:$AIETOOLS/bin/unwrapped/lnx64.o:$AIETOOLS/tps/lnx64/target/bin/LNa64bin
-$UNWRAPPED_XCHESSCC +P 4 -p me -C Release_LLVM -D__AIENGINE__ $EXTRA_DEFS -Y clang=$DIR/chess-clang -P $LIBDIR -d -f $@
+$UNWRAPPED_XCHESSCC -p me -C Release_LLVM -D__AIENGINE__ $EXTRA_DEFS -Y clang=$DIR/chess-clang -P $LIBDIR -d -f $@


### PR DESCRIPTION
Remove default +P 4 from xchesscc_wrapper. Users can instead get parallelism from their build or test system (ninja, make, lit, ...)

Instead of https://github.com/Xilinx/mlir-aie/pull/1495