### PR TITLE
Numpy bfloat16 workaround

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
       - name: Install packages
         run: |

--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -86,6 +86,7 @@ jobs:
             python -m venv aie-venv
             source aie-venv/bin/activate
             pip install -r python/requirements.txt
+            pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
             pip -q download mlir==$VERSION \

--- a/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
+++ b/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
@@ -111,6 +111,7 @@ jobs:
             python -m venv aie-venv
             source aie-venv/bin/activate
             pip install -r python/requirements.txt
+            pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
             pip -q download mlir==$VERSION \

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
       - name: Setup Cpp
         uses: aminya/setup-cpp@v1

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
       - name: Install packages
         run: |

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -80,6 +80,7 @@ jobs:
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
           pip install -r python/requirements_ml.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
           pip install jupyter
           sed -i.bak 's/OUTPUT_TIMEOUT = 10/OUTPUT_TIMEOUT = 100/g' \
             $(python -c 'import site; print(site.getsitepackages()[0])')/jupyter_client/runapp.py
@@ -137,6 +138,7 @@ jobs:
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
           pip install -r python/requirements_ml.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
           pip install jupyter
           sed -i.bak 's/OUTPUT_TIMEOUT = 10/OUTPUT_TIMEOUT = 100/g' \
             $(python -c 'import site; print(site.getsitepackages()[0])')/jupyter_client/runapp.py

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -52,6 +52,7 @@ jobs:
           python -m venv aie-venv
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
           pip -q download mlir==$VERSION \
@@ -158,6 +159,7 @@ jobs:
           python -m venv aie-venv
           source aie-venv/bin/activate
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
           source aie-venv/bin/activate
           
           export MLIR_INSTALL_ABS_PATH=$PWD/mlir

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -43,6 +43,7 @@ jobs:
           
           pip install cmake==3.27.9 numpy psutil pybind11 rich pkginfo lit PyYAML requests
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
       - name: Get MLIR
         id: mlir-wheels
@@ -204,6 +205,7 @@ jobs:
         run: |
           pip install cmake numpy psutil pybind11 rich lit
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
       - name: Install packages
         run: sudo apt-get install -y ninja-build clang lld llvm libelf-dev
@@ -234,7 +236,9 @@ jobs:
 
       - name: Install our python reqs
         if: steps.changed-files.outputs.changed-files != ''
-        run: pip install -r python/requirements.txt
+        run: |
+          pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
       - name: Build and generate coverage (Release)
         if: steps.changed-files.outputs.changed-files != ''

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -337,9 +337,10 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: macos-12
-            ARCH: x86_64
-            ENABLE_RTTI: ON
+# Disabled because macos mlir wheels are out of date, and we don't currently build for them
+#          - OS: macos-12
+#            ARCH: x86_64
+#            ENABLE_RTTI: ON
 
           - OS: ubuntu-20.04
             ARCH: x86_64

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -226,6 +226,7 @@ jobs:
         export PIP_NO_BUILD_ISOLATION=false
         
         pip install -r requirements.txt
+        pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
         pip install importlib-metadata
         CIBW_ARCHS=${{ matrix.ARCH }} MATRIX_OS=${{ matrix.OS }} ./scripts/download_mlir.sh
         
@@ -354,7 +355,9 @@ jobs:
       - name: Checkout reqs
         uses: actions/checkout@v3
         with:
-          sparse-checkout: python/requirements.txt
+          sparse-checkout: |
+            python/requirements.txt
+            pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
 
       - uses: actions/download-artifact@v3
         with:
@@ -369,6 +372,7 @@ jobs:
         shell: bash
         run: |
           pip install -r python/requirements.txt
+          pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
           unzip -o -q dist/mlir_aie\*.whl
           
           if [ x"${{ matrix.ENABLE_RTTI }}" == x"ON" ]; then

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -84,13 +84,14 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: macos-12
-            ARCH: x86_64
-            ENABLE_RTTI: ON
+# Disabled because macos mlir wheels are out of date, and we don't currently build for them
+#          - OS: macos-12
+#            ARCH: x86_64
+#            ENABLE_RTTI: ON
 
-          - OS: macos-14
-            ARCH: arm64
-            ENABLE_RTTI: ON
+#          - OS: macos-14
+#            ARCH: arm64
+#            ENABLE_RTTI: ON
 
 # disabled because openssl dep isn't being compiled from source
 # (and hence system openssl can't be linked against during cross-compile)
@@ -106,13 +107,14 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: OFF
 
-          - OS: macos-12
-            ARCH: x86_64
-            ENABLE_RTTI: OFF
+# Disabled because macos mlir wheels are out of date, and we don't currently build for them
+#          - OS: macos-12
+#            ARCH: x86_64
+#            ENABLE_RTTI: OFF
 
-          - OS: macos-14
-            ARCH: arm64
-            ENABLE_RTTI: OFF
+#          - OS: macos-14
+#            ARCH: arm64
+#            ENABLE_RTTI: OFF
 
 # disabled because openssl dep isn't being compiled from source
 # (and hence system openssl can't be linked against during cross-compile)
@@ -347,9 +349,10 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: OFF
 
-          - OS: macos-12
-            ARCH: x86_64
-            ENABLE_RTTI: OFF
+# Disabled because macos mlir wheels are out of date, and we don't currently build for them
+#          - OS: macos-12
+#            ARCH: x86_64
+#            ENABLE_RTTI: OFF
 
     steps:
       - name: Checkout reqs
@@ -409,13 +412,14 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: ON
 
-          - OS: macos-12
-            ARCH: x86_64
-            ENABLE_RTTI: ON
+# Disabled because macos mlir wheels are out of date, and we don't currently build for them
+#          - OS: macos-12
+#            ARCH: x86_64
+#            ENABLE_RTTI: ON
 
-          - OS: macos-14
-            ARCH: arm64
-            ENABLE_RTTI: ON
+#          - OS: macos-14
+#            ARCH: arm64
+#            ENABLE_RTTI: ON
 
           - OS: ubuntu-20.04
             ARCH: x86_64
