### PR TITLE
`aiex.configure_task`: Allow constant buffer references (rather than runtime sequence args)

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -44,6 +44,10 @@ struct HasValidDMAChannels
   static mlir::LogicalResult verifyTrait(mlir::Operation *op);
 };
 
+template <typename ConcreteType>
+struct SkipAccessibilityCheckTrait
+    : mlir::OpTrait::TraitBase<ConcreteType, SkipAccessibilityCheckTrait> {};
+
 class TileOp;
 } // namespace xilinx::AIE
 

--- a/include/aie/Dialect/AIE/IR/AIEInterfaces.td
+++ b/include/aie/Dialect/AIE/IR/AIEInterfaces.td
@@ -134,6 +134,15 @@ def AIETarget : OpInterface<"AIETarget"> {
 }
 
 // Don't delete - see AIEDialect::myVerifyOffsetSizeAndStrideOp
-def MyOffsetSizeAndStrideOpInterface: OpInterfaceTrait<"::xilinx::AIE::MyOffsetSizeAndStrideOpInterface"> {}
+def MyOffsetSizeAndStrideOpInterface : OpInterfaceTrait<"::xilinx::AIE::MyOffsetSizeAndStrideOpInterface"> {}
+
+// Ops may specify that the accessibility checks of their child ops are not verified.
+// For example, by default, ops will verify that all contained aie.buffers are
+// accessible from within the tile from which they are used. However, in abstract
+// definitions not tied to any tile, it may still be useful to be able to refer
+// to buffers and skip those checks.
+def SkipAccessibilityCheckTrait : NativeOpTrait<"SkipAccessibilityCheckTrait"> {
+  string cppNamespace = "::xilinx::AIE";
+}
 
 #endif // AIE_INTERFACES

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1988,7 +1988,7 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectfifo.register_process", []> {
   }];
 }
 
