### PR TITLE
[NFC] Another attempt to fix naming of AIE dialect documentation

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -28,7 +28,7 @@
             <li class="listedpages"><a style="color:white;" href="index.html">Overview</a></li>
             <li class="listedpages"><a style="color:white;" href="Building.html">Getting Started</a></li>
             <li><label for="btn-4 " class="show ">References </label></li>
-            <li class="listedpages"><a style="color:white;" href="AIE.html">AIE Dialect</a></li>
+            <li class="listedpages"><a style="color:white;" href="AIEDialect.html">AIE Dialect</a></li>
             <li class="listedpages"><a style="color:white;" href="AIEPasses.html">AIE Passes</a></li>
             <li class="listedpages"><a style="color:white;" href="AIEXDialect.html">AIEX Dialect</a></li>
             <li class="listedpages"><a style="color:white;" href="AIEXPasses.html">AIEX Passes</a></li>

--- a/include/aie/Dialect/AIE/IR/AIEDocs.td
+++ b/include/aie/Dialect/AIE/IR/AIEDocs.td
@@ -8,6 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// A simplified version of AIEDialect.h used to generate the on-line
+// documentation
 include "aie/Dialect/AIE/IR/AIE.td"
 include "aie/Dialect/AIE/IR/AIEAttrs.td"
 include "aie/Dialect/AIE/IR/AIEInterfaces.td"

--- a/include/aie/Dialect/AIE/IR/CMakeLists.txt
+++ b/include/aie/Dialect/AIE/IR/CMakeLists.txt
@@ -6,7 +6,9 @@
 # (c) Copyright 2021 Xilinx Inc.
 
 add_mlir_dialect(AIE aie)
-add_mlir_doc(AIEDocs AIE ./ -gen-dialect-doc)
+# Use a simplified version AIEDocs.td to generate the AIEDialect.md ending up as
+# https://xilinx.github.io/mlir-aie/AIEDialect.html
+add_mlir_doc(AIEDocs AIEDialect ./ -gen-dialect-doc)
 
 # Add AIE interfaces
 set(LLVM_TARGET_DEFINITIONS AIEInterfaces.td)

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -505,11 +505,11 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
 
     #### `metadata` -- Specifying Tile, Channel, Direction and Linking a `dma_memcpy_nd` to its Other Half
 
