### PR TITLE
Disable region simplification in `--aie-substitute-shim-dma-allocations` pass

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
@@ -67,13 +67,12 @@ struct AIESubstituteShimDMAAllocationsPass
 
     // Convert DMAConfigureTaskForOps that reference shim DMA allocations
     // to regular DMAConfigureTaskOps
-    ConversionTarget target(getContext());
-    target.addLegalDialect<AIEXDialect>();
-    target.addIllegalOp<DMAConfigureTaskForOp>();
+    GreedyRewriteConfig rewriter_config = GreedyRewriteConfig();
+    rewriter_config.enableRegionSimplification =
+        GreedySimplifyRegionLevel::Disabled;
     RewritePatternSet patterns(&getContext());
     patterns.insert<DMAConfigureTaskForOpPattern>(&getContext());
 
-    GreedyRewriteConfig rewriter_config = GreedyRewriteConfig();
     if (failed(applyPatternsAndFoldGreedily(device, std::move(patterns),
                                             rewriter_config))) {
       signalPassFailure();


### PR DESCRIPTION
The pattern rewriter in this pass previously also performed region simplification, which caused an assertion error if the MLIR contained blocks with input arguments, such as generated by:

```
          %7 = scf.if %6 -> (memref<64x32xf32>) {
            scf.yield %C_L1L2_0_0_buff_0 : memref<64x32xf32>
          } else {
            scf.yield %C_L1L2_0_0_buff_1 : memref<64x32xf32>
          }
```

This fixes that issue. I don't fully understand why the issue exists with region simplification, but the point of this pass is not to simplify regions anyways, so it is fine to disable.