### PR TITLE
Change dma bd syntax

### DIFF
--- a/docs/AIEDesignPatterns.md
+++ b/docs/AIEDesignPatterns.md
@@ -11,19 +11,19 @@ We can use the AIE Cores as below to perform some operations
 
 Define a tile and a buffer
 ```
-%tile13 = AIE.tile(1, 3)
-%buf13_0 = AIE.buffer(%tile13) { sym_name = "a" } : memref<256xi32>
+%tile13 = aie.tile(1, 3)
+%buf13_0 = aie.buffer(%tile13) { sym_name = "a" } : memref<256xi32>
 ```
 
 Perform some operations on the buffer in the core
 ```
-%core13 = AIE.core(%tile13) {
+%core13 = aie.core(%tile13) {
 	%val1 = constant 7 : i32
 	%idx1 = constant 3 : index
 	%2 = addi %val1, %val1 : i32
 	memref.store %2, %buf13_0[%idx1] : memref<256xi32>
 
-	AIE.end
+	aie.end
 }
 
 
@@ -35,52 +35,52 @@ Perform some operations on the buffer in the core
 Define the AIE tiles you want to communicate between. Here Tile (7,1) will be the source and (7,2) the destination.
 
 ```
-%t71 = AIE.tile(7, 1) // (Column, Row)
-%t72 = AIE.tile(7, 2)
+%t71 = aie.tile(7, 1) // (Column, Row)
+%t72 = aie.tile(7, 2)
 ```
 Set up switchboxes to connect the stream to DMA
 ```
