### PR TITLE
Update mm.cc to be compatible with iree's current tiling strategy 

### DIFF
--- a/aie_kernels/mm.cc
+++ b/aie_kernels/mm.cc
@@ -24,6 +24,27 @@
 
 #include "zero.cc"
 
+// Perform matmul where the expected layouts for A and B are as follows.
+//
+// Suppose A is a 64x64 tensor and B is a 64x64 tensor, and r=4, s=8, t=4.
+//
+// Let A[i,j] be the element at row i and column j of A, and
+//     B[i,j] be the element at row i and column j of B.
+//
+// The expectations for this implementation are that:
+//
+// 1) all elements of A are contiguous in memory, starting from pA + offsetA
+// 2) all elements of B are contiguous in memory, starting from pB + offsetB
+// 3) all elements of C are contiguous in memory, starting from pC + offsetC
+// 4) element A[i,j] is at pA[offsetA + i*8 + (64*8)*(j/8) + j%8]
+// 5) element B[i,j] is at pB[offsetB + i*4 + (64*4)*(j/4) + j%4]
+//
+// 4) and 5) describe vertical stripes of A and B being stored contiguously,
+// with a row-major order with each stripe. i.e. for A it looks like
+//
+// [A[0,0], ..., A[0,7], A[1,0], ..., A[1,7], A[2,0], ..., A[2,7], ... A[63,0],
+// ..., A[63,7], A[0,8], ..., A[0,15], ..., A[63, 64]]
+//
 template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
           unsigned colB, unsigned r, unsigned s, unsigned t>
 void matmul_vectorized(const T_in *__restrict pA, unsigned offsetA,
@@ -33,117 +54,47 @@ void matmul_vectorized(const T_in *__restrict pA, unsigned offsetA,
 
   event0();
 
-  for (unsigned z = 0; z < rowA; z += 4)
+  for (unsigned z = 0; z < rowA; z += 2)
     chess_loop_range(2, ) {
       T_out *__restrict pC1 = pC + offsetC + (z)*MMUL::size_C;
       T_out *__restrict pC2 = pC + offsetC + ((z + 1)) * MMUL::size_C;
-      T_out *__restrict pC3 = pC + offsetC + ((z + 2)) * MMUL::size_C;
-      T_out *__restrict pC4 = pC + offsetC + ((z + 3)) * MMUL::size_C;
 
-      for (unsigned j = 0; j < colB; j += 4)
+      for (unsigned j = 0; j < colB; j += 2)
         chess_prepare_for_pipelining chess_loop_range(8, ) {
           const T_in *__restrict pA1 = pA + offsetA + (z)*MMUL::size_A;
           const T_in *__restrict pA2 = pA + offsetA + ((z + 1)) * MMUL::size_A;
-          const T_in *__restrict pA3 = pA + offsetA + ((z + 2)) * MMUL::size_A;
-          const T_in *__restrict pA4 = pA + offsetA + ((z + 3)) * MMUL::size_A;
 
-          const T_in *__restrict pB1 = pB + offsetB + (j)*MMUL::size_B;
-          const T_in *__restrict pB2 = pB + offsetB + ((j + 1)) * MMUL::size_B;
-          const T_in *__restrict pB3 = pB + offsetB + ((j + 2)) * MMUL::size_B;
-          const T_in *__restrict pB4 = pB + offsetB + ((j + 3)) * MMUL::size_B;
+          const T_in *__restrict pB1 = pB + offsetB + (j)*colA * MMUL::size_B;
+          const T_in *__restrict pB2 =
+              pB + offsetB + ((j + 1)) * colA * MMUL::size_B;
 
           aie::vector<T_in, MMUL::size_A> A0 = aie::load_v<MMUL::size_A>(pA1);
           pA1 += rowA * MMUL::size_A;
           aie::vector<T_in, MMUL::size_A> A1 = aie::load_v<MMUL::size_A>(pA2);
           pA2 += rowA * MMUL::size_A;
-          aie::vector<T_in, MMUL::size_A> A2 = aie::load_v<MMUL::size_A>(pA3);
-          pA3 += rowA * MMUL::size_A;
-          aie::vector<T_in, MMUL::size_A> A3 = aie::load_v<MMUL::size_A>(pA4);
-          pA4 += rowA * MMUL::size_A;
           aie::vector<T_in, MMUL::size_B> B0 = aie::load_v<MMUL::size_B>(pB1);
           pB1 += MMUL::size_B;
           aie::vector<T_in, MMUL::size_B> B1 = aie::load_v<MMUL::size_B>(pB2);
           pB2 += MMUL::size_B;
-          aie::vector<T_in, MMUL::size_B> B2 = aie::load_v<MMUL::size_B>(pB3);
-          pB3 += MMUL::size_B;
-          aie::vector<T_in, MMUL::size_B> B3 = aie::load_v<MMUL::size_B>(pB4);
-          pB4 += MMUL::size_B;
 
           aie::vector<T_out, MMUL::size_C> acc_C00 =
               aie::load_v<MMUL::size_C>(pC1);
           aie::vector<T_out, MMUL::size_C> acc_C01 =
               aie::load_v<MMUL::size_C>(pC1 + MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C02 =
-              aie::load_v<MMUL::size_C>(pC1 + 2 * MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C03 =
-              aie::load_v<MMUL::size_C>(pC1 + 3 * MMUL::size_C * rowA);
-
           aie::vector<T_out, MMUL::size_C> acc_C10 =
               aie::load_v<MMUL::size_C>(pC2);
           aie::vector<T_out, MMUL::size_C> acc_C11 =
               aie::load_v<MMUL::size_C>(pC2 + MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C12 =
-              aie::load_v<MMUL::size_C>(pC2 + 2 * MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C13 =
-              aie::load_v<MMUL::size_C>(pC2 + 3 * MMUL::size_C * rowA);
-
-          aie::vector<T_out, MMUL::size_C> acc_C20 =
-              aie::load_v<MMUL::size_C>(pC3);
-          aie::vector<T_out, MMUL::size_C> acc_C21 =
-              aie::load_v<MMUL::size_C>(pC3 + MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C22 =
-              aie::load_v<MMUL::size_C>(pC3 + 2 * MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C23 =
-              aie::load_v<MMUL::size_C>(pC3 + 3 * MMUL::size_C * rowA);
-
-          aie::vector<T_out, MMUL::size_C> acc_C30 =
-              aie::load_v<MMUL::size_C>(pC4);
-          aie::vector<T_out, MMUL::size_C> acc_C31 =
-              aie::load_v<MMUL::size_C>(pC4 + MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C32 =
-              aie::load_v<MMUL::size_C>(pC4 + 2 * MMUL::size_C * rowA);
-          aie::vector<T_out, MMUL::size_C> acc_C33 =
-              aie::load_v<MMUL::size_C>(pC4 + 3 * MMUL::size_C * rowA);
 
           MMUL C00(acc_C00);
           MMUL C01(acc_C01);
-          MMUL C02(acc_C02);
-          MMUL C03(acc_C03);
-
           MMUL C10(acc_C10);
           MMUL C11(acc_C11);
-          MMUL C12(acc_C12);
-          MMUL C13(acc_C13);
-
-          MMUL C20(acc_C20);
-          MMUL C21(acc_C21);
-          MMUL C22(acc_C22);
-          MMUL C23(acc_C23);
-
-          MMUL C30(acc_C30);
-          MMUL C31(acc_C31);
-          MMUL C32(acc_C32);
-          MMUL C33(acc_C33);
 
           C00.mac(A0, B0);
           C01.mac(A0, B1);
           C10.mac(A1, B0);
           C11.mac(A1, B1);
-
-          C02.mac(A0, B2);
-          C03.mac(A0, B3);
-          C12.mac(A1, B2);
-          C13.mac(A1, B3);
-
-          C20.mac(A2, B0);
-          C21.mac(A2, B1);
-          C30.mac(A3, B0);
-          C31.mac(A3, B1);
-
-          C22.mac(A2, B2);
-          C23.mac(A2, B3);
-          C32.mac(A3, B2);
-          C33.mac(A3, B3);
 
           for (unsigned i = 1; i < colA; ++i)
             chess_prepare_for_pipelining chess_loop_range(7, ) {
@@ -151,76 +102,24 @@ void matmul_vectorized(const T_in *__restrict pA, unsigned offsetA,
               pA1 += rowA * MMUL::size_A;
               A1 = aie::load_v<MMUL::size_A>(pA2);
               pA2 += rowA * MMUL::size_A;
-              A2 = aie::load_v<MMUL::size_A>(pA3);
-              pA3 += rowA * MMUL::size_A;
-              A3 = aie::load_v<MMUL::size_A>(pA4);
-              pA4 += rowA * MMUL::size_A;
-
               B0 = aie::load_v<MMUL::size_B>(pB1);
               pB1 += MMUL::size_B;
               B1 = aie::load_v<MMUL::size_B>(pB2);
               pB2 += MMUL::size_B;
-              B2 = aie::load_v<MMUL::size_B>(pB3);
-              pB3 += MMUL::size_B;
-              B3 = aie::load_v<MMUL::size_B>(pB4);
-              pB4 += MMUL::size_B;
-
               C00.mac(A0, B0);
               C01.mac(A0, B1);
               C10.mac(A1, B0);
               C11.mac(A1, B1);
-
-              C02.mac(A0, B2);
-              C03.mac(A0, B3);
-              C12.mac(A1, B2);
-              C13.mac(A1, B3);
-
-              C20.mac(A2, B0);
-              C21.mac(A2, B1);
-              C30.mac(A3, B0);
-              C31.mac(A3, B1);
-
-              C22.mac(A2, B2);
-              C23.mac(A2, B3);
-              C32.mac(A3, B2);
-              C33.mac(A3, B3);
             }
 
           aie::store_v(pC1, C00.template to_vector<T_out>());
           pC1 += MMUL::size_C * rowA;
           aie::store_v(pC1, C01.template to_vector<T_out>());
           pC1 += MMUL::size_C * rowA;
-          aie::store_v(pC1, C02.template to_vector<T_out>());
-          pC1 += MMUL::size_C * rowA;
-          aie::store_v(pC1, C03.template to_vector<T_out>());
-          pC1 += MMUL::size_C * rowA;
-
           aie::store_v(pC2, C10.template to_vector<T_out>());
           pC2 += MMUL::size_C * rowA;
           aie::store_v(pC2, C11.template to_vector<T_out>());
           pC2 += MMUL::size_C * rowA;
-          aie::store_v(pC2, C12.template to_vector<T_out>());
-          pC2 += MMUL::size_C * rowA;
-          aie::store_v(pC2, C13.template to_vector<T_out>());
-          pC2 += MMUL::size_C * rowA;
-
-          aie::store_v(pC3, C20.template to_vector<T_out>());
-          pC3 += MMUL::size_C * rowA;
-          aie::store_v(pC3, C21.template to_vector<T_out>());
-          pC3 += MMUL::size_C * rowA;
-          aie::store_v(pC3, C22.template to_vector<T_out>());
-          pC3 += MMUL::size_C * rowA;
-          aie::store_v(pC3, C23.template to_vector<T_out>());
-          pC3 += MMUL::size_C * rowA;
-
-          aie::store_v(pC4, C30.template to_vector<T_out>());
-          pC4 += MMUL::size_C * rowA;
-          aie::store_v(pC4, C31.template to_vector<T_out>());
-          pC4 += MMUL::size_C * rowA;
-          aie::store_v(pC4, C32.template to_vector<T_out>());
-          pC4 += MMUL::size_C * rowA;
-          aie::store_v(pC4, C33.template to_vector<T_out>());
-          pC4 += MMUL::size_C * rowA;
         }
     }
 

--- a/aie_kernels/mm.cc
+++ b/aie_kernels/mm.cc
@@ -24,14 +24,12 @@
 
 #include "zero.cc"
 
-// Perform matmul where the expected layouts for A and B are as follows.
-//
 // Suppose A is a 64x64 tensor and B is a 64x64 tensor, and r=4, s=8, t=4.
 //
 // Let A[i,j] be the element at row i and column j of A, and
 //     B[i,j] be the element at row i and column j of B.
 //
-// The expectations for this implementation are that:
+// The expectations that this implementation makes are:
 //
 // 1) all elements of A are contiguous in memory, starting from pA + offsetA
 // 2) all elements of B are contiguous in memory, starting from pB + offsetB
@@ -40,7 +38,7 @@
 // 5) element B[i,j] is at pB[offsetB + i*4 + (64*4)*(j/4) + j%4]
 //
 // 4) and 5) describe vertical stripes of A and B being stored contiguously,
-// with a row-major order with each stripe. i.e. for A it looks like
+// with a row-major order within each stripe. i.e. A looks like
 //
 // [A[0,0], ..., A[0,7], A[1,0], ..., A[1,7], A[2,0], ..., A[2,7], ... A[63,0],
 // ..., A[63,7], A[0,8], ..., A[0,15], ..., A[63, 64]]


### PR DESCRIPTION
This updated kernel is based on the ukernel in https://github.com/Xilinx/mlir-air/blob/main/test/xrt/09_gemm_extern_vec_4x4/mm.cc

This is the only ukernel which works with the current tiling strategy used when lowering from IREE. 

The striding of the A tensor is different. This replacement ukernel has 4x8 tiles that are _vertically_ contiguous in A, contiguous in memory. The ukernel it replaces has 4x8 tiles which are _horizontally_ contiguous in B, contiguous in memory. 

