### PR TITLE
various updates to aie-translate txn backend

### DIFF
--- a/include/aie-c/Translation.h
+++ b/include/aie-c/Translation.h
@@ -34,6 +34,8 @@ aieTranslateToCDODirect(MlirOperation moduleOp, MlirStringRef workDirPath,
 MLIR_CAPI_EXPORTED MlirLogicalResult aieTranslateToTxn(
     MlirOperation moduleOp, MlirStringRef outputFile, MlirStringRef workDirPath,
     bool aieSim, bool xaieDebug, bool enableCores);
+MLIR_CAPI_EXPORTED MlirOperation aieTranslateBinaryToTxn(MlirContext ctx,
+                                                         MlirStringRef binary);
 
 #ifdef __cplusplus
 }

--- a/include/aie-c/Translation.h
+++ b/include/aie-c/Translation.h
@@ -31,9 +31,9 @@ aieTranslateToCDODirect(MlirOperation moduleOp, MlirStringRef workDirPath,
                         bool bigEndian, bool emitUnified, bool cdoDebug,
                         bool aieSim, bool xaieDebug, bool enableCores);
 
-MLIR_CAPI_EXPORTED MlirLogicalResult
-aieTranslateToTxn(MlirOperation moduleOp, MlirStringRef workDirPath,
-                  bool aieSim, bool xaieDebug, bool enableCores);
+MLIR_CAPI_EXPORTED MlirLogicalResult aieTranslateToTxn(
+    MlirOperation moduleOp, MlirStringRef outputFile, MlirStringRef workDirPath,
+    bool aieSim, bool xaieDebug, bool enableCores);
 
 #ifdef __cplusplus
 }

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -10,9 +10,12 @@
 #define AIE_TARGETS_AIETARGETS_H
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LogicalResult.h"
 
 #include "llvm/Support/raw_ostream.h"
