### PR TITLE
Generalize npu write32 and blockwrite operations

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -689,6 +689,7 @@ def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", []> {
   let arguments = (
     ins UI32Attr:$address,
         UI32Attr:$value,
+        OptionalAttr<FlatSymbolRefAttr>:$buffer,
         OptionalAttr<I32Attr>:$column,
         OptionalAttr<I32Attr>:$row
   );
@@ -697,7 +698,13 @@ def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", []> {
     attr-dict
   }];
   let description = [{
-    write32 operator
+    NPU write32 operator writes a 32bit value to the AIE array.
+    If 'buffer' is present then 'address' is interpreted as an offset into the
+    aie.buffer with symbol name 'buffer'.
+    If 'column' and 'row' are present then 'address' is interpreted as an offset
+    into the memory space of aie.tile(column, row).
+    If 'buffer' is not present and 'column' and 'row' are not present then
+    'address' is interpreted as a full 32-bit address in the AIE array.
   }];
 }
 
@@ -705,15 +712,24 @@ def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", []> {
 def AIE_NpuBlockWriteOp: AIEX_Op<"npu.blockwrite", []> {
   let summary = "blockwrite operator";
   let arguments = (
-    ins AnyMemRef:$data,
-        UI32Attr:$address
+    ins UI32Attr:$address,
+        AnyMemRef:$data,
+        OptionalAttr<FlatSymbolRefAttr>:$buffer,
+        OptionalAttr<I32Attr>:$column,
+        OptionalAttr<I32Attr>:$row
   );
   let results = (outs );
   let assemblyFormat = [{
     `(` $data `)` attr-dict `:` type($data)
   }];
   let description = [{
-    blockwrite operator
+    blockwrite operator writes the data from the memref 'data' to the AIE array.
+    If 'buffer' is present then 'address' is interpreted as an offset into the
+    aie.buffer with symbol name 'buffer'.
+    If 'column' and 'row' are present then 'address' is interpreted as an offset
+    into the memory space of aie.tile(column, row).
+    If 'buffer' is not present and 'column' and 'row' are not present then
+    'address' is interpreted as a full 32-bit address in the AIE array.
   }];
 }
 

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -649,14 +649,12 @@ def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", []> {
 def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", []> {
   let summary = "rtp write operator";
   let arguments = (
-    ins StrAttr:$buffer_sym_name,
-        UI32Attr:$col,
-        UI32Attr:$row,
+    ins FlatSymbolRefAttr:$buffer,
         UI32Attr:$index,
         I32Attr:$value
   );
   let results = (outs );
