### PR TITLE
[aievec] to-llvm flow for aievec.max op

### DIFF
--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -346,7 +346,7 @@ def VectorMaxLt8IntrOp :
         [TypeIs<"res",
             LLVM_StructOf<[
                 VectorOfLengthAndType<[64], [I8]>,
-                I32]>
+                VectorOfLengthAndType<[2], [I32]>]>
         >], /*numResults=*/2>,
     Arguments<(ins VectorOfLengthAndType<[64], [I8]>:$lhs,
                    VectorOfLengthAndType<[64], [I8]>:$rhs,

--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -341,6 +341,39 @@ def VectorExtractElem32I512IntrOp :
 
 // ----- MAX ELEMENT -----
 
+def VectorMaxLt8IntrOp :
+    AIEVec2_IntrOp<"vmax.lt8",
+        [TypeIs<"res",
+            LLVM_StructOf<[
+                VectorOfLengthAndType<[64], [I8]>,
+                I32]>
+        >], /*numResults=*/2>,
+    Arguments<(ins VectorOfLengthAndType<[64], [I8]>:$lhs,
+                   VectorOfLengthAndType<[64], [I8]>:$rhs,
+                   I32:$pred)> ;
+
+def VectorMaxLt16IntrOp :
+    AIEVec2_IntrOp<"vmax.lt16",
+        [TypeIs<"res",
+            LLVM_StructOf<[
+                VectorOfLengthAndType<[32], [I16]>,
+                I32]>
+        >], /*numResults=*/2>,
+    Arguments<(ins VectorOfLengthAndType<[32], [I16]>:$lhs,
+                   VectorOfLengthAndType<[32], [I16]>:$rhs,
+                   I32:$pred)> ;
+
+def VectorMaxLt32IntrOp :
+    AIEVec2_IntrOp<"vmax.lt32",
+        [TypeIs<"res",
+            LLVM_StructOf<[
+                VectorOfLengthAndType<[16], [I32]>,
+                I32]>
+        >], /*numResults=*/2>,
+    Arguments<(ins VectorOfLengthAndType<[16], [I32]>:$lhs,
+                   VectorOfLengthAndType<[16], [I32]>:$rhs,
+                   I32:$pred)> ;
+
 def VectorMaxLtBf16IntrOp :
     AIEVec2_IntrOp<"vmax.ltbf16",
         [TypeIs<"res",

--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -350,7 +350,7 @@ def VectorMaxLt8IntrOp :
         >], /*numResults=*/2>,
     Arguments<(ins VectorOfLengthAndType<[64], [I8]>:$lhs,
                    VectorOfLengthAndType<[64], [I8]>:$rhs,
-                   I32:$pred)> ;
+                   I32:$cmp)> ;
 
 def VectorMaxLt16IntrOp :
     AIEVec2_IntrOp<"vmax.lt16",
@@ -361,7 +361,7 @@ def VectorMaxLt16IntrOp :
         >], /*numResults=*/2>,
     Arguments<(ins VectorOfLengthAndType<[32], [I16]>:$lhs,
                    VectorOfLengthAndType<[32], [I16]>:$rhs,
-                   I32:$pred)> ;
+                   I32:$cmp)> ;
 
 def VectorMaxLt32IntrOp :
     AIEVec2_IntrOp<"vmax.lt32",
@@ -372,7 +372,7 @@ def VectorMaxLt32IntrOp :
         >], /*numResults=*/2>,
     Arguments<(ins VectorOfLengthAndType<[16], [I32]>:$lhs,
                    VectorOfLengthAndType<[16], [I32]>:$rhs,
-                   I32:$pred)> ;
+                   I32:$cmp)> ;
 
 def VectorMaxLtBf16IntrOp :
     AIEVec2_IntrOp<"vmax.ltbf16",

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -1513,6 +1513,7 @@ public:
     int resultLanes = getVectorLaneSize(resultType);
     int resultVectorSize = resultBitWidth * resultLanes;
 
