### PR TITLE
simplify zero.cc kernel

### DIFF
--- a/aie_kernels/aie2/mm.cc
+++ b/aie_kernels/aie2/mm.cc
@@ -456,7 +456,7 @@ extern "C" {
 #define zero_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,              \
                                mlir_type_out, r, s, t)                         \
   void zero_##mlir_type_out(ctype_out *c_out) {                                \
-    zero_vectorized<ctype_out, DIM_M, DIM_N, 32>(c_out);                       \
+    zero_vectorized<ctype_out, DIM_M, DIM_N>(c_out);                           \
   }
 
 #define zero_scalar_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out,   \

--- a/aie_kernels/aie2/mv.cc
+++ b/aie_kernels/aie2/mv.cc
@@ -81,12 +81,12 @@ void matvec_vectorized(T_in *__restrict a, T_in *__restrict b,
         aie::accum<T_acc, r> c_acc_in;
         c_acc_in.from_vector(aie::load_v<r>(c_ptr));
 
-        const aie::vector<T_in, 2 *r> a_vec_0 = aie::load_v<2 * r>(a_ptr);
-        const aie::vector<T_in, 2 *r> a_vec_1 =
+        const aie::vector<T_in, 2 * r> a_vec_0 = aie::load_v<2 * r>(a_ptr);
+        const aie::vector<T_in, 2 * r> a_vec_1 =
             aie::load_v<2 * r>(a_ptr + 2 * m);
-        const aie::vector<T_in, 2 *r> a_vec_2 =
+        const aie::vector<T_in, 2 * r> a_vec_2 =
             aie::load_v<2 * r>(a_ptr + 4 * m);
-        const aie::vector<T_in, 2 *r> a_vec_3 =
+        const aie::vector<T_in, 2 * r> a_vec_3 =
             aie::load_v<2 * r>(a_ptr + 6 * m);
 
         // The even/odd calls below extract the interleaved columns of A.

--- a/aie_kernels/aie2/mv.cc
+++ b/aie_kernels/aie2/mv.cc
@@ -81,12 +81,12 @@ void matvec_vectorized(T_in *__restrict a, T_in *__restrict b,
         aie::accum<T_acc, r> c_acc_in;
         c_acc_in.from_vector(aie::load_v<r>(c_ptr));
 
-        const aie::vector<T_in, 2 * r> a_vec_0 = aie::load_v<2 * r>(a_ptr);
-        const aie::vector<T_in, 2 * r> a_vec_1 =
+        const aie::vector<T_in, 2 *r> a_vec_0 = aie::load_v<2 * r>(a_ptr);
+        const aie::vector<T_in, 2 *r> a_vec_1 =
             aie::load_v<2 * r>(a_ptr + 2 * m);
-        const aie::vector<T_in, 2 * r> a_vec_2 =
+        const aie::vector<T_in, 2 *r> a_vec_2 =
             aie::load_v<2 * r>(a_ptr + 4 * m);
-        const aie::vector<T_in, 2 * r> a_vec_3 =
+        const aie::vector<T_in, 2 *r> a_vec_3 =
             aie::load_v<2 * r>(a_ptr + 6 * m);
 
         // The even/odd calls below extract the interleaved columns of A.
@@ -169,7 +169,7 @@ extern "C" {
 #define zero_vectorized_c_func(ctype_in, mlir_type_in, ctype_out,              \
                                mlir_type_out, ctype_acc)                       \
   void zero_vectorized_##mlir_type_out(ctype_out *c_out) {                     \
-    zero_vectorized<ctype_out, DIM_M, 1, 32>(c_out);                           \
+    zero_vectorized<ctype_out, DIM_M, 1>(c_out);                               \
   }
 
 #define zero_scalar_c_func(ctype_in, mlir_type_in, ctype_out, mlir_type_out,   \

--- a/aie_kernels/aie2/zero.cc
+++ b/aie_kernels/aie2/zero.cc
@@ -26,11 +26,11 @@ void zero_scalar(T *__restrict c) {
 template <typename T, int M, int N>
 void zero_vectorized(T *__restrict c) {
   constexpr int r = 256 / (sizeof(T) * 8); // one 256 bit store unit
-  static_assert((M * N) % (2 * r) == 0);
+  static_assert((M * N) % r == 0);
   const aie::vector<T, r> zeros = aie::zeros<T, r>();
   const T *__restrict c_end = c + M * N;
   for (; c < c_end; c += r) {
-    aie::store_v(c1, zeros);
+    aie::store_v(c, zeros);
   }
 }
 

--- a/aie_kernels/aie2/zero.cc
+++ b/aie_kernels/aie2/zero.cc
@@ -23,17 +23,14 @@ void zero_scalar(T *__restrict c) {
   }
 }
 
-template <typename T, int M, int N, int r>
+template <typename T, int M, int N>
 void zero_vectorized(T *__restrict c) {
+  constexpr int r = 256 / (sizeof(T) * 8); // one 256 bit store unit
+  static_assert((M * N) % (2 * r) == 0);
   const aie::vector<T, r> zeros = aie::zeros<T, r>();
   const T *__restrict c_end = c + M * N;
-  for (; c + r < c_end; c += r) {
-    aie::store_v(c, zeros);
-  }
-  // Do a scalar write for any remainder not divisible by vector instruction
-  // size r
-  for (; c < c_end; c++) {
-    *c = 0;
+  for (; c < c_end; c += r) {
+    aie::store_v(c1, zeros);
   }
 }
 


### PR DESCRIPTION
We're not using the scalar part of this anywhere, since the matmul kernel requires things to be aligned to vector size anyways. This saves us a few cycles.