### PR TITLE
Python buffer API refactoring, RTP Op Wrapper

### DIFF
--- a/programming_examples/basic/matrix_multiplication/cascade/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/cascade/aie2.py
@@ -251,7 +251,9 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                     )
                 else:
                     C_l1l2_buffers[row][col] = buffer(
-                        core_tiles[row][col], [m, n], dtype_out(), f"C_L1L2_{col}_{row}"
+                        core_tiles[row][col],
+                        T.memref(m, n, dtype_out()),
+                        f"C_L1L2_{col}_{row}",
                     )
 
             C_l2l3_fifos[col] = object_fifo(

--- a/programming_examples/basic/matrix_multiplication/cascade/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/cascade/aie2.py
@@ -247,7 +247,7 @@ def my_matmul(M, K, N, m, k, n, n_aie_cols, dtype_in_str, dtype_out_str):
                 else:
                     C_l1l2_buffers[row][col] = buffer(
                         core_tiles[row][col],
-                        T.memref(m, n, dtype_out()),
+                        np.ndarray[(m, n), np.dtype[dtype_out]],
                         f"C_L1L2_{col}_{row}",
                     )
 

--- a/programming_examples/basic/passthrough_pykernel/aie2.py
+++ b/programming_examples/basic/passthrough_pykernel/aie2.py
@@ -21,7 +21,7 @@ def passthroughKernel(vector_size):
 
     @device(AIEDevice.npu1_1col)
     def device_body():
-        # define types - for illustrative purposes, we use equivalent types of both MLIR MemRefType and np.ndarray type in this design
+        # define types
         line_ty = np.ndarray[(lineWidthInBytes,), np.dtype[np.uint8]]
 
         # AIE Core Python Function declarations

--- a/programming_examples/ml/bottleneck/aie2.py
+++ b/programming_examples/ml/bottleneck/aie2.py
@@ -143,16 +143,28 @@ def bottleneck4AIEs():
             # runtime parameters
 
             rtpComputeTile2 = buffer(
-                ComputeTile2, np.ndarray[(16,), np.int32], "rtpComputeTile2"
+                ComputeTile2,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile2",
+                use_write_rtp=True,
             )
             rtpComputeTile3 = buffer(
-                ComputeTile3, np.ndarray[(16,), np.int32], "rtpComputeTile3"
+                ComputeTile3,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile3",
+                use_write_rtp=True,
             )
             rtpComputeTile4 = buffer(
-                ComputeTile4, np.ndarray[(16,), np.int32], "rtpComputeTile4"
+                ComputeTile4,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile4",
+                use_write_rtp=True,
             )
             rtpComputeTile5 = buffer(
-                ComputeTile5, np.ndarray[(16,), np.int32], "rtpComputeTile5"
+                ComputeTile5,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile5",
+                use_write_rtp=True,
             )
 
             # set up data movement with OFs
@@ -532,13 +544,12 @@ def bottleneck4AIEs():
                     npu_write32(0, 2, 0x1D20C, 0x3)
 
                 # write RTP parameters
-                NpuWriteRTPOp("rtpComputeTile2", index=0, value=1)  # scale
-                NpuWriteRTPOp("rtpComputeTile3", index=0, value=1)  # scale
-                NpuWriteRTPOp("rtpComputeTile5", index=0, value=1)  # scale
-                NpuWriteRTPOp(
-                    "rtpComputeTile4", index=0, value=1
-                )  # scale: conv1x1 with the same scale as the input so we match the scaling factor of output after conv1x1 and the initial input
-                NpuWriteRTPOp("rtpComputeTile4", index=1, value=0)  # skip_scale
+                rtpComputeTile2[0] = 1  # scale
+                rtpComputeTile3[0] = 1  # scale
+                rtpComputeTile5[0] = 1  # scale
+                # scale: conv1x1 with the same scale as the input so we match the scaling factor of output after conv1x1 and the initial input
+                rtpComputeTile4[0] = 1
+                rtpComputeTile4[1] = 0  # skip_scale
 
                 npu_dma_memcpy_nd(
                     metadata=of_inOF_act_L3L2,

--- a/programming_examples/ml/bottleneck/aie2.py
+++ b/programming_examples/ml/bottleneck/aie2.py
@@ -142,10 +142,18 @@ def bottleneck4AIEs():
 
             # runtime parameters
 
-            rtpComputeTile2 = buffer(ComputeTile2, [16], np.int32, "rtpComputeTile2")
-            rtpComputeTile3 = buffer(ComputeTile3, [16], np.int32, "rtpComputeTile3")
-            rtpComputeTile4 = buffer(ComputeTile4, [16], np.int32, "rtpComputeTile4")
-            rtpComputeTile5 = buffer(ComputeTile5, [16], np.int32, "rtpComputeTile5")
+            rtpComputeTile2 = buffer(
+                ComputeTile2, np.ndarray[(16), np.int32], "rtpComputeTile2"
+            )
+            rtpComputeTile3 = buffer(
+                ComputeTile3, np.ndarray[(16), np.int32], "rtpComputeTile3"
+            )
+            rtpComputeTile4 = buffer(
+                ComputeTile4, np.ndarray[(16), np.int32], "rtpComputeTile4"
+            )
+            rtpComputeTile5 = buffer(
+                ComputeTile5, np.ndarray[(16), np.int32], "rtpComputeTile5"
+            )
 
             # set up data movement with OFs
             # input tensor (with broadcast for skip connection)

--- a/programming_examples/ml/bottleneck/aie2.py
+++ b/programming_examples/ml/bottleneck/aie2.py
@@ -142,10 +142,10 @@ def bottleneck4AIEs():
 
             # runtime parameters
 
-            rtpComputeTile2 = Buffer(ComputeTile2, [16], np.int32, "rtpComputeTile2")
-            rtpComputeTile3 = Buffer(ComputeTile3, [16], np.int32, "rtpComputeTile3")
-            rtpComputeTile4 = Buffer(ComputeTile4, [16], np.int32, "rtpComputeTile4")
-            rtpComputeTile5 = Buffer(ComputeTile5, [16], np.int32, "rtpComputeTile5")
+            rtpComputeTile2 = buffer(ComputeTile2, [16], np.int32, "rtpComputeTile2")
+            rtpComputeTile3 = buffer(ComputeTile3, [16], np.int32, "rtpComputeTile3")
+            rtpComputeTile4 = buffer(ComputeTile4, [16], np.int32, "rtpComputeTile4")
+            rtpComputeTile5 = buffer(ComputeTile5, [16], np.int32, "rtpComputeTile5")
 
             # set up data movement with OFs
             # input tensor (with broadcast for skip connection)

--- a/programming_examples/ml/bottleneck/aie2.py
+++ b/programming_examples/ml/bottleneck/aie2.py
@@ -143,16 +143,16 @@ def bottleneck4AIEs():
             # runtime parameters
 
             rtpComputeTile2 = buffer(
-                ComputeTile2, np.ndarray[(16), np.int32], "rtpComputeTile2"
+                ComputeTile2, np.ndarray[(16,), np.int32], "rtpComputeTile2"
             )
             rtpComputeTile3 = buffer(
-                ComputeTile3, np.ndarray[(16), np.int32], "rtpComputeTile3"
+                ComputeTile3, np.ndarray[(16,), np.int32], "rtpComputeTile3"
             )
             rtpComputeTile4 = buffer(
-                ComputeTile4, np.ndarray[(16), np.int32], "rtpComputeTile4"
+                ComputeTile4, np.ndarray[(16,), np.int32], "rtpComputeTile4"
             )
             rtpComputeTile5 = buffer(
-                ComputeTile5, np.ndarray[(16), np.int32], "rtpComputeTile5"
+                ComputeTile5, np.ndarray[(16,), np.int32], "rtpComputeTile5"
             )
 
             # set up data movement with OFs

--- a/programming_examples/ml/conv2d/aie2.py
+++ b/programming_examples/ml/conv2d/aie2.py
@@ -87,7 +87,7 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = buffer(ComputeTile2, np.ndarray[(16), np.int32], "rtp2")
+            rtp2 = buffer(ComputeTile2, np.ndarray[(16,), np.int32], "rtp2")
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1_i8.o")

--- a/programming_examples/ml/conv2d/aie2.py
+++ b/programming_examples/ml/conv2d/aie2.py
@@ -87,7 +87,12 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = buffer(ComputeTile2, np.ndarray[(16,), np.int32], "rtp2")
+            rtp2 = buffer(
+                ComputeTile2,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtp2",
+                use_write_rtp=True,
+            )
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1_i8.o")
@@ -115,7 +120,7 @@ def conv2dk1():
             # To/from AIE-array data movement
             @runtime_sequence(tensor_ty, weights_ty, tensor_ty)
             def sequence(I, W, O):
-                NpuWriteRTPOp("rtp2", index=0, value=10)
+                rtp2[0] = 10
 
                 npu_dma_memcpy_nd(
                     metadata=of_inOF_act_L3L2,

--- a/programming_examples/ml/conv2d/aie2.py
+++ b/programming_examples/ml/conv2d/aie2.py
@@ -87,7 +87,7 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = buffer(ComputeTile2, [16], np.int32, "rtp2")
+            rtp2 = buffer(ComputeTile2, np.ndarray[(16), np.int32], "rtp2")
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1_i8.o")

--- a/programming_examples/ml/conv2d/aie2.py
+++ b/programming_examples/ml/conv2d/aie2.py
@@ -87,7 +87,7 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = Buffer(ComputeTile2, [16], np.int32, "rtp2")
+            rtp2 = buffer(ComputeTile2, [16], np.int32, "rtp2")
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1_i8.o")

--- a/programming_examples/ml/conv2d_fused_relu/aie2.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2.py
@@ -96,7 +96,7 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = Buffer(ComputeTile2, [16], T.i32(), "rtp2")
+            rtp2 = buffer(ComputeTile2, [16], T.i32(), "rtp2")
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1.o")

--- a/programming_examples/ml/conv2d_fused_relu/aie2.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2.py
@@ -96,7 +96,7 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = buffer(ComputeTile2, [16], T.i32(), "rtp2")
+            rtp2 = buffer(ComputeTile2, T.memref(16, T.i32()), "rtp2")
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1.o")

--- a/programming_examples/ml/conv2d_fused_relu/aie2.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2.py
@@ -96,7 +96,9 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = buffer(ComputeTile2, T.memref(16, T.i32()), "rtp2", use_write_rtp=True)
+            rtp2 = buffer(
+                ComputeTile2, T.memref(16, T.i32()), "rtp2", use_write_rtp=True
+            )
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1.o")

--- a/programming_examples/ml/conv2d_fused_relu/aie2.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2.py
@@ -96,7 +96,7 @@ def conv2dk1():
 
             # Set up compute tiles
 
-            rtp2 = buffer(ComputeTile2, T.memref(16, T.i32()), "rtp2")
+            rtp2 = buffer(ComputeTile2, T.memref(16, T.i32()), "rtp2", use_write_rtp=True)
 
             # Compute tile 2
             @core(ComputeTile2, "conv2dk1.o")
@@ -204,7 +204,7 @@ def conv2dk1():
                     # Set start BD to our shim bd_Id (3)
                     npu_write32(column=0, row=0, address=0x1D20C, value=trace_bd_id)
 
-                NpuWriteRTPOp("rtp2", index=0, value=1)
+                rtp2[0] = 1
 
                 npu_dma_memcpy_nd(
                     metadata=of_inOF_act_L3L2,

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2.py
@@ -363,9 +363,6 @@ def resnet_conv_x():
                 conv2dk1_skip_ui8,
             ]
 
-            act1_fifo_names = ["act1_00_02_01", "act1_04_15_01", "act1_13_22_21"]
-            act1_fifos = {}
-
             # input tensor (with broadcast for skip connection)
             act1_fifo_names = ["act1_00_02_01", "act1_04_15_11", "act1_13_22_21"]
             act1_fifos = {}

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2.py
@@ -252,20 +252,20 @@ def resnet_conv_x():
 
             # runtime parameters
 
-            rtpComputeTile02 = Buffer(ComputeTile02, [16], np.int32, "rtpComputeTile02")
-            rtpComputeTile03 = Buffer(ComputeTile03, [16], np.int32, "rtpComputeTile03")
-            rtpComputeTile04 = Buffer(ComputeTile05, [16], np.int32, "rtpComputeTile04")
-            rtpComputeTile05 = Buffer(ComputeTile04, [16], np.int32, "rtpComputeTile05")
+            rtpComputeTile02 = buffer(ComputeTile02, [16], np.int32, "rtpComputeTile02")
+            rtpComputeTile03 = buffer(ComputeTile03, [16], np.int32, "rtpComputeTile03")
+            rtpComputeTile04 = buffer(ComputeTile05, [16], np.int32, "rtpComputeTile04")
+            rtpComputeTile05 = buffer(ComputeTile04, [16], np.int32, "rtpComputeTile05")
 
-            rtpComputeTile12 = Buffer(ComputeTile12, [16], np.int32, "rtpComputeTile12")
-            rtpComputeTile13 = Buffer(ComputeTile13, [16], np.int32, "rtpComputeTile13")
-            rtpComputeTile14 = Buffer(ComputeTile14, [16], np.int32, "rtpComputeTile14")
-            rtpComputeTile15 = Buffer(ComputeTile15, [16], np.int32, "rtpComputeTile15")
+            rtpComputeTile12 = buffer(ComputeTile12, [16], np.int32, "rtpComputeTile12")
+            rtpComputeTile13 = buffer(ComputeTile13, [16], np.int32, "rtpComputeTile13")
+            rtpComputeTile14 = buffer(ComputeTile14, [16], np.int32, "rtpComputeTile14")
+            rtpComputeTile15 = buffer(ComputeTile15, [16], np.int32, "rtpComputeTile15")
 
-            rtpComputeTile22 = Buffer(ComputeTile22, [16], np.int32, "rtpComputeTile22")
-            rtpComputeTile23 = Buffer(ComputeTile23, [16], np.int32, "rtpComputeTile23")
-            rtpComputeTile24 = Buffer(ComputeTile24, [16], np.int32, "rtpComputeTile24")
-            rtpComputeTile25 = Buffer(ComputeTile25, [16], np.int32, "rtpComputeTile25")
+            rtpComputeTile22 = buffer(ComputeTile22, [16], np.int32, "rtpComputeTile22")
+            rtpComputeTile23 = buffer(ComputeTile23, [16], np.int32, "rtpComputeTile23")
+            rtpComputeTile24 = buffer(ComputeTile24, [16], np.int32, "rtpComputeTile24")
+            rtpComputeTile25 = buffer(ComputeTile25, [16], np.int32, "rtpComputeTile25")
 
             rtp = [
                 [

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2.py
@@ -252,20 +252,44 @@ def resnet_conv_x():
 
             # runtime parameters
 
-            rtpComputeTile02 = buffer(ComputeTile02, [16], np.int32, "rtpComputeTile02")
-            rtpComputeTile03 = buffer(ComputeTile03, [16], np.int32, "rtpComputeTile03")
-            rtpComputeTile04 = buffer(ComputeTile05, [16], np.int32, "rtpComputeTile04")
-            rtpComputeTile05 = buffer(ComputeTile04, [16], np.int32, "rtpComputeTile05")
+            rtpComputeTile02 = buffer(
+                ComputeTile02, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile02"
+            )
+            rtpComputeTile03 = buffer(
+                ComputeTile03, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile03"
+            )
+            rtpComputeTile04 = buffer(
+                ComputeTile05, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile04"
+            )
+            rtpComputeTile05 = buffer(
+                ComputeTile04, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile05"
+            )
 
-            rtpComputeTile12 = buffer(ComputeTile12, [16], np.int32, "rtpComputeTile12")
-            rtpComputeTile13 = buffer(ComputeTile13, [16], np.int32, "rtpComputeTile13")
-            rtpComputeTile14 = buffer(ComputeTile14, [16], np.int32, "rtpComputeTile14")
-            rtpComputeTile15 = buffer(ComputeTile15, [16], np.int32, "rtpComputeTile15")
+            rtpComputeTile12 = buffer(
+                ComputeTile12, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile12"
+            )
+            rtpComputeTile13 = buffer(
+                ComputeTile13, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile13"
+            )
+            rtpComputeTile14 = buffer(
+                ComputeTile14, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile14"
+            )
+            rtpComputeTile15 = buffer(
+                ComputeTile15, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile15"
+            )
 
-            rtpComputeTile22 = buffer(ComputeTile22, [16], np.int32, "rtpComputeTile22")
-            rtpComputeTile23 = buffer(ComputeTile23, [16], np.int32, "rtpComputeTile23")
-            rtpComputeTile24 = buffer(ComputeTile24, [16], np.int32, "rtpComputeTile24")
-            rtpComputeTile25 = buffer(ComputeTile25, [16], np.int32, "rtpComputeTile25")
+            rtpComputeTile22 = buffer(
+                ComputeTile22, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile22"
+            )
+            rtpComputeTile23 = buffer(
+                ComputeTile23, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile23"
+            )
+            rtpComputeTile24 = buffer(
+                ComputeTile24, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile24"
+            )
+            rtpComputeTile25 = buffer(
+                ComputeTile25, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile25"
+            )
 
             rtp = [
                 [

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2.py
@@ -253,42 +253,78 @@ def resnet_conv_x():
             # runtime parameters
 
             rtpComputeTile02 = buffer(
-                ComputeTile02, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile02"
+                ComputeTile02,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile02",
+                use_write_rtp=True,
             )
             rtpComputeTile03 = buffer(
-                ComputeTile03, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile03"
+                ComputeTile03,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile03",
+                use_write_rtp=True,
             )
             rtpComputeTile04 = buffer(
-                ComputeTile05, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile04"
+                ComputeTile05,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile04",
+                use_write_rtp=True,
             )
             rtpComputeTile05 = buffer(
-                ComputeTile04, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile05"
+                ComputeTile04,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile05",
+                use_write_rtp=True,
             )
 
             rtpComputeTile12 = buffer(
-                ComputeTile12, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile12"
+                ComputeTile12,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile12",
+                use_write_rtp=True,
             )
             rtpComputeTile13 = buffer(
-                ComputeTile13, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile13"
+                ComputeTile13,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile13",
+                use_write_rtp=True,
             )
             rtpComputeTile14 = buffer(
-                ComputeTile14, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile14"
+                ComputeTile14,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile14",
+                use_write_rtp=True,
             )
             rtpComputeTile15 = buffer(
-                ComputeTile15, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile15"
+                ComputeTile15,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile15",
+                use_write_rtp=True,
             )
 
             rtpComputeTile22 = buffer(
-                ComputeTile22, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile22"
+                ComputeTile22,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile22",
+                use_write_rtp=True,
             )
             rtpComputeTile23 = buffer(
-                ComputeTile23, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile23"
+                ComputeTile23,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile23",
+                use_write_rtp=True,
             )
             rtpComputeTile24 = buffer(
-                ComputeTile24, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile24"
+                ComputeTile24,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile24",
+                use_write_rtp=True,
             )
             rtpComputeTile25 = buffer(
-                ComputeTile25, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile25"
+                ComputeTile25,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile25",
+                use_write_rtp=True,
             )
 
             rtp = [
@@ -860,24 +896,24 @@ def resnet_conv_x():
             )
             def sequence(inputFromL3, weightsFromL3, outputToL3):
 
-                NpuWriteRTPOp("rtpComputeTile02", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile03", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile04", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile05", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile05", index=1, value=0)
-                NpuWriteRTPOp("rtpComputeTile05", index=2, value=1)
+                rtpComputeTile02[0] = 1
+                rtpComputeTile03[0] = 1
+                rtpComputeTile04[0] = 1
+                rtpComputeTile05[0] = 1
+                rtpComputeTile05[1] = 0
+                rtpComputeTile05[2] = 1
 
-                NpuWriteRTPOp("rtpComputeTile15", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile14", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile12", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile13", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile13", index=1, value=0)
+                rtpComputeTile15[0] = 1
+                rtpComputeTile14[0] = 1
+                rtpComputeTile12[0] = 1
+                rtpComputeTile13[0] = 1
+                rtpComputeTile13[1] = 0
 
-                NpuWriteRTPOp("rtpComputeTile22", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile23", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile25", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile24", index=0, value=1)
-                NpuWriteRTPOp("rtpComputeTile24", index=1, value=0)
+                rtpComputeTile22[0] = 1
+                rtpComputeTile23[0] = 1
+                rtpComputeTile25[0] = 1
+                rtpComputeTile24[0] = 1
+                rtpComputeTile24[1] = 0
 
                 npu_dma_memcpy_nd(
                     metadata="act1_00_02_01",

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2.py
@@ -365,171 +365,189 @@ def resnet_conv_x():
 
             # input tensor (with broadcast for skip connection)
             act1_fifo_names = ["act1_00_02_01", "act1_04_15_11", "act1_13_22_21"]
-            act1_fifos = {}
+            act1_fifos = []
 
-            skip_fifo_names = ["skip_0", "skip_1", "skip_2"]
-            skip_fifos = {}
+            skip_fifos = []
 
-            act1_fifos[act1_fifo_names[0]] = object_fifo(
-                act1_fifo_names[0],
-                shims[0],
-                [cores[0][0], mems[0]],
-                [2, 2, 4],
-                laye1_act_sizes[0],
+            act1_fifos.append(
+                object_fifo(
+                    act1_fifo_names[0],
+                    shims[0],
+                    [cores[0][0], mems[0]],
+                    [2, 2, 4],
+                    laye1_act_sizes[0],
+                )
             )
-            skip_fifos[skip_fifo_names[0]] = object_fifo(
-                skip_fifo_names[0], mems[0], cores[0][2], 2, laye1_act_sizes[0]
+            skip_fifos.append(
+                object_fifo("skip_0", mems[0], cores[0][2], 2, laye1_act_sizes[0])
             )
-            object_fifo_link(act1_fifo_names[0], skip_fifo_names[0])
+            object_fifo_link(act1_fifos[0], skip_fifos[0])
 
             for i in range(1, repeat + 1):
                 if i == 1:
-                    act1_fifos[act1_fifo_names[i]] = object_fifo(
-                        act1_fifo_names[i],
-                        cores[i - 1][2],
-                        [cores[i][0], mems[i - 1]],
-                        [2, 2, 4],
-                        laye1_act_sizes[i],
+                    act1_fifos.append(
+                        object_fifo(
+                            act1_fifo_names[i],
+                            cores[i - 1][2],
+                            [cores[i][0], mems[i - 1]],
+                            [2, 2, 4],
+                            laye1_act_sizes[i],
+                        )
                     )
-                    skip_fifos[skip_fifo_names[i]] = object_fifo(
-                        skip_fifo_names[i],
-                        mems[i - 1],
-                        cores[i][2],
-                        2,
-                        laye1_act_sizes[i],
+                    skip_fifos.append(
+                        object_fifo(
+                            f"skip_{i}",
+                            mems[i - 1],
+                            cores[i][2],
+                            2,
+                            laye1_act_sizes[i],
+                        )
                     )
-                    object_fifo_link(act1_fifo_names[i], skip_fifo_names[i])
+                    object_fifo_link(act1_fifos[i], skip_fifos[i])
                 else:
-                    act1_fifos[act1_fifo_names[i]] = object_fifo(
-                        act1_fifo_names[i],
-                        cores[i - 1][2],
-                        [cores[i][0], mems[i]],
-                        [2, 2, 4],
-                        laye1_act_sizes[i],
+                    act1_fifos.append(
+                        object_fifo(
+                            act1_fifo_names[i],
+                            cores[i - 1][2],
+                            [cores[i][0], mems[i]],
+                            [2, 2, 4],
+                            laye1_act_sizes[i],
+                        )
                     )
-                    skip_fifos[skip_fifo_names[i]] = object_fifo(
-                        skip_fifo_names[i],
-                        mems[i],
-                        cores[i][2],
-                        2,
-                        laye1_act_sizes[i],
+                    skip_fifos.append(
+                        object_fifo(
+                            f"skip_{i}",
+                            mems[i],
+                            cores[i][2],
+                            2,
+                            laye1_act_sizes[i],
+                        )
                     )
-                    object_fifo_link(act1_fifo_names[i], skip_fifo_names[i])
+                    object_fifo_link(act1_fifos[i], skip_fifos[i])
 
             act2_fifo_names = ["act2_02_03_05", "act2_15_12_14", "act2_22_23_25"]
-            act2_fifos = {}
+            act2_fifos = []
 
             act3_fifo_names_1 = ["act3_03_04", "act3_14_13", "act3_23_24"]
-            act3_fifo_1 = {}
+            act3_fifos_1 = []
 
             act3_fifo_names_2 = ["act3_05_04", "act3_12_13", "act3_25_24"]
-            act3_fifo_2 = {}
+            act3_fifos_2 = []
 
             for i in range(n_cols):
                 if i == 1:
                     # 1x1 -> 3x3
-                    act2_fifos[act2_fifo_names[i]] = object_fifo(
-                        act2_fifo_names[i],
-                        cores[i][0],
-                        [cores[i][3], cores[i][1]],
-                        4,
-                        tensorLayer1Out_ty,
+                    act2_fifos.append(
+                        object_fifo(
+                            act2_fifo_names[i],
+                            cores[i][0],
+                            [cores[i][3], cores[i][1]],
+                            4,
+                            tensorLayer1Out_ty,
+                        )
                     )
 
                     # 3x3 -> 1x1
-                    act3_fifo_1[act3_fifo_names_1[i]] = object_fifo(
-                        act3_fifo_names_1[i],
-                        cores[i][1],
-                        cores[i][2],
-                        2,
-                        tensorLayer2Out_ty,
+                    act3_fifos_1.append(
+                        object_fifo(
+                            act3_fifo_names_1[i],
+                            cores[i][1],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
                     )
                     # 3x3 -> 1x1
-                    act3_fifo_2[act3_fifo_names_2[i]] = object_fifo(
-                        act3_fifo_names_2[i],
-                        cores[i][3],
-                        cores[i][2],
-                        2,
-                        tensorLayer2Out_ty,
+                    act3_fifos_2.append(
+                        object_fifo(
+                            act3_fifo_names_2[i],
+                            cores[i][3],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
                     )
                 else:
                     # 1x1 -> 3x3
-                    act2_fifos[act2_fifo_names[i]] = object_fifo(
-                        act2_fifo_names[i],
-                        cores[i][0],
-                        [cores[i][1], cores[i][3]],
-                        4,
-                        tensorLayer1Out_ty,
+                    act2_fifos.append(
+                        object_fifo(
+                            act2_fifo_names[i],
+                            cores[i][0],
+                            [cores[i][1], cores[i][3]],
+                            4,
+                            tensorLayer1Out_ty,
+                        )
                     )
 
                     # 3x3 -> 1x1
-                    act3_fifo_1[act3_fifo_names_1[i]] = object_fifo(
-                        act3_fifo_names_1[i],
-                        cores[i][1],
-                        cores[i][2],
-                        2,
-                        tensorLayer2Out_ty,
+                    act3_fifos_1.append(
+                        object_fifo(
+                            act3_fifo_names_1[i],
+                            cores[i][1],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
                     )
                     # 3x3 -> 1x1
-                    act3_fifo_2[act3_fifo_names_2[i]] = object_fifo(
-                        act3_fifo_names_2[i],
-                        cores[i][3],
-                        cores[i][2],
-                        2,
-                        tensorLayer2Out_ty,
+                    act3_fifos_2.append(
+                        object_fifo(
+                            act3_fifo_names_2[i],
+                            cores[i][3],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
                     )
-            wts_fifo_names = ["wts_0_L3L2", "wts_1_L3L2", "wts_2_L3L2"]
-            wts_fifos = {}
-            wts_sub_fifo_names = [
-                ["wts_buf_00", "wts_buf_01", "wts_buf_02"],
-                ["wts_buf_10", "wts_buf_11", "wts_buf_12"],
-                ["wts_buf_20", "wts_buf_21", "wts_buf_22"],
-            ]
-            wts_sub_fifos = {}
+            wts_fifos = []
+            wts_sub_fifos = [[], [], []]
 
             for i in range(n_cols):
 
-                wts_fifos[wts_fifo_names[i]] = object_fifo(
-                    wts_fifo_names[i], shims[i], mems[i], 1, wts_sizes[i]
+                wts_fifos.append(
+                    object_fifo(f"wts_{i}_L3L2", shims[i], mems[i], 1, wts_sizes[i])
                 )
-                wts_sub_fifos[wts_sub_fifo_names[i][0]] = object_fifo(
-                    wts_sub_fifo_names[i][0],
-                    mems[i],
-                    cores[i][0],
-                    1,
-                    layer1_wts_sizes[i],
+                wts_sub_fifos[i].append(
+                    object_fifo(
+                        f"wts_buf_{i}0",
+                        mems[i],
+                        cores[i][0],
+                        1,
+                        layer1_wts_sizes[i],
+                    )
                 )
                 if i == 1:
-                    wts_sub_fifos[wts_sub_fifo_names[i][1]] = object_fifo(
-                        wts_sub_fifo_names[i][1],
-                        mems[i],
-                        [cores[i][3], cores[i][1]],
-                        1,
-                        weightsLayer2_ty,
+                    wts_sub_fifos[i].append(
+                        object_fifo(
+                            f"wts_buf_{i}1",
+                            mems[i],
+                            [cores[i][3], cores[i][1]],
+                            1,
+                            weightsLayer2_ty,
+                        )
                     )
-
                 else:
-                    wts_sub_fifos[wts_sub_fifo_names[i][1]] = object_fifo(
-                        wts_sub_fifo_names[i][1],
-                        mems[i],
-                        [cores[i][1], cores[i][3]],
-                        1,
-                        weightsLayer2_ty,
+                    wts_sub_fifos[i].append(
+                        object_fifo(
+                            f"wts_buf_{i}1",
+                            mems[i],
+                            [cores[i][1], cores[i][3]],
+                            1,
+                            weightsLayer2_ty,
+                        )
                     )
-                wts_sub_fifos[wts_sub_fifo_names[i][2]] = object_fifo(
-                    wts_sub_fifo_names[i][2],
-                    mems[i],
-                    cores[i][2],
-                    1,
-                    layer3_wts_sizes[i],
+                wts_sub_fifos[i].append(
+                    object_fifo(
+                        f"wts_buf_{i}2",
+                        mems[i],
+                        cores[i][2],
+                        1,
+                        layer3_wts_sizes[i],
+                    )
                 )
                 object_fifo_link(
-                    wts_fifo_names[i],
-                    [
-                        wts_sub_fifo_names[i][0],
-                        wts_sub_fifo_names[i][1],
-                        wts_sub_fifo_names[i][2],
-                    ],
+                    wts_fifos[i],
+                    wts_sub_fifos[i],
                     [],
                     [
                         0,
@@ -542,12 +560,11 @@ def resnet_conv_x():
             outOFL2L3 = object_fifo(
                 "outOFL2L3", cores[2][2], shims[1], 2, tensorLayer3Out_ty
             )
-            conv3_out_fifo = [
-                act1_fifos[act1_fifo_names[1]],
-                act1_fifos[act1_fifo_names[2]],
+            conv3_out_fifos = [
+                act1_fifos[1],
+                act1_fifos[2],
                 outOFL2L3,
             ]
-            conv3_out_fifo_names = ["act1_04_15_11", "act1_13_22_21", "outOFL2L3"]
             # # 1x1 conv2d
             for i in range(n_cols):
 
@@ -556,17 +573,17 @@ def resnet_conv_x():
                     for _ in range_(sys.maxsize):
 
                         # acquire weights once
-                        element0Weights = wts_sub_fifos[
-                            wts_sub_fifo_names[i][0]
-                        ].acquire(ObjectFifoPort.Consume, 1)
+                        element0Weights = wts_sub_fifos[i][0].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
                         scale = rtp[i][0][0]
                         for _ in range_(tensorInH):
-                            element0ActivactionsIn = act1_fifos[
-                                act1_fifo_names[i]
-                            ].acquire(ObjectFifoPort.Consume, 1)
-                            element0ActivactionsOut = act2_fifos[
-                                act2_fifo_names[i]
-                            ].acquire(ObjectFifoPort.Produce, 1)
+                            element0ActivactionsIn = act1_fifos[i].acquire(
+                                ObjectFifoPort.Consume, 1
+                            )
+                            element0ActivactionsOut = act2_fifos[i].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
                             if i == 0:
                                 conv1_kernels_call[i](
                                     element0ActivactionsIn,
@@ -588,16 +605,9 @@ def resnet_conv_x():
                                     scale,
                                 )
 
-                            objectfifo_release(
-                                ObjectFifoPort.Consume, act1_fifo_names[i], 1
-                            )
-
-                            objectfifo_release(
-                                ObjectFifoPort.Produce, act2_fifo_names[i], 1
-                            )
-                        objectfifo_release(
-                            ObjectFifoPort.Consume, wts_sub_fifo_names[i][0], 1
-                        )
+                            act1_fifos[i].release(ObjectFifoPort.Consume, 1)
+                            act2_fifos[i].release(ObjectFifoPort.Produce, 1)
+                        wts_sub_fifos[i][0].release(ObjectFifoPort.Consume, 1)
 
             # 3x3 conv2d OFM 0-31
             for i in range(n_cols):
@@ -608,18 +618,18 @@ def resnet_conv_x():
                     for _ in range_(sys.maxsize):
 
                         # acquire weights and rtps once
-                        element0Weights = wts_sub_fifos[
-                            wts_sub_fifo_names[i][1]
-                        ].acquire(ObjectFifoPort.Consume, 1)
+                        element0Weights = wts_sub_fifos[i][1].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
                         # scale = memref.load(rtpComputeTile03, 0)
 
                         # pre-amble: top row
-                        elementActivactionsIn = act2_fifos[act2_fifo_names[i]].acquire(
+                        elementActivactionsIn = act2_fifos[i].acquire(
                             ObjectFifoPort.Consume, 2
                         )
-                        element0ActivactionsOut = act3_fifo_1[
-                            act3_fifo_names_1[i]
-                        ].acquire(ObjectFifoPort.Produce, 1)
+                        element0ActivactionsOut = act3_fifos_1[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
                         conv2dk3(
                             elementActivactionsIn[0],
                             elementActivactionsIn[0],
@@ -635,18 +645,16 @@ def resnet_conv_x():
                             scale,
                             0,
                         )
-                        objectfifo_release(
-                            ObjectFifoPort.Produce, act3_fifo_names_1[i], 1
-                        )
+                        act3_fifos_1[i].release(ObjectFifoPort.Produce, 1)
 
                         # middle
                         for _ in range_(tensorInH - 2):
-                            elementActivactionsIn = act2_fifos[
-                                act2_fifo_names[i]
-                            ].acquire(ObjectFifoPort.Consume, 3)
-                            element0ActivactionsOut = act3_fifo_1[
-                                act3_fifo_names_1[i]
-                            ].acquire(ObjectFifoPort.Produce, 1)
+                            elementActivactionsIn = act2_fifos[i].acquire(
+                                ObjectFifoPort.Consume, 3
+                            )
+                            element0ActivactionsOut = act3_fifos_1[i].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
                             conv2dk3(
                                 elementActivactionsIn[0],
                                 elementActivactionsIn[1],
@@ -663,20 +671,16 @@ def resnet_conv_x():
                                 0,
                             )
 
-                            objectfifo_release(
-                                ObjectFifoPort.Consume, act2_fifo_names[i], 1
-                            )
-                            objectfifo_release(
-                                ObjectFifoPort.Produce, act3_fifo_names_1[i], 1
-                            )
+                            act2_fifos[i].release(ObjectFifoPort.Consume, 1)
+                            act3_fifos_1[i].release(ObjectFifoPort.Produce, 1)
 
                         # last part
-                        elementActivactionsIn = act2_fifos[act2_fifo_names[i]].acquire(
+                        elementActivactionsIn = act2_fifos[i].acquire(
                             ObjectFifoPort.Consume, 2
                         )
-                        element0ActivactionsOut = act3_fifo_1[
-                            act3_fifo_names_1[i]
-                        ].acquire(ObjectFifoPort.Produce, 1)
+                        element0ActivactionsOut = act3_fifos_1[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
                         conv2dk3(
                             elementActivactionsIn[0],
                             elementActivactionsIn[1],
@@ -692,17 +696,9 @@ def resnet_conv_x():
                             scale,
                             0,
                         )
-
-                        objectfifo_release(
-                            ObjectFifoPort.Consume, act2_fifo_names[i], 2
-                        )
-                        objectfifo_release(
-                            ObjectFifoPort.Produce, act3_fifo_names_1[i], 1
-                        )
-
-                        objectfifo_release(
-                            ObjectFifoPort.Consume, wts_sub_fifo_names[i][1], 1
-                        )
+                        act2_fifos[i].release(ObjectFifoPort.Consume, 2)
+                        act3_fifos_1[i].release(ObjectFifoPort.Produce, 1)
+                        wts_sub_fifos[i][1].release(ObjectFifoPort.Consume, 1)
 
             # 3x3 conv2d OFM 32-63
 
@@ -714,18 +710,18 @@ def resnet_conv_x():
                     for _ in range_(sys.maxsize):
 
                         # acquire weights and rtps once
-                        element0Weights = wts_sub_fifos[
-                            wts_sub_fifo_names[i][1]
-                        ].acquire(ObjectFifoPort.Consume, 1)
+                        element0Weights = wts_sub_fifos[i][1].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
                         # scale = memref.load(rtpComputeTile05, 0)
 
                         # pre-amble: top row
-                        elementActivactionsIn = act2_fifos[act2_fifo_names[i]].acquire(
+                        elementActivactionsIn = act2_fifos[i].acquire(
                             ObjectFifoPort.Consume, 2
                         )
-                        element0ActivactionsOut = act3_fifo_2[
-                            act3_fifo_names_2[i]
-                        ].acquire(ObjectFifoPort.Produce, 1)
+                        element0ActivactionsOut = act3_fifos_2[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
                         conv2dk3(
                             elementActivactionsIn[0],
                             elementActivactionsIn[0],
@@ -742,18 +738,16 @@ def resnet_conv_x():
                             tensorInCInit // 2,
                         )
 
-                        objectfifo_release(
-                            ObjectFifoPort.Produce, act3_fifo_names_2[i], 1
-                        )
+                        act3_fifos_2[i].release(ObjectFifoPort.Produce, 1)
 
                         # middle
                         for _ in range_(tensorInH - 2):
-                            elementActivactionsIn = act2_fifos[
-                                act2_fifo_names[i]
-                            ].acquire(ObjectFifoPort.Consume, 3)
-                            element0ActivactionsOut = act3_fifo_2[
-                                act3_fifo_names_2[i]
-                            ].acquire(ObjectFifoPort.Produce, 1)
+                            elementActivactionsIn = act2_fifos[i].acquire(
+                                ObjectFifoPort.Consume, 3
+                            )
+                            element0ActivactionsOut = act3_fifos_2[i].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
                             conv2dk3(
                                 elementActivactionsIn[0],
                                 elementActivactionsIn[1],
@@ -770,20 +764,16 @@ def resnet_conv_x():
                                 tensorInCInit // 2,
                             )
 
-                            objectfifo_release(
-                                ObjectFifoPort.Consume, act2_fifo_names[i], 1
-                            )
-                            objectfifo_release(
-                                ObjectFifoPort.Produce, act3_fifo_names_2[i], 1
-                            )
+                            act2_fifos[i].release(ObjectFifoPort.Consume, 1)
+                            act3_fifos_2[i].release(ObjectFifoPort.Produce, 1)
 
                         # last part
-                        elementActivactionsIn = act2_fifos[act2_fifo_names[i]].acquire(
+                        elementActivactionsIn = act2_fifos[i].acquire(
                             ObjectFifoPort.Consume, 2
                         )
-                        element0ActivactionsOut = act3_fifo_2[
-                            act3_fifo_names_2[i]
-                        ].acquire(ObjectFifoPort.Produce, 1)
+                        element0ActivactionsOut = act3_fifos_2[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
                         conv2dk3(
                             elementActivactionsIn[0],
                             elementActivactionsIn[1],
@@ -799,15 +789,9 @@ def resnet_conv_x():
                             scale,
                             tensorInCInit // 2,
                         )
-                        objectfifo_release(
-                            ObjectFifoPort.Consume, act2_fifo_names[i], 2
-                        )
-                        objectfifo_release(
-                            ObjectFifoPort.Produce, act3_fifo_names_2[i], 1
-                        )
-                        objectfifo_release(
-                            ObjectFifoPort.Consume, wts_sub_fifo_names[i][1], 1
-                        )
+                        act2_fifos[i].release(ObjectFifoPort.Consume, 2)
+                        act3_fifos_2[i].release(ObjectFifoPort.Produce, 1)
+                        wts_sub_fifos[i][1].release(ObjectFifoPort.Consume, 1)
 
             # # 1x1 conv2d and add skip
             for i in range(n_cols):
@@ -817,9 +801,9 @@ def resnet_conv_x():
                     for _ in range_(sys.maxsize):
 
                         # acquire weights and rtps once
-                        element0Weights = wts_sub_fifos[
-                            wts_sub_fifo_names[i][2]
-                        ].acquire(ObjectFifoPort.Consume, 1)
+                        element0Weights = wts_sub_fifos[i][2].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
                         if i == 0:
                             scale = rtp[0][3][0]
                             skipScale = rtp[0][3][1]
@@ -829,17 +813,17 @@ def resnet_conv_x():
                             skipScale = rtp[i][2][1]
 
                         for _ in range_(tensorInH):
-                            element0ActivactionsIn = act3_fifo_1[
-                                act3_fifo_names_1[i]
-                            ].acquire(ObjectFifoPort.Consume, 1)
-                            element1ActivactionsIn = act3_fifo_2[
-                                act3_fifo_names_2[i]
-                            ].acquire(ObjectFifoPort.Consume, 1)
+                            element0ActivactionsIn = act3_fifos_1[i].acquire(
+                                ObjectFifoPort.Consume, 1
+                            )
+                            element1ActivactionsIn = act3_fifos_2[i].acquire(
+                                ObjectFifoPort.Consume, 1
+                            )
 
-                            elementActivactionsOut = conv3_out_fifo[i].acquire(
+                            elementActivactionsOut = conv3_out_fifos[i].acquire(
                                 ObjectFifoPort.Produce, 1
                             )
-                            elementSkipsIn = skip_fifos[skip_fifo_names[i]].acquire(
+                            elementSkipsIn = skip_fifos[i].acquire(
                                 ObjectFifoPort.Consume, 1
                             )
                             if i == 0:
@@ -870,22 +854,11 @@ def resnet_conv_x():
                                     scale,
                                     skipScale,
                                 )
-                            objectfifo_release(
-                                ObjectFifoPort.Consume, act3_fifo_names_1[i], 1
-                            )
-                            objectfifo_release(
-                                ObjectFifoPort.Consume, act3_fifo_names_2[i], 1
-                            )
-                            objectfifo_release(
-                                ObjectFifoPort.Produce, conv3_out_fifo_names[i], 1
-                            )
-
-                            objectfifo_release(
-                                ObjectFifoPort.Consume, skip_fifo_names[i], 1
-                            )
-                        objectfifo_release(
-                            ObjectFifoPort.Consume, wts_sub_fifo_names[i][2], 1
-                        )
+                            act3_fifos_1[i].release(ObjectFifoPort.Consume, 1)
+                            act3_fifos_2[i].release(ObjectFifoPort.Consume, 1)
+                            conv3_out_fifos[i].release(ObjectFifoPort.Produce, 1)
+                            skip_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        wts_sub_fifos[i][2].release(ObjectFifoPort.Consume, 1)
 
             # instruction stream generation
             @runtime_sequence(
@@ -913,20 +886,20 @@ def resnet_conv_x():
                 rtpComputeTile24[1] = 0
 
                 npu_dma_memcpy_nd(
-                    metadata="act1_00_02_01",
+                    metadata=act1_fifos[0],
                     bd_id=0,
                     mem=inputFromL3,
                     sizes=[1, 1, 1, activationsIn],
                 )
                 npu_dma_memcpy_nd(
-                    metadata="wts_0_L3L2",
+                    metadata=wts_fifos[0],
                     bd_id=1,
                     mem=weightsFromL3,
                     sizes=[1, 1, 1, totalWeights_init],
                 )
 
                 npu_dma_memcpy_nd(
-                    metadata="wts_1_L3L2",
+                    metadata=wts_fifos[1],
                     bd_id=1,
                     mem=weightsFromL3,
                     offsets=[0, 0, 0, totalWeights_init],
@@ -934,7 +907,7 @@ def resnet_conv_x():
                 )
 
                 npu_dma_memcpy_nd(
-                    metadata="wts_2_L3L2",
+                    metadata=wts_fifos[2],
                     bd_id=1,
                     mem=weightsFromL3,
                     offsets=[
@@ -946,13 +919,13 @@ def resnet_conv_x():
                     sizes=[1, 1, 1, totalWeights_rest],
                 )
                 npu_dma_memcpy_nd(
-                    metadata="outOFL2L3",
+                    metadata=outOFL2L3,
                     bd_id=2,
                     mem=outputToL3,
                     sizes=[1, 1, 1, acitivationsOut],
                 )
                 # outOFL2L3 will only complete after inputs complete, so we just wait on outOFL2L3 instead of all
-                dma_wait("outOFL2L3")
+                dma_wait(outOFL2L3)
 
     res = ctx.module.operation.verify()
     if res == True:

--- a/programming_examples/vision/color_threshold/aie2_colorThreshold.py
+++ b/programming_examples/vision/color_threshold/aie2_colorThreshold.py
@@ -103,10 +103,18 @@ def color_threshold():
             )
 
             # Runtime parameters
-            rtpComputeTile2 = buffer(ComputeTile2, [16], np.int32, "rtpComputeTile2")
-            rtpComputeTile3 = buffer(ComputeTile3, [16], np.int32, "rtpComputeTile3")
-            rtpComputeTile4 = buffer(ComputeTile4, [16], np.int32, "rtpComputeTile4")
-            rtpComputeTile5 = buffer(ComputeTile5, [16], np.int32, "rtpComputeTile5")
+            rtpComputeTile2 = buffer(
+                ComputeTile2, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile2"
+            )
+            rtpComputeTile3 = buffer(
+                ComputeTile3, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile3"
+            )
+            rtpComputeTile4 = buffer(
+                ComputeTile4, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile4"
+            )
+            rtpComputeTile5 = buffer(
+                ComputeTile5, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile5"
+            )
 
             # Set up compute tiles
 

--- a/programming_examples/vision/color_threshold/aie2_colorThreshold.py
+++ b/programming_examples/vision/color_threshold/aie2_colorThreshold.py
@@ -103,10 +103,10 @@ def color_threshold():
             )
 
             # Runtime parameters
-            rtpComputeTile2 = Buffer(ComputeTile2, [16], np.int32, "rtpComputeTile2")
-            rtpComputeTile3 = Buffer(ComputeTile3, [16], np.int32, "rtpComputeTile3")
-            rtpComputeTile4 = Buffer(ComputeTile4, [16], np.int32, "rtpComputeTile4")
-            rtpComputeTile5 = Buffer(ComputeTile5, [16], np.int32, "rtpComputeTile5")
+            rtpComputeTile2 = buffer(ComputeTile2, [16], np.int32, "rtpComputeTile2")
+            rtpComputeTile3 = buffer(ComputeTile3, [16], np.int32, "rtpComputeTile3")
+            rtpComputeTile4 = buffer(ComputeTile4, [16], np.int32, "rtpComputeTile4")
+            rtpComputeTile5 = buffer(ComputeTile5, [16], np.int32, "rtpComputeTile5")
 
             # Set up compute tiles
 

--- a/programming_examples/vision/color_threshold/aie2_colorThreshold.py
+++ b/programming_examples/vision/color_threshold/aie2_colorThreshold.py
@@ -104,16 +104,28 @@ def color_threshold():
 
             # Runtime parameters
             rtpComputeTile2 = buffer(
-                ComputeTile2, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile2"
+                ComputeTile2,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile2",
+                use_write_rtp=True,
             )
             rtpComputeTile3 = buffer(
-                ComputeTile3, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile3"
+                ComputeTile3,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile3",
+                use_write_rtp=True,
             )
             rtpComputeTile4 = buffer(
-                ComputeTile4, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile4"
+                ComputeTile4,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile4",
+                use_write_rtp=True,
             )
             rtpComputeTile5 = buffer(
-                ComputeTile5, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile5"
+                ComputeTile5,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile5",
+                use_write_rtp=True,
             )
 
             # Set up compute tiles
@@ -221,21 +233,21 @@ def color_threshold():
             )
             def sequence(inTensor, notUsed, outTensor):
                 # thresholdValue, maxValue, thresholdType
-                NpuWriteRTPOp("rtpComputeTile2", index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile2", index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile2", index=2, value=0)
+                rtpComputeTile2[0] = 50
+                rtpComputeTile2[1] = 255
+                rtpComputeTile2[2] = 0
 
-                NpuWriteRTPOp("rtpComputeTile3", index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile3", index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile3", index=2, value=0)
+                rtpComputeTile3[0] = 50
+                rtpComputeTile3[1] = 255
+                rtpComputeTile3[2] = 0
 
-                NpuWriteRTPOp("rtpComputeTile4", index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile4", index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile4", index=2, value=0)
+                rtpComputeTile4[0] = 50
+                rtpComputeTile4[1] = 255
+                rtpComputeTile4[2] = 0
 
-                NpuWriteRTPOp("rtpComputeTile5", index=0, value=50)
-                NpuWriteRTPOp("rtpComputeTile5", index=1, value=255)
-                NpuWriteRTPOp("rtpComputeTile5", index=2, value=0)
+                rtpComputeTile5[0] = 50
+                rtpComputeTile5[1] = 255
+                rtpComputeTile5[2] = 0
 
                 npu_dma_memcpy_nd(
                     metadata=inOOB_L3L2,

--- a/programming_examples/vision/edge_detect/aie2_edgeDetect.py
+++ b/programming_examples/vision/edge_detect/aie2_edgeDetect.py
@@ -161,8 +161,15 @@ def edge_detect():
                 v0 = 0
                 v1 = 4096
                 v_minus4 = -16384
-                initial_value = np.array([[v0, v1, v0], [v1, v_minus4, v1], [v0, v1, v0]], dtype=np.int16)
-                kernel = buffer(ComputeTile3, np.ndarray[(3, 3), np.dtype[np.int16]], "kernel", initial_value=initial_value)
+                initial_value = np.array(
+                    [[v0, v1, v0], [v1, v_minus4, v1], [v0, v1, v0]], dtype=np.int16
+                )
+                kernel = buffer(
+                    ComputeTile3,
+                    np.ndarray[(3, 3), np.dtype[np.int16]],
+                    "kernel",
+                    initial_value=initial_value,
+                )
 
                 for _ in range_(sys.maxsize):
                     # Preamble : Top Border

--- a/programming_examples/vision/edge_detect/aie2_edgeDetect.py
+++ b/programming_examples/vision/edge_detect/aie2_edgeDetect.py
@@ -9,7 +9,6 @@ import sys
 
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
-from aie.extras.dialects.ext import memref
 from aie.extras.context import mlir_mod_ctx
 from aie.extras.dialects.ext.scf import _for as range_
 
@@ -159,19 +158,11 @@ def edge_detect():
             # Compute tile 3
             @core(ComputeTile3, "filter2d.cc.o")
             def core_body():
-                kernel = memref.alloc(3, 3, T.i16())
                 v0 = 0
                 v1 = 4096
                 v_minus4 = -16384
-                kernel[0, 0] = v0
-                kernel[0, 1] = v1
-                kernel[0, 2] = v0
-                kernel[1, 0] = v1
-                kernel[1, 1] = v_minus4
-                kernel[1, 2] = v1
-                kernel[2, 0] = v0
-                kernel[2, 1] = v1
-                kernel[2, 2] = v0
+                initial_value = np.array([[v0, v1, v0], [v1, v_minus4, v1], [v0, v1, v0]], dtype=np.int16)
+                kernel = buffer(ComputeTile3, np.ndarray[(3, 3), np.dtype[np.int16]], "kernel", initial_value=initial_value)
 
                 for _ in range_(sys.maxsize):
                     # Preamble : Top Border

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -237,7 +237,7 @@ class buffer(MemRef):
             assert isinstance(initial_value, np.ndarray)
             initial_value = DenseElementsAttr.get(
                 initial_value,
-                type=memref_type.dtype,
+                type=memref_type.element_type,
                 context=None,
             )
         my_buffer = BufferOp(

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -219,7 +219,7 @@ class Core(CoreOp):
 # Create an aie buffer of (shape x datatype) on given tile.
 # shape examples: [256], [256, 256], [256, 256,]
 # This class hides the BufferOp and instead pretends to be a MemRef
-class Buffer(MemRef):
+class buffer(MemRef):
     def __init__(self):
         raise ValueError("Should never be called")
 
@@ -254,7 +254,7 @@ class Buffer(MemRef):
 # Create an aie external buffer of (shape x datatype).
 # shape examples: [256], [256, 256], [256, 256,]
 # This class hides the ExternalBufferOp and instead pretends to be a MemRef
-class ExternalBuffer(MemRef):
+class external_buffer(MemRef):
     def __init__(self):
         raise ValueError("Should never be called")
 
@@ -270,9 +270,6 @@ class ExternalBuffer(MemRef):
 
 # Create an aie objectFifo between specified tiles, with given depth and memref datatype.
 # depth examples: 2, [2,2,7]
-from typing import Literal
-
-
 class object_fifo(ObjectFifoCreateOp):
     def __init__(
         self,
@@ -520,30 +517,6 @@ def next_bd(
     if isinstance(dest, ContextManagedBlock):
         dest = dest.block
     return NextBDOp(dest, loc=loc, ip=ip).dest
-
-
-def buffer(tile, shape, dtype, name=None, initial_value=None, loc=None, ip=None):
-    if name is not None and not name:
-        name = _get_sym_name(inspect.currentframe().f_back, "aie\\.buffer|buffer")
-    return Buffer(
-        tile,
-        shape,
-        dtype,
-        name=name,
-        initial_value=initial_value,
-        loc=loc,
-        ip=ip,
-    )
-
-
-def external_buffer(shape, dtype, name=None, loc=None, ip=None):
-    return ExternalBuffer(
-        shape,
-        dtype,
-        name=name,
-        loc=loc,
-        ip=ip,
-    )
 
 
 _lock = lock

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -227,13 +227,13 @@ class buffer(MemRef):
         cls,
         tile,
         datatype: MemRefType | type[np.ndarray],
-        initial_value: np.ndarray | None = None,
         name: str | None = None,
+        initial_value: np.ndarray | None = None,
         loc=None,
         ip=None,
     ):
         memref_type = try_convert_np_type_to_mlir_type(datatype)
-        if initial_value is not None:
+        if not (initial_value is None):
             assert isinstance(initial_value, np.ndarray)
             initial_value = DenseElementsAttr.get(
                 initial_value,

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -836,3 +836,11 @@ def dma_start_bd_chain_for(symbol, args, alloc, *pyargs, **kwargs):
     return DMAStartBdChainForOp(
         T.index(), chain_sym, args, alloc_sym, *pyargs, **kwargs
     )
+
+
+# NpuWriteRTPOp("rtp2", index=0, value=10)
+class npu_write_rtp(NpuWriteRTPOp):
+    def __init__(self, buffer, index, value, loc=None, ip=None):
+        super().__init__(
+            buffer=buffer.get_name(), index=index, value=value, loc=loc, ip=ip
+        )

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -440,8 +440,7 @@ class Channel:
         self,
         tile,
         buffer=None,
-        shape=None,
-        dtype=None,
+        datatype: MemRefType | type[np.ndarray] | None = None,
         buffer_name=None,
         initial_value=None,
         producer_lock_id=None,
@@ -457,12 +456,11 @@ class Channel:
     ):
         if buffer is None:
             assert (
-                shape is not None and dtype is not None
-            ), f"must provide either existing buffer or buffer shape and dtype"
+                datatype is not None
+            ), f"must provide either existing buffer or datatype"
             buffer = aie.buffer(
                 tile,
-                shape,
-                dtype,
+                datatype,
                 name=buffer_name,
                 initial_value=initial_value,
                 loc=loc,
@@ -588,9 +586,9 @@ class TileArray:
         return broadcast_flow(self.df, other.df, *args, **kwargs)
 
     def channel(self, *args, **kwargs):
-        args = _broadcast_args_to((self.df,) + args, self.shape)
+        args = _broadcast_args_to((self.df,) + args, self.datatype)
         kwargs = dict(
-            zip(kwargs.keys(), _broadcast_args_to(kwargs.values(), self.shape))
+            zip(kwargs.keys(), _broadcast_args_to(kwargs.values(), self.datatype))
         )
         r = np.vectorize(Channel, otypes=[object])(*args, **kwargs)
         if r.size == 1:
@@ -648,9 +646,9 @@ class TileArray:
         return find_matching_buffers(self, **kwargs)
 
     def buffer(self, *args, **kwargs):
-        args = _broadcast_args_to((self.df,) + args, self.shape)
+        args = _broadcast_args_to((self.df,) + args, self.datatype)
         kwargs = dict(
-            zip(kwargs.keys(), _broadcast_args_to(kwargs.values(), self.shape))
+            zip(kwargs.keys(), _broadcast_args_to(kwargs.values(), self.datatype))
         )
         r = np.vectorize(aie.buffer, otypes=[object])(*args, **kwargs)
         if r.size == 1:
@@ -658,9 +656,9 @@ class TileArray:
         return r
 
     def lock(self, *args, **kwargs):
-        args = _broadcast_args_to((self.df,) + args, self.shape)
+        args = _broadcast_args_to((self.df,) + args, self.datatype)
         kwargs = dict(
-            zip(kwargs.keys(), _broadcast_args_to(kwargs.values(), self.shape))
+            zip(kwargs.keys(), _broadcast_args_to(kwargs.values(), self.datatype))
         )
         r = np.vectorize(aie.lock, otypes=[object])(*args, **kwargs)
         if r.size == 1:

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -659,7 +659,7 @@ class TileArray:
             return aie.buffer(*args, **kwargs)
 
         # np.vectorize doesn't seem to play well with ndarray types, so I use this buffer_creator hack
-        r = np.vectorize(buffer_creator, otypes=[object])(*args, **kwargs)
+        r = np.vectorize(buffer_constructor, otypes=[object])(*args, **kwargs)
 
         if r.size == 1:
             r = r[0]

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -836,11 +836,3 @@ def dma_start_bd_chain_for(symbol, args, alloc, *pyargs, **kwargs):
     return DMAStartBdChainForOp(
         T.index(), chain_sym, args, alloc_sym, *pyargs, **kwargs
     )
-
-
-# NpuWriteRTPOp("rtp2", index=0, value=10)
-class npu_write_rtp(NpuWriteRTPOp):
-    def __init__(self, buffer, index, value, loc=None, ip=None):
-        super().__init__(
-            buffer=buffer.get_name(), index=index, value=value, loc=loc, ip=ip
-        )

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -83,11 +83,10 @@ def deviceOp():
 @construct_and_print_module
 def bufferOp():
     t = tile(col=0, row=3)
-    b = buffer(t, (12,), T.i32())
+    b = buffer(t, np.ndarray[(12,), np.dtype[np.int32]])
     b = buffer(
         t,
-        (2, 2),
-        T.i32(),
+        T.memref(2, 2, T.i32()),
         initial_value=np.arange(2 * 2, dtype=np.int32).reshape(2, 2),
     )
 
@@ -96,7 +95,7 @@ def bufferOp():
 # CHECK: %[[VAL_0:.*]] = aie.external_buffer : memref<12xi32>
 @construct_and_print_module
 def externalBufferOp():
-    b = external_buffer((12,), T.i32())
+    b = external_buffer(T.memref(12, T.i32()))
 
 
 # CHECK-LABEL: objFifo

--- a/test/python/dma_tasks.py
+++ b/test/python/dma_tasks.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # RUN: %python %s | FileCheck %s
-
+import numpy as np
 from aie.extras.context import mlir_mod_ctx
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
@@ -17,9 +17,9 @@ with mlir_mod_ctx() as ctx:
         mem_tile = tile(0, 1)
 
         # CHECK: %[[buf0:.+]] = aie.buffer
-        buf0 = buffer(mem_tile, (16,), T.i16())
+        buf0 = buffer(mem_tile, np.ndarray[(16,), np.dtype[np.int16]])
         # CHECK: %[[buf1:.+]] = aie.buffer
-        buf1 = buffer(mem_tile, (32,), T.i16())
+        buf1 = buffer(mem_tile, T.memref(32, T.i16()))
 
         of0 = object_fifo("of0", shim_tile, mem_tile, 2, T.memref(256, T.i32()))
 

--- a/test/python/simple_with_bindings.py
+++ b/test/python/simple_with_bindings.py
@@ -39,7 +39,7 @@ def simple_with_bindings_example():
     dev_block = Block.create_at_start(dev.body_region)
     with InsertionPoint(dev_block):
         tile_a = tile(1, 4)
-        buff = buffer(tile=tile_a, shape=(256,), dtype=T.i32())
+        buff = buffer(tile_a, T.memref(256, T.i32()))
 
         C = Core(tile_a)
         bb = Block.create_at_start(C.body)

--- a/test/python/static_bd_config.py
+++ b/test/python/static_bd_config.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # RUN: %python %s | FileCheck %s
-
+import numpy as np
 from aie.extras.context import mlir_mod_ctx
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
@@ -16,9 +16,9 @@ with mlir_mod_ctx() as ctx:
         # CHECK: %[[tile_0_2:.+]] = aie.tile
         tile_0_2 = tile(0, 2)
         # CHECK: %[[buf0:.+]] = aie.buffer
-        buf0 = buffer(tile_0_2, (16,), T.i32())
+        buf0 = buffer(tile_0_2, T.memref(16, T.i32()))
         # CHECK: %[[buf1:.+]] = aie.buffer
-        buf1 = buffer(tile_0_2, (16,), T.i32())
+        buf1 = buffer(tile_0_2, np.ndarray[(16,), np.dtype[np.int32]])
         # CHECK: %[[lock0:.+]] = aie.lock
         lock0 = lock(tile_0_2)
         # CHECK: %[[lock1:.+]] = aie.lock

--- a/test/python/tile_array.py
+++ b/test/python/tile_array.py
@@ -288,9 +288,7 @@ def channels_basic(module):
         )
         c = Channel(tiles[2, 2].tile, b)
         c = Channel(
-            tiles[2, 2].tile,
-            datatype=np.ndarray[(10, 10), np.dtype[np.int32]],
-            buffer_name="alice",
+            tiles[2, 2].tile, shape=(10, 10), dtype=np.int32, buffer_name="alice"
         )
 
     # CHECK: %bob = aie.buffer(%tile_2_2) {sym_name = "bob"} : memref<10x10xi32>
@@ -309,9 +307,7 @@ def channels_basic(module):
         tiles = TileArray()
 
         c = Channel(
-            tiles[2, 2].tile,
-            datatype=np.ndarray[(10, 10), np.dtype[np.int32]],
-            buffer_name="alice",
+            tiles[2, 2].tile, shape=(10, 10), dtype=np.int32, buffer_name="alice"
         )
 
         @aie.mem(tiles[2, 2].tile)
@@ -350,11 +346,11 @@ def nd_channels(module):
     def npu():
         tiles = TileArray()
 
-        datatypes = [np.array([(10, 10)], dtype="i,i").astype(object)]
-        c = tiles[2, 2].channel(datatype=datatypes)
+        shapes = np.array([(10, 10)], dtype="i,i").astype(object)
+        c = tiles[2, 2].channel(shape=shapes, dtype=[np.int32])
         # CHECK: <Channel: buffer=MemRef(%buffer_2_2, memref<10x10xi32>) producer_lock=Scalar(%buffer_2_2_producer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_producer_lock"}) consumer_lock=Scalar(%buffer_2_2_consumer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_consumer_lock"})>
         print(c)
-        cs = tiles[2:4, 2:4].channel(datatype=datatypes)
+        cs = tiles[2:4, 2:4].channel(shape=shapes, dtype=[np.int32])
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) <Channel: buffer=MemRef(%buffer_2_2_0, memref<10x10xi32>) producer_lock=Scalar(%buffer_2_2_0_producer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_0_producer_lock"}) consumer_lock=Scalar(%buffer_2_2_0_consumer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_0_consumer_lock"})>
@@ -364,8 +360,10 @@ def nd_channels(module):
         for idx, c in np.ndenumerate(cs):
             print(idx, c)
 
-        datatypes = np.array([[(1, 2), (3, 4)], [(5, 6), (7, 8)]], dtype="i,i")
-        cs = tiles[2:4, 2:4].channel(datatype=datatypes)
+        shapes = np.array([[(1, 2), (3, 4)], [(5, 6), (7, 8)]], dtype="i,i").astype(
+            object
+        )
+        cs = tiles[2:4, 2:4].channel(shape=shapes, dtype=[np.int32])
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) <Channel: buffer=MemRef(%buffer_2_2_1, memref<1x2xi32>) producer_lock=Scalar(%buffer_2_2_1_producer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_1_producer_lock"}) consumer_lock=Scalar(%buffer_2_2_1_consumer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_1_consumer_lock"})>
@@ -385,11 +383,11 @@ def buffer_test_this_needs_to_distinct_from_all_other_mentions_of_buffer_in_this
     def npu():
         tiles = TileArray()
 
-        buff_type = np.ndarray[(10, 10), np.dtype[np.int32]]
-        c = tiles[2, 2].buffer(buff_type)
+        shapes = [(10, 10)]
+        c = tiles[2, 2].buffer(shape=shapes, dtype=[np.int32])
         # CHECK: MemRef(%buffer_2_2, memref<10x10xi32>)
         print(c)
-        cs = tiles[2:4, 2:4].buffer(buff_type)
+        cs = tiles[2:4, 2:4].buffer(shape=shapes, dtype=[np.int32])
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) MemRef(%buffer_2_2_0, memref<10x10xi32>)
@@ -399,17 +397,8 @@ def buffer_test_this_needs_to_distinct_from_all_other_mentions_of_buffer_in_this
         for idx, c in np.ndenumerate(cs):
             print(idx, c)
 
-        buff_types = [
-            [
-                np.ndarray[(1, 2), np.dtype[np.int32]],
-                np.ndarray[(3, 4), np.dtype[np.int32]],
-            ],
-            [
-                np.ndarray[(5, 6), np.dtype[np.int32]],
-                np.ndarray[(7, 8), np.dtype[np.int32]],
-            ],
-        ]
-        cs = tiles[2:4, 2:4].buffer(buff_types)
+        shapes = [[(1, 2), (3, 4)], [(5, 6), (7, 8)]]
+        cs = tiles[2:4, 2:4].buffer(shape=shapes, dtype=[np.int32])
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) MemRef(%buffer_2_2_1, memref<1x2xi32>)

--- a/test/python/tile_array.py
+++ b/test/python/tile_array.py
@@ -288,7 +288,9 @@ def channels_basic(module):
         )
         c = Channel(tiles[2, 2].tile, b)
         c = Channel(
-            tiles[2, 2].tile, shape=(10, 10), dtype=T.i32(), buffer_name="alice"
+            tiles[2, 2].tile,
+            datatype=np.ndarray[(10, 10), np.dtype[np.int32]],
+            buffer_name="alice",
         )
 
     # CHECK: %bob = aie.buffer(%tile_2_2) {sym_name = "bob"} : memref<10x10xi32>
@@ -307,7 +309,9 @@ def channels_basic(module):
         tiles = TileArray()
 
         c = Channel(
-            tiles[2, 2].tile, shape=(10, 10), dtype=T.i32(), buffer_name="alice"
+            tiles[2, 2].tile,
+            datatype=np.ndarray[(10, 10), np.dtype[np.int32]],
+            buffer_name="alice",
         )
 
         @aie.mem(tiles[2, 2].tile)
@@ -346,11 +350,11 @@ def nd_channels(module):
     def npu():
         tiles = TileArray()
 
-        shapes = np.array([(10, 10)], dtype="i,i").astype(object)
-        c = tiles[2, 2].channel(shape=shapes, dtype=[T.i32()])
+        datatypes = [np.array([(10, 10)], dtype="i,i").astype(object)]
+        c = tiles[2, 2].channel(datatype=datatypes)
         # CHECK: <Channel: buffer=MemRef(%buffer_2_2, memref<10x10xi32>) producer_lock=Scalar(%buffer_2_2_producer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_producer_lock"}) consumer_lock=Scalar(%buffer_2_2_consumer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_consumer_lock"})>
         print(c)
-        cs = tiles[2:4, 2:4].channel(shape=shapes, dtype=[T.i32()])
+        cs = tiles[2:4, 2:4].channel(datatype=datatypes)
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) <Channel: buffer=MemRef(%buffer_2_2_0, memref<10x10xi32>) producer_lock=Scalar(%buffer_2_2_0_producer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_0_producer_lock"}) consumer_lock=Scalar(%buffer_2_2_0_consumer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_0_consumer_lock"})>
@@ -360,10 +364,8 @@ def nd_channels(module):
         for idx, c in np.ndenumerate(cs):
             print(idx, c)
 
-        shapes = np.array([[(1, 2), (3, 4)], [(5, 6), (7, 8)]], dtype="i,i").astype(
-            object
-        )
-        cs = tiles[2:4, 2:4].channel(shape=shapes, dtype=[T.i32()])
+        datatypes = np.array([[(1, 2), (3, 4)], [(5, 6), (7, 8)]], dtype="i,i")
+        cs = tiles[2:4, 2:4].channel(datatype=datatypes)
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) <Channel: buffer=MemRef(%buffer_2_2_1, memref<1x2xi32>) producer_lock=Scalar(%buffer_2_2_1_producer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_1_producer_lock"}) consumer_lock=Scalar(%buffer_2_2_1_consumer_lock = aie.lock(%tile_2_2) {sym_name = "buffer_2_2_1_consumer_lock"})>

--- a/test/python/tile_array.py
+++ b/test/python/tile_array.py
@@ -283,7 +283,9 @@ def channels_basic(module):
     def npu():
         tiles = TileArray()
 
-        b = aie.buffer(tiles[2, 2].tile, (10, 10), T.i32(), name="bob")
+        b = aie.buffer(
+            tiles[2, 2].tile, np.ndarray[(10, 10), np.dtype[np.int32]], name="bob"
+        )
         c = Channel(tiles[2, 2].tile, b)
         c = Channel(
             tiles[2, 2].tile, shape=(10, 10), dtype=T.i32(), buffer_name="alice"
@@ -381,11 +383,11 @@ def buffer_test_this_needs_to_distinct_from_all_other_mentions_of_buffer_in_this
     def npu():
         tiles = TileArray()
 
-        shapes = [(10, 10)]
-        c = tiles[2, 2].buffer(shape=shapes, dtype=[T.i32()])
+        buff_type = np.ndarray[(10, 10), np.dtype[np.int32]]
+        c = tiles[2, 2].buffer(buff_type)
         # CHECK: MemRef(%buffer_2_2, memref<10x10xi32>)
         print(c)
-        cs = tiles[2:4, 2:4].buffer(shape=shapes, dtype=[T.i32()])
+        cs = tiles[2:4, 2:4].buffer(buff_type)
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) MemRef(%buffer_2_2_0, memref<10x10xi32>)
@@ -395,8 +397,17 @@ def buffer_test_this_needs_to_distinct_from_all_other_mentions_of_buffer_in_this
         for idx, c in np.ndenumerate(cs):
             print(idx, c)
 
-        shapes = [[(1, 2), (3, 4)], [(5, 6), (7, 8)]]
-        cs = tiles[2:4, 2:4].buffer(shape=shapes, dtype=[T.i32()])
+        buff_types = [
+            [
+                np.ndarray[(1, 2), np.dtype[np.int32]],
+                np.ndarray[(3, 4), np.dtype[np.int32]],
+            ],
+            [
+                np.ndarray[(5, 6), np.dtype[np.int32]],
+                np.ndarray[(7, 8), np.dtype[np.int32]],
+            ],
+        ]
+        cs = tiles[2:4, 2:4].buffer(buff_types)
         assert cs.shape == (2, 2)
 
         # CHECK: (0, 0) MemRef(%buffer_2_2_1, memref<1x2xi32>)


### PR DESCRIPTION
This PR cleans up some aspects of using buffers and also RTP writes in conjunction with buffers. Previously, the API could be used something like this (from the `ml/bottleneck` example):
```python
rtpComputeTile5 = Buffer(ComputeTile5, [16], np.int32, "rtpComputeTile5")
...
NpuWriteRTPOp("rtpComputeTile2", index=0, value=1)  # scale
```

With the changes, these code snippets become:
```python
rtpComputeTile2 = buffer(ComputeTile2, np.ndarray[(16,), np.dtype[np.int32]], "rtpComputeTile2", use_write_rtp=True)
...
rtpComputeTile2[0] = 1  # scale
```

I also cleaned up a few examples, for instance replacing a `memref.alloc` with a `buffer` and replacing the last lingering `objectfifo_release()` with the more object-oriented version.