### PR TITLE
Enable objectfifo memtile repeat examples

### DIFF
--- a/programming_examples/basic/memtile_repeat/distribute_repeat/README.md
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/README.md
@@ -12,7 +12,9 @@
 
 This reference design can be run on a Ryzen™ AI NPU.
 
-TODO
+In the [design](./aie2.py) data is brought from external memory via the `ShimTile` to the `MemTile`. The data is then split between two `ComputeTile`s using a distribute operation specified via an `object_fifo_link`. Each input objectfifo between the `MemTile` and each `ComputeTile` is further configured to repeat the data so as to send multiple copies of that data to each `ComputeTile`.
+
+For more information, the `object_fifo_link` operation as well as the concept of distribution and its functionality is described in more depth in [Section-2b](../../../programming_guide/section-2/section-2b/03_Link_Distribute_Join/README.md#object-fifo-link) of the programming guide.
 
 To compile and run the design for NPU:
 ```

--- a/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
@@ -14,9 +14,9 @@ from aie.dialects.scf import *
 from aie.extras.dialects.ext import arith
 from aie.extras.context import mlir_mod_ctx
 
-N = 36
 dev = AIEDevice.npu1_1col
 col = 0
+N = 36
 
 if len(sys.argv) > 1:
     N = int(sys.argv[1])

--- a/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
@@ -5,18 +5,18 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
-
 import sys
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.dialects.scf import *
-from aie.extras.dialects.ext import memref, arith
+from aie.extras.dialects.ext import arith
 from aie.extras.context import mlir_mod_ctx
 
+N = 4096
 dev = AIEDevice.npu1_1col
 col = 0
-N = 36
+repeat_counter = 6
 
 if len(sys.argv) > 1:
     N = int(sys.argv[1])
@@ -32,7 +32,7 @@ if len(sys.argv) > 2:
 if len(sys.argv) > 3:
     col = int(sys.argv[3])
 
-repeat_counter = 6
+assert N % 2 == 0, "N must be even"
 out_size = N * (repeat_counter + 1)
 
 
@@ -41,9 +41,9 @@ def distribute_repeat():
 
         @device(dev)
         def device_body():
-            memRef_in_ty = T.memref(N, T.i32())
+            memRef_ty = T.memref(N, T.i32())
+            memRef_half_ty = T.memref(N // 2, T.i32())
             memRef_out_ty = T.memref(out_size, T.i32())
-            memRef_18_ty = T.memref(N // 2, T.i32())
 
             # Tile declarations
             ShimTile = tile(col, 0)
@@ -52,15 +52,15 @@ def distribute_repeat():
             ComputeTile3 = tile(col, 3)
 
             # AIE-array data movement with object fifos
-            of_in = object_fifo("in", ShimTile, MemTile, 1, memRef_in_ty)
-            of_in2 = object_fifo("in2", MemTile, ComputeTile2, 2, memRef_18_ty)
-            of_in3 = object_fifo("in3", MemTile, ComputeTile3, 2, memRef_18_ty)
+            of_in = object_fifo("in", ShimTile, MemTile, 1, memRef_ty)
+            of_in2 = object_fifo("in2", MemTile, ComputeTile2, 2, memRef_half_ty)
+            of_in3 = object_fifo("in3", MemTile, ComputeTile3, 2, memRef_half_ty)
             of_in2.set_memtile_repeat(repeat_counter)
             of_in3.set_memtile_repeat(repeat_counter)
             object_fifo_link(of_in, [of_in2, of_in3], [], [0, N // 2])
 
-            of_out2 = object_fifo("out2", ComputeTile2, MemTile, 2, memRef_18_ty)
-            of_out3 = object_fifo("out3", ComputeTile3, MemTile, 2, memRef_18_ty)
+            of_out2 = object_fifo("out2", ComputeTile2, MemTile, 2, memRef_half_ty)
+            of_out3 = object_fifo("out3", ComputeTile3, MemTile, 2, memRef_half_ty)
             of_out = object_fifo("out", MemTile, ShimTile, 1, memRef_out_ty)
             object_fifo_link([of_out2, of_out3], of_out, [0, out_size // 2], [])
 
@@ -97,10 +97,10 @@ def distribute_repeat():
                     yield_([])
 
             # To/from AIE-array data movement
+            tensor_ty = T.memref(N, T.i32())
             tensor_out_ty = T.memref(out_size, T.i32())
-            tensor_in_ty = T.memref(N, T.i32())
 
-            @runtime_sequence(tensor_in_ty, tensor_in_ty, tensor_out_ty)
+            @runtime_sequence(tensor_ty, tensor_ty, tensor_out_ty)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(
                     metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, out_size]

--- a/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
 import sys
 
 from aie.dialects.aie import *
@@ -13,10 +14,9 @@ from aie.dialects.scf import *
 from aie.extras.dialects.ext import arith
 from aie.extras.context import mlir_mod_ctx
 
-N = 4096
+N = 32
 dev = AIEDevice.npu1_1col
 col = 0
-repeat_counter = 6
 
 if len(sys.argv) > 1:
     N = int(sys.argv[1])
@@ -33,6 +33,7 @@ if len(sys.argv) > 3:
     col = int(sys.argv[3])
 
 assert N % 2 == 0, "N must be even"
+repeat_counter = 6
 out_size = N * (repeat_counter + 1)
 
 
@@ -41,7 +42,7 @@ def distribute_repeat():
 
         @device(dev)
         def device_body():
-            memRef_ty = T.memref(N, T.i32())
+            memRef_in_ty = T.memref(N, T.i32())
             memRef_half_ty = T.memref(N // 2, T.i32())
             memRef_out_ty = T.memref(out_size, T.i32())
 
@@ -52,7 +53,7 @@ def distribute_repeat():
             ComputeTile3 = tile(col, 3)
 
             # AIE-array data movement with object fifos
-            of_in = object_fifo("in", ShimTile, MemTile, 1, memRef_ty)
+            of_in = object_fifo("in", ShimTile, MemTile, 1, memRef_in_ty)
             of_in2 = object_fifo("in2", MemTile, ComputeTile2, 2, memRef_half_ty)
             of_in3 = object_fifo("in3", MemTile, ComputeTile3, 2, memRef_half_ty)
             of_in2.set_memtile_repeat(repeat_counter)
@@ -97,10 +98,10 @@ def distribute_repeat():
                     yield_([])
 
             # To/from AIE-array data movement
-            tensor_ty = T.memref(N, T.i32())
             tensor_out_ty = T.memref(out_size, T.i32())
+            tensor_in_ty = T.memref(N, T.i32())
 
-            @runtime_sequence(tensor_ty, tensor_ty, tensor_out_ty)
+            @runtime_sequence(tensor_in_ty, tensor_in_ty, tensor_out_ty)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(
                     metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, out_size]

--- a/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/aie2.py
@@ -14,7 +14,7 @@ from aie.dialects.scf import *
 from aie.extras.dialects.ext import arith
 from aie.extras.context import mlir_mod_ctx
 
-N = 32
+N = 36
 dev = AIEDevice.npu1_1col
 col = 0
 

--- a/programming_examples/basic/memtile_repeat/distribute_repeat/run_makefile.lit
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/run_makefile.lit
@@ -6,4 +6,4 @@
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
 // RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
-// XFAIL: *
+// CHECK: PASS!

--- a/programming_examples/basic/memtile_repeat/distribute_repeat/test.cpp
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/test.cpp
@@ -180,17 +180,17 @@ int main(int argc, const char *argv[]) {
   for (uint32_t i = 0; i < out_size / 2; i++) {
     uint32_t ref = (i % (N / 2)) + 2;
     if (*(bufOut + i) != ref) {
-      errors++;
       std::cout << "error at index[" << i << "]: expected " << ref << " got "
                 << *(bufOut + i) << std::endl;
+      errors++;
     }
   }
   for (uint32_t i = out_size / 2; i < out_size; i++) {
     uint32_t ref = (i % (N / 2)) + (N / 2) + 3;
     if (*(bufOut + i) != ref) {
-      errors++;
       std::cout << "error at index[" << i << "]: expected " << ref << " got "
                 << *(bufOut + i) << std::endl;
+      errors++;
     }
   }
 

--- a/programming_examples/basic/memtile_repeat/distribute_repeat/test.cpp
+++ b/programming_examples/basic/memtile_repeat/distribute_repeat/test.cpp
@@ -92,8 +92,12 @@ int main(int argc, const char *argv[]) {
     std::cout << "Sequence instr count: " << instr_v.size() << std::endl;
 
   int N = vm["length"].as<int>();
-  int R = 6;
-  int O = N * (R + 1);
+  if ((N % 2 == 1)) {
+    std::cerr << "Length must be a multiple of 2." << std::endl;
+    return 1;
+  }
+  int repeat_count = 6;
+  int out_size = N * (repeat_count + 1);
 
   // Start the XRT test code
   // Get a device handle
@@ -138,13 +142,13 @@ int main(int argc, const char *argv[]) {
   auto kernel = xrt::kernel(context, kernelName);
 
   auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
-                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(0));
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
   auto bo_inA = xrt::bo(device, N * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
-                        kernel.group_id(2));
-  auto bo_inB = xrt::bo(device, N * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
                         kernel.group_id(3));
-  auto bo_out = xrt::bo(device, O * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
+  auto bo_inB = xrt::bo(device, N * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
                         kernel.group_id(4));
+  auto bo_out = xrt::bo(device, out_size * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
 
   if (verbosity >= 1)
     std::cout << "Writing data into buffer objects." << std::endl;
@@ -152,7 +156,7 @@ int main(int argc, const char *argv[]) {
   int32_t *bufInA = bo_inA.map<int32_t *>();
   std::vector<uint32_t> srcVecA;
   for (int i = 0; i < N; i++)
-    srcVecA.push_back(1);
+    srcVecA.push_back(i + 1);
   memcpy(bufInA, srcVecA.data(), (srcVecA.size() * sizeof(uint32_t)));
 
   void *bufInstr = bo_instr.map<void *>();
@@ -163,7 +167,8 @@ int main(int argc, const char *argv[]) {
 
   if (verbosity >= 1)
     std::cout << "Running Kernel." << std::endl;
-  auto run = kernel(bo_instr, instr_v.size(), bo_inA, bo_inB, bo_out);
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), bo_inA, bo_inB, bo_out);
   run.wait();
 
   bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
@@ -171,18 +176,21 @@ int main(int argc, const char *argv[]) {
   uint32_t *bufOut = bo_out.map<uint32_t *>();
 
   int errors = 0;
-  int repeat_pattern_limit_1 = O / 2;
 
-  for (uint32_t i = 0; i < O; i++) {
-    uint32_t ref = i;
-    if (i < repeat_pattern_limit_1)
-      ref = 2;
-    else
-      ref = 3;
+  for (uint32_t i = 0; i < out_size / 2; i++) {
+    uint32_t ref = (i % (N / 2)) + 2;
     if (*(bufOut + i) != ref) {
+      errors++;
       std::cout << "error at index[" << i << "]: expected " << ref << " got "
                 << *(bufOut + i) << std::endl;
+    }
+  }
+  for (uint32_t i = out_size / 2; i < out_size; i++) {
+    uint32_t ref = (i % (N / 2)) + (N / 2) + 3;
+    if (*(bufOut + i) != ref) {
       errors++;
+      std::cout << "error at index[" << i << "]: expected " << ref << " got "
+                << *(bufOut + i) << std::endl;
     }
   }
 

--- a/programming_examples/basic/memtile_repeat/simple_repeat/README.md
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/README.md
@@ -18,7 +18,7 @@ The implicit copy is performed using the `object_fifo_link` operation that speci
 
 The repeat count is specified as follows:
 ```
-of_out.set_memtile_repeat(3)
+of_out.set_memtile_repeat(memtile_repeat_count)
 ```
 Specifically, the instruction above specifies the number of repetitions that the producer side of the `of_out` objectfifo should do.
 

--- a/programming_examples/basic/memtile_repeat/simple_repeat/README.md
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/README.md
@@ -17,7 +17,7 @@ In the [design](./aie2.py) data is brought from external memory via the `ShimTil
 The implicit copy is performed using the `object_fifo_link` operation that specifies how input data arriving via `of_in` should be sent further via `of_out` by specifically leveraging the compute tile's DMA. This operation and its functionality are described in more depth in [Section-2b](../../../programming_guide/section-2/section-2b/03_Link_Distribute_Join/README.md#object-fifo-link) of the programming guide.
 
 The repeat count is specified as follows:
-```
+```python
 of_out.set_memtile_repeat(memtile_repeat_count)
 ```
 Specifically, the instruction above specifies the number of repetitions that the producer side of the `of_out` objectfifo should do.

--- a/programming_examples/basic/memtile_repeat/simple_repeat/aie2.py
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/aie2.py
@@ -1,4 +1,4 @@
-# passthrough_dmas/aie2.py -*- Python -*-
+# memtile_repeat/simple_repeat/aie2.py -*- Python -*-
 #
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
@@ -33,7 +33,7 @@ if len(sys.argv) > 3:
     col = int(sys.argv[3])
 
 
-def my_passthrough():
+def simple_repeat():
     with mlir_mod_ctx() as ctx:
 
         @device(dev)
@@ -68,4 +68,4 @@ def my_passthrough():
     print(ctx.module)
 
 
-my_passthrough()
+simple_repeat()

--- a/programming_examples/basic/memtile_repeat/simple_repeat/aie2.py
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/aie2.py
@@ -56,7 +56,12 @@ def my_passthrough():
 
             @runtime_sequence(tensor_ty, tensor_ty, tensor_out_ty)
             def sequence(A, B, C):
-                npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N * (memtile_repeat_count + 1)])
+                npu_dma_memcpy_nd(
+                    metadata="out",
+                    bd_id=0,
+                    mem=C,
+                    sizes=[1, 1, 1, N * (memtile_repeat_count + 1)],
+                )
                 npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])
                 npu_sync(column=0, row=0, direction=0, channel=0)
 

--- a/programming_examples/basic/memtile_repeat/simple_repeat/run_makefile.lit
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/run_makefile.lit
@@ -6,4 +6,3 @@
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
 // RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
-// XFAIL: *

--- a/programming_examples/basic/memtile_repeat/simple_repeat/run_makefile.lit
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/run_makefile.lit
@@ -6,3 +6,4 @@
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
 // RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!

--- a/programming_examples/basic/memtile_repeat/simple_repeat/test.cpp
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/test.cpp
@@ -66,8 +66,7 @@ int main(int argc, const char *argv[]) {
       "length,l", po::value<int>()->default_value(4096),
       "the length of the transfer in int32_t")(
       "repeat,r", po::value<int>()->default_value(3),
-      "the memtile repeat count"
-      );
+      "the memtile repeat count");
   po::variables_map vm;
 
   try {
@@ -149,8 +148,8 @@ int main(int argc, const char *argv[]) {
                         kernel.group_id(3));
   auto bo_inB = xrt::bo(device, N * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
                         kernel.group_id(4));
-  auto bo_out = xrt::bo(device, N * (repeat_count + 1) * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
-                        kernel.group_id(5));
+  auto bo_out = xrt::bo(device, N * (repeat_count + 1) * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
 
   if (verbosity >= 1)
     std::cout << "Writing data into buffer objects." << std::endl;

--- a/programming_examples/basic/memtile_repeat/simple_repeat/test.cpp
+++ b/programming_examples/basic/memtile_repeat/simple_repeat/test.cpp
@@ -180,6 +180,8 @@ int main(int argc, const char *argv[]) {
   for (uint32_t i = 0; i < N * (repeat_count + 1); i++) {
     uint32_t ref = (i % N) + 1;
     if (*(bufOut + i) != ref) {
+      std::cout << "error at index[" << i << "]: expected " << ref << " got "
+                << *(bufOut + i) << std::endl;
       errors++;
     }
   }


### PR DESCRIPTION
The objectfifo memtile repeat programming examples were not functional due to minor bugs. This PR fixes both examples and enables their lit tests, as well as adds a bit of documentation for the distribute repeat example.