### PR TITLE
Fix offset bug in matrix multiply cascade

### DIFF
--- a/programming_examples/basic/matrix_multiplication/cascade/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/cascade/aie2.py
@@ -230,6 +230,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                         (t, 1),
                     ],
                 )
+            of_offsets = [n * k * i for i in range(n_aie_cols)]
             object_fifo_link(
                 B_l3l2_fifos[col],
                 [B_l2l1_fifos[row][col] for row in range(n_aie_rows)],


### PR DESCRIPTION
I had introduced a bug in both matrix multiply whole array and matrix multiply cascade. I fixed it for matrix multiply whole array but did not realize the bug affected cascade as well until recently.