### PR TITLE
Minor cleanup of 'keep_pkt_header' attribute

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -498,7 +498,8 @@ def AIE_MasterSetOp: AIE_Op<"masterset", [
   let arguments = (
     ins WireBundle:$dest_bundle,
         ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$dest_channel,
-        Variadic<Index>:$amsels
+        Variadic<Index>:$amsels,
+        OptionalAttr<BoolAttr>:$keep_pkt_header
   );
   let summary = "Packet switched input connection";
   let description = [{

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -317,8 +317,8 @@ void AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder) {
         destCoords = {destTile.colIndex(), destTile.rowIndex()};
         // Assign "keep_pkt_header flag"
         auto keep = pktFlowOp.getKeepPktHeader();
-        keepPktHeaderAttr[{destTile, destPort}] = keep ?
-            BoolAttr::get(Op.getContext(), *keep) : nullptr;
+        keepPktHeaderAttr[{destTile, destPort}] =
+            keep ? BoolAttr::get(Op.getContext(), *keep) : nullptr;
 
         TileID srcSB = {srcCoords.col, srcCoords.row};
         if (PathEndPoint srcPoint = {srcSB, srcPort};
@@ -707,9 +707,9 @@ void AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder) {
         amsels.push_back(amselOps[msel]);
       }
 
-      builder.create<MasterSetOp>(builder.getUnknownLoc(),
-                                  builder.getIndexType(), bundle,
-                                  channel, amsels, keepPktHeaderAttr[{tileOp, tileMaster}]);
+      builder.create<MasterSetOp>(
+          builder.getUnknownLoc(), builder.getIndexType(), bundle, channel,
+          amsels, keepPktHeaderAttr[{tileOp, tileMaster}]);
     }
 
     // Generate the packet rules

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -288,7 +288,7 @@ void AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder) {
   SmallVector<std::pair<PhysPort, int>, 4> slavePorts;
   DenseMap<std::pair<PhysPort, int>, int> slaveAMSels;
   // Map from a port to
-  DenseMap<PhysPort, Attribute> keepPktHeaderAttr;
+  DenseMap<PhysPort, BoolAttr> keepPktHeaderAttr;
 
   for (auto tileOp : device.getOps<TileOp>()) {
     int col = tileOp.colIndex();
@@ -316,9 +316,10 @@ void AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder) {
         destPort = pktDest.port();
         destCoords = {destTile.colIndex(), destTile.rowIndex()};
         // Assign "keep_pkt_header flag"
-        if (pktFlowOp->hasAttr("keep_pkt_header"))
-          keepPktHeaderAttr[{destTile, destPort}] =
-              StringAttr::get(Op.getContext(), "true");
+        auto keep = pktFlowOp.getKeepPktHeader();
+        keepPktHeaderAttr[{destTile, destPort}] = keep ?
+            BoolAttr::get(Op.getContext(), *keep) : nullptr;
+
         TileID srcSB = {srcCoords.col, srcCoords.row};
         if (PathEndPoint srcPoint = {srcSB, srcPort};
             !analyzer.processedFlows[srcPoint]) {
@@ -706,11 +707,9 @@ void AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder) {
         amsels.push_back(amselOps[msel]);
       }
 
-      auto msOp = builder.create<MasterSetOp>(builder.getUnknownLoc(),
-                                              builder.getIndexType(), bundle,
-                                              channel, amsels);
-      if (auto pktFlowAttrs = keepPktHeaderAttr[{tileOp, tileMaster}])
-        msOp->setAttr("keep_pkt_header", pktFlowAttrs);
+      builder.create<MasterSetOp>(builder.getUnknownLoc(),
+                                  builder.getIndexType(), bundle,
+                                  channel, amsels, keepPktHeaderAttr[{tileOp, tileMaster}]);
     }
 
     // Generate the packet rules

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -626,52 +626,62 @@ struct AIEControl {
             WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getDestBundle()),
             connectOp.destIndex());
 
-      for (auto connectOp : b.getOps<MasterSetOp>()) {
+      for (auto masterSetOp : b.getOps<MasterSetOp>()) {
         int mask = 0;
         int arbiter = -1;
 
-        for (auto val : connectOp.getAmsels()) {
+        for (auto val : masterSetOp.getAmsels()) {
           AMSelOp amsel = cast<AMSelOp>(val.getDefiningOp());
           arbiter = amsel.arbiterIndex();
           int msel = amsel.getMselValue();
           mask |= (1 << msel);
         }
 
-        bool isdma = connectOp.getDestBundle() == WireBundle::DMA;
+        // the default is to keep header
+        bool keepHeader = true;
+        // the default for dma destinations is to drop the header
+        if (masterSetOp.getDestBundle() == WireBundle::DMA)
+          keepHeader = false;
         // assume a connection going south from row zero gets wired to shimdma
         // by a shimmux. But if it's south 0 assume it's tct routing and don't
         // drop header. TODO: fix the assumption
-        if (!isdma && (switchboxOp.rowIndex() == 0))
-          isdma = (connectOp.getDestBundle() == WireBundle::South) &&
-                  (connectOp.destIndex() != 0);
-        // Flag for overriding DROP_HEADER. TODO: Formalize this in tablegen
-        isdma &= !connectOp->hasAttr("keep_pkt_header");
-        auto dropHeader =
-            isdma ? XAIE_SS_PKT_DROP_HEADER : XAIE_SS_PKT_DONOT_DROP_HEADER;
+        if (switchboxOp.rowIndex() == 0 &&
+            masterSetOp.getDestBundle() == WireBundle::South &&
+            masterSetOp.destIndex() != 0)
+          keepHeader = false;
+
+        // "keep_pkt_header" attribute overrides the above defaults, if set
+        if (auto keep = masterSetOp.getKeepPktHeader())
+          keepHeader = *keep;
+
+        auto dropHeader = keepHeader ? XAIE_SS_PKT_DONOT_DROP_HEADER
+                                     : XAIE_SS_PKT_DROP_HEADER;
         TRY_XAIE_API_EMIT_ERROR(
-            connectOp, XAie_StrmPktSwMstrPortEnable, &devInst, tileLoc,
-            WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getDestBundle()),
-            connectOp.destIndex(), dropHeader, arbiter, mask);
+            masterSetOp, XAie_StrmPktSwMstrPortEnable, &devInst, tileLoc,
+            WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(masterSetOp.getDestBundle()),
+            masterSetOp.destIndex(), dropHeader, arbiter, mask);
       }
 
-      for (auto connectOp : b.getOps<PacketRulesOp>()) {
+      for (auto packetRulesOp : b.getOps<PacketRulesOp>()) {
         int slot = 0;
-        Block &block = connectOp.getRules().front();
+        Block &block = packetRulesOp.getRules().front();
         for (auto slotOp : block.getOps<PacketRuleOp>()) {
           AMSelOp amselOp = cast<AMSelOp>(slotOp.getAmsel().getDefiningOp());
           int arbiter = amselOp.arbiterIndex();
           int msel = amselOp.getMselValue();
-          TRY_XAIE_API_EMIT_ERROR(
-              connectOp, XAie_StrmPktSwSlavePortEnable, &devInst, tileLoc,
-              WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getSourceBundle()),
-              connectOp.sourceIndex());
+          TRY_XAIE_API_EMIT_ERROR(packetRulesOp, XAie_StrmPktSwSlavePortEnable,
+                                  &devInst, tileLoc,
+                                  WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(
+                                      packetRulesOp.getSourceBundle()),
+                                  packetRulesOp.sourceIndex());
           auto packetInit = XAie_PacketInit(slotOp.valueInt(), /*PktType*/ 0);
           // TODO Need to better define packet id,type used here
-          TRY_XAIE_API_EMIT_ERROR(
-              connectOp, XAie_StrmPktSwSlaveSlotEnable, &devInst, tileLoc,
-              WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getSourceBundle()),
-              connectOp.sourceIndex(), slot, packetInit, slotOp.maskInt(), msel,
-              arbiter);
+          TRY_XAIE_API_EMIT_ERROR(packetRulesOp, XAie_StrmPktSwSlaveSlotEnable,
+                                  &devInst, tileLoc,
+                                  WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(
+                                      packetRulesOp.getSourceBundle()),
+                                  packetRulesOp.sourceIndex(), slot, packetInit,
+                                  slotOp.maskInt(), msel, arbiter);
           slot++;
         }
       }


### PR DESCRIPTION
Minor cleanup of the `keep_pkt_header` attribute. The default behavior should be the same.

* Make the `keep_pkt_header` attr a formal part of the tablegen definition for `aie.masterset` ops
* Use the auto-generated getKeepPktHeader API instead of looking up attribute 
* Make the attribute a true override*. Previously it was interpreted as true whenever present, no matter what it was set to, and not always respected. Now it will override any default.

\* in the AIETargetCODirect backend only, it doesn't seem to be mentioned in the airbin or xaie targets.