### PR TITLE
Print commit in --version output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ option(LLVM_BUILD_TOOLS
 option(AIE_INCLUDE_INTEGRATION_TESTS
        "Generate build targets for the mlir-aie integration tests." OFF)
 
+# Take note of the current git revision for outputting version strings in built executables
+execute_process(COMMAND git rev-parse HEAD OUTPUT_VARIABLE AIE_GIT_COMMIT ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 find_package(MLIR REQUIRED CONFIG)
 
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")

--- a/include/aie/CMakeLists.txt
+++ b/include/aie/CMakeLists.txt
@@ -5,5 +5,6 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
+configure_file(version.h.in version.h)
 add_subdirectory(Dialect)
 add_subdirectory(Conversion)

--- a/include/aie/version.h.in
+++ b/include/aie/version.h.in
@@ -1,0 +1,13 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2021 Xilinx Inc.
+
+#ifndef AIE_VERSION_H
+#define AIE_VERSION_H
+
+#define AIE_GIT_COMMIT "@AIE_GIT_COMMIT@"
+
+#endif

--- a/include/aie/version.h.in
+++ b/include/aie/version.h.in
@@ -3,7 +3,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2021 Xilinx Inc.
+// (c) Copyright 2024 Xilinx Inc.
 
 #ifndef AIE_VERSION_H
 #define AIE_VERSION_H

--- a/include/aie/version.h.in
+++ b/include/aie/version.h.in
@@ -3,7 +3,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Xilinx Inc.
+// (c) Copyright 2024 Advanced Micro Devices Inc.
 
 #ifndef AIE_VERSION_H
 #define AIE_VERSION_H

--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -16,7 +16,10 @@ def parse_args(args=None):
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(prog="aiecc")
     parser.add_argument(
-        "--version", default=False, action="store_true", help="Output commit at which the compiler was built and exit."
+        "--version",
+        default=False,
+        action="store_true",
+        help="Output commit at which the compiler was built and exit.",
     )
     parser.add_argument(
         "filename", nargs="?", metavar="file", default=None, help="MLIR file to compile"

--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -16,6 +16,9 @@ def parse_args(args=None):
         args = sys.argv[1:]
     parser = argparse.ArgumentParser(prog="aiecc")
     parser.add_argument(
+        "--version", default=False, action="store_true", help="Output commit at which the compiler was built and exit."
+    )
+    parser.add_argument(
         "filename", nargs="?", metavar="file", default=None, help="MLIR file to compile"
     )
     parser.add_argument(

--- a/python/compiler/aiecc/configure.py.in
+++ b/python/compiler/aiecc/configure.py.in
@@ -9,6 +9,8 @@ import os
 
 from aie.util import pythonize_bool
 
+git_commit = "@AIE_GIT_COMMIT@"
+
 aie_link_with_xchesscc = pythonize_bool("@AIECC_LINK_WITH_XCHESSCC@")
 aie_compile_with_xchesscc = pythonize_bool("@AIECC_COMPILE_WITH_XCHESSCC@")
 aie_disable_link = not pythonize_bool("@AIECC_LINK@")

--- a/python/compiler/aiecc/configure.py.in
+++ b/python/compiler/aiecc/configure.py.in
@@ -34,7 +34,8 @@ if not os.path.exists(peano_install_dir):
 if not os.path.exists(peano_install_dir):
     peano_install_dir = "peano_not_found"
 
+
 def install_path():
     path = os.path.dirname(os.path.realpath(__file__))
-    path = os.path.join(path, '..', '..', '..', '..')
+    path = os.path.join(path, "..", "..", "..", "..")
     return os.path.realpath(path)

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1186,6 +1186,11 @@ def run(mlir_module, args=None):
 def main():
     global opts
     opts = aie.compiler.aiecc.cl_arguments.parse_args()
+
+    if opts.version:
+        print(f"aiecc.py {aie.compiler.aiecc.configure.git_commit}")
+        sys.exit(0)
+
     if opts.filename is None:
         print("error: the 'file' positional argument is required.")
         sys.exit(1)

--- a/tools/aie-opt/aie-opt.cpp
+++ b/tools/aie-opt/aie-opt.cpp
@@ -21,9 +21,14 @@
 #include "aie/Dialect/AIEVec/Transforms/Passes.h"
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 #include "aie/InitialAllDialect.h"
+#include "aie/version.h"
 
 using namespace llvm;
 using namespace mlir;
+
+void version_printer(raw_ostream &os) {
+  os << "aie-opt " << AIE_GIT_COMMIT << "\n";
+}
 
 int main(int argc, char **argv) {
 
@@ -42,6 +47,8 @@ int main(int argc, char **argv) {
   registerAllExtensions(registry);
 
   xilinx::aievec::registerTransformDialectExtension(registry);
+
+  cl::AddExtraVersionPrinter(version_printer);
 
   return failed(
       MlirOptMain(argc, argv, "MLIR modular optimizer driver\n", registry));

--- a/tools/aie-translate/aie-translate.cpp
+++ b/tools/aie-translate/aie-translate.cpp
@@ -11,6 +11,7 @@
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIEVec/IR/AIEVecDialect.h"
 #include "aie/Target/LLVMIR/Dialect/All.h"
+#include "aie/version.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/InitAllTranslations.h"
 #include "mlir/Support/LogicalResult.h"
@@ -44,6 +45,10 @@ void registerToLLVMIRTranslation() {
 }
 } // namespace aie
 
+void version_printer(raw_ostream &os) {
+  os << "aie-translate " << AIE_GIT_COMMIT << "\n";
+}
+
 int main(int argc, char **argv) {
   // NOTE: these are the contents of registerAllTranslations();
   registerFromLLVMIRTranslation();
@@ -54,6 +59,8 @@ int main(int argc, char **argv) {
 
   xilinx::AIE::registerAIETranslations();
   xilinx::aievec::registerAIEVecToCppTranslation();
+
+  llvm::cl::AddExtraVersionPrinter(version_printer);
 
   return failed(mlirTranslateMain(argc, argv, "AIE Translation Tool"));
 }


### PR DESCRIPTION
We have had a number of people run into issues because they ran an older compiler with newer examples. Sometimes this happens in convoluted ways when a compiler executable is picked up from somewhere else in the PATH than the user may expect.

This adds a quick way to troubleshoot these issues by printing the commit hash at which the executable was built to the output of `aiecc.py --version` (new option), `aie-opt --version` and `aie-translate --version`.