-    The `metadata` attribute must point to a symbol referencing a 
-    [`aie.shim_dma_allocation` operation](AIE.html#aiedma_bd-xilinxaiedmabdop).
+    The `metadata` attribute must point to a symbol referencing a
+    [`aie.shim_dma_allocation` operation](AIEDialect.html#aiedma_bd-xilinxaiedmabdop).
     The tile coordinates of the DMA to configure, the channel number and the direction (`MM2S` or `S2MM`) are taken from this operation.
 
-    To connect the DMA to its other half (i.e. a `MM2S` DMA to its receiving end and a `S2MM` to the sending end), 
+    To connect the DMA to its other half (i.e. a `MM2S` DMA to its receiving end and a `S2MM` to the sending end),
     the user must configure a flow (`aie.flow`) between the tile and channel referenced in the `aie.shim_dma_allocation` and the corresponding other end.
 
     When using ObjectFIFOs, the `aie.shim_dma_allocation` operations and the `aie.flows` are generated automatically.
@@ -520,13 +520,13 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
     When the `dma_memcpy_nd` operation executes, it immediately reprograms the buffer descriptor with ID `bd_id` on tile (`x`, `y`), even if that buffer descriptor is currently executing.
     Without proper synchronization, this inevitably leads to nondeterministic results.
 
-    Programming a buffer descriptor that is not currently executing is harmless. 
+    Programming a buffer descriptor that is not currently executing is harmless.
     Thus, the first `dma_memcpy_nd` call for each `bd_id` requires no synchronization.
 
-    However, if you wish to later re-use a `bd_id` on the same tile, you must wait for the previous buffer descriptor to complete. 
+    However, if you wish to later re-use a `bd_id` on the same tile, you must wait for the previous buffer descriptor to complete.
     The `sync` or `dma_wait` operations can be used for this.
 
-    `sync` blocks until it receives a _task completion token_ (TCT). 
+    `sync` blocks until it receives a _task completion token_ (TCT).
     To properly synchronize, you must thus configure your BD to issue a TCT using the `issue_token` attribute, then wait on that token before reusing the BD.
 
     `dma_wait` is a convenience operation that lowers to the corresponding `sync` operation for the refrenced symbol.
@@ -537,15 +537,15 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
     #### Data Layout Transformations
 
     The `sizes` and `strides` attributes describe a data layout transformation to be performed by the DMA.
-    These transformations are described in more depth in the documentation for the 
-    [`aie.dma_bd` operation](AIE.html#aiedma_bd-xilinxaiedmabdop).
-    Note that the syntax here differs from that of the `dma_bd` operation: 
+    These transformations are described in more depth in the documentation for the
+    [`aie.dma_bd` operation](AIEDialect.html#aiedma_bd-xilinxaiedmabdop).
+    Note that the syntax here differs from that of the `dma_bd` operation:
     offsets and strides are given as separate arrays instead of tuples.
 
     The `offsets` array is used to calculate a static offset into the memref.
-    Each offset in the array is understood in relation to the shape of the memref; 
-    the lowest-dimension `offset` is a direct offset in units of memref element type, and the higher dimensions are multiplied by the size of the memref in those dimensions. 
-    Note that this is for convenience of the user only. 
+    Each offset in the array is understood in relation to the shape of the memref;
+    the lowest-dimension `offset` is a direct offset in units of memref element type, and the higher dimensions are multiplied by the size of the memref in those dimensions.
+    Note that this is for convenience of the user only.
     The hardware only supports a single static offset, and this offset is calculated at compile time.
     Thus, all offsets can be equivalently expressed with the lowest dimension only.
 
@@ -589,7 +589,7 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
     /* Returns the data transfer offset in bytes, i.e. the first N bytes of the
        target buffer will be skipped. In the IR, offsets are expressed in units
        of memref element data type size. */
-    int64_t getOffsetInBytes(); 
+    int64_t getOffsetInBytes();
 
     bool isLinearTransferWithoutTransformation();
   }];
@@ -608,7 +608,7 @@ def AIE_NpuDmaWaitOp: AIEX_Op<"npu.dma_wait", []> {
     The NpuDmaWaitOp blocks until the DMA referenced through `symbol` completes execution
     and issues a task-complete-token (TCT).
 
-    `symbol` is a reference to a `aie.shim_dma_allocation`, which contains information about the column, channel and channel direction on which to wait for a TCT. 
+    `symbol` is a reference to a `aie.shim_dma_allocation`, which contains information about the column, channel and channel direction on which to wait for a TCT.
     The `aie.shim_dma_allocation` may be generated from an ObjectFIFO, in which case you can directly pass the ObjectFIFO symbol refrence.
     `npu.dma_wait` will be lowered to the corresponding `npu.sync` operation using the information from `symbol`.
 
@@ -644,7 +644,7 @@ def AIE_NpuWriteRTPOp: AIEX_Op<"npu.rtp_write", []> {
         I32Attr:$value
   );
   let results = (outs );
-  let assemblyFormat = [{ `(` $buffer `,` $index `,` $value `)` attr-dict 
+  let assemblyFormat = [{ `(` $buffer `,` $index `,` $value `)` attr-dict
   }];
   let description = [{
     rtp write operator
@@ -996,8 +996,8 @@ def AIE_DMAStartBdChainOp: AIEX_Op<"dma_start_bd_chain", [HasParent<"RuntimeSequ
         DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count
   );
 
-  let assemblyFormat = [{ 
-     $symbol `(` $args `)` `:` `(` type($args) `)` ` ` `on` ` ` `(` $tile `,` $direction `,` $channel `)` attr-dict 
+  let assemblyFormat = [{
+     $symbol `(` $args `)` `:` `(` type($args) `)` ` ` `on` ` ` `(` $tile `,` $direction `,` $channel `)` attr-dict
   }];
 
   let hasVerifier = 1;
@@ -1027,8 +1027,8 @@ def AIE_DMAStartBdChainForOp: AIEX_Op<"dma_start_bd_chain_for", [HasParent<"Runt
         DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count
   );
 
-  let assemblyFormat = [{ 
-     $symbol `(` $args `)` `:` `(` type($args) `)` ` ` `for` ` ` $alloc attr-dict 
+  let assemblyFormat = [{
+     $symbol `(` $args `)` `:` `(` type($args) `)` ` ` `for` ` ` $alloc attr-dict
   }];
 }
 

--- a/mlir_tutorials/tutorial-1/README.md
+++ b/mlir_tutorials/tutorial-1/README.md
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2022, Advanced Micro Devices, Inc.
-// 
+//
 //===----------------------------------------------------------------------===//-->
 
 # <ins>Tutorial 1 - Modules, tile, buffer, core, lock</ins>
@@ -13,8 +13,8 @@ In the MLIR-based AI Engine representation, every physical component of the AI E
 
 ```
 module @module_name {
-    ... 
-    AI Engine array components and connections 
+    ...
+    AI Engine array components and connections
     ...
 }
 ```
@@ -26,31 +26,31 @@ AI Engine tiles are the basic building blocks of AIE designs and can be declared
 %tile24 = AIE.tile(2,4)
 %tile34 = AIE.tile(3,4)
 ```
-The two major components of an AI Engine tile are 
+The two major components of an AI Engine tile are
 
 * VLIW processor core declared as `AIE.core(tileName) { body }`
-* Local memory buffer declared as `AIE.buffer(tileName) : memref<depth x data_type> { body }`. 
+* Local memory buffer declared as `AIE.buffer(tileName) : memref<depth x data_type> { body }`.
 
 Example declarations include:
 ```
 AIE.core(%tile14) {
-    ... 
-    core body 
+    ...
+    core body
     ...
 }
 
 %buff0 = AIE.buffer(%tile14) : memref<256xi32>
 %buff1 = AIE.buffer(%tile14) : memref<256xi32>
 ```
-The association between these declarations and the physical AI Engine tile components can be seen here. For more details on mlir-aie dialect syntax, you can refer to the online reference document [here](https://xilinx.github.io/mlir-aie/AIE.html).
+The association between these declarations and the physical AI Engine tile components can be seen here. For more details on mlir-aie dialect syntax, you can refer to the online reference document [here](https://xilinx.github.io/mlir-aie/AIEDialect.html).
 <img src="../images/diagram1.png" width="1000">
 
 A third key component of a tile is the `lock` which is critical for synchronizing data between tiles and one another, and between tiles and the host controller. While not a physically large component, it plays a critical role in facilitating efficient and correct data communication.
 
 ### <ins>Tile</ins>
 
-For the tile, we simply declare its coordinates by column and row 
->**NOTE:** index values start at 0, with row 0 belonging to the shim which is not a regular row. The first regular row for first generation AI engines is row index 1. 
+For the tile, we simply declare its coordinates by column and row
+>**NOTE:** index values start at 0, with row 0 belonging to the shim which is not a regular row. The first regular row for first generation AI engines is row index 1.
 Tile declaration is mainly needed so other sub components can be associated to the tile by name. Some higher level logical components may also automatically declare tiles so they are enabled (e.g. logical flows require the intermediate tiles along the path to be enabled to support stream switch routing).
 
 >**ADF Graph NOTE:** ADF graph descriptions treat the first full row of AI Engines as row 0 and does not count the shim tiles. As such, be sure to add one to the row value when moving from ADF designs to MLIR-AIE descriptions.
@@ -63,7 +63,7 @@ The type of tiles and orientation of its associated local memory is architecture
 
 ### <ins>Buffer</ins>
 
-When declaring a buffer, we pass in the associated AIE tile and declare the buffer parameters. Those parameters are the depth and data type width (though the local memory itself is not physically organized in this way). 
+When declaring a buffer, we pass in the associated AIE tile and declare the buffer parameters. Those parameters are the depth and data type width (though the local memory itself is not physically organized in this way).
 > One important note about buffers is that one buffer is not strictly mapped to the entire local memory. You can declare multiple buffers that are associated with the local memory of a tile and they would, by default, be allocated sequentially in that tile's local memory.
 
 Operators such as buffers (and some other components such as locks) also can have a symbolic name defined in the body to make it easier to refer to the component in generated host access functions. The syntax for this looks like:
@@ -91,11 +91,11 @@ Examples:
 %lock13_11 = AIE.lock(%tile13, 11) { sym_name = "lock13_11" }
 ```
 Each tile has 16 locks and each lock is in one of two states (acquired, released) and one of two values (0, 1).
-> By default, we tend to assume (value=0 is a "write", value=1 is "read"). But there is no real definition of these values. The only key thing to remember is that the lock value starts at `val=0`, and is reset into the release `val=0` state. This means an `acquire=0` will always succeed first, while an `acquire=1` needs the lock state to be `release=1` to succeed. Once acquired, a lock can be released to the 0 or 1 state. 
+> By default, we tend to assume (value=0 is a "write", value=1 is "read"). But there is no real definition of these values. The only key thing to remember is that the lock value starts at `val=0`, and is reset into the release `val=0` state. This means an `acquire=0` will always succeed first, while an `acquire=1` needs the lock state to be `release=1` to succeed. Once acquired, a lock can be released to the 0 or 1 state.
 
-The 16 locks in a tile are accessible by its same 3 cardinal neighbors that can access the tile's local memory. This is to ensure all neighbors that can access the local memory can also access the locks. 
+The 16 locks in a tile are accessible by its same 3 cardinal neighbors that can access the tile's local memory. This is to ensure all neighbors that can access the local memory can also access the locks.
 
-To use the lock, we call the `use_lock` operation either inside a `core` operation or `mem`/`shim_dma` operation. 
+To use the lock, we call the `use_lock` operation either inside a `core` operation or `mem`/`shim_dma` operation.
 ```
 AIE.use_lock(%lockName, "Acquire|Release", 0|1)
 ```
@@ -112,9 +112,9 @@ Notice the familiar design pattern of:
 * a set of operations
 * release lock in some value (usually the other value)
 
-The acquire value must match the current lock state in order for the acquire to succeed. The release value can be either 0 or 1. 
+The acquire value must match the current lock state in order for the acquire to succeed. The release value can be either 0 or 1.
 
-We will be introducing more components and the ways these components are customized in subsequent tutorials. Additional syntax for these MLIR-based AI Engine components can be found in the github<area>.io docs [here](https://xilinx.github.io/mlir-aie/AIE.html).
+We will be introducing more components and the ways these components are customized in subsequent tutorials. Additional syntax for these MLIR-based AI Engine components can be found in the github<area>.io docs [here](https://xilinx.github.io/mlir-aie/AIEDialect.html).
 
 ## <ins>Tutorial 1 Lab</ins>
 
@@ -130,9 +130,9 @@ We will be introducing more components and the ways these components are customi
 ### <ins>MLIR-AIE Transformations</ins>
 Under the hood, `make` calls `aiecc.py` which itself calls a number of utilities that are built as part of the `mlir-aie` project (`aie-translate`, `aie-opt`). More details on these utilities can be found in [tutorial-10](../tutorial-10). These utilities are built as part of the `mlir-aie` to perform IR transformations and lowerings. In this example, since we are already describing our design at a low physical level, we will perform the final transformation and produce an AI Engine program (core_1_4.elf).
 
-The MLIR operations inside the core are then converted to an LLVM representation which the AMD internal compiler (currently `xchesscc`) takes to build the executable that will run on each individual AIE tile. 
-   
-3. In [aie.mlir](aie.mlir), what is the variable name for tile(1,4)? <img src="../images/answer1.jpg" title="%tile14" height=25> 
+The MLIR operations inside the core are then converted to an LLVM representation which the AMD internal compiler (currently `xchesscc`) takes to build the executable that will run on each individual AIE tile.
+
+3. In [aie.mlir](aie.mlir), what is the variable name for tile(1,4)? <img src="../images/answer1.jpg" title="%tile14" height=25>
 
     What about the variable name and size of the buffer that is associated with the local memory of tile(1,4)? <img src="../images/answer1.jpg" title="%buf, 256 x int32" height=25>
 
@@ -145,7 +145,7 @@ In first generation AI Engines, each tile has 32 kB of local data memory assigne
 5. Change the size of the buffer to the size of our local memory (8192 x i32) and run `make` again. What do you expect to happen and what happens instead? <img src="../images/answer1.jpg" title="You may expect to be able to define a buffer that uses the entirety of local memory. Instead, an error occurs: Allocated buffers exceed local memory. (The next paragraph explains why this happens.)" height=25>
 
 ### <ins>AI Engine Program Memory</ins>
-While we have a separate 16 kB of program memory which stores the AIE program code, the 32 kB of data memory is also used for the program stack. By default, the tool reserves 1024 bytes for the stack so all buffers are then allocated immediately after that. 
+While we have a separate 16 kB of program memory which stores the AIE program code, the 32 kB of data memory is also used for the program stack. By default, the tool reserves 1024 bytes for the stack so all buffers are then allocated immediately after that.
 
 6. Declare a horizontally adjacent tile (pay attention to which row we're in) so that tile (1,4) can access the neighbor tile's local memory. Declare a buffer in this tile that uses the entire local memory (8192 x i32) and replace the reference %buf in line 34 with the new buffer, then run `make ` again. What happens? <img src="../images/answer1.jpg" title="We are able to compile successfully, since we can use our neighbor's full local memory. Only tiles that are running program code have a stack space of 1024 bytes reserved." height=25>
 

--- a/programming_guide/section-4/section-4b/README.md
+++ b/programming_guide/section-4/section-4b/README.md
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// 
+//
 //===----------------------------------------------------------------------===//-->
 
 # <ins>Section 4b - Trace</ins>
@@ -44,7 +44,7 @@ The first necessary component for trace configuration is setting the right value
         offset=tensorSize,
     )
 ```
-This block is defined within the sequence definition for `@runtime_sequence` where we define the shimDMA data movement to the 3 inout buffers. 
+This block is defined within the sequence definition for `@runtime_sequence` where we define the shimDMA data movement to the 3 inout buffers.
 > **Note** This simplification works very well for the trace buffer from a single tile to the shimDMA. However, if we want to do something more advaned like allocating the trace buffer from multiple tiles into a single larger buffer, this function will not be able to express that. For that, please consult the [README](../../../python/utils) under `python/utils` for more guidance on how to customize the trace configuration.
 
 ### <u>(1b) Define trace event routes from tile to shimDMA</u>
@@ -59,7 +59,7 @@ flow(ComputeTile, WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
 
 `flow` creates a circuit switched flow between src and dest and has the general syntax of:
 ```python
-flow(source, source_bundle, source_channel, dest, dest_bundle, dest_channel)	
+flow(source, source_bundle, source_channel, dest, dest_bundle, dest_channel)
 ```
 * *source* - source tile of the flow
 * *source_bundle* - type of source WireBundle (see full list in [AIEAttrs.td](../../../include/aie/Dialect/AIE/IR/AIEAttrs.td))
@@ -87,9 +87,9 @@ packetflow(pkt_id, source, source_port, source_channel, dest, dest_port, dest_ch
 * *keep_pkt_header* - boolean flag to keep header
 
 
-MLIR examples are similar and are included below for quick reference but are more fully defined in the [AIE Dialect online documentation](https://xilinx.github.io/mlir-aie/AIE.html):
+MLIR examples are similar and are included below for quick reference but are more fully defined in the [AIE Dialect online documentation](https://xilinx.github.io/mlir-aie/AIEDialect.html):
 ```mlir
-packetflow(1) { 
+packetflow(1) {
     aie.packet_source<%tile02, Trace : 0> // core trace
     aie.packet_dest<%tile00, DMA : 1>
 } {keep_pkt_header = "true"}
@@ -120,7 +120,7 @@ packetflow(4, ComputeTile3, WireBundle.Trace, 1, ShimTile, WireBundle.DMA, 1, ke
 Once the trace units are configured and enabled, we want the host code to read the trace data from DDR and write it out to a text file for post-run processing. To give a better sense of how this comes together, this section provides an example design that is again a simplifed version of the [Vector Scalar Multiply example](../../../programming_examples/basic/vector_scalar_mul/).
 
 ### <u>AIE structural design code ([aie2.py](./aie2.py))</u>
-In order to write the DDR data to a text file, we need to decide where we want the DDR data to first be stored and then read from that location, before writing to a text file. This starts inside the [aie2.py](./aie2.py) file where we use the `configure_simple_tracing_aie2` function call to configure the trace units and program the shimDMA to write to 1 of the 3 inout buffers. There are many ways to configure our structural design to write this data out but one pattern is the following: `inout0` is for input data, `inout1` is for output data, and `inout2` is for output trace data as illustrated below: 
+In order to write the DDR data to a text file, we need to decide where we want the DDR data to first be stored and then read from that location, before writing to a text file. This starts inside the [aie2.py](./aie2.py) file where we use the `configure_simple_tracing_aie2` function call to configure the trace units and program the shimDMA to write to 1 of the 3 inout buffers. There are many ways to configure our structural design to write this data out but one pattern is the following: `inout0` is for input data, `inout1` is for output data, and `inout2` is for output trace data as illustrated below:
 
 | inout0 | inout1 | inout2 |
 |--------|--------|--------|
@@ -146,17 +146,17 @@ Once [aie2.py](./aie2.py) is configured to output trace data through one of the 
 > **NOTE** In our example design ([aie2.py](./aie2.py), [Makefile](./Makefile)), we provide a Makefile target `run` for standard build and `trace` for trace-enabled build. The trace-enabled build passes the trace buffer size as an argument to [aie2.py](./aie2.py) which conditionally enables the trace `flow` and calls `configure_simple_tracing_aie2` as long as `trace_size` is > 0. This is also true for the [Vector Scalar Multiply example](../../../programming_examples/basic/vector_scalar_mul).
 
 ### <u>(2a) C/C++ Host code ([test.cpp](./test.cpp))</u>
-The main changes needed for [test.cpp](./test.cpp) is the increase in the output buffer size to account for the trace buffer size, being careful to read only the output buffer portion when verifying correctness of the results. We also need to be sure to pass the correct buffer offset which points to the trace buffer data when calling `write_out_trace`. 
+The main changes needed for [test.cpp](./test.cpp) is the increase in the output buffer size to account for the trace buffer size, being careful to read only the output buffer portion when verifying correctness of the results. We also need to be sure to pass the correct buffer offset which points to the trace buffer data when calling `write_out_trace`.
 
-You can see in [test.cpp](./test.cpp) that trace_size is set based on an input argument of `-t $(trace_size)` which is defined and passed in the [Makefile](./Makefile). The `trace` target from the [Makefile](./Makefile) is shown below. 
+You can see in [test.cpp](./test.cpp) that trace_size is set based on an input argument of `-t $(trace_size)` which is defined and passed in the [Makefile](./Makefile). The `trace` target from the [Makefile](./Makefile) is shown below.
 
 ```Makefile
-trace: ${targetname}.exe build/final.xclbin build/insts.txt 
+trace: ${targetname}.exe build/final.xclbin build/insts.txt
 	${powershell} ./$< -x build/final.xclbin -i build/insts.txt -k MLIR_AIE -t 8192
 	../../../programming_examples/utils/parse_trace.py --filename trace.txt --mlir build/aie.mlir --colshift 1 > trace_4b.json
 ```
-Following the invocation of the executable, we call the `parse_trace.py` python script which we will cover in more detail in step 3. 
-Within the [test.cpp](./test.cpp), we redefine OUT_SIZE to be the sum of output buffer size (in bytes) and the trace buffer size. 
+Following the invocation of the executable, we call the `parse_trace.py` python script which we will cover in more detail in step 3.
+Within the [test.cpp](./test.cpp), we redefine OUT_SIZE to be the sum of output buffer size (in bytes) and the trace buffer size.
 ```c++
     int OUT_SIZE = IN_SIZE + trace_size;
 ```
@@ -184,7 +184,7 @@ During verification, the `output_buffer` excludes the trace data and uses the `r
     entire_buffer = bo_inout2.read(OUT_SIZE, 0).view(np.uint32)
     output_buffer = entire_buffer[:INOUT2_VOLUME]
 ```
-Finally, we read `trace buffer` from the entire_buffer starting at the offset of the `INOUT2_VOLUME` and pass the trace buffer to the python equivalent of `write_out_trace` which is defined in `aie.utils.trace`. 
+Finally, we read `trace buffer` from the entire_buffer starting at the offset of the `INOUT2_VOLUME` and pass the trace buffer to the python equivalent of `write_out_trace` which is defined in `aie.utils.trace`.
 > **Note** This version doesn't need the trace_size as our python function recognizes when the array is empty.
 ```python
     if opts.trace_size > 0:
@@ -193,14 +193,14 @@ Finally, we read `trace buffer` from the entire_buffer starting at the offset of
 ```
 
 ## <u>3. Parse text file to generate a waveform json file</u>
-Once the packet trace text file is generated (`trace.txt`), we use a python-based trace parser ([parse_trace.py](../../../programming_examples/utils/parse_trace.py)) to interpret the trace values and generate a waveform json file for visualization (with Perfetto). 
+Once the packet trace text file is generated (`trace.txt`), we use a python-based trace parser ([parse_trace.py](../../../programming_examples/utils/parse_trace.py)) to interpret the trace values and generate a waveform json file for visualization (with Perfetto).
 ```Makefile
 	../../../programming_examples/utils/parse_trace.py --filename trace.txt --mlir build/aie_trace.mlir --colshift 1 > trace_vs.json
 ```
-This leverages the python parse scripts under [programming_examples/utils](../../../programming_examples/utils/). Follow [this link](../../../programming_examples/utils/) to get more details about how to use the python parse scripts. 
+This leverages the python parse scripts under [programming_examples/utils](../../../programming_examples/utils/). Follow [this link](../../../programming_examples/utils/) to get more details about how to use the python parse scripts.
 
 ## <u>4. Open json file in a visualization tool like Perfetto</u>
-Open https://ui.perfetto.dev in your browser and then open up the waveform json file generated in step 3. You can navigate the waveform viewer as you would a standard waveform viewer and can even zoom/pan the waveform with the a,s,w,d keyboard keys. 
+Open https://ui.perfetto.dev in your browser and then open up the waveform json file generated in step 3. You can navigate the waveform viewer as you would a standard waveform viewer and can even zoom/pan the waveform with the a,s,w,d keyboard keys.
 
 ## <u>Additional Debug Hints</u>
 * If you are getting 0's in your trace outputs. Check these things:
@@ -209,7 +209,7 @@ Open https://ui.perfetto.dev in your browser and then open up the waveform json 
     * For packet-routed flows, check correctly matching packet IDs. The packet flow ID must match the configured ID value in Trace Control 1 register or else the packets don't get routed.
 
 ## <u>Exercises</u>
-1. Let's give tracing a try. In this directory, we're been examining a simplified version of the `vector ccalar multiply` example. Run `make trace`. This compiles the design, generates a trace data file, and run `prase_trace.py` to generate the `trace_4b.json` waveform file. 
+1. Let's give tracing a try. In this directory, we're been examining a simplified version of the `vector ccalar multiply` example. Run `make trace`. This compiles the design, generates a trace data file, and run `prase_trace.py` to generate the `trace_4b.json` waveform file.
 
     > **NOTE** In this example, `make`, `make run` and `make trace` will all build a structural design with tracing enabled to keep things simple. But only `make trace` will enable tracing in the host code and call `parse_trace.py`. In contrast, the reference `vector scalar multiply example` has a more robust `Makefile` where `make` and `make run` builds the structural design with tracing disabled.
 


### PR DESCRIPTION
Keep the "Dialect" in "AIEDialect" since it is the convention used with all the other dialects of the project.