### PR TITLE
fix out of bounds access in memory allocator

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -208,6 +208,8 @@ bool checkAndAddBufferWithMemBank(BufferOp buffer, int numBanks,
 int setBufferAddress(BufferOp buffer, int numBanks, int startBankIndex,
                      std::vector<int64_t> &nextAddrInBanks,
                      std::vector<BankLimits> &bankLimits) {
+  assert(startBankIndex < numBanks ||
+         "Unexpected input value for startBankIndex");
   int bankIndex = startBankIndex;
   for (int i = 0; i < numBanks; i++) {
     int64_t startAddr = nextAddrInBanks[bankIndex];
@@ -215,12 +217,11 @@ int setBufferAddress(BufferOp buffer, int numBanks, int startBankIndex,
     if (endAddr <= bankLimits[bankIndex].endAddr || i == numBanks - 1) {
       buffer.setMemBank(bankIndex);
       setAndUpdateAddressInBank(buffer, startAddr, endAddr, nextAddrInBanks);
-      bankIndex++;
+      bankIndex = (bankIndex + 1) % numBanks;
       break;
     }
-    bankIndex++;
+    bankIndex = (bankIndex + 1) % numBanks;
   }
-  bankIndex %= numBanks;
   return bankIndex;
 }
 

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -208,7 +208,7 @@ bool checkAndAddBufferWithMemBank(BufferOp buffer, int numBanks,
 int setBufferAddress(BufferOp buffer, int numBanks, int startBankIndex,
                      std::vector<int64_t> &nextAddrInBanks,
                      std::vector<BankLimits> &bankLimits) {
-  assert(startBankIndex < numBanks ||
+  assert(startBankIndex < numBanks &&
          "Unexpected input value for startBankIndex");
   int bankIndex = startBankIndex;
   for (int i = 0; i < numBanks; i++) {

--- a/test/assign-buffer-addresses/bank_aware_alloc_memory_exhausted.mlir
+++ b/test/assign-buffer-addresses/bank_aware_alloc_memory_exhausted.mlir
@@ -1,0 +1,25 @@
+//===- simple.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --verify-diagnostics --aie-assign-buffer-addresses=basic-alloc=0 %s
+
+module {
+  aie.device(npu1_2col) {
+    // expected-error@+2 {{allocated buffers exceeded available memory}}
+    // expected-note@+1 {{}}
+    %tile_0_2 = aie.tile(0, 2)
+    %C_L1L2_0_0_buff_0 = aie.buffer(%tile_0_2) : memref<64x96xf32> 
+    %C_L1L2_0_0_buff_1 = aie.buffer(%tile_0_2) : memref<64x96xf32> 
+    %B_L2L1_0_0_cons_buff_0 = aie.buffer(%tile_0_2) : memref<32x96xbf16> 
+    %B_L2L1_0_0_cons_buff_1 = aie.buffer(%tile_0_2) : memref<32x96xbf16> 
+    %A_L2L1_0_0_cons_buff_0 = aie.buffer(%tile_0_2) : memref<64x32xbf16> 
+    %A_L2L1_0_0_cons_buff_1 = aie.buffer(%tile_0_2) : memref<64x32xbf16> 
+  }
+}


### PR DESCRIPTION
plus add a test that previously caused the compiler to crash. Thank you @pvasireddy-amd for the help