-  let assemblyFormat = [{ `(` $col `,` $row `,` $index `,` $value `)` attr-dict 
+  let assemblyFormat = [{ `(` $buffer `,` $index `,` $value `)` attr-dict 
   }];
   let description = [{
     rtp write operator

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -69,6 +69,79 @@ private:
 };
 } // namespace
 
+struct Write32SymToAddr : OpConversionPattern<NpuWrite32Op> {
+  using OpConversionPattern::OpConversionPattern;
+
+  Write32SymToAddr(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpConversionPattern(context, benefit) {}
+
+  LogicalResult
+  matchAndRewrite(NpuWrite32Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    if (!op.getBuffer())
+      return failure();
+
+    auto device = op->getParentOfType<AIE::DeviceOp>();
+    auto buffer = device.lookupSymbol<AIE::BufferOp>(*op.getBuffer());
+    if (!buffer)
+      return op->emitError("buffer '" + *op.getBuffer() +
+                           "' not found in device");
+
+    if (!buffer.getAddress())
+      return op->emitError("buffer must have address assigned");
+
+    const AIE::AIETargetModel &tm = device.getTargetModel();
+    uint32_t address = static_cast<uint32_t>(*buffer.getAddress()) +
+                       op.getAddress() * sizeof(uint32_t);
+    auto col = buffer.getTileOp().getCol();
+    auto row = buffer.getTileOp().getRow();
+    address |= ((col & 0xff) << tm.getColumnShift()) |
+               ((row & 0xff) << tm.getRowShift()) | (address & 0xFFFFF);
+
+    rewriter.replaceOpWithNewOp<NpuWrite32Op>(op, address, op.getValue(),
+                                              nullptr, nullptr, nullptr);
+    return success();
+  }
+};
+
+struct BlockWriteSymToAddr : OpConversionPattern<NpuBlockWriteOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  BlockWriteSymToAddr(MLIRContext *context, PatternBenefit benefit = 1)
+      : OpConversionPattern(context, benefit) {}
+
+  LogicalResult
+  matchAndRewrite(NpuBlockWriteOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    if (!op.getBuffer())
+      return failure();
+
+    auto device = op->getParentOfType<AIE::DeviceOp>();
+
+    auto buffer = device.lookupSymbol<AIE::BufferOp>(*op.getBuffer());
+    if (!buffer)
+      return op->emitError("buffer '" + *op.getBuffer() +
+                           "' not found in device");
+
+    if (!buffer.getAddress())
+      return op->emitError("buffer must have address assigned");
+
+    const AIE::AIETargetModel &tm = device.getTargetModel();
+    uint32_t address = static_cast<uint32_t>(*buffer.getAddress()) +
+                       op.getAddress() * sizeof(uint32_t);
+    auto col = buffer.getTileOp().getCol();
+    auto row = buffer.getTileOp().getRow();
+    address |= ((col & 0xff) << tm.getColumnShift()) |
+               ((row & 0xff) << tm.getRowShift()) | (address & 0xFFFFF);
+
+    rewriter.replaceOpWithNewOp<NpuBlockWriteOp>(op, address, op.getData(),
+                                                 nullptr, nullptr, nullptr);
+    return success();
+  }
+};
+
 struct RtpToWrite32Pattern : OpConversionPattern<NpuWriteRTPOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -96,7 +169,7 @@ struct RtpToWrite32Pattern : OpConversionPattern<NpuWriteRTPOp> {
     uint32_t idx = op.getIndex() * sizeof(uint32_t);
     uint32_t address = buffer.getAddress().value() + idx;
 
-    rewriter.create<NpuWrite32Op>(op->getLoc(), address, op.getValue(),
+    rewriter.create<NpuWrite32Op>(op->getLoc(), address, op.getValue(), nullptr,
                                   rewriter.getI32IntegerAttr(tile.getCol()),
                                   rewriter.getI32IntegerAttr(tile.getRow()));
 
@@ -135,10 +208,10 @@ public:
     if (op.getIssueToken())
       cmd |= 0x80000000;
 
-    auto i32ty = IntegerType::get(op->getContext(), 32);
-    auto column = IntegerAttr::get(i32ty, op.getColumn());
-    auto row = IntegerAttr::get(i32ty, 0);
-    rewriter.create<NpuWrite32Op>(op->getLoc(), queue_offset, cmd, column, row);
+    auto column = rewriter.getI32IntegerAttr(op.getColumn());
+    auto row = rewriter.getI32IntegerAttr(0);
+    rewriter.create<NpuWrite32Op>(op->getLoc(), queue_offset, cmd, nullptr,
+                                  column, row);
     rewriter.eraseOp(op);
     return success();
   }
@@ -452,7 +525,8 @@ struct WriteBdToBlockWritePattern : OpConversionPattern<NpuWriteBdOp> {
     auto memref = rewriter.create<memref::GetGlobalOp>(op->getLoc(), memrefType,
                                                        global.getName());
     (void)rewriter.replaceOpWithNewOp<NpuBlockWriteOp>(
-        op, memref.getResult(), rewriter.getUI32IntegerAttr(bd_addr));
+        op, rewriter.getUI32IntegerAttr(bd_addr), memref.getResult(), nullptr,
+        nullptr, nullptr);
     return success();
   }
 };
@@ -480,12 +554,18 @@ struct AIEDmaToNpuPass : AIEDmaToNpuBase<AIEDmaToNpuPass> {
     target.addIllegalOp<NpuPushQueueOp>();
     target.addIllegalOp<NpuWriteRTPOp>();
     target.addIllegalOp<NpuWriteBdOp>();
+    target.addDynamicallyLegalOp<NpuWrite32Op>(
+        [&](NpuWrite32Op op) { return !op.getBuffer(); });
+    target.addDynamicallyLegalOp<NpuBlockWriteOp>(
+        [&](NpuBlockWriteOp op) { return !op.getBuffer(); });
 
     RewritePatternSet patterns(&getContext());
+    patterns.insert<BlockWriteSymToAddr>(&getContext());
     patterns.insert<DmaToNpuPattern>(&getContext(), cachingGetter);
     patterns.insert<DmaWaitToSyncPattern>(&getContext(), cachingGetter);
     patterns.insert<PushQueuetoWrite32Pattern>(&getContext());
     patterns.insert<RtpToWrite32Pattern>(&getContext());
+    patterns.insert<Write32SymToAddr>(&getContext());
     patterns.insert<WriteBdToBlockWritePattern>(&getContext());
 
     if (failed(applyPartialConversion(device, target, std::move(patterns))))

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -71,6 +71,11 @@ void appendWrite32(std::vector<uint32_t> &instructions, NpuWrite32Op op) {
   auto words = reserveAndGetTail(instructions, 6);
   const AIETargetModel &tm = op->getParentOfType<DeviceOp>().getTargetModel();
 
+  if (op.getBuffer()) {
+    op.emitOpError("Cannot translate symbolic address");
+    return;
+  }
+
   // XAIE_IO_WRITE
   words[0] = TXN_OPC_WRITE;
   words[1] = 0;

--- a/programming_examples/ml/bottleneck/aie2.py
+++ b/programming_examples/ml/bottleneck/aie2.py
@@ -596,19 +596,19 @@ def bottleneck4AIEs():
 
                 # write RTP parameters
                 NpuWriteRTPOp(
-                    "rtpComputeTile2", col=0, row=2, index=0, value=1
+                    "rtpComputeTile2", index=0, value=1
                 )  # scale
                 NpuWriteRTPOp(
-                    "rtpComputeTile3", col=0, row=3, index=0, value=1
+                    "rtpComputeTile3", index=0, value=1
                 )  # scale
                 NpuWriteRTPOp(
-                    "rtpComputeTile5", col=0, row=5, index=0, value=1
+                    "rtpComputeTile5", index=0, value=1
                 )  # scale
                 NpuWriteRTPOp(
-                    "rtpComputeTile4", col=0, row=4, index=0, value=1
+                    "rtpComputeTile4", index=0, value=1
                 )  # scale: conv1x1 with the same scale as the input so we match the scaling factor of output after conv1x1 and the initial input
                 NpuWriteRTPOp(
-                    "rtpComputeTile4", col=0, row=4, index=1, value=0
+                    "rtpComputeTile4", index=1, value=0
                 )  # skip_scale
 
                 npu_dma_memcpy_nd(

--- a/programming_examples/ml/bottleneck/aie2.py
+++ b/programming_examples/ml/bottleneck/aie2.py
@@ -595,21 +595,13 @@ def bottleneck4AIEs():
                     npu_write32(0, 2, 0x1D20C, 0x3)
 
                 # write RTP parameters
-                NpuWriteRTPOp(
-                    "rtpComputeTile2", index=0, value=1
-                )  # scale
-                NpuWriteRTPOp(
-                    "rtpComputeTile3", index=0, value=1
-                )  # scale
-                NpuWriteRTPOp(
-                    "rtpComputeTile5", index=0, value=1
-                )  # scale
+                NpuWriteRTPOp("rtpComputeTile2", index=0, value=1)  # scale
+                NpuWriteRTPOp("rtpComputeTile3", index=0, value=1)  # scale
+                NpuWriteRTPOp("rtpComputeTile5", index=0, value=1)  # scale
                 NpuWriteRTPOp(
                     "rtpComputeTile4", index=0, value=1
                 )  # scale: conv1x1 with the same scale as the input so we match the scaling factor of output after conv1x1 and the initial input
-                NpuWriteRTPOp(
-                    "rtpComputeTile4", index=1, value=0
-                )  # skip_scale
+                NpuWriteRTPOp("rtpComputeTile4", index=1, value=0)  # skip_scale
 
                 npu_dma_memcpy_nd(
                     metadata="inOF_act_L3L2",

--- a/programming_examples/ml/conv2d/aie2.py
+++ b/programming_examples/ml/conv2d/aie2.py
@@ -144,7 +144,7 @@ def conv2dk1():
 
             @runtime_sequence(tensor_ty, memRef_wts_ty, tensor_ty)
             def sequence(I, W, O):
-                NpuWriteRTPOp("rtp2", col=0, row=2, index=0, value=10)
+                NpuWriteRTPOp("rtp2", index=0, value=10)
 
                 npu_dma_memcpy_nd(
                     metadata="inOF_act_L3L2",

--- a/programming_examples/ml/conv2d_fused_relu/aie2.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2.py
@@ -229,7 +229,7 @@ def conv2dk1():
                     # Set start BD to our shim bd_Id (3)
                     npu_write32(column=0, row=0, address=0x1D20C, value=trace_bd_id)
 
-                NpuWriteRTPOp("rtp2", col=0, row=2, index=0, value=1)
+                NpuWriteRTPOp("rtp2", index=0, value=1)
 
                 npu_dma_memcpy_nd(
                     metadata="inOF_act_L3L2",

--- a/programming_examples/ml/resnet/layers_conv2_x/aie.mlir
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie.mlir
@@ -970,24 +970,24 @@ aie.device(npu1_3col) {
 
 
 
-      aiex.npu.rtp_write(0, 2, 0,  1) { buffer_sym_name = "rtp2" }
-      aiex.npu.rtp_write(0, 3, 0,  1) { buffer_sym_name = "rtp3" }
-      aiex.npu.rtp_write(0, 5, 0,  1) { buffer_sym_name = "rtp4" }
-      aiex.npu.rtp_write(0, 4, 0,  1)  { buffer_sym_name = "rtp5" }
-      aiex.npu.rtp_write(0, 4, 1,  0)  { buffer_sym_name = "rtp5" }
-      aiex.npu.rtp_write(0, 4, 2,  1)  { buffer_sym_name = "rtp5" }
+      aiex.npu.rtp_write(@rtp2, 0, 1)
+      aiex.npu.rtp_write(@rtp3, 0, 1)
+      aiex.npu.rtp_write(@rtp4, 0, 1)
+      aiex.npu.rtp_write(@rtp5, 0, 1)
+      aiex.npu.rtp_write(@rtp5, 1, 0)
+      aiex.npu.rtp_write(@rtp5, 2, 1)
 
-      aiex.npu.rtp_write(1, 5, 0,  1) { buffer_sym_name = "rtp15" }
-      aiex.npu.rtp_write(1, 4, 0,  1) { buffer_sym_name = "rtp14" }
-      aiex.npu.rtp_write(1, 2, 0,  1) { buffer_sym_name = "rtp12" }
-      aiex.npu.rtp_write(1, 3, 0,  1)  { buffer_sym_name = "rtp13" }
-      aiex.npu.rtp_write(1, 3, 1,  0)  { buffer_sym_name = "rtp13" }
+      aiex.npu.rtp_write(@rtp15, 0, 1)
+      aiex.npu.rtp_write(@rtp14, 0, 1)
+      aiex.npu.rtp_write(@rtp12, 0, 1)
+      aiex.npu.rtp_write(@rtp13, 0, 1)
+      aiex.npu.rtp_write(@rtp13, 1, 0)
 
-      aiex.npu.rtp_write(2, 2, 0,  1) { buffer_sym_name = "rtp22" }
-      aiex.npu.rtp_write(2, 3, 0,  1) { buffer_sym_name = "rtp23" }
-      aiex.npu.rtp_write(2, 5, 0,  1) { buffer_sym_name = "rtp25" }
-      aiex.npu.rtp_write(2, 4, 0,  1)  { buffer_sym_name = "rtp24" }
-      aiex.npu.rtp_write(2, 4, 1,  0)  { buffer_sym_name = "rtp24" }
+      aiex.npu.rtp_write(@rtp22, 0, 1)
+      aiex.npu.rtp_write(@rtp23, 0, 1)
+      aiex.npu.rtp_write(@rtp25, 0, 1)
+      aiex.npu.rtp_write(@rtp24, 0, 1)
+      aiex.npu.rtp_write(@rtp24, 1, 0)
 
       %c0 = arith.constant 0 : i32
       %c1 = arith.constant 1 : i32

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2.py
@@ -923,24 +923,24 @@ def resnet_conv_x():
             )
             def sequence(inputFromL3, weightsFromL3, outputToL3):
 
-                NpuWriteRTPOp("rtpComputeTile02", col=0, row=2, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile03", col=0, row=3, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile04", col=0, row=5, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile05", col=0, row=4, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile05", col=0, row=4, index=1, value=0)
-                NpuWriteRTPOp("rtpComputeTile05", col=0, row=4, index=2, value=1)
+                NpuWriteRTPOp("rtpComputeTile02", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile03", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile04", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile05", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile05", index=1, value=0)
+                NpuWriteRTPOp("rtpComputeTile05", index=2, value=1)
 
-                NpuWriteRTPOp("rtpComputeTile15", col=1, row=5, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile14", col=1, row=4, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile12", col=1, row=2, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile13", col=1, row=3, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile13", col=1, row=3, index=1, value=0)
+                NpuWriteRTPOp("rtpComputeTile15", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile14", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile12", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile13", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile13", index=1, value=0)
 
-                NpuWriteRTPOp("rtpComputeTile22", col=2, row=2, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile23", col=2, row=3, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile25", col=2, row=5, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile24", col=2, row=4, index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile24", col=2, row=4, index=1, value=0)
+                NpuWriteRTPOp("rtpComputeTile22", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile23", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile25", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile24", index=0, value=1)
+                NpuWriteRTPOp("rtpComputeTile24", index=1, value=0)
 
                 npu_dma_memcpy_nd(
                     metadata="act1_00_02_01",

--- a/programming_examples/vision/color_threshold/aie2_colorThreshold.py
+++ b/programming_examples/vision/color_threshold/aie2_colorThreshold.py
@@ -255,21 +255,21 @@ def color_threshold():
             )
             def sequence(inTensor, notUsed, outTensor):
                 # thresholdValue, maxValue, thresholdType
-                NpuWriteRTPOp("rtpComputeTile2", col=0, row=2, index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile2", col=0, row=2, index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile2", col=0, row=2, index=2, value=0)
+                NpuWriteRTPOp("rtpComputeTile2", index=0, value=50)
+                NpuWriteRTPOp("rtpComputeTile2", index=1, value=255)
+                NpuWriteRTPOp("rtpComputeTile2", index=2, value=0)
 
-                NpuWriteRTPOp("rtpComputeTile3", col=0, row=3, index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile3", col=0, row=3, index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile3", col=0, row=3, index=2, value=0)
+                NpuWriteRTPOp("rtpComputeTile3", index=0, value=50)
+                NpuWriteRTPOp("rtpComputeTile3", index=1, value=255)
+                NpuWriteRTPOp("rtpComputeTile3", index=2, value=0)
 
-                NpuWriteRTPOp("rtpComputeTile4", col=0, row=4, index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile4", col=0, row=4, index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile4", col=0, row=4, index=2, value=0)
+                NpuWriteRTPOp("rtpComputeTile4", index=0, value=50)
+                NpuWriteRTPOp("rtpComputeTile4", index=1, value=255)
+                NpuWriteRTPOp("rtpComputeTile4", index=2, value=0)
 
-                NpuWriteRTPOp("rtpComputeTile5", col=0, row=5, index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile5", col=0, row=5, index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile5", col=0, row=5, index=2, value=0)
+                NpuWriteRTPOp("rtpComputeTile5", index=0, value=50)
+                NpuWriteRTPOp("rtpComputeTile5", index=1, value=255)
+                NpuWriteRTPOp("rtpComputeTile5", index=2, value=0)
 
                 npu_dma_memcpy_nd(
                     metadata="inOOB_L3L2",

--- a/test/Conversion/DmaToNpu/bad_rtp_write.mlir
+++ b/test/Conversion/DmaToNpu/bad_rtp_write.mlir
@@ -10,8 +10,8 @@
 
 aie.device(npu1_4col) {
   aiex.runtime_sequence() {
-    // expected-error@+2 {{'aiex.npu.rtp_write' op RTP buffer address cannot be found. Has an RTP buffer been allocated?}}
+    // expected-error@+2 {{buffer 'RTP' not found in device}}
     // expected-error@+1 {{failed to legalize operation 'aiex.npu.rtp_write' that was explicitly marked illegal}}
-    aiex.npu.rtp_write(0, 2, 4, 99) { buffer_sym_name = "RTP" }
+    aiex.npu.rtp_write(@RTP, 4, 99)
   }
 }

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -85,7 +85,7 @@ module  {
 // -----
 
 // CHECK: module
-// CHECK: aiex.npu.write32 {address = 1424 : ui32, value = 1234 : ui32}
+// CHECK: aiex.npu.write32 {address = 2098576 : ui32, value = 1234 : ui32}
 module {
   aie.device(npu1_1col) {
     %tile02 = aie.tile(0,2)

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -82,3 +82,14 @@ module  {
   }
 }
 
+// -----
+
+// CHECK: module
+// CHECK: aiex.npu.write32 {address = 1424 : ui32, value = 1234 : ui32}
+module {
+  aie.device(npu1_1col) {
+    %tile02 = aie.tile(0,2)
+    %data = aie.buffer(%tile02) {address = 1024 : i32, sym_name = "data"} : memref<128xi32>
+    aiex.npu.write32 {buffer = @data, address = 100 : ui32, value = 1234 : ui32}
+  }
+}

--- a/test/Conversion/DmaToNpu/rtp_write.mlir
+++ b/test/Conversion/DmaToNpu/rtp_write.mlir
@@ -17,8 +17,8 @@ module {
     %2 = aie.tile(0, 2)
     %3 = aie.buffer(%2) {address = 3200 : i32, sym_name = "RTP"} : memref<16xi32>
     aiex.runtime_sequence() {
-      aiex.npu.rtp_write(2, 3, 0, 50) { buffer_sym_name = "rtp" }
-      aiex.npu.rtp_write(0, 2, 4, 99) { buffer_sym_name = "RTP" }
+      aiex.npu.rtp_write(@rtp, 0, 50)
+      aiex.npu.rtp_write(@RTP, 4, 99)
     }
   }
 }

--- a/test/npu-xrt/add_blockwrite/aie.mlir
+++ b/test/npu-xrt/add_blockwrite/aie.mlir
@@ -1,0 +1,115 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2022-2024 Advanced Micro Devices, Inc. or its affiliates
+// Copyright (C) 2020-2022, Xilinx Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu1_1col) {
+    memref.global "public" @objFifo_in0 : memref<64xi32>
+    memref.global "public" @objFifo_out0 : memref<64xi32>
+
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    %objFifo_in1_cons_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_0"} : memref<8xi32>
+    %objFifo_in1_cons_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_1"} : memref<8xi32>
+    %objFifo_out1_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_0"} : memref<8xi32>
+    %objFifo_out1_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_1"} : memref<8xi32>
+    %constant_buffer = aie.buffer(%tile_0_2) {sym_name = "constant_buffer"} : memref<8xi32>
+
+    %objFifo_in1_cons_prod_lock = aie.lock(%tile_0_2, 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock"}
+    %objFifo_in1_cons_cons_lock = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock"}
+    %objFifo_out1_prod_lock = aie.lock(%tile_0_2, 2) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock"}
+    %objFifo_out1_cons_lock = aie.lock(%tile_0_2, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_lock"}
+
+    aie.flow(%tile_0_0, DMA : 0, %tile_0_2, DMA : 0)
+    aie.flow(%tile_0_2, DMA : 0, %tile_0_0, DMA : 0)
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c8 = arith.constant 8 : index
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c2 = arith.constant 2 : index
+      scf.for %arg0 = %c0 to %c8 step %c2 {
+        aie.use_lock(%objFifo_in1_cons_cons_lock, AcquireGreaterEqual, 1)
+        aie.use_lock(%objFifo_out1_prod_lock, AcquireGreaterEqual, 1)
+
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          %0 = memref.load %objFifo_in1_cons_buff_0[%arg1] : memref<8xi32>
+          %1 = memref.load %constant_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %0, %1 : i32
+          memref.store %2, %objFifo_out1_buff_0[%arg1] : memref<8xi32>
+        }
+
+        aie.use_lock(%objFifo_in1_cons_prod_lock, Release, 1)
+        aie.use_lock(%objFifo_out1_cons_lock, Release, 1)
+
+        aie.use_lock(%objFifo_in1_cons_cons_lock, AcquireGreaterEqual, 1)
+        aie.use_lock(%objFifo_out1_prod_lock, AcquireGreaterEqual, 1)
+
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          %0 = memref.load %objFifo_in1_cons_buff_1[%arg1] : memref<8xi32>
+          %1 = memref.load %constant_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %0, %1 : i32
+          memref.store %2, %objFifo_out1_buff_1[%arg1] : memref<8xi32>
+        }
+
+        aie.use_lock(%objFifo_in1_cons_prod_lock, Release, 1)
+        aie.use_lock(%objFifo_out1_cons_lock, Release, 1)
+      }
+      aie.end
+    }
+
+    aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
+    aie.shim_dma_allocation @objFifo_out0(S2MM, 0, 0)
+
+    memref.global "private" @myData : memref<8xi32> = dense<[1, 2, 3, 4, 5, 6, 7, 8]>
+    aiex.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c64_i64 = arith.constant 64 : i64
+      %0 = memref.get_global @myData : memref<8xi32>
+      aiex.npu.blockwrite(%0) {buffer = @constant_buffer, address = 0 : ui32} : memref<8xi32>
+      aiex.npu.write32 {buffer = @constant_buffer, address = 4 : ui32, value = 42 : ui32}
+      aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, issue_token = true, metadata = @objFifo_in0} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, issue_token = true, metadata = @objFifo_out0} : memref<64xi32>
+      aiex.npu.dma_wait {symbol = @objFifo_in0}
+      aiex.npu.dma_wait {symbol = @objFifo_out0}
+    }
+
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
+      aie.dma_bd(%objFifo_in1_cons_buff_0 : memref<8xi32>, 0, 8)
+      aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
+      aie.next_bd ^bb2
+    ^bb2:  // pred: ^bb1
+      aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
+      aie.dma_bd(%objFifo_in1_cons_buff_1 : memref<8xi32>, 0, 8)
+      aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
+      aie.next_bd ^bb1
+    ^bb3:  // pred: ^bb0
+      %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
+    ^bb4:  // 2 preds: ^bb3, ^bb5
+      aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
+      aie.dma_bd(%objFifo_out1_buff_0 : memref<8xi32>, 0, 8)
+      aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
+      aie.next_bd ^bb5
+    ^bb5:  // pred: ^bb4
+      aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
+      aie.dma_bd(%objFifo_out1_buff_1 : memref<8xi32>, 0, 8)
+      aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
+      aie.next_bd ^bb4
+    ^bb6:  // pred: ^bb3
+      aie.end
+    }
+  }
+}

--- a/test/npu-xrt/add_blockwrite/run.lit
+++ b/test/npu-xrt/add_blockwrite/run.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+//
+// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --basic-alloc-scheme --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt | FileCheck %s
+// CHECK: PASS!
+

--- a/test/npu-xrt/add_blockwrite/test.cpp
+++ b/test/npu-xrt/add_blockwrite/test.cpp
@@ -176,7 +176,7 @@ int main(int argc, const char *argv[]) {
   uint32_t c[8] = {1, 2, 3, 4, 5, 6, 7, 8};
   c[4] = 42;
   for (uint32_t i = 0; i < 64; i++) {
-    uint32_t ref = i + 1 + c[i%8];
+    uint32_t ref = i + 1 + c[i % 8];
     if (*(bufOut + i) != ref) {
       std::cout << "Error in output " << *(bufOut + i) << " != " << ref
                 << std::endl;

--- a/test/npu-xrt/add_blockwrite/test.cpp
+++ b/test/npu-xrt/add_blockwrite/test.cpp
@@ -1,0 +1,197 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <boost/program_options.hpp>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+constexpr int IN_SIZE = 64;
+constexpr int OUT_SIZE = 64;
+
+namespace po = boost::program_options;
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  po::options_description desc("Allowed options");
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    return 1;
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+
+  std::vector<uint32_t> instr_v =
+      load_instr_sequence(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_inB = xrt::bo(device, IN_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  uint32_t *bufInA = bo_inA.map<uint32_t *>();
+  std::vector<uint32_t> srcVecA;
+  for (int i = 0; i < IN_SIZE; i++)
+    srcVecA.push_back(i + 1);
+  memcpy(bufInA, srcVecA.data(), (srcVecA.size() * sizeof(uint32_t)));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_inA.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running Kernel.\n";
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), bo_inA, bo_inB, bo_out);
+
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
+    return 1;
+  }
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  uint32_t *bufOut = bo_out.map<uint32_t *>();
+
+  int errors = 0;
+
+  uint32_t c[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  c[4] = 42;
+  for (uint32_t i = 0; i < 64; i++) {
+    uint32_t ref = i + 1 + c[i%8];
+    if (*(bufOut + i) != ref) {
+      std::cout << "Error in output " << *(bufOut + i) << " != " << ref
+                << std::endl;
+      errors++;
+    } else {
+      std::cout << "Correct output " << *(bufOut + i) << " == " << ref
+                << std::endl;
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nfailed.\n\n";
+    return 1;
+  }
+}

--- a/test/npu-xrt/two_col/aie.mlir
+++ b/test/npu-xrt/two_col/aie.mlir
@@ -132,14 +132,14 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c2048 = arith.constant 2048 : i64
-      aiex.npu.rtp_write(0, 2, 0, 50) { buffer_sym_name = "rtp0" }
-      aiex.npu.rtp_write(0, 3, 0, 50) { buffer_sym_name = "rtp1" }
-      aiex.npu.rtp_write(1, 4, 0, 50) { buffer_sym_name = "rtp2" }
-      aiex.npu.rtp_write(1, 5, 0, 50) { buffer_sym_name = "rtp3" }
-      aiex.npu.rtp_write(0, 2, 1, 0) { buffer_sym_name = "rtp0" }
-      aiex.npu.rtp_write(0, 3, 1, 0) { buffer_sym_name = "rtp1" }
-      aiex.npu.rtp_write(1, 4, 1, 0) { buffer_sym_name = "rtp2" }
-      aiex.npu.rtp_write(1, 5, 1, 0) { buffer_sym_name = "rtp3" }
+      aiex.npu.rtp_write(@rtp0, 0, 50)
+      aiex.npu.rtp_write(@rtp1, 0, 50)
+      aiex.npu.rtp_write(@rtp2, 0, 50)
+      aiex.npu.rtp_write(@rtp3, 0, 50)
+      aiex.npu.rtp_write(@rtp0, 1, 0)
+      aiex.npu.rtp_write(@rtp1, 1, 0)
+      aiex.npu.rtp_write(@rtp2, 1, 0)
+      aiex.npu.rtp_write(@rtp3, 1, 0)
       aiex.npu.dma_memcpy_nd (0, 0, %out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2048][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<2048xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2048][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<2048xi32>
       aiex.npu.dma_wait {symbol = @objFifo_out0}


### PR DESCRIPTION
This started as a PR to simplify `npu.rtp_write` ops by removing the extraneous column and row operands. It also changes the syntax to use symbols instead of strings.
Old:
```mlir
aiex.npu.rtp_write(0, 2, 0,  1) { buffer_sym_name = "rtp2" }  // rtp2[0] = 1
```
New:
```mlir
aiex.npu.rtp_write(@rtp2, 0, 1) // rtp2[0] = 1
```
But it morphed into a PR to support symbols as the address to `npu.write32` and `npu.blockwrite`. for example,
```mlir
    %constant_buffer = aie.buffer(%tile_0_2) {sym_name = "constant_buffer"} : memref<8xi32>
    memref.global "private" @myData : memref<8xi32> = dense<[1, 2, 3, 4, 5, 6, 7, 8]>
    ...
    aiex.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
      %c0_i64 = arith.constant 0 : i64
      %c1_i64 = arith.constant 1 : i64
      %c64_i64 = arith.constant 64 : i64
      %0 = memref.get_global @myData : memref<8xi32>
      // copy contents of @myData to @constant_buffer
      aiex.npu.blockwrite(%0) {buffer = @constant_buffer, address = 0 : ui32} : memref<8xi32>
      // constant_buffer[4] = 42
      aiex.npu.write32 {buffer = @constant_buffer, address = 4 : ui32, value = 42 : ui32}
      aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, issue_token = true, metadata = @objFifo_in0} : memref<64xi32>
      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c64_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, issue_token = true, metadata = @objFifo_out0} : memref<64xi32>
      aiex.npu.dma_wait {symbol = @objFifo_in0}
      aiex.npu.dma_wait {symbol = @objFifo_out0}
    }
```
which sorta makes `npu.rtp_write` obsolete.

Both `npu.write32` and `npu.blockwrite` are updated to support 3 addressing modes:
* buffer + offset (above)
* (row, col) +  offset (previously supported by write32 only)
* address (the full AIE array address)
