### PR TITLE
Add aiex.npu.blockwrite operation

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -683,6 +683,22 @@ def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", []> {
   }];
 }
 
+// BLOCKWRITE
+def AIE_NpuBlockWriteOp: AIEX_Op<"npu.blockwrite", []> {
+  let summary = "blockwrite operator";
+  let arguments = (
+    ins AnyMemRef:$data,
+        UI32Attr:$address
+  );
+  let results = (outs );
+  let assemblyFormat = [{
+    `(` $data `)` attr-dict `:` type($data)
+  }];
+  let description = [{
+    blockwrite operator
+  }];
+}
+
 // OP_SYNC
 def AIE_NpuSyncOp: AIEX_Op<"npu.sync", []> {
   let summary = "sync operator";

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -104,66 +104,50 @@ void appendAddressPatch(std::vector<uint32_t> &instructions,
   words[11] = 0;
 }
 
-void appendWriteBdShimTile(std::vector<uint32_t> &instructions,
-                           NpuWriteBdOp op) {
+void appendBlockWrite(std::vector<uint32_t> &instructions, NpuBlockWriteOp op) {
 
-  auto words = reserveAndGetTail(instructions, 12);
-  const AIETargetModel &tm = op->getParentOfType<DeviceOp>().getTargetModel();
+  Value memref = op.getData();
+  int64_t width = cast<MemRefType>(memref.getType()).getElementTypeBitWidth();
+  if (width != 32) {
+    op.emitWarning("Only 32-bit data type is supported for now");
+    return;
+  }
+
+  memref::GetGlobalOp getGlobal = memref.getDefiningOp<memref::GetGlobalOp>();
+  if (!getGlobal) {
+    op.emitError("Only MemRefs from memref.get_global are supported");
+    return;
+  }
+
+  auto global = dyn_cast_if_present<memref::GlobalOp>(
+      op->getParentOfType<AIE::DeviceOp>().lookupSymbol(getGlobal.getName()));
+  if (!global) {
+    op.emitError("Global symbol not found");
+    return;
+  }
+
+  auto initVal = global.getInitialValue();
+  if (!initVal) {
+    op.emitError("Global symbol has no initial value");
+    return;
+  }
+
+  auto data = dyn_cast<DenseIntElementsAttr>(*initVal);
+  if (!data) {
+    op.emitError("Global symbol initial value is not a dense int array");
+    return;
+  }
 
   // XAIE_IO_BLOCKWRITE
+  auto words = reserveAndGetTail(instructions, data.size() + 4);
   words[0] = TXN_OPC_BLOCKWRITE;
   words[1] = 0;
-
-  // RegOff
-  auto bd_id = op.getBdId();
-  uint32_t bd_addr = (op.getColumn() << tm.getColumnShift()) |
-                     (op.getRow() << tm.getRowShift()) |
-                     (0x1D000 + bd_id * 0x20);
-  words[2] = bd_addr;                         // ADDR
+  words[2] = op.getAddress();
   words[3] = words.size() * sizeof(uint32_t); // Operation Size
 
-  // DMA_BDX_0
-  words[4] = op.getBufferLength();
-
-  // DMA_BDX_1
-  words[5] = op.getBufferOffset();
-
-  // DMA_BDX_2
-  // En Packet , OoO BD ID , Packet ID , Packet Type
-  words[6] |= (op.getEnablePacket() & 0x1) << 30;
-  words[6] |= (op.getOutOfOrderId() & 0x3f) << 24;
-  words[6] |= (op.getPacketId() & 0x1f) << 19;
-  words[6] |= (op.getPacketType() & 0x7) << 16;
-
-  // DMA_BDX_3
-  // TODO: Secure Access
-  words[7] |= (op.getD0Size() & 0x3ff) << 20;
-  words[7] |= op.getD0Stride() & 0xfffff;
-
-  // DMA_BDX_4
-  words[8] = 0x80000000; // burst length;
-  words[8] |= (op.getD1Size() & 0x3ff) << 20;
-  words[8] |= op.getD1Stride() & 0xfffff;
-
-  // DMA_BDX_5
-  // TODO: SIMID, AxCache, AXQoS
-  words[9] = op.getD2Stride() & 0xfffff;
-
-  // DMA_BDX_6
-  words[10] |= (op.getIterationCurrent() & 0x3f) << 26;
-  words[10] |= (op.getIterationSize() & 0x3f) << 20;
-  words[10] |= op.getIterationStride() & 0xfffff;
-
-  // DMA_BDX_7
-  // TODO: TLAST Suppress
-  words[11] |= (op.getNextBd() & 0xf) << 27;
-  words[11] |= (op.getUseNextBd() & 0x1) << 26;
-  words[11] |= (op.getValidBd() & 0x1) << 25;
-  words[11] |= (op.getLockRelVal() & 0xef) << 18;
-  words[11] |= (op.getLockRelId() & 0xf) << 13;
-  words[11] |= (op.getLockAcqEnable() & 0x1) << 12;
-  words[11] |= (op.getLockAcqVal() & 0xef) << 5;
-  words[11] |= op.getLockAcqId() & 0xf;
+  unsigned i = 4;
+  for (auto d : data)
+    words[i++] = d.getZExtValue();
 }
 
 } // namespace
@@ -195,13 +179,13 @@ std::vector<uint32_t> xilinx::AIE::AIETranslateToNPU(ModuleOp module) {
             count++;
             appendWrite32(instructions, op);
           })
