### PR TITLE
[Ctrl Pkt Reconfig E2E] More restrictive column control overlay generation

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -39,6 +39,77 @@ int getUnusedPacketIdFrom(DeviceOp device) {
   return unusedPacketIdFrom + 1;
 }
 
+// AIE arch-specific tile id to controller id mapping. Users can use those
+// packet ids for design but run into risk of deadlocking control packet flows.
+DenseMap<AIE::TileID, int>
+getTileToControllerIdMap(bool clColumnWiseUniqueIDs,
+                         const AIETargetModel &targetModel) {
+  // Below column controller id combinations were chosen to avoid packet flow
+  // deadlock due to single-level LUT bit-masking on packet header, which could
+  // fail to differentiate certain packet id combinations. Controller ids for
+  // shim tiles were chosen to be < 16, because when they act as actor id in TCT
+  // tokens, the actor id field only has 4 bits.
+  // FIXME
+  SmallVector<SmallVector<int>> validTileIds = {{15, 26, 27, 29, 30, 31},
+                                                {14, 21, 22, 23, 24, 25},
+                                                {13, 11, 17, 18, 19, 20},
+                                                {12, 28, 7, 8, 9, 10}};
+  DenseMap<AIE::TileID, int> tileIDMap;
+  for (int col = 0; col < targetModel.columns(); col++) {
+    for (int row = 0; row < targetModel.rows(); row++) {
+      if (clColumnWiseUniqueIDs)
+        tileIDMap[{col, row}] = validTileIds[0][row];
+      else
+        tileIDMap[{col, row}] = validTileIds[col][row];
+    }
+  }
+
+  return tileIDMap;
+}
+
+// AIE arch-specific row id to shim dma mm2s channel mapping. All shim mm2s
+// channels were assumed to be available for control packet flow routing (i.e.
+// not reserved by any aie.flow circuit-switched routing).
+DenseMap<int, int> getRowToShimChanMap(const AIETargetModel &targetModel,
+                                       WireBundle bundle) {
+  DenseMap<int, int> rowMap;
+  SmallVector<int>
+      thresholdsToNextShimChannel; // a list of thresholds on the number of
+                                   // control ports that the ith shim channel
+                                   // could connect to, before advancing to
+                                   // the next shim channel in round robin
+  TileID shimTile = {0, 0};
+  while (!targetModel.isShimNOCTile(shimTile.col, shimTile.row)) {
+    shimTile.col++;
+    if (shimTile.col == targetModel.columns()) {
+      shimTile.col = 0;
+      shimTile.row++;
+    }
+    assert(!(shimTile.col == targetModel.columns() &&
+             shimTile.row == targetModel.rows()));
+  }
+
+  int numShimChans = targetModel.getNumSourceShimMuxConnections(
+      shimTile.col, shimTile.row, AIE::WireBundle::DMA);
+  for (int i = 1; i < numShimChans + 1; i++)
+    thresholdsToNextShimChannel.push_back(targetModel.rows() / numShimChans *
+                                          i);
+
+  if (bundle == WireBundle::DMA) { // Ctrl packets
+    int shimChanIdx = 0;
+    for (int r = 0; r < targetModel.rows(); r++) {
+      if (r >= thresholdsToNextShimChannel[shimChanIdx])
+        shimChanIdx++;
+      rowMap[r] = shimChanIdx;
+    }
+  } else if (bundle == WireBundle::South) { // TCT
+    for (int r = 0; r < targetModel.rows(); r++)
+      rowMap[r] = 0;
+  }
+
+  return rowMap;
+}
+
 struct AIEAssignTileCtrlIDsPass
     : AIEAssignTileCtrlIDsBase<AIEAssignTileCtrlIDsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -51,7 +122,7 @@ struct AIEAssignTileCtrlIDsPass
     if (targetModel.getTargetArch() == AIEArch::AIE1)
       return; // Disable this pass for AIE1; AIE1 support NYI.
 
-    // Collect TileOps
+    // Collect all TileOps in columns occupied by the design.
     llvm::MapVector<AIE::TileID, AIE::TileOp> tiles;
     llvm::SmallSet<int, 1> occupiedCols;
     for (auto tile : device.getOps<AIE::TileOp>()) {
@@ -61,12 +132,9 @@ struct AIEAssignTileCtrlIDsPass
       occupiedCols.insert(colIndex);
     }
 
