### PR TITLE
fix linux build instructions

### DIFF
--- a/docs/buildHostLin.md
+++ b/docs/buildHostLin.md
@@ -122,7 +122,7 @@ You will...
 
     ```bash
     cd $LINUX_SRC_DIR
-    make olddefconfig
+    make O=$LINUX_BUILD_DIR olddefconfig
     ./scripts/config --file $LINUX_BUILD_DIR/.config --disable MODULE_SIG
     ./scripts/config --file $LINUX_BUILD_DIR/.config --disable SYSTEM_TRUSTED_KEYS
     ./scripts/config --file $LINUX_BUILD_DIR/.config --disable SYSTEM_REVOCATION_KEYS


### PR DESCRIPTION
`make olddefconfig` needs to run in the build directory, not the source. Verified that this fixed issues Joe and Kristof were having when following these instructions.