### PR TITLE
[ObjectFifoStatefulTransform] Reuse mlir::loopUnrollByFactor instead of custom function

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Iterators.h"
@@ -782,147 +783,12 @@ struct AIEObjectFifoStatefulTransformPass
     return lcm;
   }
 
-  // Recursively calls itself if it finds a nested for loop.
-  // Returns the next index to use to uniquely identify operations
-  // on the body of the innerLoop.
-  int identifyDependencies(scf::ForOp outerLoop, scf::ForOp innerLoop,
-                           std::vector<Operation *> &operations,
-                           DenseMap<Operation *, int> &opIndex,
-                           std::vector<std::vector<int>> &dependencies,
-                           int startIndex) {
-    Block *body = innerLoop.getBody();
-    auto withoutTerminator = --body->end();
-    int index = startIndex;
-    for (auto op = body->begin(); op != withoutTerminator; ++op) {
-      operations.push_back(&*op);
-      opIndex[&*op] = index;
-
-      // identify dependencies
-      auto numOperands = op->getNumOperands();
-      std::vector<int> dependecyIndices;
-      for (int i = 0; static_cast<unsigned>(i) < numOperands; i++) {
-        auto operand = op->getOperand(i);
-        int dependencyIndex = -1;
-
-        if (operand == outerLoop.getInductionVar()) {
-          dependencyIndex = LOOP_VAR_DEPENDENCY;
-        } else {
-          if (auto definingOp = operand.getDefiningOp();
-              opIndex.find(definingOp) != opIndex.end())
-            dependencyIndex = opIndex[definingOp];
-        }
-        dependecyIndices.push_back(dependencyIndex);
-      }
-      dependencies.push_back(dependecyIndices);
-
-      index++;
-
-      // if op was a nested for-loop, also keep track of dependencies inside it
-      if (auto nestedLoop = dyn_cast<scf::ForOp>(op))
-        index = identifyDependencies(outerLoop, nestedLoop, operations, opIndex,
-                                     dependencies, index);
-    }
-    return index;
-  }
-
-  // Replace operands of cloned operation with results from other
-  // duplicated operations based on the index of the original
-  // operation and its dependencies.
-  void replaceOperands(OpBuilder &builder, Operation *clone,
-                       int originalOpIndex, Value base, int64_t step,
-                       bool inLoop, int currentDuplication,
-                       std::vector<std::vector<int>> &dependencies,
-                       std::vector<Operation *> &duplicatedOperations) {
-    auto numOperands = clone->getNumOperands();
-    for (int operandIndex = 0;
-         static_cast<unsigned>(operandIndex) < numOperands; operandIndex++) {
-
-      if (int originalDependencyIndex =
-              dependencies[originalOpIndex][operandIndex];
-          originalDependencyIndex >= 0) {
-        // replace the operand with the result of operation with
-        // same index in current duplication
-        auto duplicatedOp = duplicatedOperations[originalDependencyIndex];
-        Value result = duplicatedOp->getResult(0);
-        clone->setOperand(operandIndex, result);
-
-      } else if (originalDependencyIndex == LOOP_VAR_DEPENDENCY) {
-        int64_t increment_value;
-        if (inLoop)
-          // +1 because we do not duplicate original loop body
-          increment_value = (currentDuplication + 1) * step;
-        else
-          increment_value = currentDuplication * step;
-
-        auto increment = builder.create<arith::ConstantOp>(
-            builder.getUnknownLoc(), builder.getIndexAttr(increment_value));
-        auto sum = builder.create<arith::AddIOp>(builder.getUnknownLoc(),
-                                                 builder.getIndexType(), base,
-                                                 increment->getResult(0));
-        clone->setOperand(operandIndex, sum->getResult(0));
-      }
-    }
-    duplicatedOperations.push_back(clone);
-  }
-
-  // Function that duplicates given operations for the given number
-  // of times. !!! Assumes builder insertion point is set. !!!
-  // If there is a dependency on a loop induction variable, the given
-  // base mlir::Value is used to resolve it.
-  void duplicateBlock(OpBuilder &builder, int numDuplications,
-                      std::vector<Operation *> &operations,
-                      std::vector<std::vector<int>> &dependencies, Value base,
-                      int64_t step, bool inLoop) {
-    std::vector<Operation *> duplicatedOperations; // operations in current
-    // Recursive function to replace operands, uses recursion to handle nested
-    // loop structures.
-    std::function<void(Operation *, unsigned &, unsigned)> replaceOpsNested =
-        [&](Operation *op, unsigned &opIndex,
-            unsigned numDuplications) -> void {
-      if (auto loopOp = dyn_cast<scf::ForOp>(op)) {
-        Block *body = loopOp.getBody();
-        auto withoutTerminator = --body->end();
-        // NOTE(jornt): This only handles the cases where the nested scf::for is
-        // located at the start of the body. This should be the most common
-        // case, but is not fully generic.
-        if (auto nestedLoop = dyn_cast<scf::ForOp>(body->begin())) {
-          opIndex++;
-          replaceOperands(builder, nestedLoop, opIndex, base, step, inLoop,
-                          numDuplications, dependencies, duplicatedOperations);
-          replaceOpsNested(nestedLoop, opIndex, numDuplications);
-        } else {
-          for (auto loopBodyOp = body->begin(); loopBodyOp != withoutTerminator;
-               ++loopBodyOp) {
-            opIndex++;
-            replaceOperands(builder, &*loopBodyOp, opIndex, base, step, inLoop,
-                            numDuplications, dependencies,
-                            duplicatedOperations);
-          }
-        }
-      }
-    };
-
-    // duplication iteration
-    for (int i = 0; i < numDuplications; i++) {
-      duplicatedOperations.clear();
-      for (unsigned opIndex = 0; opIndex < operations.size(); opIndex++) {
-        // for each operand, check whether there was a dependecy
-        auto op = operations[opIndex];
-        auto clone = op->clone();
-        replaceOperands(builder, clone, opIndex, base, step, inLoop, i,
-                        dependencies, duplicatedOperations);
-        builder.insert(clone);
-        replaceOpsNested(clone, opIndex, i);
-      }
-    }
-  }
-
   // Function that unrolls for-loops that contain objectFifo operations.
