### PR TITLE
`aiex.configure_task`: Allow referencing `shim_dma_allocation`

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -118,6 +118,8 @@ def AIE_TileOp: AIE_Op<"tile", [
           return coreOp;
       return nullptr;
     }
+
+    static AIE::TileOp getOrCreate(mlir::OpBuilder builder, AIE::DeviceOp device, int col, int row);
   }];
 
   let assemblyFormat = [{
@@ -1568,6 +1570,10 @@ def AIE_ShimDMAAllocationOp : AIE_Op<"shim_dma_allocation", [HasParent<"DeviceOp
 
   let assemblyFormat = [{
     $sym_name `(` $channel_dir `,` $channel_index `,` $col `)` attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    static ::xilinx::AIE::ShimDMAAllocationOp getForSymbol(::xilinx::AIE::DeviceOp device, ::llvm::StringRef symbol);
   }];
 }
 

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -956,7 +956,6 @@ def AIE_DMAAwaitTaskOp : AIEX_Op<"dma_await_task", [HasParent<"RuntimeSequenceOp
   }];
 }
 
-
 def AIE_DMAStartBdChainOp: AIEX_Op<"dma_start_bd_chain", [HasParent<"RuntimeSequenceOp">, TileElement]>,
     Results<(outs Index:$result)>
   {
@@ -994,6 +993,24 @@ def AIE_DMAStartBdChainOp: AIEX_Op<"dma_start_bd_chain", [HasParent<"RuntimeSequ
     AIE::TileOp DMAStartBdChainOp::getTileOp() { return cast<AIE::TileOp>(getTile().getDefiningOp()); }
   }];
 
+}
+
+def AIE_DMAStartBdChainForOp: AIEX_Op<"dma_start_bd_chain_for", [HasParent<"RuntimeSequenceOp">]>,
+    Results<(outs Index:$result)>
+  {
+  let summary = "As dma_start_bd_chain, but specify tile, direction and channel by reference to a Shim DMA allocation op";
+
+  let arguments = (
+    ins FlatSymbolRefAttr:$symbol,
+        Variadic<AnyType>:$args,
+        FlatSymbolRefAttr:$alloc,
+        DefaultValuedOptionalAttr<BoolAttr, "false">:$issue_token,
+        DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count
+  );
+
+  let assemblyFormat = [{ 
+     $symbol `(` $args `)` `:` `(` type($args) `)` ` ` `for` ` ` $alloc attr-dict 
+  }];
 }
 
 #endif // AIEX_OPS

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -869,6 +869,18 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSe
   let hasCanonicalizeMethod = 1;
 }
 