+          .Case<NpuBlockWriteOp>([&](auto op) {
+            count++;
+            appendBlockWrite(instructions, op);
+          })
           .Case<NpuAddressPatchOp>([&](auto op) {
             count++;
             appendAddressPatch(instructions, op);
-          })
-          .Case<NpuWriteBdOp>([&](auto op) {
-            count++;
-            appendWriteBdShimTile(instructions, op);
           });
     }
   }

--- a/test/Conversion/DmaToNpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToNpu/aiert_insts.mlir
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
-// CHECK: aiex.npu.writebd {bd_id = 1 : i32, buffer_length = 32 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+// CHECK: aiex.npu.blockwrite(%{{.*}}) {address = 118816 : ui32} : memref<8xi32>
 // CHECK: aiex.npu.write32 {address = 119300 : ui32, column = 0 : i32, row = 0 : i32, value = 2147483649 : ui32}
-// CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 32 : i32, buffer_offset = 128 : i32, column = 0 : i32, d0_size = 8 : i32, d0_stride = 0 : i32, d1_size = 2 : i32, d1_stride = 7 : i32, d2_stride = 15 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+// CHECK: aiex.npu.blockwrite(%{{.*}}) {address = 118784 : ui32} : memref<8xi32>
 // CHECK: aiex.npu.write32 {address = 119316 : ui32, column = 0 : i32, row = 0 : i32, value = 0 : ui32}
 
 module {
@@ -24,8 +24,8 @@ module {
       %c8 = arith.constant 8 : i64
       %c16 = arith.constant 16 : i64
       %c32 = arith.constant 32 : i64
-      aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0, %c1]) { metadata = @of_toMem, id = 1 : i64 } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8, %c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<4x2x8xi32>
+      aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0, %c1]) { metadata = @of_toMem, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8, %c1]) { metadata = @of_fromMem, id = 0 : i64, issue_token = false } : memref<4x2x8xi32>
       return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -12,11 +12,10 @@
 
 // TODO - more
 // CHECK-LABEL: dma_memcpy_nd_0