+    // aievec.max op has the AllTypesMatch constraint on lhs/rhs/res
     if (resultVectorSize != 512) {
       op.emitWarning() << "aievec.max conversion with " << resultVectorSize
                        << "-bit result is not supported.\n";
@@ -1532,7 +1533,7 @@ public:
             mlir::LLVM::LLVMStructType::getLiteral(
                 rewriter.getContext(),
                 {VectorType::get({64}, rewriter.getI8Type()),
-                 rewriter.getI32Type()}),
+                 VectorType::get({2}, rewriter.getI32Type())}),
             forceCastOperandsToSignature(
                 rewriter, loc, operands,
                 {VectorType::get({64}, rewriter.getI8Type()),
@@ -1579,7 +1580,10 @@ public:
     }
 
     if (!maxOp) {
-      op.emitError() << "aievec.max conversion is not supported.\n";
+      // We have checked the lhs/rhs/res to be 512-bit vectors. Hence, a
+      // possible failure here is due to unsupported element datatype.
+      op.emitWarning() << "aievec.max conversion fails due to unsupported "
+                          "element data type.\n";
       return failure();
     }
 

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -1579,7 +1579,7 @@ public:
     }
 
     if (!maxOp) {
-      op.emitWarning() << "aievec.max conversion is not supported.\n";
+      op.emitError() << "aievec.max conversion is not supported.\n";
       return failure();
     }
 

--- a/test/Conversion/AIEVecToLLVM/test-max.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-max.mlir
@@ -1,0 +1,62 @@
+// RUN: aie-opt %s -split-input-file -convert-aievec-to-llvm | FileCheck %s
+
+func.func @i8_max(%arg0 : vector<64xi8>) -> vector<64xi8> {
+  %0 = aievec.max %arg0, %arg0 : vector<64xi8>
+  return %0 : vector<64xi8>
+}
+
+// CHECK-LABEL: @i8_max
+// CHECK-SAME: %[[ARG0:.*]]: vector<64xi8>
+// CHECK: %[[CST:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[VMAX:.*]] = "xllvm.intr.aie2.vmax.lt8"(
+// CHECK-SAME: %[[ARG0]], %[[ARG0]], %[[CST]]) : 
+// CHECK-SAME: (vector<64xi8>, vector<64xi8>, i32) -> !llvm.struct<(vector<64xi8>, i32)>
+// CHECK-NEXT: %[[RES:.*]] = llvm.extractvalue %[[VMAX]][0] : !llvm.struct<(vector<64xi8>, i32)>
+// CHECK-NEXT: return %[[RES]] : vector<64xi8>
+
+// -----
+
+func.func @i16_max(%arg0 : vector<32xi16>) -> vector<32xi16> {
+  %0 = aievec.max %arg0, %arg0 : vector<32xi16>
+  return %0 : vector<32xi16>
+}
+
+// CHECK-LABEL: @i16_max
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xi16>
+// CHECK: %[[CST:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[VMAX:.*]] = "xllvm.intr.aie2.vmax.lt16"(
+// CHECK-SAME: %[[ARG0]], %[[ARG0]], %[[CST]]) : 
+// CHECK-SAME: (vector<32xi16>, vector<32xi16>, i32) -> !llvm.struct<(vector<32xi16>, i32)>
+// CHECK-NEXT: %[[RES:.*]] = llvm.extractvalue %[[VMAX]][0] : !llvm.struct<(vector<32xi16>, i32)>
+// CHECK-NEXT: return %[[RES]] : vector<32xi16>
+
+// -----
+
+func.func @i32_max(%arg0 : vector<16xi32>) -> vector<16xi32> {
+  %0 = aievec.max %arg0, %arg0 : vector<16xi32>
+  return %0 : vector<16xi32>
+}
+
+// CHECK-LABEL: @i32_max
+// CHECK-SAME: %[[ARG0:.*]]: vector<16xi32>
+// CHECK: %[[CST:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT: %[[VMAX:.*]] = "xllvm.intr.aie2.vmax.lt32"(
+// CHECK-SAME: %[[ARG0]], %[[ARG0]], %[[CST]]) : 
+// CHECK-SAME: (vector<16xi32>, vector<16xi32>, i32) -> !llvm.struct<(vector<16xi32>, i32)>
+// CHECK-NEXT: %[[RES:.*]] = llvm.extractvalue %[[VMAX]][0] : !llvm.struct<(vector<16xi32>, i32)>
+// CHECK-NEXT: return %[[RES]] : vector<16xi32>
+
+// -----
+
+func.func @bf16_max(%arg0 : vector<32xbf16>) -> vector<32xbf16> {
+  %0 = aievec.max %arg0, %arg0 : vector<32xbf16>
+  return %0 : vector<32xbf16>
+}
+
+// CHECK-LABEL: @bf16_max
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xbf16>
+// CHECK-NEXT: %[[VMAX:.*]] = "xllvm.intr.aie2.vmax.ltbf16"(
+// CHECK-SAME: %[[ARG0]], %[[ARG0]]) : 
+// CHECK-SAME: (vector<32xbf16>, vector<32xbf16>) -> !llvm.struct<(vector<32xbf16>, i32)>
+// CHECK-NEXT: %[[RES:.*]] = llvm.extractvalue %[[VMAX]][0] : !llvm.struct<(vector<32xbf16>, i32)> 
+// CHECK-NEXT: return %[[RES]] : vector<32xbf16>

