### PR TITLE
Add getDependentDialects to conversion passes

### DIFF
--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -492,6 +492,9 @@ namespace {
 
 struct ConvertAIEToTransactionPass
     : ConvertAIEToTransactionBase<ConvertAIEToTransactionPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<memref::MemRefDialect, AIEX::AIEXDialect>();
+  }
   void runOnOperation() override {
     if (failed(convertAIEToConfiguration(getOperation(), clElfDir,
                                          OutputType::Transaction)))
@@ -501,6 +504,9 @@ struct ConvertAIEToTransactionPass
 
 struct ConvertAIEToControlPacketsPass
     : public ConvertAIEToControlPacketsBase<ConvertAIEToControlPacketsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<memref::MemRefDialect, AIEX::AIEXDialect>();
+  }
   void runOnOperation() override {
     if (failed(convertAIEToConfiguration(getOperation(), clElfDir,
                                          OutputType::ControlPacket)))


### PR DESCRIPTION
The passes create memref and aiex ops, so these are depended dialects and aie-opt might crash on input not containing these dialects.