-def AIE_BDChainOp: AIE_Op<"bd_chain", [Symbol]> {
+def AIE_BDChainOp: AIE_Op<"bd_chain", [Symbol, SkipAccessibilityCheckTrait]> {
   let summary = "Definition of a Parametrizable Chain of Buffer Descriptors";
   let description = [{
     This operation allows you to define buffer descriptor chains with parametrizable inputs. 

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -945,7 +945,7 @@ def AIE_DMAAwaitTaskOp : AIEX_Op<"dma_await_task", [HasParent<"RuntimeSequenceOp
 }
 
 
-def AIE_DMAStartBdChainOp: AIEX_Op<"dma_start_bd_chain", [HasParent<"RuntimeSequenceOp">]>,
+def AIE_DMAStartBdChainOp: AIEX_Op<"dma_start_bd_chain", [HasParent<"RuntimeSequenceOp">, TileElement]>,
     Results<(outs Index:$result)>
   {
 
@@ -975,6 +975,7 @@ def AIE_DMAStartBdChainOp: AIEX_Op<"dma_start_bd_chain", [HasParent<"RuntimeSequ
   let extraClassDeclaration = [{
     AIE::TileOp getTileOp();
     AIE::BDChainOp getBDChainOp();
+    using ::xilinx::AIE::TileElement::Trait<AIEX::DMAStartBdChainOp>::getAsmResultNames;
   }];
 
   let extraClassDefinition = [{

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -829,7 +829,7 @@ def AIE_NpuWriteBdOp: AIEX_Op<"npu.writebd", []> {
   }];
 }
 
-def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSequenceOp">]>, Results<(outs Index:$result)> {
+def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSequenceOp">, TileElement]>, Results<(outs Index:$result)> {
   let summary = "Concrete Instantiation of a Buffer Descriptor Chain as a Task on a Channel and Direction on a Tile";
   let description = [{
     Encapsulates the DMA configuration of one task, that is the (chain of) buffer descriptors to be executed on a given channel and direction on a tile.
@@ -858,6 +858,7 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSe
   let extraClassDeclaration = [{
     AIE::TileOp getTileOp();
     std::optional<uint32_t> getFirstBdId();
+    using ::xilinx::AIE::TileElement::Trait<AIEX::DMAConfigureTaskOp>::getAsmResultNames;
   }];
 
   let extraClassDefinition = [{

--- a/include/aie/Dialect/AIEX/IR/AIEXDialect.h
+++ b/include/aie/Dialect/AIEX/IR/AIEXDialect.h
@@ -24,9 +24,8 @@
 namespace xilinx {
 namespace AIEX {
 
-uint64_t
-getBufferDescriptorAddressRegisterAddress(const AIE::AIETargetModel &tm,
-                                          unsigned bd_id, unsigned col);
+uint64_t getBufferDescriptorAddressRegisterAddress(
+    const AIE::AIETargetModel &tm, unsigned bd_id, unsigned col, unsigned row);
 void getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
                              mlir::MemRefType referencedBufType,
                              llvm::SmallVector<int64_t, 4> inputSizes,

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -172,7 +172,9 @@ struct UsesAreAccessible {
       if (user->getParentWithTrait<SkipAccessibilityCheckTrait>()) {
         continue;
       }
-      if (auto element = getParentTileElement(user)) {
+      TileElement element;
+      if ((element = llvm::dyn_cast<TileElement>(user)) ||
+          (element = getParentTileElement(user))) {
         auto tileID = element.getTileID();
         if (!targetModel.isLegalMemAffinity(tileID.col, tileID.row, thisID.col,
                                             thisID.row))

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -155,7 +155,7 @@ static TileElement getParentTileElement(Operation *op) {
   return llvm::dyn_cast<TileElement>(parent);
 }
 
-struct UsesAreAccessable {
+struct UsesAreAccessible {
   static LogicalResult verifyTrait(Operation *op) {
     auto thisElement = cast<TileElement>(op);
     auto thisID = thisElement.getTileID();
@@ -1291,7 +1291,7 @@ int64_t BufferOp::getAllocationSize() {
 TileOp BufferOp::getTileOp() { return cast<TileOp>(getTile().getDefiningOp()); }
 
 LogicalResult BufferOp::verify() {
-  if (UsesAreAccessable::verifyTrait(*this).failed())
+  if (UsesAreAccessible::verifyTrait(*this).failed())
     return failure();
   return success();
 }
@@ -2012,7 +2012,7 @@ int LockOp::colIndex() { return getTileOp().colIndex(); }
 int LockOp::rowIndex() { return getTileOp().rowIndex(); }
 
 LogicalResult LockOp::verify() {
-  if (auto result = UsesAreAccessable::verifyTrait(*this); result.failed())
+  if (auto result = UsesAreAccessible::verifyTrait(*this); result.failed())
     return result;
 
   if (getLockID().has_value()) {

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -31,10 +31,11 @@ void AIEXDialect::initialize() {
       >();
 }
 
-uint64_t
-getBufferDescriptorAddressRegisterAddress(const AIE::AIETargetModel &tm,
-                                          unsigned bd_id, unsigned col) {
-  return ((uint64_t)col << tm.getColumnShift()) | (0x1D004 + bd_id * 0x20);
+uint64_t getBufferDescriptorAddressRegisterAddress(
+    const AIE::AIETargetModel &tm, unsigned bd_id, unsigned col, unsigned row) {
+  assert(bd_id < tm.getNumBDs(col, row));
+  return ((col & 0xff) << tm.getColumnShift()) |
+         ((row & 0xff) << tm.getRowShift()) | (0x1D004 + bd_id * 0x20);
 }
 
 /* Return the correct values to write to the hardware registers to configure

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -568,17 +568,18 @@ std::optional<uint32_t> AIEX::DMAConfigureTaskOp::getFirstBdId() {
 LogicalResult
 AIEX::DMAConfigureTaskOp::canonicalize(AIEX::DMAConfigureTaskOp op,
                                        PatternRewriter &rewriter) {
-  // Verify inlined basic blocks do form a chain reachable from the start;
-  // Remove empty blocks
+  // Remove blocks that contain nothing but a terminator
   Region &body = op.getBody();
   bool did_rewrite = false;
   for (auto it = body.begin(); it != body.end(); ++it) {
     Block &block = *it;
+    if (block.empty()) {
+      continue;
+    }
     auto ops_it = block.without_terminator();
     if (std::distance(ops_it.begin(), ops_it.end()) == 0) {
       rewriter.eraseOp(block.getTerminator());
       did_rewrite = true;
-      continue;
     }
   }
   if (did_rewrite) {
@@ -591,6 +592,9 @@ LogicalResult AIEX::DMAConfigureTaskOp::verify() {
   Region &body = getBody();
   for (auto it = body.begin(); it != body.end(); ++it) {
     Block &block = *it;
+    if (block.empty()) {
+      continue;
+    }
     if (block.hasNoPredecessors() && !block.isEntryBlock()) {
       auto error = block.getTerminator()->emitError(
           "Block ending in this terminator does not form a chain with "

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -438,8 +438,8 @@ public:
         iteration_size, iteration_stride, next_bd, row, use_next_bd, valid_bd,
         lock_rel_val, lock_rel_id, lock_acq_enable, lock_acq_val, lock_acq_id);
 
-    uint64_t addr =
-        getBufferDescriptorAddressRegisterAddress(targetModel, op.getId(), col);
+    uint64_t addr = getBufferDescriptorAddressRegisterAddress(
+        targetModel, op.getId(), col, 0);
 
     rewriter.create<NpuAddressPatchOp>(op->getLoc(), addr, arg_idx, offset);
 

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-10.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-10.mlir
@@ -9,6 +9,9 @@
 //
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
 
+// This test ensures the proper error is emitted if a user attempts to configure a task 
+// that accesses a buffer that is inaccessible from the tile it is configured to run on.
+
 module {
   aie.device(npu1_4col) {
     %tile_0_0 = aie.tile(0, 0)

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-10.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-10.mlir
@@ -1,0 +1,29 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    // expected-error@+1 {{accessed from an unreachable tile}}
+    %buf = aie.buffer(%tile_0_2) {addr = 0xBEEF : i32} : memref<32xi8> 
+
+    aiex.runtime_sequence(%arg0: memref<32xi8>) {
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+          // expected-note@+1 {{user}}
+          aie.dma_bd(%buf : memref<32xi8>, 4, 32) {bd_id = 0 : i32}
+          aie.end
+      }
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-11.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-11.mlir
@@ -9,6 +9,10 @@
 //
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
 
+// This test ensures the proper error is emitted if a user tries to lower a 
+// BD in a aiex.dma_configure_task operation in the runtime sequence before
+// the address of all referenced buffers is known.
+
 module {
   aie.device(npu1_4col) {
     %tile_0_0 = aie.tile(0, 0)

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-11.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-11.mlir
@@ -1,0 +1,28 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    %buf = aie.buffer(%tile_0_1) : memref<32xi8> 
+
+    aiex.runtime_sequence(%arg0: memref<32xi8>) {
+      %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
+          // expected-error@+1 {{without associated address}}
+          aie.dma_bd(%buf : memref<32xi8>, 4, 32) {bd_id = 0 : i32}
+          aie.end
+      }
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-1.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-1.mlir
@@ -16,7 +16,7 @@
 module {
   aie.device(npu1_4col) {
     %tile_0_0 = aie.tile(0, 0)
-    %tile_0_2 = aie.tile(0, 2)
+    %tile_2_0 = aie.tile(2, 0)
 
     aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<10xi32>) {
       // CHECK: aiex.npu.writebd {bd_id = 7 : i32, buffer_length = 4 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
@@ -25,20 +25,20 @@ module {
         aie.dma_bd(%arg0 : memref<8xi16>, 0, 8) {bd_id = 7 : i32}
         aie.end
       } {issue_token = true}
-      // CHECK: aiex.npu.writebd {bd_id = 8 : i32, buffer_length = 10 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 2 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.address_patch {addr = 119044 : ui32, arg_idx = 1 : i32, arg_plus = 0 : i32} 
-      %t2 = aiex.dma_configure_task(%tile_0_2, S2MM, 1) {
+      // CHECK: aiex.npu.writebd {bd_id = 8 : i32, buffer_length = 10 : i32, buffer_offset = 0 : i32, column = 2 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+      // CHECK: aiex.npu.address_patch {addr = 67227908 : ui32, arg_idx = 1 : i32, arg_plus = 0 : i32} 
+      %t2 = aiex.dma_configure_task(%tile_2_0, S2MM, 1) {
         aie.dma_bd(%arg1 : memref<10xi32>, 0, 10) {bd_id = 8 : i32}
         aie.end
       } {repeat_count = 2 : i32, issue_token = true}
 
       // CHECK: aiex.npu.push_queue(0, 0, MM2S : 0) {bd_id = 7 : i32, issue_token = true, repeat_count = 0 : i32}
       aiex.dma_start_task(%t1)
-      // CHECK: aiex.npu.push_queue(0, 2, S2MM : 1) {bd_id = 8 : i32, issue_token = true, repeat_count = 2 : i32}
+      // CHECK: aiex.npu.push_queue(2, 0, S2MM : 1) {bd_id = 8 : i32, issue_token = true, repeat_count = 2 : i32}
       aiex.dma_start_task(%t2)
       // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
       aiex.dma_await_task(%t1)
-      // CHECK: aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 2 : i32, row_num = 1 : i32}
+      // CHECK: aiex.npu.sync {channel = 1 : i32, column = 2 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       aiex.dma_await_task(%t2)
     }
   }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
@@ -21,9 +21,9 @@ module {
     %buf = aie.buffer(%tile_0_1) { address = 0xBEEF : i32 } : memref<32xi8> 
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
-      // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.write32 {address = 118788 : ui32, value = 48879 : ui32}
-      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 1 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+      // CHECK: aiex.npu.write32 {address = 1167364 : ui32, value = 48879 : ui32}
+      %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
           aie.dma_bd(%buf : memref<32xi8>, 4, 16,
                      [<size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>]) {bd_id = 0 : i32}
           aie.end

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
@@ -9,6 +9,10 @@
 //
 // RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
 
+// This test ensures that a buffer descriptor configuration that references a buffer
+// on a mem tile gets lowered to the correct NPU instruction sequence register write
+// setting that BD's address.
+
 module {
   aie.device(npu1_4col) {
     %tile_0_0 = aie.tile(0, 0)

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
@@ -1,0 +1,30 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    %buf = aie.buffer(%tile_0_1) { address = 0xBEEF : i32 } : memref<32xi8> 
+
+    aiex.runtime_sequence(%arg0: memref<32xi8>) {
+      // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+      // CHECK: aiex.npu.write32 {address = 118788 : ui32, value = 0xBEEF : ui32}
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+          aie.dma_bd(%buf : memref<32xi8>, 4, 16,
+                     [<size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>]) {bd_id = 0 : i32}
+          aie.end
+      }
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
@@ -18,7 +18,7 @@ module {
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.write32 {address = 118788 : ui32, value = 0xBEEF : ui32}
+      // CHECK: aiex.npu.write32 {address = 118788 : ui32, value = 48879 : ui32}
       %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
           aie.dma_bd(%buf : memref<32xi8>, 4, 16,
                      [<size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>]) {bd_id = 0 : i32}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
@@ -1,0 +1,35 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --aie-assign-buffer-addresses --aie-dma-tasks-to-npu %s | FileCheck %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    // CHECK: %{{.*}} = aie.buffer(%tile_0_1) {address = [[ADDR1:[0-9]+]] {{.*}}}
+    %buf0 = aie.buffer(%tile_0_1) : memref<32xi8> 
+    // CHECK: %{{.*}} = aie.buffer(%tile_0_1) {address = [[ADDR2:[0-9]+]] {{.*}}}
+    %buf1 = aie.buffer(%tile_0_1) : memref<32xi8> 
+
+    aiex.runtime_sequence(%arg0: memref<32xi8>) {
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+          // CHECK: aiex.npu.write32 {address = 118788 : ui32, value = [[ADDR1]] : ui32}
+          aie.dma_bd(%buf0 : memref<32xi8>, 4, 16) {bd_id = 0 : i32}
+          aie.next_bd ^bd2
+        ^bd2:
+          // CHECK: aiex.npu.write32 {address = 118820 : ui32, value = [[ADDR2]] : ui32}
+          aie.dma_bd(%buf1 : memref<32xi8>, 4, 16) {bd_id = 1 : i32}
+          aie.end
+      }
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
@@ -25,12 +25,12 @@ module {
     %buf1 = aie.buffer(%tile_0_1) : memref<32xi8> 
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
-      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-          // CHECK: aiex.npu.write32 {address = 118788 : ui32, value = [[ADDR1]] : ui32}
+      %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
+          // CHECK: aiex.npu.write32 {address = 1167364 : ui32, value = [[ADDR1]] : ui32}
           aie.dma_bd(%buf0 : memref<32xi8>, 4, 16) {bd_id = 0 : i32}
           aie.next_bd ^bd2
         ^bd2:
-          // CHECK: aiex.npu.write32 {address = 118820 : ui32, value = [[ADDR2]] : ui32}
+          // CHECK: aiex.npu.write32 {address = 1167396 : ui32, value = [[ADDR2]] : ui32}
           aie.dma_bd(%buf1 : memref<32xi8>, 4, 16) {bd_id = 1 : i32}
           aie.end
       }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
@@ -9,6 +9,11 @@
 //
 // RUN: aie-opt --aie-assign-buffer-addresses --aie-dma-tasks-to-npu %s | FileCheck %s
 
+// This test ensures that a chained buffer descriptor configuration in the runtime
+// sequence gets lowered to the correct NPU instruction sequence register write
+// instructions to set all BDs addresses to their correct value when combined with
+// the automatic buffer address allocation.
+
 module {
   aie.device(npu1_4col) {
     %tile_0_0 = aie.tile(0, 0)


### PR DESCRIPTION
With this PR, you can reference buffers on the mem tile, as long as the `dma_configure_task` configures the task on a tile that has access to that buffer. As of now, that's not possible. Only address_patch instructions are emitted for the shim, so only runtime sequence arguments can be used.

This PR is part of a chain of changes that are independent but build on each other. GitHub shows the diff to `main`, so later PRs also contain the changes of previous PRs.

To see minimal diffs (compared to previous PR in chain), click the arrow links between the PRs below:

**#1698  [-->](https://github.com/andrej/mlir-aie/compare/bd-chain-tests..configure-task-allow-other-bufs)  #1689 (this PR)**  [-->](https://github.com/andrej/mlir-aie/compare/configure-task-allow-other-bufs..shim-dma-alloc)  #1693  [-->](https://github.com/andrej/mlir-aie/compare/shim-dma-alloc..py)  #1696  [-->](https://github.com/andrej/mlir-aie/compare/py..bd-py)  #1699