### PR TITLE
Avoid aievec tests which mix chess and peano

### DIFF
--- a/test/unit_tests/aievec_tests/bf16_max_reduce/bf16_max_reduce-llvm.mlir
+++ b/test/unit_tests/aievec_tests/bf16_max_reduce/bf16_max_reduce-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/bf16xbf16_mul_elem-llvm-scalar.mlir
+++ b/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/bf16xbf16_mul_elem-llvm-scalar.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-generic-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/bf16xbf16_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/bf16xbf16_mul_elem/bf16xbf16_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/bf16xbf16_mul_elem_2/bf16xbf16_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/bf16xbf16_mul_elem_2/bf16xbf16_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/floatxfloat_mul_elem/floatxfloat_mul_elem-llvm-scalar.mlir
+++ b/test/unit_tests/aievec_tests/floatxfloat_mul_elem/floatxfloat_mul_elem-llvm-scalar.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-generic-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/floatxfloat_mul_elem/floatxfloat_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/floatxfloat_mul_elem/floatxfloat_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem-llvm-scalar.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem-llvm-scalar.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-generic-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem/i16xi16_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem-llvm-scalar.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem-llvm-scalar.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-generic-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/i16xi16_mul_elem_2/i16xi16_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem-llvm-scalar.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem-llvm-scalar.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-generic-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/i32xi32_mul_elem/i32xi32_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=16" %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem-llvm-scalar.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem-llvm-scalar.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-generic-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem/i8xi8_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem-llvm-scalar.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem-llvm-scalar.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s %vector-to-generic-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll

--- a/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem-llvm.mlir
+++ b/test/unit_tests/aievec_tests/i8xi8_mul_elem_2/i8xi8_mul_elem-llvm.mlir
@@ -2,7 +2,7 @@
 // Copyright (C) 2023, Advanced Micro Devices, Inc.
 
 // REQUIRES: valid_xchess_license
-// REQUIRES: peano
+// REQUIRES: peano, peano_and_chess
 // RUN: mkdir -p %t/data; cd %t
 // RUN: aie-opt %s -affine-super-vectorize="virtual-vector-size=32" %vector-to-llvmir% -o llvmir.mlir
 // RUN: aie-translate llvmir.mlir %llvmir-to-ll% -o dut.ll


### PR DESCRIPTION
These tests are not supported, even when chess and peano are both available.