### PR TITLE
Rename `func.func @sequence` to its own op

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -20,6 +20,7 @@ include "mlir/IR/EnumAttr.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/CommonAttrConstraints.td"
 
 def AIEX_Dialect : Dialect {
   let name = "aiex";
@@ -463,9 +464,29 @@ def AIE_SelectOp: AIEX_Op<"select", []>, Results<(outs Index)> {
   ];
 }
 
+def AIE_RuntimeSequenceOp : AIEX_Op<"runtime_sequence", [NoTerminator, HasParent<"AIE::DeviceOp">]> {
+  let summary = "Program the configuration co-processor of the AI Engine array";
+  let description = [{
+    Instructions in this operation allow for runtime (re-)configuration of the AI Engine array, such as configuring data movement buffer descriptors.
+    These instructions will execute on the configuration co-processor of the AI Engine array.
+
+    Typically, these instructions include configuring the data transfers between host and AIE array on the shims.
+    The input arguments are arguments passed in from the host at kernel invocation time. This may include buffers on the host.
+  }];
+  let arguments = (ins
+    Variadic<AnyType>:$args
+  );
+  let regions = (region
+    AnyRegion:$body
+  );
+  let hasCustomAssemblyFormat = 1;
+  let hasVerifier = 1;
+}
+
 def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
     AttrSizedOperandSegments,
-    MyOffsetSizeAndStrideOpInterface
+    MyOffsetSizeAndStrideOpInterface,
+    HasParent<"RuntimeSequenceOp">
   ]> {
   let summary = "half DMA operator";
 
@@ -592,7 +613,7 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
   let hasVerifier = 1;
 }
 
