### PR TITLE
refactor legal switchbox connection checks in target model

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -98,11 +98,6 @@ public:
            src.row < rows();
   }
 
-  /// Return true if the given port in the given tile is a valid destination for
-  /// traces
-  virtual bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                                  int destIndex) const = 0;
-
   /// Return the tile ID of the memory to the west of the given tile, if it
   /// exists.
   virtual std::optional<TileID> getMemWest(TileID src) const = 0;
@@ -200,9 +195,9 @@ public:
                                                   WireBundle bundle) const = 0;
 
   // Return true if the stream switch connection is legal, false otherwise.
-  virtual bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
-                                        WireBundle dstBundle,
-                                        int dstChan) const = 0;
+  virtual bool isLegalTileConnection(int col, int row, WireBundle srcBundle,
+                                     int srcChan, WireBundle dstBundle,
+                                     int dstChan) const = 0;
 
   // Run consistency checks on the target model.
   void validate() const;
@@ -273,18 +268,9 @@ public:
                                         WireBundle bundle) const override;
   uint32_t getNumSourceShimMuxConnections(int col, int row,
                                           WireBundle bundle) const override;
-  bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
-                                WireBundle dstBundle,
-                                int dstChan) const override;
-
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override {
-    if (isCoreTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    return false;
-  }
+  bool isLegalTileConnection(int col, int row, WireBundle srcBundle,
+                             int srcChan, WireBundle dstBundle,
+                             int dstChan) const override;
 
   uint32_t getColumnShift() const override { return 23; }
   uint32_t getRowShift() const override { return 18; }
@@ -342,9 +328,9 @@ public:
                                         WireBundle bundle) const override;
   uint32_t getNumSourceShimMuxConnections(int col, int row,
                                           WireBundle bundle) const override;
-  bool isLegalMemtileConnection(WireBundle srcBundle, int srcChan,
-                                WireBundle dstBundle,
-                                int dstChan) const override;
+  bool isLegalTileConnection(int col, int row, WireBundle srcBundle,
+                             int srcChan, WireBundle dstBundle,
+                             int dstChan) const override;
 
   uint32_t getColumnShift() const override { return 25; }
   uint32_t getRowShift() const override { return 20; }
@@ -404,27 +390,6 @@ public:
   }
 
   uint32_t getNumMemTileRows() const override { return 1; }
-
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override {
-    if (isCoreTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    if (isCoreTile(col, row) && destBundle == WireBundle::DMA && destIndex == 0)
-      return true;
-    if (isMemTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    if (isMemTile(col, row) && destBundle == WireBundle::DMA && destIndex == 5)
-      return true;
-    if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::West &&
-        destIndex == 0)
-      return true;
-    if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::East &&
-        destIndex == 0)
-      return true;
-    return false;
-  }
 };
 
 class VE2802TargetModel : public AIE2TargetModel {
@@ -459,27 +424,6 @@ public:
   }
 
   uint32_t getNumMemTileRows() const override { return 2; }
-
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override {
-    if (isCoreTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    if (isCoreTile(col, row) && destBundle == WireBundle::DMA && destIndex == 0)
-      return true;
-    if (isMemTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    if (isMemTile(col, row) && destBundle == WireBundle::DMA && destIndex == 5)
-      return true;
-    if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::South)
-      return true;
-    if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::West &&
-        destIndex == 0)
-      return true;
-    if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::East &&
-        destIndex == 0)
-      return true;
-    return false;
-  }
 };
 
 class BaseNPUTargetModel : public AIE2TargetModel {
@@ -502,9 +446,6 @@ public:
   }
 
   uint32_t getNumMemTileRows() const override { return 1; }
-
-  bool isValidTraceMaster(int col, int row, WireBundle destBundle,
-                          int destIndex) const override;
 
   // Return true if the device model is virtualized.  This is used
   // during CDO code generation to configure aie-rt properly.

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1084,24 +1084,24 @@ bool TileOp::isShimNOCorPLTile() {
   return targetModel.isShimNOCorPLTile(getCol(), getRow());
 }
 
