### PR TITLE
[aievec][nfc] update e2e tests to use bare ptr for to-llvm flow

### DIFF
--- a/test/unit_tests/aievec_tests/i16xi16_max_elem/i16xi16_max_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_max_elem/i16xi16_max_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i16xi16_max_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i16xi16_max_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int16_t *restrict in0, int16_t *restrict in1, int16_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int16_t *in0_allocated, int16_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int16_t *in1_allocated,
-         int16_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int16_t *out0_allocated, int16_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int16_t *restrict in0, int16_t *restrict in1, int16_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -38,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i16xi16_min_elem/i16xi16_min_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_min_elem/i16xi16_min_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i16xi16_min_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i16xi16_min_elem/testbench.cc
@@ -4,17 +4,15 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#ifdef TO_CPP
-void dut(int16_t *restrict in0, int16_t *restrict in1, int16_t *restrict out0);
-#elif TO_LLVM
+
+#ifdef TO_LLVM
 extern "C" {
-void dut(int16_t *in0_allocated, int16_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int16_t *in1_allocated,
-         int16_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int16_t *out0_allocated, int16_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int16_t *restrict in0, int16_t *restrict in1, int16_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
+
 void dut_ref(int16_t *in0, int16_t *in1, int16_t *out0);
 
 alignas(32) int16_t g_in0[IN0_SIZE];
@@ -36,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int16_t *restrict in0, int16_t *restrict in1, int16_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int16_t *in0_allocated, int16_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int16_t *in1_allocated,
-         int16_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int16_t *out0_allocated, int16_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int16_t *restrict in0, int16_t *restrict in1, int16_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -37,11 +33,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/testbench.cc
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int16_t *restrict in0, int16_t *restrict in1, int32_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int16_t *in0_allocated, int16_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int16_t *in1_allocated,
-         int16_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int32_t *out0_allocated, int32_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int16_t *restrict in0, int16_t *restrict in1, int32_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -37,11 +33,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i32xi32_max_elem/i32xi32_max_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_max_elem/i32xi32_max_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i32xi32_max_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i32xi32_max_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int32_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int32_t *in0_allocated, int32_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int32_t *in1_allocated,
-         int32_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int32_t *out0_allocated, int32_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int32_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -38,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i32xi32_min_elem/i32xi32_min_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_min_elem/i32xi32_min_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i32xi32_min_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i32xi32_min_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int32_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int32_t *in0_allocated, int32_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int32_t *in1_allocated,
-         int32_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int32_t *out0_allocated, int32_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int32_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -38,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i32xi32_mul_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i32xi32_mul_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int32_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int32_t *in0_allocated, int32_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int32_t *in1_allocated,
-         int32_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int32_t *out0_allocated, int32_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int32_t *restrict in0, int32_t *restrict in1, int32_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -38,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i8xi8_max_elem/i8xi8_max_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_max_elem/i8xi8_max_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=64" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i8xi8_max_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i8xi8_max_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int8_t *restrict in0, int8_t *restrict in1, int8_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int8_t *in0_allocated, int8_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int8_t *in1_allocated,
-         int8_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int8_t *out0_allocated, int8_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int8_t *restrict in0, int8_t *restrict in1, int8_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -38,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i8xi8_min_elem/i8xi8_min_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_min_elem/i8xi8_min_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=64" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i8xi8_min_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i8xi8_min_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int8_t *restrict in0, int8_t *restrict in1, int8_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int8_t *in0_allocated, int8_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int8_t *in1_allocated,
-         int8_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int8_t *out0_allocated, int8_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int8_t *restrict in0, int8_t *restrict in1, int8_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -38,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem/testbench.cc
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int8_t *restrict in0, int8_t *restrict in1, int32_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int8_t *in0_allocated, int8_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int8_t *in1_allocated,
-         int8_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int32_t *out0_allocated, int32_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int8_t *restrict in0, int8_t *restrict in1, int32_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -38,11 +34,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem.mlir
@@ -5,7 +5,7 @@
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" --convert-vector-to-aievec="aie-target=aieml" -lower-affine | aie-translate -aieml=true --aievec-to-cpp -o dut.cc
 // RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. -c dut.cc -o dut.o
-// RUN: xchesscc_wrapper %xchesscc_aie2_args -DTO_CPP +w work +o work -I%S -I. %S/testbench.cc work/dut.o
+// RUN: xchesscc_wrapper %xchesscc_aie2_args +w work +o work -I%S -I. %S/testbench.cc work/dut.o
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/testbench.cc
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/testbench.cc
@@ -5,15 +5,11 @@
 #include <cstdio>
 #include <cstdlib>
 
-#ifdef TO_CPP
-void dut(int8_t *restrict in0, int8_t *restrict in1, int8_t *restrict out0);
-#elif TO_LLVM
+#ifdef TO_LLVM
 extern "C" {
-void dut(int8_t *in0_allocated, int8_t *in0_aligned, int64_t in0_offset,
-         int64_t in0_sizes_0, int64_t in0_strides_0, int8_t *in1_allocated,
-         int8_t *in1_aligned, int64_t in1_offset, int64_t in1_sizes_0,
-         int64_t in1_strides_0, int8_t *out0_allocated, int8_t *out0_aligned,
-         int64_t out0_offset, int64_t out0_sizes_0, int64_t out0_strides_0);
+#endif
+void dut(int8_t *restrict in0, int8_t *restrict in1, int8_t *restrict out0);
+#ifdef TO_LLVM
 }
 #endif
 
@@ -37,11 +33,7 @@ int main(int argc, char *argv[]) {
 
   chess_memory_fence();
   auto cyclesBegin = chess_cycle_count();
-#ifdef TO_CPP
   dut(g_in0, g_in1, g_out0);
-#elif TO_LLVM
-  dut(g_in0, g_in0, 0, 0, 0, g_in1, g_in1, 0, 0, 0, g_out0, g_out0, 0, 0, 0);
-#endif
   auto cyclesEnd = chess_cycle_count();
   chess_memory_fence();
 

--- a/test/unit_tests/lit.local.cfg
+++ b/test/unit_tests/lit.local.cfg
@@ -25,8 +25,8 @@ if "peano" in config.available_features:
 
     # pipelines for using aie-opt and aie-translate
     vector_to_aievec = '--convert-vector-to-aievec="aie-target=aieml target-backend=llvmir"'
-    aievec_to_llvmir = '--convert-aievec-to-llvm -convert-vector-to-llvm -lower-affine -convert-scf-to-cf -canonicalize -cse -convert-math-to-llvm -expand-strided-metadata -finalize-memref-to-llvm -convert-func-to-llvm -convert-index-to-llvm -canonicalize -cse'
-    vector_to_generic_llvmir = '-canonicalize-vector-for-aievec=aie-target=aieml -convert-vector-to-llvm -lower-affine -convert-scf-to-cf -canonicalize -cse -convert-math-to-llvm -expand-strided-metadata -finalize-memref-to-llvm -convert-func-to-llvm -convert-index-to-llvm -canonicalize -cse'
+    aievec_to_llvmir = '--convert-aievec-to-llvm -convert-vector-to-llvm -lower-affine -convert-scf-to-cf -canonicalize -cse -convert-math-to-llvm -expand-strided-metadata -finalize-memref-to-llvm -convert-func-to-llvm=\'use-bare-ptr-memref-call-conv\' -convert-index-to-llvm -canonicalize -cse'
+    vector_to_generic_llvmir = '-canonicalize-vector-for-aievec=aie-target=aieml -convert-vector-to-llvm -lower-affine -convert-scf-to-cf -canonicalize -cse -convert-math-to-llvm -expand-strided-metadata -finalize-memref-to-llvm -convert-func-to-llvm=\'use-bare-ptr-memref-call-conv\' -convert-index-to-llvm -canonicalize -cse'
     llvmir_to_ll = '--mlir-to-llvmir'
     config.substitutions.append(('%vector-to-aievec%', vector_to_aievec))
     config.substitutions.append(('%aievec-to-llvmir%', aievec_to_llvmir))


### PR DESCRIPTION
As suggested in https://github.com/Xilinx/mlir-aie/pull/1548. We can use `-convert-func-to-llvm='use-bare-ptr-memref-call-conv'` to minimize the changes to `testbench.cc` when handling the to-llvm tests. This PR updates i8/i16/i32 max/min/mul elem tests.