### PR TITLE
Fixup pathfinder pktflow sorting by sorting on src coords and port only

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -252,6 +252,9 @@ public:
   ShimMuxOp getShimMux(mlir::OpBuilder &builder, int col);
 };
 
+// Get enum int value from WireBundle.
+int getWireBundleAsInt(WireBundle bundle);
+
 } // namespace xilinx::AIE
 
 namespace llvm {

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -354,25 +354,13 @@ void Pathfinder::sortFlows(const int maxCol, const int maxRow) {
       normalFlows.push_back(f);
   }
   std::sort(priorityFlows.begin(), priorityFlows.end(),
-            [maxCol, maxRow](const auto &lhs, const auto &rhs) {
+            [maxCol](const auto &lhs, const auto &rhs) {
               int lhsUniqueID = lhs.src.coords.col;
               lhsUniqueID += lhs.src.coords.row * maxCol;
-              int currMultiplier = maxCol * maxRow;
-              for (auto dest : lhs.dsts) {
-                lhsUniqueID += currMultiplier;
-                lhsUniqueID += dest.coords.col;
-                lhsUniqueID += dest.coords.row * maxCol;
-                currMultiplier += maxCol * maxRow;
-              }
+              lhsUniqueID += getWireBundleAsInt(lhs.src.port.bundle);
               int rhsUniqueID = rhs.src.coords.col;
               rhsUniqueID += rhs.src.coords.row * maxCol;
-              currMultiplier = maxCol * maxRow;
-              for (auto dest : rhs.dsts) {
-                rhsUniqueID += currMultiplier;
-                rhsUniqueID += dest.coords.col;
-                rhsUniqueID += dest.coords.row * maxCol;
-                currMultiplier += maxCol * maxRow;
-              }
+              rhsUniqueID += getWireBundleAsInt(rhs.src.port.bundle);
               return lhsUniqueID < rhsUniqueID;
             });
   flows = priorityFlows;
@@ -692,4 +680,33 @@ Pathfinder::findPaths(const int maxIterations) {
 
   LLVM_DEBUG(llvm::dbgs() << "\t---End Pathfinder::findPaths---\n");
   return routingSolution;
+}
+
+// Get enum int value from WireBundle.
+int AIE::getWireBundleAsInt(WireBundle bundle) {
+  switch (bundle) {
+  case WireBundle::Core:
+    return 0;
+  case WireBundle::DMA:
+    return 1;
+  case WireBundle::FIFO:
+    return 2;
+  case WireBundle::South:
+    return 3;
+  case WireBundle::West:
+    return 4;
+  case WireBundle::North:
+    return 5;
+  case WireBundle::East:
+    return 6;
+  case WireBundle::PLIO:
+    return 7;
+  case WireBundle::NOC:
+    return 8;
+  case WireBundle::Trace:
+    return 9;
+  case WireBundle::Ctrl:
+    return 10;
+  }
+  return -1;
 }

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -354,13 +354,18 @@ void Pathfinder::sortFlows(const int maxCol, const int maxRow) {
       normalFlows.push_back(f);
   }
   std::sort(priorityFlows.begin(), priorityFlows.end(),
-            [maxCol](const auto &lhs, const auto &rhs) {
+            [maxCol, maxRow](const auto &lhs, const auto &rhs) {
               int lhsUniqueID = lhs.src.coords.col;
               lhsUniqueID += lhs.src.coords.row * maxCol;
+              lhsUniqueID += maxRow * maxCol;
               lhsUniqueID += getWireBundleAsInt(lhs.src.port.bundle);
+              lhsUniqueID += AIE::getMaxEnumValForWireBundle();
+              lhsUniqueID += lhs.src.port.channel;
               int rhsUniqueID = rhs.src.coords.col;
               rhsUniqueID += rhs.src.coords.row * maxCol;
+              rhsUniqueID += maxRow * maxCol;
               rhsUniqueID += getWireBundleAsInt(rhs.src.port.bundle);
+              rhsUniqueID += rhs.src.port.channel;
               return lhsUniqueID < rhsUniqueID;
             });
   flows = priorityFlows;

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -689,29 +689,5 @@ Pathfinder::findPaths(const int maxIterations) {
 
 // Get enum int value from WireBundle.
 int AIE::getWireBundleAsInt(WireBundle bundle) {
-  switch (bundle) {
-  case WireBundle::Core:
-    return 0;
-  case WireBundle::DMA:
-    return 1;
-  case WireBundle::FIFO:
-    return 2;
-  case WireBundle::South:
-    return 3;
-  case WireBundle::West:
-    return 4;
-  case WireBundle::North:
-    return 5;
-  case WireBundle::East:
-    return 6;
-  case WireBundle::PLIO:
-    return 7;
-  case WireBundle::NOC:
-    return 8;
-  case WireBundle::Trace:
-    return 9;
-  case WireBundle::Ctrl:
-    return 10;
-  }
-  return -1;
+  return static_cast<typename std::underlying_type<WireBundle>::type>(bundle);
 }


### PR DESCRIPTION
Previous sorting method tries to sort on src and dest coords only, but this does not guarantee determinism in control packet routings because:
- port (wirebundle, channel) is not taken into account,
- control packet flows could have fused with data movement packet flows, leading to inconsistent control packet flow routings if all destinations (which could include both CTRL and DMA, NSWE) were taken into account when sorted,
- "Flow" struct in PathFinder assumes uniqueness in source; sorting the source coords, wirebundle and channels is sufficient to enforce determinism in the sorted order.