### PR TITLE
[aievec] Rename aievec target name from aieml to aie2

### DIFF
--- a/include/aie/Dialect/AIEVec/AIEVecUtils.h
+++ b/include/aie/Dialect/AIEVec/AIEVecUtils.h
@@ -75,14 +75,14 @@ inline bool isAIEOp(mlir::Operation *op) {
 
 // Determine the output type for a vector operation based on whether
 // it operates on integer or floating point data.
-inline mlir::VectorType getVectorOpDestType(mlir::VectorType type, bool AIEML) {
+inline mlir::VectorType getVectorOpDestType(mlir::VectorType type, bool AIE2) {
   mlir::Type stype = type.getElementType();
 
   if (auto itype = llvm::dyn_cast<mlir::IntegerType>(stype)) {
     // Integer vector types are sized for the appropriate accumulators
     assert(itype.getWidth() <= 64);
     unsigned width;
-    if (AIEML)
+    if (AIE2)
       width = itype.getWidth() <= 16 ? 32 : 64;
     else
       width = itype.getWidth() <= 16 ? 48 : 80;
@@ -92,7 +92,7 @@ inline mlir::VectorType getVectorOpDestType(mlir::VectorType type, bool AIEML) {
   }
 
   if (auto ftype = llvm::dyn_cast<mlir::FloatType>(stype)) {
-    if (AIEML && ftype.getWidth() == 16)
+    if (AIE2 && ftype.getWidth() == 16)
       return mlir::VectorType::get(type.getShape(),
                                    mlir::FloatType::getF32(ftype.getContext()));
 

--- a/include/aie/Dialect/AIEVec/Analysis/Passes.td
+++ b/include/aie/Dialect/AIEVec/Analysis/Passes.td
@@ -17,7 +17,7 @@ include "mlir/Pass/PassBase.td"
 
 def AIEVecConvAnalysis : Pass<"aievec-convolution-analysis"> {
   let summary = "Find MAC chains that can be replaced by convolution ops in "
-                "AIE-ML";
+                "AIE2";
   let constructor = "xilinx::aievec::createAIEVecConvolutionAnalysisPass()";
   let options = [
     Option<"printResult", "print", "bool", /*default=*/"false",

--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -85,7 +85,7 @@ def AIEVec_AddElemOp:
   Results<(outs AnyVector:$result)> {
   let summary = "AIE vector add elem";
   let description = [{
-    AMD-specific aie-ml intrinsic that allows you to perform addition operation
+    AMD-specific AIE2 intrinsic that allows you to perform addition operation
     on all types of vectors.`$result = `$lhs + $rhs`.
   }];
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
@@ -143,7 +143,7 @@ def AIEVec_SubElemOp:
   Results<(outs AnyVector:$result)> {
   let summary = "AIE vector sub elem";
   let description = [{
-    AMD-specific aie-ml intrinsic that allows you to perform substraction operation
+    AMD-specific AIE2 intrinsic that allows you to perform substraction operation
     on all types of vectors.`$result = `$lhs - $rhs`.
   }];
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($result)";
@@ -228,7 +228,7 @@ def AIEVec_FMAElemOp :
   Arguments<(ins AnyVector:$lhs, AnyVector:$rhs, AnyVector:$acc,
                DefaultValuedAttr<BoolAttr, "false">:$fmsub)>,
   Results<(outs AnyVector:$result)> {
-  let summary = "AIE-ML element-wise vector fused multiply-add";
+  let summary = "AIE2 element-wise vector fused multiply-add";
   let description = [{
     AMD-specific multiply-add operation. It multiplies two 1-D vectors in the same channel,
     and adds the result to an accumulator.
@@ -318,7 +318,7 @@ def AIEVec_MulElemOp:
   ]>,
   Arguments<(ins AnyVector:$lhs, AnyVector:$rhs)>,
   Results<(outs AnyVector:$result)> {
-  let summary = "AIE-ML vector element-wise multiply";
+  let summary = "AIE2 vector element-wise multiply";
   let description = [{
     AMD-specific multiply operation that multiplies two 1-D vectors in the same channel.
     The vector sizes are at least 512 bits.
@@ -337,7 +337,7 @@ def AIEVec_BroadcastOp:
   Arguments<(ins AnyVector:$source,
           DefaultValuedAttr<ConfinedAttr<AIEI8Attr, [IntNonNegative]>, "0">:$idx)>,
   Results<(outs AnyVector:$result)> {
-  let summary = "AIE-ML broadcast";
+  let summary = "AIE2 broadcast";
   let description = [{
     AMD-specific broadcast intrinsic. Extract element index from vector and broadcasts its
     value to all lanes of the vector.
@@ -355,7 +355,7 @@ def AIEVec_BroadcastScalarOp:
   ]>,
   Arguments<(ins AnyTypeOf<[BF16, F32, I32, I16, I8]>:$source)>,
   Results<(outs AnyVector:$result)> {
-  let summary = "AIE-ML broadcast scalar";
+  let summary = "AIE2 broadcast scalar";
   let description = [{
     AMD-specific broadcast scalar intrinsic. Broadcasts input value to all vector lanes.
     `$result = broadcast_scalar($source)`
@@ -395,7 +395,7 @@ def AIEVec_CastOp:
   Results<(outs AnyVector:$result)> {
   let summary = "AIE cast";
   let description = [{
-    AIE-ML cast intrinsic. Cast values from source data type to result data types.
+    AIE2 cast intrinsic. Cast values from source data type to result data types.
     `$result = cast($source, isResAcc)`
   }];
   let builders = [
@@ -848,7 +848,7 @@ def AIEVec_MatMulOp:
                  AIE2MatMulRHS:$rhs,
                  AIE2MatMulACC:$acc)>,
   Results<(outs AIE2MatMulACC:$result)> {
-  let summary = "AIEML matrix-multiply and accummulate";
+  let summary = "AIE2 matrix-multiply and accummulate";
   let description = [{
     AMD AIEv2-specific intrinsic that performs a matrix multiplications
     between `lhs` and `rhs`, and accumulates the result in `acc`.

--- a/include/aie/Dialect/AIEVec/Pipelines/Passes.h
+++ b/include/aie/Dialect/AIEVec/Pipelines/Passes.h
@@ -19,8 +19,9 @@
 
 namespace xilinx {
 enum class AIEArch {
-  AIE,    // Original AIE
-  AIE_ML, // ML/V2 version of AIE
+  AIE,   // Original AIE
+  AIE2,  // AIE-ML/V2 arch version of AIE
+  AIE2P, // AIE2P arch version of AIE
 };
 enum class TargetBackend {
   CPP,    // Convert to aievec targeting C++ backend
@@ -38,7 +39,7 @@ struct CanonicalizeVectorForAIEVecOptions
     : public mlir::PassPipelineOptions<CanonicalizeVectorForAIEVecOptions> {
   PassOptions::Option<std::string> aieTarget{
       *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
+      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{
@@ -54,7 +55,7 @@ struct LowerVectorToAIEVecOptions
     : public mlir::PassPipelineOptions<LowerVectorToAIEVecOptions> {
   PassOptions::Option<std::string> aieTarget{
       *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
+      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{
@@ -70,7 +71,7 @@ struct OptimizeAIEVecOptions
     : public mlir::PassPipelineOptions<OptimizeAIEVecOptions> {
   PassOptions::Option<std::string> aieTarget{
       *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
+      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{
@@ -106,7 +107,7 @@ struct ConvertVectorToAIEVecOptions
       llvm::cl::init(2)};
   PassOptions::Option<std::string> aieTarget{
       *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
+      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -2160,7 +2160,7 @@ class MatMulOpConversion
   }
 };
 
-// This pattern folds aievec.cast op. For AIE-ML, the accumulators are in 32/64
+// This pattern folds aievec.cast op. For AIE2, the accumulators are in 32/64
 // bits, and the vectors are in 4/8/16/32 bits. Hence, we don't have to
 // explicitly express the casting between accumulators and vectors at the LLVM
 // dialect level. The backend LLVM compiler will decide the correct accumulator

--- a/lib/Dialect/AIEVec/Transforms/AIEVecOptimizations.cpp
+++ b/lib/Dialect/AIEVec/Transforms/AIEVecOptimizations.cpp
@@ -265,7 +265,7 @@ struct AIEVecTransformationPass
 
   Option<std::string> aieTarget{
       *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
+      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
 
@@ -284,8 +284,8 @@ struct AIEVecTransformationPass
     AIEArch aieVersion = AIEArch::AIE;
     if (!aieTarget.empty()) {
       std::string target = aieTarget;
-      if (target == "aieml") {
-        aieVersion = AIEArch::AIE_ML;
+      if (target == "aieml" || target == "aie2") {
+        aieVersion = AIEArch::AIE2;
       } else if (target != "aie") {
         op->emitError() << "unknown AIE target '" << aieTarget << "'";
         signalPassFailure();
@@ -350,7 +350,7 @@ struct AIEVecConvOpTransformationPass
     return "test-aievec-convolution-optimize";
   }
   StringRef getDescription() const final {
-    return "Optimize chains of macs into AIEML conv ops.";
+    return "Optimize chains of macs into AIE2 conv ops.";
   }
   void getDependentDialects(DialectRegistry &registry) const override {
     // TODO: Review list of dependent dialects.
@@ -361,7 +361,7 @@ struct AIEVecConvOpTransformationPass
 
   Option<std::string> aieTarget{
       *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aieml\". This will "
+      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
                      "determine the vector size and available operations."),
       llvm::cl::init("aie")};
 
@@ -385,8 +385,8 @@ struct AIEVecConvOpTransformationPass
     AIEArch aieVersion = AIEArch::AIE;
     if (!aieTarget.empty()) {
       std::string target = aieTarget;
-      if (target == "aieml") {
-        aieVersion = AIEArch::AIE_ML;
+      if (target == "aieml" || target == "aie2") {
+        aieVersion = AIEArch::AIE2;
       } else if (target != "aie") {
         op->emitError() << "unknown AIE target '" << aieTarget << "'";
         signalPassFailure();
@@ -412,7 +412,7 @@ struct AIEVecConvOpTransformationPass
     }
 
     AnalysisManager am = getAnalysisManager();
-    if (aieVersion == AIEArch::AIE_ML) {
+    if (aieVersion == AIEArch::AIE2) {
       populateAIEVecConvOpTransformationPatterns(patterns, am, shiftParam,
                                                  backend);
       configureAIEVecConvOpTransformationLegalizations(target, am, backend);
@@ -442,7 +442,7 @@ void xilinx::aievec::buildOptimizeAIEVec(OpPassManager &pm,
   pm.addPass(createCanonicalizerPass());
 
   // Add generating aievec convolution ops pass
-  if (options.aieTarget == "aieml") {
+  if (options.aieTarget == "aieml" || options.aieTarget == "aie2") {
     pm.addPass(createAIEVecConvolutionAnalysisPass());
     pm.addPass(createAIEVecConvOpTransformationPass(options));
   }

--- a/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
+++ b/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 // This is the implementation of the folding pass from mul add chain
-// to AIEVec convolution operations, compatible with the AIE-ML architecture.
+// to AIEVec convolution operations, compatible with the AIE2 architecture.
 //===----------------------------------------------------------------------===//
 
 #include "FoldMulAddChainToConvOp.h"
@@ -38,7 +38,7 @@ namespace xilinx::aievec {
 /// This analysis builds the longest possible chain of MAC operations whose
 /// operands are a vector that may or may not be shifted, and a broadcast.
 /// That is, these MACs represent `vector x scalar` ops, and are candidates to
-/// be grouped and replaced by mul_conv/fma_conv ops in AIE-ML.
+/// be grouped and replaced by mul_conv/fma_conv ops in AIE2.
 //
 // We build this chain recursively, climbing up the
 struct LongestConvMACChainAnalysis {

--- a/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.h
+++ b/lib/Dialect/AIEVec/Transforms/FoldMulAddChainToConvOp.h
@@ -19,7 +19,7 @@ enum class TargetBackend;
 namespace aievec {
 //===----------------------------------------------------------------------===//
 // This is the implementation of the folding pass from mul add chain
-// to AIEVec convolution operations, compatible with the AIE-ML architecture.
+// to AIEVec convolution operations, compatible with the AIE2 architecture.
 //===----------------------------------------------------------------------===//
 
 // Configure the legalizations for aievec conv op transformation

--- a/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
+++ b/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
@@ -87,7 +87,7 @@ LogicalResult interleaveCommaWithError(const Container &c, raw_ostream &os,
 namespace {
 /// Emitter that uses dialect specific emitters to emit C++ code.
 struct CppEmitter {
-  explicit CppEmitter(raw_ostream &os, bool declareVariablesAtTop, bool aieml);
+  explicit CppEmitter(raw_ostream &os, bool declareVariablesAtTop, bool aie2);
 
   /// Emits attribute or returns failure.
   LogicalResult emitAttribute(Location loc, Attribute attr);
@@ -200,7 +200,7 @@ struct CppEmitter {
   /// be declared at the beginning of a function.
   bool shouldDeclareVariablesAtTop() { return declareVariablesAtTop; }
 
-  bool aieml() { return aieml_; }
+  bool aie2() { return aie2_; }
 
 private:
   using ValueMapper = llvm::ScopedHashTable<Value, std::string>;
@@ -230,7 +230,7 @@ private:
 
   llvm::SmallSet<StringRef, 16> includeNames;
 
-  bool aieml_;
+  bool aie2_;
 };
 } // namespace
 
@@ -260,7 +260,7 @@ static bool skippedOp(Operation *op, CppEmitter &emitter,
             // If the underlying element types are float, then we do not really
             // need an srs op if source of srsOp has only one use.
             Value source = srsOp.getSource();
-            if (!emitter.aieml() && llvm::isa<FloatType>(eltType) &&
+            if (!emitter.aie2() && llvm::isa<FloatType>(eltType) &&
                 source.getDefiningOp()->hasOneUse()) {
               StringRef srcName = emitter.getOrCreateName(source);
               emitter.setName(srsOp->getResult(0), srcName);
@@ -276,7 +276,7 @@ static bool skippedOp(Operation *op, CppEmitter &emitter,
             // If the underlying element types are float, then we do not really
             // need a ups op if the source accumulator has only one use.
             Value source = upsOp.getSource();
-            if (!emitter.aieml() && llvm::isa<FloatType>(eltType) &&
+            if (!emitter.aie2() && llvm::isa<FloatType>(eltType) &&
                 source.getDefiningOp()->hasOneUse()) {
               StringRef srcName = emitter.getOrCreateName(source);
               emitter.setName(upsOp->getResult(0), srcName);
@@ -600,9 +600,9 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPDOp updOp) {
   }
 
   // If the vector size to be loaded is less than or equal to 256, we
-  // can just do a direct memory copy. If the translation is for AIEML,
+  // can just do a direct memory copy. If the translation is for AIE2,
   // this number should be doubled
-  if (vecSizeInBits <= (emitter.aieml() ? 1024 : 256)) {
+  if (vecSizeInBits <= (emitter.aie2() ? 1024 : 256)) {
     // Print the lhs
     if (failed(emitter.emitAssignPrefix(*updOp)))
       return failure();
@@ -702,7 +702,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
 
   // If the underlying element types are float, then we do not really need a
   // ups op. We can simply generate an assignment
-  if (!emitter.aieml() && llvm::isa<FloatType>(eltType)) {
+  if (!emitter.aie2() && llvm::isa<FloatType>(eltType)) {
     os << emitter.getOrCreateName(source);
     return success();
   }
@@ -715,9 +715,9 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
       os << "l";
   }
 
-  if (iType && emitter.aieml()) {
+  if (iType && emitter.aie2()) {
     os << "ups_to_v" << lanes << "acc" << iType.getWidth();
-  } else if (fType && emitter.aieml()) {
+  } else if (fType && emitter.aie2()) {
     os << "ups_to_v16accfloat";
   } else {
     os << "ups";
@@ -725,7 +725,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
 
   os << "(";
   os << emitter.getOrCreateName(source);
-  if (!(fType && emitter.aieml())) {
+  if (!(fType && emitter.aie2())) {
     os << ", ";
     os << std::to_string(shift);
   }
@@ -734,10 +734,10 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::UPSOp upsOp) {
   return success();
 }
 
-// Generate the cast intrinsic for AIE-ML
+// Generate the cast intrinsic for AIE2
 static LogicalResult printOperation(CppEmitter &emitter,
                                     aievec::CastOp castOp) {
-  if (!emitter.aieml()) {
+  if (!emitter.aie2()) {
     return failure();
   }
 
@@ -784,7 +784,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
   return success();
 }
 
-// Generate the unpack intrinsic for AIE-ML
+// Generate the unpack intrinsic for AIE2
 static LogicalResult printOperation(CppEmitter &emitter,
                                     aievec::UnpackOp unpackOp) {
 
@@ -829,7 +829,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::SRSOp srsOp) {
   // If the underlying element types are float, then we do not really need an
   // srs op. We can simply generate an assignment
   if (llvm::isa<FloatType>(eltType)) {
-    if (emitter.aieml()) {
+    if (emitter.aie2()) {
       if (unsigned width = getElementSizeInBits(resType); width == 32)
         os << "srs";
       else if (width == 16)
@@ -858,7 +858,7 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::SRSOp srsOp) {
   else if (srcWidth == 48 && resultWidth == 8)
     os << "b";
 
-  if (emitter.aieml())
+  if (emitter.aie2())
     os << "srs_to_v" << std::to_string(lanes) << "int"
        << std::to_string(resWidth);
   else
@@ -949,8 +949,8 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::ExtOp extOp) {
   unsigned lanes = getVectorLaneSize(resType);
   unsigned resWidth = getElementSizeInBits(resType);
 
-  // Print the version of ext for aie-ml
-  if (emitter.aieml()) {
+  // Print the version of ext for AIE2
+  if (emitter.aie2()) {
     os << "extract_v" << std::to_string(lanes);
     if (llvm::isa<IntegerType>(eltType))
       os << "int" << std::to_string(resWidth);
@@ -1988,9 +1988,9 @@ static LogicalResult printOperation(CppEmitter &emitter,
   return success();
 }
 
-// Generate the comparison intrinsics(eq, ne, lt, le, gt, ge) for AIE-ML
+// Generate the comparison intrinsics(eq, ne, lt, le, gt, ge) for AIE2
 static LogicalResult printOperation(CppEmitter &emitter, aievec::CmpOp cmpOp) {
-  if (!emitter.aieml())
+  if (!emitter.aie2())
     return failure();
 
   // The lhs and rhs should have already been emitted
@@ -2048,9 +2048,9 @@ static LogicalResult printOperation(CppEmitter &emitter, aievec::CmpOp cmpOp) {
   return success();
 }
 
-// Generate the sel intrinsic for AIE-ML
+// Generate the sel intrinsic for AIE2
 static LogicalResult printOperation(CppEmitter &emitter, aievec::SelOp selOp) {
-  if (!emitter.aieml())
+  if (!emitter.aie2())
     return failure();
 
   // The lhs, rhs and sel should have already been emitted
@@ -2773,8 +2773,8 @@ static LogicalResult printOperation(CppEmitter &emitter,
   return success();
 }
 
-CppEmitter::CppEmitter(raw_ostream &os, bool declareVariablesAtTop, bool aieml)
-    : os(os), declareVariablesAtTop(declareVariablesAtTop), aieml_(aieml) {
+CppEmitter::CppEmitter(raw_ostream &os, bool declareVariablesAtTop, bool aie2)
+    : os(os), declareVariablesAtTop(declareVariablesAtTop), aie2_(aie2) {
   valueInScopeCount.push(0);
   labelInScopeCount.push(0);
 }
@@ -2935,7 +2935,7 @@ LogicalResult CppEmitter::emitAttribute(Location loc, Attribute attr) {
   }
 
   if (auto dense = llvm::dyn_cast<DenseFPElementsAttr>(attr)) {
-    if (aieml() && dense.isSplat()) {
+    if (aie2() && dense.isSplat()) {
       if (auto vType = llvm::dyn_cast<VectorType>(dense.getType()))
         if (auto fType = llvm::dyn_cast<FloatType>(vType.getElementType())) {
           unsigned width = fType.getWidth();
@@ -2978,7 +2978,7 @@ LogicalResult CppEmitter::emitAttribute(Location loc, Attribute attr) {
             os << ", 0)";
           }
         }
-      // TODO: Deal with multiple dense value case for AIEML.
+      // TODO: Deal with multiple dense value case for AIE2.
     } else {
       os << '{';
       interleaveComma(dense, os, [&](const APFloat &val) { printFloat(val); });
@@ -3022,7 +3022,7 @@ LogicalResult CppEmitter::emitAttribute(Location loc, Attribute attr) {
       if (auto iType = llvm::dyn_cast<IntegerType>(vType.getElementType())) {
         unsigned width = iType.getWidth();
         if (llvm::all_of(dense, [](const APInt &val) { return val == 0; })) {
-          if (aieml()) {
+          if (aie2()) {
             if (width * getVectorLaneSize(vType) == 1024) {
               os << "concat(broadcast_zero_s" << width << "(), broadcast_zero_s"
                  << width << "())";
@@ -3039,7 +3039,7 @@ LogicalResult CppEmitter::emitAttribute(Location loc, Attribute attr) {
           return success();
         }
 
-        if (aieml() && dense.isSplat()) {
+        if (aie2() && dense.isSplat()) {
           std::string splatValue;
           if (width == 32)
             splatValue = getSplatValueOfIntDense<int32_t>(dense);
@@ -3056,7 +3056,7 @@ LogicalResult CppEmitter::emitAttribute(Location loc, Attribute attr) {
           os << ")";
           os << splatValue;
           os << ")";
-          // TODO: Handle multiple dense value case in AIEML.
+          // TODO: Handle multiple dense value case in AIE2.
         } else {
           os << '{';
           interleaveComma(dense, os, [&](const APInt &val) {
@@ -3381,9 +3381,9 @@ CppEmitter::genCppTypeName(Type type, bool stdintType, bool isAcc) {
     auto iElTy = dyn_cast<IntegerType>(eltType);
     if (iElTy)
       iElTyBitWidth = iElTy.getWidth();
-    if (aieml() && (isAcc || iElTyBitWidth == 64)) {
+    if (aie2() && (isAcc || iElTyBitWidth == 64)) {
       if (iElTy) {
-        // AIE-ML has `ups_to_v16acc32`, `ups_to_v16acc64`, `ups_to_v32acc32`
+        // AIE2 has `ups_to_v16acc32`, `ups_to_v16acc64`, `ups_to_v32acc32`
         // intrinsics
         if ((numElems == 16 && iElTyBitWidth == 64) ||
             (numElems == 32 && iElTyBitWidth == 32) ||
@@ -3394,7 +3394,7 @@ CppEmitter::genCppTypeName(Type type, bool stdintType, bool isAcc) {
         return {};
       }
       if (isa<FloatType>(eltType)) {
-        // AIE-ML only has a `ups_to_v16accfloat` intrinsic
+        // AIE2 only has a `ups_to_v16accfloat` intrinsic
         ss << "accfloat";
         return ss.str();
       }
@@ -3438,8 +3438,8 @@ LogicalResult CppEmitter::emitTupleType(Location loc, ArrayRef<Type> types) {
   return success();
 }
 
-LogicalResult aievec::translateAIEVecToCpp(Operation *op, bool aieml,
+LogicalResult aievec::translateAIEVecToCpp(Operation *op, bool aie2,
                                            raw_ostream &os) {
-  CppEmitter emitter(os, false, aieml);
+  CppEmitter emitter(os, false, aie2);
   return emitter.emitOperation(*op, /*trailingSemicolon=*/false);
 }


### PR DESCRIPTION
This is a very first step to 1. separate the AIE1 and AIE-ML/AIE2 and 2. add support of AIE2P to AIEVEC. Changing from `AIE-ML` to `AIE2` aligns to the target naming convention in `AIE/AIEX` dialects and passes. 

Changes:
- Add `AIE2P` in the AIEVEC pipeline enum.
- Rename `aieml/aie_ml/aie-ml` to `aie2` in the AIEVEC related passes and ops in the dialect.
- Keep the support of both `-convert-vector-to-aievec="aie-target=aieml"` and `-convert-vector-to-aievec="aie-target=aie2"` for compatibility. 
 
Todo:
- Update `aie-ml` to `aie2` in `lib/Targets/AIEVecToCpp/TranslateRegistration.cpp` and update other corresponding python e2e tests. 
- Update aievec unit tests and integration tests to use `aie-target=aie2`