### PR TITLE
Cleanup aie2 simulation lit commands and remove meaningless run_on_board

### DIFF
--- a/test/unit_tests/aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/aie2/05_shim_dma_core_function/aie.mlir
@@ -65,7 +65,7 @@ module @test_chess_05_shim_dma_core_function {
     %m73 = aie.mem(%t73) {
         %srcDma = aie.dma_start("S2MM", 0, ^bd0, ^dma0)
       ^dma0:
-        %dstDma = aie.dma_start("MM2S", 1, ^bd2, ^end)
+        %dstDma = aie.dma_start("MM2S", 0, ^bd2, ^end)
       ^bd0:
         aie.use_lock(%lock_a_write, AcquireGreaterEqual, 1)
         aie.dma_bd(%buf_a_ping : memref<16xi32>, 0, 16)
@@ -100,7 +100,7 @@ module @test_chess_05_shim_dma_core_function {
 
     // Shim DMA connection to kernel
     aie.flow(%t70, "DMA" : 0, %t73, "DMA" : 0)
-    aie.flow(%t73, "DMA" : 1, %t70, "DMA" : 0)
+    aie.flow(%t73, "DMA" : 0, %t70, "DMA" : 0)
 
     // Shim DMA loads large buffer to local memory
     %dma = aie.shim_dma(%t70) {

--- a/test/unit_tests/chess_compiler_tests_aie2/01_precompiled_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/01_precompiled_core_function/aie.mlir
@@ -10,8 +10,7 @@
 
 // REQUIRES: valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
-// RUN: %PYTHON aiecc.py -v --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s %test_lib_flags %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// RUN: %PYTHON aiecc.py -v --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS

--- a/test/unit_tests/chess_compiler_tests_aie2/02_precompiled_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/02_precompiled_kernel/aie.mlir
@@ -9,9 +9,8 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: valid_xchess_license, !hsa
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: xchesscc_wrapper aie2 +l aie.mlir.prj/core_1_3.bcf %S/kernel.cc -o custom_1_3.elf
-// RUN: %run_on_board ./test.elf
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS

--- a/test/unit_tests/chess_compiler_tests_aie2/03_cascade_core_functions/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/03_cascade_core_functions/aie.mlir
@@ -10,8 +10,7 @@
 
 // REQUIRES: valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS

--- a/test/unit_tests/chess_compiler_tests_aie2/03_simple/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/03_simple/aie.mlir
@@ -8,9 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: !hsa
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %extraAieCcFlags% %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// REQUIRES: valid_xchess_license, !hsa
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 
 // CHECK: AIE2 ISS

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie.mlir
@@ -9,11 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// aiecc.py -j0 --aiesim --xchesscc --xbridge aie.mlir -I/wrk/hdstaff/stephenn/nobkup/acdc-install-wsl/runtime_lib/x86_64/test_lib/include test.cpp -o test.elf -L/wrk/hdstaff/stephenn/nobkup/acdc-install-wsl/runtime_lib/x86_64/test_lib/lib -ltest_lib
-// aiecc.py -j0 --aiesim --xchesscc --xbridge aie.mlir -I/wrk/hdstaff/stephenn/nobkup/acdc-install-wsl/runtime_lib/x86_64/test_lib/include test.cpp -o test.elf /wrk/hdstaff/stephenn/nobkup/acdc-install-wsl/runtime_lib/x86_64/test_lib/lib/test_library.cpp
-
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %extraAieCcFlags% %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// REQUIRES: valid_xchess_license, !hsa
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %s %test_lib_flags %S/test.cpp
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie_row.mlir
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s %test_lib_flags %extraAieCcFlags% %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// REQUIRES: valid_xchess_license, !hsa
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: aie_row.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
@@ -10,12 +10,10 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: valid_xchess_license, !!hsa
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: xchesscc_wrapper aie2 +l aie.mlir.prj/core_7_3.bcf %S/kernel.cc -o custom_7_3.elf
-// RUN: %run_on_board ./test.elf
 
-// FIXME: this hangs in simulation
-// RU: aie.mlir.prj/aiesim.sh | FileCheck %s
+// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
 
 // CHECK: AIE2 ISS
 // CHECK: test start.

--- a/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
@@ -11,8 +11,7 @@
 
 // REQUIRES: valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 
 // FIXME this hangs in simulation
 // RU: aie.mlir.prj/aiesim.sh | FileCheck %s

--- a/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
@@ -8,12 +8,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-//  clang -O2 --target=aie -c %S/kernel.cc
-// REQUIRES: valid_xchess_license
+// REQUIRES: valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
-// RUN: %PYTHON aiecc.py --aiesim --chesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
-// UN: aie.mlir.prj/aiesim.sh
+// RUN: %PYTHON aiecc.py --aiesim --chesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
+
+// RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
+// CHECK: PASS!
+
 // XFAIL: *
 
 module @test_chess_04_deprecated_shim_dma_precompiled_kernel{

--- a/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
@@ -10,8 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: valid_xchess_license, !hsa
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 
 // CHECK: AIE2 ISS

--- a/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
@@ -10,8 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: valid_xchess_license, !hsa
-// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
-// RUN: %run_on_board ./test.elf
+// RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 
 // CHECK: AIE2 ISS


### PR DESCRIPTION
Don't pretend to compile aie2 simulation tests for a board. `%run_on_board` is already deprecated in the `lit.cfg.py` anyway.