--- a/test/Conversion/AIEVecToLLVM/test-max.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-max.mlir
@@ -1,4 +1,4 @@
-// RUN: aie-opt %s -split-input-file -convert-aievec-to-llvm | FileCheck %s
+// RUN: aie-opt %s -split-input-file -convert-aievec-to-llvm -verify-diagnostics | FileCheck %s
 
 func.func @i8_max(%arg0 : vector<64xi8>) -> vector<64xi8> {
   %0 = aievec.max %arg0, %arg0 : vector<64xi8>
@@ -10,8 +10,8 @@ func.func @i8_max(%arg0 : vector<64xi8>) -> vector<64xi8> {
 // CHECK: %[[CST:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-NEXT: %[[VMAX:.*]] = "xllvm.intr.aie2.vmax.lt8"(
 // CHECK-SAME: %[[ARG0]], %[[ARG0]], %[[CST]]) : 
-// CHECK-SAME: (vector<64xi8>, vector<64xi8>, i32) -> !llvm.struct<(vector<64xi8>, i32)>
-// CHECK-NEXT: %[[RES:.*]] = llvm.extractvalue %[[VMAX]][0] : !llvm.struct<(vector<64xi8>, i32)>
+// CHECK-SAME: (vector<64xi8>, vector<64xi8>, i32) -> !llvm.struct<(vector<64xi8>, vector<2xi32>)>
+// CHECK-NEXT: %[[RES:.*]] = llvm.extractvalue %[[VMAX]][0] : !llvm.struct<(vector<64xi8>, vector<2xi32>)>
 // CHECK-NEXT: return %[[RES]] : vector<64xi8>
 
 // -----
@@ -60,3 +60,21 @@ func.func @bf16_max(%arg0 : vector<32xbf16>) -> vector<32xbf16> {
 // CHECK-SAME: (vector<32xbf16>, vector<32xbf16>) -> !llvm.struct<(vector<32xbf16>, i32)>
 // CHECK-NEXT: %[[RES:.*]] = llvm.extractvalue %[[VMAX]][0] : !llvm.struct<(vector<32xbf16>, i32)> 
 // CHECK-NEXT: return %[[RES]] : vector<32xbf16>
+
+// -----
+
+func.func @invalid_i4_max(%arg0 : vector<128xi4>) -> vector<128xi4> {
+  // expected-warning @+2 {{aievec.max conversion fails due to unsupported element data type.}}
+  // expected-error @+1 {{failed to legalize operation 'aievec.max' that was explicitly marked illegal}}
+  %0 = aievec.max %arg0, %arg0 : vector<128xi4>
+  return %0 : vector<128xi4>
+}
+
+// -----
+
+func.func @invalid_i8_max(%arg0 : vector<128xi8>) -> vector<128xi8> {
+  // expected-warning @+2 {{aievec.max conversion with 1024-bit result is not supported.}}
+  // expected-error @+1 {{failed to legalize operation 'aievec.max' that was explicitly marked illegal}}
+  %0 = aievec.max %arg0, %arg0 : vector<128xi8>
+  return %0 : vector<128xi8>
+}

--- a/test/Target/LLVMIR/aievec.mlir
+++ b/test/Target/LLVMIR/aievec.mlir
@@ -422,6 +422,36 @@ llvm.func @accfloat_v16_256b_ups(%v : vector<16xbf16>) -> vector<8xi64> {
 
 // -----
 
+// CHECK-LABEL: <64 x i8> @vmax_lt8
+llvm.func @vmax_lt8(%lhs: vector<64xi8>, %rhs: vector<64xi8>, %pred: i32) -> vector<64xi8> {
+    // CHECK: call { <64 x i8>, i32 } @llvm.aie2.vmax.lt8(
+    // CHECK-SAME: <64 x i8> %{{[0-9]+}}, <64 x i8> %{{[0-9]+}}, i32 %{{[0-9]+}})
+    %0 = "xllvm.intr.aie2.vmax.lt8"(%lhs, %rhs, %pred) :
+        (vector<64xi8>, vector<64xi8>, i32) -> !llvm.struct<(vector<64xi8>, i32)>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<64xi8>, i32)>
+    llvm.return %1 : vector<64xi8>
+}
+
+// CHECK-LABEL: <32 x i16> @vmax_lt16
+llvm.func @vmax_lt16(%lhs: vector<32xi16>, %rhs: vector<32xi16>, %pred: i32) -> vector<32xi16> {
+    // CHECK: call { <32 x i16>, i32 } @llvm.aie2.vmax.lt16(
+    // CHECK-SAME: <32 x i16> %{{[0-9]+}}, <32 x i16> %{{[0-9]+}}, i32 %{{[0-9]+}})
+    %0 = "xllvm.intr.aie2.vmax.lt16"(%lhs, %rhs, %pred) :
+        (vector<32xi16>, vector<32xi16>, i32) -> !llvm.struct<(vector<32xi16>, i32)>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<32xi16>, i32)>
+    llvm.return %1 : vector<32xi16>
+}
+
+// CHECK-LABEL: <16 x i32> @vmax_lt32
+llvm.func @vmax_lt32(%lhs: vector<16xi32>, %rhs: vector<16xi32>, %pred: i32) -> vector<16xi32> {
+    // CHECK: call { <16 x i32>, i32 } @llvm.aie2.vmax.lt32(
+    // CHECK-SAME: <16 x i32> %{{[0-9]+}}, <16 x i32> %{{[0-9]+}}, i32 %{{[0-9]+}})
+    %0 = "xllvm.intr.aie2.vmax.lt32"(%lhs, %rhs, %pred) :
+        (vector<16xi32>, vector<16xi32>, i32) -> !llvm.struct<(vector<16xi32>, i32)>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<16xi32>, i32)>
+    llvm.return %1 : vector<16xi32>
+}
+
 // CHECK-LABEL: <32 x bfloat> @vmax_ltbf16
 llvm.func @vmax_ltbf16(%lhs: vector<32xbf16>, %rhs: vector<32xbf16>) -> vector<32xbf16> {
     // CHECK: call { <32 x bfloat>, i32 } @llvm.aie2.vmax.ltbf16(
@@ -432,4 +462,7 @@ llvm.func @vmax_ltbf16(%lhs: vector<32xbf16>, %rhs: vector<32xbf16>) -> vector<3
     llvm.return %1 : vector<32xbf16>
 }
 
+// CHECK-LABEL: declare { <64 x i8>, i32 } @llvm.aie2.vmax.lt8(<64 x i8>, <64 x i8>, i32)
+// CHECK-LABEL: declare { <32 x i16>, i32 } @llvm.aie2.vmax.lt16(<32 x i16>, <32 x i16>, i32)
+// CHECK-LABEL: declare { <16 x i32>, i32 } @llvm.aie2.vmax.lt32(<16 x i32>, <16 x i32>, i32)
 // CHECK-LABEL: declare { <32 x bfloat>, i32 } @llvm.aie2.vmax.ltbf16(<32 x bfloat>, <32 x bfloat>)

--- a/test/Target/LLVMIR/aievec.mlir
+++ b/test/Target/LLVMIR/aievec.mlir
@@ -424,11 +424,11 @@ llvm.func @accfloat_v16_256b_ups(%v : vector<16xbf16>) -> vector<8xi64> {
 
 // CHECK-LABEL: <64 x i8> @vmax_lt8
 llvm.func @vmax_lt8(%lhs: vector<64xi8>, %rhs: vector<64xi8>, %cmp: i32) -> vector<64xi8> {
-    // CHECK: call { <64 x i8>, i32 } @llvm.aie2.vmax.lt8(
+    // CHECK: call { <64 x i8>, <2 x i32> } @llvm.aie2.vmax.lt8(
     // CHECK-SAME: <64 x i8> %{{[0-9]+}}, <64 x i8> %{{[0-9]+}}, i32 %{{[0-9]+}})
     %0 = "xllvm.intr.aie2.vmax.lt8"(%lhs, %rhs, %cmp) :
-        (vector<64xi8>, vector<64xi8>, i32) -> !llvm.struct<(vector<64xi8>, i32)>
-    %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<64xi8>, i32)>
+        (vector<64xi8>, vector<64xi8>, i32) -> !llvm.struct<(vector<64xi8>, vector<2xi32>)>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<64xi8>, vector<2xi32>)>
     llvm.return %1 : vector<64xi8>
 }
 
