### PR TITLE
Avoid test conflicts between peano and chess

### DIFF
--- a/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
+++ b/aie_runtime_lib/AIE/chess_intrinsic_wrapper.cpp
@@ -25,3 +25,12 @@ extern "C" void llvm___aie___lock___acquire___reg(unsigned id, unsigned val) {
 extern "C" void llvm___aie___lock___release___reg(unsigned id, unsigned val) {
   release(id, val);
 }
+
+extern "C" int llvm___aie___get___ss(int stream) { return get_ss(stream); }
+extern "C" float llvm___aie___getf___ss(int stream) { return getf_ss(stream); }
+extern "C" int llvm___aie___get___ss0___tlast() { return get_ss0_tlast(); }
+extern "C" int llvm___aie___get___ss1___tlast() { return get_ss1_tlast(); }
+extern "C" int llvm___aie___get___wss0___tlast() { return get_wss0_tlast(); }
+extern "C" int llvm___aie___get___wss1___tlast() { return get_wss1_tlast(); }
+extern "C" void llvm___aie___put___ms(int idx_ms, int a) { put_ms(idx_ms, a); }
+//extern "C" void llvm___aie___put___ms___tlast(int idx_ms, int a, int tlast) { put_ms(idx_ms, a, tlast); }

--- a/test/unit_tests/aie/31_stream_core/aie.mlir
+++ b/test/unit_tests/aie/31_stream_core/aie.mlir
@@ -8,11 +8,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: peano, !hsa
+// REQUIRES: !hsa
 
 // RUN: %PYTHON aiecc.py --aiesim --no-xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
-// RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 
 // CHECK: test start.
 // CHECK: PASS!

--- a/test/unit_tests/chess_compiler_tests/00_itsalive/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/00_itsalive/aie.mlir
@@ -9,13 +9,15 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
 // RUN: %PYTHON aiecc.py --no-unified --xchesscc    --xbridge %s
 // RUN: %PYTHON aiecc.py --unified    --xchesscc    --xbridge %s
-// RUN: %PYTHON aiecc.py --no-unified --no-xchesscc --xbridge %s
-// RUN: %PYTHON aiecc.py --unified    --no-xchesscc --xbridge %s
-// RUN: %PYTHON aiecc.py --no-unified --xchesscc    --no-xbridge %s
-// RUN: %PYTHON aiecc.py --unified    --xchesscc    --no-xbridge %s
+
+// These cases mix chess and peano, which is not supported.
+// DONTREQUIRES: peano
+// DONTRUN: %PYTHON aiecc.py --no-unified --no-xchesscc --xbridge %s
+// DONTRUN: %PYTHON aiecc.py --unified    --no-xchesscc --xbridge %s
+// DONTRUN: %PYTHON aiecc.py --no-unified --xchesscc    --no-xbridge %s
+// DONTRUN: %PYTHON aiecc.py --unified    --xchesscc    --no-xbridge %s
 
 module @test00_itsalive {
   %tile12 = aie.tile(1, 2)

--- a/test/unit_tests/chess_compiler_tests_aie2/00_itsalive/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/00_itsalive/aie.mlir
@@ -9,13 +9,15 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
 // RUN: %PYTHON aiecc.py --no-unified --xchesscc    --xbridge %s
 // RUN: %PYTHON aiecc.py --unified    --xchesscc    --xbridge %s
-// RUN: %PYTHON aiecc.py --no-unified --no-xchesscc --xbridge %s
-// RUN: %PYTHON aiecc.py --unified    --no-xchesscc --xbridge %s
-// RUN: %PYTHON aiecc.py --no-unified --xchesscc    --no-xbridge %s
-// RUN: %PYTHON aiecc.py --unified    --xchesscc    --no-xbridge %s
+
+// These cases mix chess and peano, which is not supported.
+// DONTREQUIRES: peano
+// DONTRUN: %PYTHON aiecc.py --no-unified --no-xchesscc --xbridge %s
+// DONTRUN: %PYTHON aiecc.py --unified    --no-xchesscc --xbridge %s
+// DONTRUN: %PYTHON aiecc.py --no-unified --xchesscc    --no-xbridge %s
+// DONTRUN: %PYTHON aiecc.py --unified    --xchesscc    --no-xbridge %s
 
 module @test00_itsalive {
   aie.device(xcve2802) {


### PR DESCRIPTION
Basically there are two kinds of tests:
1) tests which can use either compiler
2) tests which specifically use one or the other

We need to be careful in the second case to not mix the two compilers.