-    // Assign controller ids.
-    int designUnusedPacketIdFrom = getUnusedPacketIdFrom(device);
-    int unusedPacketIdFrom = designUnusedPacketIdFrom;
+    auto tileIDMap =
+        getTileToControllerIdMap(clColumnWiseUniqueIDs, targetModel);
     for (int col : occupiedCols) {
-      if (clColumnWiseUniqueIDs)
-        unusedPacketIdFrom = designUnusedPacketIdFrom;
       SmallVector<AIE::TileOp> tilesOnCol;
       for (auto &[tId, tOp] : tiles) {
         if (tId.col != col)
@@ -77,9 +145,9 @@ struct AIEAssignTileCtrlIDsPass
       for (auto tOp : tilesOnCol) {
         if (tOp->hasAttr("controller_id"))
           continue;
-        auto pktInfoAttr =
-            AIE::PacketInfoAttr::get(tOp->getContext(), /*pkt_type*/ 0,
-                                     /*pkt_id*/ unusedPacketIdFrom++);
+        auto pktInfoAttr = AIE::PacketInfoAttr::get(
+            tOp->getContext(), /*pkt_type*/ 0,
+            /*pkt_id*/ tileIDMap[{tOp.colIndex(), tOp.rowIndex()}]);
         tOp->setAttr("controller_id", pktInfoAttr);
       }
     }
@@ -90,6 +158,7 @@ struct AIEGenerateColumnControlOverlayPass
     : AIEGenerateColumnControlOverlayBase<AIEGenerateColumnControlOverlayPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<AIEDialect>();
+    registry.insert<memref::MemRefDialect>();
   }
   void runOnOperation() override {
     DeviceOp device = getOperation();
@@ -109,7 +178,7 @@ struct AIEGenerateColumnControlOverlayPass
       occupiedCols.insert(colIndex);
     }
 
-    int designUnusedPacketIdFrom = getUnusedPacketIdFrom(device);
+    auto tileIDMap = getTileToControllerIdMap(true, targetModel);
     for (int col : occupiedCols) {
       builder.setInsertionPointToStart(device.getBody());
       AIE::TileOp shimTile = TileOp::getOrCreate(builder, device, col, 0);
@@ -126,14 +195,9 @@ struct AIEGenerateColumnControlOverlayPass
           tilesOnCol.push_back(tOp);
         }
 
-        int unusedPacketIdFrom = designUnusedPacketIdFrom;
-        SmallVector<int> availableShimChans = {
-            0}; // Only using SHIM dest SOUTH 0 for TCT.
-        // Create packet flows per col
         generatePacketFlowsForControl(
             builder, device, targetModel, shimTile, AIE::WireBundle::South,
-            availableShimChans, tilesOnCol, AIE::WireBundle::Ctrl, 0,
-            unusedPacketIdFrom, false);
+            tilesOnCol, AIE::WireBundle::Ctrl, 0, tileIDMap, false);
       }
       if (clRouteShimDmaToTileCTRL) {
         // Get all tile ops on column col
@@ -141,21 +205,12 @@ struct AIEGenerateColumnControlOverlayPass
         for (auto &[tId, tOp] : tiles) {
           if (tId.col != col)
             continue;
-          if (targetModel.isCoreTile(tId.col, tId.row) ||
-              targetModel.isMemTile(tId.col, tId.row))
-            tilesOnCol.push_back(tOp);
+          tilesOnCol.push_back(tOp);
         }
 
-        int unusedPacketIdFrom = designUnusedPacketIdFrom;
-        int numShimChans = targetModel.getNumSourceShimMuxConnections(
-            shimTile.getCol(), shimTile.getRow(), AIE::WireBundle::DMA);
-        SmallVector<int> availableShimChans = getAvailableShimChans(
-            device, numShimChans, shimTile, AIE::WireBundle::DMA, true);
-        // Create packet flows per col
-        generatePacketFlowsForControl(builder, device, targetModel, shimTile,
-                                      AIE::WireBundle::DMA, availableShimChans,
-                                      tilesOnCol, AIE::WireBundle::Ctrl, 0,
-                                      unusedPacketIdFrom, true);
+        generatePacketFlowsForControl(
+            builder, device, targetModel, shimTile, AIE::WireBundle::DMA,
+            tilesOnCol, AIE::WireBundle::Ctrl, 0, tileIDMap, true);
       }
     }
   }
@@ -179,75 +234,112 @@ struct AIEGenerateColumnControlOverlayPass
     return pktFlow;
   }
 
