### PR TITLE
Fix for matrix multiply whole array object fifo offsets

### DIFF
--- a/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
@@ -257,7 +257,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                 ],
             )
             if n_aie_rows > 1:
-                of_offsets = [N * i for i in range(n_aie_rows)]
+                of_offsets = [m * n * i for i in range(n_aie_rows)]
             else:
                 of_offsets = []
             object_fifo_link(


### PR DESCRIPTION
The way I was calculating the offsets for matrix multiply was accidentally correct in some cases, but was not actually correct and broke with some configurations. I believe this is the correct way to calculate the offsets.