### PR TITLE
Add new unit tests showing control packet configuring 4 cores in a column

### DIFF
--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -152,6 +152,13 @@ def parse_args(args=None):
         help="Use basic memory allocation scheme for AIE buffer address assignment",
     )
     parser.add_argument(
+        "--generate-ctrl-pkt-overlay",
+        dest="ctrl_pkt_overlay",
+        default=False,
+        action="store_true",
+        help="Generate column-wise overlay of control packet routings",
+    )
+    parser.add_argument(
         "--aie-generate-airbin",
         dest="airbin",
         default=False,

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -36,25 +36,30 @@ from aie.dialects import aie as aiedialect
 from aie.ir import Context, Location, Module
 from aie.passmanager import PassManager
 
-INPUT_WITH_ADDRESSES_PIPELINE = lambda basic_alloc_scheme=False: (
-    Pipeline()
-    .lower_affine()
-    .add_pass("aie-canonicalize-device")
-    .Nested(
-        "aie.device",
+INPUT_WITH_ADDRESSES_PIPELINE = (
+    lambda basic_alloc_scheme=False, ctrl_pkt_overlay=False: (
         Pipeline()
-        .add_pass("aie-assign-lock-ids")
-        .add_pass("aie-register-objectFifos")
-        .add_pass("aie-objectFifo-stateful-transform")
-        .add_pass("aie-assign-bd-ids")
-        .add_pass("aie-lower-cascade-flows")
-        .add_pass("aie-lower-broadcast-packet")
-        .add_pass("aie-lower-multicast")
-        .add_pass("aie-assign-tile-controller-ids")
-        .add_pass("aie-generate-column-control-overlay")
-        .add_pass("aie-assign-buffer-addresses", basic_alloc=basic_alloc_scheme),
+        .lower_affine()
+        .add_pass("aie-canonicalize-device")
+        .Nested(
+            "aie.device",
+            Pipeline()
+            .add_pass("aie-assign-lock-ids")
+            .add_pass("aie-register-objectFifos")
+            .add_pass("aie-objectFifo-stateful-transform")
+            .add_pass("aie-assign-bd-ids")
+            .add_pass("aie-lower-cascade-flows")
+            .add_pass("aie-lower-broadcast-packet")
+            .add_pass("aie-lower-multicast")
+            .add_pass("aie-assign-tile-controller-ids")
+            .add_pass(
+                "aie-generate-column-control-overlay",
+                route_shim_to_tile_ctrl=ctrl_pkt_overlay,
+            )
+            .add_pass("aie-assign-buffer-addresses", basic_alloc=basic_alloc_scheme),
+        )
+        .convert_scf_to_cf()
     )
-    .convert_scf_to_cf()
 )
 
 LOWER_TO_LLVM_PIPELINE = (
@@ -1009,12 +1014,9 @@ class FlowRunner:
             )
 
             file_with_addresses = self.prepend_tmp("input_with_addresses.mlir")
-            if opts.basic_alloc_scheme:
-                pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE(True).materialize(
-                    module=True
-                )
-            else:
-                pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE().materialize(module=True)
+            pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE(
+                opts.basic_alloc_scheme, opts.ctrl_pkt_overlay
+            ).materialize(module=True)
             run_passes(
                 pass_pipeline,
                 self.mlir_module_str,

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/aie.mlir
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/aie.mlir
@@ -1,0 +1,388 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu1_4col) {
+    memref.global "public" @ctrlin0 : memref<8xi32>
+    memref.global "public" @ctrlin1 : memref<8xi32>
+    memref.global "public" @out0 : memref<8xi32>
+    memref.global "public" @out1 : memref<8xi32>
+    memref.global "public" @out2 : memref<8xi32>
+    memref.global "public" @out3 : memref<8xi32>
+    memref.global "public" @ctrl0 : memref<8xi32>
+
+    %tile_0_0 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
+    %tile_1_0 = aie.tile(1, 0)
+    %tile_2_0 = aie.tile(2, 0)
+    %tile_0_2 = aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
+    %tile_0_3 = aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
+    %tile_0_4 = aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 7>}
+    %tile_0_5 = aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 8>}
+
+    %input_0_2_lock0 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "input_0_2_lock0"}
+    %input_0_2_lock2 = aie.lock(%tile_0_2, 2) {init = 0 : i32, sym_name = "input_0_2_lock2"}
+    %output_0_2_lock4 = aie.lock(%tile_0_2, 4) {init = 0 : i32, sym_name = "output_0_2_lock4"}
+    %output_0_2_lock5 = aie.lock(%tile_0_2, 5) {init = 1 : i32, sym_name = "output_0_2_lock5"}
+
+    %input_0_2_buffer = aie.buffer(%tile_0_2) {sym_name = "input_0_2_buffer"} : memref<8xi32>
+    %output_0_2_buffer = aie.buffer(%tile_0_2) {sym_name = "output_0_2_buffer"} : memref<8xi32>
+
+    %input_0_3_lock0 = aie.lock(%tile_0_3, 0) {init = 0 : i32, sym_name = "input_0_3_lock0"}
+    %input_0_3_lock2 = aie.lock(%tile_0_3, 2) {init = 0 : i32, sym_name = "input_0_3_lock2"}
+    %output_0_3_lock4 = aie.lock(%tile_0_3, 4) {init = 0 : i32, sym_name = "output_0_3_lock4"}
+    %output_0_3_lock5 = aie.lock(%tile_0_3, 5) {init = 1 : i32, sym_name = "output_0_3_lock5"}
+
+    %input_0_3_buffer = aie.buffer(%tile_0_3) {sym_name = "input_0_3_buffer"} : memref<8xi32>
+    %output_0_3_buffer = aie.buffer(%tile_0_3) {sym_name = "output_0_3_buffer"} : memref<8xi32>
+
+    %input_0_4_lock0 = aie.lock(%tile_0_4, 0) {init = 0 : i32, sym_name = "input_0_4_lock0"}
+    %input_0_4_lock2 = aie.lock(%tile_0_4, 2) {init = 0 : i32, sym_name = "input_0_4_lock2"}
+    %output_0_4_lock4 = aie.lock(%tile_0_4, 4) {init = 0 : i32, sym_name = "output_0_4_lock4"}
+    %output_0_4_lock5 = aie.lock(%tile_0_4, 5) {init = 1 : i32, sym_name = "output_0_4_lock5"}
+
+    %input_0_4_buffer = aie.buffer(%tile_0_4) {sym_name = "input_0_4_buffer"} : memref<8xi32>
+    %output_0_4_buffer = aie.buffer(%tile_0_4) {sym_name = "output_0_4_buffer"} : memref<8xi32>
+
+    %input_0_5_lock0 = aie.lock(%tile_0_5, 0) {init = 0 : i32, sym_name = "input_0_5_lock0"}
+    %input_0_5_lock2 = aie.lock(%tile_0_5, 2) {init = 0 : i32, sym_name = "input_0_5_lock2"}
+    %output_0_5_lock4 = aie.lock(%tile_0_5, 4) {init = 0 : i32, sym_name = "output_0_5_lock4"}
+    %output_0_5_lock5 = aie.lock(%tile_0_5, 5) {init = 1 : i32, sym_name = "output_0_5_lock5"}
+
+    %input_0_5_buffer = aie.buffer(%tile_0_5) {sym_name = "input_0_5_buffer"} : memref<8xi32>
+    %output_0_5_buffer = aie.buffer(%tile_0_5) {sym_name = "output_0_5_buffer"} : memref<8xi32>
+
+    aie.packet_flow(0x5) {
+      aie.packet_source<%tile_0_0, DMA : 0>
+      aie.packet_dest<%tile_0_2, Ctrl : 0>
+    }
+    aie.packet_flow(0x6) {
+      aie.packet_source<%tile_0_0, DMA : 0>
+      aie.packet_dest<%tile_0_3, Ctrl : 0>
+    }
+    aie.packet_flow(0x7) {
+      aie.packet_source<%tile_0_0, DMA : 0>
+      aie.packet_dest<%tile_0_4, Ctrl : 0>
+    }
+    aie.packet_flow(0x8) {
+      aie.packet_source<%tile_0_0, DMA : 1>
+      aie.packet_dest<%tile_0_5, Ctrl : 0>
+    }
+
+    aie.flow(%tile_0_2, DMA : 0, %tile_0_0, DMA : 1)
+    aie.flow(%tile_0_3, DMA : 0, %tile_1_0, DMA : 0)
+    aie.flow(%tile_0_4, DMA : 0, %tile_1_0, DMA : 1)
+    aie.flow(%tile_0_5, DMA : 0, %tile_2_0, DMA : 0)
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_2_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_2_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_2_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_2_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_2_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_2_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_2_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_2_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_2_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_2_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    %core_0_3 = aie.core(%tile_0_3) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_3_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_3_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_3_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_3_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_3_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_3_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_3_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_3 = aie.mem(%tile_0_3) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_3_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_3_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_3_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    %core_0_4 = aie.core(%tile_0_4) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_4_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_4_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_4_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_4_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_4_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_4_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_4_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_4 = aie.mem(%tile_0_4) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_4_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_4_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_4_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    %core_0_5 = aie.core(%tile_0_5) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_5_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_5_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_5_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_5_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_5_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_5_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_5_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_5 = aie.mem(%tile_0_5) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_5_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_5_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_5_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    aie.shim_dma_allocation @ctrlin0(MM2S, 0, 0)
+    aie.shim_dma_allocation @ctrlin1(MM2S, 1, 0)
+    aie.shim_dma_allocation @ctrl0(S2MM, 0, 0)
+    aie.shim_dma_allocation @out0(S2MM, 1, 0)
+    aie.shim_dma_allocation @out1(S2MM, 0, 1)
+    aie.shim_dma_allocation @out2(S2MM, 1, 1)
+    aie.shim_dma_allocation @out3(S2MM, 0, 2)
+
+    aiex.runtime_sequence @seq(%arg0: memref<8xi32>, %arg1: memref<8xi32>, %arg2: memref<32xi32>) {
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c2_i64 = arith.constant 2 : i64
+      %c4_i64 = arith.constant 4 : i64
+      %c6_i64 = arith.constant 6 : i64
+      %c8_i64 = arith.constant 8 : i64
+      %c10_i64 = arith.constant 10 : i64
+      %c12_i64 = arith.constant 12 : i64
+      %c14_i64 = arith.constant 14 : i64
+      %c16_i64 = arith.constant 16 : i64
+      %c24_i64 = arith.constant 24 : i64
+
+      // start reading output
+      aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, issue_token = true, metadata = @ctrl0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 2 : i64, issue_token = true, metadata = @out0} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c8_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 3 : i64, issue_token = true, metadata = @out1} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c16_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 4 : i64, issue_token = true, metadata = @out2} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c24_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 5 : i64, issue_token = true, metadata = @out3} : memref<32xi32>
+
+      // write bd0
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 5, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c4_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 6, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c8_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c12_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 8, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+
+      // patch bd0 address for packet 1, push to mm2s_0_task_queue, wait
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c2_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 5, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c6_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 6, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c10_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c14_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 8, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+
+      // wait for dma output
+      aiex.npu.dma_wait {symbol = @out0}
+      aiex.npu.dma_wait {symbol = @out1}
+      aiex.npu.dma_wait {symbol = @out2}
+      aiex.npu.dma_wait {symbol = @out3}
+    }
+  }
+}

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+//
+// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --basic-alloc-scheme --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt | FileCheck %s
+// CHECK: PASS!
+

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
@@ -1,0 +1,240 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <boost/program_options.hpp>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+constexpr int CTRL_IN_SIZE = 64;
+constexpr int CTRL_OUT_SIZE = 64;
+constexpr int OUT_SIZE = 64;
+
+namespace po = boost::program_options;
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  po::options_description desc("Allowed options");
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    return 1;
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+
+  std::vector<uint32_t> instr_v =
+      load_instr_sequence(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_ctrlOut = xrt::bo(device, CTRL_OUT_SIZE * sizeof(int32_t),
+                            XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_ctrlIn = xrt::bo(device, CTRL_IN_SIZE * sizeof(int32_t),
+                           XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  uint32_t beats = 1 - 1;
+  uint32_t operation = 0;
+  uint32_t stream_id = 0;
+  auto parity = [](uint32_t n) {
+    uint32_t p = 0;
+    while (n) {
+      p += n & 1;
+      n >>= 1;
+    }
+    return (p % 2) == 0;
+  };
+
+  // Lock0_value
+  uint32_t address = 0x0001F000;
+  uint32_t header0 = stream_id << 24 | operation << 22 | beats << 20 | address;
+  header0 |= (0x1 & parity(header0)) << 31;
+
+  // Lock2_value
+  address += 0x20;
+  uint32_t header1 = stream_id << 24 | operation << 22 | beats << 20 | address;
+  header1 |= (0x1 & parity(header1)) << 31;
+
+  // set lock values to 2
+  uint32_t data = 2;
+  std::vector<uint32_t> ctrlPackets = {
+      // Ctrl pkt for tile (0, 2)
+      header0,
+      data,
+      header1,
+      data,
+      // Ctrl pkt for tile (0, 3)
+      header0,
+      data,
+      header1,
+      data,
+      // Ctrl pkt for tile (0, 4)
+      header0,
+      data,
+      header1,
+      data,
+      // Ctrl pkt for tile (0, 5)
+      header0,
+      data,
+      header1,
+      data,
+  };
+  void *bufctrlIn = bo_ctrlIn.map<void *>();
+  memcpy(bufctrlIn, ctrlPackets.data(), ctrlPackets.size() * sizeof(int));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_ctrlIn.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running Kernel.\n";
+  unsigned int opcode = 3;
+  auto run =
+      kernel(opcode, bo_instr, instr_v.size(), bo_ctrlOut, bo_ctrlIn, bo_out);
+
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
+    return 1;
+  }
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  uint32_t *bufOut = bo_out.map<uint32_t *>();
+
+  int errors = 0;
+
+  for (uint32_t i = 0; i < 32; i++) {
+    uint32_t ref = 7 + i % 8;
+    if (*(bufOut + i) != ref) {
+      std::cout << "Error in dma output " << *(bufOut + i) << " != " << ref
+                << std::endl;
+      errors++;
+    } else {
+      std::cout << "Correct dma output " << *(bufOut + i) << " == " << ref
+                << std::endl;
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nfailed.\n\n";
+    return 1;
+  }
+}

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/aie.mlir
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/aie.mlir
@@ -1,0 +1,371 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu1_4col) {
+    memref.global "public" @ctrlin0 : memref<8xi32>
+    memref.global "public" @ctrlin1 : memref<8xi32>
+    memref.global "public" @out0 : memref<8xi32>
+    memref.global "public" @out1 : memref<8xi32>
+    memref.global "public" @out2 : memref<8xi32>
+    memref.global "public" @out3 : memref<8xi32>
+    memref.global "public" @ctrl0 : memref<8xi32>
+
+    %tile_0_0 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
+    %tile_1_0 = aie.tile(1, 0)
+    %tile_2_0 = aie.tile(2, 0)
+    %tile_0_2 = aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
+    %tile_0_3 = aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
+    %tile_0_4 = aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 7>}
+    %tile_0_5 = aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 8>}
+
+    %input_0_2_lock0 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "input_0_2_lock0"}
+    %input_0_2_lock2 = aie.lock(%tile_0_2, 2) {init = 0 : i32, sym_name = "input_0_2_lock2"}
+    %output_0_2_lock4 = aie.lock(%tile_0_2, 4) {init = 0 : i32, sym_name = "output_0_2_lock4"}
+    %output_0_2_lock5 = aie.lock(%tile_0_2, 5) {init = 1 : i32, sym_name = "output_0_2_lock5"}
+
+    %input_0_2_buffer = aie.buffer(%tile_0_2) {sym_name = "input_0_2_buffer"} : memref<8xi32>
+    %output_0_2_buffer = aie.buffer(%tile_0_2) {sym_name = "output_0_2_buffer"} : memref<8xi32>
+
+    %input_0_3_lock0 = aie.lock(%tile_0_3, 0) {init = 0 : i32, sym_name = "input_0_3_lock0"}
+    %input_0_3_lock2 = aie.lock(%tile_0_3, 2) {init = 0 : i32, sym_name = "input_0_3_lock2"}
+    %output_0_3_lock4 = aie.lock(%tile_0_3, 4) {init = 0 : i32, sym_name = "output_0_3_lock4"}
+    %output_0_3_lock5 = aie.lock(%tile_0_3, 5) {init = 1 : i32, sym_name = "output_0_3_lock5"}
+
+    %input_0_3_buffer = aie.buffer(%tile_0_3) {sym_name = "input_0_3_buffer"} : memref<8xi32>
+    %output_0_3_buffer = aie.buffer(%tile_0_3) {sym_name = "output_0_3_buffer"} : memref<8xi32>
+
+    %input_0_4_lock0 = aie.lock(%tile_0_4, 0) {init = 0 : i32, sym_name = "input_0_4_lock0"}
+    %input_0_4_lock2 = aie.lock(%tile_0_4, 2) {init = 0 : i32, sym_name = "input_0_4_lock2"}
+    %output_0_4_lock4 = aie.lock(%tile_0_4, 4) {init = 0 : i32, sym_name = "output_0_4_lock4"}
+    %output_0_4_lock5 = aie.lock(%tile_0_4, 5) {init = 1 : i32, sym_name = "output_0_4_lock5"}
+
+    %input_0_4_buffer = aie.buffer(%tile_0_4) {sym_name = "input_0_4_buffer"} : memref<8xi32>
+    %output_0_4_buffer = aie.buffer(%tile_0_4) {sym_name = "output_0_4_buffer"} : memref<8xi32>
+
+    %input_0_5_lock0 = aie.lock(%tile_0_5, 0) {init = 0 : i32, sym_name = "input_0_5_lock0"}
+    %input_0_5_lock2 = aie.lock(%tile_0_5, 2) {init = 0 : i32, sym_name = "input_0_5_lock2"}
+    %output_0_5_lock4 = aie.lock(%tile_0_5, 4) {init = 0 : i32, sym_name = "output_0_5_lock4"}
+    %output_0_5_lock5 = aie.lock(%tile_0_5, 5) {init = 1 : i32, sym_name = "output_0_5_lock5"}
+
+    %input_0_5_buffer = aie.buffer(%tile_0_5) {sym_name = "input_0_5_buffer"} : memref<8xi32>
+    %output_0_5_buffer = aie.buffer(%tile_0_5) {sym_name = "output_0_5_buffer"} : memref<8xi32>
+
+    aie.flow(%tile_0_2, DMA : 0, %tile_0_0, DMA : 1)
+    aie.flow(%tile_0_3, DMA : 0, %tile_1_0, DMA : 0)
+    aie.flow(%tile_0_4, DMA : 0, %tile_1_0, DMA : 1)
+    aie.flow(%tile_0_5, DMA : 0, %tile_2_0, DMA : 0)
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_2_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_2_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_2_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_2_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_2_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_2_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_2_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_2_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_2_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_2_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_2_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_2_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    %core_0_3 = aie.core(%tile_0_3) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_3_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_3_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_3_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_3_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_3_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_3_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_3_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_3_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_3_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_3 = aie.mem(%tile_0_3) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_3_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_3_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_3_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    %core_0_4 = aie.core(%tile_0_4) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_4_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_4_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_4_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_4_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_4_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_4_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_4_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_4_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_4_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_4 = aie.mem(%tile_0_4) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_4_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_4_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_4_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    %core_0_5 = aie.core(%tile_0_5) {
+      %c0 = arith.constant 0 : index
+      %c1_i32 = arith.constant 1 : i32
+      %c3_i32 = arith.constant 3 : i32
+      %c1 = arith.constant 1 : index
+      %c8 = arith.constant 8 : index
+      // initialize to i + 3
+      scf.for %arg1 = %c0 to %c8 step %c1 {
+        %arg1_i32 = arith.index_cast %arg1 : index to i32
+        %1 = arith.addi %arg1_i32, %c3_i32 : i32
+        memref.store %1, %input_0_5_buffer[%arg1] : memref<8xi32>
+      }
+      %c4294967295 = arith.constant 4294967295 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        aie.use_lock(%input_0_5_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 4
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_5_lock0, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 5
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_5_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 6
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%input_0_5_lock2, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+          // 7
+          %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+          %2 = arith.addi %1, %c1_i32 : i32
+          memref.store %2, %input_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        // write to output buffer
+        aie.use_lock(%output_0_5_lock5, AcquireGreaterEqual, 1)
+        scf.for %arg1 = %c0 to %c8 step %c1 {
+            %1 = memref.load %input_0_5_buffer[%arg1] : memref<8xi32>
+            memref.store %1, %output_0_5_buffer[%arg1] : memref<8xi32>
+        }
+        aie.use_lock(%output_0_5_lock4, Release, 1)
+      }
+      aie.end
+    }
+
+    %mem_0_5 = aie.mem(%tile_0_5) {
+      %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
+    ^bb1:  // 2 preds: ^bb0, ^bb2
+      aie.use_lock(%output_0_5_lock4, AcquireGreaterEqual, 1)
+      aie.dma_bd(%output_0_5_buffer : memref<8xi32>, 0, 8)
+      aie.use_lock(%output_0_5_lock5, Release, 1)
+      aie.next_bd ^bb1
+    ^bb2:
+      aie.end
+    }
+
+    aie.shim_dma_allocation @ctrlin0(MM2S, 0, 0)
+    aie.shim_dma_allocation @ctrlin1(MM2S, 1, 0)
+    aie.shim_dma_allocation @ctrl0(S2MM, 0, 0)
+    aie.shim_dma_allocation @out0(S2MM, 1, 0)
+    aie.shim_dma_allocation @out1(S2MM, 0, 1)
+    aie.shim_dma_allocation @out2(S2MM, 1, 1)
+    aie.shim_dma_allocation @out3(S2MM, 0, 2)
+
+    aiex.runtime_sequence @seq(%arg0: memref<8xi32>, %arg1: memref<8xi32>, %arg2: memref<32xi32>) {
+      %c0_i64 = arith.constant 0 : i64
+      %c1_i64 = arith.constant 1 : i64
+      %c2_i64 = arith.constant 2 : i64
+      %c4_i64 = arith.constant 4 : i64
+      %c6_i64 = arith.constant 6 : i64
+      %c8_i64 = arith.constant 8 : i64
+      %c10_i64 = arith.constant 10 : i64
+      %c12_i64 = arith.constant 12 : i64
+      %c14_i64 = arith.constant 14 : i64
+      %c16_i64 = arith.constant 16 : i64
+      %c24_i64 = arith.constant 24 : i64
+
+      // start reading output
+      aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, issue_token = true, metadata = @ctrl0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 2 : i64, issue_token = true, metadata = @out0} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c8_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 3 : i64, issue_token = true, metadata = @out1} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c16_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 4 : i64, issue_token = true, metadata = @out2} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c24_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 5 : i64, issue_token = true, metadata = @out3} : memref<32xi32>
+
+      // write bd0
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 5, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c4_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 6, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c8_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c12_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 8, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+
+      // patch bd0 address for packet 1, push to mm2s_0_task_queue, wait
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c2_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 5, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c6_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 6, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c10_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c14_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 8, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+
+      // wait for dma output
+      aiex.npu.dma_wait {symbol = @out0}
+      aiex.npu.dma_wait {symbol = @out1}
+      aiex.npu.dma_wait {symbol = @out2}
+      aiex.npu.dma_wait {symbol = @out3}
+    }
+  }
+}

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+//
+// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --basic-alloc-scheme --generate-ctrl-pkt-overlay --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
+// RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt | FileCheck %s
+// CHECK: PASS!
+

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
@@ -1,0 +1,240 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <boost/program_options.hpp>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+constexpr int CTRL_IN_SIZE = 64;
+constexpr int CTRL_OUT_SIZE = 64;
+constexpr int OUT_SIZE = 64;
+
+namespace po = boost::program_options;
+
+void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+  if (!vm_in.count(name)) {
+    throw std::runtime_error("Error: no " + name + " file was provided\n");
+  } else {
+    std::ifstream test(vm_in[name].as<std::string>());
+    if (!test) {
+      throw std::runtime_error("The " + name + " file " +
+                               vm_in[name].as<std::string>() +
+                               " does not exist.\n");
+    }
+  }
+}
+
+std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
+  std::ifstream instr_file(instr_path);
+  std::string line;
+  std::vector<uint32_t> instr_v;
+  while (std::getline(instr_file, line)) {
+    std::istringstream iss(line);
+    uint32_t a;
+    if (!(iss >> std::hex >> a)) {
+      throw std::runtime_error("Unable to parse instruction file\n");
+    }
+    instr_v.push_back(a);
+  }
+  return instr_v;
+}
+
+int main(int argc, const char *argv[]) {
+
+  // Program arguments parsing
+  po::options_description desc("Allowed options");
+  desc.add_options()("help,h", "produce help message")(
+      "xclbin,x", po::value<std::string>()->required(),
+      "the input xclbin path")(
+      "kernel,k", po::value<std::string>()->required(),
+      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", po::value<int>()->default_value(0),
+      "the verbosity of the output")(
+      "instr,i", po::value<std::string>()->required(),
+      "path of file containing userspace instructions to be sent to the LX6");
+  po::variables_map vm;
+
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+
+    if (vm.count("help")) {
+      std::cout << desc << "\n";
+      return 1;
+    }
+  } catch (const std::exception &ex) {
+    std::cerr << ex.what() << "\n\n";
+    std::cerr << "Usage:\n" << desc << "\n";
+    return 1;
+  }
+
+  check_arg_file_exists(vm, "xclbin");
+  check_arg_file_exists(vm, "instr");
+
+  std::vector<uint32_t> instr_v =
+      load_instr_sequence(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_ctrlOut = xrt::bo(device, CTRL_OUT_SIZE * sizeof(int32_t),
+                            XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_ctrlIn = xrt::bo(device, CTRL_IN_SIZE * sizeof(int32_t),
+                           XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  uint32_t beats = 1 - 1;
+  uint32_t operation = 0;
+  uint32_t stream_id = 0;
+  auto parity = [](uint32_t n) {
+    uint32_t p = 0;
+    while (n) {
+      p += n & 1;
+      n >>= 1;
+    }
+    return (p % 2) == 0;
+  };
+
+  // Lock0_value
+  uint32_t address = 0x0001F000;
+  uint32_t header0 = stream_id << 24 | operation << 22 | beats << 20 | address;
+  header0 |= (0x1 & parity(header0)) << 31;
+
+  // Lock2_value
+  address += 0x20;
+  uint32_t header1 = stream_id << 24 | operation << 22 | beats << 20 | address;
+  header1 |= (0x1 & parity(header1)) << 31;
+
+  // set lock values to 2
+  uint32_t data = 2;
+  std::vector<uint32_t> ctrlPackets = {
+      // Ctrl pkt for tile (0, 2)
+      header0,
+      data,
+      header1,
+      data,
+      // Ctrl pkt for tile (0, 3)
+      header0,
+      data,
+      header1,
+      data,
+      // Ctrl pkt for tile (0, 4)
+      header0,
+      data,
+      header1,
+      data,
+      // Ctrl pkt for tile (0, 5)
+      header0,
+      data,
+      header1,
+      data,
+  };
+  void *bufctrlIn = bo_ctrlIn.map<void *>();
+  memcpy(bufctrlIn, ctrlPackets.data(), ctrlPackets.size() * sizeof(int));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_ctrlIn.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running Kernel.\n";
+  unsigned int opcode = 3;
+  auto run =
+      kernel(opcode, bo_instr, instr_v.size(), bo_ctrlOut, bo_ctrlIn, bo_out);
+
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
+    return 1;
+  }
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  uint32_t *bufOut = bo_out.map<uint32_t *>();
+
+  int errors = 0;
+
+  for (uint32_t i = 0; i < 32; i++) {
+    uint32_t ref = 7 + i % 8;
+    if (*(bufOut + i) != ref) {
+      std::cout << "Error in dma output " << *(bufOut + i) << " != " << ref
+                << std::endl;
+      errors++;
+    } else {
+      std::cout << "Correct dma output " << *(bufOut + i) << " == " << ref
+                << std::endl;
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nfailed.\n\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
Adds two new board tests on control packets
- `add_one_ctrl_packet_4_cores`: user manually routed control packet flow to 4 core tiles in a column, fanned out from round-robin 2 shim dma mm2s channels,
- `add_one_ctrl_packet_col_overlay`: same as above, but with packet flows bing compiler-generated via `--generate-ctrl-pkt-overlay` flag in `aiecc.py`.

Delivery of control packets from DDR implemented via `aiex.npu.dma_memcpy_nd` ops only; no `write32` or `blockwrite` needed at frontend.