### PR TITLE
fix CI race condition with matmul tests in same directory

### DIFF
--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
@@ -1,0 +1,11 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, chess
+//
+// RUN: mkdir -p %S/test_1_col
+// RUN: cd %S/test_1_col
+// RUN: make -f %S/Makefile clean
+// RUN: env n_aie_cols=1 make -f %S/Makefile 
+// RUN: %run_on_npu env n_aie_cols=2 make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
@@ -3,6 +3,8 @@
 //
 // REQUIRES: ryzen_ai, chess
 //
+// RUN: mkdir -p %S/test_2_col
+// RUN: cd %S/test_2_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=2 make -f %S/Makefile 
 // RUN: %run_on_npu env n_aie_cols=2 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
@@ -3,6 +3,8 @@
 //
 // REQUIRES: ryzen_ai, chess
 //
+// RUN: mkdir -p %S/test_4_col
+// RUN: cd %S/test_4_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=4 make -f %S/Makefile 
 // RUN: %run_on_npu env n_aie_cols=4 make -f %S/Makefile run | FileCheck %s


### PR DESCRIPTION
I believe this should fix the issue we were having with #1608. It seems to be you cannot have two tests run inside the same directory, as they are run concurrently and may delete files away from under each other, so this also affected the 2 and 4 column designs (which were intermittently failing).