-  // Create packet flows per col which moves control packets to and from shim
-  // dma
-  void generatePacketFlowsForControl(OpBuilder builder, DeviceOp device,
-                                     const AIETargetModel &targetModel,
-                                     TileOp shimTile, WireBundle shimWireBundle,
-                                     SmallVector<int> availableShimChans,
-                                     SmallVector<AIE::TileOp> ctrlTiles,
-                                     WireBundle ctrlWireBundle,
-                                     int coreOrMemChanId,
-                                     int unusedPacketIdFrom, bool isShimMM2S) {
-    // Create packet flows
-    SmallVector<int>
-        thresholdsToNextShimChannel; // a list of thresholds on the number of
-                                     // control ports that the ith shim channel
-                                     // could connect to, before advancing to
-                                     // the next shim channel in round robin
-    for (int i = 1; i < (int)availableShimChans.size() + 1; i++)
-      thresholdsToNextShimChannel.push_back(ctrlTiles.size() /
-                                            availableShimChans.size() * i);
-    int ctrlPktFlowID = unusedPacketIdFrom;
-    int shimChanIdx = 0;
-    for (int i = 0; i < (int)ctrlTiles.size(); i++) {
-      if (ctrlTiles[i]->hasAttr("controller_id"))
-        ctrlPktFlowID =
-            (int)ctrlTiles[i]
-                ->getAttrOfType<AIE::PacketInfoAttr>("controller_id")
-                .getPktId();
-      builder.setInsertionPointToEnd(device.getBody());
-      auto keep_pkt_header = builder.getBoolAttr(true);
-      if (isShimMM2S)
-        (void)createPacketFlowOp(
-            builder, ctrlPktFlowID, shimTile, shimWireBundle,
-            availableShimChans[shimChanIdx], ctrlTiles[i], ctrlWireBundle,
-            coreOrMemChanId, keep_pkt_header);
-      else
-        (void)createPacketFlowOp(
-            builder, ctrlPktFlowID, ctrlTiles[i], ctrlWireBundle,
-            coreOrMemChanId, shimTile, shimWireBundle,
-            availableShimChans[shimChanIdx], keep_pkt_header);
-      if (i >= thresholdsToNextShimChannel[shimChanIdx]) {
-        shimChanIdx++;
-        ctrlPktFlowID = unusedPacketIdFrom;
-      }
-    }
-  }
-
   // Get a vector of shim channels not reserved by any circuit-switched aie.flow
   // op
