### PR TITLE
[aievec] Add reordering of extsi -> broadcast ops

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
@@ -326,6 +326,47 @@ struct HoistCastOpToDataSourcePattern : public RewritePattern {
   }
 };
 
+// This pattern swaps a UnaryOpA followed by UnaryOpB. This pattern can be used
+// to improve pattern matching for mixed-type arithmetic ops, by getting sign
+// extension ops closer to the single-type arithmetic operations.
+template <class UnaryOpA, class UnaryOpB>
+struct SwapUnaryOpsPattern : public OpRewritePattern<UnaryOpB> {
+  using OpRewritePattern<UnaryOpB>::OpRewritePattern;
+  // This function takes the chain of operations A->B, and returns the new type
+  // between B and A after the swap.
+  using InferTypeB2AFnTy = std::function<Type(UnaryOpA aOp, UnaryOpB bOp)>;
+  InferTypeB2AFnTy inferTypeB2A = nullptr;
+
+  SwapUnaryOpsPattern(MLIRContext *context, InferTypeB2AFnTy inferType)
+      : OpRewritePattern<UnaryOpB>(context), inferTypeB2A(inferType) {}
+
+  LogicalResult matchAndRewrite(UnaryOpB bOp,
+                                PatternRewriter &rewriter) const override {
+    static_assert(
+        UnaryOpA::template hasTrait<OpTrait::OneOperand>(),
+        "SwapUnaryOps can only be instantiated for single-operand ops");
+    static_assert(
+        UnaryOpB::template hasTrait<OpTrait::OneOperand>(),
+        "SwapUnaryOps can only be instantiated for single-operand ops");
+    UnaryOpA aOp = bOp.getOperand().template getDefiningOp<UnaryOpA>();
+    if (!aOp)
+      return rewriter.notifyMatchFailure(bOp, UnaryOpB::getOperationName() +
+                                                  " not preceeded by " +
+                                                  UnaryOpA::getOperationName());
+
+    Type newA2BTy = inferTypeB2A(aOp, bOp);
+
+    auto newA =
+        rewriter.create<UnaryOpB>(bOp->getLoc(), SmallVector<Type>({newA2BTy}),
+                                  aOp->getOperands(), bOp->getAttrs());
+    auto newB = rewriter.create<UnaryOpA>(
+        bOp->getLoc(), SmallVector<Type>({bOp.getResult().getType()}),
+        newA->getResults(), aOp->getAttrs());
+    rewriter.replaceOp(bOp, newB.getResult());
+    return success();
+  }
+};
+
 static SmallVector<Value> collapseInnerMostDimIndices(PatternRewriter &b,
                                                       Location loc, int numDims,
                                                       ValueRange indices,
@@ -779,6 +820,33 @@ static std::unique_ptr<::mlir::Pass> createHoistCastOpToDataSourcePass() {
   return std::make_unique<HoistCastOpToDataSourcePass>();
 }
 
+struct ReorderOperationsPass
+    : public PassWrapper<ReorderOperationsPass, OperationPass<>> {
+
+  void runOnOperation() override {
+    auto op = getOperation();
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+
+    patterns.add<SwapUnaryOpsPattern<arith::ExtSIOp, vector::BroadcastOp>>(
+        patterns.getContext(),
+        [](arith::ExtSIOp extOp, vector::BroadcastOp bcastOp) -> Type {
+          Type extInElemTy = extOp.getIn().getType();
+          auto extInVecTy = dyn_cast<VectorType>(extInElemTy);
+          if (extInVecTy)
+            extInElemTy = extInVecTy.getElementType();
+          return VectorType::get(bcastOp.getResultVectorType().getShape(),
+                                 extInElemTy);
+        });
+
+    (void)applyPatternsAndFoldGreedily(op, std::move(patterns));
+  }
+};
+
+static std::unique_ptr<::mlir::Pass> createReorderOperationsPass() {
+  return std::make_unique<ReorderOperationsPass>();
+}
+
 //============================================================================//
 //=============== Main Vector2Vector Pipeline Configuration ==================//
 //============================================================================//
@@ -788,6 +856,8 @@ void xilinx::aievec::buildCanonicalizeVectorForAIEVec(
   // Add `Vector` code canonicalization passes
   // TODO: Add passes to unroll vector with unsupported types
   // TODO: Add passes to split vectors that won't fit in registers
+  if (decodeTargetBackend(options.targetBackend) == TargetBackend::LLVMIR)
+    pm.addPass(createReorderOperationsPass());
   pm.addPass(createCopyRemovalPass());
   pm.addPass(createCanonicalizeVectorForAIEVecPass(options));
   if (decodeTargetBackend(options.targetBackend) == TargetBackend::CPP)

--- a/test/dialect/AIEVec/precanonicalization-aieml-llvmir.mlir
+++ b/test/dialect/AIEVec/precanonicalization-aieml-llvmir.mlir
@@ -1,0 +1,23 @@
+// RUN: aie-opt %s -canonicalize-vector-for-aievec="aie-target=aie2 target-backend=llvmir" -split-input-file | FileCheck %s
+
+// CHECK-LABEL: @extsi_to_broadcast_swap(
+// CHECK-SAME: %[[VIN:.*]]: vector<8xi8>
+func.func @extsi_to_broadcast_swap(%v: vector<8xi8>) -> vector<4x8xi32> {
+    // CHECK: %[[BCAST:.*]] = vector.broadcast %[[VIN]] : vector<8xi8> to vector<4x8xi8>
+    // CHECK: %[[EXT:.*]] = arith.extsi %[[BCAST]] : vector<4x8xi8> to vector<4x8xi32>
+    %0 = arith.extsi %v : vector<8xi8> to vector<8xi32>
+    %1 = vector.broadcast %0 : vector<8xi32> to vector<4x8xi32>
+    return %1 : vector<4x8xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @scalar_extsi_to_broadcast_swap(
+// CHECK-SAME: %[[SIN:.*]]: i8
+func.func @scalar_extsi_to_broadcast_swap(%s: i8) -> vector<32xi32> {
+    // CHECK: %[[BCAST:.*]] = vector.broadcast %[[SIN]] : i8 to vector<32xi8>
+    // CHECK: %[[EXT:.*]] = arith.extsi %[[BCAST]] : vector<32xi8> to vector<32xi32>
+    %0 = arith.extsi %s : i8 to i32
+    %1 = vector.broadcast %0 : i32 to vector<32xi32>
+    return %1 : vector<32xi32>
+}


### PR DESCRIPTION
Since, in MLIR, mixed-type arithmetic operations such as:

```mlir
%result = arith.<op> %operandA, %operandB : <narrow type> to <wide type>
```

Are canonically represented as:

```mlir
%wideA = arith.ext<ty> %operandA : <narrow type> to <wide type>
%wideB = arith.ext<ty> %operandB : <narrow type> to <wide type>
%result = arith.<op> %wideA, %wideB : <wide type>
```

This change should improve the chances of matching mixed-type arithmetic ops by getting the sign extension operations closer to the arithmetic, enabling the `ext/ext -> arith` pattern match when a broadcast op ends up between one of the `ext` ops and the `arith` op.

The rewrite pattern is provided as a template so it can be reused whenever more of these "swappable" `ext -> op -> arith` cases show up.