@@ -462,7 +462,7 @@ llvm.func @vmax_ltbf16(%lhs: vector<32xbf16>, %rhs: vector<32xbf16>) -> vector<3
     llvm.return %1 : vector<32xbf16>
 }
 
-// CHECK-LABEL: declare { <64 x i8>, i32 } @llvm.aie2.vmax.lt8(<64 x i8>, <64 x i8>, i32)
+// CHECK-LABEL: declare { <64 x i8>, <2 x i32> } @llvm.aie2.vmax.lt8(<64 x i8>, <64 x i8>, i32)
 // CHECK-LABEL: declare { <32 x i16>, i32 } @llvm.aie2.vmax.lt16(<32 x i16>, <32 x i16>, i32)
 // CHECK-LABEL: declare { <16 x i32>, i32 } @llvm.aie2.vmax.lt32(<16 x i32>, <16 x i32>, i32)
 // CHECK-LABEL: declare { <32 x bfloat>, i32 } @llvm.aie2.vmax.ltbf16(<32 x bfloat>, <32 x bfloat>)

--- a/test/Target/LLVMIR/aievec.mlir
+++ b/test/Target/LLVMIR/aievec.mlir
@@ -423,30 +423,30 @@ llvm.func @accfloat_v16_256b_ups(%v : vector<16xbf16>) -> vector<8xi64> {
 // -----
 
 // CHECK-LABEL: <64 x i8> @vmax_lt8
-llvm.func @vmax_lt8(%lhs: vector<64xi8>, %rhs: vector<64xi8>, %pred: i32) -> vector<64xi8> {
+llvm.func @vmax_lt8(%lhs: vector<64xi8>, %rhs: vector<64xi8>, %cmp: i32) -> vector<64xi8> {
     // CHECK: call { <64 x i8>, i32 } @llvm.aie2.vmax.lt8(
     // CHECK-SAME: <64 x i8> %{{[0-9]+}}, <64 x i8> %{{[0-9]+}}, i32 %{{[0-9]+}})
-    %0 = "xllvm.intr.aie2.vmax.lt8"(%lhs, %rhs, %pred) :
+    %0 = "xllvm.intr.aie2.vmax.lt8"(%lhs, %rhs, %cmp) :
         (vector<64xi8>, vector<64xi8>, i32) -> !llvm.struct<(vector<64xi8>, i32)>
     %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<64xi8>, i32)>
     llvm.return %1 : vector<64xi8>
 }
 
 // CHECK-LABEL: <32 x i16> @vmax_lt16
-llvm.func @vmax_lt16(%lhs: vector<32xi16>, %rhs: vector<32xi16>, %pred: i32) -> vector<32xi16> {
+llvm.func @vmax_lt16(%lhs: vector<32xi16>, %rhs: vector<32xi16>, %cmp: i32) -> vector<32xi16> {
     // CHECK: call { <32 x i16>, i32 } @llvm.aie2.vmax.lt16(
     // CHECK-SAME: <32 x i16> %{{[0-9]+}}, <32 x i16> %{{[0-9]+}}, i32 %{{[0-9]+}})
-    %0 = "xllvm.intr.aie2.vmax.lt16"(%lhs, %rhs, %pred) :
+    %0 = "xllvm.intr.aie2.vmax.lt16"(%lhs, %rhs, %cmp) :
         (vector<32xi16>, vector<32xi16>, i32) -> !llvm.struct<(vector<32xi16>, i32)>
     %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<32xi16>, i32)>
     llvm.return %1 : vector<32xi16>
 }
 
 // CHECK-LABEL: <16 x i32> @vmax_lt32
-llvm.func @vmax_lt32(%lhs: vector<16xi32>, %rhs: vector<16xi32>, %pred: i32) -> vector<16xi32> {
+llvm.func @vmax_lt32(%lhs: vector<16xi32>, %rhs: vector<16xi32>, %cmp: i32) -> vector<16xi32> {
     // CHECK: call { <16 x i32>, i32 } @llvm.aie2.vmax.lt32(
     // CHECK-SAME: <16 x i32> %{{[0-9]+}}, <16 x i32> %{{[0-9]+}}, i32 %{{[0-9]+}})
-    %0 = "xllvm.intr.aie2.vmax.lt32"(%lhs, %rhs, %pred) :
+    %0 = "xllvm.intr.aie2.vmax.lt32"(%lhs, %rhs, %cmp) :
         (vector<16xi32>, vector<16xi32>, i32) -> !llvm.struct<(vector<16xi32>, i32)>
     %1 = llvm.extractvalue %0[0] : !llvm.struct<(vector<16xi32>, i32)>
     llvm.return %1 : vector<16xi32>


### PR DESCRIPTION
This PR add the support for `aievec.max` op going through the to-llvm flow.

Changes:
- Add `vmax` intrinsic ops to XLLVM dialect.
- Add aievec-to-llvm conversion pattern/tests for the `aievec.max` op.
- Add lit test for translating to external llvm.