### PR TITLE
Add control packet op and control packet to binary translation

### DIFF
--- a/include/aie-c/Translation.h
+++ b/include/aie-c/Translation.h
@@ -19,6 +19,7 @@ MLIR_CAPI_EXPORTED MlirStringRef aieTranslateAIEVecToCpp(MlirOperation op,
                                                          bool aie2);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateModuleToLLVMIR(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToNPU(MlirOperation op);
+MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToControlPackets(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToXAIEV2(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToHSA(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToBCF(MlirOperation op, int col,

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -791,6 +791,23 @@ def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", []> {
   }];
 }
 
+def AIE_NpuControlPacketOp: AIEX_Op<"control_packet", []> {
+  let summary = "AIE control packet";
+  let arguments = (
+    ins UI32Attr:$address,
+        OptionalAttr<I32Attr>:$length,
+        I32Attr:$opcode,
+        I32Attr:$stream_id,
+        OptionalAttr<DenseI32ArrayAttr>:$data
+  );
+  let results = (outs );
+  let assemblyFormat = [{ attr-dict }];
+  let description = [{
+    The control_packet operation represents a low-level AIE control packet header
+    and payload.
+  }];
+}
+
 // NPU Bd Write operation
 def AIE_NpuWriteBdOp: AIEX_Op<"npu.writebd", []> {
   let summary = "dma operator";

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -33,7 +33,11 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
                                          llvm::raw_ostream &);
 mlir::LogicalResult AIETranslateToNPU(mlir::ModuleOp module,
                                       llvm::raw_ostream &output);
-std::vector<uint32_t> AIETranslateToNPU(mlir::ModuleOp);
+mlir::LogicalResult AIETranslateToNPU(mlir::ModuleOp, std::vector<uint32_t> &);
+mlir::LogicalResult AIETranslateToControlPackets(mlir::ModuleOp module,
+                                                 llvm::raw_ostream &output);
+mlir::LogicalResult AIETranslateToControlPackets(mlir::ModuleOp,
+                                                 std::vector<uint32_t> &);
 mlir::LogicalResult AIETranslateToLdScript(mlir::ModuleOp module,
                                            llvm::raw_ostream &output,
                                            int tileCol, int tileRow);

--- a/lib/CAPI/Translation.cpp
+++ b/lib/CAPI/Translation.cpp
@@ -109,6 +109,17 @@ MlirStringRef aieTranslateToNPU(MlirOperation moduleOp) {
   return mlirStringRefCreate(cStr, npu.size());
 }
 
+MlirStringRef aieTranslateToControlPackets(MlirOperation moduleOp) {
+  std::string npu;
+  llvm::raw_string_ostream os(npu);
+  ModuleOp mod = llvm::cast<ModuleOp>(unwrap(moduleOp));
+  if (failed(AIETranslateToControlPackets(mod, os)))
+    return mlirStringRefCreate(nullptr, 0);
+  char *cStr = static_cast<char *>(malloc(npu.size()));
+  npu.copy(cStr, npu.size());
+  return mlirStringRefCreate(cStr, npu.size());
+}
+
 MlirStringRef aieTranslateToXAIEV2(MlirOperation moduleOp) {
   std::string xaie;
   llvm::raw_string_ostream os(xaie);

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -92,8 +92,9 @@ void writeBufferMap(raw_ostream &output, BufferOp buf, int offset) {
   std::string bufName(buf.name().getValue());
   int bufferBaseAddr = getBufferBaseAddress(buf);
   int numBytes = buf.getAllocationSize();
-  output << "_symbol " << bufName << " " << "0x"
-         << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes << '\n';
+  output << "_symbol " << bufName << " "
+         << "0x" << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes
+         << '\n';
 }
 
 LogicalResult AIETranslateToTargetArch(ModuleOp module, raw_ostream &output) {

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -143,6 +143,18 @@ PYBIND11_MODULE(_aie, m) {
       "module"_a);
 
   m.def(
+      "generate_control_packets",
+      [&stealCStr](MlirOperation op) {
+        py::str ctrlPackets = stealCStr(aieTranslateToControlPackets(op));
+        auto individualInstructions =
+            ctrlPackets.attr("split")().cast<py::list>();
+        for (size_t i = 0; i < individualInstructions.size(); ++i)
+          individualInstructions[i] = individualInstructions[i].attr("strip")();
+        return individualInstructions;
+      },
+      "module"_a);
+
+  m.def(
       "generate_xaie",
       [&stealCStr](MlirOperation op) {
         return stealCStr(aieTranslateToXAIEV2(op));

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -24,6 +24,7 @@ from .._mlir_libs._aie import (
     generate_cdo,
     generate_txn,
     generate_xaie,
+    generate_control_packets,
     npu_instgen,
     register_dialect,
     translate_aie_vec_to_cpp,

--- a/test/Targets/AIETargetCDODirect/control_packets.mlir
+++ b/test/Targets/AIETargetCDODirect/control_packets.mlir
@@ -1,0 +1,29 @@
+//===- control_packets.mlir ------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-translate --aie-ctrlpkt-to-bin %s |& FileCheck %s
+
+// CHECK: 0001F000
+// CHECK: 00000002
+// CHECK: 09B1F020
+// CHECK: 00000003
+// CHECK: 00000004
+// CHECK: 00000005
+// CHECK: 00000006
+// CHECK: 02700400
+module {
+  aie.device(npu1) {
+    aiex.runtime_sequence() {
+      aiex.control_packet {address = 126976 : ui32, data = array<i32: 2>, opcode = 0 : i32, stream_id = 0 : i32}
+      aiex.control_packet {address = 127008 : ui32, data = array<i32: 3, 4, 5, 6>, opcode = 2 : i32, stream_id = 9 : i32}
+      aiex.control_packet {address = 1024 : ui32, length = 4 : i32, opcode = 1 : i32, stream_id = 2 : i32}
+    }
+  }
+}

--- a/test/dialect/AIEX/roundtrip.mlir
+++ b/test/dialect/AIEX/roundtrip.mlir
@@ -50,3 +50,17 @@ aie.device(npu1_4col) {
     aiex.npu.write32 {address = 432 : ui32, value = 1 : ui32}
   }
 }
+
+// -----
+
+// CHECK: aie.device
+// CHECK: aiex.control_packet {address = 1234 : ui32, data = array<i32: 1>, opcode = 0 : i32, stream_id = 1 : i32}
+// CHECK: aiex.control_packet {address = 5678 : ui32, data = array<i32: 22, 42, 62, 72>, opcode = 2 : i32, stream_id = 7 : i32}
+// CHECK: aiex.control_packet {address = 43981 : ui32, length = 3 : i32, opcode = 1 : i32, stream_id = 4 : i32}
+aie.device(npu1) {
+  aiex.runtime_sequence() {
+    aiex.control_packet {address = 1234 : ui32, data = array<i32: 1>, opcode = 0 : i32, stream_id = 1 : i32}
+    aiex.control_packet {address = 5678 : ui32, data = array<i32: 22, 42, 62, 72>, opcode = 2 : i32, stream_id = 7 : i32}
+    aiex.control_packet {address = 0xABCD : ui32, length = 3 : i32, opcode = 1 : i32, stream_id = 4 : i32}
+  }
+}

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -7,6 +7,6 @@
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.txt %S/aie1.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-txn --aie-generate-npu --no-compile-host --npu-insts-name=add_two_insts.txt %S/aie2.mlir
 // RUN: %python txn2mlir.py aie2.mlir.prj/txn.bin > add_two_cfg.mlir
-// RUN: aie-translate -aie-npu-instgen -aie-npu-instgen-binary=true add_two_cfg.mlir -o add_two_cfg.bin
+// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true add_two_cfg.mlir -o add_two_cfg.bin
 // RUN: %run_on_npu ./test.exe -x add_one.xclbin -i add_one_insts.txt -c add_two_cfg.bin -j add_two_insts.txt | FileCheck %s
 // CHECK: PASS!

--- a/test/python/control_packets.py
+++ b/test/python/control_packets.py
@@ -1,0 +1,41 @@
+
+# test.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+# RUN: python %s | FileCheck %s
+
+from aie.dialects.aie import *
+import aie.dialects.aiex as aiex
+from aie.extras.context import mlir_mod_ctx
+
+from aie.dialects.aie import generate_control_packets
+
+def gen_cp_sequence():
+    with mlir_mod_ctx() as ctx:
+        @device(AIEDevice.npu1)
+        def device_body():
+            params = []
+            @aiex.runtime_sequence(*params)
+            def sequence(*args):
+                # CHECK: 0001F000
+                # CHECK: 00000002
+                aiex.control_packet(address = 0x0001F000, opcode = 0, stream_id = 0, data = [2])
+                # CHECK: 09B1F020
+                # CHECK: 00000003
+                # CHECK: 00000004
+                # CHECK: 00000005
+                # CHECK: 00000006
+                aiex.control_packet(address = 0x0001F020, opcode = 2, stream_id = 9, data = [3, 4, 5, 6])
+                # CHECK: 02700400
+                aiex.control_packet(address = 0x00000400, opcode = 1, stream_id = 2, length = 4)
+        return ctx.module
+
+aie_module = gen_cp_sequence()
+print(aie_module)
+for i in generate_control_packets(aie_module.operation):
+    print(i)

--- a/test/python/control_packets.py
+++ b/test/python/control_packets.py
@@ -1,4 +1,3 @@
-
 # test.py -*- Python -*-
 #
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
@@ -15,25 +14,32 @@ from aie.extras.context import mlir_mod_ctx
 
 from aie.dialects.aie import generate_control_packets
 
+
 def gen_cp_sequence():
     with mlir_mod_ctx() as ctx:
+
         @device(AIEDevice.npu1)
         def device_body():
             params = []
+
             @aiex.runtime_sequence(*params)
             def sequence(*args):
                 # CHECK: 0001F000
                 # CHECK: 00000002
-                aiex.control_packet(address = 0x0001F000, opcode = 0, stream_id = 0, data = [2])
+                aiex.control_packet(address=0x0001F000, opcode=0, stream_id=0, data=[2])
                 # CHECK: 09B1F020
                 # CHECK: 00000003
                 # CHECK: 00000004
                 # CHECK: 00000005
                 # CHECK: 00000006
-                aiex.control_packet(address = 0x0001F020, opcode = 2, stream_id = 9, data = [3, 4, 5, 6])
+                aiex.control_packet(
+                    address=0x0001F020, opcode=2, stream_id=9, data=[3, 4, 5, 6]
+                )
                 # CHECK: 02700400
-                aiex.control_packet(address = 0x00000400, opcode = 1, stream_id = 2, length = 4)
+                aiex.control_packet(address=0x00000400, opcode=1, stream_id=2, length=4)
+
         return ctx.module
+
 
 aie_module = gen_cp_sequence()
 print(aie_module)

--- a/test/txn2mlir/roundtrip_npu1_1col.mlir
+++ b/test/txn2mlir/roundtrip_npu1_1col.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate -aie-npu-instgen -aie-npu-instgen-binary=true %s | %python txn2mlir.py | FileCheck %s
+// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true %s | %python txn2mlir.py | FileCheck %s
 
 // CHECK: aie.device(npu1_1col)
 // CHECK: memref.global "private" constant @blockwrite_data : memref<2xi32> = dense<[4195328, 0]>

--- a/test/txn2mlir/roundtrip_npu1_4col.mlir
+++ b/test/txn2mlir/roundtrip_npu1_4col.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate -aie-npu-instgen -aie-npu-instgen-binary=true %s | %python txn2mlir.py | FileCheck %s
+// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true %s | %python txn2mlir.py | FileCheck %s
 
 // CHECK: aie.device(npu1_4col)
 // CHECK: aiex.npu.maskwrite32 {address = 2301952 : ui32, mask = 1 : ui32, value = 1 : ui32}


### PR DESCRIPTION
* add `aiex.control_packet` op to represent AIE control packets
* add `aie-translate --aie-ctrlpkt-to-bin` and corresponding `generate_control_packets` python method to lower control packet operations to binary
* rename `aie-translate` `--aie-npu-instgen-binary` option to `--aie-output-binary` to make it more generic. Can be used with `aie-ctrlpkt-to-bin` or `aie-npu-instgen`