@@ -429,13 +433,14 @@ jobs:
             ARCH: AMD64
             ENABLE_RTTI: OFF
 
-          - OS: macos-12
-            ARCH: x86_64
-            ENABLE_RTTI: OFF
+# Disabled because macos mlir wheels are out of date, and we don't currently build for them
+#          - OS: macos-12
+#            ARCH: x86_64
+#            ENABLE_RTTI: OFF
 
-          - OS: macos-14
-            ARCH: arm64
-            ENABLE_RTTI: OFF
+#          - OS: macos-14
+#            ARCH: arm64
+#            ENABLE_RTTI: OFF
 
     steps:
       - uses: actions/download-artifact@v3

--- a/programming_examples/basic/matrix_multiplication/cascade/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/cascade/aie2.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2024 AMD Inc.
-
+from numpy import np
 import sys
 import argparse
 
@@ -13,6 +13,15 @@ from aie.extras.context import mlir_mod_ctx
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.extras.dialects.ext.scf import _for as range_
+from aie.extras.util import bfloat16
+
+dtype_map = {
+    "bf16": bfloat16,
+    "i8": np.int8,
+    "i16": np.int16,
+    "f32": np.float32,
+    "i32": np.int32,
+}
 
 
 def main():
@@ -59,20 +68,8 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
     n_aie_rows = 4
     n_aie_cores = n_aie_rows * n_aie_cols
 
-    dtype_in = None
-    if dtype_in_str == "bf16":
-        dtype_in = T.bf16
-    elif dtype_in_str == "i16":
-        dtype_in = T.i16
-    dtype_out = None
-    if dtype_out_str == "bf16":
-        dtype_out = T.bf16
-    elif dtype_out_str == "i16":
-        dtype_out = T.i16
-    elif dtype_out_str == "f32":
-        dtype_out = T.f32
-    elif dtype_out_str == "i32":
-        dtype_out = T.i32
+    dtype_in = dtype_map(dtype_in_str)
+    dtype_out = dtype_map(dtype_out_str)
 
     if dtype_in_str == "bf16":
         r = 4
@@ -125,28 +122,26 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
 
     @device(dev)
     def device_body():
-        A_l2_memref_ty = T.memref(m * k * n_A_tiles_per_shim, dtype_in())
-        B_l2_memref_ty = T.memref(k * n * n_aie_rows, dtype_in())
-        C_l2_memref_ty = T.memref(m * n, dtype_out())
-        A_l1_memref_ty = T.memref(m, k, dtype_in())
-        B_l1_memref_ty = T.memref(k, n, dtype_in())
-        C_l1_memref_ty = T.memref(m, n, dtype_out())
+        A_l2_ty = np.ndarray[(m * k * n_A_tiles_per_shim,), np.dtype[dtype_in]]
+        B_l2_ty = np.ndarray[(k * n * n_aie_rows,), np.dtype[dtype_in]]
+        C_l2_ty = np.ndarray[(m * n,), np.dtype[dtype_out]]
+        A_l1_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
+        B_l1_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
+        C_l1_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
 
         # AIE Core Function declarations
-        zero_scalar = external_func(
-            f"zero_scalar_{dtype_out_str}", inputs=[C_l1_memref_ty]
-        )
+        zero_scalar = external_func(f"zero_scalar_{dtype_out_str}", inputs=[C_l1_ty])
         matmul_scalar_cascade_get_only = external_func(
             f"matmul_scalar_cascade_get_only_{dtype_in_str}_{dtype_out_str}",
-            inputs=[A_l1_memref_ty, B_l1_memref_ty, C_l1_memref_ty],
+            inputs=[A_l1_ty, B_l1_ty, C_l1_ty],
         )
         matmul_scalar_cascade_put_only = external_func(
             f"matmul_scalar_cascade_put_only_{dtype_in_str}_{dtype_out_str}",
-            inputs=[A_l1_memref_ty, B_l1_memref_ty, C_l1_memref_ty],
+            inputs=[A_l1_ty, B_l1_ty, C_l1_ty],
         )
         matmul_scalar_cascade_put_get = external_func(
             f"matmul_scalar_cascade_put_get_{dtype_in_str}_{dtype_out_str}",
-            inputs=[A_l1_memref_ty, B_l1_memref_ty, C_l1_memref_ty],
+            inputs=[A_l1_ty, B_l1_ty, C_l1_ty],
         )
 
         # Tile declarations as tile[row][col]