-bool isLegalMemtileConnection(const AIETargetModel &targetModel,
-                              MasterSetOp masterOp, PacketRulesOp slaveOp) {
+bool isLegalTileConnection(TileOp tile, const AIETargetModel &targetModel,
+                           MasterSetOp masterOp, PacketRulesOp slaveOp) {
   auto srcBundle = slaveOp.sourcePort().bundle;
   auto srcChan = slaveOp.sourcePort().channel;
   auto dstBundle = masterOp.destPort().bundle;
   auto dstChan = masterOp.destPort().channel;
-  return targetModel.isLegalMemtileConnection(srcBundle, srcChan, dstBundle,
-                                              dstChan);
+  return targetModel.isLegalTileConnection(
+      tile.colIndex(), tile.rowIndex(), srcBundle, srcChan, dstBundle, dstChan);
 }
 
-bool isLegalMemtileConnection(const AIETargetModel &targetModel,
-                              ConnectOp connectOp) {
+bool isLegalTileConnection(TileOp tile, const AIETargetModel &targetModel,
+                           ConnectOp connectOp) {
   auto srcBundle = connectOp.getSourceBundle();
   auto srcChan = connectOp.getSourceChannel();
   auto dstBundle = connectOp.getDestBundle();
   auto dstChan = connectOp.getDestChannel();
-  return targetModel.isLegalMemtileConnection(srcBundle, srcChan, dstBundle,
-                                              dstChan);
+  return targetModel.isLegalTileConnection(
+      tile.colIndex(), tile.rowIndex(), srcBundle, srcChan, dstBundle, dstChan);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1712,20 +1712,9 @@ LogicalResult SwitchboxOp::verify() {
               .failed())
         return failure();
 
-      // Memtile stream switch connection constraints
-      if (tile.isMemTile() && !isLegalMemtileConnection(targetModel, connectOp))
-        return connectOp.emitOpError(
-            "illegal memtile stream switch connection");
-
-      // Trace stream switch connection constraints
-      if (connectOp.getDestBundle() == WireBundle::Trace)
-        return connectOp.emitOpError("Trace port cannot be a destination");
-
-      if (connectOp.getSourceBundle() == WireBundle::Trace &&
-          !targetModel.isValidTraceMaster(tile.getCol(), tile.getRow(),
-                                          connectOp.getDestBundle(),
-                                          connectOp.getDestChannel()))
-        return connectOp.emitOpError("illegal Trace destination");
+      // Stream switch connection constraints
+      if (!isLegalTileConnection(tile, targetModel, connectOp))
+        return connectOp.emitOpError("illegal stream switch connection");
 
     } else if (auto connectOp = dyn_cast<MasterSetOp>(ops)) {
       Port dest = {connectOp.getDestBundle(), connectOp.destIndex()};
@@ -1770,20 +1759,10 @@ LogicalResult SwitchboxOp::verify() {
           mstrs.push_back(m);
       }
       for (auto m : mstrs) {
-        // Trace stream switch connection constraints
-        if (m.destPort().bundle == WireBundle::Trace)
-          return connectOp.emitOpError("Trace port cannot be a destination");
         for (auto s : slvs) {
-          if (s.sourcePort().bundle == WireBundle::Trace &&
-              !targetModel.isValidTraceMaster(tile.getCol(), tile.getRow(),
-                                              m.destPort().bundle,
-                                              m.destPort().channel))
-            return amselOp.emitOpError("illegal Trace destination");
-
-          // Memtile stream switch connection constraints
-          if (tile.isMemTile() && !isLegalMemtileConnection(targetModel, m, s))
-            return amselOp->emitOpError(
-                "illegal memtile stream switch connection");
+          // Stream switch connection constraints
+          if (!isLegalTileConnection(tile, targetModel, m, s))
+            return amselOp->emitOpError("illegal stream switch connection");
         }
       }
     } else if (isa<EndOp>(ops)) {

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -257,10 +257,34 @@ AIE1TargetModel::getNumSourceShimMuxConnections(int col, int row,
   return 0;
 }
 
-bool AIE1TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
-                                               int srcChan,
-                                               WireBundle dstBundle,
-                                               int dstChan) const {
+bool AIE1TargetModel::isLegalTileConnection(int col, int row,
+                                            WireBundle srcBundle, int srcChan,
+                                            WireBundle dstBundle,
+                                            int dstChan) const {
+  // Check Channel Id within the range
+  if (srcChan >= int(getNumSourceSwitchboxConnections(col, row, srcBundle)))
+    return false;
+  if (dstChan >= int(getNumDestSwitchboxConnections(col, row, dstBundle)))
+    return false;
+
+  // Memtile
+  if (isMemTile(col, row)) {
+    return false;
+  }
+  // Shimtile
+  else if (isShimNOCorPLTile(col, row)) {
+    if (srcBundle == WireBundle::Trace)
+      return dstBundle == WireBundle::South;
+    else
+      return true;
+  }
+  // Coretile
+  else if (isCoreTile(col, row)) {
+    if (srcBundle == WireBundle::Trace)
+      return dstBundle == WireBundle::South;
+    else
+      return true;
+  }
   return false;
 }
 
@@ -530,29 +554,95 @@ AIE2TargetModel::getNumSourceShimMuxConnections(int col, int row,
   return 0;
 }
 
-bool AIE2TargetModel::isLegalMemtileConnection(WireBundle srcBundle,
-                                               int srcChan,
-                                               WireBundle dstBundle,
-                                               int dstChan) const {
-  // Memtile north-south stream switch constraint
-  // Memtile stream interconnect master South and slave North must have equal
-  // channel indices
-  if (srcBundle == WireBundle::North && dstBundle == WireBundle::South &&
-      srcChan != dstChan)
+bool AIE2TargetModel::isLegalTileConnection(int col, int row,
+                                            WireBundle srcBundle, int srcChan,
+                                            WireBundle dstBundle,
+                                            int dstChan) const {
+  // Check Channel Id within the range
+  if (srcChan >= int(getNumSourceSwitchboxConnections(col, row, srcBundle)))
     return false;
-  if (srcBundle == WireBundle::South && dstBundle == WireBundle::North &&
-      srcChan != dstChan)
+  if (dstChan >= int(getNumDestSwitchboxConnections(col, row, dstBundle)))
     return false;
-  // Memtile has no east or west connections
-  if (srcBundle == WireBundle::East)
-    return false;
-  if (srcBundle == WireBundle::West)
-    return false;
-  if (dstBundle == WireBundle::East)
-    return false;
-  if (dstBundle == WireBundle::West)
-    return false;
-  return true;
+
+  // Lambda function to check if a bundle is in a list
+  auto isBundleInList = [](WireBundle bundle,
+                           std::initializer_list<WireBundle> bundles) {
+    return std::find(bundles.begin(), bundles.end(), bundle) != bundles.end();
+  };
+
+  // Memtile
+  if (isMemTile(col, row)) {
+    if (srcBundle == WireBundle::DMA) {
+      if (dstBundle == WireBundle::DMA)
+        return srcChan == dstChan;
+      if (isBundleInList(dstBundle, {WireBundle::Ctrl, WireBundle::South,
+                                     WireBundle::North}))
+        return true;
+    }
+    if (srcBundle == WireBundle::Ctrl) {
+      if (dstBundle == WireBundle::DMA)
+        return dstChan == 5;
+      if (isBundleInList(dstBundle, {WireBundle::South, WireBundle::North}))
+        return true;
+    }
+    if (isBundleInList(srcBundle, {WireBundle::South, WireBundle::North})) {
+      if (isBundleInList(dstBundle, {WireBundle::DMA, WireBundle::Ctrl}))
+        return true;
+      if (isBundleInList(dstBundle, {WireBundle::South, WireBundle::North}))
+        return srcChan == dstChan;
+    }
+    if (srcBundle == WireBundle::Trace) {
+      if (dstBundle == WireBundle::DMA)
+        return dstChan == 5;
+      if (dstBundle == WireBundle::South)
+        return true;
+    }
+  }
+  // Shimtile
+  else if (isShimNOCorPLTile(col, row)) {
+    if (srcBundle == WireBundle::Ctrl)
+      return dstBundle != WireBundle::Ctrl;
+    if (isBundleInList(srcBundle, {WireBundle::FIFO, WireBundle::South}))
+      return isBundleInList(dstBundle, {WireBundle::Ctrl, WireBundle::FIFO,
+                                        WireBundle::South, WireBundle::West,
+                                        WireBundle::North, WireBundle::East});
+    if (isBundleInList(srcBundle,
+                       {WireBundle::West, WireBundle::North, WireBundle::East}))
+      return (srcBundle == dstBundle)
+                 ? (srcChan == dstChan)
+                 : isBundleInList(dstBundle,
+                                  {WireBundle::Ctrl, WireBundle::FIFO,
+                                   WireBundle::South, WireBundle::West,
+                                   WireBundle::North, WireBundle::East});
+    if (srcBundle == WireBundle::Trace) {
+      if (isBundleInList(dstBundle, {WireBundle::FIFO, WireBundle::South}))
+        return true;
+      if (isBundleInList(dstBundle, {WireBundle::West, WireBundle::East}))
+        return dstChan == 0;
+    }
+  }
+  // Coretile
+  else if (isCoreTile(col, row)) {
+    if (isBundleInList(srcBundle,
+                       {WireBundle::DMA, WireBundle::FIFO, WireBundle::South,
+                        WireBundle::West, WireBundle::North, WireBundle::East}))
+      if (isBundleInList(dstBundle,
+                         {WireBundle::Core, WireBundle::DMA, WireBundle::Ctrl,
+                          WireBundle::FIFO, WireBundle::South, WireBundle::West,
+                          WireBundle::North, WireBundle::East}))
+        return (srcBundle == dstBundle) ? (srcChan == dstChan) : true;
+    if (srcBundle == WireBundle::Core)
+      return dstBundle != WireBundle::Core;
+    if (srcBundle == WireBundle::Ctrl)
+      return dstBundle != WireBundle::Ctrl && dstBundle != WireBundle::DMA;
+    if (srcBundle == WireBundle::Trace) {
+      if (dstBundle == WireBundle::DMA)
+        return dstChan == 0;
+      if (isBundleInList(dstBundle, {WireBundle::FIFO, WireBundle::South}))
+        return true;
+    }
+  }
+  return false;
 }
 
 void AIETargetModel::validate() const {
@@ -611,28 +701,6 @@ void AIETargetModel::validate() const {
     for (int j = 0; j < columns(); j++)
       assert(getNumSourceSwitchboxConnections(j, i, WireBundle::FIFO) ==
              getNumDestSwitchboxConnections(j, i, WireBundle::FIFO));
-}
-
-bool BaseNPUTargetModel::isValidTraceMaster(int col, int row,
-                                            WireBundle destBundle,
-                                            int destIndex) const {
-  if (isCoreTile(col, row) && destBundle == WireBundle::South)
-    return true;
-  if (isCoreTile(col, row) && destBundle == WireBundle::DMA && destIndex == 0)
-    return true;
-  if (isMemTile(col, row) && destBundle == WireBundle::South)
-    return true;
-  if (isMemTile(col, row) && destBundle == WireBundle::DMA && destIndex == 5)
-    return true;
-  if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::South)
-    return true;
-  if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::West &&
-      destIndex == 0)
-    return true;
-  if (isShimNOCorPLTile(col, row) && destBundle == WireBundle::East &&
-      destIndex == 0)
-    return true;
-  return false;
 }
 
 } // namespace AIE

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -928,9 +928,10 @@ void AIEPathfinderPass::runOnOperation() {
       // Constraint: memtile stream switch constraints
       if (auto tile = sw.getTileOp();
           tile.isMemTile() &&
-          !targetModel.isLegalMemtileConnection(
-              connect.getSourceBundle(), connect.getSourceChannel(),
-              connect.getDestBundle(), connect.getDestChannel())) {
+          !targetModel.isLegalTileConnection(
+              tile.colIndex(), tile.rowIndex(), connect.getSourceBundle(),
+              connect.getSourceChannel(), connect.getDestBundle(),
+              connect.getDestChannel())) {
         problemConnects.push_back(
             {sw, connect.sourcePort(), connect.destPort()});
       }
@@ -952,9 +953,10 @@ void AIEPathfinderPass::runOnOperation() {
         for (auto s : slvs) {
           if (auto tile = sw.getTileOp();
               tile.isMemTile() &&
-              !targetModel.isLegalMemtileConnection(
-                  s.sourcePort().bundle, s.sourcePort().channel,
-                  m.destPort().bundle, m.destPort().channel))
+              !targetModel.isLegalTileConnection(
+                  tile.colIndex(), tile.rowIndex(), s.sourcePort().bundle,
+                  s.sourcePort().channel, m.destPort().bundle,
+                  m.destPort().channel))
             problemConnects.push_back({sw, s.sourcePort(), m.destPort()});
         }
       }

--- a/test/dialect/AIE/badmemtile_circ_sw.mlir
+++ b/test/dialect/AIE/badmemtile_circ_sw.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal memtile stream switch connection
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %01 = aie.tile(0, 1)

--- a/test/dialect/AIE/badmemtile_pkt_sw.mlir
+++ b/test/dialect/AIE/badmemtile_pkt_sw.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.amsel' op illegal memtile stream switch connection
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %01 = aie.tile(0, 1)

--- a/test/dialect/AIE/badtrace_core-vc1902.mlir
+++ b/test/dialect/AIE/badtrace_core-vc1902.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcvc1902) {
   %01 = aie.tile(0, 3)
@@ -20,7 +20,7 @@ aie.device(xcvc1902) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcvc1902) {
   %02 = aie.tile(0, 3)

--- a/test/dialect/AIE/badtrace_core-ve2302.mlir
+++ b/test/dialect/AIE/badtrace_core-ve2302.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcve2302) {
   %01 = aie.tile(0, 3)
@@ -20,7 +20,7 @@ aie.device(xcve2302) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcve2302) {
   %02 = aie.tile(0, 3)

--- a/test/dialect/AIE/badtrace_core-ve2802.mlir
+++ b/test/dialect/AIE/badtrace_core-ve2802.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %01 = aie.tile(0, 3)
@@ -20,7 +20,7 @@ aie.device(xcve2802) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %02 = aie.tile(0, 3)

--- a/test/dialect/AIE/badtrace_memtile-ve2302.mlir
+++ b/test/dialect/AIE/badtrace_memtile-ve2302.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcve2302) {
   %01 = aie.tile(0, 1)
@@ -20,7 +20,7 @@ aie.device(xcve2302) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcve2302) {
   %02 = aie.tile(0, 1)

--- a/test/dialect/AIE/badtrace_memtile-ve2802.mlir
+++ b/test/dialect/AIE/badtrace_memtile-ve2802.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %01 = aie.tile(2, 1)
@@ -20,7 +20,7 @@ aie.device(xcve2802) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %02 = aie.tile(0, 1)

--- a/test/dialect/AIE/badtrace_shim-vc1902.mlir
+++ b/test/dialect/AIE/badtrace_shim-vc1902.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcvc1902) {
   %01 = aie.tile(2, 0)
@@ -20,7 +20,7 @@ aie.device(xcvc1902) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcvc1902) {
   %02 = aie.tile(1, 0)

--- a/test/dialect/AIE/badtrace_shim-ve2302.mlir
+++ b/test/dialect/AIE/badtrace_shim-ve2302.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcve2302) {
   %01 = aie.tile(2, 0)
@@ -20,7 +20,7 @@ aie.device(xcve2302) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcve2302) {
   %02 = aie.tile(1, 0)

--- a/test/dialect/AIE/badtrace_shim-ve2802.mlir
+++ b/test/dialect/AIE/badtrace_shim-ve2802.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: not aie-opt -split-input-file %s 2>&1 | FileCheck %s
-// CHECK: error{{.*}} 'aie.connect' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.connect' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %01 = aie.tile(2, 0)
@@ -20,7 +20,7 @@ aie.device(xcve2802) {
 
 // -----
 
-// CHECK: error{{.*}} 'aie.amsel' op illegal Trace destination
+// CHECK: error{{.*}} 'aie.amsel' op illegal stream switch connection
 
 aie.device(xcve2802) {
   %02 = aie.tile(1, 0)

--- a/test/dialect/AIE/switchbox-ve2802.mlir
+++ b/test/dialect/AIE/switchbox-ve2802.mlir
@@ -83,7 +83,6 @@ module {
     %01 = aie.tile(0, 1) // mem tile
     aie.switchbox(%01) {
       aie.connect<South: 0, South: 0> // Feedback OK
-      aie.connect<South: 0, South: 2> // Bounce OK
       aie.connect<DMA: 5, North: 1>  // 5 DMA connections
       aie.connect<South: 5, North: 5> // 6 northgoing connections
       aie.connect<North: 3, South: 3> // 4 southgoing connections
@@ -95,7 +94,6 @@ module {
     %03 = aie.tile(1, 3) // core tile
     aie.switchbox(%03) {
       aie.connect<East: 0, East: 0> // Feedback OK
-      aie.connect<South: 0, South: 2> // Bounce OK
       aie.connect<DMA: 1, East: 1>  // Two DMA connections
       aie.connect<Core: 0, East: 2> // One core connections
       aie.connect<FIFO: 0, West: 2> // One fifo connections

--- a/test/unit_tests/aie/21_shim_dma_packet/aie.mlir
+++ b/test/unit_tests/aie/21_shim_dma_packet/aie.mlir
@@ -22,7 +22,7 @@ module @kernel_gemm  {
   %4 = aie.switchbox(%3)  {
     %43 = aie.amsel<0> (0)
     %44 = aie.masterset(West : 0, %43)
-    aie.packet_rules(DMA : 0)  {
+    aie.packet_rules(South : 0)  {
       aie.rule(31, 2, %43)
     }
   }
@@ -44,7 +44,7 @@ module @kernel_gemm  {
   %10 = aie.switchbox(%9)  {
     %43 = aie.amsel<0> (0)
     %44 = aie.masterset(West : 0, %43)
-    aie.packet_rules(DMA : 1)  {
+    aie.packet_rules(South : 1)  {
       aie.rule(31, 3, %43)
     }
     aie.packet_rules(East : 0)  {


### PR DESCRIPTION
merge `isValidTraceMaster`, `isLegalMemtileConnection` into one function, and add other connectivity constraints according to the hardware spec. related to #1567 