### PR TITLE
revert change to bo limit

### DIFF
--- a/test/aie2xclbin/buffers_xclbin.mlir
+++ b/test/aie2xclbin/buffers_xclbin.mlir
@@ -71,6 +71,13 @@
 // CHECK:             "name": "bo4",
 // CHECK:             "offset": "0x34",
 // CHECK:             "type": "void*"
+// CHECK:           },
+// CHECK:           {
+// CHECK:             "address-qualifier": "GLOBAL",
+// CHECK:             "memory-connection": "HOST",
+// CHECK:             "name": "bo5",
+// CHECK:             "offset": "0x3c",
+// CHECK:             "type": "void*"
 // CHECK:           }
 // CHECK:         ],
 // CHECK:         "extended-data": {

--- a/tools/aie2xclbin/XCLBinGen.cpp
+++ b/tools/aie2xclbin/XCLBinGen.cpp
@@ -432,7 +432,12 @@ static json::Object makeKernelJSON(std::string name, std::string id,
                                              {"memory-connection", "HOST"},
                                              {"address-qualifier", "GLOBAL"},
                                              {"type", "void*"},
-                                             {"offset", "0x34"}}}},
+                                             {"offset", "0x34"}},
+                                json::Object{{"name", "bo5"},
+                                             {"memory-connection", "HOST"},
+                                             {"address-qualifier", "GLOBAL"},
+                                             {"type", "void*"},
+                                             {"offset", "0x3c"}}}},
       {"instances", json::Array{json::Object{{"name", instance}}}}};
 }
 


### PR DESCRIPTION
This reverts the buffer object limit in aie2xclbin to what it was before #1517