### PR TITLE
Update concurrency group labels

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -18,7 +18,7 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
-  group: ci-build-test-cpp-linux-${{ github.event.number || github.sha }}
+  group: ci-build-test-cpp-linux-${{ github.event.number || github.sha }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
+++ b/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
@@ -27,7 +27,7 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
-  group: ci-build-test-aie-tools-linux-${{ github.event.number || github.sha }}
+  group: ci-build-test-aie-tools-linux-hsa-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -23,7 +23,7 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
-  group: ci-build-test-multi-cpp-linux-${{ github.event.number || github.sha }}
+  group: ci-build-test-multi-cpp-linux-${{ github.event.number || github.sha }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -18,7 +18,7 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
-  group: ci-build-test-pythons-cpp-linux-${{ github.event.number || github.sha }}
+  group: ci-build-test-pythons-cpp-linux-${{ github.event.number || github.sha }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -32,7 +32,7 @@ concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit).
-  group: ci-build-test-ryzenai-${{ github.event.number || github.sha }}
+  group: ci-build-test-ryzenai-${{ github.event.number || github.sha }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
We seem to get occasional conflicts between checks for `merge_group` and checks on push to `main`. Because some of the `merge_group` checks are not required for merge, they might still be running when the push to `main` checks run (post-merge), resulting in cancellations because they share the same concurrency group name. This PR add `${{ github.event_name }}` to the concurrency group to attempt to distinguish between the two. Another solution might be to remove the push to `main` checks, as they could be redundant.