### PR TITLE
fix unused variable error in release build

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -75,15 +75,15 @@ struct ConvertFlowsToInterconnect : OpConversionPattern<FlowOp> {
     auto srcChannel = flowOp.getSourceChannel();
     Port srcPort = {srcBundle, srcChannel};
 
-    auto dstTile = cast<TileOp>(flowOp.getDest().getDefiningOp());
-    auto dstBundle = flowOp.getDestBundle();
-    auto dstChannel = flowOp.getDestChannel();
-
     if (keepFlowOp) {
       auto *clonedOp = Op->clone();
       flowOps.push_back(clonedOp);
     }
 #ifndef NDEBUG
+    auto dstTile = cast<TileOp>(flowOp.getDest().getDefiningOp());
+    auto dstBundle = flowOp.getDestBundle();
+    auto dstChannel = flowOp.getDestChannel();
+
     TileID dstCoords = {dstTile.colIndex(), dstTile.rowIndex()};
     LLVM_DEBUG(llvm::dbgs()
                << "\n\t---Begin rewrite() for flowOp: (" << srcCoords.col


### PR DESCRIPTION
After #1553, building the compiler in release mode leads to a compilation error (at least for me -- see below). This is due to a unused variable that is only used in debug builds.

I'm surprised CI did not catch this? Do we not build a release build for CI? Or is something on my end misconfigured?

```
[59/439] Building CXX object lib/Dialect/AIE/Transforms/CMakeFiles/obj.AIETransforms.dir/AIECreatePathFindFlows.cpp.o
FAILED: lib/Dialect/AIE/Transforms/CMakeFiles/obj.AIETransforms.dir/AIECreatePathFindFlows.cpp.o 
/usr/bin/c++ -DGTEST_HAS_RTTI=0 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/andre/mlir-aie/llvm/llvm/include -I/home/andre/mlir-aie/llvm/build/include -I/home/andre/mlir-aie/llvm/mlir/include -I/home/andre/mlir-aie/llvm/build/tools/mlir/include -I/home/andre/mlir-aie/include -I/home/andre/mlir-aie/build/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -fno-lifetime-dse -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -Wimplicit-fallthrough -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -Werror=sign-compare -Werror=unused -Werror=return-type -Werror=mismatched-tags -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden   -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fno-exceptions -funwind-tables -fno-rtti -MD -MT lib/Dialect/AIE/Transforms/CMakeFiles/obj.AIETransforms.dir/AIECreatePathFindFlows.cpp.o -MF lib/Dialect/AIE/Transforms/CMakeFiles/obj.AIETransforms.dir/AIECreatePathFindFlows.cpp.o.d -o lib/Dialect/AIE/Transforms/CMakeFiles/obj.AIETransforms.dir/AIECreatePathFindFlows.cpp.o -c /home/andre/mlir-aie/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
/home/andre/mlir-aie/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp: In member function ‘virtual void {anonymous}::ConvertFlowsToInterconnect::rewrite(xilinx::AIE::FlowOp, mlir::OpConversionPattern<xilinx::AIE::FlowOp>::OpAdaptor, mlir::ConversionPatternRewriter&) const’:
/home/andre/mlir-aie/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp:78:10: error: variable ‘dstTile’ set but not used [-Werror=unused-but-set-variable]
   78 |     auto dstTile = cast<TileOp>(flowOp.getDest().getDefiningOp());
      |          ^~~~~~~
/home/andre/mlir-aie/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp:79:10: error: unused variable ‘dstBundle’ [-Werror=unused-variable]
   79 |     auto dstBundle = flowOp.getDestBundle();
      |          ^~~~~~~~~
/home/andre/mlir-aie/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp:80:10: error: unused variable ‘dstChannel’ [-Werror=unused-variable]
   80 |     auto dstChannel = flowOp.getDestChannel();
      |          ^~~~~~~~~~
```