### PR TITLE
group packet flows with overlapped source or destination

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -49,6 +49,8 @@ using SwitchboxConnect = struct SwitchboxConnect {
   std::vector<std::vector<int>> usedCapacity;
   // how many packet streams are actually using this Channel
   std::vector<std::vector<int>> packetFlowCount;
+  // only sharing the channel with the same packet group id
+  std::vector<std::vector<int>> packetGroupId;
 
   // resize the matrices to the size of srcPorts and dstPorts
   void resize() {
@@ -60,6 +62,7 @@ using SwitchboxConnect = struct SwitchboxConnect {
     usedCapacity.resize(srcPorts.size(), std::vector<int>(dstPorts.size(), 0));
     packetFlowCount.resize(srcPorts.size(),
                            std::vector<int>(dstPorts.size(), 0));
+    packetGroupId.resize(srcPorts.size(), std::vector<int>(dstPorts.size(), 0));
   }
 
   // update demand at the beginning of each dijkstraShortestPaths iteration
@@ -114,7 +117,7 @@ using PathEndPoint = struct PathEndPoint {
 };
 
 using Flow = struct Flow {
-  bool isPacketFlow;
+  int packetGroupId;
   PathEndPoint src;
   std::vector<PathEndPoint> dsts;
 };

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -285,16 +285,42 @@ void Pathfinder::initialize(int maxCol, int maxRow,
 void Pathfinder::addFlow(TileID srcCoords, Port srcPort, TileID dstCoords,
                          Port dstPort, bool isPacketFlow) {
   // check if a flow with this source already exists
-  for (auto &[isPkt, src, dsts] : flows) {
+  for (auto &[_, src, dsts] : flows) {
     if (src.coords == srcCoords && src.port == srcPort) {
       dsts.emplace_back(PathEndPoint{dstCoords, dstPort});
       return;
     }
   }
 
+  // Assign a group ID for packet flows
+  // any overlapping in source/destination will lead to the same group ID
+  // channel sharing will happen within the same group ID
+  // for circuit flows, group ID is always -1, and no channel sharing
+  int packetGroupId = -1;
+  if (isPacketFlow) {
+    bool found = false;
+    for (auto &[existingId, src, dsts] : flows) {
+      if (src.coords == srcCoords && src.port == srcPort) {
+        packetGroupId = existingId;
+        found = true;
+        break;
+      }
+      for (auto &dst : dsts) {
+        if (dst.coords == dstCoords && dst.port == dstPort) {
+          packetGroupId = existingId;
+          found = true;
+          break;
+        }
+      }
+      packetGroupId = std::max(packetGroupId, existingId);
+    }
+    if (!found) {
+      packetGroupId++;
+    }
+  }
   // If no existing flow was found with this source, create a new flow.
   flows.push_back(
-      Flow{isPacketFlow, PathEndPoint{srcCoords, srcPort},
+      Flow{packetGroupId, PathEndPoint{srcCoords, srcPort},
            std::vector<PathEndPoint>{PathEndPoint{dstCoords, dstPort}}});
 }
 
@@ -437,6 +463,15 @@ Pathfinder::findPaths(const int maxIterations) {
     }
   }
 
+  // group flows based on packetGroupId
+  std::map<int, std::vector<Flow>> groupedFlows;
+  for (auto &f : flows) {
+    if (groupedFlows.count(f.packetGroupId) == 0) {
+      groupedFlows[f.packetGroupId] = std::vector<Flow>();
+    }
+    groupedFlows[f.packetGroupId].push_back(f);
+  }
+
   int iterationCount = -1;
   int illegalEdges = 0;
   int totalPathLength = 0;
@@ -466,77 +501,97 @@ Pathfinder::findPaths(const int maxIterations) {
         for (size_t j = 0; j < sb.dstPorts.size(); j++) {
           sb.usedCapacity[i][j] = 0;
           sb.packetFlowCount[i][j] = 0;
+          sb.packetGroupId[i][j] = -1;
         }
       }
     }
 
     // for each flow, find the shortest path from source to destination
     // update used_capacity for the path between them
-    for (const auto &[isPkt, src, dsts] : flows) {
-      // Use dijkstra to find path given current demand from the start
-      // switchbox; find the shortest paths to each other switchbox. Output is
-      // in the predecessor map, which must then be processed to get
-      // individual switchbox settings
-      std::set<PathEndPoint> processed;
-      std::map<PathEndPoint, PathEndPoint> preds = dijkstraShortestPaths(src);
 
-      // trace the path of the flow backwards via predecessors
-      // increment used_capacity for the associated channels
-      SwitchSettings switchSettings;
-      processed.insert(src);
-      for (auto endPoint : dsts) {
-        if (endPoint == src) {
-          // route to self
-          switchSettings[src.coords].srcs.push_back(src.port);
-          switchSettings[src.coords].dsts.push_back(src.port);
+    for (const auto &[_, flows] : groupedFlows) {
+      for (const auto &[packetGroupId, src, dsts] : flows) {
+        // Use dijkstra to find path given current demand from the start
+        // switchbox; find the shortest paths to each other switchbox. Output is
+        // in the predecessor map, which must then be processed to get
+        // individual switchbox settings
+        std::set<PathEndPoint> processed;
+        std::map<PathEndPoint, PathEndPoint> preds = dijkstraShortestPaths(src);
+
+        // trace the path of the flow backwards via predecessors
+        // increment used_capacity for the associated channels
+        SwitchSettings switchSettings;
+        processed.insert(src);
+        for (auto endPoint : dsts) {
+          if (endPoint == src) {
+            // route to self
+            switchSettings[src.coords].srcs.push_back(src.port);
+            switchSettings[src.coords].dsts.push_back(src.port);
+          }
+          auto curr = endPoint;
+          // trace backwards until a vertex already processed is reached
+          while (!processed.count(curr)) {
+            auto &sb = graph[std::make_pair(preds[curr].coords, curr.coords)];
+            size_t i =
+                std::distance(sb.srcPorts.begin(),
+                              std::find(sb.srcPorts.begin(), sb.srcPorts.end(),
+                                        preds[curr].port));
+            size_t j = std::distance(
+                sb.dstPorts.begin(),
+                std::find(sb.dstPorts.begin(), sb.dstPorts.end(), curr.port));
+            assert(i < sb.srcPorts.size());
+            assert(j < sb.dstPorts.size());
+            if (packetGroupId >= 0 &&
+                (sb.packetGroupId[i][j] == -1 ||
+                 sb.packetGroupId[i][j] == packetGroupId)) {
+              for (size_t k = 0; k < sb.srcPorts.size(); k++) {
+                for (size_t l = 0; l < sb.dstPorts.size(); l++) {
+                  if (k == i || l == j) {
+                    sb.packetGroupId[k][l] = packetGroupId;
+                  }
+                }
+              }
+              sb.packetFlowCount[i][j]++;
+              // maximum packet stream sharing per channel
+              if (sb.packetFlowCount[i][j] >= MAX_PACKET_STREAM_CAPACITY) {
+                sb.packetFlowCount[i][j] = 0;
+                sb.usedCapacity[i][j]++;
+              }
+            } else {
+              sb.usedCapacity[i][j]++;
+            }
+            // if at capacity, bump demand to discourage using this Channel
+            // this means the order matters!
+            sb.bumpDemand(i, j);
+            if (preds[curr].coords == curr.coords) {
+              switchSettings[preds[curr].coords].srcs.push_back(
+                  preds[curr].port);
+              switchSettings[curr.coords].dsts.push_back(curr.port);
+            }
+            processed.insert(curr);
+            curr = preds[curr];
+          }
         }
-        auto curr = endPoint;
-        // trace backwards until a vertex already processed is reached
-        while (!processed.count(curr)) {
-          auto &sb = graph[std::make_pair(preds[curr].coords, curr.coords)];
-          size_t i =
-              std::distance(sb.srcPorts.begin(),
-                            std::find(sb.srcPorts.begin(), sb.srcPorts.end(),
-                                      preds[curr].port));
-          size_t j = std::distance(
-              sb.dstPorts.begin(),
-              std::find(sb.dstPorts.begin(), sb.dstPorts.end(), curr.port));
-          assert(i < sb.srcPorts.size());
-          assert(j < sb.dstPorts.size());
-          if (isPkt) {
-            sb.packetFlowCount[i][j]++;
-            // maximum packet stream per channel
-            if (sb.packetFlowCount[i][j] >= MAX_PACKET_STREAM_CAPACITY) {
+        // add this flow to the proposed solution
+        routingSolution[src] = switchSettings;
+      }
+      for (auto &[_, sb] : graph) {
+        for (size_t i = 0; i < sb.srcPorts.size(); i++) {
+          for (size_t j = 0; j < sb.dstPorts.size(); j++) {
+            // fix used capacity for packet flows
+            if (sb.packetFlowCount[i][j] > 0) {
               sb.packetFlowCount[i][j] = 0;
               sb.usedCapacity[i][j]++;
             }
-          } else {
-            sb.packetFlowCount[i][j] = 0;
-            sb.usedCapacity[i][j]++;
+            sb.bumpDemand(i, j);
           }
-          // if at capacity, bump demand to discourage using this Channel
-          // this means the order matters!
-          sb.bumpDemand(i, j);
-          if (preds[curr].coords == curr.coords) {
-            switchSettings[preds[curr].coords].srcs.push_back(preds[curr].port);
-            switchSettings[curr.coords].dsts.push_back(curr.port);
-          }
-          processed.insert(curr);
-          curr = preds[curr];
         }
       }
-      // add this flow to the proposed solution
-      routingSolution[src] = switchSettings;
     }
 
     for (auto &[_, sb] : graph) {
       for (size_t i = 0; i < sb.srcPorts.size(); i++) {
         for (size_t j = 0; j < sb.dstPorts.size(); j++) {
-          // fix used capacity for packet flows
-          if (sb.packetFlowCount[i][j] > 0) {
-            sb.packetFlowCount[i][j] = 0;
-            sb.usedCapacity[i][j]++;
-          }
           // check that every channel does not exceed max capacity
           if (sb.usedCapacity[i][j] > MAX_CIRCUIT_STREAM_CAPACITY) {
             sb.overCapacity[i][j]++;

--- a/test/create-packet-flows/test_congestion0.mlir
+++ b/test/create-packet-flows/test_congestion0.mlir
@@ -10,8 +10,6 @@
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
-// XFAIL: *
-
 // CHECK1:    %[[VAL_0:.*]] = aie.tile(0, 1)
 // CHECK1:    %[[VAL_1:.*]] = aie.tile(0, 2)
 // CHECK1:    %[[VAL_2:.*]] = aie.tile(0, 3)
@@ -22,7 +20,7 @@
 // CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 0>
 // CHECK1:    }
 // CHECK1:    aie.packet_flow(4) {
-// CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 1>
+// CHECK1:      aie.packet_source<%[[VAL_1:.*]], DMA : 0>
 // CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 4>
 // CHECK1:    }
 // CHECK1:    aie.packet_flow(1) {
@@ -38,7 +36,7 @@
 // CHECK1:      aie.packet_dest<%[[VAL_0:.*]], DMA : 3>
 // CHECK1:    }
 
-// CHECK2: "total_path_length": 8
+// CHECK2: "total_path_length": 10
 
 module {
  aie.device(npu1_1col) {
@@ -65,7 +63,7 @@ module {
     aie.packet_dest<%tile_0_1, DMA : 3>
   }
   aie.packet_flow(4) { 
-    aie.packet_source<%tile_0_2, DMA : 1> 
+    aie.packet_source<%tile_0_2, DMA : 0> 
     aie.packet_dest<%tile_0_1, DMA : 4>
   }
  }

--- a/test/create-packet-flows/test_congestion0.mlir
+++ b/test/create-packet-flows/test_congestion0.mlir
@@ -10,6 +10,8 @@
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt
 // RUN: aie-translate --aie-flows-to-json %t.opt | FileCheck %s --check-prefix=CHECK2
 
+// XFAIL: *
+
 // CHECK1:    %[[VAL_0:.*]] = aie.tile(0, 1)
 // CHECK1:    %[[VAL_1:.*]] = aie.tile(0, 2)
 // CHECK1:    %[[VAL_2:.*]] = aie.tile(0, 3)

--- a/test/create-packet-flows/test_congestion1.mlir
+++ b/test/create-packet-flows/test_congestion1.mlir
@@ -17,17 +17,17 @@
 // CHECK1:    %[[TILE_0_4:.*]] = aie.tile(0, 4)
 // CHECK1:    %[[TILE_0_5:.*]] = aie.tile(0, 5)
 // CHECK1:    %[[TILE_1_0:.*]] = aie.tile(1, 0)
+// CHECK1:    aie.packet_flow(0) {
+// CHECK1:      aie.packet_source<%[[TILE_0_5]], DMA : 1>
+// CHECK1:      aie.packet_dest<%[[TILE_0_1]], DMA : 4>
+// CHECK1:    }
 // CHECK1:    aie.flow(%[[TILE_0_1]], DMA : 0, %[[TILE_0_0]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_2]], DMA : 0, %[[TILE_0_1]], DMA : 0)
 // CHECK1:    aie.flow(%[[TILE_0_3]], DMA : 0, %[[TILE_0_1]], DMA : 1)
 // CHECK1:    aie.flow(%[[TILE_0_4]], DMA : 0, %[[TILE_0_1]], DMA : 2)
 // CHECK1:    aie.flow(%[[TILE_0_5]], DMA : 0, %[[TILE_0_1]], DMA : 3)
-// CHECK1:    aie.packet_flow(0) {
-// CHECK1:      aie.packet_source<%[[TILE_0_5]], DMA : 1>
-// CHECK1:      aie.packet_dest<%[[TILE_0_1]], DMA : 4>
-// CHECK1:    }
 
-// CHECK2: "total_path_length": 23
+// CHECK2: "total_path_length": 22
 
 module {
  aie.device(npu1_2col) {


### PR DESCRIPTION
Before doing the routing, the Pathfinder will now assign `group_id` to packet-switched flows. Flows with any overlapping source/destination ports will be assigned with the same id. Only flows with the same group_id can share channels, which is to prevent deadlocks during arbitration. No impact on circuit-switched flows.