### PR TITLE
Update RyzenAI detection for newer XRT

### DIFF
--- a/docs/buildHostLin.md
+++ b/docs/buildHostLin.md
@@ -243,11 +243,11 @@ You will...
     sudo dpkg -i xrt_plugin.2.18.0_ubuntu22.04-x86_64-amdxdna.deb
     ```
     
-1. Check that the NPU is working if the device appears with xbutil:
+1. Check that the NPU is working if the device appears with xrt-smi:
    
    ```bash
    source /opt/xilinx/xrt/setup.sh
-   xbutil examine
+   xrt-smi examine
    ```
 
    > At the bottom of the output you should see:

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -121,13 +121,17 @@ if config.xrt_lib_dir:
         config.xrt_include_dir, config.xrt_lib_dir
     )
     try:
-        xbutil = os.path.join(config.xrt_bin_dir, "xbutil")
+        # xbutil is deprecated/renamed to xrt-smi, leaving it xbutil for now for
+        # compatibility with older versions of XRT
+        # xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
+        xrtsmi = os.path.join(config.xrt_bin_dir, "xbutil")
         result = subprocess.run(
-            [xbutil, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         result = result.stdout.decode("utf-8").split("\n")
         # Starting with Linux 6.8 the format is like "[0000:66:00.1]  :  RyzenAI-npu1"
-        p = re.compile("\[.+:.+:.+\].+(Phoenix|RyzenAI-(npu\d))")
+        # Starting with Linux 6.10 the format is like "|[0000:41:00.1]  ||RyzenAI-npu1  |"
+        p = re.compile("[\|]?\[.+:.+:.+\].+(Phoenix|RyzenAI-(npu\d))")
         for l in result:
             m = p.match(l)
             if m:
@@ -141,7 +145,7 @@ if config.xrt_lib_dir:
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
     except:
-        print("Failed to run xbutil")
+        print("Failed to run xrt-smi")
         pass
 else:
     print("xrt not found")

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -121,13 +121,17 @@ if config.xrt_lib_dir:
         config.xrt_include_dir, config.xrt_lib_dir
     )
     try:
-        xbutil = os.path.join(config.xrt_bin_dir, "xbutil")
+        # xbutil is deprecated/renamed to xrt-smi, leaving it xbutil for now for
+        # compatibility with older versions of XRT
+        # xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
+        xrtsmi = os.path.join(config.xrt_bin_dir, "xbutil")
         result = subprocess.run(
-            [xbutil, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         result = result.stdout.decode("utf-8").split("\n")
         # Starting with Linux 6.8 the format is like "[0000:66:00.1]  :  RyzenAI-npu1"
-        p = re.compile("\[.+:.+:.+\].+(Phoenix|RyzenAI-(npu\d))")
+        # Starting with Linux 6.10 the format is like "|[0000:41:00.1]  ||RyzenAI-npu1  |"
+        p = re.compile("[\|]?\[.+:.+:.+\].+(Phoenix|RyzenAI-(npu\d))")
         for l in result:
             m = p.match(l)
             if m:
@@ -141,7 +145,7 @@ if config.xrt_lib_dir:
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
     except:
-        print("Failed to run xbutil")
+        print("Failed to run xrt-smi")
         pass
 else:
     print("xrt not found")

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -129,13 +129,17 @@ if config.xrt_lib_dir:
     )
     config.available_features.add("xrt")
     try:
-        xbutil = os.path.join(config.xrt_bin_dir, "xbutil")
+        # xbutil is deprecated/renamed to xrt-smi, leaving it xbutil for now for
+        # compatibility with older versions of XRT
+        # xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
+        xrtsmi = os.path.join(config.xrt_bin_dir, "xbutil")
         result = subprocess.run(
-            [xbutil, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         result = result.stdout.decode("utf-8").split("\n")
         # Starting with Linux 6.8 the format is like "[0000:66:00.1]  :  RyzenAI-npu1"
-        p = re.compile("\[.+:.+:.+\].+(Phoenix|RyzenAI-(npu\d))")
+        # Starting with Linux 6.10 the format is like "|[0000:41:00.1]  ||RyzenAI-npu1  |"
+        p = re.compile("[\|]?\[.+:.+:.+\].+(Phoenix|RyzenAI-(npu\d))")
         for l in result:
             m = p.match(l)
             if m:
@@ -149,7 +153,7 @@ if config.xrt_lib_dir:
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
     except:
-        print("Failed to run xbutil")
+        print("Failed to run xrt-smi")
         pass
 else:
     print("xrt not found")

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -17,12 +17,12 @@
 
 echo "Setting up RyzenAI developement tools..."
 if [[ $WSL_DISTRO_NAME == "" ]]; then
-  XBUTIL=`which xbutil`
-  if ! test -f "$XBUTIL"; then 
+  XRTSMI=`which xrt-smi`
+  if ! test -f "$XRTSMI"; then
     echo "XRT is not installed"
     return 1
   fi
-  NPU=`/opt/xilinx/xrt/bin/xbutil examine | grep RyzenAI`
+  NPU=`/opt/xilinx/xrt/bin/xrt-smi examine | grep RyzenAI`
   if [[ $NPU == *"RyzenAI"* ]]; then
     echo "Ryzen AI NPU found:"
     echo $NPU


### PR DESCRIPTION
* replace renamed `xbutil` with `xrt-smi` in docs and quick-start.sh
* update regex for detecting driver in CI scripts
* continue to use `xbutil` in CI scripts for now for backward compatibility until xbutil disappears. 