-def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", []> {
+def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "Blocking operation to wait for a DMA to complete execution.";
   let description = [{
     The NpuDmaWaitOp blocks until the DMA referenced through `symbol` completes execution
@@ -626,7 +647,7 @@ def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", []> {
 }
 
 // Write RTP
-def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", []> {
+def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "rtp write operator";
   let arguments = (
     ins StrAttr:$buffer_sym_name,
@@ -644,7 +665,7 @@ def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", []> {
 }
 
 // Push BD to Queue
-def AIE_NpuPushQueueOp: AIEX_Op<"npu.push_queue", []> {
+def AIE_NpuPushQueueOp: AIEX_Op<"npu.push_queue", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "bd queue push operator";
   let arguments = (
     ins I32Attr:$column,
@@ -666,7 +687,7 @@ def AIE_NpuPushQueueOp: AIEX_Op<"npu.push_queue", []> {
 }
 
 // WRITE32
-def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", []> {
+def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "write32 operator";
   let arguments = (
     ins UI32Attr:$address,
@@ -700,7 +721,7 @@ def AIE_NpuBlockWriteOp: AIEX_Op<"npu.blockwrite", []> {
 }
 
 // OP_SYNC
-def AIE_NpuSyncOp: AIEX_Op<"npu.sync", []> {
+def AIE_NpuSyncOp: AIEX_Op<"npu.sync", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "sync operator";
   let arguments = (
     ins I32Attr:$column,
@@ -725,7 +746,7 @@ def AIE_NpuSyncOp: AIEX_Op<"npu.sync", []> {
 }
 
 // XAIE_IO_CUSTOM_OP_BEGIN + 1 (address patch)
-def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", []> {
+def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "address patch operator";
   let arguments = (
     ins UI32Attr:$addr,
@@ -742,7 +763,7 @@ def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", []> {
 }
 
 // NPU Bd Write operation
-def AIE_NpuWriteBdOp: AIEX_Op<"npu.writebd", []> {
+def AIE_NpuWriteBdOp: AIEX_Op<"npu.writebd", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "dma operator";
   let arguments = (
     ins I32Attr:$column,

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -485,8 +485,7 @@ def AIE_RuntimeSequenceOp : AIEX_Op<"runtime_sequence", [NoTerminator, HasParent
 
 def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
     AttrSizedOperandSegments,
-    MyOffsetSizeAndStrideOpInterface,
-    HasParent<"RuntimeSequenceOp">
+    MyOffsetSizeAndStrideOpInterface
   ]> {
   let summary = "half DMA operator";
 
@@ -613,7 +612,7 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
   let hasVerifier = 1;
 }
 
-def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", [HasParent<"RuntimeSequenceOp">]> {
+def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", []> {
   let summary = "Blocking operation to wait for a DMA to complete execution.";
   let description = [{
     The NpuDmaWaitOp blocks until the DMA referenced through `symbol` completes execution
@@ -647,7 +646,7 @@ def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", [HasParent<"RuntimeSequenceOp">]> 
 }
 
 // Write RTP
-def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", [HasParent<"RuntimeSequenceOp">]> {
+def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", []> {
   let summary = "rtp write operator";
   let arguments = (
     ins StrAttr:$buffer_sym_name,
@@ -665,7 +664,7 @@ def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", [HasParent<"RuntimeSequenceOp">]
 }
 
 // Push BD to Queue
-def AIE_NpuPushQueueOp: AIEX_Op<"npu.push_queue", [HasParent<"RuntimeSequenceOp">]> {
+def AIE_NpuPushQueueOp: AIEX_Op<"npu.push_queue", []> {
   let summary = "bd queue push operator";
   let arguments = (
     ins I32Attr:$column,
@@ -687,7 +686,7 @@ def AIE_NpuPushQueueOp: AIEX_Op<"npu.push_queue", [HasParent<"RuntimeSequenceOp"
 }
 
 // WRITE32
-def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", [HasParent<"RuntimeSequenceOp">]> {
+def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", []> {
   let summary = "write32 operator";
   let arguments = (
     ins UI32Attr:$address,
@@ -721,7 +720,7 @@ def AIE_NpuBlockWriteOp: AIEX_Op<"npu.blockwrite", []> {
 }
 
 // OP_SYNC
-def AIE_NpuSyncOp: AIEX_Op<"npu.sync", [HasParent<"RuntimeSequenceOp">]> {
+def AIE_NpuSyncOp: AIEX_Op<"npu.sync", []> {
   let summary = "sync operator";
   let arguments = (
     ins I32Attr:$column,
@@ -746,7 +745,7 @@ def AIE_NpuSyncOp: AIEX_Op<"npu.sync", [HasParent<"RuntimeSequenceOp">]> {
 }
 
 // XAIE_IO_CUSTOM_OP_BEGIN + 1 (address patch)
-def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", [HasParent<"RuntimeSequenceOp">]> {
+def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", []> {
   let summary = "address patch operator";
   let arguments = (
     ins UI32Attr:$addr,
@@ -763,7 +762,7 @@ def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", [HasParent<"RuntimeSeque
 }
 
 // NPU Bd Write operation
-def AIE_NpuWriteBdOp: AIEX_Op<"npu.writebd", [HasParent<"RuntimeSequenceOp">]> {
+def AIE_NpuWriteBdOp: AIEX_Op<"npu.writebd", []> {
   let summary = "dma operator";
   let arguments = (
     ins I32Attr:$column,

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -277,3 +277,71 @@ LogicalResult AIEX::NpuWriteBdOp::verify() {
     return emitOpError("Iteration Stride exceeds the [0:1M-1] range.");
   return success();
 }
+
+//===----------------------------------------------------------------------===//
+// RuntimeSequenceOp
+//===----------------------------------------------------------------------===//
+
+ParseResult AIEX::RuntimeSequenceOp::parse(OpAsmParser &parser,
+                                           OperationState &result) {
+  SmallVector<OpAsmParser::Argument> entryArgs;
+
+  // Entry arguments,  e.g. (%addr: memref<1xi32>)
+  ParseResult argParseResult = parser.parseCommaSeparatedList(
+      OpAsmParser::Delimiter::Paren, [&]() -> ParseResult {
+        OpAsmParser::Argument argument;
+        if (parser.parseArgument(argument, true, true)) {
+          return failure();
+        }
+        entryArgs.push_back(argument);
+        return success();
+      });
+  if (argParseResult) {
+    return argParseResult;
+  }
+
+  // Body
+  auto *body = result.addRegion();
+  ParseResult bodyParseResult = parser.parseRegion(*body, entryArgs, false);
+  if (bodyParseResult) {
+    return bodyParseResult;
+  }
+
+  return success();
+}
+
+void AIEX::RuntimeSequenceOp::print(OpAsmPrinter &printer) {
+  Region &body = getRegion();
+
+  printer << '(';
+  for (unsigned i = 0, n = body.getNumArguments(); i < n; i++) {
+    if (i > 0) {
+      printer << ", ";
+    }
+    printer.printRegionArgument(body.getArgument(i));
+  }
+  printer << ')';
+
+  printer << ' ';
+  printer.printRegion(body, false, true);
+}
+
+LogicalResult AIEX::RuntimeSequenceOp::verify() {
+  AIE::DeviceOp device = (*this)->getParentOfType<AIE::DeviceOp>();
+  if (!device) {
+    // this check is redudnant with the HasParent trait, but can't hurt
+    (*this)->emitOpError() << "must be inside AIE device operation.";
+    return failure();
+  }
+  auto seq_ops = device.getOps<AIEX::RuntimeSequenceOp>();
+  if (std::distance(seq_ops.begin(), seq_ops.end()) > 1) {
+    auto err = device.emitOpError()
+               << "Cannot have more than one runtime sequence per device.";
+    for (auto it = seq_ops.begin(); it != seq_ops.end(); ++it) {
+      AIEX::RuntimeSequenceOp seq_op = *it;
+      err.attachNote(seq_op.getLoc()) << "Sequence operation definition here.";
+    }
+    return failure();
+  }
+  return success();
+}

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -451,7 +451,7 @@ struct WriteBdToBlockWritePattern : OpConversionPattern<NpuWriteBdOp> {
     {
       OpBuilder::InsertionGuard guard(rewriter);
       std::string name = "blockwrite_data_";
-      rewriter.setInsertionPoint(op->getParentOfType<func::FuncOp>());
+      rewriter.setInsertionPoint(op->getParentOfType<AIEX::RuntimeSequenceOp>());
       int id = 0;
       while (dev.lookupSymbol(name + std::to_string(id)))
         id++;

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -12,7 +12,6 @@
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/DenseMap.h"
@@ -227,7 +226,11 @@ public:
     column = IntegerAttr::get(i32ty, col);
 
     // arg_idx
-    Block &entryBB = op->getParentOfType<func::FuncOp>().getBody().front();
+    AIEX::RuntimeSequenceOp seq_op =
+        op->getParentOfType<AIEX::RuntimeSequenceOp>();
+    assert(seq_op && "NpuDmaMemcpyNdOp must be inside a RuntimeSequenceOp; "
+                     "verify() should have ensured this.");
+    Block &entryBB = seq_op.getBody().front();
     int arg_idx = -1;
     for (int i = 0, e = entryBB.getNumArguments(); i < e; i++) {
       if (entryBB.getArgument(i) == memref) {

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -451,7 +451,8 @@ struct WriteBdToBlockWritePattern : OpConversionPattern<NpuWriteBdOp> {
     {
       OpBuilder::InsertionGuard guard(rewriter);
       std::string name = "blockwrite_data_";
-      rewriter.setInsertionPoint(op->getParentOfType<AIEX::RuntimeSequenceOp>());
+      rewriter.setInsertionPoint(
+          op->getParentOfType<AIEX::RuntimeSequenceOp>());
       int id = 0;
       while (dev.lookupSymbol(name + std::to_string(id)))
         id++;

--- a/lib/Targets/AIETargetHSA.cpp
+++ b/lib/Targets/AIETargetHSA.cpp
@@ -70,10 +70,10 @@ mlir::LogicalResult AIETranslateToHSA(ModuleOp module, raw_ostream &output) {
 
   // Getting the sequence function op which contains the instructions
   auto sequenceOps = targetOp.getOps<AIEX::RuntimeSequenceOp>();
-  if(sequenceOps.empty()) {
+  if (sequenceOps.empty()) {
     // If no sequenceOp then just return
     return success();
-  } else if(std::distance(sequenceOps.begin(), sequenceOps.end()) > 1) {
+  } else if (std::distance(sequenceOps.begin(), sequenceOps.end()) > 1) {
     return module.emitOpError("expected at most one sequence operation");
   }
   AIEX::RuntimeSequenceOp sequenceOp = *sequenceOps.begin();
@@ -90,7 +90,8 @@ mlir::LogicalResult AIETranslateToHSA(ModuleOp module, raw_ostream &output) {
   for (auto op : sequenceOp.getOps<NpuDmaMemcpyNdOp>()) {
     // Getting the IDs of the buffers
     auto memref = op.getMemref();
-    Block &entryBB = op->getParentOfType<AIEX::RuntimeSequenceOp>().getBody().front();
+    Block &entryBB =
+        op->getParentOfType<AIEX::RuntimeSequenceOp>().getBody().front();
     int arg_idx = -1;
     for (int i = 0, e = entryBB.getNumArguments(); i < e; i++) {
       if (entryBB.getArgument(i) == memref) {
@@ -155,7 +156,8 @@ mlir::LogicalResult AIETranslateToHSA(ModuleOp module, raw_ostream &output) {
 
     // Getting the ID of the buffer that we are using
     auto memref = op.getMemref();
-    Block &entryBB = op->getParentOfType<AIEX::RuntimeSequenceOp>().getBody().front();
+    Block &entryBB =
+        op->getParentOfType<AIEX::RuntimeSequenceOp>().getBody().front();
     int arg_idx = -1;
     for (int i = 0, e = entryBB.getNumArguments(); i < e; i++) {
       if (entryBB.getArgument(i) == memref) {

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -163,12 +163,10 @@ std::vector<uint32_t> xilinx::AIE::AIETranslateToNPU(ModuleOp module) {
   words[1] = 0x00000105;
 
   DeviceOp deviceOp = *module.getOps<DeviceOp>().begin();
-  auto funcOps = deviceOp.getOps<func::FuncOp>();
+  auto sequenceOps = deviceOp.getOps<AIEX::RuntimeSequenceOp>();
   int count = 0;
-  for (auto f : funcOps) {
-    if (f.isDeclaration())
-      continue;
-    Block &entry = f.getRegion().front();
+  for (auto f : sequenceOps) {
+    Block &entry = f.getBody().front();
     for (auto &o : entry) {
       llvm::TypeSwitch<Operation *>(&o)
           .Case<NpuSyncOp>([&](auto op) {

--- a/programming_examples/basic/dma_transpose/aie2.py
+++ b/programming_examples/basic/dma_transpose/aie2.py
@@ -51,7 +51,7 @@ def my_passthrough():
             # To/from AIE-array data movement
             tensor_ty = T.memref(N, T.i32())
 
-            @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
                 # The strides below are configured to read across all rows in the same column

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/README.md
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/README.md
@@ -17,7 +17,7 @@ In this design, one or multiple AI Engine compute cores (spread across hardware 
 ## Differences from the [Whole-Array Matrix-Matrix Multiplication Design](../whole_array/README.md)
 
 - A specialized matrix-*vector* microkernel, named `matvec_vectorized` is used in this design, as opposed to the more general matrix-matrix microkernel (`matmul_vectorized`) used in the matrix-matrix-multiplication designs.
-- The data movement in this design varies as follows: An identical `32`-element chunk of the vector `B` is **broadcast** to the cores in all columns, whereas _distinct_ subsequent `32`&times;`32`-sized tiles of the `A` matrix are **distributed** to the cores. As such, each core is responsible for a distinct `32`-element chunk of the output vector `C`. These chunks are assembled (**joined**) at the shim tile level (in the `sequence()` function).
+- The data movement in this design varies as follows: An identical `32`-element chunk of the vector `B` is **broadcast** to the cores in all columns, whereas _distinct_ subsequent `32`&times;`32`-sized tiles of the `A` matrix are **distributed** to the cores. As such, each core is responsible for a distinct `32`-element chunk of the output vector `C`. These chunks are assembled (**joined**) at the shim tile level (in the `aiex.runtime_sequence()`).
 - This design does not use all available compute cores. Instead, it uses at most one core in each hardware column. The variable `n_cores` defines the number of columns to be used. It would however be possible to extend this design to use all cores.
 
 ## Building and Running the Design

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/aie2.py
@@ -185,7 +185,7 @@ def my_matmul():
 
             # To/from AIE-array data movement
 
-            @FuncOp.from_py_func(
+            @runtime_sequence(
                 T.memref(A_sz, dtype_in()),
                 T.memref(B_sz, dtype_in()),
                 T.memref(C_sz, dtype_out()),

--- a/programming_examples/basic/matrix_multiplication/single_core/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/aie2.py
@@ -231,7 +231,7 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
 
             # To/from AIE-array data movement
 
-            @FuncOp.from_py_func(
+            @runtime_sequence(
                 T.memref(A_sz, dtype_in()),
                 T.memref(B_sz, dtype_in()),
                 T.memref(C_sz, dtype_out()),

--- a/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
@@ -294,7 +294,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                             yield_([])
 
         # To/from AIE-array data movement
-        @FuncOp.from_py_func(
+        @runtime_sequence(
             T.memref(M * K, dtype_in()),
             T.memref(K * N, dtype_in()),
             T.memref(M * N, dtype_out()),

--- a/programming_examples/basic/matrix_scalar_add/aie2.py
+++ b/programming_examples/basic/matrix_scalar_add/aie2.py
@@ -78,7 +78,7 @@ def my_matrix_add_one():
 
         tensor_ty = T.memref(TILE_SIZE, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(inTensor, notUsed, outTensor):
             npu_dma_memcpy_nd(
                 metadata="out0",

--- a/programming_examples/basic/passthrough_dmas/aie2.py
+++ b/programming_examples/basic/passthrough_dmas/aie2.py
@@ -60,7 +60,7 @@ def my_passthrough():
             # To/from AIE-array data movement
             tensor_ty = T.memref(N, T.i32())
 
-            @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
                 npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/basic/passthrough_kernel/README.md
+++ b/programming_examples/basic/passthrough_kernel/README.md
@@ -54,9 +54,9 @@ This design performs a memcpy operation on a vector of input data. The AIE desig
 
 1. **Core Definition:** The `core_body` function loops through sub-vectors of the input data, acquiring elements from `of_in`, processing using `passThroughLine`, and outputting the result to `of_out`.
 
-1. **Data Movement Configuration:** The `sequence` function configures data movement and synchronization on the `ShimTile` for input and output buffer management.
+1. **Data Movement Configuration:** The `aie.runtime_sequence` operation configures data movement and synchronization on the `ShimTile` for input and output buffer management.
 
-1. **Tracing Configuration (Optional):** Trace control, event groups, and buffer descriptors are set up in the `sequence` function when tracing is enabled.
+1. **Tracing Configuration (Optional):** Trace control, event groups, and buffer descriptors are set up in the `aie.runtime_sequence` operation when tracing is enabled.
 
 1. **Generate the design:** The `passthroughKernel()` function triggers the code generation process. The final print statement outputs the MLIR representation of the AIE array configuration.
 

--- a/programming_examples/basic/passthrough_kernel/aie2.py
+++ b/programming_examples/basic/passthrough_kernel/aie2.py
@@ -59,7 +59,7 @@ def passthroughKernel(vector_size, trace_size):
 
         tensor_ty = T.memref(N, T.ui8())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(inTensor, outTensor, notUsed):
             if trace_size > 0:
                 trace_utils.configure_simple_tracing_aie2(

--- a/programming_examples/basic/row_wise_bias_add/README.md
+++ b/programming_examples/basic/row_wise_bias_add/README.md
@@ -21,7 +21,7 @@ The data movement and call into the kernel (see below) is described in `aie2.py`
 A single AIE core is configured to process chunks of `m`&times;`n` of `in` and chunks of `n` of `bias` to produce `m`&times;`n` chunks of output.
 Therefore, the output is tiled into `M/m`&times;`N/n` tiles, and the kernel function is called that number of times.
 To avoid unnecessarily reloading the `bias` vector, we iterate through these tiles in a column-major fashion.
-The `strides` and `sizes` in the `sequence` function describe this column-major iteration.
+The `strides` and `sizes` in the `aie.runtime_sequence` operation describe this column-major iteration.
 
 ## Kernel
 

--- a/programming_examples/basic/row_wise_bias_add/aie2.py
+++ b/programming_examples/basic/row_wise_bias_add/aie2.py
@@ -57,9 +57,7 @@ def row_wise_bias_add(M, N, m, n):
                     yield_([])
                 yield_([])
 
-        @runtime_sequence(
-            complete_in_memref, complete_bias_memref, complete_out_memref
-        )
+        @runtime_sequence(complete_in_memref, complete_bias_memref, complete_out_memref)
         def sequence(inp, bias, out):
             npu_dma_memcpy_nd(
                 metadata=in_fifo.sym_name.value,

--- a/programming_examples/basic/row_wise_bias_add/aie2.py
+++ b/programming_examples/basic/row_wise_bias_add/aie2.py
@@ -57,7 +57,7 @@ def row_wise_bias_add(M, N, m, n):
                     yield_([])
                 yield_([])
 
-        @FuncOp.from_py_func(
+        @runtime_sequence(
             complete_in_memref, complete_bias_memref, complete_out_memref
         )
         def sequence(inp, bias, out):

--- a/programming_examples/basic/vector_exp/aie2.py
+++ b/programming_examples/basic/vector_exp/aie2.py
@@ -100,7 +100,7 @@ def my_eltwise_exp():
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.bf16())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):
             npu_dma_memcpy_nd(metadata="outC", bd_id=0, mem=C, sizes=[1, 1, 1, N])
             npu_dma_memcpy_nd(metadata="inA", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/basic/vector_reduce_add/aie2.py
+++ b/programming_examples/basic/vector_reduce_add/aie2.py
@@ -66,7 +66,7 @@ def my_reduce_add():
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, 1])
             npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/basic/vector_reduce_max/aie2.py
+++ b/programming_examples/basic/vector_reduce_max/aie2.py
@@ -66,7 +66,7 @@ def my_reduce_max():
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, 1])
             npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/basic/vector_reduce_min/aie2.py
+++ b/programming_examples/basic/vector_reduce_min/aie2.py
@@ -66,7 +66,7 @@ def my_reduce_min():
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, 1])
             npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/basic/vector_scalar_add/aie2.py
+++ b/programming_examples/basic/vector_scalar_add/aie2.py
@@ -63,7 +63,7 @@ def my_vector_bias_add():
         # To/from AIE-array data movement
         tensor_ty = T.memref(PROBLEM_SIZE, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(inTensor, outTensor):
             npu_dma_memcpy_nd(
                 metadata="out0", bd_id=0, mem=outTensor, sizes=[1, 1, 1, PROBLEM_SIZE]

--- a/programming_examples/basic/vector_scalar_add/aie2.py
+++ b/programming_examples/basic/vector_scalar_add/aie2.py
@@ -20,7 +20,6 @@ AIE_TILE_WIDTH = 32
 
 
 def my_vector_bias_add():
-
     @device(AIEDevice.npu1_1col)
     def device_body():
         memRef_mem_tile_ty = T.memref(MEM_TILE_WIDTH, T.i32())

--- a/programming_examples/basic/vector_scalar_add_runlist/aie2.py
+++ b/programming_examples/basic/vector_scalar_add_runlist/aie2.py
@@ -63,7 +63,7 @@ def my_vector_bias_add():
         # To/from AIE-array data movement
         tensor_ty = T.memref(PROBLEM_SIZE, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(inTensor, outTensor):
             npu_dma_memcpy_nd(
                 metadata="out0", bd_id=0, mem=outTensor, sizes=[1, 1, 1, PROBLEM_SIZE]

--- a/programming_examples/basic/vector_scalar_add_runlist/aie2.py
+++ b/programming_examples/basic/vector_scalar_add_runlist/aie2.py
@@ -20,7 +20,6 @@ AIE_TILE_WIDTH = 32
 
 
 def my_vector_bias_add():
-
     @device(AIEDevice.npu1_1col)
     def device_body():
         memRef_mem_tile_ty = T.memref(MEM_TILE_WIDTH, T.i32())

--- a/programming_examples/basic/vector_scalar_mul/README.md
+++ b/programming_examples/basic/vector_scalar_mul/README.md
@@ -54,9 +54,9 @@ This design performs a memcpy operation on a vector of input data. The AIE desig
 
 1. **Core Definition:** The `core_body` function loops through sub-vectors of the input data, acquiring elements from `of_in`, processing using `vector_scalar_mul_aie_scalar()` or `vector_scalar_mul_aie()`, and outputting the result to `of_out`.
 
-1. **Data Movement Configuration:** The `sequence` function configures data movement and synchronization on the `ShimTile` for input and output buffer management.
+1. **Data Movement Configuration:** The `aie.runtime_sequence` operation configures data movement and synchronization on the `ShimTile` for input and output buffer management.
 
-1. **Tracing Configuration (Optional):** Trace control, event groups, and buffer descriptors are set up in the `sequence` function when tracing is enabled.
+1. **Tracing Configuration (Optional):** Trace control, event groups, and buffer descriptors are set up in the `aie.runtime_sequence` operation when tracing is enabled.
 
 1. **Generate the design:** The `my_vector_scalar()` function triggers the code generation process. The final print statement outputs the MLIR representation of the AIE array configuration.
 

--- a/programming_examples/basic/vector_scalar_mul/aie2.py
+++ b/programming_examples/basic/vector_scalar_mul/aie2.py
@@ -83,7 +83,7 @@ def my_vector_scalar(vector_size, trace_size):
         tensor_ty = T.memref(N, T.i16())
         scalar_ty = T.memref(1, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, scalar_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, scalar_ty, tensor_ty)
         def sequence(A, F, C):
 
             if trace_size > 0:

--- a/programming_examples/basic/vector_vector_add/aie2.py
+++ b/programming_examples/basic/vector_vector_add/aie2.py
@@ -76,7 +76,7 @@ def my_vector_add():
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
             npu_dma_memcpy_nd(metadata="in1", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/basic/vector_vector_modulo/aie2.py
+++ b/programming_examples/basic/vector_vector_modulo/aie2.py
@@ -76,7 +76,7 @@ def my_vector_add():
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
             npu_dma_memcpy_nd(metadata="in1", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/basic/vector_vector_mul/aie2.py
+++ b/programming_examples/basic/vector_vector_mul/aie2.py
@@ -76,7 +76,7 @@ def my_vector_mul():
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
             npu_dma_memcpy_nd(metadata="in1", bd_id=1, mem=A, sizes=[1, 1, 1, N])

--- a/programming_examples/ml/bottleneck/aie2.py
+++ b/programming_examples/ml/bottleneck/aie2.py
@@ -512,7 +512,7 @@ def bottleneck4AIEs():
             activationsInL3_ty = MemRefType.get((activationsIn,), int8_ty)
             weightsInL3_ty = MemRefType.get((totalWeights,), uint8_ty)
 
-            @FuncOp.from_py_func(activationsInL3_ty, weightsInL3_ty, activationsInL3_ty)
+            @runtime_sequence(activationsInL3_ty, weightsInL3_ty, activationsInL3_ty)
             def sequence(inputFromL3, weightsFromL3, outputToL3):
 
                 if enableTrace:

--- a/programming_examples/ml/conv2d/aie2.py
+++ b/programming_examples/ml/conv2d/aie2.py
@@ -142,7 +142,7 @@ def conv2dk1():
             memRef_wts_ty = T.memref(weights, T.i8())
             # memRef_16x16_ty = T.memref(16, 16, T.i32())
 
-            @FuncOp.from_py_func(tensor_ty, memRef_wts_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, memRef_wts_ty, tensor_ty)
             def sequence(I, W, O):
                 NpuWriteRTPOp("rtp2", col=0, row=2, index=0, value=10)
 

--- a/programming_examples/ml/conv2d_fused_relu/aie2.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2.py
@@ -149,7 +149,7 @@ def conv2dk1():
             memRef_wts_ty = T.memref(weights, T.i8())
             # memRef_16x16_ty = T.memref(16, 16, T.i32())
 
-            @FuncOp.from_py_func(tensor_ty, memRef_wts_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, memRef_wts_ty, tensor_ty)
             def sequence(I, W, O):
                 if enableTrace:
                     # 0x340D0: Trace Control 0

--- a/programming_examples/ml/eltwise_add/aie2.py
+++ b/programming_examples/ml/eltwise_add/aie2.py
@@ -127,7 +127,7 @@ def my_eltwise_add(trace_size):
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.bf16())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):
 
             if trace_size > 0:

--- a/programming_examples/ml/eltwise_mul/aie2.py
+++ b/programming_examples/ml/eltwise_mul/aie2.py
@@ -128,7 +128,7 @@ def my_eltwise_mul(trace_size):
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.bf16())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):
 
             if trace_size > 0:

--- a/programming_examples/ml/relu/aie2.py
+++ b/programming_examples/ml/relu/aie2.py
@@ -104,7 +104,7 @@ def my_relu(trace_size):
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.bf16())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):
 
             if trace_size > 0:

--- a/programming_examples/ml/resnet/layers_conv2_x/aie.mlir
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie.mlir
@@ -880,7 +880,7 @@ aie.device(npu1_3col) {
     } { link_with="conv2dk1_skip.o" }
 
 
-  func.func @sequence(%in0 : memref<16384xi32>, %wts0 : memref<53248xi32>, %out : memref<65536xi32>) {
+  aiex.runtime_sequence(%in0 : memref<16384xi32>, %wts0 : memref<53248xi32>, %out : memref<65536xi32>) {
                   // Trace output
 
       // Trace_Event0, Trace_Event1: Select which events to trace.
@@ -1006,7 +1006,6 @@ aie.device(npu1_3col) {
       aiex.npu.dma_memcpy_nd(0, 0, %wts0[0, 0, 0, %total_wts_3_off][1, 1, 1, %total_wts_3][0, 0, 0, 1]) {id = 1 : i64, metadata = @inOF_wts_2_L3L2} : memref<53248xi32>
 
       aiex.npu.sync {channel = 0 : i32, column = 1 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      return
     }
 
     }

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2.py
@@ -918,7 +918,7 @@ def resnet_conv_x():
 
             weightsInL3_ty_complete = MemRefType.get((totalWeights_complete,), int8_ty)
 
-            @FuncOp.from_py_func(
+            @runtime_sequence(
                 activationsInL3_ty, weightsInL3_ty_complete, activationsOutL3_ty
             )
             def sequence(inputFromL3, weightsFromL3, outputToL3):

--- a/programming_examples/ml/softmax/aie2.py
+++ b/programming_examples/ml/softmax/aie2.py
@@ -107,7 +107,7 @@ def vector_softmax(trace_size):
         # To/from AIE-array data movement
         tensor_ty = T.memref(N, T.bf16())
 
-        @FuncOp.from_py_func(tensor_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):
 
             if trace_size > 0:

--- a/programming_examples/vision/color_detect/aie2_colorDetect.py
+++ b/programming_examples/vision/color_detect/aie2_colorDetect.py
@@ -249,7 +249,7 @@ def color_detect():
                 T.i32(),
             )
 
-            @FuncOp.from_py_func(tensor_ty, memRef_16x16_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, memRef_16x16_ty, tensor_ty)
             def sequence(I, B, O):
                 npu_dma_memcpy_nd(
                     metadata="inOF_L3L2",

--- a/programming_examples/vision/color_threshold/aie2_colorThreshold.py
+++ b/programming_examples/vision/color_threshold/aie2_colorThreshold.py
@@ -248,7 +248,7 @@ def color_threshold():
 
             tensorSize = width * height
 
-            @FuncOp.from_py_func(
+            @runtime_sequence(
                 T.memref(tensorSize, T.i8()),
                 T.memref(32, T.i32()),  # not used
                 T.memref(tensorSize, T.i8()),

--- a/programming_examples/vision/edge_detect/aie2_edgeDetect.py
+++ b/programming_examples/vision/edge_detect/aie2_edgeDetect.py
@@ -296,7 +296,7 @@ def edge_detect():
             tensor_ty = T.memref(tensorSize, T.i8())
             memRef_16x16_ty = T.memref(16, 16, T.i32())
 
-            @FuncOp.from_py_func(tensor_ty, memRef_16x16_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, memRef_16x16_ty, tensor_ty)
             def sequence(I, B, O):
                 npu_dma_memcpy_nd(
                     metadata="outOF_L2L3",

--- a/programming_examples/vision/vision_passthrough/aie2.py
+++ b/programming_examples/vision/vision_passthrough/aie2.py
@@ -69,7 +69,7 @@ def passThroughAIE2():
             tensorSize = width * height
             tensor_ty = T.memref(tensorSize, T.i8())
 
-            @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
             def sequence(inTensor, notUsed, outTensor):
                 if enableTrace:
                     # Trace output

--- a/programming_examples/vision/vision_passthrough/aie2_lineBased_8b_1080.mlir
+++ b/programming_examples/vision/vision_passthrough/aie2_lineBased_8b_1080.mlir
@@ -46,7 +46,7 @@ module @passThroughLine_aie2 {
             aie.end
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
-        func.func @sequence(%in : memref<518400xi32>, %arg1 : memref<1xi32>, %out : memref<518400xi32>) {
+        aiex.runtime_sequence(%in : memref<518400xi32>, %arg1 : memref<1xi32>, %out : memref<518400xi32>) {
             %c0 = arith.constant 0 : i64
             %c1 = arith.constant 1 : i64
             %tileheight = arith.constant 1080  : i64
@@ -56,7 +56,6 @@ module @passThroughLine_aie2 {
             aiex.npu.dma_memcpy_nd (0, 0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth, %c1]) { metadata = @inOF, id = 1 : i64 } : memref<518400xi32>
             aiex.npu.dma_memcpy_nd (0, 0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth, %c1]) { metadata = @outOF, id = 0 : i64 } : memref<518400xi32>
             aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-            return
         }
     }
 }

--- a/programming_examples/vision/vision_passthrough/aie2_lineBased_8b_8k.mlir
+++ b/programming_examples/vision/vision_passthrough/aie2_lineBased_8b_8k.mlir
@@ -46,7 +46,7 @@ module @passThroughLine_aie2 {
             aie.end
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
-        func.func @sequence(%in : memref<2073600xi32>, %arg1 : memref<1xi32>, %out : memref<2073600xi32>) {
+        aiex.runtime_sequence(%in : memref<2073600xi32>, %arg1 : memref<1xi32>, %out : memref<2073600xi32>) {
             %c0 = arith.constant 0 : i64
             %c1 = arith.constant 1 : i64
             %tileheight = arith.constant 1080  : i64
@@ -57,7 +57,6 @@ module @passThroughLine_aie2 {
             aiex.npu.dma_memcpy_nd (0, 0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0, %c1]) { metadata = @inOF, id = 1 : i64 } : memref<2073600xi32>
             aiex.npu.dma_memcpy_nd (0, 0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %c1, %totalLenRGBA][%c0, %c0, %c0, %c1]) { metadata = @outOF, id = 0 : i64 } : memref<2073600xi32>
             aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-            return
         }
     }
 }

--- a/programming_examples/vision/vision_passthrough/aie2_lineBased_8b_tiny.mlir
+++ b/programming_examples/vision/vision_passthrough/aie2_lineBased_8b_tiny.mlir
@@ -46,7 +46,7 @@ module @passThroughLine_aie2 {
             aie.end
         } { link_with="passThrough.cc.o" } // indicate kernel object name used by this core
 
-        func.func @sequence(%in : memref<1152xi32>, %arg1 : memref<1xi32>, %out : memref<1152xi32>) {
+        aiex.runtime_sequence(%in : memref<1152xi32>, %arg1 : memref<1xi32>, %out : memref<1152xi32>) {
             %c0 = arith.constant 0 : i64
             %c1 = arith.constant 1 : i64
             %tileheight = arith.constant 9  : i64
@@ -56,7 +56,6 @@ module @passThroughLine_aie2 {
             aiex.npu.dma_memcpy_nd (0, 0, %in[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth, %c1]) { metadata = @inOF, id = 1 : i64 } : memref<1152xi32>
             aiex.npu.dma_memcpy_nd (0, 0, %out[%c0, %c0, %c0, %c0][%c1, %c1, %tileheight, %tilewidth][%c0, %c0, %tilewidth, %c1]) { metadata = @outOF, id = 0 : i64 } : memref<1152xi32>
             aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-            return
         }
     }
 }

--- a/programming_guide/section-2/section-2e/02_external_mem_to_core/ext_to_core.py
+++ b/programming_guide/section-2/section-2e/02_external_mem_to_core/ext_to_core.py
@@ -52,7 +52,7 @@ def external_mem_to_core():
 
             memRef_48_ty = T.memref(48, T.i32())
 
-            @FuncOp.from_py_func(memRef_48_ty, memRef_48_ty, memRef_48_ty)
+            @runtime_sequence(memRef_48_ty, memRef_48_ty, memRef_48_ty)
             def sequence(inTensor, notUsed, outTensor):
                 npu_dma_memcpy_nd(
                     metadata="out", bd_id=0, mem=outTensor, sizes=[1, 1, 1, 48]

--- a/programming_guide/section-2/section-2e/03_external_mem_to_core_L2/ext_to_core_L2.py
+++ b/programming_guide/section-2/section-2e/03_external_mem_to_core_L2/ext_to_core_L2.py
@@ -56,7 +56,7 @@ def external_mem_to_core_L2():
             memRef_48_ty = T.memref(48, T.i32())
 
             # To/from AIE-array data movement
-            @FuncOp.from_py_func(memRef_48_ty, memRef_48_ty, memRef_48_ty)
+            @runtime_sequence(memRef_48_ty, memRef_48_ty, memRef_48_ty)
             def sequence(inTensor, notUsed, outTensor):
                 npu_dma_memcpy_nd(
                     metadata="out0", bd_id=0, mem=outTensor, sizes=[1, 1, 1, 48]

--- a/programming_guide/section-2/section-2e/05_join_L2/distribute_and_join_L2.py
+++ b/programming_guide/section-2/section-2e/05_join_L2/distribute_and_join_L2.py
@@ -93,7 +93,7 @@ def distribute_join_L2():
 
             memRef_48_ty = T.memref(48, T.i32())
 
-            @FuncOp.from_py_func(memRef_48_ty, memRef_48_ty, memRef_48_ty)
+            @runtime_sequence(memRef_48_ty, memRef_48_ty, memRef_48_ty)
             def sequence(inTensor, notUsed, outTensor):
                 npu_dma_memcpy_nd(
                     metadata="out", bd_id=0, mem=outTensor, sizes=[1, 1, 1, 48]

--- a/programming_guide/section-2/section-2g/README.md
+++ b/programming_guide/section-2/section-2g/README.md
@@ -23,7 +23,7 @@
 
 In the preceding sections, we looked at how we can describe data movement between tiles *within* the AIE-array. However, to do anything useful, we need to get data from outside the array, i.e., from the "host", into the AIE-array and back. On NPU devices, we can achieve this with the operations described in this section. 
 
-The operations that will be described in this section must be placed in a separate `sequence` function. The arguments to this function describe buffers that will be available on the host side; the body of the function describes how those buffers are moved into the AIE-array. [Section 3](../../section-3/) contains an example.
+The operations that will be described in this section must be placed in a separate `aie.runtime_sequence` operation. The arguments to this function describe buffers that will be available on the host side; the body of the function describes how those buffers are moved into the AIE-array. [Section 3](../../section-3/) contains an example.
 
 ### Guide to Managing Runtime Data Movement to/from Host Memory
 

--- a/programming_guide/section-3/README.md
+++ b/programming_guide/section-3/README.md
@@ -74,7 +74,7 @@ We also need to set up the data movement to/from the AIE-array: configure n-dime
         tensor_ty = T.memref(4096, T.i32())
         scalar_ty = T.memref(1, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, scalar_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, scalar_ty, tensor_ty)
         def sequence(A, F, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, 4096])
             npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, 4096])

--- a/programming_guide/section-3/aie2.py
+++ b/programming_guide/section-3/aie2.py
@@ -17,7 +17,6 @@ import aie.utils.trace as trace_utils
 
 
 def my_vector_scalar():
-
     @device(AIEDevice.npu1_1col)
     def device_body():
         memRef_ty = T.memref(1024, T.i32())

--- a/programming_guide/section-3/aie2.py
+++ b/programming_guide/section-3/aie2.py
@@ -61,7 +61,7 @@ def my_vector_scalar():
         tensor_ty = T.memref(4096, T.i32())
         scalar_ty = T.memref(1, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, scalar_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, scalar_ty, tensor_ty)
         def sequence(A, F, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, 4096])
             npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, 4096])

--- a/programming_guide/section-4/section-4a/aie2.py
+++ b/programming_guide/section-4/section-4a/aie2.py
@@ -17,7 +17,6 @@ import aie.utils.trace as trace_utils
 
 
 def my_vector_scalar():
-
     @device(AIEDevice.npu1_1col)
     def device_body():
         memRef_ty = T.memref(1024, T.i32())

--- a/programming_guide/section-4/section-4a/aie2.py
+++ b/programming_guide/section-4/section-4a/aie2.py
@@ -61,7 +61,7 @@ def my_vector_scalar():
         tensor_ty = T.memref(4096, T.i32())
         scalar_ty = T.memref(1, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, scalar_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, scalar_ty, tensor_ty)
         def sequence(A, F, C):
             npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, 4096])
             npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, 4096])

--- a/programming_guide/section-4/section-4b/README.md
+++ b/programming_guide/section-4/section-4b/README.md
@@ -44,7 +44,7 @@ The first necessary component for trace configuration is setting the right value
         offset=tensorSize,
     )
 ```
-This block is defined within the sequence definition for `@FuncOp.from_py_func` where we define the shimDMA data movement to the 3 inout buffers. 
+This block is defined within the sequence definition for `@runtime_sequence` where we define the shimDMA data movement to the 3 inout buffers. 
 > **Note** This simplification works very well for the trace buffer from a single tile to the shimDMA. However, if we want to do something more advaned like allocating the trace buffer from multiple tiles into a single larger buffer, this function will not be able to express that. For that, please consult the [README](../../../python/utils) under `python/utils` for more guidance on how to customize the trace configuration.
 
 ### <u>(1b) Define trace event routes from tile to shimDMA</u>

--- a/programming_guide/section-4/section-4b/aie2.py
+++ b/programming_guide/section-4/section-4b/aie2.py
@@ -68,7 +68,7 @@ def my_vector_scalar():
         tensor_ty = T.memref(4096, T.i32())
         scalar_ty = T.memref(1, T.i32())
 
-        @FuncOp.from_py_func(tensor_ty, scalar_ty, tensor_ty)
+        @runtime_sequence(tensor_ty, scalar_ty, tensor_ty)
         def sequence(A, F, C):
             if enableTrace:
                 trace_utils.configure_simple_tracing_aie2(

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -23,7 +23,7 @@ from .aie import (
 from .transform.structured import MixedValues, _dispatch_mixed_values
 from .._mlir_libs import get_dialect_registry
 from .._mlir_libs._aie import *
-from ..ir import DictAttr, IntegerAttr, UnitAttr
+from ..ir import DictAttr, IntegerAttr, UnitAttr, Type, InsertionPoint
 
 # noinspection PyUnresolvedReferences
 from ..extras.dialects.ext import memref
@@ -761,3 +761,17 @@ def broadcast_flow(
     if len(flows) == 1:
         flows = flows[0]
     return flows
+
+
+# Runtime sequence
+
+
+def runtime_sequence(*inputs: Type):
+    def decorator(f):
+        seq_op = RuntimeSequenceOp(args=[])
+        entry_block = seq_op.body.blocks.append(*inputs)
+        args = entry_block.arguments
+        with InsertionPoint(entry_block):
+            f(*args)
+
+    return decorator

--- a/python/utils/README.md
+++ b/python/utils/README.md
@@ -130,7 +130,7 @@ configure_tracing_aie2(
 `PortEvent` is defined in `aie.utils.trace` and `CoreEvent` is defined in `aie.utils.trace_events_enum`.
 
 ### Configure tile trace settings
-Within the `func.func @sequence` block, we call a set of configuration register writes (`aiex.npu.write32`) to configure the tile trace units and (`aiex.npu.writebd`) to configure the shimDMA. 
+Within the `aiex.runtime_sequence` block, we call a set of configuration register writes (`aiex.npu.write32`) to configure the tile trace units and (`aiex.npu.writebd`) to configure the shimDMA. 
 
 For a give AIE2 tile, we configure the trace control registers for the tile core and tile memory separately. There are 4 registers we generally use to configure the trace unit behavior. 2 are for configuring the general trace control and the other 2 are to specify which events our tile's trace hardware is monitoring.
 

--- a/test/Conversion/DmaToNpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToNpu/aiert_insts.mlir
@@ -16,7 +16,7 @@ module {
   aie.device(npu1_4col) {
     memref.global "public" @of_toMem : memref<32xi32>
     memref.global "public" @of_fromMem : memref<32xi32>
-    func.func @sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
+    aiex.runtime_sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
@@ -26,7 +26,6 @@ module {
       %c32 = arith.constant 32 : i64
       aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0, %c1]) { metadata = @of_toMem, id = 1 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8, %c1]) { metadata = @of_fromMem, id = 0 : i64, issue_token = false } : memref<4x2x8xi32>
-      return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)
     aie.shim_dma_allocation @of_toMem (S2MM, 0, 0)

--- a/test/Conversion/DmaToNpu/bad_dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/bad_dma_to_npu.mlir
@@ -18,10 +18,9 @@
 module @shimDmaMemcpy{
   aie.device(xcve2302) {
     memref.global "public" @toMem : memref<1xbf16>
-    func.func @sequence(%arg0: memref<1xbf16>, %arg1: memref<1xbf16>, %arg2: memref<1xbf16>) {
+    aiex.runtime_sequence(%arg0: memref<1xbf16>, %arg1: memref<1xbf16>, %arg2: memref<1xbf16>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][4, 4, 64, 64][0, 64, 256, 1]) {id = 0 : i64, metadata = @toMem} : memref<1xbf16>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      return
     }
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
   }

--- a/test/Conversion/DmaToNpu/bad_dma_to_npu_datatype.mlir
+++ b/test/Conversion/DmaToNpu/bad_dma_to_npu_datatype.mlir
@@ -18,10 +18,9 @@
 module @shimDmaMemcpy{
   aie.device(xcve2302) {
     memref.global "public" @toMem : memref<65536xi64>
-    func.func @sequence(%arg0: memref<65536xi64>, %arg1: memref<65536xi64>, %arg2: memref<65536xi64>) {
+    aiex.runtime_sequence(%arg0: memref<65536xi64>, %arg1: memref<65536xi64>, %arg2: memref<65536xi64>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][4, 4, 64, 64][0, 64, 256, 1]) {id = 0 : i64, metadata = @toMem} : memref<65536xi64>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      return
     }
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
   }

--- a/test/Conversion/DmaToNpu/bad_rtp_write.mlir
+++ b/test/Conversion/DmaToNpu/bad_rtp_write.mlir
@@ -9,10 +9,9 @@
 // RUN: aie-opt --aie-dma-to-npu -verify-diagnostics %s
 
 aie.device(npu1_4col) {
-  func.func @sequence() {
+  aiex.runtime_sequence() {
     // expected-error@+2 {{'aiex.npu.rtp_write' op RTP buffer address cannot be found. Has an RTP buffer been allocated?}}
     // expected-error@+1 {{failed to legalize operation 'aiex.npu.rtp_write' that was explicitly marked illegal}}
     aiex.npu.rtp_write(0, 2, 4, 99) { buffer_sym_name = "RTP" }
-    return
   }
 }

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -11,8 +11,14 @@
 // RUN: aie-opt --split-input-file -aie-dma-to-npu %s | FileCheck %s
 
 // TODO - more
+<<<<<<< HEAD
 // CHECK-LABEL: dma_memcpy_nd_0
 // CHECK: aiex.npu.blockwrite
+=======
+// CHECK: module
+// CHECK: aiex.npu.writebd
+// CHECK-SAME: valid_bd = 1 : i32
+>>>>>>> 5aca5d36 (fix tests depending on runtime sequence name)
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
 // CHECK: aiex.npu.blockwrite
@@ -33,8 +39,14 @@ module  {
 
 // -----
 
+<<<<<<< HEAD
 // CHECK-LABEL: dma_wait_s2mm
 // CHECK: aiex.npu.blockwrite
+=======
+// CHECK: module
+// CHECK: aiex.npu.writebd
+// CHECK-SAME: valid_bd = 1 : i32
+>>>>>>> 5aca5d36 (fix tests depending on runtime sequence name)
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
 // CHECK: aiex.npu.write32
@@ -59,7 +71,7 @@ module  {
 
 // -----
 
-// CHECK-LABEL: dma_wait_mm2s
+// CHECK: module
 // CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -22,10 +22,9 @@ module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
     memref.global "public" @fromMem : memref<16xi32>
-    func.func @dma_memcpy_nd_0(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
+    aiex.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_memcpy_nd (0, 1, %arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
-      return
     }
     aie.shim_dma_allocation @fromMem (MM2S, 0, 0)
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
@@ -50,10 +49,9 @@ module  {
 module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
-    func.func @dma_wait_s2mm(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
+    aiex.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
-      return
     }
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
   }
@@ -77,10 +75,9 @@ module  {
 module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
-    func.func @dma_wait_mm2s(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
+    aiex.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
-      return
     }
     aie.shim_dma_allocation @toMem (MM2S, 1, 1)
   }

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -11,14 +11,8 @@
 // RUN: aie-opt --split-input-file -aie-dma-to-npu %s | FileCheck %s
 
 // TODO - more
-<<<<<<< HEAD
-// CHECK-LABEL: dma_memcpy_nd_0
-// CHECK: aiex.npu.blockwrite
-=======
 // CHECK: module
-// CHECK: aiex.npu.writebd
-// CHECK-SAME: valid_bd = 1 : i32
->>>>>>> 5aca5d36 (fix tests depending on runtime sequence name)
+// CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
 // CHECK: aiex.npu.blockwrite
@@ -39,14 +33,7 @@ module  {
 
 // -----
 
-<<<<<<< HEAD
-// CHECK-LABEL: dma_wait_s2mm
-// CHECK: aiex.npu.blockwrite
-=======
 // CHECK: module
-// CHECK: aiex.npu.writebd
-// CHECK-SAME: valid_bd = 1 : i32
->>>>>>> 5aca5d36 (fix tests depending on runtime sequence name)
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32
 // CHECK: aiex.npu.write32

--- a/test/Conversion/DmaToNpu/dma_to_npu_invalid.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_invalid.mlir
@@ -13,11 +13,10 @@
 module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
-    func.func @sequence() {
+    aiex.runtime_sequence() {
       // expected-error@+2 {{failed to legalize operation 'aiex.npu.dma_wait' that was explicitly marked illegal}}
       // expected-error@+1 {{couldn't find shim_dma_allocation op}}
       aiex.npu.dma_wait {symbol = @toMem}
-      return
     }
   }
 }

--- a/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
@@ -26,10 +26,9 @@ module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
     memref.global "public" @fromMem : memref<16xi32>
-    func.func @test1(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
+    aiex.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
         aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64, issue_token = true } : memref<16xi32>
         aiex.npu.dma_memcpy_nd (0, 1, %arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64, issue_token = false } : memref<16xi32>
-        return
     }
     aie.shim_dma_allocation @fromMem (MM2S, 0, 0)
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
@@ -11,7 +11,6 @@
 // RUN: aie-opt -aie-dma-to-npu %s | FileCheck %s
 
 // TODO - more
-// CHECK-LABEL: test1
 // CHECK: aiex.npu.blockwrite
 // CHECK: aiex.npu.address_patch
 // CHECK-SAME: arg_idx = 0 : i32

--- a/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
@@ -15,7 +15,7 @@
 // CHECK-LABEL:  aie.device(xcve2302) {
 // CHECK:  memref.global "public" @toMem : memref<65536xbf16>
 // CHECK:  memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, -2080374657, 31, 0, 33554432]>
-// CHECK:  func.func @sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
+// CHECK:  aiex.runtime_sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
 // CHECK:    %0 = memref.get_global @blockwrite_data_0 : memref<8xi32>
 // CHECK:    aiex.npu.blockwrite(%0) {address = 118784 : ui32} : memref<8xi32>
 // CHECK:    aiex.npu.address_patch {addr = 118788 : ui32, arg_idx = 0 : i32, arg_plus = 0 : i32}
@@ -27,10 +27,9 @@
 module @shimDmaMemcpy{
   aie.device(xcve2302) {
     memref.global "public" @toMem : memref<65536xbf16>
-    func.func @sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
+    aiex.runtime_sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
       aiex.npu.dma_memcpy_nd (2, 0, %arg0[0, 0, 0, 0][4, 4, 64, 64][0, 64, 256, 1]) {id = 0 : i64, metadata = @toMem} : memref<65536xbf16>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      return
     }
     aie.shim_dma_allocation @toMem (S2MM, 0, 0)
   }

--- a/test/Conversion/DmaToNpu/push_to_queue.mlir
+++ b/test/Conversion/DmaToNpu/push_to_queue.mlir
@@ -12,10 +12,9 @@
 
 module {
   aie.device(npu1_4col) {
-    func.func @sequence() {
+    aiex.runtime_sequence() {
       aiex.npu.push_queue (0, 0, S2MM:1) {issue_token = true, repeat_count = 0 : i32, bd_id = 3 : i32 }
       aiex.npu.push_queue (2, 0, MM2S:0) {issue_token = false, repeat_count = 3 : i32, bd_id = 2 : i32 }
-      return
     }
   }
 }

--- a/test/Conversion/DmaToNpu/rtp_write.mlir
+++ b/test/Conversion/DmaToNpu/rtp_write.mlir
@@ -16,10 +16,9 @@ module {
     %1 = aie.buffer(%0) {address = 1536 : i32, sym_name = "rtp"} : memref<16xi32>
     %2 = aie.tile(0, 2)
     %3 = aie.buffer(%2) {address = 3200 : i32, sym_name = "RTP"} : memref<16xi32>
-    func.func @sequence() {
+    aiex.runtime_sequence() {
       aiex.npu.rtp_write(2, 3, 0, 50) { buffer_sym_name = "rtp" }
       aiex.npu.rtp_write(0, 2, 4, 99) { buffer_sym_name = "RTP" }
-      return
     }
   }
 }

--- a/test/Targets/AIETargetHSA/input_with_addresses.mlir
+++ b/test/Targets/AIETargetHSA/input_with_addresses.mlir
@@ -54,11 +54,10 @@ module {
     aie.shim_dma_allocation @in0(MM2S, 0, 6)
     aie.shim_dma_allocation @out0(S2MM, 0, 6)
 
-    func.func @sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
+    aiex.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 0 : i64, metadata = @out0} : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 1 : i64, metadata = @in0} : memref<64xi32>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      return
     }
   }
 }

--- a/test/Targets/NPU/npu_instgen.mlir
+++ b/test/Targets/NPU/npu_instgen.mlir
@@ -11,7 +11,7 @@
 // RUN: aie-opt --aie-dma-to-npu %s | aie-translate --aie-npu-instgen | FileCheck %s
 module {
   aie.device(npu1_4col) {
-    func.func @test0(%arg0: memref<16xf32>, %arg1: memref<16xf32>) {
+    aiex.runtime_sequence(%arg0: memref<16xf32>, %arg1: memref<16xf32>) {
 
       // TXN header
       // CHECK: 06030100
@@ -73,7 +73,6 @@ module {
       // CHECK: 00030401
       // CHECK: 05010200
       aiex.npu.sync { column = 3 : i32, row = 4 : i32, direction = 1 : i32, channel = 5 : i32, column_num = 1 : i32, row_num = 2 : i32 }
-      return
     }
   }
 }

--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -94,7 +94,7 @@ module {
     %02 = aie.tile(0, 2)
     %12 = aie.tile(1, 2)
     %22 = aie.tile(2, 2)
-    func.func @sequence(%arg0: memref<1024xi32>, %arg1: memref<1024xi32>, %arg2: memref<1024xi32>, %arg3: memref<1024xi32>, %arg4: memref<1024xi32>, %arg5: memref<1024xi32>) {
+    aiex.runtime_sequence(%arg0: memref<1024xi32>, %arg1: memref<1024xi32>, %arg2: memref<1024xi32>, %arg3: memref<1024xi32>, %arg4: memref<1024xi32>, %arg5: memref<1024xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 0 : i64, metadata = @in0} : memref<1024xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg1[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 1 : i64, metadata = @out0} : memref<1024xi32>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
@@ -104,7 +104,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg4[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 2 : i64, metadata = @in2} : memref<1024xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg5[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 3 : i64, metadata = @out2} : memref<1024xi32>
       aiex.npu.sync {channel = 0 : i32, column = 2 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      return
     }
   }
 }

--- a/test/dialect/AIEX/bad_npu_nd.mlir
+++ b/test/dialect/AIEX/bad_npu_nd.mlir
@@ -13,14 +13,13 @@
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd_length(%in : memref<1920x1080xi32>, %buf : memref<32xi32>, %out : memref<1920x1080xi32>) {
+    aiex.runtime_sequence(%in : memref<1920x1080xi32>, %buf : memref<32xi32>, %out : memref<1920x1080xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c1920 = arith.constant 1920 : i64
       %c1080 = arith.constant 1080 : i64
       // expected-error@+1 {{Size 0 exceeds the [0:1023] range}}
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1920,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<1920x1080xi32>
-      return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)
   }
@@ -30,7 +29,7 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd_repeat(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+    aiex.runtime_sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
@@ -41,7 +40,6 @@ module {
       %c128 = arith.constant 128 : i64
       // expected-error@+1 {{Size 3 exceeds the [1:64] range}}
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c128,%c2,%c2,%c8][%c0,%c16,%c8,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<128x4x2x8xi32>
-      return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)
   }
@@ -51,14 +49,13 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd_stride(%in : memref<8388608xi32>, %buf : memref<32xi32>, %out : memref<8388608xi32>) {
+    aiex.runtime_sequence(%in : memref<8388608xi32>, %buf : memref<32xi32>, %out : memref<8388608xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
       %c2097152 = arith.constant 2097152 : i64
       // expected-error@+1 {{Stride 1 exceeds the [1:1048576] range}}
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2][%c0,%c0,%c2097152,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<8388608xi32>
-      return
     }
     aie.shim_dma_allocation @of_fromMem (MM2S, 0, 0)
   }
@@ -70,14 +67,13 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd_stride(%a : memref<8xi8>) {
+    aiex.runtime_sequence(%a : memref<8xi8>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Offset must be 4-byte-aligned}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c1][%c1,%c1,%c1,%c8][%c0,%c0,%c1,%c1]) { metadata = @fifo, id = 0 : i64 } : memref<8xi8>
-      return
     }
     aie.shim_dma_allocation @fifo (MM2S, 0, 0)
   }
@@ -90,7 +86,7 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd(%a : memref<8xi8>) {
+    aiex.runtime_sequence(%a : memref<8xi8>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
@@ -100,7 +96,6 @@ module {
       // Although 2048 exceeds the 0:1023 limit for size 0, since the elements are i8s,
       // this should be a size of 512 in address granularity (4 bytes) and hence pass the test.
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2048][%c0,%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }
@@ -110,7 +105,7 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd(%a : memref<8xi16>) {
+    aiex.runtime_sequence(%a : memref<8xi16>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
@@ -119,7 +114,6 @@ module {
       %c2048 = arith.constant 2048 : i64
       // expected-error@+1 {{Size 0 exceeds the [0:1023] range}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2048][%c0,%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi16>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }
@@ -132,14 +126,13 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd(%a : memref<8xi8>) {
+    aiex.runtime_sequence(%a : memref<8xi8>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64  // Stride of 2 i8s = 2 bytes < 4 byte granularity, should not be possible
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Stride 1 is 2 elements * 1 bytes = 2 bytes, which is not divisible by 4}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c8][%c0,%c0,%c2,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }
@@ -149,7 +142,7 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd(%a : memref<8xi8>) {
+    aiex.runtime_sequence(%a : memref<8xi8>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
@@ -157,7 +150,6 @@ module {
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{2 elements at 1 bytes each equal 2 bytes, which is not divisible by 4}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2][%c0,%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }
@@ -169,7 +161,7 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd(%a : memref<8xi8>) {
+    aiex.runtime_sequence(%a : memref<8xi8>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
@@ -177,7 +169,6 @@ module {
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Stride 0 is 2 elements * 1 bytes = 2 bytes, which is not divisible by 4}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c8][%c0,%c0,%c0,%c2]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }
@@ -189,14 +180,13 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd(%a : memref<8xi16>) {
+    aiex.runtime_sequence(%a : memref<8xi16>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c3 = arith.constant 3 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{3 elements at 2 bytes each equal 6 bytes, which is not divisible by 4}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c3][%c0,%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi16>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }
@@ -208,14 +198,13 @@ module {
 
 module {
   aie.device(npu1) {
-    func.func @bad_npu_nd(%a : memref<8xi16>) {
+    aiex.runtime_sequence(%a : memref<8xi16>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c4 = arith.constant 4 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Unsupported tile type at (0, 0) Must be ShimNOC, Mem or Core.}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c4][%c0,%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi16>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }
@@ -227,7 +216,7 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_npu_nd(%a : memref<8xi32>) {
+    aiex.runtime_sequence(%a : memref<8xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2 = arith.constant 2 : i64
@@ -237,7 +226,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c1,%c0,%c0,%c0][%c1,%c1,%c1,%c2][%c1572864,%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi32>
       // expected-error@+1 {{Stride 3 exceeds the [1:1048576] range.}}
       aiex.npu.dma_memcpy_nd (0, 0, %a[%c1,%c0,%c0,%c0][%c2,%c1,%c1,%c2][%c1572864,%c0,%c0,%c1]) { metadata = @objectfifo, id = 1 : i64 } : memref<8xi32>
-      return
     }
     aie.shim_dma_allocation @objectfifo (MM2S, 0, 0)
   }

--- a/test/dialect/AIEX/bad_npu_push_queue.mlir
+++ b/test/dialect/AIEX/bad_npu_push_queue.mlir
@@ -13,10 +13,9 @@
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_bd_id(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+    aiex.runtime_sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       // expected-error@+1 {{BD ID exceeds the maximum ID.}}
       aiex.npu.push_queue (0, 0, MM2S:0) {issue_token = false, repeat_count = 3 : i32, bd_id = 28 : i32 }
-      return
     }
   }
 }
@@ -25,10 +24,9 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_repeat_count(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+    aiex.runtime_sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       // expected-error@+1 {{Repeat count exceeds the [0:255] range.}}
       aiex.npu.push_queue (0, 0, MM2S:0) {issue_token = false, repeat_count = 384 : i32, bd_id = 8 : i32 }
-      return
     }
   }
 }

--- a/test/dialect/AIEX/bad_npu_write_bd.mlir
+++ b/test/dialect/AIEX/bad_npu_write_bd.mlir
@@ -13,10 +13,9 @@
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_bd_id(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+    aiex.runtime_sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       // expected-error@+1 {{BD ID exceeds the maximum ID.}}
       aiex.npu.writebd {bd_id = 17 : i32, buffer_length = 32 : i32, buffer_offset = 128 : i32, column = 0 : i32, row = 0 : i32, d0_stride = 0 : i32, d0_size = 8 : i32, d1_stride = 7 : i32, d1_size = 2 : i32, d2_stride = 15 : i32, ddr_id = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_stride = 0 : i32, iteration_size = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      return
     }
   }
 }
@@ -25,10 +24,9 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_iteration_size(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+    aiex.runtime_sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       // expected-error@+1 {{Iteration Size exceeds the [0:63] range.}}
       aiex.npu.writebd {bd_id = 7 : i32, buffer_length = 32 : i32, buffer_offset = 128 : i32, column = 0 : i32, row = 0 : i32, d0_stride = 0 : i32, d0_size = 8 : i32, d1_stride = 7 : i32, d1_size = 4 : i32, d2_stride = 15 : i32, ddr_id = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_stride = 1024 : i32, iteration_size = 128 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      return
     }
   }
 }
@@ -37,10 +35,9 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_stride(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+    aiex.runtime_sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       // expected-error@+1 {{D0 Stride exceeds the [0:1M-1] range.}}
       aiex.npu.writebd {bd_id = 2 : i32, buffer_length = 32 : i32, buffer_offset = 128 : i32, column = 0 : i32, row = 0 : i32, d0_stride = 2097356 : i32, d0_size = 8 : i32, d1_stride = 7 : i32, d1_size = 2 : i32, d2_stride = 15 : i32, ddr_id = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_stride = 0 : i32, iteration_size = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      return
     }
   }
 }
@@ -49,10 +46,9 @@ module {
 
 module {
   aie.device(npu1_4col) {
-    func.func @bad_size(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
+    aiex.runtime_sequence(%in : memref<128x4x2x8xi32>, %buf : memref<32xi32>, %out : memref<8192xi32>) {
       // expected-error@+1 {{D1 Size exceeds the [0:1023] range.}}
       aiex.npu.writebd {bd_id = 7 : i32, buffer_length = 32 : i32, buffer_offset = 128 : i32, column = 0 : i32, row = 0 : i32, d0_stride = 0 : i32, d0_size = 8 : i32, d1_stride = 7 : i32, d1_size = 1024 : i32, d2_stride = 15 : i32, ddr_id = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_stride = 0 : i32, iteration_size = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      return
     }
   }
 }

--- a/test/dialect/AIEX/invalid.mlir
+++ b/test/dialect/AIEX/invalid.mlir
@@ -11,9 +11,8 @@
 // RUN: aie-opt --split-input-file --verify-diagnostics %s
 
 aie.device(npu1_4col) {
-  func.func @npu_dma_wait_no_symbol() {
+  aiex.runtime_sequence() {
     // expected-error@+1 {{'aiex.npu.dma_wait' op couldn't find symbol in parent device}}
     aiex.npu.dma_wait {symbol = @out0}
-    return
   }
 }

--- a/test/dialect/AIEX/roundtrip.mlir
+++ b/test/dialect/AIEX/roundtrip.mlir
@@ -10,30 +10,27 @@
 
 // RUN: aie-opt --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: func.func @npu_dma_wait
+// CHECK-LABEL: aiex.runtime_sequence
 // CHECK: aiex.npu.dma_wait {symbol = @out0}
 aie.device(npu1_4col) {
   memref.global "public" @out0 : memref<16xi32>
-  func.func @npu_dma_wait() {
+  aiex.runtime_sequence() {
     aiex.npu.dma_wait {symbol = @out0}
-    return
   }
 }
 
 // -----
 
-// CHECK-LABEL: func.func @npu_dma_wait_no_device
+// CHECK-LABEL: aiex.runtime_sequence
 // CHECK: aiex.npu.dma_wait {symbol = @out0}
-func.func @npu_dma_wait_no_device() {
+aiex.runtime_sequence() {
   aiex.npu.dma_wait {symbol = @out0}
-  return
 }
 
 // -----
 
-// CHECK-LABEL: func.func @npu_addr_patch
+// CHECK-LABEL: aiex.runtime_sequence
 // CHECK: aiex.npu.address_patch {addr = 123 : ui32, arg_idx = 3 : i32, arg_plus = 0 : i32}
-func.func @npu_addr_patch() {
+aiex.runtime_sequence() {
   aiex.npu.address_patch {addr = 123 : ui32, arg_idx = 3 : i32, arg_plus = 0 : i32}
-  return
 }

--- a/test/dialect/AIEX/roundtrip.mlir
+++ b/test/dialect/AIEX/roundtrip.mlir
@@ -10,7 +10,7 @@
 
 // RUN: aie-opt --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: aiex.runtime_sequence
+// CHECK: aie.device
 // CHECK: aiex.npu.dma_wait {symbol = @out0}
 aie.device(npu1_4col) {
   memref.global "public" @out0 : memref<16xi32>
@@ -21,16 +21,21 @@ aie.device(npu1_4col) {
 
 // -----
 
-// CHECK-LABEL: aiex.runtime_sequence
+// CHECK: aie.device
 // CHECK: aiex.npu.dma_wait {symbol = @out0}
-aiex.runtime_sequence() {
-  aiex.npu.dma_wait {symbol = @out0}
+aie.device(npu1_4col) {
+  memref.global "public" @out0 : memref<16xi32>
+  aiex.runtime_sequence() {
+    aiex.npu.dma_wait {symbol = @out0}
+  }
 }
 
 // -----
 
-// CHECK-LABEL: aiex.runtime_sequence
+// CHECK: aie.device
 // CHECK: aiex.npu.address_patch {addr = 123 : ui32, arg_idx = 3 : i32, arg_plus = 0 : i32}
-aiex.runtime_sequence() {
-  aiex.npu.address_patch {addr = 123 : ui32, arg_idx = 3 : i32, arg_plus = 0 : i32}
+aie.device(npu1_4col) {
+  aiex.runtime_sequence() {
+    aiex.npu.address_patch {addr = 123 : ui32, arg_idx = 3 : i32, arg_plus = 0 : i32}
+  }
 }

--- a/test/lower-to-standard/aiex_standard_lowering.mlir
+++ b/test/lower-to-standard/aiex_standard_lowering.mlir
@@ -10,16 +10,14 @@
 
 // RUN: aie-opt --split-input-file --aiex-standard-lowering %s | FileCheck %s
 
-// CHECK-LABEL: dma_and_wait
 // CHECK-NOT: aiex.npu.dma_memcpy_nd
 // CHECK-NOT: aiex.npu.dma_wait
 module  {
   aie.device(npu1_4col) {
     memref.global "public" @toMem : memref<16xi32>
-    func.func @dma_and_wait(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
+    aiex.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
-      return
     }
     aie.shim_dma_allocation @toMem (MM2S, 1, 1)
   }

--- a/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/aie.mlir
@@ -56,7 +56,7 @@ module {
 
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
-    func.func @bobsyouruncle(%arg0: memref<61x56xi8>, %arg1: memref<32xi8>, %arg2: memref<64x64xi8>) {
+    aiex.runtime_sequence(%arg0: memref<61x56xi8>, %arg1: memref<32xi8>, %arg2: memref<64x64xi8>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c56_i64 = arith.constant 56 : i64
@@ -65,7 +65,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c61_i64, %c56_i64][%c0_i64, %c0_i64, %c56_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<61x56xi8>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
-      return
     }
 
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {

--- a/test/npu-xrt/add_21_i8_using_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_21_i8_using_dma_op_with_padding/aie.mlir
@@ -64,7 +64,7 @@ module {
 
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
-    func.func @bobsyouruncle(%arg0: memref<64xi8>, %arg1: memref<32xi8>, %arg2: memref<64xi8>) {
+    aiex.runtime_sequence(%arg0: memref<64xi8>, %arg1: memref<32xi8>, %arg2: memref<64xi8>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c32_i64 = arith.constant 32 : i64
@@ -72,7 +72,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c32_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi8>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
-      return
     }
 
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {

--- a/test/npu-xrt/add_256_using_dma_op_no_double_buffering/aie.mlir
+++ b/test/npu-xrt/add_256_using_dma_op_no_double_buffering/aie.mlir
@@ -102,11 +102,10 @@ module {
     memref.global "public" @data_out : memref<1xi32>
     aie.shim_dma_allocation @data_in(MM2S, 0, 0)
     aie.shim_dma_allocation @data_out(S2MM, 0, 0)
-    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
+    aiex.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 0 : i64, metadata = @data_in} : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 1 : i64, metadata = @data_out, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @data_out}
-      return
     }
   }
 }

--- a/test/npu-xrt/add_314_using_dma_op/aie.mlir
+++ b/test/npu-xrt/add_314_using_dma_op/aie.mlir
@@ -64,14 +64,13 @@ module {
 
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
-    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
+    aiex.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c64_i64 = arith.constant 64 : i64
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
-      return
     }
 
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {

--- a/test/npu-xrt/add_378_i32_using_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_378_i32_using_dma_op_with_padding/aie.mlir
@@ -64,7 +64,7 @@ module {
 
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
-    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
+    aiex.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c52_i64 = arith.constant 52 : i64
@@ -72,7 +72,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c52_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @objFifo_out0}
-      return
     }
 
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {

--- a/test/npu-xrt/add_one_objFifo/aie.mlir
+++ b/test/npu-xrt/add_one_objFifo/aie.mlir
@@ -43,14 +43,13 @@ module {
       }
       aie.end
     }
-    func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
+    aiex.runtime_sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
       aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
-      return
     }
   }
 }

--- a/test/npu-xrt/add_one_two/aie1.mlir
+++ b/test/npu-xrt/add_one_two/aie1.mlir
@@ -40,14 +40,13 @@ module {
       }
       aie.end
     }
-    func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
+    aiex.runtime_sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
       aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
-      return
     }
   }
 }

--- a/test/npu-xrt/add_one_two/aie2.mlir
+++ b/test/npu-xrt/add_one_two/aie2.mlir
@@ -40,14 +40,13 @@ module {
       }
       aie.end
     }
-    func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
+    aiex.runtime_sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
       aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
-      return
     }
   }
 }

--- a/test/npu-xrt/add_one_using_dma/aie.mlir
+++ b/test/npu-xrt/add_one_using_dma/aie.mlir
@@ -75,14 +75,13 @@ module {
 
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
-    func.func @bobsyouruncle(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
+    aiex.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c64_i64 = arith.constant 64 : i64
       aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
       aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @objFifo_out0}
-      return
     }
 
     %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {

--- a/test/npu-xrt/cascade_flows/aie.mlir
+++ b/test/npu-xrt/cascade_flows/aie.mlir
@@ -59,14 +59,13 @@ module {
       aie.end
     } { link_with="kernel3.o" }
 
-    func.func @sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
+    aiex.runtime_sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
       aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
-      return
     }
   }
 }

--- a/test/npu-xrt/e2e/tiled_matrix_add.ipynb
+++ b/test/npu-xrt/e2e/tiled_matrix_add.ipynb
@@ -375,7 +375,7 @@
       "    aie.flow(%tile_0_1, DMA : 1, %tile_0_2, DMA : 1)\n",
       "    aie.flow(%tile_0_2, DMA : 0, %tile_0_1, DMA : 2)\n",
       "    aie.flow(%tile_0_1, DMA : 2, %tile_0_0, DMA : 0)\n",
-      "    func.func @bobsyouruncle() {\n",
+      "    aiex.runtime_sequence() {\n",
       "      aiex.npu.writebd_shimtile {bd_id = 0 : i32, buffer_length = 64 : i32, buffer_offset = 0 : i32, column = 0 : i32, column_num = 1 : i32, d0_size = 8 : i32, d0_stride = 0 : i32, d1_size = 8 : i32, d1_stride = 15 : i32, d2_stride = 0 : i32, ddr_id = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}\n",
       "      aiex.npu.write32 {address = 119316 : ui32, column = 0 : i32, row = 0 : i32, value = 0 : ui32}\n",
       "      aiex.npu.writebd_shimtile {bd_id = 1 : i32, buffer_length = 64 : i32, buffer_offset = 32 : i32, column = 0 : i32, column_num = 1 : i32, d0_size = 8 : i32, d0_stride = 0 : i32, d1_size = 8 : i32, d1_stride = 15 : i32, d2_stride = 0 : i32, ddr_id = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}\n",

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
@@ -642,7 +642,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait {symbol = @airMemcpyId12}
-      return
     }
   } {sym_name = "segment_0"}
 }

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
@@ -568,7 +568,7 @@ module {
     memref.global "public" @airMemcpyId4 : memref<16x16xi32, 1 : i32>
     aie.shim_dma_allocation @airMemcpyId5(MM2S, 1, 0)
     memref.global "public" @airMemcpyId5 : memref<16x16xi32, 1 : i32>
-    func.func @matmul_16x16_16xi32__dispatch_0_matmul_16x16x16_i32(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {
+    aiex.runtime_sequence(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {
       // <trace>
       aiex.npu.write32 {address = 212992 : ui32, column = 3 : i32, row = 2 : i32, value = 31232 : ui32} // [14:8] reset event: 122(BROADCAST_15)	
       aiex.npu.write32 {address = 213200 : ui32, column = 3 : i32, row = 2 : i32, value = 7995392 : ui32} // [22:16] start event: 122(BROADCAST_15)

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
@@ -490,7 +490,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait {symbol = @airMemcpyId12}
-      return
     }
   } {sym_name = "segment_0"}
 }

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
@@ -416,7 +416,7 @@ module {
     memref.global "public" @airMemcpyId4 : memref<16x16xi32, 1 : i32>
     aie.shim_dma_allocation @airMemcpyId5(MM2S, 1, 0)
     memref.global "public" @airMemcpyId5 : memref<16x16xi32, 1 : i32>
-    func.func @matmul_16x16_16xi32__dispatch_0_matmul_16x16x16_i32(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {
+    aiex.runtime_sequence(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {
       // <trace>
       aiex.npu.write32 {address = 212992 : ui32, column = 3 : i32, row = 2 : i32, value = 31232 : ui32} // [14:8] reset event: 122(BROADCAST_15)	
       aiex.npu.write32 {address = 213200 : ui32, column = 3 : i32, row = 2 : i32, value = 7995392 : ui32} // [22:16] start event: 122(BROADCAST_15)

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
@@ -195,7 +195,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait { symbol = @airMemcpyId12}
-      return
     }
   } {sym_name = "segment_0"}
 }

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
@@ -162,7 +162,7 @@ module {
     memref.global "public" @airMemcpyId4 : memref<16x16xi32, 1 : i32>
     aie.shim_dma_allocation @airMemcpyId5(MM2S, 1, 0)
     memref.global "public" @airMemcpyId5 : memref<16x16xi32, 1 : i32>
-    func.func @matmul_16x16_16xi32__dispatch_0_matmul_16x16x16_i32(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {     
+    aiex.runtime_sequence(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {     
       // <trace>
       aiex.npu.write32 {address = 212992 : ui32, column = 0 : i32, row = 2 : i32, value = 31232 : ui32} // [14:8] reset event: 122(BROADCAST_15)
       aiex.npu.write32 {address = 213200 : ui32, column = 0 : i32, row = 2 : i32, value = 7995392 : ui32} // [22:16] start event: 122(BROADCAST_15)

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
@@ -442,7 +442,7 @@ module {
     memref.global "public" @airMemcpyId4 : memref<16x16xi32, 1 : i32>
     aie.shim_dma_allocation @airMemcpyId5(MM2S, 1, 0)
     memref.global "public" @airMemcpyId5 : memref<16x16xi32, 1 : i32>
-    func.func @matmul_16x16_16xi32__dispatch_0_matmul_16x16x16_i32(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {     
+    aiex.runtime_sequence(%arg0: memref<16x16xi32>, %arg1: memref<16x16xi32>, %arg2: memref<16x16xi32>) {     
       // <trace>
       aiex.npu.write32 {address = 212992 : ui32, column = 3 : i32, row = 2 : i32, value = 31232 : ui32} // [14:8] reset event: 122(BROADCAST_15)	
       aiex.npu.write32 {address = 213200 : ui32, column = 3 : i32, row = 2 : i32, value = 7995392 : ui32} // [22:16] start event: 122(BROADCAST_15)

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
@@ -526,7 +526,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait {symbol = @airMemcpyId12}
-      return
     }
   } {sym_name = "segment_0"}
 }

--- a/test/npu-xrt/matrix_transpose/aie2.py
+++ b/test/npu-xrt/matrix_transpose/aie2.py
@@ -68,7 +68,7 @@ def design():
                     yield_([])
 
             # To/from AIE-array data movement
-            @FuncOp.from_py_func(matrix_memref, matrix_memref)
+            @runtime_sequence(matrix_memref, matrix_memref)
             def sequence(inp, out):
                 npu_dma_memcpy_nd(
                     metadata=fifo_in.sym_name.value,

--- a/test/npu-xrt/nd_memcpy_transforms/aie2.py
+++ b/test/npu-xrt/nd_memcpy_transforms/aie2.py
@@ -84,7 +84,7 @@ def design():
                     yield_([])
 
             # To/from AIE-array data movement
-            @FuncOp.from_py_func(memref_a, memref_b, memref_c)
+            @runtime_sequence(memref_a, memref_b, memref_c)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(
                     metadata=fifo_a.sym_name.value,

--- a/test/npu-xrt/sync_task_complete_token/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token/aie2.py
@@ -70,7 +70,7 @@ def design():
                     yield_([])
 
             # To/from AIE-array data movement
-            @FuncOp.from_py_func(memref_t, memref_t)
+            @runtime_sequence(memref_t, memref_t)
             def sequence(input, output):
                 for i in range(output_sz):
                     # Configure and start, and wait for 16 BDs, each transferring the next contiguous input tile.

--- a/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
@@ -70,7 +70,7 @@ def design():
                     yield_([])
 
             # To/from AIE-array data movement
-            @FuncOp.from_py_func(memref_t, memref_t)
+            @runtime_sequence(memref_t, memref_t)
             def sequence(input, output):
                 for i in range(output_sz):
 

--- a/test/npu-xrt/two_col/aie.mlir
+++ b/test/npu-xrt/two_col/aie.mlir
@@ -128,7 +128,7 @@ module {
       }
       aie.end
     } {link_with = "threshold.o"}
-    func.func @sequence(%in : memref<2048xi32>, %buf : memref<32xi32>, %out : memref<2048xi32>) {
+    aiex.runtime_sequence(%in : memref<2048xi32>, %buf : memref<32xi32>, %out : memref<2048xi32>) {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2048 = arith.constant 2048 : i64
@@ -143,7 +143,6 @@ module {
       aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2048][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<2048xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2048][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<2048xi32>
       aiex.npu.dma_wait {symbol = @objFifo_out0}
-      return
     }
   }
 }

--- a/test/npu-xrt/vector_scalar_using_dma/aie.mlir
+++ b/test/npu-xrt/vector_scalar_using_dma/aie.mlir
@@ -65,14 +65,13 @@ module {
 
     aie.shim_dma_allocation @in(MM2S, 0, 0)
 
-    func.func @sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
+    aiex.runtime_sequence(%arg0: memref<4096xi32>, %arg1: memref<4096xi32>, %arg2: memref<4096xi32>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c4096_i64 = arith.constant 4096 : i64
       aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c4096_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @out, issue_token = true} : memref<4096xi32>
       aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c4096_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @in} : memref<4096xi32>
       aiex.npu.dma_wait { symbol = @out }
-      return
     }
 
     aie.shim_dma_allocation @out(S2MM, 0, 0)

--- a/test/python/npu.py
+++ b/test/python/npu.py
@@ -23,7 +23,7 @@ from aie.dialects.aie import (
     object_fifo_link,
     tile,
 )
-from aie.dialects.aiex import npu_sync, npu_dma_memcpy_nd
+from aie.dialects.aiex import npu_sync, npu_dma_memcpy_nd, runtime_sequence
 from aie.dialects.func import FuncOp
 from aie.dialects.scf import for_
 from aie.dialects.scf import yield_

--- a/test/python/npu.py
+++ b/test/python/npu.py
@@ -75,7 +75,7 @@ def my_vector_scalar(module):
                     yield_([])
                 yield_([])
 
-        @FuncOp.from_py_func(
+        @runtime_sequence(
             T.memref(N, T.i32()), T.memref(N, T.i32()), T.memref(N, T.i32())
         )
         def sequence(A, B, C):
@@ -177,7 +177,7 @@ def my_matmul(module):
                     yield_([])
                 yield_([])
 
-        @FuncOp.from_py_func(
+        @runtime_sequence(
             T.memref(A_sz_in_i32s, T.i32()),
             T.memref(B_sz_in_i32s, T.i32()),
             T.memref(C_sz_in_i32s, T.i32()),
@@ -437,7 +437,7 @@ def edge_detect(module):
                 outOF_L1L2.release(ObjectFifoPort.Produce, 1)
                 yield_([])
 
-        @FuncOp.from_py_func(
+        @runtime_sequence(
             T.memref(2304, T.i32()), T.memref(2304, T.i32()), T.memref(2304, T.i32())
         )
         def sequence(I, B, O):
@@ -492,7 +492,7 @@ def my_add_one_objFifo(module):
                 of_out1.release(ObjectFifoPort.Produce, 1)
                 yield_([])
 
-        @FuncOp.from_py_func(
+        @runtime_sequence(
             T.memref(64, T.i32()), T.memref(32, T.i32()), T.memref(64, T.i32())
         )
         def sequence(inTensor, notUsed, outTensor):

--- a/test/python/trace_utils.py
+++ b/test/python/trace_utils.py
@@ -81,7 +81,7 @@ def passthroughKernel():
             tensorSizeInInt32s = tensorSize // 4
             tensor_ty = T.memref(lineWidthInInt32s, T.i32())
 
-            @FuncOp.from_py_func(tensor_ty, tensor_ty, tensor_ty)
+            @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
             def sequence(inTensor, outTensor, notUsed):
                 if enableTrace:
                     configure_simple_tracing_aie2(


### PR DESCRIPTION
For the following benefits:
 - Enables use of SSA values defined outside of the sequence function scope, so we can e.g. reference `%tile_0_0` defined in the device
 - Previous point will enable better refactorings of some of the NPU ops to use SSA values instead of integers in the future (helps catch mistakes early)
 - Limit to just one sequence function per device
 - Make sure NPU ops are properly nested inside a sequence