### PR TITLE
update upload/download-artifact action

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -83,7 +83,7 @@ jobs:
           mv "$WHL_FN" "`echo $WHL_FN | sed "s/cp310-cp310/py3-none/"`"
 
       - name: Upload mlir_aie
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/repaired_wheel/mlir_aie*whl
           name: mlir_aie
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload wheels
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/repaired_wheel/aie_python_bindings*.whl
           name: ryzen_ai_wheel

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload clang-tidy fixes
         if: ${{ steps.clang-tidy-fixes.outputs.FIXES }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: fixes.yml
           name: clang-tidy-fixes.yml
@@ -142,7 +142,7 @@ jobs:
           cat clang-format.diff
 
       - name: Upload clang-format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: clang-format.diff
           name: format_diffs
@@ -164,7 +164,7 @@ jobs:
           cat black-format.diff
 
       - name: Upload black-format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: black-format.diff
           name: format_diffs

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -352,7 +352,7 @@ jobs:
 
     - name: Upload wheels
       if: github.event_name != 'schedule'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}/wheelhouse/*.whl
         name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -395,7 +395,7 @@ jobs:
           #   ENABLE_RTTI: OFF
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
           path: dist
@@ -471,7 +471,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir


### PR DESCRIPTION
Fix deprecated Node.js version warnings. Also, according to README, actions/download-artifact@v3 is scheduled for deprecation on November 30, 2024.