### PR TITLE
Fix imports in some npu-xrt tests

### DIFF
--- a/test/npu-xrt/matrix_transpose/aie2.py
+++ b/test/npu-xrt/matrix_transpose/aie2.py
@@ -18,6 +18,7 @@ from aie.extras.context import mlir_mod_ctx
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
+from aie.ir import MemRefType
 from aie.extras.dialects.ext.scf import _for as range_
 
 matrix_rows = 7

--- a/test/npu-xrt/nd_memcpy_transforms/aie2.py
+++ b/test/npu-xrt/nd_memcpy_transforms/aie2.py
@@ -19,7 +19,7 @@ from aie.extras.context import mlir_mod_ctx
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.extras.dialects.ext.scf import _for as range_
-
+from aie.ir import MemRefType
 
 dtype = T.i16
 a_len = 8

--- a/test/npu-xrt/sync_task_complete_token/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token/aie2.py
@@ -17,7 +17,6 @@ from aie.extras.context import mlir_mod_ctx
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
-from aie.extras.dialects.ext import arith
 from aie.extras.dialects.ext.scf import _for as range_
 
 
@@ -57,7 +56,7 @@ def design():
             def core_body():
                 for _ in range_(0xFFFFFFFF):
                     elem_output = fifo_output.acquire(ObjectFifoPort.Produce, 1)
-                    zero = arith.constant(T.i32(), 0)
+                    zero = constant(0)
                     memref.store(zero, elem_output, [0])
                     for _ in range_(16):
                         elem_input = fifo_input.acquire(ObjectFifoPort.Consume, 1)

--- a/test/npu-xrt/sync_task_complete_token/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token/aie2.py
@@ -17,6 +17,7 @@ from aie.extras.context import mlir_mod_ctx
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
+from aie.extras.dialects.ext import arith
 from aie.extras.dialects.ext.scf import _for as range_
 
 
@@ -56,7 +57,7 @@ def design():
             def core_body():
                 for _ in range_(0xFFFFFFFF):
                     elem_output = fifo_output.acquire(ObjectFifoPort.Produce, 1)
-                    zero = constant(T.i32(), 0)
+                    zero = arith.constant(T.i32(), 0)
                     memref.store(zero, elem_output, [0])
                     for _ in range_(16):
                         elem_input = fifo_input.acquire(ObjectFifoPort.Consume, 1)

--- a/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
@@ -17,7 +17,6 @@ from aie.extras.context import mlir_mod_ctx
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
-from aie.extras.dialects.ext import arith
 from aie.extras.dialects.ext.scf import _for as range_
 
 
@@ -57,7 +56,7 @@ def design():
             def core_body():
                 for _ in range_(0xFFFFFFFF):
                     elem_output = fifo_output.acquire(ObjectFifoPort.Produce, 1)
-                    zero = arith.constant(T.i32(), 0)
+                    zero = constant(0)
                     memref.store(zero, elem_output, [0])
                     for _ in range_(16):
                         elem_input = fifo_input.acquire(ObjectFifoPort.Consume, 1)

--- a/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
@@ -17,6 +17,7 @@ from aie.extras.context import mlir_mod_ctx
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
+from aie.extras.dialects.ext import arith
 from aie.extras.dialects.ext.scf import _for as range_
 
 
@@ -56,7 +57,7 @@ def design():
             def core_body():
                 for _ in range_(0xFFFFFFFF):
                     elem_output = fifo_output.acquire(ObjectFifoPort.Produce, 1)
-                    zero = constant(T.i32(), 0)
+                    zero = arith.constant(T.i32(), 0)
                     memref.store(zero, elem_output, [0])
                     for _ in range_(16):
                         elem_input = fifo_input.acquire(ObjectFifoPort.Consume, 1)


### PR DESCRIPTION
Even though it passed the tests run by the CI in the PR, https://github.com/Xilinx/mlir-aie/pull/1785 appears to have broken some imports for some of the npu-xrt tests once it was merged into main. The tests that (sometimes) appear broken are:

```
 Failed Tests (6):
  AIE :: npu-xrt/add_12_i8_using_2d_dma_op_with_padding/run.lit
  AIE :: npu-xrt/add_21_i8_using_dma_op_with_padding/run.lit
  AIE :: npu-xrt/matrix_transpose/aie2.py
  AIE :: npu-xrt/nd_memcpy_transforms/aie2.py
  AIE :: npu-xrt/sync_task_complete_token/aie2.py
  AIE :: npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
```

This test fixes the python errors reported for the last four failures, but as I'm still unsure why the first two tests are breaking, this PR does not fix those.

