### PR TITLE
Faster (static) method to get unique id for creating global op

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -16,9 +16,6 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/DenseMap.h"
 
-#include <charconv>
-#include <string>
-
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::AIEX;

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -16,6 +16,9 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/DenseMap.h"
 
+#include <charconv>
+#include <string>
+
 using namespace mlir;
 using namespace xilinx;
 using namespace xilinx::AIEX;
@@ -66,6 +69,38 @@ private:
 
     return std::nullopt;
   }
+};
+
+// Helper class to get a unique int id for creating a GlobalOp.
+
+struct UniqueGlobalOpIdGetter {
+
+public:
+  // Return an int id unique to all previous ids allocated to existing
+  // GlobalOps.
+  std::optional<int> get() {
+    int id = 0;
+    while (llvm::is_contained(idCache, id))
+      id++;
+    idCache.push_back(id);
+    return id;
+  }
+
+  // Initialize idCache with existing global ops' ids.
+  void init(AIE::DeviceOp dev, std::string blockwriteSymPrefix) {
+    dev.walk([&](memref::GlobalOp globalOp) {
+      std::string name = globalOp.getSymName().str();
+      if (name.find(blockwriteSymPrefix) == std::string::npos)
+        return;
+      int id = 0;
+      std::from_chars(&name[blockwriteSymPrefix.length()], &name[name.length()],
+                      id);
+      idCache.push_back(id);
+    });
+  }
+
+private:
+  llvm::SmallVector<int> idCache;
 };
 } // namespace
 
@@ -518,8 +553,14 @@ public:
 struct WriteBdToBlockWritePattern : OpConversionPattern<NpuWriteBdOp> {
   using OpConversionPattern::OpConversionPattern;
 
-  WriteBdToBlockWritePattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpConversionPattern(context, benefit) {}
+private:
+  UniqueGlobalOpIdGetter &idGetter;
+
+public:
+  WriteBdToBlockWritePattern(MLIRContext *context,
+                             UniqueGlobalOpIdGetter &getter,
+                             PatternBenefit benefit = 1)
+      : OpConversionPattern(context, benefit), idGetter(getter) {}
 
   LogicalResult
   matchAndRewrite(NpuWriteBdOp op, OpAdaptor adaptor,
@@ -634,10 +675,10 @@ struct WriteBdToBlockWritePattern : OpConversionPattern<NpuWriteBdOp> {
       std::string name = "blockwrite_data_";
       rewriter.setInsertionPoint(
           op->getParentOfType<AIEX::RuntimeSequenceOp>());
-      int id = 0;
-      while (dev.lookupSymbol(name + std::to_string(id)))
-        id++;
-      name += std::to_string(id);
+      auto id = idGetter.get();
+      if (!id)
+        return failure();
+      name += std::to_string(*id);
       global = rewriter.create<memref::GlobalOp>(
           op->getLoc(), name, rewriter.getStringAttr("private"), memrefType,
           DenseElementsAttr::get<uint32_t>(tensorType, words), true, nullptr);
@@ -689,7 +730,9 @@ struct AIEDmaToNpuPass : AIEDmaToNpuBase<AIEDmaToNpuPass> {
     patterns.insert<PushQueuetoWrite32Pattern>(&getContext());
     patterns.insert<RtpToWrite32Pattern>(&getContext());
     patterns.insert<Write32SymToAddr>(&getContext());
-    patterns.insert<WriteBdToBlockWritePattern>(&getContext());
+    UniqueGlobalOpIdGetter cachingIdGetter;
+    cachingIdGetter.init(device, /*GlobalOp symbol prefix*/ "blockwrite_data_");
+    patterns.insert<WriteBdToBlockWritePattern>(&getContext(), cachingIdGetter);
 
     if (failed(applyPartialConversion(device, target, std::move(patterns))))
       signalPassFailure();


### PR DESCRIPTION
Optimize the existing method of getting unique id for creating `memref.global` ops, as it was running in multiple minutes if the number of NpuWriteBdOps in input IR goes over a thousand.