-%sw71 = AIE.switchbox(%t71) {
-	AIE.connect<"DMA" : 0, "North" : 3>
+%sw71 = aie.switchbox(%t71) {
+	aie.connect<"DMA" : 0, "North" : 3>
 }
-%sw72 = AIE.switchbox(%t72) {
-	AIE.connect<"South" : 3, "DMA" : 0>
+%sw72 = aie.switchbox(%t72) {
+	aie.connect<"South" : 3, "DMA" : 0>
 }
 ```
 Define the locks and buffers
 ```
-%lock71 = AIE.lock(%t71, 0)  // Tile, Lock Number (0-15)
-%lock72 = AIE.lock(%t72, 0) 
+%lock71 = aie.lock(%t71, 0)  // Tile, Lock Number (0-15)
+%lock72 = aie.lock(%t72, 0) 
 
-%buf71 = AIE.buffer(%t71) { sym_name = "a71" } : memref<512xi32>
-%buf72 = AIE.buffer(%t72) { sym_name = "a72" } : memref<512xi32>
+%buf71 = aie.buffer(%t71) { sym_name = "a71" } : memref<512xi32>
+%buf72 = aie.buffer(%t72) { sym_name = "a72" } : memref<512xi32>
 ```
 
 Start the Memory Map to Stream DMA from the source:
 ```
-%mem71 = AIE.mem(%tile71) {
-	%dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
+%mem71 = aie.mem(%tile71) {
+	%dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
 	^bd0:
-		AIE.use_lock(%lock71, "Acquire", 0) // Acquire in State 0
-		AIE.dma_bd(%buf71 : memref<512xi32>, 0, 512)
-		AIE.use_lock(%lock71, "Release", 1) // Release in State 1
+		aie.use_lock(%lock71, "Acquire", 0) // Acquire in State 0
+		aie.dma_bd(%buf71 : memref<512xi32>) { offset = 0 : i32, len = 512 : i32 }
+		aie.use_lock(%lock71, "Release", 1) // Release in State 1
 		br ^end 
 	^end:
-	AIE.end
+	aie.end
 }
 ```
 Start the Stream to Memory Map DMA from the destination:
 
 ```
-%mem72 = AIE.mem(%tile72) {
-	%dma0 = AIE.dma_start("S2MM", 0, ^bd0, ^end)
+%mem72 = aie.mem(%tile72) {
+	%dma0 = aie.dma_start("S2MM", 0, ^bd0, ^end)
 	^bd0:
-		AIE.use_lock(%lock72, "Acquire", 0)
-		AIE.dma_bd(%buf72 : memref<512xi32>, 0, 512)
-		AIE.use_lock(%lock72, "Release", 1)
+		aie.use_lock(%lock72, "Acquire", 0)
+		aie.dma_bd(%buf72 : memref<512xi32>) { offset = 0 : i32, len = 512 : i32 }
+		aie.use_lock(%lock72, "Release", 1)
 		br ^end 
 	^end:
-	AIE.end
+	aie.end
 }
 ```
 
@@ -88,14 +88,14 @@ We can also perform some operations in the AIE core using the same locks. When t
 
 
 ```
-%c72 = AIE.core(%t72) {
+%c72 = aie.core(%t72) {
 	%val1 = constant 7 : i32
 	%idx1 = constant 3 : index
 	%2 = addi %val1, %val1 : i32
 	
-	AIE.use_lock(%lock72, "Acquire", 1) // acquire for consume in the core
+	aie.use_lock(%lock72, "Acquire", 1) // acquire for consume in the core
 	memref.store %2, %buf72[%idx1] : memref<512xi32> //Store operation
-	AIE.use_lock(%lock72, "Release", 0) // release back to the memory
+	aie.use_lock(%lock72, "Release", 0) // release back to the memory
 }
 ```
 At the end, we release the lock back in state 0. This allows for the memory to re-acquire the lock in state 0.
@@ -106,49 +106,49 @@ At the end, we release the lock back in state 0. This allows for the memory to r
 
 This example uses the same setup as the previous. For Tile (7,2) we can define an additional lock and buffer and change the buffers to be half the size:
 ```
-%lock72_0 = AIE.lock(%t72, 0) 
-%lock72_1 = AIE.lock(%t72, 1) 
+%lock72_0 = aie.lock(%t72, 0) 
+%lock72_1 = aie.lock(%t72, 1) 
 
-%buf72_0 = AIE.buffer(%t72) { sym_name = "a72" } : memref<256xi32>
-%buf72_1 = AIE.buffer(%t72) { sym_name = "b72" } : memref<256xi32>
+%buf72_0 = aie.buffer(%t72) { sym_name = "a72" } : memref<256xi32>
+%buf72_1 = aie.buffer(%t72) { sym_name = "b72" } : memref<256xi32>
 ```
 Then we can write the Stream to Memory Map DMA transfer with 2 buffer descriptors:
 ```
-%mem72 = AIE.mem(%t72) {
-	%dma0 = AIE.dma_start("S2MM", 0, ^bd0, ^end)
+%mem72 = aie.mem(%t72) {
+	%dma0 = aie.dma_start("S2MM", 0, ^bd0, ^end)
 	^bd0:
-		AIE.use_lock(%lock72_0, "Acquire", 0)
-		AIE.dma_bd(%buf72_0: memref<256xi32>, 0, 256)
-		AIE.use_lock(%lock72_0, "Release", 1)
+		aie.use_lock(%lock72_0, "Acquire", 0)
+		aie.dma_bd(%buf72_0: memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
+		aie.use_lock(%lock72_0, "Release", 1)
 		br ^bd1 // point to the next BD, or termination
 	^bd1:
-		AIE.use_lock(%lock72_1, "Acquire", 0)
-		AIE.dma_bd(%buf72_1: memref<256xi32>, 0, 256)
-		AIE.use_lock(%lock72_1, "Release", 1)
+		aie.use_lock(%lock72_1, "Acquire", 0)
+		aie.dma_bd(%buf72_1: memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
+		aie.use_lock(%lock72_1, "Release", 1)
 		br ^bd0 // point to the next BD, or termination
 	^end:
 
-AIE.end
+aie.end
 
 }
 ```
 
 We can use the core in a similar fashion, using the two locks to perform operations on each buffer:
 ```
-%c72 = AIE.core(%t72) {
+%c72 = aie.core(%t72) {
 	%val1 = constant 7 : i32
 	%idx1 = constant 3 : index
 	%idx2 = constant 10 : index
 
 	%2 = addi %val1, %val1 : i32
 	
-	AIE.use_lock(%lock72_0, "Acquire", 1) // acquire for consume in the core
+	aie.use_lock(%lock72_0, "Acquire", 1) // acquire for consume in the core
 	memref.store %2, %buf72[%idx1] : memref<512xi32> // store operation
-	AIE.use_lock(%lock72_0, "Release", 0) // release back to the memory
+	aie.use_lock(%lock72_0, "Release", 0) // release back to the memory
 	
-	AIE.use_lock(%lock72_1, "Acquire", 1) // acquire for consume in the core
+	aie.use_lock(%lock72_1, "Acquire", 1) // acquire for consume in the core
 	memref.store %2, %buf72[%idx2] : memref<512xi32> // store operation
-	AIE.use_lock(%lock72_1, "Release", 0) // release back to the memory
+	aie.use_lock(%lock72_1, "Release", 0) // release back to the memory
 }
 ```
 
@@ -162,38 +162,38 @@ We use a similar example to the single buffered communication:
 
 
 ```
-%lock71 = AIE.lock(%t71, 0)  // Tile, Lock Number (0-15)
-%lock72 = AIE.lock(%t72, 0) 
+%lock71 = aie.lock(%t71, 0)  // Tile, Lock Number (0-15)
+%lock72 = aie.lock(%t72, 0) 
 
-%buf71 = AIE.buffer(%t71) { sym_name = "a71" } : memref<512xi32>
-%buf72 = AIE.buffer(%t72) { sym_name = "a72" } : memref<512xi32>
+%buf71 = aie.buffer(%t71) { sym_name = "a71" } : memref<512xi32>
+%buf72 = aie.buffer(%t72) { sym_name = "a72" } : memref<512xi32>
 ```
 
 Start the Memory Map to Stream DMA from the source:
 ```
-%mem71 = AIE.mem(%tile71) {
-	%dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
+%mem71 = aie.mem(%tile71) {
+	%dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
 	^bd0:
-		AIE.use_lock(%lock71, "Acquire", 1) // Acquire in State 0
-		AIE.dma_bd(%buf71 : memref<512xi32>, 0, 512)
-		AIE.use_lock(%lock71, "Release", 1) // Release in State 1
+		aie.use_lock(%lock71, "Acquire", 1) // Acquire in State 0
+		aie.dma_bd(%buf71 : memref<512xi32>) { offset = 0 : i32, len = 512 : i32 }
+		aie.use_lock(%lock71, "Release", 1) // Release in State 1
 		br ^end 
 	^end:
-	AIE.end
+	aie.end
 }
 ```
 Start the Stream to Memory Map DMA from the destination:
 
 ```
-%mem72 = AIE.mem(%tile72) {
-	%dma0 = AIE.dma_start("S2MM", 0, ^bd0, ^end)
+%mem72 = aie.mem(%tile72) {
+	%dma0 = aie.dma_start("S2MM", 0, ^bd0, ^end)
 	^bd0:
-		AIE.use_lock(%lock72, "Acquire", 0)
-		AIE.dma_bd(%buf72 : memref<512xi32>, 0, 512)
-		AIE.use_lock(%lock72, "Release", 1)
+		aie.use_lock(%lock72, "Acquire", 0)
+		aie.dma_bd(%buf72 : memref<512xi32>) { offset = 0 : i32, len = 512 : i32 }
+		aie.use_lock(%lock72, "Release", 1)
 		br ^end 
 	^end:
-	AIE.end
+	aie.end
 }
 ```
 Since %lock71 is now acquired at state 1, we need to manually release the lock into that state from the host side. This is because the default state of all locks are 0, so they are immediately able to be acquired.
@@ -220,23 +220,23 @@ This allows the data transfer to begin
 
 To read/write from DDR, we declare an external buffer with a location and size
 ```
-%ext_buffer = AIE.external_buffer 0x02010004000 : memref<512 x i32>
+%ext_buffer = aie.external_buffer 0x02010004000 : memref<512 x i32>
 ```
 
 We can then use the shim_dma to read/write from that location:
 
 ```
-%lock70 = AIE.lock(%t70, 1)
+%lock70 = aie.lock(%t70, 1)
 
-%mem70 = AIE.mem(%tile70) {
-	%dma0 = AIE.dma_start("MM2S", 0, ^bd0, ^end) \\Read
+%mem70 = aie.mem(%tile70) {
+	%dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end) \\Read
 	^bd0:
-		AIE.use_lock(%lock70 , "Acquire", 0)
-		AIE.dma_bd(%ext_buffer : memref<512xi32>, 0, 512)
-		AIE.use_lock(%lolock70 k72, "Release", 1)
+		aie.use_lock(%lock70 , "Acquire", 0)
+		aie.dma_bd(%ext_buffer : memref<512xi32>) { offset = 0 : i32, len = 512 : i32 }
+		aie.use_lock(%lolock70 k72, "Release", 1)
 		br ^end 
 	^end:
-	AIE.end
+	aie.end
 }
 ```
 
@@ -263,35 +263,35 @@ In this pattern, we will show a design pattern for dynamic DDR configuration
 ```
 module {
 
-%t70 = AIE.tile(7, 0)
-%t71 = AIE.tile(7, 1)
-%t72 = AIE.tile(7, 2)
+%t70 = aie.tile(7, 0)
+%t71 = aie.tile(7, 1)
+%t72 = aie.tile(7, 2)
 
-%buf72_0 = AIE.buffer(%t72) {sym_name="a"} : memref<256xi32>
-%buf72_1 = AIE.buffer(%t72) {sym_name="b"} : memref<256xi32>
+%buf72_0 = aie.buffer(%t72) {sym_name="a"} : memref<256xi32>
+%buf72_1 = aie.buffer(%t72) {sym_name="b"} : memref<256xi32>
 
-%l72_0 = AIE.lock(%t72, 0)
-%l72_1 = AIE.lock(%t72, 1)
+%l72_0 = aie.lock(%t72, 0)
+%l72_1 = aie.lock(%t72, 1)
 
-%m72 = AIE.mem(%t72) {
+%m72 = aie.mem(%t72) {
 
-	%srcDma = AIE.dma_start("MM2S", 0, ^bd0, ^end)
+	%srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
 	^bd0:
-		AIE.use_lock(%l72_0, "Acquire", 1)
-		AIE.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
-		AIE.use_lock(%l72_0, "Release", 0)
+		aie.use_lock(%l72_0, "Acquire", 1)
+		aie.dma_bd(%buf72_0 : memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
+		aie.use_lock(%l72_0, "Release", 0)
 	br ^bd1
 	^bd1:
-		AIE.use_lock(%l72_1, "Acquire", 1)
-		AIE.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
-		AIE.use_lock(%l72_1, "Release", 0)
+		aie.use_lock(%l72_1, "Acquire", 1)
+		aie.dma_bd(%buf72_1 : memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
+		aie.use_lock(%l72_1, "Release", 0)
 	br ^bd0
 	^end:
 
-	AIE.end
+	aie.end
 }
 
-AIE.flow(%t72, "DMA" : 0, %t70, "DMA" : 0)
+aie.flow(%t72, "DMA" : 0, %t70, "DMA" : 0)
 
 }
 ```
@@ -351,106 +351,106 @@ Unlike a typical FIFO, elements are not pushed to nor popped from the objectFIFO
 
 Processes can then write to and read from these memory elements after acquiring them.
 
-Define two tiles and create an AIE.objectfifo named @of0 of depth two between them, with the two elements being of type <memref<16xi32>>:
+Define two tiles and create an aie.objectfifo named @of0 of depth two between them, with the two elements being of type <memref<16xi32>>:
 ```
-%tile12 = AIE.tile(1, 2)
-%tile33 = AIE.tile(3, 3)
-AIE.objectfifo @of0 (%tile12, {tile33}, 2 : i32) : !AIE.objectfifo<memref<16xi32>>
+%tile12 = aie.tile(1, 2)
+%tile33 = aie.tile(3, 3)
+aie.objectfifo @of0 (%tile12, {tile33}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
 ```
-After subsequent conversion passes, each of the objectFifo elements is instantiated as an AIE.buffer with an AIE.lock.
+After subsequent conversion passes, each of the objectFifo elements is instantiated as an aie.buffer with an aie.lock.
 
 objectFIFO operations have a 'port' attribute which indicates whether a tile is a 'producer' or a 'consumer' of that objectFIFO.
-Operations can be performed on the objectFIFO in the cores: elements can be acquired from the objectFIFO and accessed via an AIE.objectfifosubview type, then released: 
+Operations can be performed on the objectFIFO in the cores: elements can be acquired from the objectFIFO and accessed via an aie.objectfifosubview type, then released: 
 ```
-%core12 = AIE.core(%tile12) {
+%core12 = aie.core(%tile12) {
 	%c0 = arith.constant 0 : index
 	%c1 = arith.constant 1 : index
 	%height = arith.constant 12 : index
 
 	scf.for %indexInHeight = %c0 to %height step %c1 {
-		%subview = AIE.objectfifo.acquire @of0 (Produce, 1) : !AIE.objectfifosubview<memref<16xi32>>
-		%elem0 = AIE.objectfifo.subview.access %subview[0] : !AIE.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+		%subview = aie.objectfifo.acquire @of0 (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+		%elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem0) : (memref<16xi32>) -> ()
-		AIE.objectfifo.release @of0 (Produce, 1)
+		aie.objectfifo.release @of0 (Produce, 1)
 	}
 	
-	AIE.end
+	aie.end
 }
 
-%core33 = AIE.core(%tile33) {
+%core33 = aie.core(%tile33) {
 	%c0 = arith.constant 0 : index
 	%c1 = arith.constant 1 : index
 	%height = arith.constant 12 : index
 
 	scf.for %indexInHeight = %c0 to %height step %c1 { 
-		%subview = AIE.objectfifo.acquire @of0 (Consume, 1) : !AIE.objectfifosubview<memref<16xi32>>
-		%elem0 = AIE.objectfifo.subview.access %subview[0] : !AIE.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+		%subview = aie.objectfifo.acquire @of0 (Consume, 1) : !aie.objectfifosubview<memref<16xi32>>
+		%elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem0) : (memref<16xi32>) -> ()
-		AIE.objectfifo.release @of0 (Consume, 1)
+		aie.objectfifo.release @of0 (Consume, 1)
 	}
 	
-	AIE.end
+	aie.end
 }
 ```
 
 For correct execution, loops that contain objectFIFO operations must be unrolled based on objectFIFO size; the previous code in core12 becomes:
 ```
-%core12 = AIE.core(%tile12) {
+%core12 = aie.core(%tile12) {
 	%c0 = arith.constant 0 : index
 	%c2 = arith.constant 2 : index
 	%height = arith.constant 12 : index
 
 	scf.for %indexInHeight = %c0 to %height step %c2 {
-		%subview0 = AIE.objectfifo.acquire @of0 (Produce, 1) : !AIE.objectfifosubview<memref<16xi32>>
-		%elem00 = AIE.objectfifo.subview.access %subview0[0] : !AIE.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+		%subview0 = aie.objectfifo.acquire @of0 (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+		%elem00 = aie.objectfifo.subview.access %subview0[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem00) : (memref<16xi32>) -> ()
-		AIE.objectfifo.release @of0 (Produce, 1)
+		aie.objectfifo.release @of0 (Produce, 1)
 
-		%subview1 = AIE.objectfifo.acquire @of0 (Produce, 1) : !AIE.objectfifosubview<memref<16xi32>>
-		%elem10 = AIE.objectfifo.subview.access %subview1[0] : !AIE.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+		%subview1 = aie.objectfifo.acquire @of0 (Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+		%elem10 = aie.objectfifo.subview.access %subview1[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
 		call @some_work(%elem10) : (memref<16xi32>) -> ()
-		AIE.objectfifo.release @of0 (Produce, 1)
+		aie.objectfifo.release @of0 (Produce, 1)
 	}
 	
-	AIE.end
+	aie.end
 }
 ```
 
-ObjectFIFOs can be established between tiles on the shim row and AIE tiles in order to bring data in from or out to external memory locations. These external memory locations are pointed to using AIE.external_buffer operations and they need to be explicitly registered to an objectFIFO so that it knows where the data has been allocated externally (in this case, the objectFIFO lowering will only allocate memory elements required by AIE tiles):
+ObjectFIFOs can be established between tiles on the shim row and AIE tiles in order to bring data in from or out to external memory locations. These external memory locations are pointed to using aie.external_buffer operations and they need to be explicitly registered to an objectFIFO so that it knows where the data has been allocated externally (in this case, the objectFIFO lowering will only allocate memory elements required by AIE tiles):
 ```
 module @objectFIFO  {
-    %tile10 = AIE.tile(1, 0)
-    %tile33 = AIE.tile(3, 3)
+    %tile10 = aie.tile(1, 0)
+    %tile33 = aie.tile(3, 3)
 
-    AIE.objectfifo @of1 (%tile10, {tile33}, 2 : i32) : !AIE.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile10, {tile33}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
 
-    %ext_buffer_in_0 = AIE.external_buffer {sym_name = "ext_buffer_in_0"}: memref<64xi32>
-    %ext_buffer_in_1 = AIE.external_buffer {sym_name = "ext_buffer_in_1"}: memref<64xi32>
-    AIE.objectfifo.register_external_buffers @of1 (%tile10, { %ext_buffer_in_0, %ext_buffer_in_1 }) : (memref<64xi32>, memref<64xi32>)
+    %ext_buffer_in_0 = aie.external_buffer {sym_name = "ext_buffer_in_0"}: memref<64xi32>
+    %ext_buffer_in_1 = aie.external_buffer {sym_name = "ext_buffer_in_1"}: memref<64xi32>
+    aie.objectfifo.register_external_buffers @of1 (%tile10, { %ext_buffer_in_0, %ext_buffer_in_1 }) : (memref<64xi32>, memref<64xi32>)
 }
 ```
 
 It is possible to copy data from one objectFifo to another. This copy can be done explicitly within the AIE cores, or implicitly using the tile DMAs. The latter case is not as much a copy as it is re-using the same memory buffers when receiving data on an input channel and sending the data out on an output channel. At the objectFIFO abstraction, this is called 'linking' two objectFIFOs. It is most commonly done inside of Mem tiles which have more memory than AIE tiles. 
 ```
 module @objectFIFO  {
-    %tile20 = AIE.tile(2, 0)
-    %tile22 = AIE.tile(2, 2)
-    %tile24 = AIE.tile(2, 4)
+    %tile20 = aie.tile(2, 0)
+    %tile22 = aie.tile(2, 2)
+    %tile24 = aie.tile(2, 4)
 
-    AIE.objectfifo @of1 (%tile20, { %tile22 }, 2 : i32) : !AIE.objectfifo<memref<16xi32>>
-	AIE.objectfifo @of2 (%tile22, { %tile24 }, 2 : i32) : !AIE.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile20, { %tile22 }, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+	aie.objectfifo @of2 (%tile22, { %tile24 }, 2 : i32) : !aie.objectfifo<memref<16xi32>>
 
-	AIE.objectfifo.link [@of1] -> [@of2] ()
+	aie.objectfifo.link [@of1] -> [@of2] ()
 }
 ```
 
 At a higher abstraction level, a process can be registered to an objectFIFO using access patterns and work functions:
 ```
 module @objectFIFO  {
-    %tile12 = AIE.tile(1, 2)
-    %tile33 = AIE.tile(3, 3)
+    %tile12 = aie.tile(1, 2)
+    %tile33 = aie.tile(3, 3)
 
-    AIE.objectfifo @of1 (%tile12, {tile33}, 2 : i32) : !AIE.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile12, {tile33}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
 
     %prodAcqPattern = arith.constant dense<[1]> : tensor<1xi32>
     %prodRelPattern = arith.constant dense<[1]> : tensor<1xi32>
@@ -459,7 +459,7 @@ module @objectFIFO  {
         return
     }
 
-    AIE.objectfifo.register_process @of1 (Produce, %prodAcqPattern : tensor<1xi32>, %prodRelPattern : tensor<1xi32>, @producer_work, %prodLength)
+    aie.objectfifo.register_process @of1 (Produce, %prodAcqPattern : tensor<1xi32>, %prodRelPattern : tensor<1xi32>, @producer_work, %prodLength)
 }
 ```
 
@@ -477,24 +477,24 @@ source port (%t72, "DMA" : 0) to broadcast data to %t73, %t63(ID: 0x0) and %t74,
 
 Define tiles
 ```
-%t72 = AIE.tile(7, 2)
-%t63 = AIE.tile(6, 3)
-%t64 = AIE.tile(6, 4)
-%t73 = AIE.tile(7, 3)
-%t74 = AIE.tile(7, 4)
+%t72 = aie.tile(7, 2)
+%t63 = aie.tile(6, 3)
+%t64 = aie.tile(6, 4)
+%t73 = aie.tile(7, 3)
+%t74 = aie.tile(7, 4)
 
 ```
 
 broadcast_packet 
 ```
-AIE.broadcast_packet(%t72, "DMA" : 0){
-  AIE.bp_id(0x0){
-    AIE.bp_dest<%t73, "DMA" : 0>
-    AIE.bp_dest<%t63, "DMA" : 0>
+aie.broadcast_packet(%t72, "DMA" : 0){
+  aie.bp_id(0x0){
+    aie.bp_dest<%t73, "DMA" : 0>
+    aie.bp_dest<%t63, "DMA" : 0>
   }
-  AIE.bp_id(0x1){
-    AIE.bp_dest<%t74, "DMA" : 0>
-    AIE.bp_dest<%t64, "DMA" : 0>
+  aie.bp_id(0x1){
+    aie.bp_dest<%t74, "DMA" : 0>
+    aie.bp_dest<%t64, "DMA" : 0>
   }
 }
 

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -264,7 +264,7 @@ def AIE_ShimDMAOp: AIE_Op<"shim_dma", [
           aie.dma_start(MM2S, 0, ^bd0, ^end)
         ^bd0:
           aie.use_lock(%lock1, Acquire, 1)
-          aie.dma_bd(%buf : memref<512 x i16>, 0, 512)
+          aie.dma_bd(%buf : memref<512 x i16>) { offset = 0 : i32, len = 512 : i32 }
           aie.use_lock(%lock1, Release, 0)
           aie.next_bd ^bd0
         ^end:
@@ -776,13 +776,13 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
       ^bd5:
         aie.use_lock(%lck, "Acquire", 0)
         // transfer the first 32 elements of the memref
-        aie.dma_bd(<$buf0 : memref<128xi32>, 0, 32)
+        aie.dma_bd(<$buf0 : memref<128xi32>) { offset = 0 : i32, len = 32 : i32 }
         aie.use_lock(%lck, "Release", 1)
         aie.next_bd ^bd6 // point to the next bb, which describes the next buffer descriptor
       ^bd6:
         aie.use_lock(%lck, "Acquire", 1)
         // transfer the last 32 elements of the memref
-        aie.dma_bd(<$buf1 : memref<128xi32>, 96, 32)
+        aie.dma_bd(<$buf1 : memref<128xi32>) { offset = 96 : i32, len = 32 : i32 }
         aie.use_lock(%lck, "Release", 0)
         aie.next_bd ^end
 
@@ -790,7 +790,7 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
 
       // this defines a BD that does not use any lock
       ^bd8:
-        aie.dma_bd(<$buf2 : memref<64xi32>, 0, 64)
+        aie.dma_bd(<$buf2 : memref<64xi32>) { offset = 0 : i32, len = 64 : i32 }
     ```
 
     #### Background/context
@@ -864,8 +864,8 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
         DefaultValuedOptionalAttr<AIEI32Attr, "0">:$offset,
         // in multiples of element width (not bytes)
         OptionalAttr<AIEI32Attr>:$len,
-        OptionalAttr<BDDimLayoutArrayAttr>:$dimensions,
-        OptionalAttr<BDPadLayoutArrayAttr>:$pad_dimensions,
+        OptionalAttr<BDDimLayoutArrayAttr>:$dims,
+        OptionalAttr<BDPadLayoutArrayAttr>:$pad_dims,
         DefaultValuedOptionalAttr<AIEI32Attr, "0">:$pad_value,
         OptionalAttr<AIEI32Attr>:$bd_id,
         // should never be assigned by user...
@@ -875,7 +875,7 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `(` $buffer `:` type($buffer) (`,` $dimensions^)? (`,` $pad_dimensions^)? `)` attr-dict
+    `(` $buffer `:` type($buffer) (`,` `dims` `=` $dims^)? (`,` `pad_dims` `=` $pad_dims^)? `)` attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -903,20 +903,20 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
       $_state.addOperands(buffer);
       $_state.addAttribute("offset", $_builder.getI32IntegerAttr(offset));
       $_state.addAttribute("len", $_builder.getI32IntegerAttr(len));
-      $_state.addAttribute("dimensions", dims);
+      $_state.addAttribute("dims", dims);
     }]>,
     OpBuilder<(ins "mlir::Value":$buffer, "int":$offset, "int":$len, "BDPadLayoutArrayAttr":$paddims), [{
       $_state.addOperands(buffer);
       $_state.addAttribute("offset", $_builder.getI32IntegerAttr(offset));
       $_state.addAttribute("len", $_builder.getI32IntegerAttr(len));
-      $_state.addAttribute("pad_dimensions", paddims);
+      $_state.addAttribute("pad_dims", paddims);
     }]>,
     OpBuilder<(ins "mlir::Value":$buffer, "int":$offset, "int":$len, "BDDimLayoutArrayAttr":$dims, "BDPadLayoutArrayAttr":$paddims), [{
       $_state.addOperands(buffer);
       $_state.addAttribute("offset", $_builder.getI32IntegerAttr(offset));
       $_state.addAttribute("len", $_builder.getI32IntegerAttr(len));
-      $_state.addAttribute("dimensions", dims);
-      $_state.addAttribute("pad_dimensions", paddims);
+      $_state.addAttribute("dims", dims);
+      $_state.addAttribute("pad_dims", paddims);
     }]>
   ];
 }
@@ -939,7 +939,7 @@ def AIE_DMAStartOp: AIE_Op<"dma_start", [
         aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         aie.use_lock(%lock0, "Acquire", 0)
-        aie.dma_bd(%buffer : memref<16 x f32>, 0, 16)
+        aie.dma_bd(%buffer : memref<16 x f32>) { offset = 0 : i32, len = 16 : i32 }
         aie.use_lock(%lock0, "Release", 1)
         br ^bd0
       ^end:
@@ -1023,7 +1023,7 @@ def AIE_MemOp: AIE_Op<"mem", [
           %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
         ^bd0:
           aie.use_lock(%lock, "Acquire", 0)
-          aie.dma_bd(%buf : memref<64xi16>, 0, 64)
+          aie.dma_bd(%buf : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
           aie.use_lock(%lock, "Release", 1)
           aie.next_bd ^bd0
         ^end:
@@ -1117,7 +1117,7 @@ def AIE_NextBDOp: AIE_Op<"next_bd", [
           %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
         ^bd0:
           aie.use_lock(%lock, "Acquire", 0)
-          aie.dma_bd(%buf : memref<64xi16>, 0, 64)
+          aie.dma_bd(%buf : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
           aie.use_lock(%lock, "Release", 1)
           aie.next_bd ^bd0
         ^end:

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -875,7 +875,7 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", [
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `(` $buffer `:` type($buffer) (`,` $offset^)? (`,` $len^)? (`,` $dimensions^)? (`,` $pad_dimensions^)? (`,` `pad_value` `=` $pad_value^)? `)` attr-dict
+    `(` $buffer `:` type($buffer) (`,` $dimensions^)? (`,` $pad_dimensions^)? `)` attr-dict
   }];
 
   let extraClassDeclaration = [{

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1619,7 +1619,7 @@ LogicalResult DMABDOp::verify() {
           "For <32b width datatypes, inner-most dim stride must be 1");
   }
   if (auto paddims = getPadDimensions(); paddims.has_value()) {
-    auto dims = getDimensions();
+    auto dims = getDims();
     if (!dims.has_value())
       return emitOpError() << "Padding requires n-d data layouts expressed as"
                            << " wrap(s) and stride(s).";

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1576,7 +1576,7 @@ LogicalResult DMABDOp::verify() {
   if (std::optional<int32_t> nextBdId = getNextBdId();
       nextBdId.has_value() && static_cast<uint32_t>(*nextBdId) >= maxBds)
     return emitOpError("nextBdId attribute exceeds max: ") << maxBds - 1;
-  if (auto dims = getDimensions(); dims.has_value()) {
+  if (auto dims = getDims(); dims.has_value()) {
     size_t maxNDims = 3;
     if (isa_and_nonnull<MemTileDMAOp>(getOperation()->getParentOp()))
       maxNDims = 4;

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1618,7 +1618,7 @@ LogicalResult DMABDOp::verify() {
       return emitOpError(
           "For <32b width datatypes, inner-most dim stride must be 1");
   }
-  if (auto paddims = getPadDimensions(); paddims.has_value()) {
+  if (auto paddims = getPadDims(); paddims.has_value()) {
     auto dims = getDims();
     if (!dims.has_value())
       return emitOpError() << "Padding requires n-d data layouts expressed as"

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -282,7 +282,7 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
       baseAddr += BASE_ADDR_A_INCR;
   }
 
-  std::optional<llvm::ArrayRef<BDDimLayoutAttr>> dims = bdOp.getDimensions();
+  std::optional<llvm::ArrayRef<BDDimLayoutAttr>> dims = bdOp.getDims();
   int lenInBytes = bdOp.getLenInBytes();
   int basePlusOffsetInBytes = baseAddr + bdOp.getOffsetInBytes();
   if (!dims) {

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -325,8 +325,7 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
   }
 
   // ND zero padding.
-  std::optional<llvm::ArrayRef<BDPadLayoutAttr>> padDims =
-      bdOp.getPadDims();
+  std::optional<llvm::ArrayRef<BDPadLayoutAttr>> padDims = bdOp.getPadDims();
   if (padDims) {
     XAie_DmaPadTensor dmaPadTensor = {};
     dmaPadTensor.NumDim = padDims->size();

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -326,7 +326,7 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
 
   // ND zero padding.
   std::optional<llvm::ArrayRef<BDPadLayoutAttr>> padDims =
-      bdOp.getPadDimensions();
+      bdOp.getPadDims();
   if (padDims) {
     XAie_DmaPadTensor dmaPadTensor = {};
     dmaPadTensor.NumDim = padDims->size();

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -118,8 +118,8 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
       lenA = op.getLenInBytes();
       offsetA = op.getOffsetInBytes();
       elementWidthInBytes = op.getBufferElementTypeWidthInBytes();
-      if (op.getDimensions()) {
-        dims = *op.getDimensions();
+      if (op.getDims()) {
+        dims = *op.getDims();
         ndims = dims.size();
       }
     }
@@ -205,14 +205,11 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
                  << "/* QoS */ 0, "
                  << "/* Cache */ 0, "
                  << "/* Secure */ " << enable << "));\n";
-        } else {
-          if ((BaseAddrA + offsetA) % 4)
-            return memOp.emitError("bd address must be 4B (32b) aligned");
+        } else
           output << "__mlir_aie_try(XAie_DmaSetAddrLen("
                  << tileDMAInstRefStr(col, row, bdNum) << ", /* addrA */ "
                  << "0x" << llvm::utohexstr(BaseAddrA + offsetA) << ", "
                  << " /* len */ " << lenA << "));\n";
-        }
       } else
         generateXAieDmaSetMultiDimAddr(output, ndims, dims, col, row, bdNum,
                                        BaseAddrA, offsetA, lenA,

--- a/mlir_tutorials/tutorial-4/flow/README.md
+++ b/mlir_tutorials/tutorial-4/flow/README.md
@@ -54,7 +54,7 @@ There are 2 tile DMAs connected to the local switchbox, each with a read and wri
     %dma1 = AIE.dma_start("MM2S", 0, ^bd0, ^end)
     ^bd0:
         AIE.use_lock(%lock14_6, "Acquire", 1)
-        AIE.dma_bd(%buf14: memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf14: memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
         AIE.use_lock(%lock14_6, "Release", 0)
         AIE.next_bd ^end
     ^end:
@@ -105,22 +105,22 @@ In a common scenario where we may declare 2x DMAs (1x MM2S, 1x S2MM), each with 
         %dma2 = AIE.dma_start("S2MM", 0, ^bd3, ^end)
     ^bd0:
         AIE.use_lock(%lock14_6, "Acquire", 0)
-        AIE.dma_bd(%buf14_1: memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf14_1: memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
         AIE.use_lock(%lock14_6, "Release", 1)
         AIE.next_bd ^bd1
     ^bd1:
         AIE.use_lock(%lock14_7, "Acquire", 0)
-        AIE.dma_bd(%buf14_2: memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf14_2: memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
         AIE.use_lock(%lock14_7, "Release", 1)
         AIE.next_bd ^bd0
     ^bd3:
         AIE.use_lock(%lock14_10, "Acquire", 0)
-        AIE.dma_bd(%buf14_3: memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf14_3: memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
         AIE.use_lock(%lock14_10, "Release", 1)
         AIE.next_bd ^bd4
     ^bd4:
         AIE.use_lock(%lock14_11, "Acquire", 0)
-        AIE.dma_bd(%buf14_4: memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf14_4: memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
         AIE.use_lock(%lock14_11, "Release", 1)
         AIE.next_bd ^bd3
     ^end:

--- a/mlir_tutorials/tutorial-4/flow/aie.mlir
+++ b/mlir_tutorials/tutorial-4/flow/aie.mlir
@@ -57,7 +57,7 @@ module @tutorial_4 {
         aie.dma_start("MM2S", 0, ^bd0, ^end)
         ^bd0:
             aie.use_lock(%lock14_6, Acquire, 1)
-            aie.dma_bd(%buf14 : memref<256xi32>, 0, 256)
+            aie.dma_bd(%buf14 : memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
             aie.use_lock(%lock14_6, Release, 0)
             aie.next_bd ^end
         ^end:
@@ -102,7 +102,7 @@ module @tutorial_4 {
             // 0   - offset of transfer
             // 256 - length of transfer
             // 0   - A/B mode enable (default is disabled)
-            aie.dma_bd(%buf34 : memref<256xi32>, 0, 256)
+            aie.dma_bd(%buf34 : memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
             aie.use_lock(%lock34_7, Release, 1)
             aie.next_bd ^end
         ^end:

--- a/mlir_tutorials/tutorial-4/flow/answers/aie_q5.mlir
+++ b/mlir_tutorials/tutorial-4/flow/answers/aie_q5.mlir
@@ -56,7 +56,7 @@ module @tutorial_4 {
         aie.dma_start("MM2S", 0, ^bd0, ^end)
         ^bd0:
             aie.use_lock(%lock14_6, Acquire, 1)
-            aie.dma_bd(%buf14 : memref<256xi32>, 0, 256)
+            aie.dma_bd(%buf14 : memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
             aie.use_lock(%lock14_6, Release, 0)
             aie.next_bd ^bd0
         ^end:

--- a/mlir_tutorials/tutorial-6/README.md
+++ b/mlir_tutorials/tutorial-6/README.md
@@ -64,7 +64,7 @@ An example of this inside a BD definition would be:
     ^bd0:
         AIE.use_lock(%lock14_6, Acquire, 1)
         AIE.dma_bd_packet(0x4, 0xD) 
-        AIE.dma_bd(%buf14 : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf14 : memref<256xi32>) { offset = 0 : i32, len = 256 : i32 }
         AIE.use_lock(%lock14_6, Release, 0)
         cf.br ^end
 ```

--- a/programming_examples/mlir/MM_2x2/circuit_switched_version/aie.mlir
+++ b/programming_examples/mlir/MM_2x2/circuit_switched_version/aie.mlir
@@ -104,22 +104,22 @@ module @MM_2x2 {
       aie.dma_start("S2MM", 1, ^bd7, ^end)
     ^bd4:
       aie.use_lock(%lock60_0, "Acquire", 1)
-      aie.dma_bd(%buffer0 : memref<1024xi32>, 0, 1024)    //send LHS_tile0
+      aie.dma_bd(%buffer0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send LHS_tile0
       aie.use_lock(%lock60_0, "Release", 0)
       aie.next_bd ^bd4
     ^bd5:
       aie.use_lock(%lock60_1, "Acquire", 1)
-      aie.dma_bd(%buffer1 : memref<1024xi32>, 0, 1024)    //send LHS_tile1
+      aie.dma_bd(%buffer1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send LHS_tile1
       aie.use_lock(%lock60_1, "Release", 0)
       aie.next_bd ^bd5
     ^bd6:
       aie.use_lock(%lock60_2, "Acquire", 1)
-      aie.dma_bd(%buffer6 : memref<1025xi32>, 0, 1025)    //send Out_tile0
+      aie.dma_bd(%buffer6 : memref<1025xi32>) { offset = 0 : i32, len = 1025 : i32 }    //send Out_tile0
       aie.use_lock(%lock60_2, "Release", 0)
       aie.next_bd ^bd6
     ^bd7:
       aie.use_lock(%lock60_3, "Acquire", 1)
-      aie.dma_bd(%buffer7 : memref<1025xi32>, 0, 1025)    //send Out_tile1
+      aie.dma_bd(%buffer7 : memref<1025xi32>) { offset = 0 : i32, len = 1025 : i32 }    //send Out_tile1
       aie.use_lock(%lock60_3, "Release", 0)
       aie.next_bd ^bd7
     ^end:
@@ -132,12 +132,12 @@ module @MM_2x2 {
       aie.dma_start("MM2S", 1, ^bd5, ^end)
     ^bd4:
       aie.use_lock(%lock70_0, "Acquire", 1)
-      aie.dma_bd(%buffer2 : memref<1024xi32>, 0, 1024)    //send RHS_tile0
+      aie.dma_bd(%buffer2 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile0
       aie.use_lock(%lock70_0, "Release", 0)
       aie.next_bd ^bd4
     ^bd5:
       aie.use_lock(%lock70_1, "Acquire", 1)
-      aie.dma_bd(%buffer3 : memref<1024xi32>, 0, 1024)    //send RHS_tile1
+      aie.dma_bd(%buffer3 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile1
       aie.use_lock(%lock70_1, "Release", 0)
       aie.next_bd ^bd5
     ^end:
@@ -150,12 +150,12 @@ module @MM_2x2 {
       aie.dma_start("MM2S", 1, ^bd5, ^end)
     ^bd4:
       aie.use_lock(%lock100_0, "Acquire", 1)
-      aie.dma_bd(%buffer4 : memref<1024xi32>, 0, 1024)    //send RHS_tile2
+      aie.dma_bd(%buffer4 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile2
       aie.use_lock(%lock100_0, "Release", 0)
       aie.next_bd ^bd4
     ^bd5:
       aie.use_lock(%lock100_1, "Acquire", 1)
-      aie.dma_bd(%buffer5 : memref<1024xi32>, 0, 1024)    //send RHS_tile3
+      aie.dma_bd(%buffer5 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile3
       aie.use_lock(%lock100_1, "Release", 0)
       aie.next_bd ^bd5
     ^end:
@@ -168,12 +168,12 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     aie.use_lock(%lock63_0, Acquire, 0)
-    aie.dma_bd(%buf63_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf63_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock63_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock63_1, Acquire, 0)
-    aie.dma_bd(%buf63_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf63_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock63_1, Release, 1)
     aie.next_bd ^bd1
   ^end: 
@@ -186,19 +186,19 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     aie.use_lock(%lock64_0, Acquire, 0)
-    aie.dma_bd(%buf64_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf64_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock64_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock64_1, Acquire, 0)
-    aie.dma_bd(%buf64_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf64_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock64_1, Release, 1)
     aie.next_bd ^bd1
   ^dma1:
     aie.dma_start("MM2S", 0, ^bd2, ^end)
   ^bd2:
     aie.use_lock(%lock64_2, Acquire, 1)
-    aie.dma_bd(%buf64_2 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf64_2 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock64_2, Release, 0)
     aie.next_bd ^bd2
   ^end: 
@@ -237,12 +237,12 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     aie.use_lock(%lock73_0, Acquire, 0)
-    aie.dma_bd(%buf73_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf73_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock73_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock73_1, Acquire, 0)
-    aie.dma_bd(%buf73_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf73_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock73_1, Release, 1)
     aie.next_bd ^bd1
   ^end: 
@@ -255,19 +255,19 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     aie.use_lock(%lock74_0, Acquire, 0)
-    aie.dma_bd(%buf74_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf74_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock74_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock74_1, Acquire, 0)
-    aie.dma_bd(%buf74_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf74_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock74_1, Release, 1)
     aie.next_bd ^bd1
   ^dma1:
     aie.dma_start("MM2S", 0, ^bd2, ^end)
   ^bd2:
     aie.use_lock(%lock74_2, Acquire, 1)
-    aie.dma_bd(%buf74_2 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf74_2 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock74_2, Release, 0)
     aie.next_bd ^bd2
   ^end: 

--- a/programming_examples/mlir/MM_2x2/packet_switched_version/aie.mlir
+++ b/programming_examples/mlir/MM_2x2/packet_switched_version/aie.mlir
@@ -105,25 +105,25 @@ module @MM_2x2 {
     ^bd4:
       aie.use_lock(%lock60_0, "Acquire", 1)
       aie.dma_bd_packet(0x0, 0x0)
-      aie.dma_bd(%buffer0 : memref<1024xi32>, 0, 1024)    //send LHS_tile0 with Pack_ID=0
+      aie.dma_bd(%buffer0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send LHS_tile0 with Pack_ID=0
       aie.use_lock(%lock60_0, "Release", 0)
       aie.next_bd ^bd5
     ^bd5:
       aie.use_lock(%lock60_1, "Acquire", 1)
       aie.dma_bd_packet(0x1, 0x1)
-      aie.dma_bd(%buffer1 : memref<1024xi32>, 0, 1024)    //send LHS_tile1 with Pack_ID=1
+      aie.dma_bd(%buffer1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send LHS_tile1 with Pack_ID=1
       aie.use_lock(%lock60_1, "Release", 0)
       aie.next_bd ^bd4
     ^bd6:
       aie.use_lock(%lock60_2, "Acquire", 1)
       aie.dma_bd_packet(0x2, 0x2)
-      aie.dma_bd(%buffer2 : memref<1024xi32>, 0, 1024)    //send RHS_tile0 with Pack_ID=2
+      aie.dma_bd(%buffer2 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile0 with Pack_ID=2
       aie.use_lock(%lock60_2, "Release", 0)
       aie.next_bd ^bd7
     ^bd7:
       aie.use_lock(%lock60_3, "Acquire", 1)
       aie.dma_bd_packet(0x3, 0x3)
-      aie.dma_bd(%buffer3 : memref<1024xi32>, 0, 1024)    //send RHS_tile1 with Pack_ID=3
+      aie.dma_bd(%buffer3 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile1 with Pack_ID=3
       aie.use_lock(%lock60_3, "Release", 0)
       aie.next_bd ^bd6
     ^end:
@@ -137,20 +137,20 @@ module @MM_2x2 {
     ^bd4:
       aie.use_lock(%lock70_0, "Acquire", 1)
       aie.dma_bd_packet(0x4, 0x4)
-      aie.dma_bd(%buffer4 : memref<1024xi32>, 0, 1024)    //send RHS_tile2 with Pack_ID=4
+      aie.dma_bd(%buffer4 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile2 with Pack_ID=4
       aie.use_lock(%lock70_0, "Release", 0)
       aie.next_bd ^bd5
     ^bd5:
       aie.use_lock(%lock70_1, "Acquire", 1)
       aie.dma_bd_packet(0x5, 0x5)
-      aie.dma_bd(%buffer5 : memref<1024xi32>, 0, 1024)    //send RHS_tile3 with Pack_ID=5
+      aie.dma_bd(%buffer5 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }    //send RHS_tile3 with Pack_ID=5
       aie.use_lock(%lock70_1, "Release", 0)
       aie.next_bd ^bd4
     ^bd6:
-      aie.dma_bd(%buffer6 : memref<1025xi32>, 0, 1025)    //send Out_tile0 with Pack_ID=6
+      aie.dma_bd(%buffer6 : memref<1025xi32>) { offset = 0 : i32, len = 1025 : i32 }    //send Out_tile0 with Pack_ID=6
       aie.next_bd ^bd7
     ^bd7:
-      aie.dma_bd(%buffer7 : memref<1025xi32>, 0, 1025)    //send Out_tile1 with Pack_ID=7
+      aie.dma_bd(%buffer7 : memref<1025xi32>) { offset = 0 : i32, len = 1025 : i32 }    //send Out_tile1 with Pack_ID=7
       aie.next_bd ^bd6
     ^end:
       aie.end
@@ -165,12 +165,12 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     aie.use_lock(%lock63_0, Acquire, 0)
-    aie.dma_bd(%buf63_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf63_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock63_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock63_1, Acquire, 0)
-    aie.dma_bd(%buf63_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf63_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock63_1, Release, 1)
     aie.next_bd ^bd1
   ^end: 
@@ -187,12 +187,12 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     aie.use_lock(%lock64_0, Acquire, 0)
-    aie.dma_bd(%buf64_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf64_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock64_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock64_1, Acquire, 0)
-    aie.dma_bd(%buf64_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf64_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock64_1, Release, 1)
     aie.next_bd ^bd1
   ^dma1:
@@ -200,7 +200,7 @@ module @MM_2x2 {
   ^bd2:
     aie.use_lock(%lock64_2, Acquire, 1)
     aie.dma_bd_packet(0x0, 0x6)
-    aie.dma_bd(%buf64_2 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf64_2 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock64_2, Release, 0)
     aie.next_bd ^bd2
   ^end: 
@@ -247,12 +247,12 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     aie.use_lock(%lock73_0, Acquire, 0)
-    aie.dma_bd(%buf73_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf73_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock73_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock73_1, Acquire, 0)
-    aie.dma_bd(%buf73_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf73_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock73_1, Release, 1)
     aie.next_bd ^bd1
   ^end: 
@@ -269,12 +269,12 @@ module @MM_2x2 {
     aie.dma_start("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     aie.use_lock(%lock74_0, Acquire, 0)
-    aie.dma_bd(%buf74_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf74_0 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock74_0, Release, 1)
     aie.next_bd ^bd0
   ^bd1: 
     aie.use_lock(%lock74_1, Acquire, 0)
-    aie.dma_bd(%buf74_1 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf74_1 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock74_1, Release, 1)
     aie.next_bd ^bd1
   ^dma1:
@@ -282,7 +282,7 @@ module @MM_2x2 {
   ^bd2:
     aie.use_lock(%lock74_2, Acquire, 1)
     aie.dma_bd_packet(0x0, 0x7)
-    aie.dma_bd(%buf74_2 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf74_2 : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%lock74_2, Release, 0)
     aie.next_bd ^bd2
   ^end: 

--- a/programming_examples/mlir/autocorrelation/aie.mlir
+++ b/programming_examples/mlir/autocorrelation/aie.mlir
@@ -57,12 +57,12 @@ module @autocorrelation {
      aie.dma_start("S2MM", 0, ^bdout, ^end)
     ^bdin:
       aie.use_lock(%input_lock, "Acquire", 1)
-      aie.dma_bd(%input : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%input : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
       aie.use_lock(%input_lock, "Release", 0)
       aie.next_bd ^end
     ^bdout:
       aie.use_lock(%output_lock, "Acquire", 0)
-      aie.dma_bd(%output : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%output : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
       aie.use_lock(%output_lock, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -85,12 +85,12 @@ module @autocorrelation {
     aie.dma_start("MM2S", 0, ^bd1, ^end)
   ^bd0: 
     aie.use_lock(%buf1_in_lock, Acquire, 0)
-    aie.dma_bd(%buf1_in : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf1_in : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%buf1_in_lock, Release, 1)
     aie.next_bd ^end
   ^bd1: 
     aie.use_lock(%buf1_out_lock, Acquire, 1)
-    aie.dma_bd(%buf1_out : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf1_out : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%buf1_out_lock, Release, 0)
     aie.next_bd ^end
   ^end:
@@ -101,7 +101,7 @@ module @autocorrelation {
     aie.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     aie.use_lock(%buf2_in_lock, Acquire, 0)
-    aie.dma_bd(%buf2_in : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf2_in : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%buf2_in_lock, Release, 1)
     aie.next_bd ^end
   ^end:
@@ -112,7 +112,7 @@ module @autocorrelation {
     aie.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     aie.use_lock(%buf3_in_lock, Acquire, 0)
-    aie.dma_bd(%buf3_in : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf3_in : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%buf3_in_lock, Release, 1)
     aie.next_bd ^end
   ^end:
@@ -123,7 +123,7 @@ module @autocorrelation {
     aie.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     aie.use_lock(%buf4_in_lock, Acquire, 0)
-    aie.dma_bd(%buf4_in : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf4_in : memref<1024xi32>) { offset = 0 : i32, len = 1024 : i32 }
     aie.use_lock(%buf4_in_lock, Release, 1)
     aie.next_bd ^end
   ^end:

--- a/programming_examples/mlir/idct/aie.mlir
+++ b/programming_examples/mlir/idct/aie.mlir
@@ -136,22 +136,22 @@ module @idct {
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_73_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_73_aping : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_73_aping : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_73_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_73_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_73_apong : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_73_apong : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_73_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_73_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_73_bping : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_73_bping : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_73_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_73_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_73_bpong : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_73_bpong : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_73_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -165,22 +165,22 @@ module @idct {
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_74_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_74_aping : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_74_aping : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_74_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_74_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_74_apong : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_74_apong : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_74_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_74_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_74_bping : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_74_bping : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_74_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_74_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_74_bpong : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_74_bpong : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_74_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -194,22 +194,22 @@ module @idct {
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_75_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_75_aping : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_75_aping : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_75_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_75_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_75_apong : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_75_apong : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_75_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_75_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_75_bping : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_75_bping : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_75_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_75_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_75_bpong : memref<64xi16>, 0, 64)
+      aie.dma_bd(%buf_75_bpong : memref<64xi16>) { offset = 0 : i32, len = 64 : i32 }
       aie.use_lock(%lock_75_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -230,12 +230,12 @@ module @idct {
       aie.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock1, "Acquire", 1)
-      aie.dma_bd(%buffer_in : memref<512 x i16>, 0, 512)
+      aie.dma_bd(%buffer_in : memref<512 x i16>) { offset = 0 : i32, len = 512 : i32 }
       aie.use_lock(%lock1, "Release", 0)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%lock2, "Acquire", 1)
-      aie.dma_bd(%buffer_out : memref<512 x i16>, 0, 512)
+      aie.dma_bd(%buffer_out : memref<512 x i16>) { offset = 0 : i32, len = 512 : i32 }
       aie.use_lock(%lock2, "Release", 0)
       aie.next_bd ^bd1
     ^end:

--- a/test/Passes/assign-bd-ids/bad_bd_assignments.mlir
+++ b/test/Passes/assign-bd-ids/bad_bd_assignments.mlir
@@ -19,7 +19,7 @@ module {
       %player_a = aie.dma(S2MM, 0) [{
         aie.use_lock(%lock_Y, Acquire, 0)
         // expected-error@+1 {{'aie.dma_bd' op bdId attribute exceeds max: 15}}
-        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 16 : i32, next_bd_id = 1 : i32}
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 16 : i32, next_bd_id = 1 : i32}
         aie.use_lock(%lock_Y, Release, 0)
       }]
       aie.end
@@ -119,7 +119,7 @@ module {
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%lock_0_1, AcquireGreaterEqual)
         // expected-error@+1 {{'aie.dma_bd' op transfer length must be multiple of 4 (i.e., represent 4 byte aligned address)}}
-        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 0, 129)
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>) { len = 129 : i32 }
         aie.use_lock(%lock_0_1_0, Release)
       }]
       aie.end

--- a/test/Passes/assign-bd-ids/basic.mlir
+++ b/test/Passes/assign-bd-ids/basic.mlir
@@ -18,10 +18,10 @@
 // CHECK:  %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) : memref<32xi32>
 // CHECK:  %[[VAL_5:.*]] = aie.lock(%[[VAL_2]]) {init = 1 : i32, sym_name = "lock_X"}
 // CHECK:  %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "lock_Y"}
-// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 0 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 0 : i32, next_bd_id = 1 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 2 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 2 : i32, next_bd_id = 0 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 3 : i32, next_bd_id = 4 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 3 : i32, next_bd_id = 4 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 4 : i32, next_bd_id = 5 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 5 : i32, next_bd_id = 3 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 0 : i32}
@@ -41,7 +41,7 @@ module {
     %mem_0_2 = aie.mem(%tile_0_2) {
       %player_a = aie.dma(S2MM, 0) {sym_name = "player_a"} [{
         aie.use_lock(%lock_Y, Acquire, 0)
-        aie.dma_bd(%double_buffer : memref<32xi32>, 0)
+        aie.dma_bd(%double_buffer : memref<32xi32>)
         aie.use_lock(%lock_Y, Release, 0)
       }, {
         aie.use_lock(%lock_X, Acquire, 1)
@@ -54,7 +54,7 @@ module {
       }]
       %player_b = aie.dma(S2MM, 1) {sym_name = "player_b"} [{
         aie.use_lock(%lock_Y, Acquire, 1)
-        aie.dma_bd(%double_buffer : memref<32xi32>, 0)
+        aie.dma_bd(%double_buffer : memref<32xi32>)
         aie.use_lock(%lock_Y, Release, 0)
       }, {
         aie.use_lock(%lock_X, Acquire, 1)
@@ -104,10 +104,10 @@ module {
 // CHECK:  %[[VAL_1:.*]] = aie.buffer(%[[VAL_0]]) {address = 8192 : i32, sym_name = "in"} : memref<16xi32>
 // CHECK:  %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {address = 1824 : i32, sym_name = "out"} : memref<16xi32>
 // CHECK:  %[[VAL_8:.*]] = aie.memtile_dma(%[[VAL_0]]) {
-// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) {bd_id = 0 : i32, next_bd_id = 0 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 16) {bd_id = 24 : i32, next_bd_id = 24 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 25 : i32, next_bd_id = 25 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 1 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, dims = [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) {bd_id = 0 : i32, len = 128 : i32, next_bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>) {bd_id = 24 : i32, len = 16 : i32, next_bd_id = 24 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {bd_id = 25 : i32, len = 16 : i32, next_bd_id = 25 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {bd_id = 1 : i32, len = 16 : i32, next_bd_id = 1 : i32}
 
 module @aie_module  {
   aie.device(xcve2302) {
@@ -130,22 +130,22 @@ module @aie_module  {
         %dstDma = aie.dma_start(MM2S, 0, ^bd3, ^end)
       ^bd0:
         aie.use_lock(%l01_0, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>])
+        aie.dma_bd(%buf01_0 : memref<16xi32>, dims = [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) { len = 128 : i32 }
         aie.use_lock(%l01_1, "Release", 1)
         aie.next_bd ^bd0
       ^bd1:
         aie.use_lock(%l01_1, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf01_0 : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%l01_0, "Release", 1)
         aie.next_bd ^bd1
       ^bd2:
         aie.use_lock(%l01_2, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%l01_3, "Release", 1)
         aie.next_bd ^bd2
       ^bd3:
         aie.use_lock(%l01_3, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%l01_2, "Release", 1)
         aie.next_bd ^bd3
       ^end:

--- a/test/Passes/assign-bd-ids/user_assigned.mlir
+++ b/test/Passes/assign-bd-ids/user_assigned.mlir
@@ -16,10 +16,10 @@
 // CHECK:  %[[VAL_2:.*]] = aie.tile(0, 2)
 // CHECK:  %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "double_buffer"} : memref<32xi32>
 // CHECK:  %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) : memref<32xi32>
-// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 0 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 0 : i32, next_bd_id = 1 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 2 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 2 : i32, next_bd_id = 0 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 3 : i32, next_bd_id = 4 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 3 : i32, next_bd_id = 4 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 4 : i32, next_bd_id = 5 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 5 : i32, next_bd_id = 3 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 0 : i32}
@@ -39,7 +39,7 @@ module {
     %mem_0_2 = aie.mem(%tile_0_2) {
       %player_a = aie.dma(S2MM, 0) {sym_name = "player_a"} [{
         aie.use_lock(%lock_Y, Acquire, 0)
-        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 0 : i32}
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 0 : i32}
         aie.use_lock(%lock_Y, Release, 0)
       }, {
         aie.use_lock(%lock_X, Acquire, 1)
@@ -52,7 +52,7 @@ module {
       }]
       %player_b = aie.dma(S2MM, 1) {sym_name = "player_b"} [{
         aie.use_lock(%lock_Y, Acquire, 1)
-        aie.dma_bd(%double_buffer : memref<32xi32>, 0)
+        aie.dma_bd(%double_buffer : memref<32xi32>)
         aie.use_lock(%lock_Y, Release, 0)
       }, {
         aie.use_lock(%lock_X, Acquire, 1)
@@ -101,10 +101,10 @@ module {
 // CHECK:  %[[VAL_0:.*]] = aie.tile(2, 1)
 // CHECK:  %[[VAL_1:.*]] = aie.buffer(%[[VAL_0]]) {address = 8192 : i32, sym_name = "in"} : memref<16xi32>
 // CHECK:  %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {address = 1824 : i32, sym_name = "out"} : memref<16xi32>
-// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) {bd_id = 0 : i32, next_bd_id = 0 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, 0, 16) {bd_id = 24 : i32, next_bd_id = 24 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 25 : i32, next_bd_id = 25 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16) {bd_id = 1 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>, dims = [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) {bd_id = 0 : i32, len = 128 : i32, next_bd_id = 0 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_1]] : memref<16xi32>) {bd_id = 24 : i32, len = 16 : i32, next_bd_id = 24 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {bd_id = 25 : i32, len = 16 : i32, next_bd_id = 25 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {bd_id = 1 : i32, len = 16 : i32, next_bd_id = 1 : i32}
 
 module @aie_module  {
   aie.device(xcve2302) {
@@ -127,22 +127,22 @@ module @aie_module  {
         %dstDma = aie.dma_start(MM2S, 0, ^bd3, ^end)
       ^bd0:
         aie.use_lock(%l01_0, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>])
+        aie.dma_bd(%buf01_0 : memref<16xi32>, dims = [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) { len = 128 : i32 }
         aie.use_lock(%l01_1, "Release", 1)
         aie.next_bd ^bd0
       ^bd1:
         aie.use_lock(%l01_1, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 16) {bd_id = 24 : i32}
+        aie.dma_bd(%buf01_0 : memref<16xi32>) { len = 16 : i32, bd_id = 24 : i32 }
         aie.use_lock(%l01_0, "Release", 1)
         aie.next_bd ^bd1
       ^bd2:
         aie.use_lock(%l01_2, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%l01_3, "Release", 1)
         aie.next_bd ^bd2
       ^bd3:
         aie.use_lock(%l01_3, "AcquireGreaterEqual", 1)
-        aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16) {bd_id = 1 : i32}
+        aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32, bd_id = 1 : i32 }
         aie.use_lock(%l01_2, "Release", 1)
         aie.next_bd ^bd3
       ^end:
@@ -159,10 +159,10 @@ module @aie_module  {
 // CHECK:  %[[VAL_2:.*]] = aie.tile(0, 2)
 // CHECK:  %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "double_buffer"} : memref<32xi32>
 // CHECK:  %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) : memref<32xi32>
-// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 5 : i32, next_bd_id = 4 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 5 : i32, next_bd_id = 4 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 4 : i32, next_bd_id = 3 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 3 : i32, next_bd_id = 5 : i32}
-// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>, 0) {bd_id = 2 : i32, next_bd_id = 1 : i32}
+// CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 2 : i32, next_bd_id = 1 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 1 : i32, next_bd_id = 0 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_3]] : memref<32xi32>) {bd_id = 0 : i32, next_bd_id = 2 : i32}
 // CHECK:  aie.dma_bd(%[[VAL_4]] : memref<32xi32>) {bd_id = 0 : i32}
@@ -182,7 +182,7 @@ module {
     %mem_0_2 = aie.mem(%tile_0_2) {
       %player_a = aie.dma(S2MM, 0) {sym_name = "player_a"} [{
         aie.use_lock(%lock_Y, Acquire, 0)
-        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 5 : i32}
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 5 : i32}
         aie.use_lock(%lock_Y, Release, 0)
       }, {
         aie.use_lock(%lock_X, Acquire, 1)
@@ -195,7 +195,7 @@ module {
       }]
       %player_b = aie.dma(S2MM, 1) {sym_name = "player_b"} [{
         aie.use_lock(%lock_Y, Acquire, 1)
-        aie.dma_bd(%double_buffer : memref<32xi32>, 0) {bd_id = 2 : i32}
+        aie.dma_bd(%double_buffer : memref<32xi32>) {bd_id = 2 : i32}
         aie.use_lock(%lock_Y, Release, 0)
       }, {
         aie.use_lock(%lock_X, Acquire, 1)

--- a/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_nd_DMA.mlir
@@ -44,22 +44,22 @@ module @aie_module  {
       %dstDma = aie.dma_start(MM2S, 0, ^bd3, ^end)
     ^bd0:
       aie.use_lock(%l01_0, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 128, [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>])
+      aie.dma_bd(%buf01_0 : memref<16xi32>, dims = [<size = 2, stride = 1>, <size = 3, stride = 2>, <size = 2, stride = 4>, <size = 1, stride = 1>]) { len = 128 : i32 }
       aie.use_lock(%l01_1, "Release", 1)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%l01_1, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf01_0 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%l01_0, "Release", 1)
       aie.next_bd ^bd1
     ^bd2:
       aie.use_lock(%l01_2, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%l01_3, "Release", 1)
       aie.next_bd ^bd2
     ^bd3:
       aie.use_lock(%l01_3, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%l01_2, "Release", 1)
       aie.next_bd ^bd3
     ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA.mlir
@@ -35,7 +35,7 @@ module @aie_module  {
       ^bd0:
         // Note: acquire and release are different locks.
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_a_ping : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA2.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA2.mlir
@@ -36,7 +36,7 @@ module @aie_module  {
       ^bd0:
         // Note: acquire and release are different locks.
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_a_ping : memref<256xi32>) { len = 256 : i32 }
         // aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA3.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA3.mlir
@@ -36,7 +36,7 @@ module @aie_module  {
       ^bd0:
         // Note: acquire and release are different locks.
         //aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_a_ping : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA4.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA4.mlir
@@ -35,7 +35,7 @@
        ^bd0:
          // Note: acquire and release are different locks.
          aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-         aie.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
+         aie.dma_bd(%buf_a_ping : memref<256xi32>) { len = 256 : i32 }
          aie.use_lock(%lock_a_read, Release, 1)
          aie.next_bd ^end
        ^end:

--- a/test/Targets/AIEGenerateXAIE/aie2_tileDMA_locks.mlir
+++ b/test/Targets/AIEGenerateXAIE/aie2_tileDMA_locks.mlir
@@ -43,19 +43,19 @@ module @aie_module  {
         %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
       ^bd0:
         aie.use_lock(%lock_l1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l2, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l1, Release, 1)
         aie.next_bd ^bd2
       ^bd2:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l1, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l1, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/Targets/AIEGenerateXAIE/memTileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/memTileDMA.mlir
@@ -58,22 +58,22 @@ module @aie_module  {
       %dstDma = aie.dma_start(MM2S, 0, ^bd3, ^end)
     ^bd0:
       aie.use_lock(%l01_0, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf01_0 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%l01_1, "Release", 1)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%l01_1, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_0 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf01_0 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%l01_0, "Release", 1)
       aie.next_bd ^bd1
     ^bd2:
       aie.use_lock(%l01_2, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%l01_3, "Release", 1)
       aie.next_bd ^bd2
     ^bd3:
       aie.use_lock(%l01_3, "AcquireGreaterEqual", 1)
-      aie.dma_bd(%buf01_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf01_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%l01_2, "Release", 1)
       aie.next_bd ^bd3
     ^end:

--- a/test/Targets/AIEGenerateXAIE/memTileDMA2.mlir
+++ b/test/Targets/AIEGenerateXAIE/memTileDMA2.mlir
@@ -53,15 +53,15 @@ module @aie_module  {
   %m01 = aie.memtile_dma(%t01) {
       %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
-      aie.dma_bd(%buf_w : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf_w : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%lock_w, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf_l : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf_l : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%lock_l, "Release", 1)
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf_e : memref<16xi32>, 0, 16)
+      aie.dma_bd(%buf_e : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%lock_e, "Release", 1)
       aie.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/packet_drop_header.mlir
+++ b/test/Targets/AIEGenerateXAIE/packet_drop_header.mlir
@@ -69,13 +69,13 @@ module @aie_module {
     ^bb2:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%4, Acquire, 0)
       aie.dma_bd_packet(2, 3)
-      aie.dma_bd(%5 : memref<16xi32, 2>, 0, 16)
+      aie.dma_bd(%5 : memref<16xi32, 2>) { len = 16 : i32 }
       aie.use_lock(%4, Release, 1)
       aie.next_bd ^bb2
     ^bb3:  // 2 preds: ^bb1, ^bb3
       aie.use_lock(%4, Acquire, 1)
       aie.dma_bd_packet(6, 10)
-      aie.dma_bd(%5 : memref<16xi32, 2>, 0, 16)
+      aie.dma_bd(%5 : memref<16xi32, 2>) { len = 16 : i32 }
       aie.use_lock(%4, Release, 0)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb1

--- a/test/Targets/AIEGenerateXAIE/packet_shim_header.mlir
+++ b/test/Targets/AIEGenerateXAIE/packet_shim_header.mlir
@@ -61,7 +61,7 @@ module @aie_module {
       %10 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%5, Acquire, 0)
-      aie.dma_bd(%6 : memref<32xi32, 2>, 0, 32)
+      aie.dma_bd(%6 : memref<32xi32, 2>) { len = 32 : i32 }
       aie.use_lock(%5, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb0
@@ -73,7 +73,7 @@ module @aie_module {
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%10, Acquire, 1)
       aie.dma_bd_packet(6, 10)
-      aie.dma_bd(%7 : memref<32xi32>, 0, 32)
+      aie.dma_bd(%7 : memref<32xi32>) { len = 32 : i32 }
       aie.use_lock(%10, Release, 0)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb0

--- a/test/Targets/AIEGenerateXAIE/shim.mlir
+++ b/test/Targets/AIEGenerateXAIE/shim.mlir
@@ -64,12 +64,12 @@ module {
       aie.dma_start(MM2S, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock0, Acquire, 0)
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 16)
+      aie.dma_bd(%buffer : memref<16 x f32>) { len = 16 : i32 }
       aie.use_lock(%lock0, Release, 1)
       aie.next_bd ^bd0
     ^bd1:
       // aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 4)
+      aie.dma_bd(%buffer : memref<16 x f32>) { len = 4 : i32 }
       // aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd1
     ^end:

--- a/test/Targets/AIEGenerateXAIE/shim_dma_packet.mlir
+++ b/test/Targets/AIEGenerateXAIE/shim_dma_packet.mlir
@@ -37,7 +37,7 @@ module {
   ^bb1:  // 2 preds: ^bb0, ^bb1
     aie.use_lock(%lock70, Acquire, 1)
     aie.dma_bd_packet(0, 2)
-    aie.dma_bd(%buf : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%buf : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%lock70, Release, 0)
     aie.next_bd ^bb1
   ^bb2:  // pred: ^bb0

--- a/test/Targets/AIEGenerateXAIE/test_xaie1.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie1.mlir
@@ -32,7 +32,7 @@ module @test_xaie1 {
       %srcDma = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l33_0, Acquire, 0)
-      aie.dma_bd(%buf33_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_0, Release, 1)
       aie.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie2.mlir
@@ -42,12 +42,12 @@ module @test_xaie2 {
       %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l33_0, Acquire, 0)
-      aie.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_0, Release, 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%l33_0, Acquire, 0)
-      aie.dma_bd(%buf33_1 : memref<16xi32>, 0, 4)
+      aie.dma_bd(%buf33_1 : memref<16xi32>) { len = 4 : i32 }
       aie.use_lock(%l33_0, Release, 1)
       aie.next_bd ^bd0
     ^end:

--- a/test/Targets/AIEGenerateXAIE/test_xaie3.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie3.mlir
@@ -27,7 +27,7 @@ module @test_xaie3 {
       %srcDma = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l33_0, Acquire, 1)
-      aie.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_0, Release, 0)
       aie.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
+++ b/test/Targets/AIEGenerateXAIE/test_xaie4.mlir
@@ -47,12 +47,12 @@ module @test_xaie3 {
       %destDma = aie.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%l33_0, Acquire, 1)
-      aie.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_0, Release, 0)
       aie.next_bd ^end
     ^bd1:
       aie.use_lock(%l33_1, Acquire, 1)
-      aie.dma_bd(%buf33_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_1, Release, 0)
       aie.next_bd ^end
     ^end:

--- a/test/Targets/AIEGenerateXAIE/tileDMA.mlir
+++ b/test/Targets/AIEGenerateXAIE/tileDMA.mlir
@@ -34,7 +34,7 @@ module @aie_module  {
     %38 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     aie.use_lock(%25, Acquire, 0)
-    aie.dma_bd(%24 : memref<64xi32, 2>, 0, 64)
+    aie.dma_bd(%24 : memref<64xi32, 2>) { len = 64 : i32 }
     aie.use_lock(%25, Release, 1)
     aie.next_bd ^bb1
   ^bb2:  // pred: ^bb3
@@ -43,7 +43,7 @@ module @aie_module  {
     %39 = aie.dma_start(MM2S, 0, ^bb4, ^bb2)
   ^bb4:  // 2 preds: ^bb3, ^bb4
     aie.use_lock(%27, Acquire, 1)
-    aie.dma_bd(%26 : memref<64xi32, 2>, 0, 64)
+    aie.dma_bd(%26 : memref<64xi32, 2>) { len = 64 : i32 }
     aie.use_lock(%27, Release, 0)
     aie.next_bd ^bb4
   }

--- a/test/Targets/AIETargetAirbin/aie.mlir
+++ b/test/Targets/AIETargetAirbin/aie.mlir
@@ -151,22 +151,22 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
     ^bb2:  // 2 preds: ^bb0, ^bb3
       aie.use_lock(%lock_6_2, Acquire, 0)
-      aie.dma_bd(%buffer_6_2 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%buffer_6_2 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%lock_6_2, Release, 1)
       aie.next_bd ^bb3
     ^bb3:  // pred: ^bb2
       aie.use_lock(%lock_6_2_3, Acquire, 0)
-      aie.dma_bd(%buffer_6_2_1 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%buffer_6_2_1 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%lock_6_2_3, Release, 1)
       aie.next_bd ^bb2
     ^bb4:  // 2 preds: ^bb1, ^bb5
       aie.use_lock(%lock_6_2_4, Acquire, 1)
-      aie.dma_bd(%buffer_6_2_0 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%buffer_6_2_0 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%lock_6_2_4, Release, 0)
       aie.next_bd ^bb5
     ^bb5:  // pred: ^bb4
       aie.use_lock(%lock_6_2_5, Acquire, 1)
-      aie.dma_bd(%buffer_6_2_2 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%buffer_6_2_2 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%lock_6_2_5, Release, 0)
       aie.next_bd ^bb4
     ^bb6:  // pred: ^bb1

--- a/test/Targets/AIETargetCDODirect/oneshim.mlir
+++ b/test/Targets/AIETargetCDODirect/oneshim.mlir
@@ -30,7 +30,7 @@ module {
   aie.shim_dma(%t00)  {
       aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 4)  {bd_id = 0 : i32}
+      aie.dma_bd(%buffer : memref<16 x f32>)  {bd_id = 0 : i32, len = 4 : i32}
       aie.next_bd ^end
     ^end:
       aie.end

--- a/test/Targets/AIETargetCDODirect/shims.mlir
+++ b/test/Targets/AIETargetCDODirect/shims.mlir
@@ -94,7 +94,7 @@ module {
   aie.shim_dma(%t00)  {
       aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 4)  {bd_id = 0 : i32}
+      aie.dma_bd(%buffer : memref<16 x f32>) {len = 4 : i32, bd_id = 0 : i32}
       aie.next_bd ^end
     ^end:
       aie.end
@@ -105,7 +105,7 @@ module {
   aie.shim_dma(%t10)  {
       aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 4)  {bd_id = 0 : i32}
+      aie.dma_bd(%buffer : memref<16 x f32>) {len = 4 : i32, bd_id = 0 : i32}
       aie.next_bd ^end
     ^end:
       aie.end
@@ -125,12 +125,12 @@ module {
       aie.dma_start(MM2S, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock0, Acquire, 0)
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 16) {bd_id = 0 : i32}
+      aie.dma_bd(%buffer : memref<16 x f32>) {len = 16 : i32, bd_id = 0 : i32}
       aie.use_lock(%lock0, Release, 1)
       aie.next_bd ^bd0
     ^bd1:
       // aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 4) {bd_id = 1 : i32}
+      aie.dma_bd(%buffer : memref<16 x f32>) {len = 4 : i32, bd_id = 1 : i32}
       // aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd1
     ^end:
@@ -142,7 +142,7 @@ module {
   aie.shim_dma(%t30)  {
       aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
-      aie.dma_bd(%buffer : memref<16 x f32>, 0, 4) {bd_id = 0 : i32}
+      aie.dma_bd(%buffer : memref<16 x f32>) {len = 4 : i32, bd_id = 0 : i32}
       aie.next_bd ^end
     ^end:
       aie.end

--- a/test/assign-buffer-addresses/bad_alignment.mlir
+++ b/test/assign-buffer-addresses/bad_alignment.mlir
@@ -20,7 +20,7 @@ module {
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%lock_0_1, AcquireGreaterEqual)
         // expected-error@+1 {{'aie.dma_bd' op bd address must be 4 byte (32b) aligned; got base+offset: 1 (bytes)}}
-        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 0, 128)
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>) { len = 128 : i32 }
         aie.use_lock(%lock_0_1_0, Release)
       }]
       aie.end
@@ -39,7 +39,7 @@ module {
       %buffer_0_1 = aie.buffer(%tile_0_1) {address = 1 : i32} : memref<128xi16>
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%lock_0_1, AcquireGreaterEqual)
-        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 3, 128)
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>) { offset = 3 : i32, len = 128 : i32 }
         // expected-error@above {{'aie.dma_bd' op bd address must be 4 byte (32b) aligned; got base+offset: 7 (bytes)}}
         aie.use_lock(%lock_0_1_0, Release)
       }]
@@ -65,7 +65,7 @@ module {
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%lock_0_1, AcquireGreaterEqual)
         // 2*6 + 2 = 8 bytes i.e., 4B aligned...
-        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 3, 128)
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>) { offset = 3 : i32, len = 128 : i32 }
         aie.use_lock(%lock_0_1_0, Release)
       }]
       aie.end
@@ -86,7 +86,7 @@ module {
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%lock_0_1, AcquireGreaterEqual)
         // expected-error@below {{'aie.dma_bd' op bd address must be 4 byte (32b) aligned; got base+offset: 6 (bytes)}}
-        aie.dma_bd(%buffer_0_1 : memref<128xi16>, 3, 128)
+        aie.dma_bd(%buffer_0_1 : memref<128xi16>) { offset = 3 : i32, len = 128 : i32 }
         aie.use_lock(%lock_0_1_0, Release)
       }]
       aie.end

--- a/test/benchmarks/01_DDR_SHIM_LM_FillRate/aie.mlir
+++ b/test/benchmarks/01_DDR_SHIM_LM_FillRate/aie.mlir
@@ -38,7 +38,7 @@ module @benchmark01_DDR_SHIM_fill_rate {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -54,7 +54,7 @@ module @benchmark01_DDR_SHIM_fill_rate {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l71_0, "Acquire", 0)
-      aie.dma_bd(%buf71_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf71_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l71_0, "Release", 1)
       aie.next_bd ^end
     ^end:

--- a/test/benchmarks/02_LM_SHIM_DDR_FillRate/aie.mlir
+++ b/test/benchmarks/02_LM_SHIM_DDR_FillRate/aie.mlir
@@ -26,7 +26,7 @@ module @benchmark_02_LM2DDR {
       %srcDma = aie.dma_start(MM2S, 1, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf71_0 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buf71_0 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock_a_ping, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -40,7 +40,7 @@ module @benchmark_02_LM2DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:

--- a/test/benchmarks/03_Flood_DDR/aie.mlir
+++ b/test/benchmarks/03_Flood_DDR/aie.mlir
@@ -35,7 +35,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l21_0, "Acquire", 0)
-      aie.dma_bd(%buf21_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf21_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l21_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -50,7 +50,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%l20, Acquire, 1)
-      aie.dma_bd(%buffer_out_20 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_20 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l20, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -78,7 +78,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l31_0, "Acquire", 0)
-      aie.dma_bd(%buf31_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf31_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l31_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -94,7 +94,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_30 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_30 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -122,7 +122,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l61_0, "Acquire", 0)
-      aie.dma_bd(%buf61_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf61_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l61_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -137,7 +137,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_60 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_60 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -168,7 +168,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l71_0, "Acquire", 0)
-      aie.dma_bd(%buf71_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf71_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l71_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -184,7 +184,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_70 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_70 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -215,7 +215,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l101_0, "Acquire", 0)
-      aie.dma_bd(%buf101_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf101_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l101_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -230,7 +230,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_100 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_100 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -258,7 +258,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l111_0, "Acquire", 0)
-      aie.dma_bd(%buf111_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf111_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l111_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -273,7 +273,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_110 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_110 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -301,7 +301,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l181_0, "Acquire", 0)
-      aie.dma_bd(%buf181_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf181_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l181_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -317,7 +317,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_180 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_180 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -346,7 +346,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l191_0, "Acquire", 0)
-      aie.dma_bd(%buf191_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf191_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l191_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -361,7 +361,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_190 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_190 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -389,7 +389,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l261_0, "Acquire", 0)
-      aie.dma_bd(%buf261_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf261_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l261_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -405,7 +405,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_260 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_260 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -434,7 +434,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l271_0, "Acquire", 0)
-      aie.dma_bd(%buf271_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf271_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l271_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -450,7 +450,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_270 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_270 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -478,7 +478,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l341_0, "Acquire", 0)
-      aie.dma_bd(%buf341_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf341_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l341_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -493,7 +493,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_340 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_340 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -521,7 +521,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l351_0, "Acquire", 0)
-      aie.dma_bd(%buf351_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf351_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l351_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -536,7 +536,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_350 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_350 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -557,7 +557,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l421, "Acquire", 0)
-      aie.dma_bd(%buf421_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf421_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l421, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -573,7 +573,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_out_420 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_420 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -601,7 +601,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l431_0, "Acquire", 0)
-      aie.dma_bd(%buf431_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf431_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l431_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -617,7 +617,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%l430, Acquire, 1)
-      aie.dma_bd(%buffer_out_430 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_430 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l430, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -646,7 +646,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l461_0, "Acquire", 0)
-      aie.dma_bd(%buf461_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf461_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l461_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -661,7 +661,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%l460, Acquire, 1)
-      aie.dma_bd(%buffer_out_460 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_460 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l460, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -690,7 +690,7 @@ module @benchmark03_Flood_DDR {
     %srcDma = aie.dma_start(S2MM, 0, ^bd0, ^end)
       ^bd0:
       aie.use_lock(%l471_0, "Acquire", 0)
-      aie.dma_bd(%buf471_0 : memref< 7168xi32>, 0, 7168)
+      aie.dma_bd(%buf471_0 : memref< 7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l471_0, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -706,7 +706,7 @@ module @benchmark03_Flood_DDR {
 
     ^bd0:
       aie.use_lock(%l470, Acquire, 1)
-      aie.dma_bd(%buffer_out_470 : memref<7168xi32>, 0, 7168)
+      aie.dma_bd(%buffer_out_470 : memref<7168xi32>) { len = 7168 : i32 }
       aie.use_lock(%l470, Release, 0)
       aie.next_bd ^bd0
     ^end:

--- a/test/benchmarks/04_Tile_Tile_FillRate/aie.mlir
+++ b/test/benchmarks/04_Tile_Tile_FillRate/aie.mlir
@@ -29,7 +29,7 @@ module @test04_tile_tiledma {
     %dma0 = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock13_5, "Acquire", 1)
-      aie.dma_bd(%buf13_0 : memref<512xi32>, 0, 512)
+      aie.dma_bd(%buf13_0 : memref<512xi32>) { len = 512 : i32 }
       aie.use_lock(%lock13_5, "Release", 0)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -45,7 +45,7 @@ module @test04_tile_tiledma {
     %dma0 = aie.dma_start(S2MM, 1, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock14_6, "Acquire", 0)
-      aie.dma_bd(%buf14_0: memref<512xi32>, 0, 512)
+      aie.dma_bd(%buf14_0: memref<512xi32>) { len = 512 : i32 }
       aie.use_lock(%lock14_6, "Release", 1)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:

--- a/test/benchmarks/12_Stream_Delay/aie.mlir
+++ b/test/benchmarks/12_Stream_Delay/aie.mlir
@@ -34,7 +34,7 @@ module @test12_stream_delay {
     %dma0 = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock13_5, "Acquire", 1)
-      aie.dma_bd(%buf13_0 : memref<512xi32>, 0, 512)
+      aie.dma_bd(%buf13_0 : memref<512xi32>) { len = 512 : i32 }
       aie.use_lock(%lock13_5, "Release", 0)
       aie.next_bd ^end
     ^end:
@@ -52,7 +52,7 @@ module @test12_stream_delay {
      %dma0 = aie.dma_start(S2MM, 1, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock43_6, "Acquire", 0)
-      aie.dma_bd(%buf43_0: memref<512xi32>, 0, 512)
+      aie.dma_bd(%buf43_0: memref<512xi32>) { len = 512 : i32 }
       aie.use_lock(%lock43_6, "Release", 1)
       aie.next_bd ^end
     ^end:

--- a/test/create-cores/duplicate_dma.mlir
+++ b/test/create-cores/duplicate_dma.mlir
@@ -19,14 +19,14 @@ module @duplicate_dma  {
     %15 = aie.dma_start(MM2S, 0, ^bb1, ^bb4)
   ^bb1:  // pred: ^bb0
     aiex.useToken @token0(Acquire, 1)
-    aie.dma_bd(%1 : memref<256xi32>, 0, 256)
+    aie.dma_bd(%1 : memref<256xi32>) { len = 256 : i32 }
     aiex.useToken @token0(Release, 2)
     aie.next_bd ^bb2
   ^bb2:  
     %16 = aie.dma_start(MM2S, 0, ^bb3, ^bb4)
   ^bb3:  
     aiex.useToken @token1(Acquire, 1)
-    aie.dma_bd(%1 : memref<256xi32>, 0, 256)
+    aie.dma_bd(%1 : memref<256xi32>) { len = 256 : i32 }
     aiex.useToken @token1(Release, 2)
     aie.next_bd ^bb4
   ^bb4:  // 4 preds: ^bb0, ^bb1, ^bb2, ^bb3

--- a/test/create-cores/hello_world.mlir
+++ b/test/create-cores/hello_world.mlir
@@ -17,7 +17,7 @@
 // CHECK:           %[[VAL_3:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<512xi32>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<512xi32>) {len = 512 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -29,7 +29,7 @@
 // CHECK:           %[[VAL_7:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32>, 0, 512)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<512xi32>) {len = 512 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-cores/test_dma0.mlir
+++ b/test/create-cores/test_dma0.mlir
@@ -17,7 +17,7 @@
 // CHECK:           %[[VAL_3:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -29,7 +29,7 @@
 // CHECK:           %[[VAL_7:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-cores/test_dma1.mlir
+++ b/test/create-cores/test_dma1.mlir
@@ -20,14 +20,14 @@
 // CHECK:           %[[VAL_3:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb4)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_4:.*]] = aie.dma_start(MM2S, 0, ^bb3, ^bb4)
 // CHECK:         ^bb3:
 // CHECK:           aiex.useToken @token1(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token1(Release, 2)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb4:
@@ -39,7 +39,7 @@
 // CHECK:           %[[VAL_8:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_6]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -51,7 +51,7 @@
 // CHECK:           %[[VAL_12:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token1(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_10]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token1(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-cores/test_dma2.mlir
+++ b/test/create-cores/test_dma2.mlir
@@ -18,7 +18,7 @@
 // CHECK:           %[[VAL_3:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -30,7 +30,7 @@
 // CHECK:           %[[VAL_7:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token1(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token1(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -43,14 +43,14 @@
 // CHECK:           %[[VAL_12:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_9]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_13:.*]] = aie.dma_start(S2MM, 0, ^bb3, ^bb4)
 // CHECK:         ^bb3:
 // CHECK:           aiex.useToken @token1(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_10]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token1(Release, 2)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb4:

--- a/test/create-cores/test_dma3.mlir
+++ b/test/create-cores/test_dma3.mlir
@@ -18,7 +18,7 @@
 // CHECK:           %[[VAL_3:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
@@ -30,14 +30,14 @@
 // CHECK:           %[[VAL_7:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 1)
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 2)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb2:
 // CHECK:           %[[VAL_8:.*]] = aie.dma_start(MM2S, 0, ^bb3, ^bb4)
 // CHECK:         ^bb3:
 // CHECK:           aiex.useToken @token0(Acquire, 3)
-// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_5]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 4)
 // CHECK:           aie.next_bd ^bb4
 // CHECK:         ^bb4:
@@ -49,7 +49,7 @@
 // CHECK:           %[[VAL_12:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:         ^bb1:
 // CHECK:           aiex.useToken @token0(Acquire, 3)
-// CHECK:           aie.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
+// CHECK:           aie.dma_bd(%[[VAL_10]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:           aiex.useToken @token0(Release, 4)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:

--- a/test/create-flows/mmult.mlir
+++ b/test/create-flows/mmult.mlir
@@ -50,26 +50,26 @@ module @aie.herd_0  {
       %63 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%9, Acquire, 0)
-      aie.dma_bd(%10 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%10 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%9, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%4, Acquire, 0)
-      aie.dma_bd(%6 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%6 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%4, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%7, Acquire, 0)
-      aie.dma_bd(%8 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%8 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%7, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%5, Acquire, 1)
-      aie.dma_bd(%6 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%6 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%5, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -91,26 +91,26 @@ module @aie.herd_0  {
       %63 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%23, Acquire, 0)
-      aie.dma_bd(%24 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%24 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%23, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%18, Acquire, 0)
-      aie.dma_bd(%20 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%20 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%18, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%21, Acquire, 0)
-      aie.dma_bd(%22 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%22 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%21, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%19, Acquire, 1)
-      aie.dma_bd(%20 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%20 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%19, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -132,26 +132,26 @@ module @aie.herd_0  {
       %63 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%37, Acquire, 0)
-      aie.dma_bd(%38 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%38 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%37, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%32, Acquire, 0)
-      aie.dma_bd(%34 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%34 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%32, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%35, Acquire, 0)
-      aie.dma_bd(%36 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%36 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%35, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%33, Acquire, 1)
-      aie.dma_bd(%34 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%34 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%33, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -173,26 +173,26 @@ module @aie.herd_0  {
       %63 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%51, Acquire, 0)
-      aie.dma_bd(%52 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%52 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%51, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%46, Acquire, 0)
-      aie.dma_bd(%48 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%48 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%46, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %64 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%49, Acquire, 0)
-      aie.dma_bd(%50 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%50 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%49, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %65 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%47, Acquire, 1)
-      aie.dma_bd(%48 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%48 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%47, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3

--- a/test/create-flows/unit_mmult.mlir
+++ b/test/create-flows/unit_mmult.mlir
@@ -26,26 +26,26 @@
 // CHECK:             %[[VAL_12:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             aie.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_13:.*]] = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_14:.*]] = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 0)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -67,26 +67,26 @@
 // CHECK:             %[[VAL_28:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_25]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_26]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_26]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_25]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             aie.use_lock(%[[VAL_20]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_29:.*]] = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             aie.use_lock(%[[VAL_23]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_24]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_24]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_23]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_30:.*]] = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             aie.use_lock(%[[VAL_21]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 0)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -108,26 +108,26 @@
 // CHECK:             %[[VAL_44:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_41]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_42]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_42]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_41]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             aie.use_lock(%[[VAL_36]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_38]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_38]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_36]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_45:.*]] = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             aie.use_lock(%[[VAL_39]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_40]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_40]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_39]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_46:.*]] = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             aie.use_lock(%[[VAL_37]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_38]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_38]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_37]], Release, 0)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -149,26 +149,26 @@
 // CHECK:             %[[VAL_60:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_57]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_58]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_58]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_57]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             aie.use_lock(%[[VAL_52]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_54]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_54]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_52]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:             %[[VAL_61:.*]] = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
 // CHECK:           ^bb4:
 // CHECK:             aie.use_lock(%[[VAL_55]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_56]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_56]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_55]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb5:
 // CHECK:             %[[VAL_62:.*]] = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
 // CHECK:           ^bb6:
 // CHECK:             aie.use_lock(%[[VAL_53]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_54]] : memref<16x16xf32, 2>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_54]] : memref<16x16xf32, 2>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_53]], Release, 0)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb7:
@@ -441,26 +441,26 @@ module @aie.herd_0 {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%lock_8_3_3, Acquire, 0)
-      aie.dma_bd(%buffer_8_3_4 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_3_4 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_3_3, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%lock_8_3, Acquire, 0)
-      aie.dma_bd(%buffer_8_3 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_3 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_3, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_8_3_1, Acquire, 0)
-      aie.dma_bd(%buffer_8_3_2 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_3_2 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_3_1, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_8_3_0, Acquire, 1)
-      aie.dma_bd(%buffer_8_3 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_3 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_3_0, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -482,26 +482,26 @@ module @aie.herd_0 {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%lock_7_3_8, Acquire, 0)
-      aie.dma_bd(%buffer_7_3_9 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_3_9 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_3_8, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%lock_7_3, Acquire, 0)
-      aie.dma_bd(%buffer_7_3 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_3 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_3, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_7_3_6, Acquire, 0)
-      aie.dma_bd(%buffer_7_3_7 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_3_7 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_3_6, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_7_3_5, Acquire, 1)
-      aie.dma_bd(%buffer_7_3 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_3 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_3_5, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -523,26 +523,26 @@ module @aie.herd_0 {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%lock_8_2_13, Acquire, 0)
-      aie.dma_bd(%buffer_8_2_14 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_2_14 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_2_13, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%lock_8_2, Acquire, 0)
-      aie.dma_bd(%buffer_8_2 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_2 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_2, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_8_2_11, Acquire, 0)
-      aie.dma_bd(%buffer_8_2_12 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_2_12 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_2_11, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_8_2_10, Acquire, 1)
-      aie.dma_bd(%buffer_8_2 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_8_2 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_8_2_10, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3
@@ -564,26 +564,26 @@ module @aie.herd_0 {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%lock_7_2_18, Acquire, 0)
-      aie.dma_bd(%buffer_7_2_19 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_2_19 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_2_18, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%lock_7_2, Acquire, 0)
-      aie.dma_bd(%buffer_7_2 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_2 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_2, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb5
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb7)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_7_2_16, Acquire, 0)
-      aie.dma_bd(%buffer_7_2_17 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_2_17 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_2_16, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_7_2_15, Acquire, 1)
-      aie.dma_bd(%buffer_7_2 : memref<16x16xf32, 2>, 0, 256)
+      aie.dma_bd(%buffer_7_2 : memref<16x16xf32, 2>) { len = 256 : i32 }
       aie.use_lock(%lock_7_2_15, Release, 0)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb3

--- a/test/create-flows/unit_vecmul_4x4.mlir
+++ b/test/create-flows/unit_vecmul_4x4.mlir
@@ -26,21 +26,21 @@
 // CHECK:             %[[VAL_12:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_13:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_14:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -80,21 +80,21 @@
 // CHECK:             %[[VAL_32:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_29]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_30]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_30]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_29]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_33:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_27]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_28]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_28]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_27]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_34:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_25]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_26]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_26]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_25]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -134,21 +134,21 @@
 // CHECK:             %[[VAL_52:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_49]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_50]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_50]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_49]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_53:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_47]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_48]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_48]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_47]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_54:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_45]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_46]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_46]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_45]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -188,21 +188,21 @@
 // CHECK:             %[[VAL_72:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_69]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_70]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_70]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_69]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_73:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_67]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_68]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_68]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_67]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_74:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_65]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_66]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_66]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_65]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -241,21 +241,21 @@
 // CHECK:             %[[VAL_91:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_88]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_89]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_89]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_88]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_92:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_86]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_87]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_87]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_86]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_93:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_84]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_85]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_85]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_84]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -294,21 +294,21 @@
 // CHECK:             %[[VAL_110:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_107]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_108]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_108]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_107]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_111:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_105]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_106]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_106]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_105]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_112:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_103]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_104]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_104]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_103]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -348,21 +348,21 @@
 // CHECK:             %[[VAL_130:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_127]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_128]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_128]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_127]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_131:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_125]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_126]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_126]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_125]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_132:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_123]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_124]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_124]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_123]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -402,21 +402,21 @@
 // CHECK:             %[[VAL_150:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_147]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_148]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_148]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_147]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_151:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_145]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_146]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_146]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_145]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_152:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_143]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_144]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_144]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_143]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -455,21 +455,21 @@
 // CHECK:             %[[VAL_169:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_166]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_167]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_167]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_166]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_170:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_164]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_165]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_165]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_164]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_171:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_162]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_163]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_163]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_162]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -508,21 +508,21 @@
 // CHECK:             %[[VAL_188:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_185]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_186]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_186]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_185]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_189:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_183]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_184]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_184]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_183]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_190:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_181]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_182]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_182]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_181]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -562,21 +562,21 @@
 // CHECK:             %[[VAL_208:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_205]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_206]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_206]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_205]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_209:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_203]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_204]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_204]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_203]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_210:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_201]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_202]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_202]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_201]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -615,21 +615,21 @@
 // CHECK:             %[[VAL_227:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_224]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_225]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_225]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_224]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_228:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_222]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_223]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_223]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_222]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_229:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_220]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_221]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_221]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_220]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -667,21 +667,21 @@
 // CHECK:             %[[VAL_245:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_242]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_243]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_243]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_242]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_246:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_240]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_241]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_241]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_240]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_247:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_238]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_239]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_239]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_238]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -720,21 +720,21 @@
 // CHECK:             %[[VAL_264:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_261]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_262]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_262]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_261]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_265:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_259]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_260]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_260]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_259]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_266:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_257]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_258]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_258]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_257]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -774,21 +774,21 @@
 // CHECK:             %[[VAL_284:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_281]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_282]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_282]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_281]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_285:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_279]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_280]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_280]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_279]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_286:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_277]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_278]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_278]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_277]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -828,21 +828,21 @@
 // CHECK:             %[[VAL_304:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_301]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_302]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_302]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_301]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:
 // CHECK:             %[[VAL_305:.*]] = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_299]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_300]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_300]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_299]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:
 // CHECK:             %[[VAL_306:.*]] = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[VAL_297]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_298]] : memref<64xi32, 2>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_298]] : memref<64xi32, 2>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_297]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb6:
@@ -2971,21 +2971,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%9, Acquire, 0)
-      aie.dma_bd(%10 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%10 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%9, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%7, Acquire, 0)
-      aie.dma_bd(%8 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%8 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%7, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%5, Acquire, 1)
-      aie.dma_bd(%6 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%6 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%5, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3025,21 +3025,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%22, Acquire, 0)
-      aie.dma_bd(%23 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%23 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%22, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%20, Acquire, 0)
-      aie.dma_bd(%21 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%21 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%20, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%18, Acquire, 1)
-      aie.dma_bd(%19 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%19 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%18, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3079,21 +3079,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%35, Acquire, 0)
-      aie.dma_bd(%36 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%36 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%35, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%33, Acquire, 0)
-      aie.dma_bd(%34 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%34 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%33, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%31, Acquire, 1)
-      aie.dma_bd(%32 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%32 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%31, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3133,21 +3133,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%48, Acquire, 0)
-      aie.dma_bd(%49 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%49 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%48, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%46, Acquire, 0)
-      aie.dma_bd(%47 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%47 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%46, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%44, Acquire, 1)
-      aie.dma_bd(%45 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%45 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%44, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3186,21 +3186,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%60, Acquire, 0)
-      aie.dma_bd(%61 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%61 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%60, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%58, Acquire, 0)
-      aie.dma_bd(%59 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%59 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%58, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%56, Acquire, 1)
-      aie.dma_bd(%57 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%57 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%56, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3239,21 +3239,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%72, Acquire, 0)
-      aie.dma_bd(%73 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%73 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%72, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%70, Acquire, 0)
-      aie.dma_bd(%71 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%71 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%70, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%68, Acquire, 1)
-      aie.dma_bd(%69 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%69 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%68, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3293,21 +3293,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%85, Acquire, 0)
-      aie.dma_bd(%86 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%86 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%85, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%83, Acquire, 0)
-      aie.dma_bd(%84 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%84 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%83, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%81, Acquire, 1)
-      aie.dma_bd(%82 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%82 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%81, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3347,21 +3347,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%98, Acquire, 0)
-      aie.dma_bd(%99 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%99 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%98, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%96, Acquire, 0)
-      aie.dma_bd(%97 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%97 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%96, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%94, Acquire, 1)
-      aie.dma_bd(%95 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%95 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%94, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3400,21 +3400,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%110, Acquire, 0)
-      aie.dma_bd(%111 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%111 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%110, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%108, Acquire, 0)
-      aie.dma_bd(%109 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%109 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%108, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%106, Acquire, 1)
-      aie.dma_bd(%107 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%107 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%106, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3453,21 +3453,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%122, Acquire, 0)
-      aie.dma_bd(%123 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%123 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%122, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%120, Acquire, 0)
-      aie.dma_bd(%121 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%121 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%120, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%118, Acquire, 1)
-      aie.dma_bd(%119 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%119 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%118, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3507,21 +3507,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%135, Acquire, 0)
-      aie.dma_bd(%136 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%136 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%135, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%133, Acquire, 0)
-      aie.dma_bd(%134 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%134 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%133, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%131, Acquire, 1)
-      aie.dma_bd(%132 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%132 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%131, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3560,21 +3560,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%147, Acquire, 0)
-      aie.dma_bd(%148 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%148 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%147, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%145, Acquire, 0)
-      aie.dma_bd(%146 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%146 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%145, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%143, Acquire, 1)
-      aie.dma_bd(%144 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%144 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%143, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3612,21 +3612,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%158, Acquire, 0)
-      aie.dma_bd(%159 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%159 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%158, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%156, Acquire, 0)
-      aie.dma_bd(%157 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%157 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%156, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%154, Acquire, 1)
-      aie.dma_bd(%155 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%155 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%154, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3665,21 +3665,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%170, Acquire, 0)
-      aie.dma_bd(%171 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%171 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%170, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%168, Acquire, 0)
-      aie.dma_bd(%169 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%169 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%168, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%166, Acquire, 1)
-      aie.dma_bd(%167 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%167 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%166, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3719,21 +3719,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%183, Acquire, 0)
-      aie.dma_bd(%184 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%184 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%183, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%181, Acquire, 0)
-      aie.dma_bd(%182 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%182 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%181, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%179, Acquire, 1)
-      aie.dma_bd(%180 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%180 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%179, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -3773,21 +3773,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%196, Acquire, 0)
-      aie.dma_bd(%197 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%197 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%196, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%194, Acquire, 0)
-      aie.dma_bd(%195 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%195 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%194, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%192, Acquire, 1)
-      aie.dma_bd(%193 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%193 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%192, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2

--- a/test/create-flows/vecmul_4x4.mlir
+++ b/test/create-flows/vecmul_4x4.mlir
@@ -109,21 +109,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%9, Acquire, 0)
-      aie.dma_bd(%10 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%10 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%9, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%7, Acquire, 0)
-      aie.dma_bd(%8 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%8 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%7, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%5, Acquire, 1)
-      aie.dma_bd(%6 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%6 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%5, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -163,21 +163,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%22, Acquire, 0)
-      aie.dma_bd(%23 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%23 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%22, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%20, Acquire, 0)
-      aie.dma_bd(%21 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%21 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%20, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%18, Acquire, 1)
-      aie.dma_bd(%19 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%19 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%18, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -217,21 +217,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%35, Acquire, 0)
-      aie.dma_bd(%36 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%36 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%35, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%33, Acquire, 0)
-      aie.dma_bd(%34 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%34 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%33, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%31, Acquire, 1)
-      aie.dma_bd(%32 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%32 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%31, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -271,21 +271,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%48, Acquire, 0)
-      aie.dma_bd(%49 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%49 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%48, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%46, Acquire, 0)
-      aie.dma_bd(%47 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%47 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%46, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%44, Acquire, 1)
-      aie.dma_bd(%45 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%45 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%44, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -324,21 +324,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%60, Acquire, 0)
-      aie.dma_bd(%61 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%61 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%60, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%58, Acquire, 0)
-      aie.dma_bd(%59 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%59 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%58, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%56, Acquire, 1)
-      aie.dma_bd(%57 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%57 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%56, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -377,21 +377,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%72, Acquire, 0)
-      aie.dma_bd(%73 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%73 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%72, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%70, Acquire, 0)
-      aie.dma_bd(%71 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%71 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%70, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%68, Acquire, 1)
-      aie.dma_bd(%69 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%69 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%68, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -431,21 +431,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%85, Acquire, 0)
-      aie.dma_bd(%86 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%86 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%85, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%83, Acquire, 0)
-      aie.dma_bd(%84 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%84 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%83, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%81, Acquire, 1)
-      aie.dma_bd(%82 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%82 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%81, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -485,21 +485,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%98, Acquire, 0)
-      aie.dma_bd(%99 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%99 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%98, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%96, Acquire, 0)
-      aie.dma_bd(%97 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%97 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%96, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%94, Acquire, 1)
-      aie.dma_bd(%95 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%95 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%94, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -538,21 +538,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%110, Acquire, 0)
-      aie.dma_bd(%111 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%111 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%110, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%108, Acquire, 0)
-      aie.dma_bd(%109 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%109 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%108, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%106, Acquire, 1)
-      aie.dma_bd(%107 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%107 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%106, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -591,21 +591,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%122, Acquire, 0)
-      aie.dma_bd(%123 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%123 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%122, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%120, Acquire, 0)
-      aie.dma_bd(%121 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%121 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%120, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%118, Acquire, 1)
-      aie.dma_bd(%119 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%119 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%118, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -645,21 +645,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%135, Acquire, 0)
-      aie.dma_bd(%136 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%136 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%135, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%133, Acquire, 0)
-      aie.dma_bd(%134 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%134 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%133, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%131, Acquire, 1)
-      aie.dma_bd(%132 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%132 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%131, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -698,21 +698,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%147, Acquire, 0)
-      aie.dma_bd(%148 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%148 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%147, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%145, Acquire, 0)
-      aie.dma_bd(%146 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%146 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%145, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%143, Acquire, 1)
-      aie.dma_bd(%144 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%144 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%143, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -750,21 +750,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%158, Acquire, 0)
-      aie.dma_bd(%159 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%159 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%158, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%156, Acquire, 0)
-      aie.dma_bd(%157 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%157 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%156, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%154, Acquire, 1)
-      aie.dma_bd(%155 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%155 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%154, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -803,21 +803,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%170, Acquire, 0)
-      aie.dma_bd(%171 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%171 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%170, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%168, Acquire, 0)
-      aie.dma_bd(%169 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%169 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%168, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%166, Acquire, 1)
-      aie.dma_bd(%167 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%167 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%166, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -857,21 +857,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%183, Acquire, 0)
-      aie.dma_bd(%184 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%184 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%183, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%181, Acquire, 0)
-      aie.dma_bd(%182 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%182 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%181, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%179, Acquire, 1)
-      aie.dma_bd(%180 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%180 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%179, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2
@@ -911,21 +911,21 @@ module @vecmul_4x4  {
       %200 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%196, Acquire, 0)
-      aie.dma_bd(%197 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%197 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%196, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb4
       %201 = aie.dma_start(S2MM, 1, ^bb3, ^bb6)
     ^bb3:  // 2 preds: ^bb2, ^bb3
       aie.use_lock(%194, Acquire, 0)
-      aie.dma_bd(%195 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%195 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%194, Release, 1)
       aie.next_bd ^bb3
     ^bb4:  // pred: ^bb0
       %202 = aie.dma_start(MM2S, 0, ^bb5, ^bb2)
     ^bb5:  // 2 preds: ^bb4, ^bb5
       aie.use_lock(%192, Acquire, 1)
-      aie.dma_bd(%193 : memref<64xi32, 2>, 0, 64)
+      aie.dma_bd(%193 : memref<64xi32, 2>) { len = 64 : i32 }
       aie.use_lock(%192, Release, 0)
       aie.next_bd ^bb5
     ^bb6:  // pred: ^bb2

--- a/test/create-locks/test_lock3.mlir
+++ b/test/create-locks/test_lock3.mlir
@@ -22,7 +22,7 @@
 // CHECK:             %[[VAL_7:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_3]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_3]], Release, 0)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -32,7 +32,7 @@
 // CHECK:             %[[VAL_9:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -66,7 +66,7 @@ module @test_lock3 {
       %dmaSt = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -76,7 +76,7 @@ module @test_lock3 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf44 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf44 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock4.mlir
+++ b/test/create-locks/test_lock4.mlir
@@ -26,7 +26,7 @@
 // CHECK:             %[[VAL_11:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 0)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -38,12 +38,12 @@
 // CHECK:             %[[VAL_14:.*]] = aie.dma_start(MM2S, 0, ^bb3, ^bb4)
 // CHECK:           ^bb2:
 // CHECK:             aie.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb3:
 // CHECK:             aie.use_lock(%[[VAL_3]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_3]], Release, 0)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:
@@ -53,7 +53,7 @@
 // CHECK:             %[[VAL_16:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
@@ -98,7 +98,7 @@ module @test_lock4 {
       %dmaSt = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -111,12 +111,12 @@ module @test_lock4 {
       %dmaSt1 = aie.dma_start(MM2S, 0, ^bd1, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf44 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf44 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^bd1:
       aiex.useToken @token0(Acquire, 3)
-      aie.dma_bd(%buf44 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf44 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 4)
       aie.next_bd ^end
     ^end:
@@ -127,7 +127,7 @@ module @test_lock4 {
     %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 3)
-      aie.dma_bd(%buf55 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf55 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 4)
       aie.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock5.mlir
+++ b/test/create-locks/test_lock5.mlir
@@ -23,21 +23,21 @@
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_0]]) : memref<256xi32>
 // CHECK:           %[[VAL_10:.*]] = aie.mem(%[[VAL_4]]) {
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 0)
 // CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 0)
 // CHECK:           }
 // CHECK:           %[[VAL_13:.*]] = aie.mem(%[[VAL_2]]) {
 // CHECK:             aie.use_lock(%[[VAL_3]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:             aie.end
 // CHECK:           }
 // CHECK:           %[[VAL_15:.*]] = aie.mem(%[[VAL_0]]) {
 // CHECK:             aie.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             aie.end
 // CHECK:           }
@@ -86,12 +86,12 @@ module @test_lock5 {
       %dmaSt1 = aie.dma_start("MM2S", 1, ^bd1, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^bd1:
       aiex.useToken @token1(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token1(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -102,7 +102,7 @@ module @test_lock5 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf44 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf44 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -113,7 +113,7 @@ module @test_lock5 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token1(Acquire, 1)
-      aie.dma_bd(%buf55 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf55 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token1(Release, 2)
       aie.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock6.mlir
+++ b/test/create-locks/test_lock6.mlir
@@ -26,22 +26,22 @@
 // CHECK:           aiex.token(0) {sym_name = "token1"}
 // CHECK:           %[[VAL_11:.*]] = aie.mem(%[[VAL_5]]) {
 // CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 0)
 // CHECK:             aie.end
 // CHECK:           }
 // CHECK:           %[[VAL_13:.*]] = aie.mem(%[[VAL_3]]) {
 // CHECK:             aie.use_lock(%[[VAL_4]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_4]], Release, 0)
 // CHECK:             aie.end
 // CHECK:           }
 // CHECK:           %[[VAL_15:.*]] = aie.mem(%[[VAL_0]]) {
 // CHECK:             aie.use_lock(%[[VAL_2]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_2]], Release, 1)
 // CHECK:             aie.use_lock(%[[VAL_1]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_1]], Release, 1)
 // CHECK:             aie.end
 // CHECK:           }
@@ -90,7 +90,7 @@ module @test_lock6 {
       %dmaSt = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -101,7 +101,7 @@ module @test_lock6 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token1(Acquire, 1)
-      aie.dma_bd(%buf44 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf44 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token1(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -114,12 +114,12 @@ module @test_lock6 {
       %dmaSt1 = aie.dma_start("S2MM", 1, ^bd1, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf55_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf55_0 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^bd1:
       aiex.useToken @token1(Acquire, 1)
-      aie.dma_bd(%buf55_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf55_1 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token1(Release, 2)
       aie.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock7.mlir
+++ b/test/create-locks/test_lock7.mlir
@@ -28,22 +28,22 @@
 // CHECK:  aiex.token(0) {sym_name = "token1"}
 // CHECK:  %10 = aie.mem(%4) {
 // CHECK:    aie.use_lock({{.*}}, Acquire, 1)
-// CHECK:    aie.dma_bd(%7 : memref<256xi32>, 0, 256)
+// CHECK:    aie.dma_bd(%7 : memref<256xi32>) {len = 256 : i32}
 // CHECK:    aie.use_lock({{.*}}, Release, 0)
 // CHECK:    aie.use_lock({{.*}}, Acquire, 1)
-// CHECK:    aie.dma_bd(%7 : memref<256xi32>, 0, 256)
+// CHECK:    aie.dma_bd(%7 : memref<256xi32>) {len = 256 : i32}
 // CHECK:    aie.use_lock({{.*}}, Release, 0)
 // CHECK:    aie.end
 // CHECK:  }
 // CHECK:  %11 = aie.mem(%2) {
 // CHECK:    aie.use_lock(%3, Acquire, 0)
-// CHECK:    aie.dma_bd(%8 : memref<256xi32>, 0, 256)
+// CHECK:    aie.dma_bd(%8 : memref<256xi32>) {len = 256 : i32}
 // CHECK:    aie.use_lock(%3, Release, 1)
 // CHECK:    aie.end
 // CHECK:  }
 // CHECK:  %12 = aie.mem(%0) {
 // CHECK:    aie.use_lock(%1, Acquire, 0)
-// CHECK:    aie.dma_bd(%9 : memref<256xi32>, 0, 256)
+// CHECK:    aie.dma_bd(%9 : memref<256xi32>) {len = 256 : i32}
 // CHECK:    aie.use_lock(%1, Release, 1)
 // CHECK:    aie.end
 // CHECK:  }
@@ -92,12 +92,12 @@ module @test_lock5 {
       %dmaSt1 = aie.dma_start("MM2S1", ^bd1, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^bd1:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -108,7 +108,7 @@ module @test_lock5 {
       %dmaSt = aie.dma_start(S2MM0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf44 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf44 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -119,7 +119,7 @@ module @test_lock5 {
       %dmaSt = aie.dma_start(S2MM0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf55 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf55 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:

--- a/test/create-locks/test_lock_shimdma.mlir
+++ b/test/create-locks/test_lock_shimdma.mlir
@@ -25,7 +25,7 @@
 // CHECK:     %10 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     aie.use_lock(%2, Acquire, 0)
-// CHECK:     aie.dma_bd(%0 : memref<256xi32>, 0, 256)
+// CHECK:     aie.dma_bd(%0 : memref<256xi32>) {len = 256 : i32}
 // CHECK:     aie.use_lock(%2, Release, 1)
 // CHECK:     aie.next_bd ^bb2
 // CHECK:   ^bb2:  // 2 preds: ^bb0, ^bb1
@@ -43,7 +43,7 @@
 // CHECK:     %10 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     aie.use_lock(%6, Acquire, 1)
-// CHECK:     aie.dma_bd(%7 : memref<256xi32>, 0, 256)
+// CHECK:     aie.dma_bd(%7 : memref<256xi32>) {len = 256 : i32}
 // CHECK:     aie.use_lock(%6, Release, 0)
 // CHECK:     aie.next_bd ^bb2
 // CHECK:   ^bb2:  // 2 preds: ^bb0, ^bb1
@@ -73,7 +73,7 @@ module @test_lock_shimdma {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf_ext : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_ext : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:
@@ -91,7 +91,7 @@ module @test_lock_shimdma {
       %dmaSt = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aiex.useToken @token0(Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aiex.useToken @token0(Release, 2)
       aie.next_bd ^end
     ^end:

--- a/test/dialect/AIE/bad_dma_op.mlir
+++ b/test/dialect/AIE/bad_dma_op.mlir
@@ -22,7 +22,7 @@ module {
     ^bb0:
       aie.dma(S2MM, 0) [{
         aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16)
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       }]
       aie.next_bd ^bb1

--- a/test/dialect/AIE/badmem_toomanybds.mlir
+++ b/test/dialect/AIE/badmem_toomanybds.mlir
@@ -17,55 +17,55 @@ aie.device(xcvc1902) {
   %mem = aie.mem(%t1) {
     %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^bd15)
     ^bd0:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd3
     ^bd3:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd4
     ^bd4:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd5
     ^bd5:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd6
     ^bd6:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd7
     ^bd7:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd8
     ^bd8:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd9
     ^bd9:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd10
     ^bd10:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd11
     ^bd11:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd12
     ^bd12:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd13
     ^bd13:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd14
     ^bd14:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd16
     ^bd16:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.end
   }
 }

--- a/test/dialect/AIE/badmemtiledma2.mlir
+++ b/test/dialect/AIE/badmemtiledma2.mlir
@@ -47,31 +47,31 @@ module @test {
         ^dma6:
           %dma6 = aie.dma_start("MM2S", 6, ^bd6, ^end)
         ^bd0:
-          aie.dma_bd(%buf_0 : memref<256xi32>, 0, 256)
+          aie.dma_bd(%buf_0 : memref<256xi32>) { len = 256 : i32 }
           aie.use_lock(%lock_0, Release, 1)
           aie.next_bd ^bd0
         ^bd1:
-          aie.dma_bd(%buf_1 : memref<256xi32>, 0, 256)
+          aie.dma_bd(%buf_1 : memref<256xi32>) { len = 256 : i32 }
           aie.use_lock(%lock_1, Release, 1)
           aie.next_bd ^bd1
         ^bd2:
-          aie.dma_bd(%buf_2 : memref<256xi32>, 0, 256)
+          aie.dma_bd(%buf_2 : memref<256xi32>) { len = 256 : i32 }
           aie.use_lock(%lock_2, Release, 1)
           aie.next_bd ^bd2
         ^bd3:
-          aie.dma_bd(%buf_3 : memref<256xi32>, 0, 256)
+          aie.dma_bd(%buf_3 : memref<256xi32>) { len = 256 : i32 }
           aie.use_lock(%lock_3, Release, 1)
           aie.next_bd ^bd3
         ^bd4:
-          aie.dma_bd(%buf_4 : memref<256xi32>, 0, 256)
+          aie.dma_bd(%buf_4 : memref<256xi32>) { len = 256 : i32 }
           aie.use_lock(%lock_4, Release, 1)
           aie.next_bd ^bd4
         ^bd5:
-          aie.dma_bd(%buf_5 : memref<256xi32>, 0, 256)
+          aie.dma_bd(%buf_5 : memref<256xi32>) { len = 256 : i32 }
           aie.use_lock(%lock_5, Release, 1)
           aie.next_bd ^bd5
         ^bd6:
-          aie.dma_bd(%buf_6 : memref<256xi32>, 0, 256)
+          aie.dma_bd(%buf_6 : memref<256xi32>) { len = 256 : i32 }
           aie.use_lock(%lock_6, Release, 1)
           aie.next_bd ^bd6
         ^end:

--- a/test/dialect/AIE/badmemtiledma_channel4buffer.mlir
+++ b/test/dialect/AIE/badmemtiledma_channel4buffer.mlir
@@ -26,10 +26,10 @@ aie.device(xcve2802) {
     ^dma1:
     aie.dma_start("MM2S", 4, ^bd1, ^dma1)
     ^bd0:
-      aie.dma_bd(%buf1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf1 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd1:
-      aie.dma_bd(%buf2 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf2 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
       aie.end

--- a/test/dialect/AIE/badmemtiledma_channel4lock.mlir
+++ b/test/dialect/AIE/badmemtiledma_channel4lock.mlir
@@ -27,11 +27,11 @@ aie.device(xcve2802) {
     aie.dma_start("MM2S", 1, ^bd1, ^dma1)
     ^bd0:
       aie.use_lock(%lock2, "Acquire", 1)
-      aie.dma_bd(%buf1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf1 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd1:
       aie.use_lock(%lock1, "Acquire", 1)
-      aie.dma_bd(%buf1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf1 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
       aie.end

--- a/test/dialect/AIE/badmemtiledma_neighboraccess.mlir
+++ b/test/dialect/AIE/badmemtiledma_neighboraccess.mlir
@@ -25,19 +25,19 @@ aie.device(xcve2802) {
     ^dma1:
     aie.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf0 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf2 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf2 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd16
     ^bd16:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.end
   }
 }

--- a/test/dialect/AIE/badshim_toomanybds.mlir
+++ b/test/dialect/AIE/badshim_toomanybds.mlir
@@ -17,55 +17,55 @@ aie.device(xcvc1902) {
   %mem = aie.shim_dma(%t1) {
     %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^bd15)
     ^bd0:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd3
     ^bd3:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd4
     ^bd4:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd5
     ^bd5:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd6
     ^bd6:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd7
     ^bd7:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd8
     ^bd8:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd9
     ^bd9:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd10
     ^bd10:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd11
     ^bd11:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd12
     ^bd12:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd13
     ^bd13:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd14
     ^bd14:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd16
     ^bd16:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.end
   }
 }

--- a/test/dialect/AIE/badshimtiledma.mlir
+++ b/test/dialect/AIE/badshimtiledma.mlir
@@ -31,15 +31,15 @@ module @test {
       ^dma2:
         %dma3 = aie.dma_start("S2MM", 2, ^bd2, ^end)
       ^bd0:
-        aie.dma_bd(%buf_l : memref<256xi32>, 1, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 1 : i32, len = 256 : i32 }
         aie.use_lock(%lock_e, Release, 1)
         aie.next_bd ^bd0
       ^bd1:
-        aie.dma_bd(%buf_l : memref<256xi32>, 1, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 1 : i32, len = 256 : i32 }
         aie.use_lock(%lock_l, Release, 1)
         aie.next_bd ^bd1
       ^bd2:
-        aie.dma_bd(%buf_l : memref<256xi32>, 1, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 1 : i32, len = 256 : i32 }
         aie.use_lock(%lock_n, Release, 1)
         aie.next_bd ^bd2
       ^end:

--- a/test/dialect/AIE/badtiledma.mlir
+++ b/test/dialect/AIE/badtiledma.mlir
@@ -34,19 +34,19 @@ module @test {
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_l, Acquire, 0)
-        aie.dma_bd(%buf_e : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_e : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_e, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l, Release, 1)
         aie.next_bd ^end
       ^bd2:
-        aie.dma_bd(%buf_n : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_n : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_n, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
-        aie.dma_bd(%buf_s : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_s : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_s, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/dialect/AIE/badtiledma2.mlir
+++ b/test/dialect/AIE/badtiledma2.mlir
@@ -33,19 +33,19 @@ module @test {
       ^dma1:
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
-        aie.dma_bd(%buf_e : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_e : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_e, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l, Release, 1)
         aie.next_bd ^end
       ^bd2:
-        aie.dma_bd(%buf_n : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_n : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_n, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
-        aie.dma_bd(%buf_s : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_s : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_s, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/dialect/AIE/badtiledma3.mlir
+++ b/test/dialect/AIE/badtiledma3.mlir
@@ -33,19 +33,19 @@ module @test {
       ^dma1:
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_e, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l, Release, 1)
         aie.next_bd ^end
       ^bd2:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_n, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_s, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/dialect/AIE/badtiledma4.mlir
+++ b/test/dialect/AIE/badtiledma4.mlir
@@ -31,15 +31,15 @@ module @test {
       ^dma2:
         %dma3 = aie.dma_start("MM2S", 2, ^bd2, ^end)
       ^bd0:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_e, Release, 1)
         aie.next_bd ^bd0
       ^bd1:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_l, Release, 1)
         aie.next_bd ^bd1
       ^bd2:
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 256)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 256 : i32 }
         aie.use_lock(%lock_n, Release, 1)
         aie.next_bd ^bd2
       ^end:

--- a/test/dialect/AIE/example0.mlir
+++ b/test/dialect/AIE/example0.mlir
@@ -49,12 +49,12 @@ module @example0 {
       %dmaSt1 = aie.dma_start("MM2S", 1, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%l33_0, Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_0, Release, 0)
       aie.next_bd ^end
     ^bd1:
       aie.use_lock(%l33_1, Acquire, 0)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_1, Release, 1)
       aie.next_bd ^end
     ^end:
@@ -65,7 +65,7 @@ module @example0 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l42_0, Acquire, 0)
-      aie.dma_bd(%buf42 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf42 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l42_0, Release, 1)
       aie.next_bd ^end
     ^end:
@@ -76,7 +76,7 @@ module @example0 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l44_0, Acquire, 1)
-      aie.dma_bd(%buf44 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf44 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l44_0, Release, 0)
       aie.next_bd ^end
     ^end:

--- a/test/dialect/AIE/memtiledma.mlir
+++ b/test/dialect/AIE/memtiledma.mlir
@@ -65,13 +65,13 @@ aie.device(xcve2802) {
       aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd14
     ^bd14:
-      aie.dma_bd(%buf : memref<256xi32>, [<size = 2, stride = 128>]) { len = 256 : i32 }
+      aie.dma_bd(%buf : memref<256xi32>, dims = [<size = 2, stride = 128>]) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, [<size = 2, stride = 128>], [<const_pad_before = 1, const_pad_after = 1>]) { len = 256 : i32 }
+      aie.dma_bd(%buf : memref<256xi32>, dims = [<size = 2, stride = 128>], pad_dims = [<const_pad_before = 1, const_pad_after = 1>]) { len = 256 : i32 }
       aie.next_bd ^bd16
     ^bd16:
-      aie.dma_bd(%buf : memref<256xi32>, [<size = 2, stride = 128>], [<const_pad_before = 1, const_pad_after = 1>], pad_value = 0) { len = 256 : i32 }
+      aie.dma_bd(%buf : memref<256xi32>, dims = [<size = 2, stride = 128>], pad_dims = [<const_pad_before = 1, const_pad_after = 1>]) { len = 256 : i32, pad_value = 0 : i32 }
       aie.end
   }
 }

--- a/test/dialect/AIE/memtiledma.mlir
+++ b/test/dialect/AIE/memtiledma.mlir
@@ -23,55 +23,55 @@ aie.device(xcve2802) {
     ^dma1:
     aie.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd3
     ^bd3:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd4
     ^bd4:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd5
     ^bd5:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd6
     ^bd6:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd7
     ^bd7:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd8
     ^bd8:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd9
     ^bd9:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd10
     ^bd10:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd11
     ^bd11:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd12
     ^bd12:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd13
     ^bd13:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd14
     ^bd14:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256, [<size = 2, stride = 128>])
+      aie.dma_bd(%buf : memref<256xi32>, [<size = 2, stride = 128>]) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256, [<size = 2, stride = 128>], [<const_pad_before = 1, const_pad_after = 1>])
+      aie.dma_bd(%buf : memref<256xi32>, [<size = 2, stride = 128>], [<const_pad_before = 1, const_pad_after = 1>]) { len = 256 : i32 }
       aie.next_bd ^bd16
     ^bd16:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256, [<size = 2, stride = 128>], [<const_pad_before = 1, const_pad_after = 1>], pad_value = 0)
+      aie.dma_bd(%buf : memref<256xi32>, [<size = 2, stride = 128>], [<const_pad_before = 1, const_pad_after = 1>], pad_value = 0) { len = 256 : i32 }
       aie.end
   }
 }

--- a/test/dialect/AIE/memtiledma_channel4buffer.mlir
+++ b/test/dialect/AIE/memtiledma_channel4buffer.mlir
@@ -25,10 +25,10 @@ aie.device(xcve2802) {
     ^dma1:
     aie.dma_start("MM2S", 1, ^bd1, ^dma1)
     ^bd0:
-      aie.dma_bd(%buf1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf1 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd1:
-      aie.dma_bd(%buf2 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf2 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
       aie.end

--- a/test/dialect/AIE/memtiledma_channel4lock.mlir
+++ b/test/dialect/AIE/memtiledma_channel4lock.mlir
@@ -27,11 +27,11 @@ aie.device(xcve2802) {
     aie.dma_start("MM2S", 1, ^bd1, ^dma1)
     ^bd0:
       aie.use_lock(%lock1, "Acquire", 1)
-      aie.dma_bd(%buf1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf1 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd1:
       aie.use_lock(%lock2, "Acquire", 1)
-      aie.dma_bd(%buf1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf1 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
       aie.end

--- a/test/dialect/AIE/memtiledma_neighboraccess.mlir
+++ b/test/dialect/AIE/memtiledma_neighboraccess.mlir
@@ -27,19 +27,19 @@ aie.device(xcve2802) {
     ^dma1:
     aie.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf0 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf2 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf2 : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd16
     ^bd16:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.end
   }
 }

--- a/test/dialect/AIE/nd-dma-bad-pad.mlir
+++ b/test/dialect/AIE/nd-dma-bad-pad.mlir
@@ -21,7 +21,7 @@ module {
       aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         // expected-error@+1 {{'aie.dma_bd' op Inner-most padding-before count must result in padding in 32-bit words.}}
-        aie.dma_bd(%buf : memref<256xi8>, 0, 8, [<size = 4, stride = 1>], [<const_pad_before = 2, const_pad_after = 2>], pad_value = 0)
+        aie.dma_bd(%buf : memref<256xi8>, dims = [<size = 4, stride = 1>], pad_dims = [<const_pad_before = 2, const_pad_after = 2>]) { len = 8 : i32, pad_value = 0 : i32 }
         aie.next_bd ^end
       ^end:
         aie.end

--- a/test/dialect/AIE/nd-dma-bad-stride.mlir
+++ b/test/dialect/AIE/nd-dma-bad-stride.mlir
@@ -22,7 +22,7 @@ module @tutorial_2b {
       %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         // expected-error@+1 {{'aie.dma_bd' op For <32b width datatypes, inner-most dim stride must be 1}}
-        aie.dma_bd(%buf14 : memref<128xi16>, 0, 128, [<size = 32, stride = 2>])
+        aie.dma_bd(%buf14 : memref<128xi16>, dims = [<size = 32, stride = 2>]) { len = 128 : i32 }
         aie.next_bd ^end
       ^end:
         aie.end

--- a/test/dialect/AIE/nd-dma-oob.mlir
+++ b/test/dialect/AIE/nd-dma-oob.mlir
@@ -30,7 +30,7 @@ module @tutorial_2b {
             // attempt an access at index 128, which is OOB for a 128xi32 
             // memref.
             // expected-error@+1 {{Specified stride(s) and size(s) result in out of bounds access}}
-            aie.dma_bd(%buf14 : memref<128xi32>, 0, 128, [<size = 2, stride = 128>])
+            aie.dma_bd(%buf14 : memref<128xi32>, dims = [<size = 2, stride = 128>]) { len = 128 : i32 }
             aie.next_bd ^end
           ^end: 
             aie.end

--- a/test/dialect/AIE/nd-dma-pad-exceeds-len.mlir
+++ b/test/dialect/AIE/nd-dma-pad-exceeds-len.mlir
@@ -21,7 +21,7 @@ module {
       aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         // expected-error@+1 {{'aie.dma_bd' op Data exceeds len after padding.}}
-        aie.dma_bd(%buf : memref<256xi32>, 0, 4, [<size = 2, stride = 128>], [<const_pad_before = 2, const_pad_after = 1>], pad_value = 0)
+        aie.dma_bd(%buf : memref<256xi32>, dims = [<size = 2, stride = 128>], pad_dims = [<const_pad_before = 2, const_pad_after = 1>]) { len = 4 : i32, pad_value = 0 : i32 }
         aie.next_bd ^end
       ^end:
         aie.end

--- a/test/dialect/AIE/nd-dma-too-many-dims-1.mlir
+++ b/test/dialect/AIE/nd-dma-too-many-dims-1.mlir
@@ -21,7 +21,7 @@ module @tutorial_2b {
           %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
           ^bd0:
             //expected-error@+1 {{Cannot give more than 4 dimensions}}
-            aie.dma_bd(%buf31 : memref<128xi32>, 0, 128, [<size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>])
+            aie.dma_bd(%buf31 : memref<128xi32>, dims = [<size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>]) { len = 128 : i32 }
             aie.next_bd ^end
           ^end: 
             aie.end

--- a/test/dialect/AIE/nd-dma-too-many-dims-2.mlir
+++ b/test/dialect/AIE/nd-dma-too-many-dims-2.mlir
@@ -21,7 +21,7 @@ module @tutorial_2b {
           %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
           ^bd0:
             //expected-error@+1 {{Cannot give more than 3 dimensions}}
-            aie.dma_bd(%buf33 : memref<128xi32>, 0, 128, [<size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>])
+            aie.dma_bd(%buf33 : memref<128xi32>, dims = [<size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>]) { len = 128 : i32 }
             aie.next_bd ^end
           ^end: 
             aie.end

--- a/test/dialect/AIE/shimdma.mlir
+++ b/test/dialect/AIE/shimdma.mlir
@@ -23,52 +23,52 @@ aie.device(xcvc1902) {
     ^dma1:
     aie.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd3
     ^bd3:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd4
     ^bd4:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd5
     ^bd5:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd6
     ^bd6:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd7
     ^bd7:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd8
     ^bd8:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd9
     ^bd9:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd10
     ^bd10:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd11
     ^bd11:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd12
     ^bd12:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd13
     ^bd13:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd14
     ^bd14:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.end
   }
 }

--- a/test/dialect/AIE/tiledma.mlir
+++ b/test/dialect/AIE/tiledma.mlir
@@ -23,52 +23,52 @@ aie.device(xcvc1902) {
     ^dma1:
     aie.dma_start("MM2S", 1, ^bd15, ^dma1)
     ^bd0:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd1
     ^bd1:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd2
     ^bd2:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd3
     ^bd3:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd4
     ^bd4:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd5
     ^bd5:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd6
     ^bd6:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd7
     ^bd7:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd8
     ^bd8:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd9
     ^bd9:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd10
     ^bd10:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd11
     ^bd11:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd12
     ^bd12:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd13
     ^bd13:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd14
     ^bd14:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.next_bd ^bd15
     ^bd15:
-      aie.dma_bd(%buf : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf : memref<256xi32>) { len = 256 : i32 }
       aie.end
   }
 }

--- a/test/lower-to-standard/lower_dma.mlir
+++ b/test/lower-to-standard/lower_dma.mlir
@@ -41,7 +41,7 @@ module @example0 {
       %dmaSt0 = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l33_0, Acquire, 1)
-      aie.dma_bd(%buf33 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l33_0, Release, 0)
       aie.next_bd ^end
     ^end:
@@ -52,7 +52,7 @@ module @example0 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l43_0, Acquire, 0)
-      aie.dma_bd(%buf43 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf43 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l43_0, Release, 1)
       aie.next_bd ^end
     ^end:

--- a/test/merge-buffers/test_buffer_merge0.mlir
+++ b/test/merge-buffers/test_buffer_merge0.mlir
@@ -78,7 +78,7 @@ module @test_buffer_merge0 {
       %dmaSt = aie.dma_start(MM2S, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l34_0, Acquire, 1)
-      aie.dma_bd(%buf34_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf34_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l34_0, Release, 0)
       aie.next_bd ^end
     ^end:
@@ -89,7 +89,7 @@ module @test_buffer_merge0 {
       %dmaSt = aie.dma_start(S2MM, 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l32_0, Acquire, 0)
-      aie.dma_bd(%buf32_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf32_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l32_0, Release, 1)
       aie.next_bd ^end
     ^end:

--- a/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/aie.mlir
@@ -78,12 +78,12 @@ module {
       %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_lock"}
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<64x64xi8>, 0, 3416)
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<64x64xi8>) {len = 3416 : i32}
         aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       }]
       %1 = aie.dma(MM2S, 0) [{
         aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<64x64xi8>, 0, 4096, [<size = 61, stride = 56>, <size = 56, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>, <const_pad_before = 4, const_pad_after = 4>])
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<64x64xi8>, dims = [<size = 61, stride = 56>, <size = 56, stride = 1>], pad_dims = [<const_pad_before = 2, const_pad_after = 1>, <const_pad_before = 4, const_pad_after = 4>]) {len = 4096 : i32}
         aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
       }]
       %2 = aie.dma(MM2S, 1) [{

--- a/test/npu-xrt/add_21_i8_using_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_21_i8_using_dma_op_with_padding/aie.mlir
@@ -85,20 +85,20 @@ module {
       %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_lock"}
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi8>, 0, 8)
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi8>) {len = 8 : i32}
         aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       }, {
         aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi8>, 0, 8)
+        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi8>) {len = 8 : i32}
         aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       }]
       %1 = aie.dma(MM2S, 0) [{
         aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi8>, 0, 16, [<size = 8, stride = 1>], [<const_pad_before = 4, const_pad_after = 4>])
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi8>, dims = [<size = 8, stride = 1>], pad_dims = [<const_pad_before = 4, const_pad_after = 4>]) {len = 16 : i32}
         aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
       }, {
         aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi8>, 0, 16, [<size = 8, stride = 1>], [<const_pad_before = 4, const_pad_after = 4>])
+        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi8>, dims = [<size = 8, stride = 1>], pad_dims = [<const_pad_before = 4, const_pad_after = 4>]) {len = 16 : i32}
         aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
       }]
       %2 = aie.dma(MM2S, 1) [{

--- a/test/npu-xrt/add_378_i32_using_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_378_i32_using_dma_op_with_padding/aie.mlir
@@ -85,20 +85,20 @@ module {
       %objFifo_out0_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_lock"}
       %0 = aie.dma(S2MM, 0) [{
         aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 13)
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>) {len = 13 : i32}
         aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       }, {
         aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, 0, 13)
+        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>) {len = 13 : i32}
         aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       }]
       %1 = aie.dma(MM2S, 0) [{
         aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16, [<size = 13, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>])
+        aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, dims = [<size = 13, stride = 1>], pad_dims = [<const_pad_before = 2, const_pad_after = 1>]) {len = 16 : i32}
         aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
       }, {
         aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
-        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, 0, 16, [<size = 13, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>])
+        aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, dims = [<size = 13, stride = 1>], pad_dims = [<const_pad_before = 2, const_pad_after = 1>]) {len = 16 : i32}
         aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
       }]
       %2 = aie.dma(MM2S, 1) [{

--- a/test/npu-xrt/add_blockwrite/aie.mlir
+++ b/test/npu-xrt/add_blockwrite/aie.mlir
@@ -88,24 +88,24 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in1_cons_buff_0 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_in1_cons_buff_0 : memref<8xi32>) {len = 8 : i32}
       aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in1_cons_buff_1 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_in1_cons_buff_1 : memref<8xi32>) {len = 8 : i32}
       aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb0
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
     ^bb4:  // 2 preds: ^bb3, ^bb5
       aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out1_buff_0 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_out1_buff_0 : memref<8xi32>) {len = 8 : i32}
       aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
       aie.next_bd ^bb5
     ^bb5:  // pred: ^bb4
       aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out1_buff_1 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_out1_buff_1 : memref<8xi32>) {len = 8 : i32}
       aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
       aie.next_bd ^bb4
     ^bb6:  // pred: ^bb3

--- a/test/npu-xrt/add_one_using_dma/aie.mlir
+++ b/test/npu-xrt/add_one_using_dma/aie.mlir
@@ -97,48 +97,48 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%objFifo_in0_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_in0_cons_cons_lock, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb0
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
     ^bb4:  // 2 preds: ^bb3, ^bb5
       aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_in0_cons_buff_0 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
       aie.next_bd ^bb5
     ^bb5:  // pred: ^bb4
       aie.use_lock(%objFifo_in0_cons_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_in0_cons_buff_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_in0_cons_prod_lock, Release, 1)
       aie.next_bd ^bb4
     ^bb6:  // pred: ^bb3
       %2 = aie.dma_start(MM2S, 1, ^bb7, ^bb9)
     ^bb7:  // 2 preds: ^bb6, ^bb8
       aie.use_lock(%objFifo_out0_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out0_buff_0 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_out0_buff_0 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_out0_prod_lock, Release, 1)
       aie.next_bd ^bb8
     ^bb8:  // pred: ^bb7
       aie.use_lock(%objFifo_out0_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out0_buff_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_out0_buff_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_out0_prod_lock, Release, 1)
       aie.next_bd ^bb7
     ^bb9:  // pred: ^bb6
       %3 = aie.dma_start(S2MM, 1, ^bb10, ^bb12)
     ^bb10:  // 2 preds: ^bb9, ^bb11
       aie.use_lock(%objFifo_out0_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out0_buff_0 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_out0_buff_0 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_out0_cons_lock, Release, 1)
       aie.next_bd ^bb11
     ^bb11:  // pred: ^bb10
       aie.use_lock(%objFifo_out0_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out0_buff_1 : memref<16xi32>, 0, 16)
+      aie.dma_bd(%objFifo_out0_buff_1 : memref<16xi32>) { len = 16 : i32 }
       aie.use_lock(%objFifo_out0_cons_lock, Release, 1)
       aie.next_bd ^bb10
     ^bb12:  // pred: ^bb9
@@ -151,24 +151,24 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in1_cons_buff_0 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_in1_cons_buff_0 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_in1_cons_buff_1 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_in1_cons_buff_1 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb0
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
     ^bb4:  // 2 preds: ^bb3, ^bb5
       aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out1_buff_0 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_out1_buff_0 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
       aie.next_bd ^bb5
     ^bb5:  // pred: ^bb4
       aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%objFifo_out1_buff_1 : memref<8xi32>, 0, 8)
+      aie.dma_bd(%objFifo_out1_buff_1 : memref<8xi32>) { len = 8 : i32 }
       aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
       aie.next_bd ^bb4
     ^bb6:  // pred: ^bb3

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
@@ -70,7 +70,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_2_5, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf2 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf2 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_0_2_6, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -79,7 +79,7 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf1 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf1 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_0_2_4, Release, 1)
       aie.next_bd ^bb4
     }
@@ -155,7 +155,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_1_2_8, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf5 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf5 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_1_2_9, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -164,7 +164,7 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf4 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf4 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_1_2_7, Release, 1)
       aie.next_bd ^bb4
     }
@@ -248,7 +248,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_2_2_11, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf8 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf8 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_2_2_12, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -257,7 +257,7 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_2_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf7 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf7 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_2_2_10, Release, 1)
       aie.next_bd ^bb4
     }
@@ -341,7 +341,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_3_2_14, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf11 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf11 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_3_2_15, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -350,14 +350,14 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_3_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf10 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf10 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_3_2_13, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_3_2_17, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf9 : memref<4x4x4x4xi32, 2 : i32>, 0, 256, [<size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf9 : memref<4x4x4x4xi32, 2 : i32>, dims = [<size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>]) {len = 256 : i32}
       aie.use_lock(%lock_3_2_16, Release, 1)
       aie.next_bd ^bb6
     }
@@ -476,7 +476,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb13, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_1, AcquireGreaterEqual, 4)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_1, Release, 4)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -485,42 +485,42 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_3, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb5
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 0, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb7
       %3 = aie.dma_start(MM2S, 1, ^bb8, ^bb5, repeat_count = 1)
     ^bb8:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 4, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 4 : i32, len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb8
     ^bb9:  // pred: ^bb9
       %4 = aie.dma_start(MM2S, 2, ^bb10, ^bb7, repeat_count = 1)
     ^bb10:  // 2 preds: ^bb7, ^bb8
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 8, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 8 : i32, len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb10
     ^bb11:  // pred: ^bb0
       %5 = aie.dma_start(MM2S, 3, ^bb12, ^bb9, repeat_count = 1)
     ^bb12:  // 2 preds: ^bb9, ^bb10
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 12, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 12 : i32, len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb12
     ^bb13:  // pred: ^bb0
       %6 = aie.dma_start(MM2S, 4, ^bb14, ^bb11, repeat_count = 1)
     ^bb14:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_3, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_2, Release, 1)
       aie.next_bd ^bb14
     }
@@ -528,7 +528,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb9, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_1_1, AcquireGreaterEqual, 4)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_1_1_0, Release, 4)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -537,28 +537,28 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 0, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb7
       %2 = aie.dma_start(MM2S, 1, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 64, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 64 : i32, len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb9
       %3 = aie.dma_start(MM2S, 2, ^bb8, ^bb5, repeat_count = 1)
     ^bb8:  // 2 preds: ^bb7, ^bb8
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 128, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 128 : i32, len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb8
     ^bb9:  // pred: ^bb0
       %4 = aie.dma_start(MM2S, 3, ^bb10, ^bb7, repeat_count = 1)
     ^bb10:  // 2 preds: ^bb9, ^bb10
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 192, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 192 : i32, len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb10
     }

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
@@ -70,7 +70,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_2_5, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf2 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf2 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_0_2_6, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -79,7 +79,7 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf1 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf1 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_0_2_4, Release, 1)
       aie.next_bd ^bb4
     }
@@ -121,7 +121,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_1_2_8, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf5 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf5 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_1_2_9, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -130,7 +130,7 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf4 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf4 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_1_2_7, Release, 1)
       aie.next_bd ^bb4
     }
@@ -172,7 +172,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_2_2_11, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf8 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf8 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_2_2_12, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -181,7 +181,7 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_2_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf7 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf7 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_2_2_10, Release, 1)
       aie.next_bd ^bb4
     }
@@ -223,7 +223,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_3_2_14, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf11 : memref<1x4x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf11 : memref<1x4x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_3_2_15, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -232,14 +232,14 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_3_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf10 : memref<4x1x4x4xi32, 2 : i32>, 0, 64)
+      aie.dma_bd(%buf10 : memref<4x1x4x4xi32, 2 : i32>) {len = 64 : i32}
       aie.use_lock(%lock_3_2_13, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_3_2_17, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf9 : memref<4x4x4x4xi32, 2 : i32>, 0, 256, [<size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf9 : memref<4x4x4x4xi32, 2 : i32>, dims = [<size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>]) {len = 256 : i32}
       aie.use_lock(%lock_3_2_16, Release, 1)
       aie.next_bd ^bb6
     }
@@ -324,7 +324,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb13, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_1, AcquireGreaterEqual, 4)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_1, Release, 4)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -333,42 +333,42 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_3, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb5
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 0, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb7
       %3 = aie.dma_start(MM2S, 1, ^bb8, ^bb5, repeat_count = 1)
     ^bb8:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 4, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 4 : i32, len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb8
     ^bb9:  // pred: ^bb9
       %4 = aie.dma_start(MM2S, 2, ^bb10, ^bb7, repeat_count = 1)
     ^bb10:  // 2 preds: ^bb7, ^bb8
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 8, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 8 : i32, len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb10
     ^bb11:  // pred: ^bb0
       %5 = aie.dma_start(MM2S, 3, ^bb12, ^bb9, repeat_count = 1)
     ^bb12:  // 2 preds: ^bb9, ^bb10
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 12, 64, [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 64>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 12 : i32, len = 64 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb12
     ^bb13:  // pred: ^bb0
       %6 = aie.dma_start(MM2S, 4, ^bb14, ^bb11, repeat_count = 1)
     ^bb14:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_3, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_2, Release, 1)
       aie.next_bd ^bb14
     }
@@ -376,7 +376,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb9, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_1_1, AcquireGreaterEqual, 4)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_1_1_0, Release, 4)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -385,28 +385,28 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 0, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb7
       %2 = aie.dma_start(MM2S, 1, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 64, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 64 : i32, len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb6
     ^bb7:  // pred: ^bb9
       %3 = aie.dma_start(MM2S, 2, ^bb8, ^bb5, repeat_count = 1)
     ^bb8:  // 2 preds: ^bb7, ^bb8
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 128, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 128 : i32, len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb8
     ^bb9:  // pred: ^bb0
       %4 = aie.dma_start(MM2S, 3, ^bb10, ^bb7, repeat_count = 1)
     ^bb10:  // 2 preds: ^bb9, ^bb10
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 192, 64, [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 4, stride = 16>, <size = 4, stride = 1>]) {offset = 192 : i32, len = 64 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb10
     }

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
@@ -33,7 +33,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_2_4, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf2 : memref<2x4x4x8xi32, 2 : i32>, 0, 256)
+      aie.dma_bd(%buf2 : memref<2x4x4x8xi32, 2 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_2_5, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -42,14 +42,14 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf1 : memref<4x2x8x4xi32, 2 : i32>, 0, 256)
+      aie.dma_bd(%buf1 : memref<4x2x8x4xi32, 2 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_2_3, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_0_2_7, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf0 : memref<4x4x4x4xi32, 2 : i32>, 0, 256, [<size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf0 : memref<4x4x4x4xi32, 2 : i32>, dims = [<size = 16, stride = 4>, <size = 4, stride = 64>, <size = 4, stride = 1>]) {len = 256 : i32}
       aie.use_lock(%lock_0_2_6, Release, 1)
       aie.next_bd ^bb6
     }
@@ -109,7 +109,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_2_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf3 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf3 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_2_1_2, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -118,7 +118,7 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_2_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf3 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf3 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_2_1, Release, 1)
       aie.next_bd ^bb4
     }
@@ -126,7 +126,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf5 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf5 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_1, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -135,7 +135,7 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf5 : memref<16x16xi32, 1 : i32>, 0, 256, [<size = 2, stride = 8>, <size = 16, stride = 16>, <size = 8, stride = 1>])
+      aie.dma_bd(%buf5 : memref<16x16xi32, 1 : i32>, dims = [<size = 2, stride = 8>, <size = 16, stride = 16>, <size = 8, stride = 1>]) {len = 256 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb4
     }
@@ -143,7 +143,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf4 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf4 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_1_1_0, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -152,7 +152,7 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_1_1_0, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf4 : memref<16x16xi32, 1 : i32>, 0, 256, [<size = 4, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf4 : memref<16x16xi32, 1 : i32>, dims = [<size = 4, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>]) {len = 256 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb4
     }

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
@@ -68,7 +68,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_2_5, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf11 : memref<2x2x4x8xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf11 : memref<2x2x4x8xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_0_2_6, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -77,14 +77,14 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf10 : memref<2x2x8x4xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf10 : memref<2x2x8x4xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_0_2_4, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_0_2_8, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf9 : memref<2x2x4x4xi32, 2 : i32>, 0, 64, [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf9 : memref<2x2x4x4xi32, 2 : i32>, dims = [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_0_2_7, Release, 1)
       aie.next_bd ^bb6
     }
@@ -128,7 +128,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_1_2_10, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf8 : memref<2x2x4x8xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf8 : memref<2x2x4x8xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_1_2_11, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -137,14 +137,14 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf7 : memref<2x2x8x4xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf7 : memref<2x2x8x4xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_1_2_9, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_1_2_13, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf6 : memref<2x2x4x4xi32, 2 : i32>, 0, 64, [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf6 : memref<2x2x4x4xi32, 2 : i32>, dims = [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_1_2_12, Release, 1)
       aie.next_bd ^bb6
     }
@@ -188,7 +188,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_2_2_15, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf5 : memref<2x2x4x8xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf5 : memref<2x2x4x8xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_2_2_16, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -197,14 +197,14 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_2_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf4 : memref<2x2x8x4xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf4 : memref<2x2x8x4xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_2_2_14, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_2_2_18, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf3 : memref<2x2x4x4xi32, 2 : i32>, 0, 64, [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf3 : memref<2x2x4x4xi32, 2 : i32>, dims = [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_2_2_17, Release, 1)
       aie.next_bd ^bb6
     }
@@ -248,7 +248,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_3_2_20, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf2 : memref<2x2x4x8xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf2 : memref<2x2x4x8xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_3_2_21, Release, 1)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -257,14 +257,14 @@ module {
       %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
     ^bb4:  // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_3_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf1 : memref<2x2x8x4xi32, 2 : i32>, 0, 128)
+      aie.dma_bd(%buf1 : memref<2x2x8x4xi32, 2 : i32>) {len = 128 : i32}
       aie.use_lock(%lock_3_2_19, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 0, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_3_2_23, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf0 : memref<2x2x4x4xi32, 2 : i32>, 0, 64, [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf0 : memref<2x2x4x4xi32, 2 : i32>, dims = [<size = 8, stride = 4>, <size = 2, stride = 32>, <size = 4, stride = 1>]) {len = 64 : i32}
       aie.use_lock(%lock_3_2_22, Release, 1)
       aie.next_bd ^bb6
     }
@@ -353,7 +353,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_0_1, AcquireGreaterEqual, 2)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_0_1_2, Release, 2)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -362,14 +362,14 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
     ^bb4: // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_0_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 0, 128, [<size = 2, stride = 8>, <size = 8, stride = 16>, <size = 8, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 2, stride = 8>, <size = 8, stride = 16>, <size = 8, stride = 1>]) {len = 128 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 1, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_0_1_2, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, 128, 128, [<size = 2, stride = 8>, <size = 8, stride = 16>, <size = 8, stride = 1>])
+      aie.dma_bd(%buf14 : memref<16x16xi32, 1 : i32>, dims = [<size = 2, stride = 8>, <size = 8, stride = 16>, <size = 8, stride = 1>]) {offset = 128 : i32, len = 128 : i32}
       aie.use_lock(%lock_0_1, Release, 1)
       aie.next_bd ^bb6
 
@@ -378,7 +378,7 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb5, repeat_count = 1)
     ^bb1:  // 2 preds: ^bb0, ^bb1
       aie.use_lock(%lock_1_1, AcquireGreaterEqual, 2)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 0, 256)
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
       aie.use_lock(%lock_1_1_1, Release, 2)
       aie.next_bd ^bb1
     ^bb2:  // pred: ^bb3
@@ -387,14 +387,14 @@ module {
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb2, repeat_count = 1)
     ^bb4: // 2 preds: ^bb3, ^bb4
       aie.use_lock(%lock_1_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 0, 128, [<size = 2, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 2, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>]) {len = 128 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb4
     ^bb5:  // pred: ^bb0
       %2 = aie.dma_start(MM2S, 1, ^bb6, ^bb3, repeat_count = 1)
     ^bb6:  // 2 preds: ^bb5, ^bb6
       aie.use_lock(%lock_1_1_1, AcquireGreaterEqual, 1)
-      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, 8, 128, [<size = 2, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>])
+      aie.dma_bd(%buf13 : memref<16x16xi32, 1 : i32>, dims = [<size = 2, stride = 4>, <size = 16, stride = 16>, <size = 4, stride = 1>]) {offset = 8 : i32, len = 128 : i32}
       aie.use_lock(%lock_1_1, Release, 1)
       aie.next_bd ^bb6
     }
@@ -402,7 +402,7 @@ module {
         %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb9, repeat_count = 1)
       ^bb1:  // 2 preds: ^bb0, ^bb1
         aie.use_lock(%lock_2_1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 0, 64, [<size = 8, stride = 16>, <size = 8, stride = 1>])
+        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, dims = [<size = 8, stride = 16>, <size = 8, stride = 1>]) {len = 64 : i32}
         aie.use_lock(%lock_2_1_0, Release, 1)
         aie.next_bd ^bb1
       ^bb2:  // pred: ^bb3
@@ -411,28 +411,28 @@ module {
         %1 = aie.dma_start(S2MM, 1, ^bb4, ^bb2, repeat_count = 1)
       ^bb4: // 2 preds: ^bb3, ^bb4
         aie.use_lock(%lock_2_1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 8, 64, [<size = 8, stride = 16>, <size = 8, stride = 1>])
+        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, dims = [<size = 8, stride = 16>, <size = 8, stride = 1>]) {offset = 8 : i32, len = 64 : i32}
         aie.use_lock(%lock_2_1_0, Release, 1)
         aie.next_bd ^bb4
       ^bb5: // pred: ^bb7
         %2 = aie.dma_start(S2MM, 2, ^bb6, ^bb3, repeat_count = 1)
       ^bb6: // 2 preds: ^bb5, ^bb6
         aie.use_lock(%lock_2_1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 128, 64, [<size = 8, stride = 16>, <size = 8, stride = 1>])
+        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, dims = [<size = 8, stride = 16>, <size = 8, stride = 1>]) {offset = 128 : i32, len = 64 : i32}
         aie.use_lock(%lock_2_1_0, Release, 1)
         aie.next_bd ^bb6
       ^bb7: // pred: ^bb9
         %3 = aie.dma_start(S2MM, 3, ^bb8, ^bb6, repeat_count = 1)
       ^bb8: // 2 preds: ^bb7, ^bb8
         aie.use_lock(%lock_2_1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 136, 64, [<size = 8, stride = 16>, <size = 8, stride = 1>])
+        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, dims = [<size = 8, stride = 16>, <size = 8, stride = 1>]) {offset = 136 : i32, len = 64 : i32}
         aie.use_lock(%lock_2_1_0, Release, 1)
         aie.next_bd ^bb8
       ^bb9:  // pred: ^bb0
         %4 = aie.dma_start(MM2S, 0, ^bb10, ^bb7, repeat_count = 1)
       ^bb10:  // 2 preds: ^bb9, ^bb10
         aie.use_lock(%lock_2_1_0, AcquireGreaterEqual, 4)
-        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>, 0, 256)
+        aie.dma_bd(%buf12 : memref<16x16xi32, 1 : i32>) {len = 256 : i32}
         aie.use_lock(%lock_2_1, Release, 4)
         aie.next_bd ^bb10
     } 

--- a/test/npu-xrt/vector_scalar_using_dma/aie.mlir
+++ b/test/npu-xrt/vector_scalar_using_dma/aie.mlir
@@ -80,24 +80,24 @@ module {
       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
     ^bb1:  // 2 preds: ^bb0, ^bb2
       aie.use_lock(%in_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%in_cons_buff_0 : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%in_cons_buff_0 : memref<1024xi32>) { len = 1024 : i32 }
       aie.use_lock(%in_cons_cons_lock, Release, 1)
       aie.next_bd ^bb2
     ^bb2:  // pred: ^bb1
       aie.use_lock(%in_cons_prod_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%in_cons_buff_1 : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%in_cons_buff_1 : memref<1024xi32>) { len = 1024 : i32 }
       aie.use_lock(%in_cons_cons_lock, Release, 1)
       aie.next_bd ^bb1
     ^bb3:  // pred: ^bb0
       %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
     ^bb4:  // 2 preds: ^bb3, ^bb5
       aie.use_lock(%out_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%out_buff_0 : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%out_buff_0 : memref<1024xi32>) { len = 1024 : i32 }
       aie.use_lock(%out_prod_lock, Release, 1)
       aie.next_bd ^bb5
     ^bb5:  // pred: ^bb4
       aie.use_lock(%out_cons_lock, AcquireGreaterEqual, 1)
-      aie.dma_bd(%out_buff_1 : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%out_buff_1 : memref<1024xi32>) { len = 1024 : i32 }
       aie.use_lock(%out_prod_lock, Release, 1)
       aie.next_bd ^bb4
     ^bb6:  // pred: ^bb3

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_dma.mlir
@@ -50,12 +50,12 @@
 // CHECK:       %[[dma0:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[CL]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[buf0_0]] : memref<i32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[buf0_0]] : memref<i32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[PL]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[CL]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[buf0_1:.*]] : memref<i32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[buf0_1:.*]] : memref<i32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[PL]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -65,17 +65,17 @@
 // CHECK:       %[[dma1:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:       aie.use_lock(%[[C_PL]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[buf1_0:.*]] : memref<i32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[buf1_0:.*]] : memref<i32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[C_CL]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[C_PL]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[buf1_1]] : memref<i32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[buf1_1]] : memref<i32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[C_CL]], Release, 1)
 // CHECK:       aie.next_bd ^bb3
 // CHECK:     ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[C_PL]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[buf1_2]] : memref<i32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[buf1_2]] : memref<i32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[C_CL]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_cyclostatic_l2.mlir
@@ -153,7 +153,7 @@
 // the stream, then move on to bb2.
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[fifo0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_buff_0]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_buff_0]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_prod_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 
@@ -161,7 +161,7 @@
 // go back to bb1. Ping-pong.
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[fifo0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_buff_1]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_buff_1]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_prod_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 
@@ -182,22 +182,22 @@
 // things through the stream:
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_0]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_0]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_1]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_1]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb3
 // CHECK:     ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_2]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_2]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb4
 // CHECK:     ^bb4:  // pred: ^bb3
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_3]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_3]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 
@@ -206,22 +206,22 @@
 // CHECK:       %[[VAL_26:.*]] = aie.dma_start(MM2S, 0, ^bb6, ^bb10)
 // CHECK:     ^bb6:  // 2 preds: ^bb5, ^bb9
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_0]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_0]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb7
 // CHECK:     ^bb7:  // pred: ^bb6
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_1]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_1]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb8
 // CHECK:     ^bb8:  // pred: ^bb7
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_2]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_2]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb9
 // CHECK:     ^bb9:  // pred: ^bb8
 // CHECK:       aie.use_lock(%[[fifo0_cons_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_3]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo0_cons_buff_3]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo0_cons_prod_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb6
 // CHECK:     ^bb10:  // pred: ^bb5
@@ -242,22 +242,22 @@
 // CHECK:       %[[dma2:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       aie.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_0]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_0]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_1]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_1]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb3
 // CHECK:     ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_2]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_2]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb4
 // CHECK:     ^bb4:  // pred: ^bb3
 // CHECK:       aie.use_lock(%[[fifo1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_3]] : memref<1xi32>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo1_cons_buff_3]] : memref<1xi32>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo1_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb5:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/AIE2_dynamic_locks.mlir
@@ -137,7 +137,7 @@
 // CHECK:       %11 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%[[fifo_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo_buff_0]] : memref<i64>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo_buff_0]] : memref<i64>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo_prod_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb2:  // pred: ^bb0
@@ -147,7 +147,7 @@
 // CHECK:       %11 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%[[fifo_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[fifo_cons_buff_0]] : memref<i64>, 0, 1)
+// CHECK:       aie.dma_bd(%[[fifo_cons_buff_0]] : memref<i64>) {len = 1 : i32}
 // CHECK:       aie.use_lock(%[[fifo_cons_cons_lock]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb2:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE1.mlir
@@ -39,12 +39,12 @@
 // CHECK:       aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:       aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[VAL_10]], Acquire, 1)
-// CHECK:       aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_10]], Release, 0)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -54,12 +54,12 @@
 // CHECK:       aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:       aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/base_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base_test_AIE2.mlir
@@ -37,12 +37,12 @@
 // CHECK:       aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -52,12 +52,12 @@
 // CHECK:       aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/broadcast_test.mlir
@@ -173,12 +173,12 @@
 // CHECK:             %[[VAL_65:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_31]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_29]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_29]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_31]], Release, 0)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_32]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_30]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_30]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_32]], Release, 0)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -188,12 +188,12 @@
 // CHECK:             %[[VAL_67:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_8]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -203,17 +203,17 @@
 // CHECK:             %[[VAL_69:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             aie.use_lock(%[[VAL_12]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_13]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_13]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_14]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_11]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_11]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_14]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0
@@ -223,22 +223,22 @@
 // CHECK:             %[[VAL_71:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:             aie.use_lock(%[[VAL_19]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_20]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_21]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             aie.use_lock(%[[VAL_22]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
@@ -248,17 +248,17 @@
 // CHECK:             %[[VAL_73:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             aie.use_lock(%[[VAL_26]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_23]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_23]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_26]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_27]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_24]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_24]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_27]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_28]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_25]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_25]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_28]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE1.mlir
@@ -37,7 +37,7 @@
 // CHECK:             %[[VAL_14:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_11]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 0)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -47,24 +47,24 @@
 // CHECK:             %[[VAL_16:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_10]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_17:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_10]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 0)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -74,12 +74,12 @@
 // CHECK:             %[[VAL_19:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/link_test_AIE2.mlir
@@ -65,12 +65,12 @@
 // CHECK:             %[[VAL_32:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_13]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_11]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_11]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_13]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -80,74 +80,74 @@
 // CHECK:             %[[VAL_34:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb8)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb7
 // CHECK:             aie.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             aie.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb6:  // pred: ^bb5
 // CHECK:             aie.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_19]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_19]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:             aie.use_lock(%[[VAL_21]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_20]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_20]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb8:  // pred: ^bb0
 // CHECK:             %[[VAL_35:.*]] = aie.dma_start(MM2S, 0, ^bb9, ^bb16)
 // CHECK:           ^bb9:  // 2 preds: ^bb8, ^bb15
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb10
 // CHECK:           ^bb10:  // pred: ^bb9
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb11
 // CHECK:           ^bb11:  // pred: ^bb10
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb12
 // CHECK:           ^bb12:  // pred: ^bb11
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb13
 // CHECK:           ^bb13:  // pred: ^bb12
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb14
 // CHECK:           ^bb14:  // pred: ^bb13
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_19]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_19]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb15
 // CHECK:           ^bb15:  // pred: ^bb14
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_20]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_20]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb9
 // CHECK:           ^bb16:  // pred: ^bb8
@@ -157,22 +157,22 @@
 // CHECK:             %[[VAL_37:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:             aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<3000xi32>, 0, 3000)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<3000xi32>) {len = 3000 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
+++ b/test/objectFifo-stateful-transform/link_test_DDR_to_L1.mlir
@@ -38,7 +38,7 @@
 // CHECK:             %[[VAL_15:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -48,24 +48,24 @@
 // CHECK:             %[[VAL_17:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_18:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -75,12 +75,12 @@
 // CHECK:             %[[VAL_20:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
+++ b/test/objectFifo-stateful-transform/link_test_L1_to_DDR.mlir
@@ -37,12 +37,12 @@
 // CHECK:             %[[VAL_15:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -52,24 +52,24 @@
 // CHECK:             %[[VAL_17:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_18:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -80,7 +80,7 @@
 // CHECK:             %[[VAL_20:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_3]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/link_test_broadcast.mlir
@@ -56,24 +56,24 @@
 // CHECK:             %[[VAL_28:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_21]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_21]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_24]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_24]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_29:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_24]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_21]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_21]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_23]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_24]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_22]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_23]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -83,24 +83,24 @@
 // CHECK:             %[[VAL_31:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_32:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
@@ -110,29 +110,29 @@
 // CHECK:             %[[VAL_34:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_20]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0
 // CHECK:             %[[VAL_35:.*]] = aie.dma_start(S2MM, 1, ^bb5, ^bb7)
 // CHECK:           ^bb5:  // 2 preds: ^bb4, ^bb6
 // CHECK:             aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb6:  // pred: ^bb5
 // CHECK:             aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb7:  // pred: ^bb4

--- a/test/objectFifo-stateful-transform/link_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute.mlir
@@ -54,7 +54,7 @@
 // CHECK:             %[[VAL_25:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_22]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_23]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_23]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_21]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -64,48 +64,48 @@
 // CHECK:             %[[VAL_27:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 3)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_20]], Release, 3)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 3)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 0, 48)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>) {len = 48 : i32}
 // CHECK:             aie.use_lock(%[[VAL_20]], Release, 3)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_28:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
 // CHECK:             %[[VAL_29:.*]] = aie.dma_start(MM2S, 1, ^bb7, ^bb9)
 // CHECK:           ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 16, 20)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>) {len = 20 : i32, offset = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb8
 // CHECK:           ^bb8:  // pred: ^bb7
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 16, 20)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>) {len = 20 : i32, offset = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb9:  // pred: ^bb6
 // CHECK:             %[[VAL_30:.*]] = aie.dma_start(MM2S, 2, ^bb10, ^bb12)
 // CHECK:           ^bb10:  // 2 preds: ^bb9, ^bb11
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>, 36, 12)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<48xi32>) {len = 12 : i32, offset = 36 : i32}
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb11
 // CHECK:           ^bb11:  // pred: ^bb10
 // CHECK:             aie.use_lock(%[[VAL_20]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>, 36, 12)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<48xi32>) {len = 12 : i32, offset = 36 : i32}
 // CHECK:             aie.use_lock(%[[VAL_19]], Release, 1)
 // CHECK:             aie.next_bd ^bb10
 // CHECK:           ^bb12:  // pred: ^bb9
@@ -115,12 +115,12 @@
 // CHECK:             %[[VAL_32:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<4x4xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<4x4xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_16]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<4x4xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<4x4xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_16]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -130,12 +130,12 @@
 // CHECK:             %[[VAL_34:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<20xi32>, 0, 20)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<20xi32>) {len = 20 : i32}
 // CHECK:             aie.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<20xi32>, 0, 20)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<20xi32>) {len = 20 : i32}
 // CHECK:             aie.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -145,12 +145,12 @@
 // CHECK:             %[[VAL_36:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<12xi32>, 0, 12)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<12xi32>) {len = 12 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<12xi32>, 0, 12)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<12xi32>) {len = 12 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/link_test_join.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join.mlir
@@ -61,12 +61,12 @@
 // CHECK:             %[[VAL_30:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_27]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_24]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_24]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_26]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_27]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_25]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_25]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_26]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -76,60 +76,60 @@
 // CHECK:             %[[VAL_32:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_33:.*]] = aie.dma_start(S2MM, 1, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>, 128, 128)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>) {len = 128 : i32, offset = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>, 128, 128)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>) {len = 128 : i32, offset = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
 // CHECK:             %[[VAL_34:.*]] = aie.dma_start(S2MM, 2, ^bb7, ^bb9)
 // CHECK:           ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>, 256, 128)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>) {len = 128 : i32, offset = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb8
 // CHECK:           ^bb8:  // pred: ^bb7
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>, 256, 128)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>) {len = 128 : i32, offset = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb9:  // pred: ^bb6
 // CHECK:             %[[VAL_35:.*]] = aie.dma_start(S2MM, 3, ^bb10, ^bb12)
 // CHECK:           ^bb10:  // 2 preds: ^bb9, ^bb11
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>, 384, 128)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>) {len = 128 : i32, offset = 384 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb11
 // CHECK:           ^bb11:  // pred: ^bb10
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>, 384, 128)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>) {len = 128 : i32, offset = 384 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb10
 // CHECK:           ^bb12:  // pred: ^bb9
 // CHECK:             %[[VAL_36:.*]] = aie.dma_start(MM2S, 0, ^bb13, ^bb15)
 // CHECK:           ^bb13:  // 2 preds: ^bb12, ^bb14
 // CHECK:             aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 4)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>, 0, 512)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<512xi8>) {len = 512 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 4)
 // CHECK:             aie.next_bd ^bb14
 // CHECK:           ^bb14:  // pred: ^bb13
 // CHECK:             aie.use_lock(%[[VAL_11]], AcquireGreaterEqual, 4)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>, 0, 512)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<512xi8>) {len = 512 : i32}
 // CHECK:             aie.use_lock(%[[VAL_10]], Release, 4)
 // CHECK:             aie.next_bd ^bb13
 // CHECK:           ^bb15:  // pred: ^bb12
@@ -139,12 +139,12 @@
 // CHECK:             %[[VAL_38:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_20]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_20]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_23]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_21]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_21]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_22]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -154,12 +154,12 @@
 // CHECK:             %[[VAL_40:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_16]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_18]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_19]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_17]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_18]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -169,12 +169,12 @@
 // CHECK:             %[[VAL_42:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_14]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_15]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<128xi8>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<128xi8>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_14]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -185,7 +185,7 @@
 // CHECK:             %[[VAL_44:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_28]] : memref<512xi8>, 0, 512)
+// CHECK:             aie.dma_bd(%[[VAL_28]] : memref<512xi8>) {len = 512 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/matmul_test.mlir
+++ b/test/objectFifo-stateful-transform/matmul_test.mlir
@@ -89,36 +89,36 @@
 // CHECK:             %[[VAL_37:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_16]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<16x8xi16>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<16x8xi16>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_17]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_16]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<16x8xi16>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<16x8xi16>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_17]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_38:.*]] = aie.dma_start(S2MM, 1, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<8x16xi16>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<8x16xi16>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<8x16xi16>, 0, 128)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<8x16xi16>) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3
 // CHECK:             %[[VAL_39:.*]] = aie.dma_start(MM2S, 0, ^bb7, ^bb9)
 // CHECK:           ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16x16xi16>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16x16xi16>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb8
 // CHECK:           ^bb8:  // pred: ^bb7
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16x16xi16>, 0, 256)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16x16xi16>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb9:  // pred: ^bb6

--- a/test/objectFifo-stateful-transform/memTile_test.mlir
+++ b/test/objectFifo-stateful-transform/memTile_test.mlir
@@ -31,12 +31,12 @@
 // CHECK:             %[[VAL_11:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -46,12 +46,12 @@
 // CHECK:             %[[VAL_13:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_base_AIE2.mlir
@@ -48,34 +48,34 @@
 // CHECK:       %[[VAL_26:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_0]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_0]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_1]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_1]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_2]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_2]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_3]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_3]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
 // CHECK:       %[[VAL_27:.*]] = aie.dma_start(MM2S, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:       aie.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_buff_0]] : memref<256xi32>, 0, 256, [<size = 128, stride = 2>])
+// CHECK:       aie.dma_bd(%[[of1_buff_0]] : memref<256xi32>, dims = [<size = 128, stride = 2>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:       aie.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_buff_1]] : memref<256xi32>, 0, 256, [<size = 128, stride = 2>])
+// CHECK:       aie.dma_bd(%[[of1_buff_1]] : memref<256xi32>, dims = [<size = 128, stride = 2>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -85,22 +85,22 @@
 // CHECK:       %[[VAL_26:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buff_0]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buff_0]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buff_1]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buff_1]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buff_2]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buff_2]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buff_3]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buff_3]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
@@ -110,12 +110,12 @@
 // CHECK:       %[[VAL_26:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of1_cons_buff_0]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of1_cons_buff_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_AIE2.mlir
@@ -44,36 +44,36 @@
 // CHECK:       %21 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock:.*]], AcquireGreaterEqual, 2)
-// CHECK:       aie.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock:.*]], Release, 2)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock:.*]], AcquireGreaterEqual, 2)
-// CHECK:       aie.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock:.*]], Release, 2)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       %22 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:     ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, 0, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb5
 // CHECK:     ^bb5:  // pred: ^bb4
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, 0, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb4
 // CHECK:     ^bb6:  // pred: ^bb3
 // CHECK:       %23 = aie.dma_start(MM2S, 1, ^bb7, ^bb9)
 // CHECK:     ^bb7:  // 2 preds: ^bb6, ^bb8
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, 512, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buf_0:.*]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32, offset = 512 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb8
 // CHECK:     ^bb8:  // pred: ^bb7
 // CHECK:       aie.use_lock(%[[of0_cons_cons_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, 512, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_cons_buf_1:.*]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32, offset = 512 : i32}
 // CHECK:       aie.use_lock(%[[of0_cons_prod_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb7
 // CHECK:     ^bb9:  // pred: ^bb6
@@ -83,12 +83,12 @@
 // CHECK:       %21 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[of1_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_cons_buf_0:.*]] : memref<128xi32>, 0, 128)
+// CHECK:       aie.dma_bd(%[[of1_cons_buf_0:.*]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:       aie.use_lock(%[[of1_cons_cons_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of1_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_cons_buf_1:.*]] : memref<128xi32>, 0, 128)
+// CHECK:       aie.dma_bd(%[[of1_cons_buf_1:.*]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:       aie.use_lock(%[[of1_cons_cons_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -98,12 +98,12 @@
 // CHECK:       %21 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[of2_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of2_cons_buf_0:.*]] : memref<128xi32>, 0, 128)
+// CHECK:       aie.dma_bd(%[[of2_cons_buf_0:.*]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:       aie.use_lock(%[[of2_cons_cons_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of2_cons_prod_lock:.*]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of2_cons_buf_1:.*]] : memref<128xi32>, 0, 128)
+// CHECK:       aie.dma_bd(%[[of2_cons_buf_1:.*]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:       aie.use_lock(%[[of2_cons_cons_lock:.*]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_distribute_broadcast_AIE2.mlir
@@ -57,36 +57,36 @@
 // CHECK:           %[[VAL_0:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:
 // CHECK:             aie.use_lock(%[[OF0_CONS_PROD_LOCK]], AcquireGreaterEqual, 2)
-// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_0]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_0]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[OF0_CONS_CONS_LOCK]], Release, 2)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:
 // CHECK:             aie.use_lock(%[[OF0_CONS_PROD_LOCK]], AcquireGreaterEqual, 2)
-// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_1]] : memref<256xi32>, 0, 256)
+// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:             aie.use_lock(%[[OF0_CONS_CONS_LOCK]], Release, 2)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:
 // CHECK:              %[[VAL_1:.+]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:
 // CHECK:             aie.use_lock(%[[OF0_CONS_CONS_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_0]] : memref<256xi32>, 0, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_0]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[OF0_CONS_PROD_LOCK]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:
 // CHECK:             aie.use_lock(%[[OF0_CONS_CONS_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_1]] : memref<256xi32>, 0, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_1]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32}
 // CHECK:             aie.use_lock(%[[OF0_CONS_PROD_LOCK]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:
 // CHECK:              %[[VAL_2:.+]] = aie.dma_start(MM2S, 1, ^bb7, ^bb9)
 // CHECK:           ^bb7:
 // CHECK:             aie.use_lock(%[[OF0_CONS_CONS_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_0]] : memref<256xi32>, 128, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_0]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32, offset = 128 : i32}
 // CHECK:             aie.use_lock(%[[OF0_CONS_PROD_LOCK]], Release, 1)
 // CHECK:             aie.next_bd ^bb8
 // CHECK:           ^bb8:
 // CHECK:             aie.use_lock(%[[OF0_CONS_CONS_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_1]] : memref<256xi32>, 128, 128, [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>])
+// CHECK:             aie.dma_bd(%[[OF0_CONS_BUFF_1]] : memref<256xi32>, dims = [<size = 4, stride = 64>, <size = 2, stride = 4>, <size = 8, stride = 8>, <size = 4, stride = 1>]) {len = 128 : i32, offset = 128 : i32}
 // CHECK:             aie.use_lock(%[[OF0_CONS_PROD_LOCK]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb9:
@@ -96,12 +96,12 @@
 // CHECK:           %{{.+}} = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[OF1_0_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF1_0_CONS_BUFF_0]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF1_0_CONS_BUFF_0]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF1_0_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[OF1_0_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF1_0_CONS_BUFF_1]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF1_0_CONS_BUFF_1]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF1_0_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -111,12 +111,12 @@
 // CHECK:           %{{.+}} = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[OF1_1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF1_1_CONS_BUFF_0]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF1_1_CONS_BUFF_0]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF1_1_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[OF1_1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF1_1_CONS_BUFF_1]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF1_1_CONS_BUFF_1]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF1_1_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -126,12 +126,12 @@
 // CHECK:           %{{.+}} = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[OF2_0_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF2_0_CONS_BUFF_0]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF2_0_CONS_BUFF_0]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF2_0_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[OF2_0_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF2_0_CONS_BUFF_1]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF2_0_CONS_BUFF_1]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF2_0_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:
@@ -141,12 +141,12 @@
 // CHECK:           %{{.+}} = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:         ^bb1:
 // CHECK:           aie.use_lock(%[[OF2_1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF2_1_CONS_BUFF_0]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF2_1_CONS_BUFF_0]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF2_1_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb2
 // CHECK:         ^bb2:
 // CHECK:           aie.use_lock(%[[OF2_1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-// CHECK:           aie.dma_bd(%[[OF2_1_CONS_BUFF_1]] : memref<128xi32>, 0, 128)
+// CHECK:           aie.dma_bd(%[[OF2_1_CONS_BUFF_1]] : memref<128xi32>) {len = 128 : i32}
 // CHECK:           aie.use_lock(%[[OF2_1_CONS_CONS_LOCK]], Release, 1)
 // CHECK:           aie.next_bd ^bb1
 // CHECK:         ^bb3:

--- a/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/nd_dma_multiple_consumers_AIE2.mlir
@@ -62,34 +62,34 @@
 // CHECK:       %[[VAL_44:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_0]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_0]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_1]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_1]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_2]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_2]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       aie.use_lock(%[[of0_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_buff_3]] : memref<256xi32>, 0, 256, [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_buff_3]] : memref<256xi32>, dims = [<size = 16, stride = 1>, <size = 16, stride = 16>, <size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
 // CHECK:       %[[VAL_45:.*]] = aie.dma_start(MM2S, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:       aie.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_buff_0]] : memref<256xi32>, 0, 256, [<size = 128, stride = 2>])
+// CHECK:       aie.dma_bd(%[[of1_buff_0]] : memref<256xi32>, dims = [<size = 128, stride = 2>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:       aie.use_lock(%[[of1_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_buff_1]] : memref<256xi32>, 0, 256, [<size = 128, stride = 2>])
+// CHECK:       aie.dma_bd(%[[of1_buff_1]] : memref<256xi32>, dims = [<size = 128, stride = 2>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -99,22 +99,22 @@
 // CHECK:       %[[VAL_44:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       aie.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_0]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_0]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_1]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_1]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_2]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_2]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       aie.use_lock(%[[of0_0_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_3]] : memref<256xi32>, 0, 256, [<size = 1, stride = 1>])
+// CHECK:       aie.dma_bd(%[[of0_0_cons_buff_3]] : memref<256xi32>, dims = [<size = 1, stride = 1>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_0_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
@@ -124,34 +124,34 @@
 // CHECK:       %[[VAL_44:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:       aie.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_0]] : memref<256xi32>, 0, 256, [<size = 3, stride = 4>])
+// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_0]] : memref<256xi32>, dims = [<size = 3, stride = 4>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_1]] : memref<256xi32>, 0, 256, [<size = 3, stride = 4>])
+// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_1]] : memref<256xi32>, dims = [<size = 3, stride = 4>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:       aie.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_2]] : memref<256xi32>, 0, 256, [<size = 3, stride = 4>])
+// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_2]] : memref<256xi32>, dims = [<size = 3, stride = 4>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:       aie.use_lock(%[[of0_1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_3]] : memref<256xi32>, 0, 256, [<size = 3, stride = 4>])
+// CHECK:       aie.dma_bd(%[[of0_1_cons_buff_3]] : memref<256xi32>, dims = [<size = 3, stride = 4>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of0_1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0
 // CHECK:       %[[VAL_45:.*]] = aie.dma_start(S2MM, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:       aie.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_cons_buff_0]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of1_cons_buff_0]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:       aie.use_lock(%[[of1_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of1_cons_buff_1]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of1_cons_buff_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of1_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -161,12 +161,12 @@
 // CHECK:       %[[VAL_44:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[of3_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of3_buff_0]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of3_buff_0]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of3_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of3_cons_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of3_buff_1]] : memref<256xi32>, 0, 256)
+// CHECK:       aie.dma_bd(%[[of3_buff_1]] : memref<256xi32>) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of3_prod_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -176,12 +176,12 @@
 // CHECK:       %[[VAL_44:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%[[of3_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of3_cons_buff_0]] : memref<256xi32>, 0, 256, [<size = 9, stride = 9>])
+// CHECK:       aie.dma_bd(%[[of3_cons_buff_0]] : memref<256xi32>, dims = [<size = 9, stride = 9>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of3_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%[[of3_cons_prod_lock]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[of3_cons_buff_1]] : memref<256xi32>, 0, 256, [<size = 9, stride = 9>])
+// CHECK:       aie.dma_bd(%[[of3_cons_buff_1]] : memref<256xi32>, dims = [<size = 9, stride = 9>]) {len = 256 : i32}
 // CHECK:       aie.use_lock(%[[of3_cons_cons_lock]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_1.mlir
@@ -63,12 +63,12 @@
 // CHECK:             %[[VAL_24:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -78,12 +78,12 @@
 // CHECK:             %[[VAL_26:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_2.mlir
@@ -75,12 +75,12 @@
 // CHECK:             %[[VAL_28:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_12]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_12]], Release, 0)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_13]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_11]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_11]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_13]], Release, 0)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -90,22 +90,22 @@
 // CHECK:             %[[VAL_30:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb5)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb4
 // CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_8]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb4:  // pred: ^bb3
 // CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb5:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/non_adjacency_test_AIE2.mlir
@@ -64,12 +64,12 @@
 // CHECK:             %[[VAL_24:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -79,12 +79,12 @@
 // CHECK:             %[[VAL_26:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers_test.mlir
@@ -45,7 +45,7 @@
 // CHECK:             %[[VAL_17:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<64xi32>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<64xi32>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -55,17 +55,17 @@
 // CHECK:             %[[VAL_19:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/shimRow_mem_test.mlir
@@ -43,7 +43,7 @@
 // CHECK:             %[[VAL_17:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<64xi32>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<64xi32>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -53,17 +53,17 @@
 // CHECK:             %[[VAL_19:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb4)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb3
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_6]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb3:  // pred: ^bb2
 // CHECK:             aie.use_lock(%[[VAL_7]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb4:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_AIE2_test.mlir
@@ -36,14 +36,14 @@
 // CHECK:             %[[VAL_17:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_13]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<64xi32>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<64xi32>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_12]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
 // CHECK:             %[[VAL_18:.*]] = aie.dma_start(S2MM, 0, ^bb3, ^bb4)
 // CHECK:           ^bb3:  // 2 preds: ^bb2, ^bb3
 // CHECK:             aie.use_lock(%[[VAL_2]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<64xi32>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_15]] : memref<64xi32>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_3]], Release, 1)
 // CHECK:             aie.next_bd ^bb3
 // CHECK:           ^bb4:  // pred: ^bb2
@@ -54,24 +54,24 @@
 // CHECK:             %[[VAL_20:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_21:.*]] = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb5
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb5
 // CHECK:           ^bb5:  // pred: ^bb4
 // CHECK:             aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_6]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb6:  // pred: ^bb3

--- a/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/shim_broadcast_test.mlir
@@ -40,7 +40,7 @@
 // CHECK:             %[[VAL_20:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:             aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<64xi32>, 0, 64)
+// CHECK:             aie.dma_bd(%[[VAL_18]] : memref<64xi32>) {len = 64 : i32}
 // CHECK:             aie.use_lock(%[[VAL_16]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb2:  // pred: ^bb0
@@ -50,12 +50,12 @@
 // CHECK:             %[[VAL_22:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_4]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_5]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_7]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -65,12 +65,12 @@
 // CHECK:             %[[VAL_24:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_8]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_10]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_9]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -80,12 +80,12 @@
 // CHECK:             %[[VAL_26:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_14]], AcquireGreaterEqual, 1)
-// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_13]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0

--- a/test/objectFifo-stateful-transform/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/tileDMA_test.mlir
@@ -53,31 +53,31 @@
 // CHECK:             %[[VAL_24:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_11]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_10]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_11]], Release, 0)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_13]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_12]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_13]], Release, 0)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
 // CHECK:             %[[VAL_25:.*]] = aie.dma_start(S2MM, 0, ^bb4, ^bb5)
 // CHECK:           ^bb4:  // 2 preds: ^bb3, ^bb4
 // CHECK:             aie.use_lock(%[[VAL_15]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_14]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_15]], Release, 1)
 // CHECK:             aie.next_bd ^bb4
 // CHECK:           ^bb5:  // pred: ^bb3
 // CHECK:             %[[VAL_26:.*]] = aie.dma_start(MM2S, 1, ^bb6, ^bb8)
 // CHECK:           ^bb6:  // 2 preds: ^bb5, ^bb7
 // CHECK:             aie.use_lock(%[[VAL_8]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_6]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_8]], Release, 0)
 // CHECK:             aie.next_bd ^bb7
 // CHECK:           ^bb7:  // pred: ^bb6
 // CHECK:             aie.use_lock(%[[VAL_9]], Acquire, 1)
-// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_7]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_9]], Release, 0)
 // CHECK:             aie.next_bd ^bb6
 // CHECK:           ^bb8:  // pred: ^bb5
@@ -87,12 +87,12 @@
 // CHECK:             %[[VAL_28:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:           ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:             aie.use_lock(%[[VAL_4]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_2]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:             aie.next_bd ^bb2
 // CHECK:           ^bb2:  // pred: ^bb1
 // CHECK:             aie.use_lock(%[[VAL_5]], Acquire, 0)
-// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
+// CHECK:             aie.dma_bd(%[[VAL_3]] : memref<16xi32>) {len = 16 : i32}
 // CHECK:             aie.use_lock(%[[VAL_5]], Release, 1)
 // CHECK:             aie.next_bd ^bb1
 // CHECK:           ^bb3:  // pred: ^bb0
@@ -137,19 +137,19 @@ module @tileDMA_channels {
             %dma1 = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
         ^bb1:
             aie.use_lock(%lock0, Acquire, 1)
-            aie.dma_bd(%buff0 : memref<16xi32>, 0, 16)
+            aie.dma_bd(%buff0 : memref<16xi32>) { len = 16 : i32 }
             aie.use_lock(%lock0, Release, 0)
             aie.next_bd ^bb2
         ^bb2:
             aie.use_lock(%lock1, Acquire, 1)
-            aie.dma_bd(%buff1 : memref<16xi32>, 0, 16)
+            aie.dma_bd(%buff1 : memref<16xi32>) { len = 16 : i32 }
             aie.use_lock(%lock1, Release, 0)
             aie.next_bd ^bb1
         ^bb3:
             %dma2 = aie.dma_start(S2MM, 0, ^bb4, ^bb5)
         ^bb4:
             aie.use_lock(%lock2, Acquire, 0)
-            aie.dma_bd(%buff2 : memref<16xi32>, 0, 16)
+            aie.dma_bd(%buff2 : memref<16xi32>) { len = 16 : i32 }
             aie.use_lock(%lock2, Release, 1)
             aie.next_bd ^bb4
         ^bb5:

--- a/test/objectFifo-stateful-transform/via_DMA_test.mlir
+++ b/test/objectFifo-stateful-transform/via_DMA_test.mlir
@@ -34,12 +34,12 @@
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%of_stream_cons_lock, AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%of_stream_buff_0 : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%of_stream_buff_0 : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%of_stream_prod_lock, Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%of_stream_cons_lock, AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%of_stream_buff_1 : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%of_stream_buff_1 : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%of_stream_prod_lock, Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0
@@ -49,12 +49,12 @@
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%of_stream_cons_prod_lock, AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%of_stream_cons_buff_0 : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%of_stream_cons_buff_0 : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%of_stream_cons_cons_lock, Release, 1)
 // CHECK:       aie.next_bd ^bb2
 // CHECK:     ^bb2:  // pred: ^bb1
 // CHECK:       aie.use_lock(%of_stream_cons_prod_lock, AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%of_stream_cons_buff_1 : memref<16xi32>, 0, 16)
+// CHECK:       aie.dma_bd(%of_stream_cons_buff_1 : memref<16xi32>) {len = 16 : i32}
 // CHECK:       aie.use_lock(%of_stream_cons_cons_lock, Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb3:  // pred: ^bb0

--- a/test/unit_tests/aie/05_tiledma/aie.mlir
+++ b/test/unit_tests/aie/05_tiledma/aie.mlir
@@ -66,7 +66,7 @@ module @test05_tiledma {
     %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock13_5, "Acquire", 1)
-      aie.dma_bd(%buf13_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf13_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock13_5, "Release", 0)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -77,7 +77,7 @@ module @test05_tiledma {
     %dma0 = aie.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock33_6, "Acquire", 0)
-      aie.dma_bd(%buf33_0: memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33_0: memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock33_6, "Release", 1)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:

--- a/test/unit_tests/aie/08_stream_broadcast/aie.mlir
+++ b/test/unit_tests/aie/08_stream_broadcast/aie.mlir
@@ -60,7 +60,7 @@ module @test08_stream_broadcast {
     %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock13_5, "Acquire", 1)
-      aie.dma_bd(%buf13_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf13_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock13_5, "Release", 0)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -97,7 +97,7 @@ module @test08_stream_broadcast {
     %dma0 = aie.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock32_6, "Acquire", 0)
-      aie.dma_bd(%buf32_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf32_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock32_6, "Release", 1)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -132,7 +132,7 @@ module @test08_stream_broadcast {
     %dma0 = aie.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock33_6, "Acquire", 0)
-      aie.dma_bd(%buf33_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf33_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock33_6, "Release", 1)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:
@@ -167,7 +167,7 @@ module @test08_stream_broadcast {
     %dma0 = aie.dma_start("S2MM", 1, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%lock34_6, "Acquire", 0)
-      aie.dma_bd(%buf34_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf34_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock34_6, "Release", 1)
       aie.next_bd ^end // point to the next BD, or termination
     ^end:

--- a/test/unit_tests/aie/09_simple_shim_dma/aie.mlir
+++ b/test/unit_tests/aie/09_simple_shim_dma/aie.mlir
@@ -32,7 +32,7 @@ module @test09_simple_shim_dma {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -51,12 +51,12 @@ module @test09_simple_shim_dma {
       %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l72_0, "Acquire", 0)
-      aie.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf72_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l72_0, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%l72_1, "Acquire", 0)
-      aie.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf72_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l72_1, "Release", 1)
       aie.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/14_stream_packet/aie.mlir
+++ b/test/unit_tests/aie/14_stream_packet/aie.mlir
@@ -54,7 +54,7 @@ module @test14_stream_packet {
     ^bd0:
       aie.use_lock(%l73, "Acquire", 0)
       aie.dma_bd_packet(0x5, 0xD)
-      aie.dma_bd(%buf73 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf73 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l73, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -66,7 +66,7 @@ module @test14_stream_packet {
     ^bd0:
       aie.use_lock(%l71, "Acquire", 0)
       aie.dma_bd_packet(0x4, 0xC)
-      aie.dma_bd(%buf71 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf71 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l71, "Release", 1)
       aie.next_bd ^end
     ^end:
@@ -86,12 +86,12 @@ module @test14_stream_packet {
     //  %srcDma1 = aie.dma_start("S2MM", 1, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%l62, "Acquire", 0)
-      aie.dma_bd(%buf62 : memref<512xi32>, 0, 512)
+      aie.dma_bd(%buf62 : memref<512xi32>) { len = 512 : i32 }
       aie.use_lock(%l62, "Release", 1)
       aie.next_bd ^end
     //^bd1:
     //  aie.use_lock(%l62_1, "Acquire", 0)
-    //  aie.dma_bd(%buf62_1 : memref<256xi32>, 0, 256)
+    //  aie.dma_bd(%buf62_1 : memref<256xi32>) {len = 256 : i32}
     //  aie.use_lock(%l62_1, "Release", 1)
     //  aie.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/17_shim_dma_with_core/aie.mlir
+++ b/test/unit_tests/aie/17_shim_dma_with_core/aie.mlir
@@ -81,22 +81,22 @@ module @test17_shim_dma_with_core{
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_a_ping : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_a_pong : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_b_ping : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_b_pong : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -128,12 +128,12 @@ module @test17_shim_dma_with_core{
       aie.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_in : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%lock2, Acquire, 1)
-      aie.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_out : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock2, Release, 0)
       aie.next_bd ^bd1
     ^end:

--- a/test/unit_tests/aie/18_simple_shim_dma_routed/aie.mlir
+++ b/test/unit_tests/aie/18_simple_shim_dma_routed/aie.mlir
@@ -24,7 +24,7 @@ module @test18_simple_shim_dma_routed {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -43,12 +43,12 @@ module @test18_simple_shim_dma_routed {
       %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l72_0, "Acquire", 0)
-      aie.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf72_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l72_0, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%l72_1, "Acquire", 0)
-      aie.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf72_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l72_1, "Release", 1)
       aie.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/19_shim_dma_with_core_routed/aie.mlir
+++ b/test/unit_tests/aie/19_shim_dma_with_core_routed/aie.mlir
@@ -79,22 +79,22 @@ module @test19_shim_dma_with_core_routed{
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_a_ping : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_a_pong : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_b_ping : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_b_pong : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -119,12 +119,12 @@ module @test19_shim_dma_with_core_routed{
       aie.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_in : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%lock2, Acquire, 1)
-      aie.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_out : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock2, Release, 0)
       aie.next_bd ^bd1
     ^end:

--- a/test/unit_tests/aie/20_shim_dma_broadcast/aie.mlir
+++ b/test/unit_tests/aie/20_shim_dma_broadcast/aie.mlir
@@ -24,7 +24,7 @@ module @test20_shim_dma_broadcast {
 
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^end:
@@ -43,12 +43,12 @@ module @test20_shim_dma_broadcast {
       %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l72_0, "Acquire", 0)
-      aie.dma_bd(%buf72_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf72_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l72_0, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%l72_1, "Acquire", 0)
-      aie.dma_bd(%buf72_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf72_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l72_1, "Release", 1)
       aie.next_bd ^bd0
     ^end:
@@ -67,12 +67,12 @@ module @test20_shim_dma_broadcast {
       %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
     ^bd0:
       aie.use_lock(%l73_0, "Acquire", 0)
-      aie.dma_bd(%buf73_0 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf73_0 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l73_0, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%l73_1, "Acquire", 0)
-      aie.dma_bd(%buf73_1 : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf73_1 : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%l73_1, "Release", 1)
       aie.next_bd ^bd0
     ^end:

--- a/test/unit_tests/aie/21_shim_dma_packet/aie.mlir
+++ b/test/unit_tests/aie/21_shim_dma_packet/aie.mlir
@@ -34,7 +34,7 @@ module @kernel_gemm  {
   ^bb1:  // 2 preds: ^bb0, ^bb1
     aie.use_lock(%5, Acquire, 1)
     aie.dma_bd_packet(0, 2)
-    aie.dma_bd(%6 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%6 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%5, Release, 0)
     aie.next_bd ^bb1
   ^bb2:  // pred: ^bb0
@@ -64,14 +64,14 @@ module @kernel_gemm  {
     %43 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     aie.use_lock(%13, Acquire, 0)
-    aie.dma_bd(%16 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%16 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%13, Release, 1)
     aie.next_bd ^bb1
   ^bb2:  // pred: ^bb0
     %44 = aie.dma_start(MM2S, 0, ^bb3, ^bb4)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     aie.use_lock(%11, Acquire, 1)
-    aie.dma_bd(%15 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%15 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%11, Release, 0)
     aie.next_bd ^bb3
   ^bb4:  // pred: ^bb2
@@ -79,7 +79,7 @@ module @kernel_gemm  {
   ^bb5:  // 2 preds: ^bb4, ^bb5
     aie.use_lock(%12, Acquire, 1)
     aie.dma_bd_packet(0, 3)
-    aie.dma_bd(%14 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%14 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%12, Release, 0)
     aie.next_bd ^bb5
   ^bb6:  // pred: ^bb4
@@ -134,7 +134,7 @@ module @kernel_gemm  {
     %43 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     aie.use_lock(%22, Acquire, 0)
-    aie.dma_bd(%31 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%31 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%22, Release, 1)
     aie.next_bd ^bb1
   ^bb2:  // pred: ^bb0
@@ -142,20 +142,20 @@ module @kernel_gemm  {
   ^bb3:  // 2 preds: ^bb2, ^bb4
     aie.use_lock(%24, Acquire, 0)
     aie.dma_bd_packet(0, 2)
-    aie.dma_bd(%29 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%29 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%24, Release, 1)
     aie.next_bd ^bb4
   ^bb4:  // pred: ^bb3
     aie.use_lock(%23, Acquire, 0)
     aie.dma_bd_packet(0, 3)
-    aie.dma_bd(%30 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%30 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%23, Release, 1)
     aie.next_bd ^bb3
   ^bb5:  // pred: ^bb2
     %45 = aie.dma_start(MM2S, 0, ^bb6, ^bb7)
   ^bb6:  // 2 preds: ^bb5, ^bb6
     aie.use_lock(%25, Acquire, 1)
-    aie.dma_bd(%26 : memref<32x32xi32>, 0, 1024)
+    aie.dma_bd(%26 : memref<32x32xi32>) { len = 1024 : i32 }
     aie.use_lock(%25, Release, 0)
     aie.next_bd ^bb6
   ^bb7:  // pred: ^bb5

--- a/test/unit_tests/aie/23_broadcast_packet/aie.mlir
+++ b/test/unit_tests/aie/23_broadcast_packet/aie.mlir
@@ -46,13 +46,13 @@ module @test23_broadcast_packet {
     ^bd4:
       aie.use_lock(%lock72_4, "Acquire", 1)
       aie.dma_bd_packet(0x0, 0x0)
-      aie.dma_bd(%buf72_0 : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%buf72_0 : memref<1024xi32>) { len = 1024 : i32 }
       aie.use_lock(%lock72_4, "Release", 0)
       aie.next_bd ^bd5
     ^bd5:
       aie.use_lock(%lock72_5, "Acquire", 1)
       aie.dma_bd_packet(0x1, 0x1)
-      aie.dma_bd(%buf72_1 : memref<1024xi32>, 0, 1024)
+      aie.dma_bd(%buf72_1 : memref<1024xi32>) { len = 1024 : i32 }
       aie.use_lock(%lock72_5, "Release", 0)
       aie.next_bd ^bd4
     ^end:
@@ -64,7 +64,7 @@ module @test23_broadcast_packet {
   aie.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     aie.use_lock(%lock63_0, Acquire, 0)
-    aie.dma_bd(%buf63_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf63_0 : memref<1024xi32>) { len = 1024 : i32 }
     aie.use_lock(%lock63_0, Release, 1)
     aie.next_bd ^bd0
   ^end:
@@ -77,7 +77,7 @@ module @test23_broadcast_packet {
   aie.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     aie.use_lock(%lock64_0, Acquire, 0)
-    aie.dma_bd(%buf64_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf64_0 : memref<1024xi32>) { len = 1024 : i32 }
     aie.use_lock(%lock64_0, Release, 1)
     aie.next_bd ^bd0
   ^end:
@@ -90,7 +90,7 @@ module @test23_broadcast_packet {
   aie.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     aie.use_lock(%lock73_0, Acquire, 0)
-    aie.dma_bd(%buf73_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf73_0 : memref<1024xi32>) { len = 1024 : i32 }
     aie.use_lock(%lock73_0, Release, 1)
     aie.next_bd ^bd0
   ^end:
@@ -103,7 +103,7 @@ module @test23_broadcast_packet {
   aie.dma_start("S2MM", 0, ^bd0, ^end)
   ^bd0:
     aie.use_lock(%lock74_0, Acquire, 0)
-    aie.dma_bd(%buf74_0 : memref<1024xi32>, 0, 1024)
+    aie.dma_bd(%buf74_0 : memref<1024xi32>) { len = 1024 : i32 }
     aie.use_lock(%lock74_0, Release, 1)
     aie.next_bd ^bd0
   ^end:

--- a/test/unit_tests/aie/23_packet_biShim/aie.mlir
+++ b/test/unit_tests/aie/23_packet_biShim/aie.mlir
@@ -28,13 +28,13 @@ module @aie_module  {
     %dstDma = aie.dma_start("MM2S", 0, ^bb3, ^end)
   ^bb2:
     aie.use_lock(%10, Acquire, 0)
-    aie.dma_bd(%11 : memref<256xi32>, 0, 256)
+    aie.dma_bd(%11 : memref<256xi32>) { len = 256 : i32 }
     aie.use_lock(%10, Release, 1)
     aie.next_bd ^bb2
   ^bb3:
     aie.use_lock(%10, Acquire, 1)
     aie.dma_bd_packet(0x6, 10)
-    aie.dma_bd(%11 : memref<256xi32>, 0, 256)
+    aie.dma_bd(%11 : memref<256xi32>) { len = 256 : i32 }
     aie.next_bd ^bb3
   ^end:
     aie.end
@@ -47,12 +47,12 @@ module @aie_module  {
   ^bb0:
     aie.use_lock(%lock1, Acquire, 1)
     aie.dma_bd_packet(0x2, 3)
-    aie.dma_bd(%buf_i : memref<256xi32>, 0, 256)
+    aie.dma_bd(%buf_i : memref<256xi32>) { len = 256 : i32 }
     aie.use_lock(%lock1, Release, 0)
     aie.next_bd ^bb0
   ^bb1:
     aie.use_lock(%lock2, Acquire, 0)
-    aie.dma_bd(%buf_o : memref<257xi32>, 0, 257)
+    aie.dma_bd(%buf_o : memref<257xi32>) { len = 257 : i32 }
     aie.use_lock(%lock2, Release, 1)
     aie.next_bd ^bb1
   ^end:

--- a/test/unit_tests/aie/29_aie2_nd_dma_even_odd/aie.mlir
+++ b/test/unit_tests/aie/29_aie2_nd_dma_even_odd/aie.mlir
@@ -83,7 +83,7 @@ module @tutorial_2b {
           ^bd0:
             aie.use_lock(%lock14_done, "AcquireGreaterEqual", 1)
                                                              ////////// new //////////
-            aie.dma_bd(%buf14 : memref<128xi32>, 0, 128, [<size = 8, stride = 16>, <size = 2, stride = 1>, <size = 8, stride = 2>])
+            aie.dma_bd(%buf14 : memref<128xi32>, dims = [<size = 8, stride = 16>, <size = 2, stride = 1>, <size = 8, stride = 2>]) { len = 128 : i32 }
                                                             // w, s    w, s    w,  s
                                                             // dim 2,  dim 1,  dim 0
             aie.use_lock(%lock14_sent, "Release", 1)
@@ -96,7 +96,7 @@ module @tutorial_2b {
           %dstDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
           ^bd0:
             aie.use_lock(%lock34_wait, "AcquireGreaterEqual", 1)
-            aie.dma_bd(%buf34 : memref<128xi32>, 0, 128)
+            aie.dma_bd(%buf34 : memref<128xi32>) { len = 128 : i32 }
             aie.use_lock(%lock34_recv, "Release", 1)
             aie.next_bd ^end
           ^end:

--- a/test/unit_tests/aie/30_aie2_nd_dma_transpose_repeat/aie.mlir
+++ b/test/unit_tests/aie/30_aie2_nd_dma_transpose_repeat/aie.mlir
@@ -62,7 +62,7 @@ module @tutorial_2b {
           ^bd0:
             aie.use_lock(%lock14_done, "AcquireGreaterEqual", 1)
                                                              ////////// new //////////
-            aie.dma_bd(%buf14 : memref<128xi32>, 0, 128, [<size = 2, stride = 1>, <size = 8, stride = 1>, <size = 8, stride = 8>])
+            aie.dma_bd(%buf14 : memref<128xi32>, dims = [<size = 2, stride = 1>, <size = 8, stride = 1>, <size = 8, stride = 8>]) { len = 128 : i32 }
                                                             // w, s    w, s    w,  s
                                                             // dim 2,  dim 1,  dim 0
             aie.use_lock(%lock14_sent, "Release", 1)
@@ -75,7 +75,7 @@ module @tutorial_2b {
           %dstDma = aie.dma_start("S2MM", 0, ^bd0, ^end)
           ^bd0:
             aie.use_lock(%lock34_wait, "AcquireGreaterEqual", 1)
-            aie.dma_bd(%buf34 : memref<128xi32>, 0, 128)
+            aie.dma_bd(%buf34 : memref<128xi32>) { len = 128 : i32 }
             aie.use_lock(%lock34_recv, "Release", 1)
             aie.next_bd ^end
           ^end:

--- a/test/unit_tests/aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/aie2/05_shim_dma_core_function/aie.mlir
@@ -68,22 +68,22 @@ module @test_chess_05_shim_dma_core_function {
         %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_ping : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_a_ping : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_pong : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_a_pong : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^bd0
       ^bd2:
         aie.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_b_ping : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_b_ping : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_b_write, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_b_pong : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_b_pong : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_b_write, Release, 1)
         aie.next_bd ^bd2
       ^end:
@@ -109,12 +109,12 @@ module @test_chess_05_shim_dma_core_function {
         aie.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         aie.use_lock(%lock1_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buffer_in : memref<32 x i32>, 0, 32)
+        aie.dma_bd(%buffer_in : memref<32 x i32>) { len = 32 : i32 }
         aie.use_lock(%lock1_write, Release, 1)
         aie.next_bd ^bd0
       ^bd1:
         aie.use_lock(%lock2_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buffer_out : memref<32 x i32>, 0, 32)
+        aie.dma_bd(%buffer_out : memref<32 x i32>) { len = 32 : i32 }
         aie.use_lock(%lock2_read, Release, 1)
         aie.next_bd ^bd1
       ^end:

--- a/test/unit_tests/aie2/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/aie2/07_shim_dma_core_function_with_loop/aie.mlir
@@ -69,22 +69,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_a_ping, "Acquire", 0)
-        aie.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_a_ping : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_a_ping, "Release", 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_a_pong, "Acquire", 0)
-        aie.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_a_pong : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_a_pong, "Release", 1)
         aie.next_bd ^bd0
       ^bd2:
         aie.use_lock(%lock_b_ping, "Acquire", 1)
-        aie.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_b_ping : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_b_ping, "Release", 0)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_b_pong, "Acquire", 1)
-        aie.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_b_pong : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_b_pong, "Release", 0)
         aie.next_bd ^bd2
       ^end:
@@ -116,12 +116,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         aie.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         aie.use_lock(%lock1, Acquire, 1)
-        aie.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
+        aie.dma_bd(%buffer_in : memref<512 x i32>) { len = 512 : i32 }
         aie.use_lock(%lock1, Release, 0)
         aie.next_bd ^bd0
       ^bd1:
         aie.use_lock(%lock2, Acquire, 1)
-        aie.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
+        aie.dma_bd(%buffer_out : memref<512 x i32>) { len = 512 : i32 }
         aie.use_lock(%lock2, Release, 0)
         aie.next_bd ^bd1
       ^end:

--- a/test/unit_tests/aie2/08_tile_locks/aie.mlir
+++ b/test/unit_tests/aie2/08_tile_locks/aie.mlir
@@ -67,22 +67,22 @@ module @test_chess_08_tile_locks {
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 4, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 4 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^end
       ^bd2:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 8, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 8 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 12, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 12 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/unit_tests/aie2/09_memtile_locks/aie.mlir
+++ b/test/unit_tests/aie2/09_memtile_locks/aie.mlir
@@ -56,7 +56,7 @@ module @test_chess_08_tile_locks {
          %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         aie.use_lock(%lock_d2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_e : memref<256xi32>, 0, 2)
+        aie.dma_bd(%buf_e : memref<256xi32>) { len = 2 : i32 }
         aie.use_lock(%lock_s2, Release, 1)
         aie.next_bd ^end
       ^end:
@@ -69,22 +69,22 @@ module @test_chess_08_tile_locks {
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_w : memref<256xi32>, 0, 2)
+        aie.dma_bd(%buf_w : memref<256xi32>) { len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_w : memref<256xi32>, 4, 2)
+        aie.dma_bd(%buf_w : memref<256xi32>) { offset = 4 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^end
       ^bd2:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_e : memref<256xi32>, 8, 2)
+        aie.dma_bd(%buf_e : memref<256xi32>) { offset = 8 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_e : memref<256xi32>, 12, 2)
+        aie.dma_bd(%buf_e : memref<256xi32>) { offset = 12 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
@@ -42,22 +42,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_a_ping : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_a_pong : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_a_pong : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_b_ping : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_b_ping : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_b_pong : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_b_pong : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -81,12 +81,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       aie.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_in : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%lock2, Acquire, 1)
-      aie.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_out : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock2, Release, 0)
       aie.next_bd ^bd1
     ^end:

--- a/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
@@ -67,22 +67,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_a_ping : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_a_ping : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_a_pong : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_a_pong : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_b_ping : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_b_ping : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_b_pong : memref<256xi32>, 0, 256)
+      aie.dma_bd(%buf_b_pong : memref<256xi32>) { len = 256 : i32 }
       aie.use_lock(%lock_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -106,12 +106,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       aie.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_in : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%lock2, Acquire, 1)
-      aie.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_out : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock2, Release, 0)
       aie.next_bd ^bd1
     ^end:

--- a/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
@@ -73,22 +73,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
     ^bd0:
       aie.use_lock(%lock_a_ping, "Acquire", 0)
-      aie.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_a_ping : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_a_ping, "Release", 1)
       aie.next_bd ^bd1
     ^bd1:
       aie.use_lock(%lock_a_pong, "Acquire", 0)
-      aie.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_a_pong : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_a_pong, "Release", 1)
       aie.next_bd ^bd0
     ^bd2:
       aie.use_lock(%lock_b_ping, "Acquire", 1)
-      aie.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_b_ping : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_b_ping, "Release", 0)
       aie.next_bd ^bd3
     ^bd3:
       aie.use_lock(%lock_b_pong, "Acquire", 1)
-      aie.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
+      aie.dma_bd(%buf_b_pong : memref<64xi32>) { len = 64 : i32 }
       aie.use_lock(%lock_b_pong, "Release", 0)
       aie.next_bd ^bd2
     ^end:
@@ -112,12 +112,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
       aie.dma_start(S2MM, 0, ^bd1, ^end)
     ^bd0:
       aie.use_lock(%lock1, Acquire, 1)
-      aie.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_in : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock1, Release, 0)
       aie.next_bd ^bd0
     ^bd1:
       aie.use_lock(%lock2, Acquire, 1)
-      aie.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
+      aie.dma_bd(%buffer_out : memref<512 x i32>) { len = 512 : i32 }
       aie.use_lock(%lock2, Release, 0)
       aie.next_bd ^bd1
     ^end:

--- a/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
@@ -62,22 +62,22 @@ module @test_chess_08_tile_locks {
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_e, Acquire, 0)
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 2 : i32 }
         aie.use_lock(%lock_e, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_l, Acquire, 0)
-        aie.dma_bd(%buf_l : memref<256xi32>, 4, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 4 : i32, len = 2 : i32 }
         aie.use_lock(%lock_l, Release, 1)
         aie.next_bd ^end
       ^bd2:
         aie.use_lock(%lock_n, Acquire, 0)
-        aie.dma_bd(%buf_l : memref<256xi32>, 8, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 8 : i32, len = 2 : i32 }
         aie.use_lock(%lock_n, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_s, Acquire, 0)
-        aie.dma_bd(%buf_l : memref<256xi32>, 12, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 12 : i32, len = 2 : i32 }
         aie.use_lock(%lock_s, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
@@ -48,22 +48,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_ping : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_a_ping : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_pong : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_a_pong : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^bd0
       ^bd2:
         aie.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_b_ping : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_b_ping : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_b_write, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_b_pong : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_b_pong : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_b_write, Release, 1)
         aie.next_bd ^bd2
       ^end:
@@ -89,12 +89,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         aie.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         aie.use_lock(%lock1_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buffer_in : memref<32 x i32>, 0, 32)
+        aie.dma_bd(%buffer_in : memref<32 x i32>) { len = 32 : i32 }
         aie.use_lock(%lock1_write, Release, 1)
         aie.next_bd ^bd0
       ^bd1:
         aie.use_lock(%lock2_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buffer_out : memref<32 x i32>, 0, 32)
+        aie.dma_bd(%buffer_out : memref<32 x i32>) { len = 32 : i32 }
         aie.use_lock(%lock2_read, Release, 1)
         aie.next_bd ^bd1
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
@@ -71,22 +71,22 @@ module @test_chess_05_shim_dma_core_function {
         %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_ping : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_a_ping : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_a_pong : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_a_pong : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_a_read, Release, 1)
         aie.next_bd ^bd0
       ^bd2:
         aie.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_b_ping : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_b_ping : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_b_write, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_b_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_b_pong : memref<16xi32>, 0, 16)
+        aie.dma_bd(%buf_b_pong : memref<16xi32>) { len = 16 : i32 }
         aie.use_lock(%lock_b_write, Release, 1)
         aie.next_bd ^bd2
       ^end:
@@ -112,12 +112,12 @@ module @test_chess_05_shim_dma_core_function {
         aie.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         aie.use_lock(%lock1_read, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buffer_in : memref<32 x i32>, 0, 32)
+        aie.dma_bd(%buffer_in : memref<32 x i32>) { len = 32 : i32 }
         aie.use_lock(%lock1_write, Release, 1)
         aie.next_bd ^bd0
       ^bd1:
         aie.use_lock(%lock2_write, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buffer_out : memref<32 x i32>, 0, 32)
+        aie.dma_bd(%buffer_out : memref<32 x i32>) { len = 32 : i32 }
         aie.use_lock(%lock2_read, Release, 1)
         aie.next_bd ^bd1
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
@@ -72,22 +72,22 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_a_ping, "Acquire", 0)
-        aie.dma_bd(%buf_a_ping : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_a_ping : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_a_ping, "Release", 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_a_pong, "Acquire", 0)
-        aie.dma_bd(%buf_a_pong : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_a_pong : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_a_pong, "Release", 1)
         aie.next_bd ^bd0
       ^bd2:
         aie.use_lock(%lock_b_ping, "Acquire", 1)
-        aie.dma_bd(%buf_b_ping : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_b_ping : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_b_ping, "Release", 0)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_b_pong, "Acquire", 1)
-        aie.dma_bd(%buf_b_pong : memref<64xi32>, 0, 64)
+        aie.dma_bd(%buf_b_pong : memref<64xi32>) { len = 64 : i32 }
         aie.use_lock(%lock_b_pong, "Release", 0)
         aie.next_bd ^bd2
       ^end:
@@ -119,12 +119,12 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
         aie.dma_start(S2MM, 0, ^bd1, ^end)
       ^bd0:
         aie.use_lock(%lock1, Acquire, 1)
-        aie.dma_bd(%buffer_in : memref<512 x i32>, 0, 512)
+        aie.dma_bd(%buffer_in : memref<512 x i32>) { len = 512 : i32 }
         aie.use_lock(%lock1, Release, 0)
         aie.next_bd ^bd0
       ^bd1:
         aie.use_lock(%lock2, Acquire, 1)
-        aie.dma_bd(%buffer_out : memref<512 x i32>, 0, 512)
+        aie.dma_bd(%buffer_out : memref<512 x i32>) { len = 512 : i32 }
         aie.use_lock(%lock2, Release, 0)
         aie.next_bd ^bd1
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
@@ -69,22 +69,22 @@ module @test_chess_08_tile_locks {
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 0, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 4, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 4 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^end
       ^bd2:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 8, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 8 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_l : memref<256xi32>, 12, 2)
+        aie.dma_bd(%buf_l : memref<256xi32>) { offset = 12 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^end
       ^end:

--- a/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
@@ -58,7 +58,7 @@ module @test_chess_08_tile_locks {
          %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
         aie.use_lock(%lock_d2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_e : memref<256xi32>, 0, 2)
+        aie.dma_bd(%buf_e : memref<256xi32>) { len = 2 : i32 }
         aie.use_lock(%lock_s2, Release, 1)
         aie.next_bd ^end
       ^end:
@@ -71,22 +71,22 @@ module @test_chess_08_tile_locks {
         %dstDma = aie.dma_start("S2MM", 0, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_w : memref<256xi32>, 0, 2)
+        aie.dma_bd(%buf_w : memref<256xi32>) { len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^bd1
       ^bd1:
         aie.use_lock(%lock_s1, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_w : memref<256xi32>, 4, 2)
+        aie.dma_bd(%buf_w : memref<256xi32>) { offset = 4 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d1, Release, 1)
         aie.next_bd ^end
       ^bd2:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_e : memref<256xi32>, 8, 2)
+        aie.dma_bd(%buf_e : memref<256xi32>) { offset = 8 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^bd3
       ^bd3:
         aie.use_lock(%lock_s2, AcquireGreaterEqual, 1)
-        aie.dma_bd(%buf_e : memref<256xi32>, 12, 2)
+        aie.dma_bd(%buf_e : memref<256xi32>) { offset = 12 : i32, len = 2 : i32 }
         aie.use_lock(%lock_d2, Release, 1)
         aie.next_bd ^end
       ^end:


### PR DESCRIPTION
These are the `dma_bd` op syntax changes from #1137. This or something similar is needed to bump mlir, due to upstream printer changes where default valued optional attributes no longer get printed in the same way. e.g. the `offset` operand is not printed when zero. This PR moves everything other than `dims` and `pad_dims` to the attribute dictionary:
```mlir
// old
aie.dma_bd(%buf01_0 : memref<16xi32>, 64, 128, [<size = 2, stride = 1>, ... ])

// new
aie.dma_bd(%buf01_0 : memref<16xi32>, dims = [<size = 2, stride = 1>, ... ]) {offset = 64 : i32, len = 128 : i32 }
```