-// CHECK: aiex.npu.writebd
-// CHECK-SAME: valid_bd = 1 : i32
+// CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
-// CHECK: aiex.npu.writebd
+// CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 1 : i32
 module  {
@@ -36,11 +35,11 @@ module  {
 // -----
 
 // CHECK-LABEL: dma_wait_s2mm
-// CHECK: aiex.npu.writebd
-// CHECK-SAME: valid_bd = 1 : i32
+// CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
 // CHECK: aiex.npu.write32
+// CHECK-SAME: value = 2147483649
 // CHECK: aiex.npu.sync 
 // CHECK-SAME: channel = 0 : i32
 // CHECK-SAME: column = 0 : i32
@@ -52,7 +51,7 @@ module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
     func.func @dma_wait_s2mm(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
       return
     }
@@ -63,11 +62,11 @@ module  {
 // -----
 
 // CHECK-LABEL: dma_wait_mm2s
-// CHECK: aiex.npu.writebd
-// CHECK-SAME: valid_bd = 1 : i32
+// CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
 // CHECK: aiex.npu.write32
+// CHECK-SAME: value = 2147483649
 // CHECK: aiex.npu.sync 
 // CHECK-SAME: channel = 1 : i32
 // CHECK-SAME: column = 1 : i32
@@ -79,7 +78,7 @@ module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
     func.func @dma_wait_mm2s(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
       return
     }

--- a/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
@@ -12,13 +12,12 @@
 
 // TODO - more
 // CHECK-LABEL: test1
-// CHECK: aiex.npu.writebd
-// CHECK-SAME: valid_bd = 1 : i32
+// CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
 // CHECK: aiex.npu.write32
 // CHECK-SAME: value = 2147483649
-// CHECK: aiex.npu.writebd
+// CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 1 : i32
 // CHECK: aiex.npu.write32
@@ -29,7 +28,7 @@ module  {
     memref.global "public" @fromMem : memref<16xi32>
     func.func @test1(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
         aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64, issue_token = true } : memref<16xi32>
-        aiex.npu.dma_memcpy_nd (0, 1, %arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
+        aiex.npu.dma_memcpy_nd (0, 1, %arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64, issue_token = false } : memref<16xi32>
         return
     }
     aie.shim_dma_allocation @fromMem (MM2S, 0, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
@@ -14,7 +14,7 @@
 
 // CHECK-LABEL:  aie.device(xcve2302) {
 // CHECK:  memref.global "public" @toMem : memref<65536xbf16>
-// CHECK:  memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, 1140850815, 31, 0, 33554432]>
+// CHECK:  memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, -2080374657, 31, 0, 33554432]>
 // CHECK:  func.func @sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
 // CHECK:    %0 = memref.get_global @blockwrite_data_0 : memref<8xi32>
 // CHECK:    aiex.npu.blockwrite(%0) {address = 118784 : ui32} : memref<8xi32>

--- a/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
@@ -12,19 +12,17 @@
 
 // RUN: aie-opt --aie-dma-to-npu %s 2>&1 | FileCheck %s
 
-//CHECK-LABEL:  aie.device(xcve2302) {
-//CHECK:      memref.global "public" @toMem : memref<65536xbf16>
-//CHECK:      func.func @sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
-//CHECK:      aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 8192 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 32 : i32, d0_stride = 0 : i32, d1_size = 64 : i32, d1_stride = 127 : i32, d2_stride = 31 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-//CHECK:      aiex.npu.address_patch {addr = 118788 : ui32, arg_idx = 0 : i32, arg_plus = 0 : i32}
-//CHECK:      aiex.npu.write32 {address = 119300 : ui32, column = 0 : i32, row = 0 : i32, value = 2147680256 : ui32}
-//CHECK:      aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-//CHECK:      return
-//CHECK:    }
-//CHECK:    aie.shim_dma_allocation @toMem(S2MM, 0, 0)
-//CHECK:  }
-
-
+// CHECK-LABEL:  aie.device(xcve2302) {
+// CHECK:  memref.global "public" @toMem : memref<65536xbf16>
+// CHECK:  memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, 1140850815, 31, 0, 33554432]>
+// CHECK:  func.func @sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
+// CHECK:    %0 = memref.get_global @blockwrite_data_0 : memref<8xi32>
+// CHECK:    aiex.npu.blockwrite(%0) {address = 118784 : ui32} : memref<8xi32>
+// CHECK:    aiex.npu.address_patch {addr = 118788 : ui32, arg_idx = 0 : i32, arg_plus = 0 : i32}
+// CHECK:    aiex.npu.write32 {address = 119300 : ui32, column = 0 : i32, row = 0 : i32, value = 2147680256 : ui32}
+// CHECK:    aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
+// CHECK:    }
+// CHECK:    aie.shim_dma_allocation @toMem(S2MM, 0, 0)
 
 module @shimDmaMemcpy{
   aie.device(xcve2302) {

--- a/test/Targets/NPU/npu_instgen.mlir
+++ b/test/Targets/NPU/npu_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-npu-instgen %s | FileCheck %s
+// RUN: aie-opt --aie-dma-to-npu %s | aie-translate --aie-npu-instgen | FileCheck %s
 module {
   aie.device(npu1_4col) {
     func.func @test0(%arg0: memref<16xf32>, %arg1: memref<16xf32>) {


### PR DESCRIPTION
This PR:
* Adds `aiex.npu.blockwrite` operation corresponding to the txn op of the same name
* Adds `npu.writebd` to `npu.blockwrite` translation in `aie-dma-to-npu` pass. The pass now legalizes all `aiex.npu.*` ops into ops supported by the firmware: `write32`, `blockwrite`, `sync` and `address_patch`
* Removes `npu.writebd` translation from `aie-translate --aie-npu-instgen`; translation only handles the four firmware ops listed above

`npu.blockwrite` takes an address and a memref as operands. Currently only constant data is supported.
Example of a typical IR after legalization and before `aie-translate` (from generated_npu_insts.mlir in an aiecc project):
```mlir
    memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[64, 0, 0, 0, 1073741824, 0, 0, 33554432]>
    memref.global "private" constant @blockwrite_data_1 : memref<8xi32> = dense<[64, 0, 0, 0, 1073741824, 0, 0, 33554432]>
    func.func @sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
      %c0_i64 = arith.constant 0 : i64
      %c1_i64 = arith.constant 1 : i64
      %c64_i64 = arith.constant 64 : i64
      %0 = memref.get_global @blockwrite_data_0 : memref<8xi32>
      aiex.npu.blockwrite(%0) {address = 118816 : ui32} : memref<8xi32>
      aiex.npu.address_patch {addr = 118820 : ui32, arg_idx = 2 : i32, arg_plus = 0 : i32}
      aiex.npu.write32 {address = 119300 : ui32, column = 0 : i32, row = 0 : i32, value = 2147483649 : ui32}
      %1 = memref.get_global @blockwrite_data_1 : memref<8xi32>
      aiex.npu.blockwrite(%1) {address = 118784 : ui32} : memref<8xi32>
      aiex.npu.address_patch {addr = 118788 : ui32, arg_idx = 0 : i32, arg_plus = 0 : i32}
      aiex.npu.write32 {address = 119316 : ui32, column = 0 : i32, row = 0 : i32, value = 0 : ui32}
      aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
      return
    }
```