### PR TITLE
Add Support for Index Dialect

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -554,6 +555,7 @@ struct AIECoreToStandardPass : AIECoreToStandardBase<AIECoreToStandardPass> {
     target.addLegalDialect<VectorDialect>();
     target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<math::MathDialect>();
+    target.addLegalDialect<index::IndexDialect>();
     target.addLegalOp<func::FuncOp, ModuleOp>();
 
     RewritePatternSet patterns(&getContext());

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Attributes.h"
@@ -82,6 +83,7 @@ static void registerDialects(DialectRegistry &registry) {
   registry.insert<VectorDialect>();
   registry.insert<LLVM::LLVMDialect>();
   registry.insert<emitc::EmitCDialect>();
+  registry.insert<index::IndexDialect>();
 }
 
 // Output the buffer map for the given buffer operations, with the given offset.

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -63,6 +63,8 @@ LOWER_TO_LLVM_PIPELINE = (
     .expand_strided_metadata()
     .lower_affine()
     .convert_math_to_llvm()
+    .convert_index_to_llvm()
+    .arith_expand()
     .convert_arith_to_llvm()
     .finalize_memref_to_llvm()
     .convert_func_to_llvm(use_bare_ptr_memref_call_conv=True)


### PR DESCRIPTION
Allows us to use the `index` dialect.

This is useful for, e.g., calculating loop bounds dynamically at runtime with run-time parameters (this is my use case).