### PR TITLE
Parametrize Number of Used AIE Columns in Whole Array Matrix Multiplication Design

### DIFF
--- a/programming_examples/basic/matrix_multiplication/whole_array/Makefile
+++ b/programming_examples/basic/matrix_multiplication/whole_array/Makefile
@@ -17,10 +17,11 @@ N?=768
 m?=16
 k?=64
 n?=48
+n_aie_cols?=2
 
 kernels=mm_${m}x${k}x${n}
-aieargs+=-m $m -k $k -n $n
-target_suffix=${M}x${K}x${N}_${m}x${k}x${n}
+aieargs+=-m $m -k $k -n $n --n-aie-cols ${n_aie_cols}
+target_suffix=${M}x${K}x${N}_${m}x${k}x${n}_${n_aie_cols}c
 
 include ${srcdir}/../makefile-common
 

--- a/programming_examples/basic/matrix_multiplication/whole_array/Makefile
+++ b/programming_examples/basic/matrix_multiplication/whole_array/Makefile
@@ -11,12 +11,12 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 subdir=whole_array
 targetname=matrixMultiplication
 
-M?=512
-K?=512
-N?=512
-m?=64
+M?=640
+K?=896
+N?=768
+m?=16
 k?=64
-n?=64
+n?=48
 
 kernels=mm_${m}x${k}x${n}
 aieargs+=-m $m -k $k -n $n

--- a/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
@@ -27,7 +27,10 @@ def main():
     argparser.add_argument("-k", type=int, default=64)
     argparser.add_argument("-n", type=int, default=64)
     args = argparser.parse_args()
-    my_matmul(args.M, args.K, args.N, args.m, args.k, args.n)
+    with mlir_mod_ctx() as ctx:
+        my_matmul(args.M, args.K, args.N, args.m, args.k, args.n)
+        # print(ctx.module.operation.verify())
+        print(ctx.module)
 
 
 def my_matmul(M, K, N, m, k, n):