+
+#include <vector>
 
 namespace xilinx {
 namespace AIE {
@@ -55,11 +58,11 @@ AIETranslateToCDODirect(mlir::ModuleOp m, llvm::StringRef workDirPath,
                         bool bigEndian = false, bool emitUnified = false,
                         bool cdoDebug = false, bool aieSim = false,
                         bool xaieDebug = false, bool enableCores = true);
-mlir::LogicalResult AIETranslateToTxn(mlir::ModuleOp m,
-                                      llvm::StringRef workDirPath,
-                                      bool aieSim = false,
-                                      bool xaieDebug = false,
-                                      bool enableCores = true);
+mlir::LogicalResult
+AIETranslateToTxn(mlir::ModuleOp m, llvm::raw_ostream &output,
+                  llvm::StringRef workDirPath, bool outputBinary = false,
+                  bool aieSim = false, bool xaieDebug = false,
+                  bool enableCores = true);
 
 #ifdef AIE_ENABLE_AIRBIN
 mlir::LogicalResult AIETranslateToAirbin(mlir::ModuleOp module,
@@ -70,6 +73,10 @@ mlir::LogicalResult AIETranslateToAirbin(mlir::ModuleOp module,
 
 mlir::LogicalResult AIETranslateToTargetArch(mlir::ModuleOp module,
                                              llvm::raw_ostream &output);
+
+std::optional<mlir::ModuleOp>
+AIETranslateBinaryToTxn(mlir::MLIRContext *ctx, std::vector<uint8_t> &binary);
+
 } // namespace AIE
 
 namespace aievec {

--- a/lib/CAPI/Translation.cpp
+++ b/lib/CAPI/Translation.cpp
@@ -16,12 +16,14 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Support.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Target/LLVMIR/Export.h"
 
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdlib>
@@ -80,21 +82,35 @@ MlirLogicalResult aieTranslateToCDODirect(MlirOperation moduleOp,
 }
 
 MlirLogicalResult aieTranslateToTxn(MlirOperation moduleOp,
+                                    MlirStringRef outputFile,
                                     MlirStringRef workDirPath, bool aieSim,
                                     bool xaieDebug, bool enableCores) {
   ModuleOp mod = llvm::cast<ModuleOp>(unwrap(moduleOp));
+  bool outputBinary = false;
+
+  std::string errorMessage;
+  auto output = openOutputFile(StringRef(outputFile.data, outputFile.length),
+                               &errorMessage);
+  if (!output) {
+    llvm::errs() << errorMessage << "\n";
+    return wrap(failure());
+  }
+
   auto status = AIETranslateToTxn(
-      mod, llvm::StringRef(workDirPath.data, workDirPath.length), aieSim,
-      xaieDebug, enableCores);
+      mod, output->os(), llvm::StringRef(workDirPath.data, workDirPath.length),
+      outputBinary, aieSim, xaieDebug, enableCores);
+
   std::vector<std::string> diagnostics;
   ScopedDiagnosticHandler handler(mod.getContext(), [&](Diagnostic &d) {
     llvm::raw_string_ostream(diagnostics.emplace_back())
         << d.getLocation() << ": " << d;
   });
+
   if (failed(status))
     for (const auto &diagnostic : diagnostics)
       std::cerr << diagnostic << "\n";
-
+  else
+    output->keep();
   return wrap(status);
 }
 

--- a/lib/CAPI/Translation.cpp
+++ b/lib/CAPI/Translation.cpp
@@ -114,6 +114,14 @@ MlirLogicalResult aieTranslateToTxn(MlirOperation moduleOp,
   return wrap(status);
 }
 
+MlirOperation aieTranslateBinaryToTxn(MlirContext ctx, MlirStringRef binary) {
+  std::vector<uint8_t> binaryData(binary.data, binary.data + binary.length);
+  auto mod = AIETranslateBinaryToTxn(unwrap(ctx), binaryData);
+  if (!mod)
+    return wrap(ModuleOp().getOperation());
+  return wrap(mod->getOperation());
+}
+
 MlirStringRef aieTranslateToNPU(MlirOperation moduleOp) {
   std::string npu;
   llvm::raw_string_ostream os(npu);

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -913,7 +913,8 @@ parseTxnBinary(const std::vector<uint8_t> &data, bool verbose = true) {
   LLVM_DEBUG(llvm::outs() << "// NumMemTileRows: "
                           << static_cast<int>(num_mem_tile_rows) << "\n");
   LLVM_DEBUG(llvm::outs() << "// NumOps: " << num_ops << "\n");
-  LLVM_DEBUG(llvm::outs() << "// TxnSize: " << txn_size << " bytes" << "\n");
+  LLVM_DEBUG(llvm::outs() << "// TxnSize: " << txn_size << " bytes"
+                          << "\n");
 
   std::vector<
       std::tuple<uint8_t, uint64_t, uint32_t, uint32_t, const uint8_t *>>

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -13,13 +13,13 @@ extern "C" {
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/IR/AIEEnums.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Region.h"
-#include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 
@@ -28,7 +28,6 @@ extern "C" {
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/ToolOutputFile.h"
 
 #include <algorithm>
 #include <cassert>
@@ -40,6 +39,7 @@ extern "C" {
 #include <map>
 #include <optional>
 #include <string>
+#include <vector>
 
 #ifndef NDEBUG
 #define XAIE_DEBUG
@@ -884,6 +884,139 @@ translateToCDODirect(ModuleOp m, llvm::StringRef workDirPath,
   return result;
 }
 
+// returns number of columns and a vector of
+// std::tuple<opc, addr, value, size|mask, data ptr>
+static std::pair<int, std::vector<std::tuple<uint8_t, uint64_t, uint32_t,
+                                             uint32_t, const uint8_t *>>>
+parseTxnBinary(const std::vector<uint8_t> &data, bool verbose = true) {
+
+  uint8_t major, minor, dev_gen, num_rows, num_cols, num_mem_tile_rows;
+  uint32_t num_ops, txn_size;
+
+  std::memcpy(&major, &data[0], 1);
+  std::memcpy(&minor, &data[1], 1);
+  std::memcpy(&dev_gen, &data[2], 1);
+  std::memcpy(&num_rows, &data[3], 1);
+  std::memcpy(&num_cols, &data[4], 1);
+  std::memcpy(&num_mem_tile_rows, &data[5], 1);
+  std::memcpy(&num_ops, &data[8], 4);
+  std::memcpy(&txn_size, &data[12], 4);
+
+  LLVM_DEBUG(llvm::outs() << "// Major: " << static_cast<int>(major) << "\n");
+  LLVM_DEBUG(llvm::outs() << "// Minor: " << static_cast<int>(minor) << "\n");
+  LLVM_DEBUG(llvm::outs() << "// DevGen: " << static_cast<int>(dev_gen)
+                          << "\n");
+  LLVM_DEBUG(llvm::outs() << "// NumRows: " << static_cast<int>(num_rows)
+                          << "\n");
+  LLVM_DEBUG(llvm::outs() << "// NumCols: " << static_cast<int>(num_cols)
+                          << "\n");
+  LLVM_DEBUG(llvm::outs() << "// NumMemTileRows: "
+                          << static_cast<int>(num_mem_tile_rows) << "\n");
+  LLVM_DEBUG(llvm::outs() << "// NumOps: " << num_ops << "\n");
+  LLVM_DEBUG(llvm::outs() << "// TxnSize: " << txn_size << " bytes" << "\n");
+
+  std::vector<
+      std::tuple<uint8_t, uint64_t, uint32_t, uint32_t, const uint8_t *>>
+      operations;
+  size_t i = 16;
+
+  if (major == 0 && minor == 1) {
+    while (i < data.size()) {
+      uint8_t opc;
+      std::memcpy(&opc, &data[i], 1);
+      LLVM_DEBUG(llvm::outs() << "opcode: " + std::to_string(opc) + "\n");
+
+      if (opc == 0x00) {
+        LLVM_DEBUG(llvm::outs() << "opcode: WRITE (0x00)\n");
+        uint32_t addr0, addr1, value, size;
+        std::memcpy(&addr0, &data[i + 8], 4);
+        std::memcpy(&addr1, &data[i + 12], 4);
+        std::memcpy(&value, &data[i + 16], 4);
+        std::memcpy(&size, &data[i + 20], 4);
+        uint64_t addr = static_cast<uint64_t>(addr1) << 32 | addr0;
+        LLVM_DEBUG(llvm::outs() << "addr: " + std::to_string(addr) + "\n");
+        LLVM_DEBUG(llvm::outs() << "value: " + std::to_string(value) + "\n");
+        LLVM_DEBUG(llvm::outs() << "size: " + std::to_string(size) + "\n");
+        operations.emplace_back(opc, addr, value, size, nullptr);
+        i += size;
+      } else if (opc == 0x01) {
+        LLVM_DEBUG(llvm::outs() << "opcode: BLOCKWRITE (0x01)\n");
+        uint32_t addr, size;
+        std::memcpy(&addr, &data[i + 8], 4);
+        std::memcpy(&size, &data[i + 12], 4);
+        LLVM_DEBUG(llvm::outs() << "addr: " + std::to_string(addr) + "\n");
+        LLVM_DEBUG(llvm::outs() << "size: " + std::to_string(size) + "\n");
+        operations.emplace_back(opc, addr, 0, size - 16, data.data() + i + 16);
+        i += size;
+      } else if (opc == 0x03) {
+        LLVM_DEBUG(llvm::outs() << "opcode: MASKWRITE (0x03)\n");
+        uint32_t addr0, addr1, value, mask, size;
+        std::memcpy(&addr0, &data[i + 8], 4);
+        std::memcpy(&addr1, &data[i + 12], 4);
+        std::memcpy(&value, &data[i + 16], 4);
+        std::memcpy(&mask, &data[i + 20], 4);
+        std::memcpy(&size, &data[i + 24], 4);
+        uint64_t addr = static_cast<uint64_t>(addr1) << 32 | addr0;
+        LLVM_DEBUG(llvm::outs() << "addr: " + std::to_string(addr) + "\n");
+        LLVM_DEBUG(llvm::outs() << "value: " + std::to_string(value) + "\n");
+        LLVM_DEBUG(llvm::outs() << "mask: " + std::to_string(mask) + "\n");
+        LLVM_DEBUG(llvm::outs() << "size: " + std::to_string(size) + "\n");
+        operations.emplace_back(opc, addr, value, mask, nullptr);
+        i += size;
+      } else {
+        //     uint32_t value;
+        //     std::memcpy(&value, &data[i], 4);
+        //     throw std::runtime_error("Unhandled header: " +
+        //     std::to_string(value));
+      }
+    }
+  } else if (major == 1 && minor == 0) {
+    while (i < data.size()) {
+      uint8_t opc;
+      std::memcpy(&opc, &data[i], 1);
+      LLVM_DEBUG(llvm::outs() << "opcode: " + std::to_string(opc) + "\n");
+
+      if (opc == 0x00) {
+        LLVM_DEBUG(llvm::outs() << "opcode: WRITE (0x00)\n");
+        uint32_t addr, value;
+        std::memcpy(&addr, &data[i + 4], 4);
+        std::memcpy(&value, &data[i + 8], 4);
+        LLVM_DEBUG(llvm::outs() << "addr: " + std::to_string(addr) + "\n");
+        LLVM_DEBUG(llvm::outs() << "value: " + std::to_string(value) + "\n");
+        operations.emplace_back(opc, addr, value, 0, nullptr);
+        i += 12;
+      } else if (opc == 0x01) {
+        LLVM_DEBUG(llvm::outs() << "opcode: BLOCKWRITE (0x01)\n");
+        uint32_t addr, size;
+        std::memcpy(&addr, &data[i + 4], 4);
+        std::memcpy(&size, &data[i + 8], 4);
+        LLVM_DEBUG(llvm::outs() << "addr: " + std::to_string(addr) + "\n");
+        LLVM_DEBUG(llvm::outs() << "size: " + std::to_string(size) + "\n");
+        operations.emplace_back(opc, addr, 0, size, data.data() + i + 12);
+        i += size;
+      } else if (opc == 0x03) {
+        LLVM_DEBUG(llvm::outs() << "opcode: MASKWRITE (0x03)\n");
+        uint32_t addr, value, mask;
+        std::memcpy(&addr, &data[i + 4], 4);
+        std::memcpy(&value, &data[i + 8], 4);
+        std::memcpy(&mask, &data[i + 12], 4);
+        LLVM_DEBUG(llvm::outs() << "addr: " + std::to_string(addr) + "\n");
+        LLVM_DEBUG(llvm::outs() << "value: " + std::to_string(value) + "\n");
+        LLVM_DEBUG(llvm::outs() << "mask: " + std::to_string(mask) + "\n");
+        operations.emplace_back(opc, addr, value, mask, nullptr);
+        i += 16;
+      } else {
+        // uint32_t value;
+        // std::memcpy(&value, &data[i], 4);
+        // throw std::runtime_error("Unhandled header: " +
+        // std::to_string(value));
+      }
+    }
+  }
+
+  return {num_cols, operations};
+}
+
 static LogicalResult generateTxn(AIEControl &ctl, const StringRef workDirPath,
                                  DeviceOp &targetOp, bool aieSim,
                                  bool enableElfs, bool enableInit,
@@ -899,9 +1032,9 @@ static LogicalResult generateTxn(AIEControl &ctl, const StringRef workDirPath,
   return success();
 }
 
-static LogicalResult translateToTxn(ModuleOp m, llvm::StringRef workDirPath,
-                                    bool aieSim, bool xaieDebug,
-                                    bool enableCores) {
+static LogicalResult translateToTxn(ModuleOp m, std::vector<uint8_t> &output,
+                                    llvm::StringRef workDirPath, bool aieSim,
+                                    bool xaieDebug, bool enableCores) {
 
   auto devOps = m.getOps<DeviceOp>();
   if (llvm::range_size(devOps) > 1)
@@ -921,24 +1054,16 @@ static LogicalResult translateToTxn(ModuleOp m, llvm::StringRef workDirPath,
 
   auto result =
       generateTxn(ctl, workDirPath, targetOp, aieSim, true, true, true);
+  if (failed(result))
+    return result;
 
   // Export the transactions to a buffer
   uint8_t *txn_ptr = XAie_ExportSerializedTransaction(&ctl.devInst, 0, 0);
-
-  // write transactions to file
   XAie_TxnHeader *hdr = (XAie_TxnHeader *)txn_ptr;
-  std::string filename =
-      (llvm::Twine(workDirPath) + std::string(1, ps) + "txn.bin").str();
+  std::vector<uint8_t> txn_data(txn_ptr, txn_ptr + hdr->TxnSize);
+  output.swap(txn_data);
 
-  std::string errorMessage;
-  auto output = openOutputFile(filename, &errorMessage);
-  if (!output) {
-    llvm::errs() << errorMessage << "\n";
-    return failure();
-  }
-  output->os().write(reinterpret_cast<const char *>(txn_ptr), hdr->TxnSize);
-  output->keep();
-  return result;
+  return success();
 }
 
 LogicalResult xilinx::AIE::AIETranslateToCDODirect(
@@ -950,9 +1075,109 @@ LogicalResult xilinx::AIE::AIETranslateToCDODirect(
                               aieSim, xaieDebug, enableCores);
 }
 
+std::optional<mlir::ModuleOp>
+xilinx::AIE::AIETranslateBinaryToTxn(mlir::MLIRContext *ctx,
+                                     std::vector<uint8_t> &binary) {
+
+  // parse the binary
+  auto [columns, operations] = parseTxnBinary(binary);
+  auto loc = mlir::UnknownLoc::get(ctx);
+
+  // create a new ModuleOp and set the insertion point
+  auto module = ModuleOp::create(loc);
+  OpBuilder builder(module.getBodyRegion());
+  builder.setInsertionPointToStart(module.getBody());
+
+  // create aie.device
+  std::vector<AIEDevice> devices{AIEDevice::npu1_1col, AIEDevice::npu1_2col,
+                                 AIEDevice::npu1_3col, AIEDevice::npu1_4col,
+                                 AIEDevice::npu1};
+  auto device = builder.create<DeviceOp>(loc, devices[columns - 1]);
+  device.getRegion().emplaceBlock();
+  builder.setInsertionPointToStart(device.getBody());
+
+  // for each blockwrite in the binary, create a GlobalOp with the data
+  std::vector<memref::GlobalOp> global_data;
+  for (auto &op : operations) {
+    uint8_t opc = std::get<0>(op);
+    if (opc != 0x01) {
+      global_data.push_back(nullptr);
+      continue;
+    }
+    uint32_t size = (std::get<3>(op) - 16) / 4;
+    const uint32_t *d = reinterpret_cast<const uint32_t *>(std::get<4>(op));
+    std::vector<uint32_t> data32(d, d + size);
+
+    int id = 0;
+    std::string name = "blockwrite_data";
+    while (device.lookupSymbol(name))
+      name = "blockwrite_data_" + std::to_string(id++);
+
+    MemRefType memrefType = MemRefType::get({size}, builder.getI32Type());
+    TensorType tensorType = RankedTensorType::get({size}, builder.getI32Type());
+    auto global = builder.create<memref::GlobalOp>(
+        loc, name, builder.getStringAttr("private"), memrefType,
+        DenseElementsAttr::get<uint32_t>(tensorType, data32), true, nullptr);
+    global_data.push_back(global);
+  }
+
+  // create aiex.runtime_sequence
+  auto seq = builder.create<AIEX::RuntimeSequenceOp>(loc, nullptr);
+  seq.getBody().push_back(new Block);
+
+  // create the txn ops
+  builder.setInsertionPointToStart(&seq.getBody().front());
+  for (auto p : llvm::zip(operations, global_data)) {
+    memref::GlobalOp payload = std::get<1>(p);
+    // operations =
+    // std::vector<std::tuple<uint8_t, uint64_t, uint32_t, uint32_t, uint8_t*>>>
+    auto op = std::get<0>(p);
+    uint8_t opc = std::get<0>(op);
+    uint64_t addr = std::get<1>(op);
+    uint32_t value = std::get<2>(op);
+    uint32_t mask = std::get<3>(op);
+
+    if (opc == 0x00) {
+      builder.create<AIEX::NpuWrite32Op>(loc, addr, value, nullptr, nullptr,
+                                         nullptr);
+    } else if (opc == 0x01) {
+      auto memref = builder.create<memref::GetGlobalOp>(loc, payload.getType(),
+                                                        payload.getName());
+      builder.create<AIEX::NpuBlockWriteOp>(
+          loc, builder.getUI32IntegerAttr(addr), memref.getResult(), nullptr,
+          nullptr, nullptr);
+    } else if (opc == 0x03) {
+      builder.create<AIEX::NpuMaskWrite32Op>(loc, addr, value, mask, nullptr,
+                                             nullptr, nullptr);
+    } else {
+      ; // return std::nullopt;
+    }
+  }
+
+  return module;
+}
+
 LogicalResult xilinx::AIE::AIETranslateToTxn(ModuleOp m,
+                                             llvm::raw_ostream &output,
                                              llvm::StringRef workDirPath,
-                                             bool aieSim, bool xaieDebug,
-                                             bool enableCores) {
-  return translateToTxn(m, workDirPath, aieSim, xaieDebug, enableCores);
+                                             bool outputBinary, bool enableSim,
+                                             bool xaieDebug, bool enableCores) {
+  std::vector<uint8_t> bin;
+  auto result =
+      translateToTxn(m, bin, workDirPath, enableSim, xaieDebug, enableCores);
+  if (failed(result))
+    return result;
+
+  if (outputBinary) {
+    output.write(reinterpret_cast<const char *>(bin.data()), bin.size());
+    return success();
+  }
+
+  auto new_module = AIETranslateBinaryToTxn(m.getContext(), bin);
+  if (!new_module)
+    return failure();
+
+  new_module->print(output);
+
+  return success();
 }

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -887,11 +887,12 @@ translateToCDODirect(ModuleOp m, llvm::StringRef workDirPath,
 
 namespace {
 
-// An TxnBinaryOperation encapulates an aie-rt TnxCmd struct
-struct TxnBinaryOperation {
+// An TransactionBinaryOperation encapulates an aie-rt TnxCmd struct
+struct TransactionBinaryOperation {
   struct XAie_TxnCmd cmd;
-  TxnBinaryOperation(XAie_TxnOpcode opc, uint32_t mask, uint64_t addr,
-                     uint32_t value, const uint8_t *data, uint32_t size) {
+  TransactionBinaryOperation(XAie_TxnOpcode opc, uint32_t mask, uint64_t addr,
+                             uint32_t value, const uint8_t *data,
+                             uint32_t size) {
     cmd.Opcode = opc;
     cmd.Mask = mask;
     cmd.RegOff = addr;
@@ -904,8 +905,9 @@ struct TxnBinaryOperation {
 
 // Parse a TXN binary blob. On success return the number of columns from the
 // header and a vector of parsed operations. On failure return std::nullopt.
-static std::optional<int> parseTxnBinary(const std::vector<uint8_t> &data,
-                                         std::vector<TxnBinaryOperation> &ops) {
+static std::optional<int>
+parseTransactionBinary(const std::vector<uint8_t> &data,
+                       std::vector<TransactionBinaryOperation> &ops) {
 
   uint32_t major = data[0];
   uint32_t minor = data[1];
@@ -945,8 +947,8 @@ static std::optional<int> parseTxnBinary(const std::vector<uint8_t> &data,
   };
 
   // Parse the binary blob. There are two versions supported, 0.1 and 1.0.
-  // For both versions, build a list of TxnBinaryOperation objects representing
-  // the parsed operations.
+  // For both versions, build a list of TransactionBinaryOperation objects
+  // representing the parsed operations.
   if (major == 0 && minor == 1) {
     while (i < data.size()) {
 
@@ -1111,8 +1113,8 @@ xilinx::AIE::AIETranslateBinaryToTxn(mlir::MLIRContext *ctx,
                                      std::vector<uint8_t> &binary) {
 
   // parse the binary
-  std::vector<TxnBinaryOperation> operations;
-  auto c = parseTxnBinary(binary, operations);
+  std::vector<TransactionBinaryOperation> operations;
+  auto c = parseTransactionBinary(binary, operations);
   if (!c) {
     llvm::errs() << "Failed to parse binary\n";
     return std::nullopt;

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -92,8 +92,9 @@ void writeBufferMap(raw_ostream &output, BufferOp buf, int offset) {
   std::string bufName(buf.name().getValue());
   int bufferBaseAddr = getBufferBaseAddress(buf);
   int numBytes = buf.getAllocationSize();
-  output << "_symbol " << bufName << " " << "0x"
-         << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes << '\n';
+  output << "_symbol " << bufName << " "
+         << "0x" << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes
+         << '\n';
 }
 
 LogicalResult AIETranslateToTargetArch(ModuleOp module, raw_ostream &output) {

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -92,9 +92,8 @@ void writeBufferMap(raw_ostream &output, BufferOp buf, int offset) {
   std::string bufName(buf.name().getValue());
   int bufferBaseAddr = getBufferBaseAddress(buf);
   int numBytes = buf.getAllocationSize();
-  output << "_symbol " << bufName << " "
-         << "0x" << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes
-         << '\n';
+  output << "_symbol " << bufName << " " << "0x"
+         << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes << '\n';
 }
 
 LogicalResult AIETranslateToTargetArch(ModuleOp module, raw_ostream &output) {
@@ -339,8 +338,10 @@ void registerAIETranslations() {
       },
       registerDialects);
   TranslateFromMLIRRegistration registrationCDOWithTxn(
-      "aie-generate-txn", "Generate TXN configuration",
-      [](ModuleOp module, raw_ostream &) {
+      "aie-generate-txn",
+      "Generate TXN configuration. Use --aie-output-binary to select between "
+      "mlir (default) and binary output",
+      [](ModuleOp module, raw_ostream &output) {
         SmallString<128> workDirPath_;
         if (workDirPath.getNumOccurrences() == 0) {
           if (llvm::sys::fs::current_path(workDirPath_))
@@ -349,8 +350,8 @@ void registerAIETranslations() {
         } else
           workDirPath_ = workDirPath.getValue();
         LLVM_DEBUG(llvm::dbgs() << "work-dir-path: " << workDirPath_ << "\n");
-        return AIETranslateToTxn(module, workDirPath_.c_str(), cdoAieSim,
-                                 cdoXaieDebug, cdoEnableCores);
+        return AIETranslateToTxn(module, output, workDirPath_, outputBinary,
+                                 cdoAieSim, cdoXaieDebug, cdoEnableCores);
       },
       registerDialects);
   TranslateFromMLIRRegistration registrationNPU(

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -133,6 +133,15 @@ PYBIND11_MODULE(_aie, m) {
       "xaie_debug"_a = false, "enable_cores"_a = true);
 
   m.def(
+      "transaction_binary_to_mlir",
+      [](MlirContext ctx, py::bytes bytes) {
+        std::string s = bytes;
+        MlirStringRef bin = {s.data(), s.size()};
+        return aieTranslateBinaryToTxn(ctx, bin);
+      },
+      "ctx"_a, "binary"_a);
+
+  m.def(
       "npu_instgen",
       [&stealCStr](MlirOperation op) {
         py::str npuInstructions = stealCStr(aieTranslateToNPU(op));

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -117,18 +117,20 @@ PYBIND11_MODULE(_aie, m) {
 
   m.def(
       "generate_txn",
-      [](MlirOperation op, const std::string &workDirPath, bool aieSim,
-         bool xaieDebug, bool enableCores) {
+      [](MlirOperation op, const std::string &outputFile,
+         const std::string &workDirPath, bool aieSim, bool xaieDebug,
+         bool enableCores) {
         mlir::python::CollectDiagnosticsToStringScope scope(
             mlirOperationGetContext(op));
         if (mlirLogicalResultIsFailure(
-                aieTranslateToTxn(op, {workDirPath.data(), workDirPath.size()},
+                aieTranslateToTxn(op, {outputFile.data(), outputFile.size()},
+                                  {workDirPath.data(), workDirPath.size()},
                                   aieSim, xaieDebug, enableCores)))
           throw py::value_error("Failed to generate txn binary because: " +
                                 scope.takeMessage());
       },
-      "module"_a, "work_dir_path"_a, "aiesim"_a = false, "xaie_debug"_a = false,
-      "enable_cores"_a = true);
+      "module"_a, "output_file"_a, "work_dir_path"_a, "aiesim"_a = false,
+      "xaie_debug"_a = false, "enable_cores"_a = true);
 
   m.def(
       "npu_instgen",

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -580,7 +580,8 @@ class FlowRunner:
             input_physical = Module.parse(
                 await read_file_async(self.prepend_tmp("input_physical.mlir"))
             )
-            generate_txn(input_physical.operation, self.tmpdirname)
+            txn_file = os.path.join(self.tmpdirname, "txn.mlir")
+            generate_txn(input_physical.operation, txn_file, self.tmpdirname)
 
     async def process_xclbin_gen(self):
         if opts.progress:

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -29,6 +29,7 @@ from .._mlir_libs._aie import (
     register_dialect,
     translate_aie_vec_to_cpp,
     translate_mlir_to_llvmir,
+    transaction_binary_to_mlir,
 )
 from ..extras import types as T
 from ..extras.dialects.ext.arith import constant

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -6,7 +6,6 @@
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ -lboost_program_options -lboost_filesystem
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.txt %S/aie1.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-txn --aie-generate-npu --no-compile-host --npu-insts-name=add_two_insts.txt %S/aie2.mlir
-// RUN: %python txn2mlir.py -f aie2.mlir.prj/txn.bin > add_two_cfg.mlir
-// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true add_two_cfg.mlir -o add_two_cfg.bin
+// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true aie2.mlir.prj/txn.mlir -o add_two_cfg.bin
 // RUN: %run_on_npu ./test.exe -x add_one.xclbin -i add_one_insts.txt -c add_two_cfg.bin -j add_two_insts.txt | FileCheck %s
 // CHECK: PASS!


### PR DESCRIPTION
* port txn2mlir.py binary to mlir conversion into AIETargetCDODirect.cpp, add it back into python via pybind
* aie-translate -aie-generate-txn respects -o option instead of dumping to workdir
* aie-translate -aie-generate-txn respects -aie-output-binary to select between mlir (default) and binary output
* aiecc --generate-txn now generates an mlir file containing a runtime sequence of npu txn ops instead of a binary blob. hardcoded to workdir/txn.mlir for now
* update test/npu-xrt/add_one_two_txn