### PR TITLE
Improvements to new `aiex.dma_configure_task` and `aiex.dma_free_task`

### DIFF
--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -555,6 +555,13 @@ std::optional<uint32_t> AIEX::DMAConfigureTaskOp::getFirstBdId() {
     return std::nullopt;
   }
   auto bd_ops = body.front().getOps<AIE::DMABDOp>();
+  if (bd_ops.empty() && body.front().getNumSuccessors() == 1) {
+    // Allow the first block to be empty and point to the entry point of the
+    // chain. This allows for specifying cyclying BD chains (infinite loops)
+    // within the constraints of MLIR syntax.
+    Block &chain_entry = *body.front().getSuccessor(0);
+    bd_ops = chain_entry.getOps<AIE::DMABDOp>();
+  }
   if (bd_ops.empty()) {
     return std::nullopt;
   }

--- a/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
@@ -113,8 +113,10 @@ struct AIEAssignRuntimeSequenceBDIDsPass
             bd_op.emitOpError("Free called on BD chain with unassigned IDs.");
             return WalkResult::interrupt();
           }
-          assert(gen.bdIdAlreadyAssigned(bd_op.getBdId().value()) &&
-                 "MLIR state and BdIDGenerator state out of sync.");
+          if (!gen.bdIdAlreadyAssigned(bd_op.getBdId().value())) {
+            // Ignore double-frees.
+            return WalkResult::advance();
+          }
           gen.freeBdId(bd_op.getBdId().value());
           return WalkResult::advance();
         });

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-9.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-9.mlir
@@ -9,7 +9,7 @@
 //
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
-// This test ensures the proper error is emitted if a task with no BDs are issued in the runtime sequence.
+// This test ensures the proper error is emitted if a task with no BDs is issued in the runtime sequence.
 
 module {
   aie.device(npu1_4col) {
@@ -19,6 +19,9 @@ module {
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       // expected-note@+1 {{Error encountered}}
       %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        ^bb0:
+          aie.next_bd ^bb1
+        ^bb1:
           // expected-error@+1 {{Block ending in this terminator does not contain a required}}
           aie.end
       }


### PR DESCRIPTION
After using the new syntax on some GEMM examples, I found these changes useful:

- Stop compiler from compiling about redundant `aiex.dma_free_task` ops. Those errors were too strict for productive use.
- Allow empty BD chain entry blocks to facilitate defining cycles of BDs:

```
aiex.dma_configure_task {
  ^bd0:
      aie.next_bd ^bd1
  ^bd1:
      aie.dma_bd ...
      aie.next_bd ^bd1   // note the cycle
}
```

An empty entry block is necessary because MLIR does not allow the entry block of a region to have predecessors.