### PR TITLE
Temporarily Remove Failing Test

### DIFF
--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
@@ -1,9 +1,0 @@
-// (c) Copyright 2024 Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-// REQUIRES: ryzen_ai, chess
-//
-// RUN: make -f %S/Makefile clean
-// RUN: env n_aie_cols=1 make -f %S/Makefile 
-// RUN: %run_on_npu env n_aie_cols=1 make -f %S/Makefile run | FileCheck %s
-// CHECK: PASS!


### PR DESCRIPTION
We merged #1598 yesterday, which added a test for a 1-column matrix multiplication design. It appears the tolerances are too low, and the test only passes sometimes.

Until we rewrite that test to either use i16 or increased tolerance, let's remove it so the CI tests can pass.
