### PR TITLE
Remove unrequired REQUIRES

### DIFF
--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/bad-1.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/bad-1.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-assign-runtime-sequence-bd-ids %s
 
 // This test ensures that the proper error is emitted if a user tries to reference not-yet-lowered BD chains in aiex.dma_await_task.

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/bad-2.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/bad-2.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-assign-runtime-sequence-bd-ids %s
 
 // This test ensures that the proper error is emitted if a user tries to use more buffer descriptors than

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/bad-3.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/bad-3.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-assign-runtime-sequence-bd-ids %s
 
 // This test ensures that the proper error is issued if the user tries to reuse buffer descriptor IDs

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-1.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-1.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-materialize-bd-chains --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
 
 // This tests ensures that each `aie.dma_bd` operation below gets assigned a unique buffer descriptor ID.

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-2.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-2.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
 
 // This tests ensures that buffer descriptor IDs assigned to `aie.dma_bd` ops are reused after

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-3.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-3.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-assign-runtime-sequence-bd-ids %s
 
 // This test ensures that automatic buffer descriptor allocation does not collide 

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-4.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
 
 // This test ensures that all available 16 buffer descriptors are used.

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-5.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-substitute-shim-dma-allocations --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
 
 // This test ensures that all available 16 buffer descriptors are used.

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-1.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-1.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures that the proper error is emitted if the transfer length specified in a aie.dma_bd

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-10.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-10.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
 
 // This test ensures the proper error is emitted if a user attempts to configure a task 

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-11.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-11.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
 
 // This test ensures the proper error is emitted if a user tries to lower a 

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-2.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-2.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures that the proper error is emitted if the user attempts to sepcify more than

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-3.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-3.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures that the correct error is emitted if an illegal data layout transformation is specified

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-4.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-4.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures that the correct error is emitted if an illegal data layout transformation is specified

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-5.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-5.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures that the correct error is emitted if the user tries to transfer 

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-6.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-6.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures that the proper error is emitted if the user specifies an illegal offset in a dma_bd operation inside the runtime sequence.

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-7.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-7.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures the proper error message is emitted if the user tries to invoke the 

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-8.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-8.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures the proper error is emitted if a single block inside a `aiex.dma_configure_task` op

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-9.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-9.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s 
 
 // This test ensures the proper error is emitted if a task with no BDs is issued in the runtime sequence.

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-1.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-1.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
 
 // This test ensures buffer descriptor configurations, as well as `aiex.dma_start_task`,

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-2.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-2.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
 
 // This test ensures that buffer descriptor configurations with chaining get

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-3.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-3.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
 
 // This test ensures that buffer descriptor configurations with data layout transformations are

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
 
 // This test ensures that a buffer descriptor configuration that references a buffer

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-assign-buffer-addresses --aie-dma-tasks-to-npu %s | FileCheck %s
 
 // This test ensures that a chained buffer descriptor configuration in the runtime

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-6.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-substitute-shim-dma-allocations --aie-dma-tasks-to-npu %s | FileCheck %s
 
 module {

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-1.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-1.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-materialize-bd-chains %s
 
 // This test ensures that the correct error gets emitted when a BD "chain" is not

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-2.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-2.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-materialize-bd-chains %s
 
 // This test ensures that the correct error is emitted if the types of 

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-3.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-3.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-materialize-bd-chains %s
 
 // This test ensures the proper error gets emitted if the user attempts to

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-4.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-4.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-materialize-bd-chains %s
 
 module {

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-5.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/bad-5.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --verify-diagnostics --aie-materialize-bd-chains %s
 
 module {

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-1.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-1.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
 
 // This test ensures that a BD chains get lowered to correct `aiex.dma_configure_task`

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-2.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-2.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
 // XFAIL: *
 // Referencing locks inside sequence function not yet implemented

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-3.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-3.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
 
 module {

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-4.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
 
 module {

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-5.mlir
@@ -5,8 +5,6 @@
 //
 // (c) Copyright 2024 AMD Inc.
 
-// REQUIRES: ryzen_ai
-//
 // RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
 
 module {

--- a/test/create-packet-flows/aie2_memtile_connection.mlir
+++ b/test/create-packet-flows/aie2_memtile_connection.mlir
@@ -1,10 +1,12 @@
-//===- aie2_memtile_connection.mlir ------------------------------------------------*- MLIR -*-===//
+//===- aie2_memtile_connection.mlir ----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: MIT
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: ryzen_ai, chess
 
 // RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt

--- a/test/create-packet-flows/test_congestion0.mlir
+++ b/test/create-packet-flows/test_congestion0.mlir
@@ -1,10 +1,12 @@
-//===- test_congestion0.mlir ------------------------------------------------*- MLIR -*-===//
+//===- test_congestion0.mlir -----------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: MIT
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: ryzen_ai, chess
 
 // RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt

--- a/test/create-packet-flows/test_congestion1.mlir
+++ b/test/create-packet-flows/test_congestion1.mlir
@@ -1,10 +1,12 @@
-//===- test_congestion1.mlir ------------------------------------------------*- MLIR -*-===//
+//===- test_congestion1.mlir -----------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: MIT
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: ryzen_ai, chess
 
 // RUN: aie-opt --aie-create-pathfinder-flows --aie-find-flows %s -o %t.opt
 // RUN: FileCheck %s --check-prefix=CHECK1 < %t.opt

--- a/test/create-packet-flows/test_create_packet_flows5.mlir
+++ b/test/create-packet-flows/test_create_packet_flows5.mlir
@@ -7,6 +7,7 @@
 // (c) Copyright 2021 Xilinx Inc.
 //
 //===----------------------------------------------------------------------===//
+
 // RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
 // CHECK-LABEL:   aie.device(xcvc1902) {
 // CHECK:           %[[VAL_0:.*]] = aie.tile(1, 1)

--- a/test/create-packet-flows/trace_packet_routing.mlir
+++ b/test/create-packet-flows/trace_packet_routing.mlir
@@ -1,10 +1,12 @@
-//===- trace_packet_routing.mlir ------------------------------------------------*- MLIR -*-===//
+//===- trace_packet_routing.mlir -------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// SPDX-License-Identifier: MIT
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: ryzen_ai, chess
 
 // RUN: aie-opt --aie-create-pathfinder-flows %s | FileCheck %s
 // CHECK-LABEL: module @trace_packet_routing {


### PR DESCRIPTION
Remove `REQUIRES: ryzen_aie` from a bunch of tests that only run `aie-opt` and do not need npu hardware.