### PR TITLE
[TEST don't merge] test no assert build

### DIFF
--- a/utils/clone-llvm.sh
+++ b/utils/clone-llvm.sh
@@ -14,7 +14,7 @@
 
 # The LLVM commit to use.
 LLVM_PROJECT_COMMIT=5e6a1987a5d4574d3c3811f878ddbbbf7c35fa01
-DATETIME=2024082021
+DATETIME=2024082322
 WHEEL_VERSION=20.0.0.$DATETIME+${LLVM_PROJECT_COMMIT:0:8}
 
 ############################################################################################

--- a/utils/mlir_wheels/setup.py
+++ b/utils/mlir_wheels/setup.py
@@ -97,7 +97,6 @@ class CMakeBuild(build_ext):
             "-DLLVM_BUILD_TESTS=OFF",
             "-DLLVM_BUILD_UTILS=ON",
             "-DLLVM_CCACHE_BUILD=ON",
-            "-DLLVM_ENABLE_ASSERTIONS=ON",
             f"-DLLVM_ENABLE_RTTI={os.getenv('ENABLE_RTTI', 'ON')}",
             "-DLLVM_ENABLE_ZSTD=OFF",
             "-DLLVM_INCLUDE_BENCHMARKS=OFF",


### PR DESCRIPTION
This is an attempt to trigger some build errors seen in release builds with no asserts. It builds against a mlir wheel built without `-DLLVM_ENABLE_ASSERTIONS=ON`