### PR TITLE
Fix programming guide bug where trace might overwrite data

### DIFF
--- a/programming_guide/section-4/section-4b/Makefile
+++ b/programming_guide/section-4/section-4b/Makefile
@@ -20,11 +20,20 @@ build/aie.mlir: ${srcdir}/aie2.py
 	mkdir -p ${@D}
 	python3 $< > $@
 
+build/aie_trace.mlir: ${srcdir}/aie2.py
+	mkdir -p ${@D}
+	python3 $< -t ${trace_size} > $@
+
 build/scale.o: ${srcdir}/vector_scalar_mul.cc
 	mkdir -p ${@D}
 	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -c $< -o ${@F}
 
 build/final.xclbin: build/aie.mlir build/scale.o
+	mkdir -p ${@D}
+	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+
+build/trace.xclbin: build/aie_trace.mlir build/scale.o
 	mkdir -p ${@D}
 	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
 				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
@@ -40,19 +49,19 @@ else
 	cp _build/${targetname} $@ 
 endif
 
-run: ${targetname}.exe build/final.xclbin build/insts.txt 
+run: ${targetname}.exe build/final.xclbin
 	${powershell} ./$< -x build/final.xclbin -i build/insts.txt -k MLIR_AIE
 
-run_py: build/final.xclbin build/insts.txt
+run_py: build/final.xclbin
 	${powershell} python3 ${srcdir}/test.py -x build/final.xclbin -i build/insts.txt -k MLIR_AIE
 
-trace: ${targetname}.exe build/final.xclbin build/insts.txt 
-	${powershell} ./$< -x build/final.xclbin -i build/insts.txt -k MLIR_AIE -t ${trace_size}
-	../../../programming_examples/utils/parse_trace.py --filename trace.txt --mlir build/aie.mlir --colshift 1 > trace_4b.json
+trace: ${targetname}.exe build/trace.xclbin
+	${powershell} ./$< -x build/trace.xclbin -i build/insts.txt -k MLIR_AIE -t ${trace_size}
+	../../../programming_examples/utils/parse_trace.py --filename trace.txt --mlir build/aie_trace.mlir --colshift 1 > trace_4b.json
 
-trace_py: build/final.xclbin build/insts.txt
-	${powershell} python3 ${srcdir}/test.py -x build/final.xclbin -i build/insts.txt -k MLIR_AIE -t ${trace_size}
-	../../../programming_examples/utils/parse_trace.py --filename trace.txt --mlir build/aie.mlir --colshift 1 > trace_4b.json
+trace_py: build/final.xclbin
+	${powershell} python3 ${srcdir}/test.py -x build/trace.xclbin -i build/insts.txt -k MLIR_AIE -t ${trace_size}
+	../../../programming_examples/utils/parse_trace.py --filename trace.txt --mlir build/aie_trace.mlir --colshift 1 > trace_4b.json
 
 clean_trace:
 	rm -rf tmpTrace trace.txt trace*json

--- a/programming_guide/section-4/section-4b/aie2.py
+++ b/programming_guide/section-4/section-4b/aie2.py
@@ -6,6 +6,7 @@
 #
 # (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
 
+import argparse
 import sys
 
 from aie.dialects.aie import *
@@ -16,10 +17,10 @@ from aie.extras.context import mlir_mod_ctx
 import aie.utils.trace as trace_utils
 
 
-def my_vector_scalar():
+def my_vector_scalar(opts):
 
-    enableTrace = True
-    trace_size = 8192
+    enableTrace = opts.trace_size > 0
+    trace_size = opts.trace_size
 
     @device(AIEDevice.npu1_1col)
     def device_body():
@@ -85,10 +86,21 @@ def my_vector_scalar():
             npu_sync(column=0, row=0, direction=0, channel=0)
 
 
-with mlir_mod_ctx() as ctx:
-    my_vector_scalar()
-    res = ctx.module.operation.verify()
-    if res == True:
-        print(ctx.module)
-    else:
-        print(res)
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "-t",
+        "--trace_sz",
+        dest="trace_size",
+        default=0,
+        type=int,
+        help="trace size in bytes",
+    )
+    opts = p.parse_args(sys.argv[1:])
+    with mlir_mod_ctx() as ctx:
+        my_vector_scalar(opts)
+        res = ctx.module.operation.verify()
+        if res == True:
+            print(ctx.module)
+        else:
+            print(res)

--- a/programming_guide/section-4/section-4b/test.py
+++ b/programming_guide/section-4/section-4b/test.py
@@ -111,7 +111,6 @@ def main(opts):
                 print("Verifying results ...")
             ref = np.arange(1, INOUT0_VOLUME + 1, dtype=INOUT0_DATATYPE) * scale_factor
             e = np.equal(output_buffer, ref)
-            print(ref, output_buffer)
             errors = errors + np.size(e) - np.count_nonzero(e)
 
         # Write trace values if trace_size > 0

--- a/programming_guide/section-4/section-4b/test.py
+++ b/programming_guide/section-4/section-4b/test.py
@@ -111,7 +111,7 @@ def main(opts):
                 print("Verifying results ...")
             ref = np.arange(1, INOUT0_VOLUME + 1, dtype=INOUT0_DATATYPE) * scale_factor
             e = np.equal(output_buffer, ref)
-            print (ref, output_buffer)
+            print(ref, output_buffer)
             errors = errors + np.size(e) - np.count_nonzero(e)
 
         # Write trace values if trace_size > 0

--- a/programming_guide/section-4/section-4b/test.py
+++ b/programming_guide/section-4/section-4b/test.py
@@ -111,6 +111,7 @@ def main(opts):
                 print("Verifying results ...")
             ref = np.arange(1, INOUT0_VOLUME + 1, dtype=INOUT0_DATATYPE) * scale_factor
             e = np.equal(output_buffer, ref)
+            print (ref, output_buffer)
             errors = errors + np.size(e) - np.count_nonzero(e)
 
         # Write trace values if trace_size > 0


### PR DESCRIPTION
I encountered an error with `programming_guide/section-4/section-4b` where `aie2.py` is emitting an mlir-aie program with trace enabled but the host code executed by the CI via Makefile (`make run` and `make run_py`) don't expect trace to be on. For me this resulted in trace data corrupting the output for `make run` in the CI. This PR updates `aie2.py` with a trace option and things are not passing for me.