@@ -71,292 +74,211 @@ def my_matmul(M, K, N, m, k, n):
 
     n_tiles = (M // m) * (N // n) // n_cores
 
-    with mlir_mod_ctx() as ctx:
+    @device(AIEDevice.npu1_4col)
+    def device_body():
+        a_l2_memref_ty = T.memref(m * k, T.bf16())
+        b_l2_memref_ty = T.memref(k * n, T.bf16())
+        c_l2_memref_ty = T.memref(m * n * n_rows, T.bf16())
+        a_l1_memref_ty = T.memref(m, k, T.bf16())
+        b_l1_memref_ty = T.memref(k, n, T.bf16())
+        c_l1_memref_ty = T.memref(m, n, T.bf16())
 
-        @device(AIEDevice.npu1_4col)
-        def device_body():
-            memRef_inA_ty = T.memref(m * k, T.bf16())
-            memRef_inB_ty = T.memref(k * n, T.bf16())
-            memRef_outC_ty = T.memref(m * n * n_rows, T.bf16())
-            memRef_A_ty = T.memref(m, k, T.bf16())
-            memRef_B_ty = T.memref(k, n, T.bf16())
-            memRef_C_ty = T.memref(m, n, T.bf16())
+        # AIE Core Function declarations
+        zero_scalar = external_func("zero_scalar_bf16", inputs=[c_l1_memref_ty])
+        zero = external_func("zero_bf16", inputs=[c_l1_memref_ty])
+        matmul_scalar = external_func(
+            "matmul_scalar_bf16_bf16",
+            inputs=[a_l1_memref_ty, b_l1_memref_ty, c_l1_memref_ty],
+        )
+        matmul = external_func(
+            "matmul_bf16_bf16", inputs=[a_l1_memref_ty, b_l1_memref_ty, c_l1_memref_ty]
+        )
 
-            # AIE Core Function declarations
-            zero_scalar = external_func("zero_scalar_bf16", inputs=[memRef_C_ty])
-            zero = external_func("zero_bf16", inputs=[memRef_C_ty])
-            matmul_scalar = external_func(
-                "matmul_scalar_bf16_bf16",
-                inputs=[memRef_A_ty, memRef_B_ty, memRef_C_ty],
+        # Tile declarations as tile[row][col]
+        tiles = [[tile(col, row) for col in range(0, 4)] for row in range(0, 6)]
+        shim_tiles = tiles[0]
+        mem_tiles = tiles[1]
+        core_tiles = tiles[2:]
+
+        # AIE-array data movement with object fifos
+        a_l3l2_fifos = [None] * n_cols
+        a_l2l1_fifos = [None] * n_rows
+
+        b_l3l2_fifos = [None] * n_cols
+        b_l2l1_fifos = [None] * n_cols
+
+        c_l1l2_fifos = [[None] * n_cols for _ in range(n_rows)]
+        c_l2l3_fifos = [None] * n_cols
+
+        # Input A
+        for col in range(n_cols):
+            a_l3l2_fifos[col] = object_fifo(
+                f"A_L3L2_{col}",
+                shim_tiles[col],
+                mem_tiles[col],
+                fifo_depth,
+                a_l2_memref_ty,
             )
-            matmul = external_func(
-                "matmul_bf16_bf16", inputs=[memRef_A_ty, memRef_B_ty, memRef_C_ty]
+            a_l2l1_fifos[col] = object_fifo(  # TODO i --> j (n rows)
+                f"A_L2L1_{col}",
+                mem_tiles[col],
+                core_tiles[col][0:n_cols],  # broadcast along one row
+                fifo_depth,
+                a_l1_memref_ty,
+                [
+                    (m // r, r * k),
+                    (k // s, s),
+                    (r, k),
+                    (s, 1),
+                ],
             )
+            object_fifo_link(a_l3l2_fifos[col], a_l2l1_fifos[col])
 
-            # Tile declarations
-            _0_ShimTile = tile(0, 0)
-            _0_MemTile = tile(0, 1)
-            _0_ComputeTile2 = tile(0, 2)
-            _0_ComputeTile3 = tile(0, 3)
-            _0_ComputeTile4 = tile(0, 4)
-            _0_ComputeTile5 = tile(0, 5)
-            _0_cores = [
-                _0_ComputeTile2,
-                _0_ComputeTile3,
-                _0_ComputeTile4,
-                _0_ComputeTile5,
-            ]
-            _1_ShimTile = tile(1, 0)
-            _1_MemTile = tile(1, 1)
-            _1_ComputeTile2 = tile(1, 2)
-            _1_ComputeTile3 = tile(1, 3)
-            _1_ComputeTile4 = tile(1, 4)
-            _1_ComputeTile5 = tile(1, 5)
-            _1_cores = [
-                _1_ComputeTile2,
-                _1_ComputeTile3,
-                _1_ComputeTile4,
-                _1_ComputeTile5,
-            ]
-            _2_ShimTile = tile(2, 0)
-            _2_MemTile = tile(2, 1)
-            _2_ComputeTile2 = tile(2, 2)
-            _2_ComputeTile3 = tile(2, 3)
-            _2_ComputeTile4 = tile(2, 4)
-            _2_ComputeTile5 = tile(2, 5)
-            _2_cores = [
-                _2_ComputeTile2,
-                _2_ComputeTile3,
-                _2_ComputeTile4,
-                _2_ComputeTile5,
-            ]
-            _3_ShimTile = tile(3, 0)
-            _3_MemTile = tile(3, 1)
-            _3_ComputeTile2 = tile(3, 2)
-            _3_ComputeTile3 = tile(3, 3)
-            _3_ComputeTile4 = tile(3, 4)
-            _3_ComputeTile5 = tile(3, 5)
-            _3_cores = [
-                _3_ComputeTile2,
-                _3_ComputeTile3,
-                _3_ComputeTile4,
-                _3_ComputeTile5,
-            ]
-            shims = [_0_ShimTile, _1_ShimTile, _2_ShimTile, _3_ShimTile]
-            mems = [_0_MemTile, _1_MemTile, _2_MemTile, _3_MemTile]
-            cores = [
-                [_0_ComputeTile2, _0_ComputeTile3, _0_ComputeTile4, _0_ComputeTile5],
-                [_1_ComputeTile2, _1_ComputeTile3, _1_ComputeTile4, _1_ComputeTile5],
-                [_2_ComputeTile2, _2_ComputeTile3, _2_ComputeTile4, _2_ComputeTile5],
-                [_3_ComputeTile2, _3_ComputeTile3, _3_ComputeTile4, _3_ComputeTile5],
-            ]
-            t_cores = [
-                [cores[j][i] for j in range(len(cores))] for i in range(len(cores[0]))
-            ]
-            inA_fifo_names = ["inA0", "inA1", "inA2", "inA3"]
-            inA_fifos = {}
-            inB_fifo_names = ["inB0", "inB1", "inB2", "inB3"]
-            inB_fifos = {}
-            memA_fifo_names = ["memA0", "memA1", "memA2", "memA3"]
-            memA_fifos = {}
-            memB_fifo_names = ["memB0", "memB1", "memB2", "memB3"]
-            memB_fifos = {}
-            _0_outC_fifo_names = ["memC00", "memC10", "memC20", "memC30"]
-            _0_outC_fifos = {}
-            _1_outC_fifo_names = ["memC01", "memC11", "memC21", "memC31"]
-            _1_outC_fifos = {}
-            _2_outC_fifo_names = ["memC02", "memC12", "memC22", "memC32"]
-            _2_outC_fifos = {}
-            _3_outC_fifo_names = ["memC03", "memC13", "memC23", "memC33"]
-            _3_outC_fifos = {}
-            memC_fifo_names = [
-                _0_outC_fifo_names,
-                _1_outC_fifo_names,
-                _2_outC_fifo_names,
-                _3_outC_fifo_names,
-            ]
-            memC_fifos = [_0_outC_fifos, _1_outC_fifos, _2_outC_fifos, _3_outC_fifos]
-            outC_fifo_names = ["outC0", "outC1", "outC2", "outC3"]
-            outC_fifos = {}
+        # Input B
+        for col in range(n_cols):
+            b_l3l2_fifos[col] = object_fifo(
+                f"B_L3L2_{col}",
+                shim_tiles[col],
+                mem_tiles[col],
+                fifo_depth,
+                b_l2_memref_ty,
+            )
+            b_l2l1_fifos[col] = object_fifo(
+                f"B_L2L1_{col}",
+                mem_tiles[col],
+                [
+                    core_tiles[j][col] for j in range(n_rows)
+                ],  # broadcast along one column
+                fifo_depth,
+                b_l1_memref_ty,
+                [
+                    (k // s, s * n),
+                    (n // t, t),
+                    (s, n),
+                    (t, 1),
+                ],
+            )
+            object_fifo_link(b_l3l2_fifos[col], b_l2l1_fifos[col])
 
-            # AIE-array data movement with object fifos
-            # Input A
-            for i in range(n_cols):
-                inA_fifos[inA_fifo_names[i]] = object_fifo(
-                    inA_fifo_names[i],
-                    shims[i],
-                    mems[i],
+        # Output C
+        for col in range(n_cols):
+            for row in range(n_rows):
+                c_l1l2_fifos[row][col] = object_fifo(
+                    f"C_L1L2_{col}_{row}",
+                    core_tiles[row][col],
+                    mem_tiles[col],
                     fifo_depth,
-                    memRef_inA_ty,
+                    c_l1_memref_ty,
                 )
-                memA_fifos[memA_fifo_names[i]] = object_fifo(
-                    memA_fifo_names[i],
-                    mems[i],
-                    t_cores[i][0:n_cols],
-                    fifo_depth,
-                    memRef_A_ty,
-                    [
-                        (m // r, r * k),
-                        (k // s, s),
-                        (r, k),
-                        (s, 1),
-                    ],
-                )
-                object_fifo_link(inA_fifo_names[i], memA_fifo_names[i])
+            c_l2l3_fifos[col] = object_fifo(
+                f"C_L2L3_{col}",
+                mem_tiles[col],
+                shim_tiles[col],
+                fifo_depth,
+                c_l2_memref_ty,
+                [
+                    (m // r, r * n),
+                    (r, t),
+                    (n // t, r * t),
+                    (t, 1),
+                ],
+            )
+            object_fifo_link(
+                [c_l1l2_fifos[j][col] for j in range(n_rows)], c_l2l3_fifos[col]
+            )  # join along one column
 
-            # Input B
-            for i in range(n_cols):
-                inB_fifos[inB_fifo_names[i]] = object_fifo(
-                    inB_fifo_names[i],
-                    shims[i],
-                    mems[i],
-                    fifo_depth,
-                    memRef_inB_ty,
-                )
-                memB_fifos[memB_fifo_names[i]] = object_fifo(
-                    memB_fifo_names[i],
-                    mems[i],
-                    cores[i][0:n_rows],
-                    fifo_depth,
-                    memRef_B_ty,
-                    [
-                        (k // s, s * n),
-                        (n // t, t),
-                        (s, n),
-                        (t, 1),
-                    ],
-                )
-                object_fifo_link(inB_fifo_names[i], memB_fifo_names[i])
+        # Set up compute tiles
+        for row in range(n_rows):
+            for col in range(n_cols):
 
-            # Output C
-            for i in range(n_cols):
-                for j in range(n_rows):
-                    memC_fifos[i][memC_fifo_names[i][j]] = object_fifo(
-                        memC_fifo_names[i][j],
-                        cores[i][j],
-                        mems[i],
-                        fifo_depth,
-                        memRef_C_ty,
-                    )
-                outC_fifos[outC_fifo_names[i]] = object_fifo(
-                    outC_fifo_names[i],
-                    mems[i],
-                    shims[i],
-                    fifo_depth,
-                    memRef_outC_ty,
-                    [
-                        (m // r, r * n),
-                        (r, t),
-                        (n // t, r * t),
-                        (t, 1),
-                    ],
-                )
-                object_fifo_link(memC_fifo_names[i], outC_fifo_names[i])
+                @core(core_tiles[row][col], f"mm_{m}x{k}x{n}.o")
+                def core_body():
+                    for _ in for_(0xFFFFFFFF):
+                        loop = (
+                            for_(n_tiles) if n_tiles > 1 else range(1)
+                        )  # Workaround for issue #1547
+                        for _ in loop:
+                            elem_out = c_l1l2_fifos[row][col].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
+                            call(zero, [elem_out])
 
-            # Set up compute tiles
-            for j in range(n_cols):
-                for i in range(n_rows):
-                    # Compute tile i
-                    @core(cores[j][i], f"mm_{m}x{k}x{n}.o")
-                    def core_body():
-                        for _ in for_(0xFFFFFFFF):
-                            for _ in (
-                                for_(n_tiles) if n_tiles > 1 else range(1)
-                            ):  # Workaround for issue #1547
-                                elem_out = memC_fifos[j][memC_fifo_names[j][i]].acquire(
-                                    ObjectFifoPort.Produce,
-                                    1,
+                            for _ in for_(K // k):
+                                elem_in_a = a_l2l1_fifos[row].acquire(
+                                    ObjectFifoPort.Consume, 1
                                 )
-                                call(zero, [elem_out])
-
-                                for _ in for_(K // k):
-                                    elem_in_a = memA_fifos[memA_fifo_names[i]].acquire(
-                                        ObjectFifoPort.Consume,
-                                        1,
-                                    )
-                                    elem_in_b = memB_fifos[memB_fifo_names[j]].acquire(
-                                        ObjectFifoPort.Consume,
-                                        1,
-                                    )
-                                    call(matmul, [elem_in_a, elem_in_b, elem_out])
-                                    memA_fifos[memA_fifo_names[i]].release(
-                                        ObjectFifoPort.Consume, 1
-                                    )
-                                    memB_fifos[memB_fifo_names[j]].release(
-                                        ObjectFifoPort.Consume, 1
-                                    )
-                                    yield_([])
-
-                                memC_fifos[j][memC_fifo_names[j][i]].release(
-                                    ObjectFifoPort.Produce, 1
+                                elem_in_b = b_l2l1_fifos[col].acquire(
+                                    ObjectFifoPort.Consume, 1
                                 )
+                                call(matmul, [elem_in_a, elem_in_b, elem_out])
+                                a_l2l1_fifos[row].release(ObjectFifoPort.Consume, 1)
+                                b_l2l1_fifos[col].release(ObjectFifoPort.Consume, 1)
                                 yield_([])
 
-                            if n_tiles > 1:  # workaround for issue #1547
-                                yield_([])
+                            c_l1l2_fifos[row][col].release(ObjectFifoPort.Produce, 1)
+                            yield_([])
 
-            # To/from AIE-array data movement
+                        if n_tiles > 1:  # workaround for issue #1547
+                            yield_([])
 
-            @FuncOp.from_py_func(
-                T.memref(M * K, T.bf16()),
-                T.memref(K * N, T.bf16()),
-                T.memref(M * N, T.bf16()),
-            )
-            def sequence(A, B, C):
-                # only do 5 tile rows at a time before synchronizing, so we can reuse BDs
-                rows_per_block = 5
-                for tile_row_block in range(
-                    (M // m // n_rows + rows_per_block - 1) // rows_per_block
-                ):
-                    num_tile_rows = min(
-                        [
-                            rows_per_block,
-                            M // m // n_rows - tile_row_block * rows_per_block,
-                        ]
+        # To/from AIE-array data movement
+        @FuncOp.from_py_func(
+            T.memref(M * K, T.bf16()),
+            T.memref(K * N, T.bf16()),
+            T.memref(M * N, T.bf16()),
+        )
+        def sequence(A, B, C):
+            # only do 5 tile rows at a time before synchronizing, so we can reuse BDs
+            rows_per_block = 5
+            for tile_row_block in range(
+                (M // m // n_rows + rows_per_block - 1) // rows_per_block
+            ):
+                num_tile_rows = min(
+                    [
+                        rows_per_block,
+                        M // m // n_rows - tile_row_block * rows_per_block,
+                    ]
+                )
+                C_row_offset = tile_row_block * rows_per_block * m * n_rows * N
+                for col in range(n_cols):
+                    C_col_offset = col * n
+                    C_offset = C_col_offset + C_row_offset
+                    npu_dma_memcpy_nd(
+                        metadata=c_l2l3_fifos[col].sym_name.value,
+                        bd_id=0,
+                        mem=C,
+                        offsets=[0, 0, 0, C_offset],
+                        sizes=[num_tile_rows, N // n // n_cols, m * n_rows, n],
+                        strides=[m * n_rows * N, n * n_cols, N, 1],
                     )
-                    C_row_offset = tile_row_block * rows_per_block * m * n_rows * N
-                    for i in range(n_cols):
-                        C_col_offset = i * n
-                        C_offset = C_col_offset + C_row_offset
-                        npu_dma_memcpy_nd(
-                            metadata=outC_fifo_names[i],
-                            bd_id=0,
-                            mem=C,
-                            offsets=[0, 0, 0, C_offset],
-                            sizes=[num_tile_rows, N // n // n_cols, m * n_rows, n],
-                            strides=[m * n_rows * N, n * n_cols, N, 1],
+                    for tile_row in range(num_tile_rows):
+                        A_row_offset = (
+                            ((tile_row_block * rows_per_block) + tile_row)
+                            * n_rows
+                            * m
+                            * K
                         )
-                        for tile_row in range(num_tile_rows):
-                            A_row_offset = (
-                                ((tile_row_block * rows_per_block) + tile_row)
-                                * n_rows
-                                * m
-                                * K
-                            )
-                            A_col_offset = i * m * K
-                            A_offset = A_row_offset + A_col_offset
-                            B_col_offset = i * n
-                            npu_dma_memcpy_nd(
-                                metadata=inA_fifo_names[i],
-                                bd_id=2 * tile_row + 1,
-                                mem=A,
-                                offsets=[0, 0, 0, A_offset],
-                                sizes=[N // n // n_cols, K // k, m, k],
-                                strides=[0, k, K, 1],
-                            )
-                            npu_dma_memcpy_nd(
-                                metadata=inB_fifo_names[i],
-                                bd_id=2 * tile_row + 2,
-                                mem=B,
-                                offsets=[0, 0, 0, B_col_offset],
-                                sizes=[N // n // n_cols, K // k, k, n],
-                                strides=[n * n_cols, k * N, N, 1],
-                            )
-                    for i in range(n_cols):
-                        npu_sync(column=i, row=0, direction=0, channel=0)
-
-    # print(ctx.module.operation.verify())
-    print(ctx.module)
+                        A_col_offset = col * m * K
+                        A_offset = A_row_offset + A_col_offset
+                        B_col_offset = col * n
+                        npu_dma_memcpy_nd(
+                            metadata=a_l3l2_fifos[col].sym_name.value,
+                            bd_id=2 * tile_row + 1,
+                            mem=A,
+                            offsets=[0, 0, 0, A_offset],
+                            sizes=[N // n // n_cols, K // k, m, k],
+                            strides=[0, k, K, 1],
+                        )
+                        npu_dma_memcpy_nd(
+                            metadata=b_l3l2_fifos[col].sym_name.value,
+                            bd_id=2 * tile_row + 2,
+                            mem=B,
+                            offsets=[0, 0, 0, B_col_offset],
+                            sizes=[N // n // n_cols, K // k, k, n],
+                            strides=[n * n_cols, k * N, N, 1],
+                        )
+                for col in range(n_cols):
+                    npu_sync(column=col, row=0, direction=0, channel=0)
 
 
 if __name__ == "__main__":

--- a/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
@@ -262,7 +262,7 @@ def my_matmul(M, K, N, m, k, n):
                             * m
                             * K
                         )
-                        A_row_offset = col * m * K
+                        A_row_offset = col * n_A_tiles_per_shim * m * K
                         A_offset = A_block_offset + A_row_offset
                         B_col_offset = col * n
                         npu_dma_memcpy_nd(

--- a/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
@@ -87,7 +87,6 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols):
         dev = AIEDevice.npu1_2col
     elif n_aie_cols == 4:
         dev = AIEDevice.npu1_4col
-        sys.exit(1)
 
     @device(dev)
     def device_body():
@@ -129,7 +128,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols):
 
         # Input A
         for row in range(n_aie_rows):
-            A_l2l1_fifos[row] = object_fifo(  # TODO i --> j (n rows)
+            A_l2l1_fifos[row] = object_fifo(
                 f"A_L2L1_{row}",
                 mem_tiles[row // n_A_tiles_per_shim],
                 core_tiles[row][0:n_aie_cols],  # broadcast along one row

--- a/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
@@ -80,7 +80,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols):
 
     n_A_tiles_per_shim = n_aie_rows // n_aie_cols
 
-    dev = None 
+    dev = None
     if n_aie_cols == 1:
         dev = AIEDevice.npu1_1col
     elif n_aie_cols == 2:
@@ -110,7 +110,9 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols):
         )
 
         # Tile declarations as tile[row][col]
-        tiles = [[tile(col, row) for col in range(0, n_aie_cols)] for row in range(0, 6)]
+        tiles = [
+            [tile(col, row) for col in range(0, n_aie_cols)] for row in range(0, 6)
+        ]
         shim_tiles = tiles[0]
         mem_tiles = tiles[1]
         core_tiles = tiles[2:]

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
@@ -1,0 +1,9 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, chess
+//
+// RUN: make -f %S/Makefile clean
+// RUN: env n_aie_cols=1 make -f %S/Makefile 
+// RUN: %run_on_npu env n_aie_cols=1 make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
@@ -1,0 +1,9 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, chess
+//
+// RUN: make -f %S/Makefile clean
+// RUN: env n_aie_cols=2 make -f %S/Makefile 
+// RUN: %run_on_npu env n_aie_cols=2 make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
@@ -4,6 +4,6 @@
 // REQUIRES: ryzen_ai, chess
 //
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// RUN: env n_aie_cols=4 make -f %S/Makefile 
+// RUN: %run_on_npu env n_aie_cols=4 make -f %S/Makefile run | FileCheck %s
 // CHECK: PASS!


### PR DESCRIPTION
Adapts the whole array design to make it possible to run matrix multiplication on 1, 2 or 4 columns with configurable parameter `n_aie_cols`. The number of used rows remains fixed at 4.

For 4 columns (default) this should be the same as the previous whole_array design.

For 2 and 1 columns, the mem tiles hold double (or quadruple) the tile size of A and then distribute those to all rows in the array. Thus, it may be necessary to reduce tile size if you run into memory limits with designs with fewer columns.

Also cleans up the code a bit. Adds tests for 1 and 2 column designs as well by running the same design with different parameters.