### PR TITLE
Update buildAndTestMulti.yml to force gcc11

### DIFF
--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -54,13 +54,13 @@ jobs:
             ENABLE_ASSERTIONS: OFF
             ENABLE_RTTI: OFF
           - OS: ubuntu-20.04
-            COMPILER: llvm
+            COMPILER: gcc-11
             ENABLE_ASSERTIONS: ON
-            ENABLE_RTTI: OFF
+            ENABLE_RTTI: ON
           - OS: ubuntu-20.04
-            COMPILER: llvm
+            COMPILER: gcc-11
             ENABLE_ASSERTIONS: OFF
-            ENABLE_RTTI: OFF
+            ENABLE_RTTI: ON
           - OS: windows-2019
             COMPILER: msvc
             ENABLE_ASSERTIONS: ON

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -39,12 +39,28 @@ jobs:
       # Run the tests on the Cartesian product of the following
       matrix:
 
-        OS: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
+        OS: [ ubuntu-22.04, ubuntu-24.04 ]
         COMPILER: [ llvm, gcc ]
         ENABLE_ASSERTIONS: [ ON, OFF ]
         ENABLE_RTTI: [ ON, OFF ]
 
         include:
+          - OS: ubuntu-20.04
+            COMPILER: gcc-11
+            ENABLE_ASSERTIONS: ON
+            ENABLE_RTTI: OFF
+          - OS: ubuntu-20.04
+            COMPILER: gcc-11
+            ENABLE_ASSERTIONS: OFF
+            ENABLE_RTTI: OFF
+          - OS: ubuntu-20.04
+            COMPILER: llvm
+            ENABLE_ASSERTIONS: ON
+            ENABLE_RTTI: OFF
+          - OS: ubuntu-20.04
+            COMPILER: llvm
+            ENABLE_ASSERTIONS: OFF
+            ENABLE_RTTI: OFF
           - OS: windows-2019
             COMPILER: msvc
             ENABLE_ASSERTIONS: ON


### PR DESCRIPTION
* Force setup-cpp action to select gcc11 on ubuntu20.
* Remove testing of llvm/clang as the compiler on ubuntu20.