### PR TITLE
VCK5000 documentation fix

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -86,12 +86,11 @@ When targetting the VCK5000 Versal device, you must build and install our experi
     ```
     This will build LLVM in `llvm/build` and install the LLVM binaries under `llvm/install`.
 
-4. Build the MLIR-AIE tools by calling `utils/build-mlir-aie.sh` for Versal or Ryzen AI 
-    with the path to the `llvm/build` directory. The Vitis environment will have to be 
-    set up for this to succeed. Note that there are seperate scripts to run when targetting
-    Ryzen AI vs the VCK5000. See the two scripts below: 
+4. Build the MLIR-AIE tools by calling `utils/build-mlir-aie.sh` or `utils/build-mlir-aie-pcie.sh` 
+    for Versal or Ryzen AI with the path to the `llvm/build` directory. The Vitis environment 
+    will have to be set up for this to succeed.  
 
-    Building mlir-aie for the Ryzen AI system:
+    Building mlir-aie for a Ryzen AI system:
 
     ```
     source <Vitis Install Path>/settings64.sh

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -87,8 +87,8 @@ When targetting the VCK5000 Versal device, you must build and install our experi
     This will build LLVM in `llvm/build` and install the LLVM binaries under `llvm/install`.
 
 4. Build the MLIR-AIE tools by calling `utils/build-mlir-aie.sh` or `utils/build-mlir-aie-pcie.sh` 
-    for Versal or Ryzen AI with the path to the `llvm/build` directory. The Vitis environment 
-    will have to be set up for this to succeed.  
+    for Ryzen AI or Versal respectively  with the path to the `llvm/build` directory. 
+    The Vitis environment will have to be set up for this to succeed.  
 
     Building mlir-aie for a Ryzen AI system:
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -28,7 +28,7 @@ This script requires `virtualenv`.
 
 clang/llvm 14+ are recommended to be built with the provided scripts. See step 3. of the build instructions. 
 
-When targetting the VCK5000 Versal device, you must build and install our experimental ROCm runtime which allows us to communicate with the AIEs. The [ROCm-air-platforms](https://github.com/Xilinx/ROCm-air-platforms) repository contains documentation on how to install our experimental ROCm runtime. When targetting the VCK5000, it will be necessary to [install a global version of ROCM 5.6](https://rocm.docs.amd.com/en/docs-5.6.0/deploy/linux/os-native/install.html). Details of all these steps can be found in the [ROCm-air-platforms](https://github.com/Xilinx/ROCm-air-platforms#getting-started). 
+When targetting the VCK5000 Versal device, you must build and install our experimental ROCm runtime which allows us to communicate with the AIEs. The [ROCm-air-platforms](https://github.com/Xilinx/ROCm-air-platforms) repository contains documentation on how to install our experimental ROCm runtime. When targetting the VCK5000, it will be necessary to [install a global version of ROCM 5.6](https://rocm.docs.amd.com/en/docs-5.6.0/deploy/linux/os-native/install.html). Details of all these steps can be found in the [ROCm-air-platforms](https://github.com/Xilinx/ROCm-air-platforms#getting-started) repo. 
 
 ## Building on X86 for mlir-aie development
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -115,7 +115,7 @@ and llvm.
     source utils/env_setup.sh <mlir-aie>/install <llvm dir>/install
     ```
 
-6. **Only for the VCK5000:** The PCIe AIR runtime requires the use of the [AIR PCIe kernel driver](https://github.com/Xilinx/ROCm-air-platforms/tree/main/driver). The driver directory in the [ROCm-air-platforms](https://github.com/Xilinx/ROCm-air-platforms) repository contains documentation on how to compile and load the AIR PCIe kernel driver.
+6. **Only for the VCK5000:** The PCIe AIR runtime requires the use of the [AIR PCIe kernel driver](https://github.com/Xilinx/ROCm-air-platforms/tree/main/driver). This directory contains documentation on how to compile and load the AIR PCIe kernel driver.
 
 Note that when coming back to this install with a fresh environment, it is necessary to rerun the `utils/env_setup.sh` script to setup your environment as well as activate the Python virtual environment using the following command.
 ```
@@ -148,7 +148,7 @@ To install our experimental ROCm runtime  which allows us to communicate with th
 Then, set `${ROCM_ROOT}` to the ROCm install. Then, run the following command to build the mlir-aie toolchain targetting the VCK5000 pointing to the externally installed aie-rt and experimental ROCm runtime.
 
 ```
-./utils/build-mlirgaie-pcie.sh llvm/build/ build install /opt/xaiengine ${ROCM_ROOT}/lib/cmake/hsa-runtime64/ ${ROCM_ROOT}/lib/cmake/hsakmt/
+./utils/build-mlir-aie-pcie.sh llvm/build/ build install /opt/xaiengine ${ROCM_ROOT}/lib/cmake/hsa-runtime64/ ${ROCM_ROOT}/lib/cmake/hsakmt/
 ```
 
 ### Sysroot

--- a/programming_examples/basic/passthrough_dmas/Makefile
+++ b/programming_examples/basic/passthrough_dmas/Makefile
@@ -55,17 +55,14 @@ vck5000: col=6
 
 vck5000: build/aie.mlir
 	aiecc.py --link_against_hsa --host-target=x86_64-amd-linux-gnu build/aie.mlir \
-		-I/opt/xaiengine/include \
 		-I${srcdir}/../../../install/runtime_lib/x86_64-hsa/test_lib/include \
-		-L/opt/xaiengine/lib \
 		-L/lib/x86_64-linux-gnu/ \
 		${srcdir}/test_vck5000.cpp \
 		${srcdir}/../../../install/runtime_lib/x86_64-hsa/test_lib/src/test_library.cpp \
-		-Wl,-R/opt/xaiengine/lib \
 		-Wl,--whole-archive -Wl,--no-whole-archive -lstdc++ -ldl -lelf -o test.elf
 
 run_vck5000:
 	test.elf
 
 clean:
-	rm -rf build _build inst ${targetname}.exe
+	rm -rf build _build inst aie.mlir.prj core_* test.elf ${targetname}.exe

--- a/programming_examples/basic/vector_vector_add/Makefile
+++ b/programming_examples/basic/vector_vector_add/Makefile
@@ -46,13 +46,9 @@ vck5000: col=6
 
 vck5000: build/aie.mlir
 	aiecc.py --xchesscc --link_against_hsa --host-target=x86_64-amd-linux-gnu build/aie.mlir \
-		-I/opt/xaiengine/include \
 		-I${srcdir}/../../../install/runtime_lib/x86_64-hsa/test_lib/include \
-		-L/opt/xaiengine/lib \
-		-L/lib/x86_64-linux-gnu/ \
 		${srcdir}/test_vck5000.cpp \
 		${srcdir}/../../../install/runtime_lib/x86_64-hsa/test_lib/src/test_library.cpp \
-		-Wl,-R/opt/xaiengine/lib \
 		-Wl,--whole-archive -Wl,--no-whole-archive -lstdc++ -ldl -lelf -o test.elf
 
 run: ${targetname}.exe build/final.xclbin build/insts.txt 


### PR DESCRIPTION
Adding some additional functionality to the `build-mlir-aie-pcie.sh` script to automatically build ROCr and aie-rt if install paths aren't provided. Also cleaning up some of the VCK5000 build documentation. 