+def AIE_DMAConfigureTaskForOp : AIEX_Op<"dma_configure_task_for", [HasParent<"RuntimeSequenceOp">]>, Results<(outs Index:$result)> {
+  let arguments = (
+    ins FlatSymbolRefAttr:$alloc,
+        DefaultValuedOptionalAttr<BoolAttr, "false">:$issue_token,
+        DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count
+  );
+
+  let regions = (region AnyRegion:$body);
+
+  let assemblyFormat = [{ $alloc regions attr-dict }];
+}
+
 def AIE_DMAFreeTaskOp : AIEX_Op<"dma_free_task", [HasParent<"RuntimeSequenceOp">]> {
   let summary = "Free all Buffer Descriptor IDs Associated with the Given Task";
   let description = [{

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -870,6 +870,8 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"RuntimeSe
 }
 
 def AIE_DMAConfigureTaskForOp : AIEX_Op<"dma_configure_task_for", [HasParent<"RuntimeSequenceOp">]>, Results<(outs Index:$result)> {
+  let summary = "As dma_configure_task, but specify tile, direction and channel by reference to a Shim DMA allocation op";
+
   let arguments = (
     ins FlatSymbolRefAttr:$alloc,
         DefaultValuedOptionalAttr<BoolAttr, "false">:$issue_token,

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -36,6 +36,8 @@ std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIEAssignRuntimeSequenceBDIDsPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIEDMATasksToNPUPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
+createAIESubstituteShimDMAAllocationsPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -180,4 +180,14 @@ def AIEDMATasksToNPU : Pass<"aie-dma-tasks-to-npu", "AIE::DeviceOp"> {
   ];
 }
 
+def AIESubstituteShimDMAAllocations : Pass<"aie-substitute-shim-dma-allocations", "AIE::DeviceOp"> {
+  let summary = "Replace symbolic references to `aie.shim_dma_allocation` ops with their `(tile, direction, channel)` triple";
+
+  let constructor = "xilinx::AIEX::createAIESubstituteShimDMAAllocationsPass()";
+  let dependentDialects = [
+    "xilinx::AIE::AIEDialect",
+    "xilinx::AIEX::AIEXDialect",
+  ];
+}
+
 #endif

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1117,9 +1117,7 @@ TileOp TileOp::getOrCreate(mlir::OpBuilder builder, DeviceOp device, int col,
                            int row) {
   TileOp tile = nullptr;
   // Find matching predefined tile at device top level, ...
-  auto tile_ops = device.getOps<AIE::TileOp>();
-  for (auto it = tile_ops.begin(); it != tile_ops.end(); ++it) {
-    TileOp t = *it;
+  for (auto t : device.getOps<AIE::TileOp>()) {
     if (t.getRow() == row && t.getCol() == col) {
       tile = t;
       break;
@@ -1127,12 +1125,11 @@ TileOp TileOp::getOrCreate(mlir::OpBuilder builder, DeviceOp device, int col,
   }
   // ... or if undefined, create a new tile op
   if (!tile) {
-    auto s = builder.saveInsertionPoint();
+    OpBuilder::InsertionGuard guard(builder);
     mlir::Block &device_start_block = *device.getBodyRegion().begin();
     builder.setInsertionPointToStart(&device_start_block);
     tile = builder.create<TileOp>(builder.getUnknownLoc(),
                                   builder.getIndexType(), col, 0);
-    builder.restoreInsertionPoint(s);
   }
   return tile;
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1113,6 +1113,30 @@ bool isLegalTileConnection(TileOp tile, const AIETargetModel &targetModel,
       tile.colIndex(), tile.rowIndex(), srcBundle, srcChan, dstBundle, dstChan);
 }
 
+TileOp TileOp::getOrCreate(mlir::OpBuilder builder, DeviceOp device, int col,
+                           int row) {
+  TileOp tile = nullptr;
+  // Find matching predefined tile at device top level, ...
+  auto tile_ops = device.getOps<AIE::TileOp>();
+  for (auto it = tile_ops.begin(); it != tile_ops.end(); ++it) {
+    TileOp t = *it;
+    if (t.getRow() == row && t.getCol() == col) {
+      tile = t;
+      break;
+    }
+  }
+  // ... or if undefined, create a new tile op
+  if (!tile) {
+    auto s = builder.saveInsertionPoint();
+    mlir::Block &device_start_block = *device.getBodyRegion().begin();
+    builder.setInsertionPointToStart(&device_start_block);
+    tile = builder.create<TileOp>(builder.getUnknownLoc(),
+                                  builder.getIndexType(), col, 0);
+    builder.restoreInsertionPoint(s);
+  }
+  return tile;
+}
+
 //===----------------------------------------------------------------------===//
 // ShimSwitchboxOp
 //===----------------------------------------------------------------------===//
@@ -2247,6 +2271,22 @@ LogicalResult BDChainOp::verify() {
         "Number of region arguments and argument types mismatch.");
   }
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ShimDMAAllocationOp
+//===----------------------------------------------------------------------===//
+
+ShimDMAAllocationOp ShimDMAAllocationOp::getForSymbol(DeviceOp device,
+                                                      llvm::StringRef symbol) {
+  auto alloc_ops = device.getOps<ShimDMAAllocationOp>();
+  for (auto it = alloc_ops.begin(); it != alloc_ops.end(); ++it) {
+    AIE::ShimDMAAllocationOp a = *it;
+    if (a.getSymName() == symbol) {
+      return a;
+    }
+  }
+  return nullptr;
 }
 
 // Include implementations for custom attributes

--- a/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
@@ -95,6 +95,11 @@ struct AIEAssignRuntimeSequenceBDIDsPass
             << "Lower this operation first using the "
                "--aie-materialize-bd-chains pass.";
       }
+      if (llvm::isa<DMAConfigureTaskForOp>(task_op)) {
+        err.attachNote(task_op->getLoc())
+            << "Lower this operation first using the "
+               "--aie-substitute-shim-dma-allocations pass.";
+      }
       return err;
     }
 

--- a/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
@@ -1,0 +1,87 @@
+//===- AIESubstituteShimDMAAllocations.cpp -----------------------*- C++
+//-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <algorithm>
+#include <iterator>
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIEX;
+
+struct DMAConfigureTaskForOpPattern : RewritePattern {
+
+  DMAConfigureTaskForOpPattern(MLIRContext *ctx)
+      : RewritePattern(DMAConfigureTaskForOp::getOperationName(),
+                       PatternBenefit(1), ctx) {}
+
+  LogicalResult matchAndRewrite(Operation *op_any,
+                                PatternRewriter &rewriter) const override {
+    DMAConfigureTaskForOp op = llvm::dyn_cast<DMAConfigureTaskForOp>(op_any);
+    if (!op) {
+      return failure();
+    }
+    AIE::DeviceOp device = op->getParentOfType<AIE::DeviceOp>();
+
+    AIE::ShimDMAAllocationOp alloc_op =
+        AIE::ShimDMAAllocationOp::getForSymbol(device, op.getAlloc());
+    if (!alloc_op) {
+      return op.emitOpError("no shim DMA allocation found for symbol");
+    }
+
+    const int col = alloc_op.getCol();
+    AIE::TileOp tile = AIE::TileOp::getOrCreate(rewriter, device, col, 0);
+    DMAConfigureTaskOp new_op = rewriter.create<DMAConfigureTaskOp>(
+        op.getLoc(), rewriter.getIndexType(), tile.getResult(),
+        alloc_op.getChannelDir(), (int32_t)alloc_op.getChannelIndex(),
+        op.getIssueToken(), op.getRepeatCount());
+    rewriter.replaceAllUsesWith(op.getResult(), new_op.getResult());
+    rewriter.inlineRegionBefore(op.getBody(), new_op.getBody(),
+                                new_op.getBody().begin());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct AIESubstituteShimDMAAllocationsPass
+    : AIESubstituteShimDMAAllocationsBase<AIESubstituteShimDMAAllocationsPass> {
+
+  void runOnOperation() override {
+    AIE::DeviceOp device = getOperation();
+
+    // Convert DMAConfigureTaskForOps that reference shim DMA allocations
+    // to regular DMAConfigureTaskOps
+    ConversionTarget target(getContext());
+    target.addLegalDialect<AIEXDialect>();
+    target.addIllegalOp<DMAConfigureTaskForOp>();
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<DMAConfigureTaskForOpPattern>(&getContext());
+
+    GreedyRewriteConfig rewriter_config = GreedyRewriteConfig();
+    if (failed(applyPatternsAndFoldGreedily(device, std::move(patterns),
+                                            rewriter_config))) {
+      signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<AIE::DeviceOp>>
+AIEX::createAIESubstituteShimDMAAllocationsPass() {
+  return std::make_unique<AIESubstituteShimDMAAllocationsPass>();
+}

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIEMaterializeBDChains.cpp
   AIEAssignRuntimeSequenceBDIDs.cpp
   AIEDMATasksToNPU.cpp
+  AIESubstituteShimDMAAllocations.cpp
   ADDITIONAL_HEADER_DIRS
   ${AIE_BINARY_DIR}/include
 

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -96,6 +96,7 @@ DMA_TO_NPU = Pipeline().Nested(
     "aie.device",
     Pipeline()
     .add_pass("aie-materialize-bd-chains")
+    .add_pass("aie-substitute-shim-dma-allocations")
     .add_pass("aie-assign-runtime-sequence-bd-ids")
     .add_pass("aie-dma-tasks-to-npu")
     .add_pass("aie-dma-to-npu"),

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-5.mlir
@@ -1,0 +1,33 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --aie-substitute-shim-dma-allocations --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
+
+// This test ensures that all available 16 buffer descriptors are used.
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.shim_dma_allocation @alloc0 (MM2S, 0, 0)
+
+    aiex.runtime_sequence(%arg0: memref<8xi16>) {
+      // Allocate all available BD IDs
+      %t1 = aiex.dma_configure_task_for @alloc0 {
+        // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8) {bd_id = 0 : i32}
+        aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
+        aie.end
+      }
+      aiex.dma_start_task(%t1)
+      aiex.dma_await_task(%t1)
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
@@ -7,7 +7,7 @@
 
 // REQUIRES: ryzen_ai
 //
-// RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
+// RUN: aie-opt --aie-substitute-shim-dma-allocations --aie-dma-tasks-to-npu %s | FileCheck %s
 
 module {
   aie.device(npu1_4col) {

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
@@ -1,0 +1,45 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    //%tile_2_0 = aie.tile(2, 0)
+
+    aie.shim_dma_allocation @alloc0 (MM2S, 0, 0)
+    aie.shim_dma_allocation @alloc1 (S2MM, 1, 2)
+
+    aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<10xi32>) {
+      // CHECK: aiex.npu.writebd {bd_id = 7 : i32, buffer_length = 4 : i32, buffer_offset = 0 : i32, column = 0 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+      // CHECK: aiex.npu.address_patch {addr = 119012 : ui32, arg_idx = 0 : i32, arg_plus = 0 : i32}
+      %t1 = aiex.dma_configure_task_for @alloc0 {
+        aie.dma_bd(%arg0 : memref<8xi16>, 0, 8) {bd_id = 7 : i32}
+        aie.end
+      } {issue_token = true}
+      // CHECK: aiex.npu.writebd {bd_id = 8 : i32, buffer_length = 10 : i32, buffer_offset = 0 : i32, column = 2 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
+      // CHECK: aiex.npu.address_patch {addr = 119044 : ui32, arg_idx = 1 : i32, arg_plus = 0 : i32} 
+      %t2 = aiex.dma_configure_task_for @alloc1 {
+        aie.dma_bd(%arg1 : memref<10xi32>, 0, 10) {bd_id = 8 : i32}
+        aie.end
+      } {repeat_count = 2 : i32, issue_token = true}
+
+      // CHECK: aiex.npu.push_queue(0, 0, MM2S : 0) {bd_id = 7 : i32, issue_token = true, repeat_count = 0 : i32}
+      aiex.dma_start_task(%t1)
+      // CHECK: aiex.npu.push_queue(0, 2, S2MM : 1) {bd_id = 8 : i32, issue_token = true, repeat_count = 2 : i32}
+      aiex.dma_start_task(%t2)
+      // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+      aiex.dma_await_task(%t1)
+      // CHECK: aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 2 : i32, row_num = 1 : i32}
+      aiex.dma_await_task(%t2)
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
@@ -25,7 +25,7 @@ module {
         aie.end
       } {issue_token = true}
       // CHECK: aiex.npu.writebd {bd_id = 8 : i32, buffer_length = 10 : i32, buffer_offset = 0 : i32, column = 2 : i32, d0_size = 0 : i32, d0_stride = 0 : i32, d1_size = 0 : i32, d1_stride = 0 : i32, d2_stride = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 0 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.address_patch {addr = 119044 : ui32, arg_idx = 1 : i32, arg_plus = 0 : i32} 
+      // CHECK: aiex.npu.address_patch {addr = 67227908 : ui32, arg_idx = 1 : i32, arg_plus = 0 : i32} 
       %t2 = aiex.dma_configure_task_for @alloc1 {
         aie.dma_bd(%arg1 : memref<10xi32>, 0, 10) {bd_id = 8 : i32}
         aie.end
@@ -33,11 +33,11 @@ module {
 
       // CHECK: aiex.npu.push_queue(0, 0, MM2S : 0) {bd_id = 7 : i32, issue_token = true, repeat_count = 0 : i32}
       aiex.dma_start_task(%t1)
-      // CHECK: aiex.npu.push_queue(0, 2, S2MM : 1) {bd_id = 8 : i32, issue_token = true, repeat_count = 2 : i32}
+      // CHECK: aiex.npu.push_queue(2, 0, S2MM : 1) {bd_id = 8 : i32, issue_token = true, repeat_count = 2 : i32}
       aiex.dma_start_task(%t2)
       // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
       aiex.dma_await_task(%t1)
-      // CHECK: aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 2 : i32, row_num = 1 : i32}
+      // CHECK: aiex.npu.sync {channel = 1 : i32, column = 2 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
       aiex.dma_await_task(%t2)
     }
   }

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-4.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-4.mlir
@@ -1,0 +1,35 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --verify-diagnostics --aie-materialize-bd-chains %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    // expected-error@+1 {{unreachable}}
+    %buf = aie.buffer(%tile_0_2) : memref<8xi16>
+
+    aie.bd_chain @simple_chain(%arg0: memref<8xi16>) {
+            aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
+            aie.next_bd ^bd1
+        ^bd1:
+            // expected-note@+1{{user}}
+            aie.dma_bd(%buf : memref<8xi16>, 0, 8)
+            aie.end
+    }
+
+    aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
+      %t1 = aiex.dma_start_bd_chain @simple_chain(%arg0) : (memref<8xi16>)  
+                                    on (%tile_0_0, MM2S, 0) 
+      aiex.dma_await_task(%t1)
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-5.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-5.mlir
@@ -1,0 +1,35 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --verify-diagnostics --aie-materialize-bd-chains %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    // expected-error@+1 {{unreachable}}
+    %buf = aie.buffer(%tile_0_2) : memref<8xi16>
+
+    aie.bd_chain @simple_chain(%arg0: memref<8xi16>) {
+            aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
+            aie.next_bd ^bd1
+        ^bd1:
+            aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
+            aie.end
+    }
+
+    aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
+      // expected-note@+1{{user}}
+      %t1 = aiex.dma_start_bd_chain @simple_chain(%buf) : (memref<8xi16>)  
+                                    on (%tile_0_0, MM2S, 0) 
+      aiex.dma_await_task(%t1)
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-3.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-3.mlir
@@ -13,6 +13,7 @@ module {
   aie.device(npu1_4col) {
     %tile_0_0 = aie.tile(0, 0)
     %tile_0_2 = aie.tile(0, 2)
+    // CHECK: %[[buf:.+]] = aie.buffer
     %buf = aie.buffer(%tile_0_2) : memref<8xi16>
 
     aie.bd_chain @simple_chain(%arg0: memref<8xi16>) {
@@ -26,11 +27,11 @@ module {
     aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
       %t1 = aiex.dma_start_bd_chain @simple_chain(%arg0) : (memref<8xi16>)  
                                     on (%tile_0_2, MM2S, 0) 
-      // CHECK: %[[task1:[0-9]+]] = aiex.dma_configure_task(%tile_0_2, MM2S, 0) {
-      // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
+      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%tile_0_2, MM2S, 0) {
+      // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
-      // CHECK:   aie.dma_bd(%buf : memref<8xi16>, 0, 8)
+      // CHECK:   aie.dma_bd(%[[buf]] : memref<8xi16>, 0, 8)
       // CHECK:   aie.end
       // CHECK: }
       // CHECK: aiex.dma_start_task(%[[task1]])

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-3.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-3.mlir
@@ -1,0 +1,41 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %buf = aie.buffer(%tile_0_2) : memref<8xi16>
+
+    aie.bd_chain @simple_chain(%arg0: memref<8xi16>) {
+            aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
+            aie.next_bd ^bd1
+        ^bd1:
+            aie.dma_bd(%buf : memref<8xi16>, 0, 8)
+            aie.end
+    }
+
+    aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
+      %t1 = aiex.dma_start_bd_chain @simple_chain(%arg0) : (memref<8xi16>)  
+                                    on (%tile_0_2, MM2S, 0) 
+      // CHECK: %[[task1:[0-9]+]] = aiex.dma_configure_task(%tile_0_2, MM2S, 0) {
+      // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
+      // CHECK:   aie.next_bd ^bb1
+      // CHECK: ^bb1:
+      // CHECK:   aie.dma_bd(%buf : memref<8xi16>, 0, 8)
+      // CHECK:   aie.end
+      // CHECK: }
+      // CHECK: aiex.dma_start_task(%[[task1]])
+      aiex.dma_await_task(%t1)
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-4.mlir
@@ -1,0 +1,44 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    // CHECK: %[[BUF0:.+]] = aie.buffer({{.+}})
+    %buf0 = aie.buffer(%tile_0_2) : memref<8xi16>
+    // CHECK: %[[BUF1:.+]] = aie.buffer({{.+}})
+    %buf1 = aie.buffer(%tile_0_2) : memref<8xi16>
+
+    aie.bd_chain @simple_chain(%arg0: memref<8xi16>, %arg1: memref<8xi16>) {
+            aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
+            aie.next_bd ^bd1
+        ^bd1:
+            aie.dma_bd(%arg1 : memref<8xi16>, 0, 8)
+            aie.end
+    }
+
+    aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
+      %t1 = aiex.dma_start_bd_chain @simple_chain(%buf1, %buf0) : (memref<8xi16>, memref<8xi16>)
+                                    on (%tile_0_2, MM2S, 0) 
+      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%tile_0_2, MM2S, 0) {
+      // CHECK:   aie.dma_bd(%[[BUF1]] : memref<8xi16>, 0, 8)
+      // CHECK:   aie.next_bd ^bb1
+      // CHECK: ^bb1:
+      // CHECK:   aie.dma_bd(%[[BUF0]] : memref<8xi16>, 0, 8)
+      // CHECK:   aie.end
+      // CHECK: }
+      // CHECK: aiex.dma_start_task(%[[task1]])
+      aiex.dma_await_task(%t1)
+    }
+  }
+}
+

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-5.mlir
@@ -1,0 +1,61 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 AMD Inc.
+
+// REQUIRES: ryzen_ai
+//
+// RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
+
+module {
+  aie.device(npu1_4col) {
+    %tile_0_0 = aie.tile(0, 0)
+
+    aie.shim_dma_allocation @alloc0 (MM2S, 0, 0)
+    aie.shim_dma_allocation @alloc1 (MM2S, 1, 2)
+
+    aie.bd_chain @simple_chain(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
+            aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size=1, stride=0>, <size=2, stride=2>, <size=2, stride=4>, <size=2, stride=1>])
+            aie.next_bd ^bd1
+        ^bd1:
+            aie.dma_bd(%arg1 : memref<12xi16>, 0, 12)
+            aie.next_bd ^bd2
+        ^bd2:
+            aie.dma_bd(%arg2 : memref<8xi16>, 0, 8)
+            aie.end
+    }
+
+    aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
+      %t1 = aiex.dma_start_bd_chain_for @simple_chain(%arg0, %arg1, %arg2) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
+                                        for @alloc0
+      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
+      // CHECK:   aie.next_bd ^bb1
+      // CHECK: ^bb1:
+      // CHECK:   aie.dma_bd(%arg1 : memref<12xi16>, 0, 12)
+      // CHECK:   aie.next_bd ^bb2
+      // CHECK: ^bb2:
+      // CHECK:   aie.dma_bd(%arg2 : memref<8xi16>, 0, 8)
+      // CHECK:   aie.end
+      // CHECK: }
+      // CHECK: aiex.dma_start_task(%[[task1]])
+      %t2 = aiex.dma_start_bd_chain_for @simple_chain(%arg2, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
+                                        for @alloc1
+      // CHECK: %[[task2:.+]] = aiex.dma_configure_task(%tile_2_0, MM2S, 1) {
+      // CHECK:   aie.dma_bd(%arg2 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
+      // CHECK:   aie.next_bd ^bb1
+      // CHECK: ^bb1:
+      // CHECK:   aie.dma_bd(%arg1 : memref<12xi16>, 0, 12)
+      // CHECK:   aie.next_bd ^bb2
+      // CHECK: ^bb2:
+      // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8)
+      // CHECK:   aie.end
+      // CHECK: }
+      // CHECK: aiex.dma_start_task(%[[task2]])
+      aiex.dma_await_task(%t1)
+    }
+  }
+}
+


### PR DESCRIPTION
This PR is part of a chain of changes that are independent but build on each other. GitHub shows the diff to `main`, so later PRs also contain the changes of previous PRs.

To see minimal diffs (compared to previous PR in chain), click the arrow links between the PRs below:

**#1698  [-->](https://github.com/andrej/mlir-aie/compare/bd-chain-tests..configure-task-allow-other-bufs)  #1689  [-->](https://github.com/andrej/mlir-aie/compare/configure-task-allow-other-bufs..shim-dma-alloc)  #1693 (this PR)**  [-->](https://github.com/andrej/mlir-aie/compare/shim-dma-alloc..py)  #1696  [-->](https://github.com/andrej/mlir-aie/compare/py..bd-py)  #1699