@@ -175,7 +170,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                 mem_tiles[row // n_A_tiles_per_shim],
                 core_tiles[row][0:n_aie_cols],  # broadcast along one row
                 fifo_depth,
-                A_l1_memref_ty,
+                A_l1_ty,
                 [
                     (m // r, r * k),
                     (k // s, s),
@@ -189,7 +184,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                 shim_tiles[col],
                 mem_tiles[col],
                 fifo_depth,
-                A_l2_memref_ty,
+                A_l2_ty,
             )
             # If n_cols == n_rows, n_A_tiles_per_shim is 1 and
             # this simply links a_l3l2_fifos[col] to a_l2l1_fifos[row] directly,
@@ -214,7 +209,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                 shim_tiles[col],
                 mem_tiles[col],
                 fifo_depth,
-                B_l2_memref_ty,
+                B_l2_ty,
             )
             for row in range(n_aie_rows):
                 B_l2l1_fifos[row][col] = object_fifo(
@@ -222,7 +217,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                     mem_tiles[col],
                     core_tiles[row][col],
                     fifo_depth,
-                    B_l1_memref_ty,
+                    B_l1_ty,
                     [
                         (k // s, s * n),
                         (n // t, t),
@@ -247,7 +242,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                         core_tiles[row][col],
                         mem_tiles[col],
                         fifo_depth,
-                        C_l1_memref_ty,
+                        C_l1_ty,
                     )
                 else:
                     C_l1l2_buffers[row][col] = buffer(
@@ -259,7 +254,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                 mem_tiles[col],
                 shim_tiles[col],
                 fifo_depth,
-                C_l2_memref_ty,
+                C_l2_ty,
                 [
                     (m // r, r * n),
                     (r, t),
@@ -324,9 +319,9 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
 
         # To/from AIE-array data movement
         @runtime_sequence(
-            T.memref(M * K, dtype_in()),
-            T.memref(K * N, dtype_in()),
-            T.memref(M * N, dtype_out()),
+            np.ndarray[(M * K,), np.dtype[dtype_in]],
+            np.ndarray[(K * N,), np.dtype[dtype_in]],
+            np.ndarray[(M * N,), np.dtype[dtype_out]],
         )
         def sequence(A, B, C):
             # We are limited in the number of BDs. After synchronizing, we can reuse BDs.

--- a/programming_examples/basic/matrix_multiplication/cascade/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/cascade/aie2.py
@@ -246,7 +246,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                     )
                 else:
                     C_l1l2_buffers[row][col] = buffer(
-                        core_tiles[row][col], [m, n], dtype_out(), f"C_L1L2_{col}_{row}"
+                        core_tiles[row][col], [m, n], dtype_out, f"C_L1L2_{col}_{row}"
                     )
 
             C_l2l3_fifos[col] = object_fifo(

--- a/programming_examples/basic/matrix_multiplication/cascade/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/cascade/aie2.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2024 AMD Inc.
-from numpy import np
+import numpy as np
 import sys
 import argparse
 

--- a/programming_examples/basic/matrix_multiplication/cascade/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/cascade/aie2.py
@@ -68,8 +68,8 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
     n_aie_rows = 4
     n_aie_cores = n_aie_rows * n_aie_cols
 
-    dtype_in = dtype_map(dtype_in_str)
-    dtype_out = dtype_map(dtype_out_str)
+    dtype_in = dtype_map[dtype_in_str]
+    dtype_out = dtype_map[dtype_out_str]
 
     if dtype_in_str == "bf16":
         r = 4

--- a/programming_examples/basic/matrix_multiplication/single_core/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/aie2.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023 AMD Inc.
-
-import sys
 import argparse
+import numpy as np
+import sys
 
 from aie.extras.context import mlir_mod_ctx
 from aie.dialects.aie import *
@@ -14,6 +14,15 @@ from aie.dialects.aiex import *
 import aie.utils.trace as trace_utils
 from aie.utils.trace import PortEvent
 from aie.extras.dialects.ext.scf import _for as range_
+from aie.extras.util import bfloat16
+
+dtype_map = {
+    "bf16": bfloat16,
+    "i8": np.int8,
+    "i16": np.int16,
+    "f32": np.float32,
+    "i32": np.int32,
+}
 
 
 def main():
@@ -73,24 +82,8 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
     enable_tracing = False
     trace_size = 65536
 
-    dtype_in = None
-    if dtype_in_str == "bf16":
-        dtype_in = T.bf16
-    elif dtype_in_str == "i8":
-        dtype_in = T.i8
-    elif dtype_in_str == "i16":
-        dtype_in = T.i16
-    dtype_out = None
-    if dtype_out_str == "bf16":
-        dtype_out = T.bf16
-    elif dtype_out_str == "i8":
-        dtype_out = T.i8
-    elif dtype_out_str == "i16":
-        dtype_out = T.i16
-    elif dtype_out_str == "f32":
-        dtype_out = T.f32
-    elif dtype_out_str == "i32":
-        dtype_out = T.i32
+    dtype_in = dtype_map[dtype_in_str]
+    dtype_out = dtype_map[dtype_out_str]
 
     A_sz = M * K
     B_sz = K * N
@@ -113,18 +106,34 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
 
         @device(AIEDevice.npu1_1col)
         def device_body():
-            memref_a_ty = T.memref(m, k, dtype_in())
-            memref_b_ty = T.memref(k, n, dtype_in())
-            memref_c_ty = T.memref(m, n, dtype_out())
+            a_ty = np.ndarray[
+                (
+                    m,
+                    k,
+                ),
+                np.dtype[dtype_in],
+            ]
+            b_ty = np.ndarray[
+                (
+                    k,
+                    n,
+                ),
+                np.dtype[dtype_in],
+            ]
+            c_ty = np.ndarray[
+                (
+                    m,
+                    n,
+                ),
+                np.dtype[dtype_out],
+            ]
 
             # AIE Core Function declarations
             func_type = "" if vectorized else "scalar_"
-            zero = external_func(
-                f"zero_{func_type}{dtype_out_str}", inputs=[memref_c_ty]
-            )
+            zero = external_func(f"zero_{func_type}{dtype_out_str}", inputs=[c_ty])
             matmul = external_func(
                 f"matmul_{func_type}{dtype_in_str}_{dtype_out_str}",
-                inputs=[memref_a_ty, memref_b_ty, memref_c_ty],
+                inputs=[a_ty, b_ty, c_ty],
             )
 
             # Tile declarations
@@ -135,13 +144,13 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
 
             # AIE-array data movement with object fifos
             # Input A
-            inA = object_fifo("inA", shim_tile, mem_tile, 2, memref_a_ty)
+            inA = object_fifo("inA", shim_tile, mem_tile, 2, a_ty)
             memA = object_fifo(
                 "memA",
                 mem_tile,
                 compute_tile2,
                 2,
-                memref_a_ty,
+                a_ty,
                 (
                     [
                         (m // r, r * k),
@@ -156,13 +165,13 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
             object_fifo_link(inA, memA)
 
             # Input B
-            inB = object_fifo("inB", shim_tile, mem_tile, 2, memref_b_ty)
+            inB = object_fifo("inB", shim_tile, mem_tile, 2, b_ty)
             memB = object_fifo(
                 "memB",
                 mem_tile,
                 compute_tile2,
                 2,
-                memref_b_ty,
+                b_ty,
                 (
                     [
                         (k // s, s * n),
@@ -177,13 +186,13 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
             object_fifo_link(inB, memB)
 
             # Output C
-            memC = object_fifo("memC", compute_tile2, mem_tile, 2, memref_c_ty)
+            memC = object_fifo("memC", compute_tile2, mem_tile, 2, c_ty)
             outC = object_fifo(
                 "outC",
                 mem_tile,
                 shim_tile,
                 2,
-                memref_c_ty,
+                c_ty,
                 (
                     [
                         (m // r, r * n),
@@ -225,9 +234,9 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
             # To/from AIE-array data movement
 
             @runtime_sequence(
-                T.memref(A_sz, dtype_in()),
-                T.memref(B_sz, dtype_in()),
-                T.memref(C_sz, dtype_out()),
+                np.ndarray[(A_sz,), np.dtype[dtype_in]],
+                np.ndarray[(B_sz,), np.dtype[dtype_in]],
+                np.ndarray[(C_sz,), np.dtype[dtype_out]],
             )
             def sequence(A, B, C):
 

--- a/programming_examples/basic/matrix_multiplication/single_core/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/aie2.py
@@ -102,7 +102,7 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
 
     with mlir_mod_ctx() as ctx:
 
-        C_sz_in_bytes = C_sz * dtype_out().width // 8
+        C_sz_in_bytes = C_sz * np.dtype(dtype_out).itemsize // 8
 
         @device(AIEDevice.npu1_1col)
         def device_body():

--- a/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/aie2.py
@@ -4,15 +4,24 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023 AMD Inc.
-
-import sys
 import argparse
+import numpy as np
+import sys
 
 from aie.extras.context import mlir_mod_ctx
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.extras.dialects.ext.scf import _for as range_
+from aie.extras.util import bfloat16
+
+dtype_map = {
+    "bf16": bfloat16,
+    "i8": np.int8,
+    "i16": np.int16,
+    "f32": np.float32,
+    "i32": np.int32,
+}
 
 
 def main():
@@ -64,24 +73,8 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
     n_aie_rows = 4
     n_aie_cores = n_aie_rows * n_aie_cols
 
-    dtype_in = None
-    if dtype_in_str == "bf16":
-        dtype_in = T.bf16
-    elif dtype_in_str == "i8":
-        dtype_in = T.i8
-    elif dtype_in_str == "i16":
-        dtype_in = T.i16
-    dtype_out = None
-    if dtype_out_str == "bf16":
-        dtype_out = T.bf16
-    elif dtype_out_str == "i8":
-        dtype_out = T.i8
-    elif dtype_out_str == "i16":
-        dtype_out = T.i16
-    elif dtype_out_str == "f32":
-        dtype_out = T.f32
-    elif dtype_out_str == "i32":
-        dtype_out = T.i32
+    dtype_in = dtype_map[dtype_in_str]
+    dtype_out = dtype_map[dtype_out_str]
 
     if dtype_in_str == "bf16":
         r = 4
@@ -146,15 +139,15 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
 
     @device(dev)
     def device_body():
-        A_l2_memref_ty = T.memref(m * k * n_A_tiles_per_shim, dtype_in())
-        B_l2_memref_ty = T.memref(k * n, dtype_in())
-        C_l2_memref_ty = T.memref(m * n * n_aie_rows, dtype_out())
-        A_l1_memref_ty = T.memref(m, k, dtype_in())
-        B_l1_memref_ty = T.memref(k, n, dtype_in())
-        C_l1_memref_ty = T.memref(m, n, dtype_out())
+        A_l2_ty = np.ndarray[(m * k * n_A_tiles_per_shim,), np.dtype[dtype_in]]
+        B_l2_ty = np.ndarray[(k * n,), np.dtype[dtype_in]]
+        C_l2_ty = np.ndarray[(m * n * n_aie_rows,), np.dtype[dtype_out]]
+        A_l1_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
+        B_l1_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
+        C_l1_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
 
         # AIE Core Function declarations
-        zero = external_func(f"zero_{dtype_out_str}", inputs=[C_l1_memref_ty])
+        zero = external_func(f"zero_{dtype_out_str}", inputs=[C_l1_ty])
         matmul_vectorized_func_name = (
             f"matmul_{dtype_in_str}_{dtype_out_str}"
             if not b_col_maj
@@ -162,7 +155,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
         )
         matmul = external_func(
             matmul_vectorized_func_name,
-            inputs=[A_l1_memref_ty, B_l1_memref_ty, C_l1_memref_ty],
+            inputs=[A_l1_ty, B_l1_ty, C_l1_ty],
         )
 
         # Tile declarations as tile[row][col]
@@ -190,7 +183,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
                 mem_tiles[row // n_A_tiles_per_shim],
                 core_tiles[row][0:n_aie_cols],  # broadcast along one row
                 fifo_depth,
-                A_l1_memref_ty,
+                A_l1_ty,
                 [
                     (m // r, r * k),
                     (k // s, s),
@@ -204,7 +197,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
                 shim_tiles[col],
                 mem_tiles[col],
                 fifo_depth,
-                A_l2_memref_ty,
+                A_l2_ty,
             )
             # If n_cols == n_rows, n_A_tiles_per_shim is 1 and
             # this simply links a_l3l2_fifos[col] to a_l2l1_fifos[row] directly,
@@ -231,7 +224,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
                 shim_tiles[col],
                 mem_tiles[col],
                 fifo_depth,
-                B_l2_memref_ty,
+                B_l2_ty,
             )
             B_l2l1_fifos[col] = object_fifo(
                 f"B_L2L1_{col}",
@@ -240,7 +233,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
                     core_tiles[j][col] for j in range(n_aie_rows)
                 ],  # broadcast along one column
                 fifo_depth,
-                B_l1_memref_ty,
+                B_l1_ty,
                 (
                     [
                         (k // s, s * n),
@@ -267,14 +260,14 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
                     core_tiles[row][col],
                     mem_tiles[col],
                     fifo_depth,
-                    C_l1_memref_ty,
+                    C_l1_ty,
                 )
             C_l2l3_fifos[col] = object_fifo(
                 f"C_L2L3_{col}",
                 mem_tiles[col],
                 shim_tiles[col],
                 fifo_depth,
-                C_l2_memref_ty,
+                C_l2_ty,
                 [
                     (m // r, r * n),
                     (r, t),
@@ -326,9 +319,9 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str, b_col_m
 
         # To/from AIE-array data movement
         @runtime_sequence(
-            T.memref(M * K, dtype_in()),
-            T.memref(K * N, dtype_in()),
-            T.memref(M * N, dtype_out()),
+            np.ndarray[(M * K,), np.dtype[dtype_in]],
+            np.ndarray[(K * N,), np.dtype[dtype_in]],
+            np.ndarray[(M * N,), np.dtype[dtype_out]],
         )
         def sequence(A, B, C):
             # We are limited in the number of BDs. After synchronizing, we can reuse BDs.

--- a/programming_examples/basic/vector_exp/aie2.py
+++ b/programming_examples/basic/vector_exp/aie2.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
 
 from aie.dialects.aie import *  # primary mlir-aie dialect definitions
 from aie.extras.context import mlir_mod_ctx  # mlir ctx wrapper
@@ -13,6 +14,8 @@ from aie.dialects.aiex import *  # extended mlir-aie dialect definitions
 from aie.extras.dialects.ext.scf import (
     _for as range_,
 )  # scf (structured control flow) dialect
+from aie.extras.util import bfloat16
+from aie.extras.util import np_ndarray_type_get_shape
 
 
 # AI Engine structural design function
@@ -32,19 +35,15 @@ def my_eltwise_exp():
     @device(AIEDevice.npu1_1col)
     def device_body():
 
-        memRef_ty = T.memref(n, T.bf16())
-
-        # Type used in the tile memory
-        memRef_A_ty = T.memref(n, T.bf16())
-        memRef_C_ty = T.memref(n, T.bf16())
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
 
         # Type used in the memory tile which aggregates across the 4 cores
-        memRef_A_MT_ty = T.memref(n * n_cores, T.bf16())
-        memRef_C_MT_ty = T.memref(n * n_cores, T.bf16())
+        A_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
 
         # AIE Core Function declarations
 
-        exp_bf16_1024 = external_func("exp_bf16_1024", inputs=[memRef_ty, memRef_ty])
+        exp_bf16_1024 = external_func("exp_bf16_1024", inputs=[tile_ty, tile_ty])
 
         # Tile declarations
         ShimTile = tile(0, 0)
@@ -57,14 +56,15 @@ def my_eltwise_exp():
 
         # AIE-array data movement with object fifos
         # Input A
-        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, memRef_A_MT_ty)
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_ty)
         for i in range(n_cores):
             inA_fifos.append(
-                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, memRef_A_ty)
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
             )
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_A_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(A_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -73,12 +73,13 @@ def my_eltwise_exp():
         # Output C
         for i in range(n_cores):
             outC_fifos.append(
-                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, memRef_C_ty)
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
             )
-        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, memRef_C_MT_ty)
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_ty)
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_C_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(C_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -100,7 +101,7 @@ def my_eltwise_exp():
                         outC_fifos[i].release(ObjectFifoPort.Produce, 1)
 
         # To/from AIE-array data movement
-        tensor_ty = T.memref(N, T.bf16())
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
 
         @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):

--- a/programming_examples/ml/eltwise_add/aie2.py
+++ b/programming_examples/ml/eltwise_add/aie2.py
@@ -4,12 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023 AMD Inc.
+import numpy as np
 import sys
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.extras.context import mlir_mod_ctx
 from aie.extras.dialects.ext.scf import _for as range_
+from aie.extras.util import bfloat16
+from aie.extras.util import np_ndarray_type_get_shape
 
 import aie.utils.trace as trace_utils
 
@@ -30,25 +33,25 @@ def my_eltwise_add(trace_size):
 
     @device(AIEDevice.npu1_1col)
     def device_body():
-        memRef_ty = T.memref(n, T.bf16())
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
 
         # Type used in the tile memory
-        memRef_A_ty = T.memref(n, T.bf16())
-        memRef_B_ty = T.memref(n, T.bf16())
-        memRef_C_ty = T.memref(n, T.bf16())
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        B_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
 
         # Type used in the memory tile which aggregates across the 2 cores
-        memRef_A_MT_ty = T.memref(n * n_cores, T.bf16())
-        memRef_B_MT_ty = T.memref(n * n_cores, T.bf16())
-        memRef_C_MT_ty = T.memref(n * n_cores, T.bf16())
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        B_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
 
         # AIE Core Function declarations
 
         eltwise_add_bf16_scalar = external_func(
-            "eltwise_add_bf16_scalar", inputs=[memRef_ty, memRef_ty, memRef_ty]
+            "eltwise_add_bf16_scalar", inputs=[tile_ty, tile_ty, tile_ty]
         )
         eltwise_add_bf16_vector = external_func(
-            "eltwise_add_bf16_vector", inputs=[memRef_ty, memRef_ty, memRef_ty]
+            "eltwise_add_bf16_vector", inputs=[tile_ty, tile_ty, tile_ty]
         )
 
         # Tile declarations
@@ -67,28 +70,30 @@ def my_eltwise_add(trace_size):
 
         # AIE-array data movement with object fifos
         # Input A
-        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, memRef_A_MT_ty)
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
         for i in range(n_cores):
             inA_fifos.append(
-                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, memRef_A_ty)
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
             )
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_A_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
         object_fifo_link(inA, inA_fifos, [], of_offsets)
 
         # Input B
-        inB = object_fifo("inB", ShimTile, MemTile, buffer_depth, memRef_B_MT_ty)
+        inB = object_fifo("inB", ShimTile, MemTile, buffer_depth, B_memTile_ty)
         for i in range(n_cores):
             inB_fifos.append(
-                object_fifo(f"memB{i}", MemTile, cores[i], buffer_depth, memRef_B_ty)
+                object_fifo(f"memB{i}", MemTile, cores[i], buffer_depth, B_ty)
             )
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_B_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(B_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -97,12 +102,13 @@ def my_eltwise_add(trace_size):
         # Output C
         for i in range(n_cores):
             outC_fifos.append(
-                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, memRef_C_ty)
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
             )
-        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, memRef_C_MT_ty)
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_C_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -124,7 +130,7 @@ def my_eltwise_add(trace_size):
                         outC_fifos[i].release(ObjectFifoPort.Produce, 1)
 
         # To/from AIE-array data movement
-        tensor_ty = T.memref(N, T.bf16())
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
 
         @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):

--- a/programming_examples/ml/eltwise_mul/aie2.py
+++ b/programming_examples/ml/eltwise_mul/aie2.py
@@ -4,13 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023 AMD Inc.
-
+import numpy as np
 import sys
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.extras.context import mlir_mod_ctx
 from aie.extras.dialects.ext.scf import _for as range_
+from aie.extras.util import bfloat16
+from aie.extras.util import np_ndarray_type_get_shape
 
 import aie.utils.trace as trace_utils
 
@@ -31,27 +33,26 @@ def my_eltwise_mul(trace_size):
 
     @device(AIEDevice.npu1_1col)
     def device_body():
-        memRef_ty = T.memref(n, T.bf16())
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
 
         # Type used in the tile memory
-        memRef_A_ty = T.memref(n, T.bf16())
-        memRef_B_ty = T.memref(n, T.bf16())
-        memRef_C_ty = T.memref(n, T.bf16())
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        B_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
 
         # Type used in the memory tile which aggregates across the 4 cores
-        memRef_A_MT_ty = T.memref(n * n_cores, T.bf16())
-        memRef_B_MT_ty = T.memref(n * n_cores, T.bf16())
-        memRef_C_MT_ty = T.memref(n * n_cores, T.bf16())
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        B_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
 
         # AIE Core Function declarations
 
         eltwise_mul_bf16_scalar = external_func(
-            "eltwise_mul_bf16_scalar", inputs=[memRef_ty, memRef_ty, memRef_ty]
+            "eltwise_mul_bf16_scalar", inputs=[tile_ty, tile_ty, tile_ty]
         )
         eltwise_mul_bf16_vector = external_func(
-            "eltwise_mul_bf16_vector", inputs=[memRef_ty, memRef_ty, memRef_ty]
+            "eltwise_mul_bf16_vector", inputs=[tile_ty, tile_ty, tile_ty]
         )
-        # elwise_int32 = external_func("scale_int32", inputs=[memRef_ty, memRef_ty])
 
         # Tile declarations
         ShimTile = tile(0, 0)
@@ -69,28 +70,30 @@ def my_eltwise_mul(trace_size):
 
         # AIE-array data movement with object fifos
         # Input A
-        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, memRef_A_MT_ty)
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
         for i in range(n_cores):
             inA_fifos.append(
-                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, memRef_A_ty)
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
             )
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_A_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
         object_fifo_link(inA, inA_fifos, [], of_offsets)
 
         # Input B
-        inB = object_fifo("inB", ShimTile, MemTile, buffer_depth, memRef_B_MT_ty)
+        inB = object_fifo("inB", ShimTile, MemTile, buffer_depth, B_memTile_ty)
         for i in range(n_cores):
             inB_fifos.append(
-                object_fifo(f"memB{i}", MemTile, cores[i], buffer_depth, memRef_B_ty)
+                object_fifo(f"memB{i}", MemTile, cores[i], buffer_depth, B_ty)
             )
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_B_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(B_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -99,12 +102,13 @@ def my_eltwise_mul(trace_size):
         # Output C
         for i in range(n_cores):
             outC_fifos.append(
-                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, memRef_C_ty)
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
             )
-        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, memRef_C_MT_ty)
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_C_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -126,7 +130,7 @@ def my_eltwise_mul(trace_size):
                         outC_fifos[i].release(ObjectFifoPort.Produce, 1)
 
         # To/from AIE-array data movement
-        tensor_ty = T.memref(N, T.bf16())
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
 
         @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):

--- a/programming_examples/ml/relu/aie2.py
+++ b/programming_examples/ml/relu/aie2.py
@@ -4,13 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023 AMD Inc.
-
+import numpy as np
 import sys
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.extras.context import mlir_mod_ctx
 from aie.extras.dialects.ext.scf import _for as range_
+from aie.extras.util import bfloat16
+from aie.extras.util import np_ndarray_type_get_shape
 
 import aie.utils.trace as trace_utils
 
@@ -31,19 +33,19 @@ def my_relu(trace_size):
 
     @device(AIEDevice.npu1_1col)
     def device_body():
-        memRef_ty = T.memref(n, T.bf16())
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
 
         # Type used in the tile memory
-        memRef_A_ty = T.memref(n, T.bf16())
-        memRef_C_ty = T.memref(n, T.bf16())
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
 
         # Type used in the memory tile which aggregates across the 4 cores
-        memRef_A_MT_ty = T.memref(n * n_cores, T.bf16())
-        memRef_C_MT_ty = T.memref(n * n_cores, T.bf16())
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
 
         # AIE Core Function declarations
 
-        relu = external_func("bf16_relu", inputs=[memRef_ty, memRef_ty])
+        relu = external_func("bf16_relu", inputs=[tile_ty, tile_ty])
 
         # Tile declarations
         ShimTile = tile(0, 0)
@@ -56,14 +58,15 @@ def my_relu(trace_size):
 
         # AIE-array data movement with object fifos
         # Input A
-        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, memRef_A_MT_ty)
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
         for i in range(n_cores):
             inA_fifos.append(
-                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, memRef_A_ty)
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
             )
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_A_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -72,12 +75,13 @@ def my_relu(trace_size):
         # Output C
         for i in range(n_cores):
             outC_fifos.append(
-                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, memRef_C_ty)
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
             )
-        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, memRef_C_MT_ty)
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
         if n_cores > 1:
             of_offsets = [
-                (np.prod(memRef_C_MT_ty.shape) // n_cores) * i for i in range(n_cores)
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
             ]
         else:
             of_offsets = []
@@ -103,7 +107,7 @@ def my_relu(trace_size):
                         outC_fifos[i].release(ObjectFifoPort.Produce, 1)
 
         # To/from AIE-array data movement
-        tensor_ty = T.memref(N, T.bf16())
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
 
         @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, C):

--- a/python/extras/util.py
+++ b/python/extras/util.py
@@ -34,7 +34,9 @@ from ..ir import (
 )
 
 try:
-    from bfloat16 import bfloat16
+    from bfloat16 import bfloat16 as real_bfloat16
+
+    bfloat16 = real_bfloat16
 except:
     # Numpy doesn't support bfloat16 at this time.
     print(

--- a/python/extras/util.py
+++ b/python/extras/util.py
@@ -33,6 +33,15 @@ from ..ir import (
     _GlobalDebug,
 )
 
+try:
+    from bfloat16 import bfloat16
+except:
+    # Numpy doesn't support bfloat16 at this time.
+    print(
+        "Warning! bfloat16 python package not available, so using placeholder bfloat16 type"
+    )
+    bfloat16 = np.dtype([("pseudobf16", np.float16)])
+
 
 def is_relative_to(self, other):
     return other == self or other in self.parents
@@ -137,7 +146,7 @@ _np_dtype_to_mlir_type_ctor = defaultdict(
         np.float32: T.f32,
         np.float64: T.f64,
         # Block floating point types
-        # bfloat16: T.bf16,
+        bfloat16: T.bf16,
         # Index Types
         # this is technically wrong i guess but numpy by default casts python scalars to this
         # so to support passing lists of ints we map to index type
@@ -161,7 +170,7 @@ NpuDType = (
     | np.float64
     | np.longlong
     | np.uintp
-    # | bfloat16
+    | bfloat16
 )
 
 _mlir_type_ctor_to_np_dtype = lambda: {

--- a/python/extras/util.py
+++ b/python/extras/util.py
@@ -48,7 +48,8 @@ try:
 except:
     # Numpy doesn't support bfloat16 at this time. Using hacky extension of np.float16 as a placeholder, for now.
     print(
-        "Warning! bfloat16 python package not available, so using placeholder bfloat16 type"
+        "Warning! bfloat16 python package not available, so using placeholder bfloat16 type",
+        file=sys.stderr,
     )
     bfloat16 = _pseudo_bfloat16
 

--- a/python/extras/util.py
+++ b/python/extras/util.py
@@ -33,16 +33,24 @@ from ..ir import (
     _GlobalDebug,
 )
 
+
+class _pseudo_bfloat16(np.float16):
+    def __init__(*args, **kwargs):
+        raise AttributeError(
+            "This is a placeholder class for bfloat16. Install bfloat16 python package in order to instantiate bfloat16 values"
+        )
+
+
 try:
     from bfloat16 import bfloat16 as real_bfloat16
 
     bfloat16 = real_bfloat16
 except:
-    # Numpy doesn't support bfloat16 at this time.
+    # Numpy doesn't support bfloat16 at this time. Using hacky extension of np.float16 as a placeholder, for now.
     print(
         "Warning! bfloat16 python package not available, so using placeholder bfloat16 type"
     )
-    bfloat16 = np.dtype([("pseudobf16", np.float16)])
+    bfloat16 = _pseudo_bfloat16
 
 
 def is_relative_to(self, other):
@@ -149,6 +157,7 @@ _np_dtype_to_mlir_type_ctor = defaultdict(
         np.float64: T.f64,
         # Block floating point types
         bfloat16: T.bf16,
+        _pseudo_bfloat16: T.bf16,  # If bfloat16 == psuedo_bfloat16, this is okay because duplicate keys are removed
         # Index Types
         # this is technically wrong i guess but numpy by default casts python scalars to this
         # so to support passing lists of ints we map to index type

--- a/python/extras/util.py
+++ b/python/extras/util.py
@@ -36,7 +36,7 @@ from ..ir import (
 
 class _pseudo_bfloat16(np.float16):
     def __init__(*args, **kwargs):
-        raise AttributeError(
+        raise TypeError(
             "This is a placeholder class for bfloat16. Install bfloat16 python package in order to instantiate bfloat16 values"
         )
 

--- a/python/requirements_bfloat16.txt
+++ b/python/requirements_bfloat16.txt
@@ -1,0 +1,3 @@
+# Using the commit instead of bfloat16 directly allows us to bypass https://github.com/GreenWaves-Technologies/bfloat16/issues/12
+# However, this requirement should be used conditionally as it doesn't build well with vscode due to some hardcoded flags
+git+https://github.com/GreenWaves-Technologies/bfloat16.git@97e0bab

--- a/test/python/bfloat16.py
+++ b/test/python/bfloat16.py
@@ -1,19 +1,22 @@
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import numpy as np
-
-# RUN: %PYTHON %s | FileCheck %s
 from aie.extras import types as T
 from aie.extras.util import bfloat16, _pseudo_bfloat16, np_dtype_to_mlir_type
+from util import construct_and_print_module
+
+# RUN: %PYTHON %s | FileCheck %s
 
 
+# CHECK-LABEL: bfloat16Conversion
+# CHECK: PASS!
+@construct_and_print_module
 def bfloat16Conversion():
     assert np.dtype(bfloat16).itemsize == 2
     assert _pseudo_bfloat16 != np.float16
     assert np_dtype_to_mlir_type(_pseudo_bfloat16) == T.bf16()
     try:
-        # Checks if bfloat16 library is available
-        from bfloat16 import real_bfloat16
+        from bfloat16 import bfloat16 as real_bfloat16
 
         assert real_bfloat16 == bfloat16
         assert np_dtype_to_mlir_type(real_bfloat16) == T.bf16()
@@ -21,8 +24,6 @@ def bfloat16Conversion():
         assert np_dtype_to_mlir_type(real_bfloat16) == np_dtype_to_mlir_type(
             _pseudo_bfloat16
         )
-    except:
-        # CHECK: Warning! bfloat16 python package not available, so using placeholder bfloat16 type
+    except ModuleNotFoundError:
         pass
-    # CHECK: PASS
-    print("PASS")
+    print("PASS!")

--- a/test/python/bfloat16.py
+++ b/test/python/bfloat16.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import numpy as np
+
+# RUN: %PYTHON %s | FileCheck %s
+from aie.extras import types as T
+from aie.extras.util import bfloat16, _pseudo_bfloat16, np_dtype_to_mlir_type
+
+
+# CHECK: PASS
+def bfloat16Conversion():
+    assert np.dtype(bfloat16).itemsize == 2
+    assert _pseudo_bfloat16 != np.float16
+    assert np_dtype_to_mlir_type(_pseudo_bfloat16) == T.bf16()
+    try:
+        # Checks if bfloat16 library is available
+        from bfloat16 import real_bfloat16
+
+        assert real_bfloat16 == bfloat16
+        assert np_dtype_to_mlir_type(real_bfloat16) == T.bf16()
+        assert np_dtype_to_mlir_type(bfloat16) == T.bf16()
+        assert np_dtype_to_mlir_type(real_bfloat16) == np_dtype_to_mlir_type(
+            _pseudo_bfloat16
+        )
+    except:
+        # CHECK: Warning
+        pass
+    print("PASS")

--- a/test/python/bfloat16.py
+++ b/test/python/bfloat16.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022, Advanced Micro Devices, Inc.
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 import numpy as np
 from aie.extras import types as T
@@ -16,6 +16,7 @@ def bfloat16Conversion():
     assert _pseudo_bfloat16 != np.float16
     assert np_dtype_to_mlir_type(_pseudo_bfloat16) == T.bf16()
     try:
+        # Import actual bfloat16 (if it's available) for additional tests
         from bfloat16 import bfloat16 as real_bfloat16
 
         assert real_bfloat16 == bfloat16
@@ -26,4 +27,7 @@ def bfloat16Conversion():
         )
     except ModuleNotFoundError:
         pass
-    print("PASS!")
+    try:
+        _pseudo_bfloat16(1)  # Should not be able to instantiate
+    except TypeError:
+        print("PASS!")

--- a/test/python/bfloat16.py
+++ b/test/python/bfloat16.py
@@ -7,7 +7,6 @@ from aie.extras import types as T
 from aie.extras.util import bfloat16, _pseudo_bfloat16, np_dtype_to_mlir_type
 
 
-# CHECK: PASS
 def bfloat16Conversion():
     assert np.dtype(bfloat16).itemsize == 2
     assert _pseudo_bfloat16 != np.float16
@@ -23,6 +22,7 @@ def bfloat16Conversion():
             _pseudo_bfloat16
         )
     except:
-        # CHECK: Warning
+        # CHECK: Warning! bfloat16 python package not available, so using placeholder bfloat16 type
         pass
+    # CHECK: PASS
     print("PASS")

--- a/test/python/core_ext_kernel.py
+++ b/test/python/core_ext_kernel.py
@@ -6,7 +6,6 @@ import numpy as np
 import aie.extras.types as T
 from aie.dialects.aie import (
     AIEDevice,
-    call,
     Core,
     Device,
     ObjectFifoPort,

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -77,6 +77,7 @@ if test -f "$VPP"; then
   popd
   python3 -m pip install --upgrade --force-reinstall --no-cache-dir -r python/requirements.txt
   python3 -m pip install --upgrade --force-reinstall --no-cache-dir -r python/requirements_ml.txt
+  python3 -m pip install --upgrade --force-reinstall --no-cache-dirpip python/requirements_bfloat16.txt || echo "Failed to install bfloat16, that's ok!"
   pushd programming_examples
 else
   echo "Vitis not found! Exiting..."

--- a/utils/setup_python_packages.sh
+++ b/utils/setup_python_packages.sh
@@ -22,3 +22,4 @@ else
 fi
 python3 -m pip install --upgrade pip
 python3 -m pip install -r python/requirements.txt
+python3 -m pip install bfloat16 || echo "Failed to install bfloat16, that's ok!"

--- a/utils/setup_python_packages.sh
+++ b/utils/setup_python_packages.sh
@@ -22,4 +22,4 @@ else
 fi
 python3 -m pip install --upgrade pip
 python3 -m pip install -r python/requirements.txt
-python3 -m pip install bfloat16 || echo "Failed to install bfloat16, that's ok!"
+python3 -m pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"


### PR DESCRIPTION
This PR conditionally installs `bfloat16` where possible and ignores errors otherwise. This is to allow some `bfloat16` integration in the mlir-aie python code. A workaround is necessary because the actual `bfloat16` library does not seem to compile well in vscode environments, such as used in the CI. While another long-term solution is likely necessary, this workaround allows one to create designs that look as though `bfloat16` is working properly.

The conditional installation looks like this in setup scripts and CI actions:
```bash
 pip install -r python/requirements_bfloat16.txt || echo "Failed to install bfloat16; this is ok!"
```

The conditional import in the python looks like this:
```python
class _pseudo_bfloat16(np.float16):
    def __init__(*args, **kwargs):
        raise TypeError(
            "This is a placeholder class for bfloat16. Install bfloat16 python package in order to instantiate bfloat16 values"
        )

try:
    from bfloat16 import bfloat16 as real_bfloat16

    bfloat16 = real_bfloat16
except:
    # Numpy doesn't support bfloat16 at this time. Using hacky extension of np.float16 as a placeholder, for now.
    print(
        "Warning! bfloat16 python package not available, so using placeholder bfloat16 type",
        file=sys.stderr,
    )
    bfloat16 = _pseudo_bfloat16
```

And finally, programming examples can import a version of `bfloat16` (either real or placeholder) like so:
```python
from aie.extras.util import bfloat16
```

This PR also diasables some of the AIE distros github action, to disable MacOS builds/tests, as those aren't currently supported. They didn't work before this PR, however, the action only runs when you change the workflow definition, so it was hidden from most PRs/CI runs.