### PR TITLE
Make quick_setup.sh point to latest wheel

### DIFF
--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -61,11 +61,9 @@ if test -f "$VPP"; then
   AIETOOLS="`dirname $VPP`/../aietools"
   mkdir -p my_install
   pushd my_install
-  # pip download mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
-  wget -q --show-progress https://github.com/Xilinx/mlir-aie/releases/download/latest-wheels/mlir_aie-0.0.1.2024061822+29d5cec-py3-none-manylinux_2_35_x86_64.whl
+  pip download mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
   unzip -q mlir_aie-*_x86_64.whl
-  # pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
-  wget -q --show-progress https://github.com/Xilinx/mlir-aie/releases/download/mlir-distro/mlir-19.0.0.2024061721+a50bcc03-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+  pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
   unzip -q mlir-*_x86_64.whl
   pip install https://github.com/makslevental/mlir-python-extras/archive/d84f05582adb2eed07145dabce1e03e13d0e29a6.zip
   rm -rf mlir*.whl


### PR DESCRIPTION
As discussed with @jgmelber. This reverts to pulling the latest nightly wheel instead of whatever version was previously fixed in quick_setup.sh.

We decided that using the latest wheel of main should be sufficiently stable, and it is preferrable to have everyone on the latest version. People trying to run bleeding-edge programming examples from the repo with an outdated compiler pulled from quick_setup.sh has lead to a lot of headaches, and keeping the version in quick_setup.sh updated is laborious. 

There are arguments to keep a version hard-coded in quick_setup.sh, s.t. the repository commit and compiler commit are coupled together, but it seems generally using latest seems to be a better trade-off.

Another stage of this could be to only release wheels after testing them and passing all tests (but this might be redundant with the tests we run on main already anyways).