### PR TITLE
Change lower-cascade-flows tests to use check-dag

### DIFF
--- a/test/lower-cascade-flows/cascade_single_flow.mlir
+++ b/test/lower-cascade-flows/cascade_single_flow.mlir
@@ -12,14 +12,14 @@
 
 // CHECK: module @cascade_flow {
 // CHECK:   aie.device(xcve2802) {
-// CHECK:     %tile_1_3 = aie.tile(1, 3)
-// CHECK:     %tile_2_3 = aie.tile(2, 3)
-// CHECK:     %tile_3_4 = aie.tile(3, 4)
-// CHECK:     %tile_3_3 = aie.tile(3, 3)
-// CHECK:     aie.configure_cascade(%tile_1_3, North, East)
-// CHECK:     aie.configure_cascade(%tile_2_3, West, South)
-// CHECK:     aie.configure_cascade(%tile_3_4, North, South)
-// CHECK:     aie.configure_cascade(%tile_3_3, North, South)
+// CHECK-DAG:     %tile_1_3 = aie.tile(1, 3)
+// CHECK-DAG:     %tile_2_3 = aie.tile(2, 3)
+// CHECK-DAG:     %tile_3_4 = aie.tile(3, 4)
+// CHECK-DAG:     %tile_3_3 = aie.tile(3, 3)
+// CHECK-DAG:     aie.configure_cascade(%tile_1_3, North, East)
+// CHECK-DAG:     aie.configure_cascade(%tile_2_3, West, South)
+// CHECK-DAG:     aie.configure_cascade(%tile_3_4, North, South)
+// CHECK-DAG:     aie.configure_cascade(%tile_3_3, North, South)
 // CHECK:   }
 // CHECK: }
 

--- a/test/lower-cascade-flows/cascade_two_flows.mlir
+++ b/test/lower-cascade-flows/cascade_two_flows.mlir
@@ -12,12 +12,12 @@
 
 // CHECK: module @cascade_flow {
 // CHECK:   aie.device(xcve2802) {
-// CHECK:     %tile_1_4 = aie.tile(1, 4)
-// CHECK:     %tile_2_4 = aie.tile(2, 4)
-// CHECK:     %tile_3_4 = aie.tile(3, 4)
-// CHECK:     aie.configure_cascade(%tile_1_4, North, East)
-// CHECK:     aie.configure_cascade(%tile_2_4, West, East)
-// CHECK:     aie.configure_cascade(%tile_3_4, West, South)
+// CHECK-DAG:     %tile_1_4 = aie.tile(1, 4)
+// CHECK-DAG:     %tile_2_4 = aie.tile(2, 4)
+// CHECK-DAG:     %tile_3_4 = aie.tile(3, 4)
+// CHECK-DAG:     aie.configure_cascade(%tile_1_4, North, East)
+// CHECK-DAG:     aie.configure_cascade(%tile_2_4, West, East)
+// CHECK-DAG:     aie.configure_cascade(%tile_3_4, West, South)
 // CHECK:   }
 // CHECK: }
 


### PR DESCRIPTION
Use `CHECK-DAG` for `--aie-lower-cascade-flows` tests because output order is not guaranteed.

example: https://github.com/Xilinx/mlir-aie/actions/runs/9715514512/job/26817066152?pr=1584#step:4:3244

or run the test in a loop and it will eventually fail:
```
$ while true
> do aie-opt --aie-lower-cascade-flows cascade_single_flow.mlir | FileCheck cascade_single_flow.mlir
> done
cascade_single_flow.mlir:20:11: error: CHECK: expected string not found in input
// CHECK: aie.configure_cascade(%tile_2_3, West, South)
          ^
<stdin>:8:47: note: scanning from here
 aie.configure_cascade(%tile_1_3, North, East)
                                              ^
<stdin>:10:2: note: possible intended match here
 aie.configure_cascade(%tile_3_3, North, South)
 ^

Input file: <stdin>
Check file: cascade_single_flow.mlir

-dump-input=help explains the following input dump.

Input was:
<<<<<<
            1: module @cascade_flow { 
            2:  aie.device(xcve2802) { 
            3:  %tile_1_3 = aie.tile(1, 3) 
            4:  %tile_2_3 = aie.tile(2, 3) 
            5:  %tile_3_4 = aie.tile(3, 4) 
            6:  %tile_3_3 = aie.tile(3, 3) 
            7:  aie.configure_cascade(%tile_2_3, West, South) 
            8:  aie.configure_cascade(%tile_1_3, North, East) 
check:20'0                                                   X error: no match found
            9:  aie.configure_cascade(%tile_3_4, North, South) 
check:20'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           10:  aie.configure_cascade(%tile_3_3, North, South) 
check:20'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
check:20'1      ?                                               possible intended match
           11:  } 
check:20'0     ~~~
           12: } 
check:20'0     ~~
           13:  
check:20'0     ~