### PR TITLE
Update minimum python version in wheels to 3.10

### DIFF
--- a/utils/mlir_aie_wheels/python_bindings/setup.py
+++ b/utils/mlir_aie_wheels/python_bindings/setup.py
@@ -215,7 +215,7 @@ setup(
     ext_modules=[CMakeExtension("_aie", sourcedir=Path(__file__).parent.absolute())],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "aiecc=aie.compiler.aiecc.main:main",

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -269,5 +269,5 @@ setup(
     ext_modules=[CMakeExtension("_mlir_aie", sourcedir=MLIR_AIE_SOURCE_DIR)],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    python_requires=">=3.8",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
https://github.com/Xilinx/mlir-aie/pull/1786 changed the minimum version of Python from 3.8 to 3.10. It appears I missed some updates in the wheels files, so I've updated them here.