-  void unrollForLoops(DeviceOp &device, OpBuilder &builder,
-                      std::set<TileOp> objectFifoTiles) {
+  LogicalResult unrollForLoops(DeviceOp &device, OpBuilder &builder,
+                               std::set<TileOp> objectFifoTiles) {
     for (auto coreOp : device.getOps<CoreOp>()) {
       if (objectFifoTiles.count(coreOp.getTileOp()) > 0) {
-        coreOp.walk([&](scf::ForOp forLoop) {
+        WalkResult res = coreOp.walk([&](scf::ForOp forLoop) {
           // look for operations on objectFifos
           // when multiple fifos in same loop, must use the smallest
           // common multiplier as the unroll factor
@@ -942,91 +808,20 @@ struct AIEObjectFifoStatefulTransformPass
               computeLCM(objFifoSizes); // also counts original loop body
 
           if (found) {
-            std::vector<Operation *>
-                operations; // operations in original loop body, without
-            // terminator operation
-            DenseMap<Operation *, int>
-                opIndex; // maps operations of original loop body to their
-            // position in it
-            std::vector<std::vector<int>>
-                dependencies; // index in first vecotr corresponds to position
-            // in original loop body dependency vector has
-            // size equal to number of operands of that
-            // operation:
-            //    * if LOOP_VAR_DEPENDENCY : operand is
-            //    dependent on loop induction variable
-            //    * if -1 : operand is not dependent on any
-            //    operation in loop body
-            //    * if >=0: operand is dependent on operation
-            //    with that index in original loop body
-
-            // find new loop size and step
-            auto old_upper_bound = forLoop.getUpperBound()
-                                       .getDefiningOp<arith::ConstantOp>()
-                                       .getValue();
-            int64_t old_upper_value =
-                llvm::dyn_cast<IntegerAttr>(old_upper_bound).getInt();
-            auto old_lower_bound = forLoop.getLowerBound()
-                                       .getDefiningOp<arith::ConstantOp>()
-                                       .getValue();
-            int64_t old_lower_value =
-                llvm::dyn_cast<IntegerAttr>(old_lower_bound).getInt();
-            auto old_step =
-                forLoop.getStep().getDefiningOp<arith::ConstantOp>().getValue();
-            int64_t old_step_value =
-                llvm::dyn_cast<IntegerAttr>(old_step).getInt();
-            int64_t num_iter =
-                (old_upper_value - old_lower_value) / old_step_value;
-
-            int64_t num_unrolls; // number of times to unroll loop, not counting
-                                 // original body
-
-            identifyDependencies(forLoop, forLoop, operations, opIndex,
-                                 dependencies, 0);
-
-            if (num_iter <= unrollFactor) {
-              // duplicate loop body and remove loop
-              num_unrolls = num_iter;
-              builder.setInsertionPointAfter(forLoop);
-              duplicateBlock(builder, num_unrolls, operations, dependencies,
-                             forLoop.getLowerBound(), old_step_value, false);
-              forLoop.getOperation()->erase();
-
-            } else {
-              num_unrolls = unrollFactor - 1; // -1 without original loop body
-
-              // create new upper bound and step
-              int64_t new_step_value =
-                  static_cast<int64_t>(unrollFactor) * old_step_value;
-              int64_t remainder = (old_upper_value - old_lower_value) %
-                                  new_step_value / old_step_value;
-              builder.setInsertionPoint(forLoop);
-              if (remainder > 0) {
-                int64_t new_upper_bound = (old_upper_value - old_lower_value) /
-                                          new_step_value * new_step_value;
-                auto uBound = builder.create<arith::ConstantOp>(
-                    builder.getUnknownLoc(),
-                    builder.getIndexAttr(new_upper_bound));
-                forLoop.setUpperBound(uBound);
-              }
-              auto new_step = builder.create<arith::ConstantOp>(
-                  builder.getUnknownLoc(),
-                  builder.getIndexAttr(new_step_value));
-              forLoop.setStep(new_step);
-
-              // duplicate loop body, insert before terminator operation
-              builder.setInsertionPoint(&body->back());
-              duplicateBlock(builder, num_unrolls, operations, dependencies,
-                             forLoop.getInductionVar(), old_step_value, true);
-              // duplicate remainder operations after loop body
-              builder.setInsertionPointAfter(forLoop);
-              duplicateBlock(builder, remainder, operations, dependencies,
-                             forLoop.getUpperBound(), old_step_value, false);
+            if (failed(mlir::loopUnrollByFactor(forLoop, unrollFactor))) {
+              forLoop.emitOpError()
+                  << "could not be unrolled with unrollFactor: " << unrollFactor
+                  << "\n";
+              return WalkResult::interrupt();
             }
           }
+          return WalkResult::advance();
         });
+        if (res.wasInterrupted())
+          return failure();
       }
     }
+    return success();
   }
 
   /// Function used to create a UseLockOp based on input parameters.
@@ -1364,7 +1159,9 @@ struct AIEObjectFifoStatefulTransformPass
     //===------------------------------------------------------------------===//
     // Unroll for loops
     //===------------------------------------------------------------------===//
-    unrollForLoops(device, builder, objectFifoTiles);
+    if (failed(unrollForLoops(device, builder, objectFifoTiles))) {
+      signalPassFailure();
+    }
 
     //===------------------------------------------------------------------===//
     // Replace ops

--- a/test/objectFifo-stateful-transform/loop_test.aie.mlir
+++ b/test/objectFifo-stateful-transform/loop_test.aie.mlir
@@ -1,4 +1,4 @@
-//===- loop_test.aie.mlir --------------------------*- MLIR -*-===//
+//===- loop_test.aie.mlir --------------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -13,118 +13,118 @@
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
 // CHECK-LABEL:   aie.device(xcvc1902) {
-// CHECK:           memref.global "public" @loop_of : memref<16xi32>
-// CHECK:           %[[VAL_0:.*]] = aie.tile(1, 2)
-// CHECK:           %[[VAL_1:.*]] = aie.tile(1, 3)
-// CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_0"} : memref<16xi32>
-// CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "loop_of_lock_2"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "loop_of_lock_3"}
+// CHECK-DAG:       %[[TILE_1_2:.*]] = aie.tile(1, 2)
+// CHECK-DAG:       %[[BUFF_0:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "loop_of_buff_0"} : memref<16xi32>
+// CHECK-DAG:       %[[BUFF_1:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "loop_of_buff_1"} : memref<16xi32>
+// CHECK-DAG:       %[[BUFF_2:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "loop_of_buff_2"} : memref<16xi32>
+// CHECK-DAG:       %[[BUFF_3:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "loop_of_buff_3"} : memref<16xi32>
+// CHECK-DAG:       %[[LOCK_0:.*]] = aie.lock(%[[TILE_1_2]], 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
+// CHECK-DAG:       %[[LOCK_1:.*]] = aie.lock(%[[TILE_1_2]], 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
+// CHECK-DAG:       %[[LOCK_2:.*]] = aie.lock(%[[TILE_1_2]], 2) {init = 0 : i32, sym_name = "loop_of_lock_2"}
+// CHECK-DAG:       %[[LOCK_3:.*]] = aie.lock(%[[TILE_1_2]], 3) {init = 0 : i32, sym_name = "loop_of_lock_3"}
 // CHECK:           func.func @some_work(%[[VAL_10:.*]]: memref<16xi32>, %[[VAL_11:.*]]: index) {
 // CHECK:             return
 // CHECK:           }
-// CHECK:           %[[VAL_12:.*]] = aie.core(%[[VAL_0]]) {
+// CHECK:           %[[CORE_1_2:.*]] = aie.core(%[[TILE_1_2]]) {
 // CHECK:             %[[VAL_13:.*]] = arith.constant 0 : index
-// CHECK:             %[[VAL_14:.*]] = arith.constant 1 : index
-// CHECK:             %[[VAL_15:.*]] = arith.constant 2 : index
-// CHECK:             %[[VAL_16:.*]] = arith.constant 4 : index
-// CHECK:             %[[VAL_17:.*]] = arith.constant 21 : index
-// CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             func.call @some_work(%[[VAL_2]], %[[VAL_13]]) : (memref<16xi32>, index) -> ()
-// CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
-// CHECK:             %[[VAL_18:.*]] = arith.constant 16 : index
+// CHECK:             %[[C1:.*]] = arith.constant 1 : index
+// CHECK:             %[[C2:.*]] = arith.constant 2 : index
+// CHECK:             %[[C4:.*]] = arith.constant 4 : index
+// CHECK:             %[[C21:.*]] = arith.constant 21 : index
+// CHECK:             aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK:             func.call @some_work(%[[BUFF_0]], %[[VAL_13]]) : (memref<16xi32>, index) -> ()
+// CHECK:             aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK:             %[[C17:.*]] = arith.constant 17 : index
 // CHECK:             %[[VAL_19:.*]] = arith.constant 8 : index
-// CHECK:             scf.for %[[VAL_20:.*]] = %[[VAL_14]] to %[[VAL_18]] step %[[VAL_19]] {
-// CHECK:               aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:               func.call @some_work(%[[VAL_3]], %[[VAL_20]]) : (memref<16xi32>, index) -> ()
-// CHECK:               aie.use_lock(%[[VAL_7]], Release, 1)
-// CHECK:               aie.use_lock(%[[VAL_8]], Acquire, 0)
-// CHECK:               %[[VAL_21:.*]] = arith.constant 2 : index
-// CHECK:               %[[VAL_22:.*]] = arith.addi %[[VAL_20]], %[[VAL_21]] : index
-// CHECK:               func.call @some_work(%[[VAL_4]], %[[VAL_22]]) : (memref<16xi32>, index) -> ()
-// CHECK:               aie.use_lock(%[[VAL_8]], Release, 1)
-// CHECK:               aie.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:               %[[VAL_23:.*]] = arith.constant 4 : index
-// CHECK:               %[[VAL_24:.*]] = arith.addi %[[VAL_20]], %[[VAL_23]] : index
-// CHECK:               func.call @some_work(%[[VAL_5]], %[[VAL_24]]) : (memref<16xi32>, index) -> ()
-// CHECK:               aie.use_lock(%[[VAL_9]], Release, 1)
-// CHECK:               aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:               %[[VAL_25:.*]] = arith.constant 6 : index
-// CHECK:               %[[VAL_26:.*]] = arith.addi %[[VAL_20]], %[[VAL_25]] : index
-// CHECK:               func.call @some_work(%[[VAL_2]], %[[VAL_26]]) : (memref<16xi32>, index) -> ()
-// CHECK:               aie.use_lock(%[[VAL_6]], Release, 1)
-// CHECK:             }
-// CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             %[[VAL_27:.*]] = arith.constant 0 : index
-// CHECK:             %[[VAL_28:.*]] = arith.addi %[[VAL_18]], %[[VAL_27]] : index
-// CHECK:             func.call @some_work(%[[VAL_3]], %[[VAL_28]]) : (memref<16xi32>, index) -> ()
-// CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
-// CHECK:             aie.use_lock(%[[VAL_8]], Acquire, 0)
-// CHECK:             %[[VAL_29:.*]] = arith.constant 2 : index
-// CHECK:             %[[VAL_30:.*]] = arith.addi %[[VAL_18]], %[[VAL_29]] : index
-// CHECK:             func.call @some_work(%[[VAL_4]], %[[VAL_30]]) : (memref<16xi32>, index) -> ()
-// CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
-// CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             %[[VAL_31:.*]] = arith.constant 0 : index
-// CHECK:             %[[VAL_32:.*]] = arith.addi %[[VAL_14]], %[[VAL_31]] : index
-// CHECK:             func.call @some_work(%[[VAL_5]], %[[VAL_32]]) : (memref<16xi32>, index) -> ()
-// CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
-// CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             %[[VAL_33:.*]] = arith.constant 1 : index
-// CHECK:             %[[VAL_34:.*]] = arith.addi %[[VAL_14]], %[[VAL_33]] : index
-// CHECK:             func.call @some_work(%[[VAL_2]], %[[VAL_34]]) : (memref<16xi32>, index) -> ()
-// CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
-// CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             %[[VAL_35:.*]] = arith.constant 2 : index
-// CHECK:             %[[VAL_36:.*]] = arith.addi %[[VAL_14]], %[[VAL_35]] : index
-// CHECK:             func.call @some_work(%[[VAL_3]], %[[VAL_36]]) : (memref<16xi32>, index) -> ()
-// CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
-// CHECK:             aie.end
-// CHECK:           }
-// CHECK:         }
-
-module @loop  {
-    aie.device(xcvc1902) {
-        %tile12 = aie.tile(1, 2)
-        %tile13 = aie.tile(1, 3)
-
-        aie.objectfifo @loop_of (%tile12, {%tile13}, 4 : i32) : !aie.objectfifo<memref<16xi32>>
-
-        func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
-            return
-        }
-
-        %core12 = aie.core(%tile12) {
-            %c0 = arith.constant 0 : index
-            %c1 = arith.constant 1 : index
-            %c2 = arith.constant 2 : index
-            %c4 = arith.constant 4 : index
-            %c21 = arith.constant 21 : index
-
-            %subviewTop0 = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
-            %elemTop0 = aie.objectfifo.subview.access %subviewTop0[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
-            func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
-            aie.objectfifo.release @loop_of (Produce, 1)
-
-            scf.for %indexInHeight = %c1 to %c21 step %c2 {
-                %subview = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
-                %elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
-                func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
-                aie.objectfifo.release @loop_of (Produce, 1)
-            }
-
-            scf.for %indexInHeight = %c1 to %c4 step %c1 {
-                %subview = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
-                %elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
-                func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
-                aie.objectfifo.release @loop_of (Produce, 1)
-            }
-
-            aie.end
-        }
+// CHECK:             scf.for %[[ARG0:.*]] = %[[C1]] to %[[C17]] step %[[VAL_19]] {
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK-NEXT:          func.call @some_work(%[[BUFF_1]], %[[ARG0]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK-DAG:           %[[C1_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:           %[[MUL_0:.*]] = arith.muli %[[C2]], %[[C1_1]] : index
+// CHECK-DAG:           %[[ADD_0:.*]] = arith.addi %[[ARG0]], %[[MUL_0]] : index
+// CHECK-DAG:           aie.use_lock(%[[LOCK_2]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_2]], %[[ADD_0]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_2]], Release, 1)
+// CHECK-DAG:           %[[C2_1:.*]] = arith.constant 2 : index
+// CHECK-DAG:           %[[MUL_1:.*]] = arith.muli %[[C2]], %[[C2_1]] : index
+// CHECK-DAG:           %[[ADD_1:.*]] = arith.addi %[[ARG0]], %[[MUL_1]] : index
+// CHECK-DAG:           aie.use_lock(%[[LOCK_3]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_3]], %[[ADD_1]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_3]], Release, 1)
+// CHECK-DAG:           %[[C3_1:.*]] = arith.constant 3 : index
+// CHECK-DAG:           %[[MUL_2:.*]] = arith.muli %[[C2]], %[[C3_1]] : index
+// CHECK-DAG:           %[[ADD_2:.*]] = arith.addi %[[ARG0]], %[[MUL_2]] : index
+// CHECK-DAG:           aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_0]], %[[ADD_2]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK-NEXT:        }
+// CHECK:             scf.for %[[ARG0:.+]] = %[[C17]] to %[[C21]] step %c2 {
+// CHECK-DAG:           aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_1]], %[[ARG0]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK-NEXT:        }
+// CHECK:             %[[C1_0:.+]] = arith.constant 1 : index
+// CHECK:             %[[C4_1:.+]] = arith.constant 4 : index
+// CHECK:             scf.for %[[ARG0:.+]] = %[[C1]] to %[[C1_0]] step %[[C4_1]] {
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_2]], Acquire, 0)
+// CHECK-NEXT:          func.call @some_work(%[[BUFF_2]], %[[ARG0]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_2]], Release, 1)
+// CHECK-DAG:           %[[C1_2:.*]] = arith.constant 1 : index
+// CHECK-DAG:           %[[MUL_0:.*]] = arith.muli %[[C1]], %[[C1_2]] : index
+// CHECK-DAG:           %[[ADD_0:.*]] = arith.addi %[[ARG0]], %[[MUL_0]] : index
+// CHECK-DAG:           aie.use_lock(%[[LOCK_3]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_3]], %[[ADD_0]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_3]], Release, 1)
+// CHECK-DAG:           %[[C2_3:.*]] = arith.constant 2 : index
+// CHECK-DAG:           %[[MUL_1:.*]] = arith.muli %[[C1]], %[[C2_3]] : index
+// CHECK-DAG:           %[[ADD_1:.*]] = arith.addi %[[ARG0]], %[[MUL_1]] : index
+// CHECK-DAG:           aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_0]], %[[ADD_1]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK-DAG:           %[[C3:.*]] = arith.constant 3 : index
+// CHECK-DAG:           %[[MUL_2:.*]] = arith.muli %[[C1]], %[[C3]] : index
+// CHECK-DAG:           %[[ADD_2:.*]] = arith.addi %[[ARG0]], %[[MUL_2]] : index
+// CHECK-DAG:           aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_1]], %[[ADD_2]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK-NEXT:        }
+// CHECK:             scf.for %[[ARG0:.+]] = %[[C1_0]] to %[[C4]] step %[[C1]] {
+// CHECK-DAG:           aie.use_lock(%[[LOCK_2]], Acquire, 0)
+// CHECK:               func.call @some_work(%[[BUFF_2]], %[[ARG0]]) : (memref<16xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_2]], Release, 1)
+// CHECK-NEXT:        }
+module {
+  aie.device(xcvc1902) {
+    %tile12 = aie.tile(1, 2)
+    %tile13 = aie.tile(1, 3)
+    aie.objectfifo @loop_of (%tile12, {%tile13}, 4 : i32) : !aie.objectfifo<memref<16xi32>>
+    func.func @some_work(%line_in:memref<16xi32>, %index:index) -> () {
+      return
     }
+    %core12 = aie.core(%tile12) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %c4 = arith.constant 4 : index
+      %c21 = arith.constant 21 : index
+      %subviewTop0 = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+      %elemTop0 = aie.objectfifo.subview.access %subviewTop0[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+      func.call @some_work(%elemTop0, %c0) : (memref<16xi32>,index) -> ()
+      aie.objectfifo.release @loop_of (Produce, 1)
+      scf.for %indexInHeight = %c1 to %c21 step %c2 {
+        %subview = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+        %elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+        func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
+        aie.objectfifo.release @loop_of (Produce, 1)
+      }
+      scf.for %indexInHeight = %c1 to %c4 step %c1 {
+        %subview = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+        %elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+        func.call @some_work(%elem0,%indexInHeight) : (memref<16xi32>,index) -> ()
+        aie.objectfifo.release @loop_of (Produce, 1)
+      }
+      aie.end
+    }
+  }
 }

--- a/test/objectFifo-stateful-transform/loop_test_nested.mlir
+++ b/test/objectFifo-stateful-transform/loop_test_nested.mlir
@@ -1,0 +1,137 @@
+//===- loop_test_nested.mlir -----------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// CHECK-LABEL:   aie.device(xcvc1902) {
+// CHECK:           memref.global "public" @loop_of : memref<16xi32>
+// CHECK-DAG:       %[[TILE_1_2:.*]] = aie.tile(1, 2)
+// CHECK-DAG:       %[[BUFF_0:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "loop_of_buff_0"} : memref<16xi32>
+// CHECK-DAG:       %[[BUFF_1:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "loop_of_buff_1"} : memref<16xi32>
+// CHECK-DAG:       %[[LOCK_0:.*]] = aie.lock(%[[TILE_1_2]], 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
+// CHECK-DAG:       %[[LOCK_1:.*]] = aie.lock(%[[TILE_1_2]], 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
+// CHECK:           func.func @some_work(%{{.+}}: memref<4x4xi32>, %{{.+}}: index) {
+// CHECK:             return
+// CHECK:           }
+// CHECK:           %[[CORE_1_2:.*]] = aie.core(%[[TILE_1_2]]) {
+// CHECK-DAG:         %[[C0:.*]] = arith.constant 0 : index
+// CHECK-DAG:         %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:         %[[C2:.*]] = arith.constant 2 : index
+// CHECK-DAG:         %[[C4:.*]] = arith.constant 4 : index
+// CHECK-DAG:         %[[C21:.*]] = arith.constant 21 : index
+// CHECK-DAG:         %[[C4294967295:.*]] = arith.constant 4294967295 : index
+// CHECK-DAG:         %[[C4294967294:.*]] = arith.constant 4294967294 : index
+// CHECK-DAG:         %[[C2_0:.*]] = arith.constant 2 : index
+// CHECK:             scf.for %[[ARG0:.+]] = %[[C0]] to %[[C4294967294]] step %[[C2_0]] {
+// CHECK:               aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK-NEXT:          %[[REINTERPRET_0:.+]] = memref.reinterpret_cast %[[BUFF_0]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:          func.call @some_work(%[[REINTERPRET_0]], %[[C0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK:               aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK-DAG:           %[[C2_4:.*]] = arith.constant 2 : index
+// CHECK:               scf.for %[[ARG1:.+]] = %[[C1]] to %[[C21]] step %[[C2_4]] {
+// CHECK-NEXT:            aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK-NEXT:            %[[REINTERPRET_1:.+]] = memref.reinterpret_cast %[[BUFF_1]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:            func.call @some_work(%[[REINTERPRET_1]], %[[ARG1]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:            aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK-DAG:             %[[C1_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:             %[[MUL_0:.*]] = arith.muli %[[C1]], %[[C1_1]] : index
+// CHECK-DAG:             %[[ADD_0:.*]] = arith.addi %[[ARG1]], %[[MUL_0]] : index
+// CHECK-DAG:             aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK:                 %[[REINTERPRET_2:.+]] = memref.reinterpret_cast %[[BUFF_0]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:            func.call @some_work(%[[REINTERPRET_2]], %[[ADD_0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:            aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK-NEXT:          }
+// CHECK:               aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK-NEXT:          %[[REINTERPRET_3:.+]] = memref.reinterpret_cast %[[BUFF_1]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:          func.call @some_work(%[[REINTERPRET_3]], %[[C0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK:               aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK-NEXT:          %[[REINTERPRET_4:.+]] = memref.reinterpret_cast %[[BUFF_0]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:          func.call @some_work(%[[REINTERPRET_4]], %[[C0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK:               %[[C2_3:.*]] = arith.constant 2 : index
+// CHECK:               scf.for %[[ARG1:.+]] = %[[C1]] to %[[C21]] step %[[C2_3]] {
+// CHECK-NEXT:            aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK-NEXT:            %[[REINTERPRET_5:.+]] = memref.reinterpret_cast %[[BUFF_1]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:            func.call @some_work(%[[REINTERPRET_5]], %[[ARG1]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:            aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK-DAG:             %[[C1_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:             %[[MUL_1:.*]] = arith.muli %[[C1]], %[[C1_1]] : index
+// CHECK-DAG:             %[[ADD_1:.*]] = arith.addi %[[ARG1]], %[[MUL_1]] : index
+// CHECK-DAG:             aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK:                 %[[REINTERPRET_6:.+]] = memref.reinterpret_cast %[[BUFF_0]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:            func.call @some_work(%[[REINTERPRET_6]], %[[ADD_1]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:            aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK-NEXT:          }
+// CHECK:               aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK-NEXT:          %[[REINTERPRET_7:.+]] = memref.reinterpret_cast %[[BUFF_1]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:          func.call @some_work(%[[REINTERPRET_7]], %[[C0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK-NEXT:        }
+// CHECK:             aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK-NEXT:        %[[REINTERPRET_8:.+]] = memref.reinterpret_cast %[[BUFF_0]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:        func.call @some_work(%[[REINTERPRET_8]], %[[C0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK:             aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK:             %[[C2_4:.*]] = arith.constant 2 : index
+// CHECK:             scf.for %[[ARG0:.+]] = %[[C1]] to %[[C21]] step %[[C2_4]] {
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK-NEXT:          %[[REINTERPRET_9:.+]] = memref.reinterpret_cast %[[BUFF_1]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:          func.call @some_work(%[[REINTERPRET_9]], %[[ARG0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_1]], Release, 1)
+// CHECK-DAG:           %[[C1_4:.*]] = arith.constant 1 : index
+// CHECK-DAG:           %[[MUL_2:.*]] = arith.muli %[[C1]], %[[C1_4]] : index
+// CHECK-DAG:           %[[ADD_2:.*]] = arith.addi %[[ARG0]], %[[MUL_2]] : index
+// CHECK-DAG:           aie.use_lock(%[[LOCK_0]], Acquire, 0)
+// CHECK:               %[[REINTERPRET_10:.+]] = memref.reinterpret_cast %[[BUFF_0]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:          func.call @some_work(%[[REINTERPRET_10]], %[[ADD_1]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:          aie.use_lock(%[[LOCK_0]], Release, 1)
+// CHECK-NEXT:        }
+// CHECK:             aie.use_lock(%[[LOCK_1]], Acquire, 0)
+// CHECK-NEXT:        %[[REINTERPRET_11:.+]] = memref.reinterpret_cast %[[BUFF_1]] to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+// CHECK-NEXT:        func.call @some_work(%[[REINTERPRET_11]], %[[C0]]) : (memref<4x4xi32>, index) -> ()
+// CHECK-NEXT:        aie.use_lock(%[[LOCK_1]], Release, 1)
+module {
+  aie.device(xcvc1902) {
+    %tile12 = aie.tile(1, 2)
+    %tile13 = aie.tile(1, 3)
+    aie.objectfifo @loop_of (%tile12, {%tile13}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    func.func @some_work(%line_in: memref<4x4xi32>, %index: index) -> () {
+      return
+    }
+    %core12 = aie.core(%tile12) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+      %c4 = arith.constant 4 : index
+      %c21 = arith.constant 21 : index
+      %cmax = arith.constant 0xFFFFFFFF : index
+      scf.for %arg0 = %c0 to %cmax step %c1 {
+        %subviewTop0 = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+        %elemTop0 = aie.objectfifo.subview.access %subviewTop0[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+        %reinterpret_cast_0 = memref.reinterpret_cast %elemTop0 to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+        func.call @some_work(%reinterpret_cast_0, %c0) : (memref<4x4xi32>, index) -> ()
+        aie.objectfifo.release @loop_of (Produce, 1)
+        scf.for %indexInHeight = %c1 to %c21 step %c1 {
+          %subview = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+          %elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+          %reinterpret_cast_1 = memref.reinterpret_cast %elem0 to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+          func.call @some_work(%reinterpret_cast_1, %indexInHeight) : (memref<4x4xi32>, index) -> ()
+          aie.objectfifo.release @loop_of (Produce, 1)
+        }
+        %subviewTop1 = aie.objectfifo.acquire @loop_of (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+        %elemTop1 = aie.objectfifo.subview.access %subviewTop1[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+        %reinterpret_cast_2 = memref.reinterpret_cast %elemTop1 to offset: [0], sizes: [4, 4], strides: [4, 1] : memref<16xi32> to memref<4x4xi32>
+        func.call @some_work(%reinterpret_cast_2, %c0) : (memref<4x4xi32>, index) -> ()
+        aie.objectfifo.release @loop_of (Produce, 1)
+      }
+      aie.end
+    }
+  }
+}


### PR DESCRIPTION
I encountered an error with a `reinterpret_cast` operation inside `aie.core`, operating on an `aie.objectfifo.subview.access` operation. The cloned reinterpret cast would be invalid after the `unrollForLoops` method was called. I debugged this a bit and it seemed operands were set incorrectly in some cases, however, instead of fixing the existing method I replaced it with the upstream `mlir::loopUnrollByFactor` method as it would be better to reuse that one instead I think. With this change the `reinterpret_cast` error got resolved as well.