### PR TITLE
Make mat mul single core python files use consistent style/API

### DIFF
--- a/programming_examples/basic/matrix_multiplication/single_core/aie2.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/aie2.py
@@ -106,27 +106,9 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str):
 
         @device(AIEDevice.npu1_1col)
         def device_body():
-            a_ty = np.ndarray[
-                (
-                    m,
-                    k,
-                ),
-                np.dtype[dtype_in],
-            ]
-            b_ty = np.ndarray[
-                (
-                    k,
-                    n,
-                ),
-                np.dtype[dtype_in],
-            ]
-            c_ty = np.ndarray[
-                (
-                    m,
-                    n,
-                ),
-                np.dtype[dtype_out],
-            ]
+            a_ty = np.ndarray[(m, k), np.dtype[dtype_in]]
+            b_ty = np.ndarray[(k, n), np.dtype[dtype_in]]
+            c_ty = np.ndarray[(m, n), np.dtype[dtype_out]]
 
             # AIE Core Function declarations
             func_type = "" if vectorized else "scalar_"


### PR DESCRIPTION
This PR applies recent Python API changes to one of the newer versions of MatMul in order to make sure the files are consistent in style/API/design. It should not change any functionality.

After these changes, the diff between `aie2.py` and `aie2_alt.py` are indeed only the intended changes between the two designs. I did not test beyond what the CI did, as I have tested `aie2.py` with the same code changes in the past.