### PR TITLE
Simplify CDO code generation

### DIFF
--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -705,8 +705,8 @@ LogicalResult generateCDOBinary(const StringRef outputPath,
                                 const std::function<LogicalResult()> &cb) {
   startCDOFileStream(outputPath.str().c_str());
   FileHeader();
-  // Never generate a completely empty CDO file.  If the file only contains a header,
-  // then bootgen flags it as invalid.
+  // Never generate a completely empty CDO file.  If the file only contains a
+  // header, then bootgen flags it as invalid.
   insertNoOpCommand(4);
   if (failed(cb()))
     return failure();

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -188,8 +188,8 @@ def emit_partition(mlir_module_str, kernel_id="0x901", start_columns=None):
             module.operation,
             lambda o: isinstance(o.operation.opview, aiedialect.TileOp),
         )
-        min_col = min([t.col.value for t in tiles]) if tiles else 0
-        max_col = max([t.col.value for t in tiles]) if tiles else 0
+        min_col = min([t.col.value for t in tiles], default=0)
+        max_col = max([t.col.value for t in tiles], default=0)
     num_cols = max_col - min_col + 1
     device = find_ops(
         module.operation,

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -188,9 +188,8 @@ def emit_partition(mlir_module_str, kernel_id="0x901", start_columns=None):
             module.operation,
             lambda o: isinstance(o.operation.opview, aiedialect.TileOp),
         )
-        min_col = min([t.col.value for t in tiles])
-        max_col = max([t.col.value for t in tiles])
-
+        min_col = min([t.col.value for t in tiles]) if tiles else 0
+        max_col = max([t.col.value for t in tiles]) if tiles else 0
     num_cols = max_col - min_col + 1
     device = find_ops(
         module.operation,
@@ -255,8 +254,9 @@ def generate_cores_list(mlir_module_str):
 
 
 def emit_design_bif(root_path, has_cores=True, enable_cores=True):
-    elf_file = f"file={root_path}/aie_cdo_elfs.bin" if has_cores else ""
-    enable_file = f"file={root_path}/aie_cdo_enable.bin" if enable_cores else ""
+    cdo_elfs_file = f"file={root_path}/aie_cdo_elfs.bin"
+    cdo_init_file = f"file={root_path}/aie_cdo_init.bin"
+    cdo_enable_file = f"file={root_path}/aie_cdo_enable.bin" if enable_cores else ""
     return dedent(
         f"""\
         all:
@@ -267,9 +267,9 @@ def emit_design_bif(root_path, has_cores=True, enable_cores=True):
           {{
             name=aie_image, id=0x1c000000
             {{ type=cdo
-               {elf_file}
-               file={root_path}/aie_cdo_init.bin
-               {enable_file}
+               {cdo_elfs_file}
+               {cdo_init_file}
+               {cdo_enable_file}
             }}
           }}
         }}
@@ -550,7 +550,7 @@ class FlowRunner:
             )
             generate_cdo(input_physical.operation, self.tmpdirname)
 
-    async def process_xclbin_gen(self, has_cores):
+    async def process_xclbin_gen(self):
         if opts.progress:
             task = self.progress_bar.add_task(
                 "[yellow] XCLBIN generation ", total=10, command="starting"
@@ -583,7 +583,7 @@ class FlowRunner:
         )
 
         await write_file_async(
-            emit_design_bif(self.tmpdirname, has_cores),
+            emit_design_bif(self.tmpdirname),
             self.prepend_tmp("design.bif"),
         )
 
@@ -1075,7 +1075,7 @@ class FlowRunner:
             if opts.cdo and opts.execute:
                 await self.process_cdo()
             if opts.cdo or opts.xcl:
-                await self.process_xclbin_gen(bool(len(cores)))
+                await self.process_xclbin_gen()
 
     def dumpprofile(self):
         sortedruntimes = sorted(


### PR DESCRIPTION
Bootgen requires CDO files to be non-empty.  In some corner cases this isn't guaraunteed, resulting in some tricky workarounds which were incomplete.  A simpler solution is to always emit a few NOOP padding bytes.