### PR TITLE
Adding XFAIL to multi_depth object fifo test until test is fixed.

### DIFF
--- a/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
@@ -11,7 +11,7 @@
 // RUN: %PYTHON aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s -I%host_runtime_lib%/test_lib/include %extraAieCcFlags% -L%host_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf
 // RUN: %run_on_vck5000 ./test.elf
 
-// XFAIL: *
+// UNSUPPORTED: *
 
 module @multi_depth {
     aie.device(xcvc1902) {

--- a/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
+++ b/test/unit_tests/aie/28_multidepth_objectFifos/multi_depth/aie.mlir
@@ -11,6 +11,8 @@
 // RUN: %PYTHON aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s -I%host_runtime_lib%/test_lib/include %extraAieCcFlags% -L%host_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf
 // RUN: %run_on_vck5000 ./test.elf
 
+// XFAIL: *
+
 module @multi_depth {
     aie.device(xcvc1902) {
         %tile20 = aie.tile(2, 0)


### PR DESCRIPTION
Related to https://github.com/Xilinx/mlir-aie/issues/1556 