-  SmallVector<int> getAvailableShimChans(DeviceOp device, int numShimChans,
-                                         TileOp shimTile,
+  SmallVector<int> getAvailableShimChans(DeviceOp device, TileOp shimTile,
                                          WireBundle shimWireBundle,
                                          bool isShimMM2S) {
     SmallVector<int> availableShimChans;
     DenseMap<int, AIE::FlowOp> flowOpUsers;
+    const auto &targetModel = device.getTargetModel();
 
     for (auto user : shimTile.getResult().getUsers()) {
       auto fOp = dyn_cast<AIE::FlowOp>(user);
       if (!fOp)
         continue;
-      if (isShimMM2S && fOp.getSource() == shimTile)
+      if (isShimMM2S && fOp.getSource() == shimTile &&
+          fOp.getSourceBundle() == shimWireBundle)
         flowOpUsers[fOp.getSourceChannel()] = fOp;
-      else if (!isShimMM2S && fOp.getDest() == shimTile)
+      else if (!isShimMM2S && fOp.getDest() == shimTile &&
+               fOp.getDestBundle() == shimWireBundle)
         flowOpUsers[fOp.getDestChannel()] = fOp;
     }
+    int numShimChans = 0;
+    if (isShimMM2S)
+      numShimChans = targetModel.getNumSourceShimMuxConnections(
+          shimTile.colIndex(), shimTile.rowIndex(), shimWireBundle);
+    else
+      numShimChans = targetModel.getNumDestShimMuxConnections(
+          shimTile.colIndex(), shimTile.rowIndex(), shimWireBundle);
     for (int i = 0; i < numShimChans; i++) {
       if (!flowOpUsers.count(i))
         availableShimChans.push_back(i);
     }
+
     return availableShimChans;
+  }
+
+  // Create packet flows per col which moves control packets to and from shim
+  // dma
+  void generatePacketFlowsForControl(
+      OpBuilder builder, DeviceOp device, const AIETargetModel &targetModel,
+      TileOp shimTile, WireBundle shimWireBundle,
+      SmallVector<AIE::TileOp> ctrlTiles, WireBundle ctrlWireBundle,
+      int coreOrMemChanId, DenseMap<TileID, int> tileIDMap, bool isShimMM2S) {
+    int ctrlPktFlowID = 0;
+    auto rowToShimChanMap = getRowToShimChanMap(targetModel, shimWireBundle);
+    // Get all available shim channels, to verify that the one being used is
+    // available
+    auto availableShimChans =
+        getAvailableShimChans(device, shimTile, shimWireBundle, isShimMM2S);
+    SmallVector<AIE::ShimDMAAllocationOp> shimAllocs;
+    for (auto tOp : ctrlTiles) {
+      if (tOp->hasAttr("controller_id"))
+        ctrlPktFlowID =
+            (int)tOp->getAttrOfType<AIE::PacketInfoAttr>("controller_id")
+                .getPktId();
+      else
+        ctrlPktFlowID = tileIDMap[{tOp.colIndex(), tOp.rowIndex()}];
+      // Check shim channel availability
+      if (!llvm::is_contained(availableShimChans,
+                              rowToShimChanMap[tOp.rowIndex()]))
+        device->emitOpError(
+            "failed to generate column control overlay from shim dma to tile "
+            "ctrl ports, because some shim mm2s dma channels were reserved "
+            "from routing control packets.");
+      builder.setInsertionPointToEnd(device.getBody());
+      auto keep_pkt_header = builder.getBoolAttr(true);
+      if (isShimMM2S)
+        (void)createPacketFlowOp(
+            builder, ctrlPktFlowID, shimTile, shimWireBundle,
+            rowToShimChanMap[tOp.rowIndex()], tOp, ctrlWireBundle,
+            coreOrMemChanId, keep_pkt_header);
+      else
+        (void)createPacketFlowOp(builder, ctrlPktFlowID, tOp, ctrlWireBundle,
+                                 coreOrMemChanId, shimTile, shimWireBundle,
+                                 rowToShimChanMap[tOp.rowIndex()],
+                                 keep_pkt_header);
+
+      // Generate shim dma alloc ops as handle for runtime sequence to pickup,
+      // when issuing control packets
+      if (shimWireBundle != WireBundle::DMA)
+        continue;
+      AIE::DMAChannelDir dir =
+          isShimMM2S ? AIE::DMAChannelDir::MM2S : AIE::DMAChannelDir::S2MM;
+      int chan = rowToShimChanMap[tOp.rowIndex()];
+      int col = shimTile.colIndex();
+      if (llvm::none_of(shimAllocs, [&](AIE::ShimDMAAllocationOp shimAlloc) {
+            return shimAlloc.getChannelDir() == dir &&
+                   shimAlloc.getChannelIndex() == chan &&
+                   shimAlloc.getCol() == col;
+          })) {
+        std::string dma_name = "ctrlpkt";
+        dma_name += "_col" + std::to_string(col);   // col
+        dma_name += isShimMM2S ? "_mm2s" : "_s2mm"; // dir
+        dma_name += "_chan" + std::to_string(chan); // chan
+        builder.setInsertionPointToEnd(device.getBody());
+        auto newShimAlloc = builder.create<AIE::ShimDMAAllocationOp>(
+            builder.getUnknownLoc(), StringRef(dma_name), dir,
+            rowToShimChanMap[tOp.rowIndex()], shimTile.colIndex(), false);
+        MemRefType memref_ty = MemRefType::get(
+            ArrayRef<int64_t>{2048}, IntegerType::get(builder.getContext(), 32),
+            nullptr, 0);
+        builder.create<memref::GlobalOp>(builder.getUnknownLoc(), dma_name,
+                                         builder.getStringAttr("public"),
+                                         memref_ty, nullptr, false, nullptr);
+        shimAllocs.push_back(newShimAlloc);
+      }
+    }
   }
 
   // Get packet-flow op with the same source or destination

--- a/test/dialect/AIE/assign_controller_ids.mlir
+++ b/test/dialect/AIE/assign_controller_ids.mlir
@@ -14,19 +14,19 @@
 // assign controller ids to aie.tile_op, for control packets
 
 // CHECK-LABEL: module {
-// CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 1>}
-// CHECK: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 2>}
-// CHECK: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
-// CHECK: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
-// CHECK: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
-// CHECK: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
+// CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+// CHECK: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>}
+// CHECK: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 27>}
+// CHECK: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 29>}
+// CHECK: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 30>}
+// CHECK: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 31>}
 // GLOBAL-LABEL: module {
-// GLOBAL: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 1>}
-// GLOBAL: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 2>}
-// GLOBAL: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
-// GLOBAL: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
-// GLOBAL: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
-// GLOBAL: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
+// GLOBAL: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+// GLOBAL: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>}
+// GLOBAL: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 27>}
+// GLOBAL: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 29>}
+// GLOBAL: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 30>}
+// GLOBAL: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 31>}
 
 aie.device(npu1_1col) {
   %tile_0_0 = aie.tile(0, 0)
@@ -40,31 +40,31 @@ aie.device(npu1_1col) {
 // -----
 
 // CHECK-LABEL: module {
-// CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 1>}
-// CHECK: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 2>}
-// CHECK: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
-// CHECK: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
-// CHECK: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
-// CHECK: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
-// CHECK: aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 1>}
-// CHECK: aie.tile(1, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 2>}
-// CHECK: aie.tile(1, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
-// CHECK: aie.tile(1, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
-// CHECK: aie.tile(1, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
-// CHECK: aie.tile(1, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
+// CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+// CHECK: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>}
+// CHECK: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 27>}
+// CHECK: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 29>}
+// CHECK: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 30>}
+// CHECK: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 31>}
+// CHECK: aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+// CHECK: aie.tile(1, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>}
+// CHECK: aie.tile(1, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 27>}
+// CHECK: aie.tile(1, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 29>}
+// CHECK: aie.tile(1, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 30>}
+// CHECK: aie.tile(1, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 31>}
 // GLOBAL-LABEL: module {
-// GLOBAL: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 1>}
-// GLOBAL: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 2>}
-// GLOBAL: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
-// GLOBAL: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
-// GLOBAL: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
-// GLOBAL: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
-// GLOBAL: aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 7>}
-// GLOBAL: aie.tile(1, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 8>}
-// GLOBAL: aie.tile(1, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 9>}
-// GLOBAL: aie.tile(1, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 10>}
-// GLOBAL: aie.tile(1, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 11>}
-// GLOBAL: aie.tile(1, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 12>}
+// GLOBAL: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+// GLOBAL: aie.tile(0, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>}
+// GLOBAL: aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 27>}
+// GLOBAL: aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 29>}
+// GLOBAL: aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 30>}
+// GLOBAL: aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 31>}
+// GLOBAL: aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 14>}
+// GLOBAL: aie.tile(1, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 21>}
+// GLOBAL: aie.tile(1, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 22>}
+// GLOBAL: aie.tile(1, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 23>}
+// GLOBAL: aie.tile(1, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 24>}
+// GLOBAL: aie.tile(1, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 25>}
 
 aie.device(npu1_2col) {
   %tile_0_0 = aie.tile(0, 0)

--- a/test/dialect/AIE/bad_column_control_overlay.mlir
+++ b/test/dialect/AIE/bad_column_control_overlay.mlir
@@ -1,0 +1,21 @@
+//===- bad_column_control_overlay.mlir -------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" --split-input-file 2>&1 | FileCheck %s
+
+// CHECK: error: 'aie.device' op failed to generate column control overlay from shim dma to tile ctrl ports, because some shim mm2s dma channels were reserved from routing control packets.
+
+aie.device(npu1_2col) {
+  %tile_0_0 = aie.tile(0, 0)
+  %tile_0_1 = aie.tile(0, 1)
+  %tile_1_0 = aie.tile(1, 0)
+  %tile_1_1 = aie.tile(1, 1)
+  aie.flow(%tile_1_0, DMA : 0, %tile_1_1, DMA : 0)
+}

--- a/test/dialect/AIE/generate_column_control_overlay.mlir
+++ b/test/dialect/AIE/generate_column_control_overlay.mlir
@@ -17,25 +17,31 @@
 // CHECK-LABEL: module {
 // CHECK: %[[tile_0_0:.*]] = aie.tile(0, 0)
 // CHECK: %[[tile_0_1:.*]] = aie.tile(0, 1)
-// CHECK: aie.packet_flow(1) {
+// CHECK: aie.packet_flow(15) {
 // CHECK:   aie.packet_source<%[[tile_0_0]], Ctrl : 0>
 // CHECK:   aie.packet_dest<%[[tile_0_0]], South : 0>
 // CHECK: } {keep_pkt_header = true}
 // TCTALLTILES-LABEL: module {
 // TCTALLTILES: %[[tile_0_0:.*]] = aie.tile(0, 0)
 // TCTALLTILES: %[[tile_0_1:.*]] = aie.tile(0, 1)
-// TCTALLTILES: aie.packet_flow(1) {
+// TCTALLTILES: aie.packet_flow(15) {
 // TCTALLTILES:   aie.packet_source<%[[tile_0_0]], Ctrl : 0>
 // TCTALLTILES:   aie.packet_dest<%[[tile_0_0]], South : 0>
 // TCTALLTILES: } {keep_pkt_header = true}
-// TCTALLTILES: aie.packet_flow(2) {
+// TCTALLTILES: aie.packet_flow(26) {
 // TCTALLTILES:   aie.packet_source<%[[tile_0_1]], Ctrl : 0>
 // TCTALLTILES:   aie.packet_dest<%[[tile_0_0]], South : 0>
 // TCTALLTILES: } {keep_pkt_header = true}
 // CTRLPKT-LABEL: module {
 // CTRLPKT: %[[tile_0_0:.*]] = aie.tile(0, 0)
 // CTRLPKT: %[[tile_0_1:.*]] = aie.tile(0, 1)
-// CTRLPKT: aie.packet_flow(1) {
+// CTRLPKT: aie.packet_flow(15) {
+// CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 0>
+// CTRLPKT:   aie.packet_dest<%[[tile_0_0]], Ctrl : 0>
+// CTRLPKT: }
+// CTRLPKT: aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan0(MM2S, 0, 0)
+// CTRLPKT: memref.global "public" @ctrlpkt_col0_mm2s_chan0 : memref<2048xi32>
+// CTRLPKT: aie.packet_flow(26) {
 // CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 0>
 // CTRLPKT:   aie.packet_dest<%[[tile_0_1]], Ctrl : 0>
 // CTRLPKT: }
@@ -54,12 +60,11 @@ aie.device(npu1_1col) {
 // CHECK: %[[tile_0_1:.*]] = aie.tile(0, 1)
 // CHECK: %[[tile_1_0:.*]] = aie.tile(1, 0)
 // CHECK: %[[tile_1_1:.*]] = aie.tile(1, 1)
-// CHECK: aie.flow
-// CHECK: aie.packet_flow(1) {
+// CHECK: aie.packet_flow(15) {
 // CHECK:   aie.packet_source<%[[tile_0_0]], Ctrl : 0>
 // CHECK:   aie.packet_dest<%[[tile_0_0]], South : 0>
 // CHECK: } {keep_pkt_header = true}
-// CHECK: aie.packet_flow(1) {
+// CHECK: aie.packet_flow(15) {
 // CHECK:   aie.packet_source<%[[tile_1_0]], Ctrl : 0>
 // CHECK:   aie.packet_dest<%[[tile_1_0]], South : 0>
 // CHECK: } {keep_pkt_header = true}
@@ -68,20 +73,19 @@ aie.device(npu1_1col) {
 // TCTALLTILES: %[[tile_0_1:.*]] = aie.tile(0, 1)
 // TCTALLTILES: %[[tile_1_0:.*]] = aie.tile(1, 0)
 // TCTALLTILES: %[[tile_1_1:.*]] = aie.tile(1, 1)
-// TCTALLTILES: aie.flow
-// TCTALLTILES: aie.packet_flow(1) {
+// TCTALLTILES: aie.packet_flow(15) {
 // TCTALLTILES:   aie.packet_source<%[[tile_0_0]], Ctrl : 0>
 // TCTALLTILES:   aie.packet_dest<%[[tile_0_0]], South : 0>
 // TCTALLTILES: } {keep_pkt_header = true}
-// TCTALLTILES: aie.packet_flow(2) {
+// TCTALLTILES: aie.packet_flow(26) {
 // TCTALLTILES:   aie.packet_source<%[[tile_0_1]], Ctrl : 0>
 // TCTALLTILES:   aie.packet_dest<%[[tile_0_0]], South : 0>
 // TCTALLTILES: } {keep_pkt_header = true}
-// TCTALLTILES: aie.packet_flow(1) {
+// TCTALLTILES: aie.packet_flow(15) {
 // TCTALLTILES:   aie.packet_source<%[[tile_1_0]], Ctrl : 0>
 // TCTALLTILES:   aie.packet_dest<%[[tile_1_0]], South : 0>
 // TCTALLTILES: } {keep_pkt_header = true}
-// TCTALLTILES: aie.packet_flow(2) {
+// TCTALLTILES: aie.packet_flow(26) {
 // TCTALLTILES:   aie.packet_source<%[[tile_1_1]], Ctrl : 0>
 // TCTALLTILES:   aie.packet_dest<%[[tile_1_0]], South : 0>
 // TCTALLTILES: } {keep_pkt_header = true}
@@ -90,12 +94,24 @@ aie.device(npu1_1col) {
 // CTRLPKT: %[[tile_0_1:.*]] = aie.tile(0, 1)
 // CTRLPKT: %[[tile_1_0:.*]] = aie.tile(1, 0)
 // CTRLPKT: %[[tile_1_1:.*]] = aie.tile(1, 1)
-// CTRLPKT: aie.packet_flow(1) {
+// CTRLPKT: aie.packet_flow(15) {
+// CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 0>
+// CTRLPKT:   aie.packet_dest<%[[tile_0_0]], Ctrl : 0>
+// CTRLPKT: }
+// CTRLPKT: aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan0(MM2S, 0, 0)
+// CTRLPKT: memref.global "public" @ctrlpkt_col0_mm2s_chan0 : memref<2048xi32>
+// CTRLPKT: aie.packet_flow(26) {
 // CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 0>
 // CTRLPKT:   aie.packet_dest<%[[tile_0_1]], Ctrl : 0>
 // CTRLPKT: }
-// CTRLPKT: aie.packet_flow(1) {
-// CTRLPKT:   aie.packet_source<%[[tile_1_0]], DMA : 1>
+// CTRLPKT: aie.packet_flow(15) {
+// CTRLPKT:   aie.packet_source<%[[tile_1_0]], DMA : 0>
+// CTRLPKT:   aie.packet_dest<%[[tile_1_0]], Ctrl : 0>
+// CTRLPKT: }
+// CTRLPKT: aie.shim_dma_allocation @ctrlpkt_col1_mm2s_chan0(MM2S, 0, 1)
+// CTRLPKT: memref.global "public" @ctrlpkt_col1_mm2s_chan0 : memref<2048xi32>
+// CTRLPKT: aie.packet_flow(26) {
+// CTRLPKT:   aie.packet_source<%[[tile_1_0]], DMA : 0>
 // CTRLPKT:   aie.packet_dest<%[[tile_1_1]], Ctrl : 0>
 // CTRLPKT: }
 
@@ -104,7 +120,6 @@ aie.device(npu1_2col) {
   %tile_0_1 = aie.tile(0, 1)
   %tile_1_0 = aie.tile(1, 0)
   %tile_1_1 = aie.tile(1, 1)
-  aie.flow(%tile_1_0, DMA : 0, %tile_1_1, DMA : 0)
 }
 
 // -----
@@ -179,6 +194,12 @@ aie.device(npu1_2col) {
 // CTRLPKT: %[[tile_0_5:.*]] = aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 2>}
 // CTRLPKT: %[[tile_1_0:.*]] = aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
 // CTRLPKT: %[[tile_1_1:.*]] = aie.tile(1, 1) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 7>}
+// CTRLPKT: aie.packet_flow(4) {
+// CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 0>
+// CTRLPKT:   aie.packet_dest<%[[tile_0_0]], Ctrl : 0>
+// CTRLPKT: }
+// CTRLPKT: aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan0(MM2S, 0, 0)
+// CTRLPKT: memref.global "public" @ctrlpkt_col0_mm2s_chan0 : memref<2048xi32>
 // CTRLPKT: aie.packet_flow(3) {
 // CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 0>
 // CTRLPKT:   aie.packet_dest<%[[tile_0_1]], Ctrl : 0>
@@ -188,9 +209,11 @@ aie.device(npu1_2col) {
 // CTRLPKT:   aie.packet_dest<%[[tile_0_2]], Ctrl : 0>
 // CTRLPKT: }
 // CTRLPKT: aie.packet_flow(1) {
-// CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 0>
+// CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 1>
 // CTRLPKT:   aie.packet_dest<%[[tile_0_3]], Ctrl : 0>
 // CTRLPKT: }
+// CTRLPKT: aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan1(MM2S, 1, 0)
+// CTRLPKT: memref.global "public" @ctrlpkt_col0_mm2s_chan1 : memref<2048xi32>
 // CTRLPKT: aie.packet_flow(6) {
 // CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 1>
 // CTRLPKT:   aie.packet_dest<%[[tile_0_4]], Ctrl : 0>
@@ -199,6 +222,12 @@ aie.device(npu1_2col) {
 // CTRLPKT:   aie.packet_source<%[[tile_0_0]], DMA : 1>
 // CTRLPKT:   aie.packet_dest<%[[tile_0_5]], Ctrl : 0>
 // CTRLPKT: }
+// CTRLPKT: aie.packet_flow(5) {
+// CTRLPKT:   aie.packet_source<%[[tile_1_0]], DMA : 0>
+// CTRLPKT:   aie.packet_dest<%[[tile_1_0]], Ctrl : 0>
+// CTRLPKT: }
+// CTRLPKT: aie.shim_dma_allocation @ctrlpkt_col1_mm2s_chan0(MM2S, 0, 1)
+// CTRLPKT: memref.global "public" @ctrlpkt_col1_mm2s_chan0 : memref<2048xi32>
 // CTRLPKT: aie.packet_flow(7) {
 // CTRLPKT:   aie.packet_source<%[[tile_1_0]], DMA : 0>
 // CTRLPKT:   aie.packet_dest<%[[tile_1_1]], Ctrl : 0>

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/aie.mlir
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/aie.mlir
@@ -18,13 +18,14 @@ module {
     memref.global "public" @out3 : memref<8xi32>
     memref.global "public" @ctrl0 : memref<8xi32>
 
-    %tile_0_0 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 4>}
+    %tile_0_0 = aie.tile(0, 0)
     %tile_1_0 = aie.tile(1, 0)
     %tile_2_0 = aie.tile(2, 0)
-    %tile_0_2 = aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
-    %tile_0_3 = aie.tile(0, 3) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 6>}
-    %tile_0_4 = aie.tile(0, 4) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 7>}
-    %tile_0_5 = aie.tile(0, 5) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 8>}
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+    %tile_0_3 = aie.tile(0, 3)
+    %tile_0_4 = aie.tile(0, 4)
+    %tile_0_5 = aie.tile(0, 5)
 
     %input_0_2_lock0 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "input_0_2_lock0"}
     %input_0_2_lock2 = aie.lock(%tile_0_2, 2) {init = 0 : i32, sym_name = "input_0_2_lock2"}
@@ -341,25 +342,30 @@ module {
       %c24_i64 = arith.constant 24 : i64
 
       // start reading output
-      aiex.npu.dma_memcpy_nd(0, 0, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, issue_token = true, metadata = @ctrl0} : memref<8xi32>
       aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 2 : i64, issue_token = true, metadata = @out0} : memref<32xi32>
       aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c8_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 3 : i64, issue_token = true, metadata = @out1} : memref<32xi32>
       aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c16_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 4 : i64, issue_token = true, metadata = @out2} : memref<32xi32>
       aiex.npu.dma_memcpy_nd(0, 0, %arg2[%c0_i64, %c0_i64, %c0_i64, %c24_i64] [%c1_i64, %c1_i64, %c1_i64, %c8_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 5 : i64, issue_token = true, metadata = @out3} : memref<32xi32>
 
       // write bd0
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 5, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c4_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 6, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c8_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c12_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 8, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 27, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c4_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 29, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c8_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 30, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c12_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 31, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
 
       // patch bd0 address for packet 1, push to mm2s_0_task_queue, wait
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c2_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 5, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c6_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 6, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c10_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
-      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c14_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 8, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c2_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 27, pkt_type = 1>) {id = 6 : i64, issue_token = true, metadata = @ctrlin0} : memref<8xi32>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c6_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 29, pkt_type = 1>) {id = 7 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c10_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 30, pkt_type = 1>) {id = 8 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
+      aiex.npu.dma_memcpy_nd(0, 0, %arg1[%c0_i64, %c0_i64, %c0_i64, %c14_i64] [%c1_i64, %c1_i64, %c1_i64, %c2_i64] [%c0_i64, %c0_i64, %c0_i64, %c1_i64], packet = <pkt_id = 31, pkt_type = 1>) {id = 9 : i64, issue_token = true, metadata = @ctrlin1} : memref<8xi32>
+      aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
 
       // wait for dma output
       aiex.npu.dma_wait {symbol = @out0}


### PR DESCRIPTION
To ensure control overlay consistency when reconfiguring across multiple designs.
- Compiler assigns fixed controller ids per AIE tile, which is hand-picked to not cause arbiter congestion.