### PR TITLE
npu maskwrite operation

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -691,6 +691,32 @@ def AIE_NpuWrite32Op: AIEX_Op<"npu.write32", []> {
   }];
 }
 
+// MASKWRITE
+def AIE_NpuMaskWrite32Op: AIEX_Op<"npu.maskwrite32", []> {
+  let summary = "Write a masked 32-bit value to the AIE array";
+  let arguments = (
+    ins UI32Attr:$address,
+        UI32Attr:$value,
+        UI32Attr:$mask,
+        OptionalAttr<FlatSymbolRefAttr>:$buffer,
+        OptionalAttr<I32Attr>:$column,
+        OptionalAttr<I32Attr>:$row
+  );
+  let results = (outs );
+  let assemblyFormat = [{
+    attr-dict
+  }];
+  let description = [{
+    NPU mask write32 operator writes a masked 32bit value to the AIE array.
+    If 'buffer' is present then 'address' is interpreted as an offset into the
+    aie.buffer with symbol name 'buffer'.
+    If 'column' and 'row' are present then 'address' is interpreted as an offset
+    into the memory space of aie.tile(column, row).
+    If 'buffer' is not present and 'column' and 'row' are not present then
+    'address' is interpreted as a full 32-bit address in the AIE array.
+  }];
+}
+
 // BLOCKWRITE
 def AIE_NpuBlockWriteOp: AIEX_Op<"npu.blockwrite", []> {
   let summary = "blockwrite operator";

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -327,6 +327,7 @@ LogicalResult configureBdInBlock(XAie_DevInst &devInst, XAie_DmaDesc &dmaTileBd,
   // ND zero padding.
   std::optional<llvm::ArrayRef<BDPadLayoutAttr>> padDims =
       bdOp.getPadDimensions();
+
   if (padDims) {
     XAie_DmaPadTensor dmaPadTensor = {};
     dmaPadTensor.NumDim = padDims->size();

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -29,6 +29,7 @@ using namespace xilinx::AIEX;
 
 #define TXN_OPC_WRITE 0x0
 #define TXN_OPC_BLOCKWRITE 0x1
+#define TXN_OPC_MASKWRITE 0x3
 #define TXN_OPC_TCT 0x80
 #define TXN_OPC_DDR_PATCH 0x81
 
@@ -89,6 +90,32 @@ void appendWrite32(std::vector<uint32_t> &instructions, NpuWrite32Op op) {
   words[3] = 0;
   words[4] = op.getValue();                   // Value
   words[5] = words.size() * sizeof(uint32_t); // Operation Size
+}
+
+void appendMaskWrite32(std::vector<uint32_t> &instructions, NpuMaskWrite32Op op) {
+
+  auto words = reserveAndGetTail(instructions, 7);
+
+  if (op.getBuffer()) {
+    op.emitOpError("Cannot translate symbolic address");
+    return;
+  }
+
+  // XAIE_IO_MASKWRITE
+  words[0] = TXN_OPC_MASKWRITE;
+  words[1] = 0;
+  words[2] = op.getAddress();
+  auto col = op.getColumn();
+  auto row = op.getRow();
+  if (col && row) {
+    const AIETargetModel &tm = op->getParentOfType<DeviceOp>().getTargetModel();
+    words[2] = ((*col & 0xff) << tm.getColumnShift()) |
+               ((*row & 0xff) << tm.getRowShift()) | (words[2] & 0xFFFFF);
+  }
+  words[3] = 0;
+  words[4] = op.getValue();                   // Value
+  words[5] = op.getMask();
+  words[6] = words.size() * sizeof(uint32_t); // Operation Size
 }
 
 void appendAddressPatch(std::vector<uint32_t> &instructions,
@@ -194,6 +221,10 @@ std::vector<uint32_t> xilinx::AIE::AIETranslateToNPU(ModuleOp module) {
           .Case<NpuBlockWriteOp>([&](auto op) {
             count++;
             appendBlockWrite(instructions, op);
+          })
+          .Case<NpuMaskWrite32Op>([&](auto op) {
+            count++;
+            appendMaskWrite32(instructions, op);
           })
           .Case<NpuAddressPatchOp>([&](auto op) {
             count++;

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -92,7 +92,8 @@ void appendWrite32(std::vector<uint32_t> &instructions, NpuWrite32Op op) {
   words[5] = words.size() * sizeof(uint32_t); // Operation Size
 }
 
-void appendMaskWrite32(std::vector<uint32_t> &instructions, NpuMaskWrite32Op op) {
+void appendMaskWrite32(std::vector<uint32_t> &instructions,
+                       NpuMaskWrite32Op op) {
 
   auto words = reserveAndGetTail(instructions, 7);
 
@@ -113,7 +114,7 @@ void appendMaskWrite32(std::vector<uint32_t> &instructions, NpuMaskWrite32Op op)
                ((*row & 0xff) << tm.getRowShift()) | (words[2] & 0xFFFFF);
   }
   words[3] = 0;
-  words[4] = op.getValue();                   // Value
+  words[4] = op.getValue(); // Value
   words[5] = op.getMask();
   words[6] = words.size() * sizeof(uint32_t); // Operation Size
 }

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -111,3 +111,17 @@ module {
    }
   }
 }
+
+// -----
+
+// CHECK: runtime_sequence
+// CHECK: aiex.npu.maskwrite32 {address = 3147552 : ui32, mask = 65535 : ui32, value = 321 : ui32}
+module {
+  aie.device(npu1_1col) {
+    %tile03 = aie.tile(0,3)
+    %s = aie.buffer(%tile03) {address = 1024 : i32, sym_name = "stuff"} : memref<128xi32>
+    aiex.runtime_sequence() {
+      aiex.npu.maskwrite32 {buffer = @stuff, address = 200 : ui32, value = 321 : ui32, mask = 0xffff : ui32}
+    }
+  }
+}

--- a/test/Targets/NPU/npu_instgen.mlir
+++ b/test/Targets/NPU/npu_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-npu-instgen | FileCheck %s
+// RUN: aie-translate --aie-npu-instgen %s | FileCheck %s
 module {
   aie.device(npu1_4col) {
     memref.global "private" constant @write_data : memref<8xi32> = dense<[100, 101, 102, 103, 104 ,105, 106, 107]>

--- a/test/Targets/NPU/npu_instgen.mlir
+++ b/test/Targets/NPU/npu_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-dma-to-npu %s | aie-translate --aie-npu-instgen | FileCheck %s
+// RUN: aie-translate --aie-npu-instgen | FileCheck %s
 module {
   aie.device(npu1_4col) {
     memref.global "private" constant @write_data : memref<8xi32> = dense<[100, 101, 102, 103, 104 ,105, 106, 107]>
@@ -18,52 +18,8 @@ module {
       // CHECK: 06030100
       // CHECK: 00000105
       // CHECK: 00000006
-      // CHECK: 000000E0
+      // CHECK: 000000CC
 
-      %c16_i64 = arith.constant 16 : i64
-      %c1_i64 = arith.constant 1 : i64
-      %c0_i64 = arith.constant 0 : i64
-      %c64_i64 = arith.constant 64 : i64
-      %c0_i32 = arith.constant 0 : i32
-      %c1_i32 = arith.constant 1 : i32
-      // CHECK: 00000001
-      // CHECK: 00000000
-      // CHECK: 0601D0C0
-      // CHECK: 00000030
-      // CHECK: 00000001
-      // CHECK: 00000002
-      // CHECK: 00000000
-      // CHECK: 00600005
-      // CHECK: 80800007
-      // CHECK: 00000009
-      // CHECK: 2CD0000C
-      // CHECK: 2E107041
-      aiex.npu.writebd { bd_id = 6 : i32,
-                         buffer_length = 1 : i32,
-                         buffer_offset = 2 : i32,
-                         enable_packet = 0 : i32,
-                         out_of_order_id = 0 : i32,
-                         packet_id = 0 : i32,
-                         packet_type = 0 : i32,
-                         column = 3 : i32,
-                         row = 0 : i32,
-                         d0_stride = 5 : i32,
-                         d0_size = 6 : i32,
-                         d1_stride = 7 : i32,
-                         d1_size = 8 : i32,
-                         d2_stride = 9 : i32,
-                         ddr_id = 10 : i32,
-                         iteration_current = 11 : i32,
-                         iteration_stride = 12 : i32,
-                         iteration_size = 13 : i32,
-                         lock_acq_enable = 1 : i32,
-                         lock_acq_id = 1 : i32,
-                         lock_acq_val = 2 : i32,
-                         lock_rel_id = 3 : i32,
-                         lock_rel_val = 4 : i32,
-                         next_bd = 5 : i32,
-                         use_next_bd = 1 : i32,
-                         valid_bd = 1 : i32}
       // CHECK: 00000000
       // CHECK: 00000000
       // CHECK: 06400DEF
@@ -108,6 +64,15 @@ module {
       // CHECK: 0000006A
       // CHECK: 0000006B
       aiex.npu.blockwrite (%0) { column = 1 : i32, row = 1 : i32, address = 100 : ui32} : memref<8xi32>
+
+      // CHECK: 00000003
+      // CHECK: 00000000
+      // CHECK: 0430567A
+      // CHECK: 00000000
+      // CHECK: 00001001
+      // CHECK: F00FF00F
+      // CHECK: 0000001C
+      aiex.npu.maskwrite32 { column = 2 : i32, row = 3 : i32, address = 0x0000567A : ui32, value = 0x1001 : ui32, mask = 0xf00ff00f : ui32 }
 
       // CHECK: 00000080
       // CHECK: 00000010

--- a/test/npu-xrt/add_maskwrite/aie.mlir
+++ b/test/npu-xrt/add_maskwrite/aie.mlir
@@ -1,0 +1,79 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu1_1col) {
+    memref.global "public" @out0 : memref<64xi32>
+
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    %input_lock0 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "input_lock0"}
+    %input_lock1 = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "input_lock1"}
+
+    %output_lock0 = aie.lock(%tile_0_2, 2) {init = 0 : i32, sym_name = "output_lock0"}
+    %output_lock1 = aie.lock(%tile_0_2, 3) {init = 1 : i32, sym_name = "output_lock1"}
+
+    %input_buffer = aie.buffer(%tile_0_2) {sym_name = "input_buffer"} : memref<8xi32>
+    %output_buffer = aie.buffer(%tile_0_2) {sym_name = "output_buffer"} : memref<8xi32>
+
+    aie.flow(%tile_0_2, DMA : 0, %tile_0_0, DMA : 0)
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 926365495 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            memref.store %c3_i32, %input_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_lock0, AcquireGreaterEqual, 1)
+        aie.use_lock(%output_lock1, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_buffer[%arg1] : memref<8xi32>
+            %2 = arith.addi %1, %c1_i32 : i32
+            memref.store %2, %output_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_lock0, Release, 1)
+        aie.use_lock(%input_lock1, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:
+      aie.use_lock(%output_lock0, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_buffer : memref<8xi32>) { len = 8 : i32 }
+      aie.use_lock(%output_lock1, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    aie.shim_dma_allocation @out0(S2MM, 0, 0)
+
+    aiex.runtime_sequence @seq(%arg0: memref<8xi32>) {
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c8_i64 = arith.constant 8 : i64
+
+      aiex.npu.maskwrite32 {row = 2 : i32, column = 0 : i32, address = 1024 : ui32, value = 0x12345678 : ui32, mask = 0xF0F0F0F0 : ui32}
+      aiex.npu.maskwrite32 {buffer = @input_buffer, address = 1 : ui32, value = 0x9ABCDEF0 : ui32, mask = 0x0F0F0F0F : ui32}
+
+      aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, issue_token = true, metadata = @out0} : memref<8xi32>
+      aiex.npu.write32 { row = 2 : i32, column = 0 : i32, address = 0x0001F000 : ui32, value = 1 : ui32 }
+      aiex.npu.dma_wait {symbol = @out0}
+    }
+  }
+}

--- a/test/npu-xrt/add_maskwrite/run.lit
+++ b/test/npu-xrt/add_maskwrite/run.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+//
+// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --basic-alloc-scheme --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt | FileCheck %s
+// CHECK: PASS!
+

--- a/test/npu-xrt/add_maskwrite/test.cpp
+++ b/test/npu-xrt/add_maskwrite/test.cpp
@@ -1,0 +1,187 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <boost/program_options.hpp>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+constexpr int IN_SIZE = 64;
+constexpr int OUT_SIZE = 64;
+
+namespace po = boost::program_options;
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  po::options_description desc("Allowed options");
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    return 1;
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+
+  std::vector<uint32_t> instr_v =
+      load_instr_sequence(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running Kernel.\n";
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), bo_out);
+
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
+    return 1;
+  }
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+  uint32_t *bufOut = bo_out.map<uint32_t *>();
+
+  std::vector<uint32_t> ref(8, 0x37373737);
+  ref[0] = ((ref[0] & ~0xF0F0F0F0) | (0x12345678 & 0xF0F0F0F0)) + 1;
+  ref[1] = ((ref[1] & ~0x0F0F0F0F) | (0x9ABCDEF0 & 0x0F0F0F0F)) + 1;
+  for (uint32_t i = 2; i < 8; i++)
+    ref[i] = ref[i] + 1;
+
+  int errors = 0;
+  for (uint32_t i = 0; i < 8; i++) {
+    if (*(bufOut + i) != ref[i]) {
+      std::cout << "Error in output " << std::hex << *(bufOut + i)
+                << " != " << ref[i] << std::endl;
+      errors++;
+    } else {
+      std::cout << "Correct output " << std::hex << *(bufOut + i)
+                << " == " << ref[i] << std::endl;
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nfailed.\n\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
This adds `aiex.npu.maskwrite32` to enable use of the npu firmware operation of the same name.

The e2e test works, but it still needs some mlir unit tests.