### PR TITLE
Support specifying vitis components on cmake command line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ set(AIE_RUNTIME_TEST_TARGET
     "x86_64"
     CACHE STRING "Runtime architecture to test with.")
 
+set(AIE_VITIS_COMPONENTS "AIE;AIE2" CACHE STRING "Vitis components")
+
 if(POLICY CMP0068)
   cmake_policy(SET CMP0068 NEW)
   set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
@@ -97,7 +99,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(AIE_TOOLS_BINARY_DIR ${AIE_BINARY_DIR}/bin)
 set(AIE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-find_package(Vitis 2023.2 COMPONENTS AIE AIE2)
+find_package(Vitis 2023.2 COMPONENTS ${AIE_VITIS_COMPONENTS})
 configure_file(./utils/vitisVariables.config.in
                ${CMAKE_BINARY_DIR}/utils/vitisVariables.config @ONLY)
 find_package(XRT)

--- a/mlir_tutorials/CMakeLists.txt
+++ b/mlir_tutorials/CMakeLists.txt
@@ -41,6 +41,8 @@ set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runt
 list(GET AIE_RUNTIME_TARGETS 0 firstRuntimeTarget)
 set(AIE_RUNTIME_TEST_TARGET ${firstRuntimeTarget} CACHE STRING "Runtime architecture to test with.")
 
+set(AIE_VITIS_COMPONENTS "AIE;AIE2" CACHE STRING "Vitis components")
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
@@ -70,7 +72,7 @@ set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 
-find_package(Vitis 2023.2 COMPONENTS AIE AIE2)
+find_package(Vitis 2023.2 COMPONENTS ${AIE_VITIS_COMPONENTS})
 find_package(Python3 COMPONENTS Interpreter)
 
 # Look for LibXAIE

--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -41,6 +41,8 @@ set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runt
 list(GET AIE_RUNTIME_TARGETS 0 firstRuntimeTarget)
 set(AIE_RUNTIME_TEST_TARGET ${firstRuntimeTarget} CACHE STRING "Runtime architecture to test with.")
 
+set(AIE_VITIS_COMPONENTS "AIE;AIE2" CACHE STRING "Vitis components")
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
@@ -68,7 +70,7 @@ set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 
-find_package(Vitis 2023.2 COMPONENTS AIE AIE2)
+find_package(Vitis 2023.2 COMPONENTS ${AIE_VITIS_COMPONENTS})
 find_package(Python3 COMPONENTS Interpreter)
 find_package(XRT)
 find_package(OpenCV)

--- a/programming_guide/CMakeLists.txt
+++ b/programming_guide/CMakeLists.txt
@@ -41,6 +41,8 @@ set(AIE_RUNTIME_TARGETS "x86_64" CACHE STRING "Architectures to compile the runt
 list(GET AIE_RUNTIME_TARGETS 0 firstRuntimeTarget)
 set(AIE_RUNTIME_TEST_TARGET ${firstRuntimeTarget} CACHE STRING "Runtime architecture to test with.")
 
+set(AIE_VITIS_COMPONENTS "AIE;AIE2" CACHE STRING "Vitis components")
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
@@ -68,7 +70,7 @@ set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
 
-find_package(Vitis 2023.2 COMPONENTS AIE AIE2)
+find_package(Vitis 2023.2 COMPONENTS ${AIE_VITIS_COMPONENTS})
 find_package(Python3 COMPONENTS Interpreter)
 find_package(XRT)
 find_package(OpenCV)


### PR DESCRIPTION
Not all aietools support all architectures. For example, Ryzen AI software does not include xchesscc support for aie1. This PR adds support for specifying the "vitis components" to build against on the cmake command line.

Adds `AIE_VITIS_COMPONENTS` as top level cmake option. Defaults to `"AIE;AIE2"` which is no change to the existing behavior.

There will be follow-up PR(s) to propagate `AIE_VITIS_COMPONENTS` to lit testing so that unsupported tests won't run.