### PR TITLE
Add github workflow for testing with Ryzen AI Software.

### DIFF
--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -1,0 +1,133 @@
+name: Build and Test with Ryzen AI Sofware
+
+on:
+  push:
+    branches:
+      - main
+      - ryzen-ai-sw-test
+#  pull_request:
+  workflow_dispatch:
+    inputs:
+      AIE_COMMIT:
+        description: 'which aie commit to build'
+        type: string
+        required: false
+        default: ''
+      LIT_FILTER:
+        description: 'LIT_FILTER for tests (regex of paths in test/)'
+        type: string
+        required: false
+        default: ''
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ci-build-test-ryzenai-tools-linux-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+
+jobs:
+  build-repo:
+    name: Build and Test with Ryzen AI Software
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Free disk space
+        uses: descriptinc/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: false
+
+      - name: Docker prune
+        shell: bash
+        run: |
+          docker system prune -a -f
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: "true"
+      - uses: uraimo/run-on-arch-action@v2.5.0
+        name: Build and Test
+        id: runcmd
+        with:
+          distro: none
+          base_image: ghcr.io/xilinx/mlir-aie/ubuntu22-ryzenai-1.3.0ea
+          githubToken: ${{ github.token }}
+          dockerRunArgs: |
+            --mac-address ${{ secrets.XILINX_MAC }}
+          run: |
+
+            MLIR_DIR=$PWD
+            pushd /workspace
+
+            # this is the inverse of `base64 -w 1000000 Xilinx.lic`
+            # the -w ("wrap after 1000000 cols") is so that there are no spaces in the XILINX_LIC env var
+            echo -n "${{ secrets.XILINX_LIC }}" | base64 --decode > /workspace/Xilinx.lic
+            export XILINXD_LICENSE_FILE=/workspace/Xilinx.lic
+
+            ccrypt -d -K ${{ secrets.RYZEN_AI_SW_KEY }} /workspace/ryzen_ai-1.3.0ea1.tgz.cpt
+            tar xvf /workspace/ryzen_ai-1.3.0ea1.tgz
+            pushd /workspace/ryzen_ai-1.3.0
+            ./install_ryzen_ai_1_3.sh -a yes -p /workspace/venv -l
+            popd
+
+            export LD_LIBRARY_PATH=
+            export PYTHONPATH=
+            source /workspace/venv/bin/activate
+            source /opt/xilinx/xrt/setup.sh
+            popd
+            
+            if [ x"${{ inputs.AIE_COMMIT }}" != x"" ]; then
+              git reset --hard ${{ inputs.AIE_COMMIT }}
+            fi
+
+            pip install onnxruntime==1.17.0
+            pip install -r python/requirements.txt
+            pip install -r python/requirements_ml.txt
+
+            VERSION=$(utils/clone-llvm.sh --get-wheel-version)
+
+            cd /workspace
+            pip -q download mlir==$VERSION \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
+            unzip -q mlir-*.whl
+
+            mkdir -p /workspace/install
+            mkdir -p /workspace/build
+
+            pushd /workspace/build
+
+            cmake $MLIR_DIR -G Ninja \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_EXE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+                -DCMAKE_MODULE_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+                -DCMAKE_SHARED_LINKER_FLAGS_INIT="-fuse-ld=lld" \
+                -DXRT_ROOT=/opt/xilinx/xrt \
+                -DAIE_ENABLE_PYTHON_PASSES=OFF \
+                -DAIE_ENABLE_XRT_PYTHON_BINDINGS=ON \
+                -DAIE_INCLUDE_INTEGRATION_TESTS=OFF \
+                -DAIE_VITIS_COMPOONENTS=AIE2 \
+                -DPython3_EXECUTABLE=$(which python) \
+                -DLLVM_EXTERNAL_LIT=$(which lit) \
+                -DCMAKE_INSTALL_PREFIX=/workspace/install \
+                -DCMAKE_MODULE_PATH=$MLIR_DIR/cmake/modulesXilinx \
+                -DMLIR_DIR=/workspace/mlir/lib/cmake/mlir
+
+            ninja install
+            ninja check-aie
+
+            popd

--- a/aie_kernels/CMakeLists.txt
+++ b/aie_kernels/CMakeLists.txt
@@ -13,7 +13,11 @@ function(add_aie_kernels arch)
     if(EXISTS "${PROJECT_SOURCE_DIR}/tools/chess-clang/xchesscc_wrapper")
         add_custom_target(${arch}_kernels ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/mm.o)
         add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/mm.o
-                      COMMAND ${PROJECT_SOURCE_DIR}/tools/chess-clang/xchesscc_wrapper ${arch} -I ${VITIS_AIETOOLS_DIR}/include -c ${CMAKE_CURRENT_SOURCE_DIR}/mm.cc -o ${CMAKE_CURRENT_BINARY_DIR}/mm.o
+                      COMMAND ${PROJECT_SOURCE_DIR}/tools/chess-clang/xchesscc_wrapper ${arch}
+                        -aietools ${VITIS_AIETOOLS_DIR}
+                        -I ${VITIS_AIETOOLS_DIR}/include
+                        -c ${CMAKE_CURRENT_SOURCE_DIR}/mm.cc
+                        -o ${CMAKE_CURRENT_BINARY_DIR}/mm.o
                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/mm.cc)
         add_dependencies(aie-kernels ${arch}_kernels)
     

--- a/aie_runtime_lib/CMakeLists.txt
+++ b/aie_runtime_lib/CMakeLists.txt
@@ -15,6 +15,7 @@ function(add_aie_runtime_libs arch)
     add_custom_target(${arch}_chess_intrinsic_wrapper ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/chess_intrinsic_wrapper.ll)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/chess_intrinsic_wrapper.ll
             COMMAND ${PROJECT_BINARY_DIR}/bin/xchesscc_wrapper ${arch}
+            -aietools ${AIETOOLS_DIR}
             -c ${CMAKE_CURRENT_SOURCE_DIR}/chess_intrinsic_wrapper.cpp
             -d # Disassemble output
             -f # Use LLVM frontend

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1184,15 +1184,29 @@ def run(mlir_module, args=None):
         opts = aie.compiler.aiecc.cl_arguments.parse_args(args)
 
     opts.aietools_path = None
-    # Try to find vitis in the path
+
+    # If Ryzen AI Software is installed then use it for aietools
+    try:
+        import ryzen_ai.__about__
+
+        version = ryzen_ai.__about__.__version__
+        path = os.path.realpath(ryzen_ai.__path__[0])
+        print(f"Found Ryzen AI software version {version} at {path}")
+        # if ryzenai software is pip installed then the path is something like:
+        # <workdir>/venv/lib/python3.10/site-packages/
+        opts.aietools_path = os.path.realpath(os.path.join(path, ".."))
+    except:
+        pass
+
+    # Try to find xchesscc in the path
     xchesscc_path = shutil.which("xchesscc")
     if xchesscc_path:
         xchesscc_bin_path = os.path.dirname(os.path.realpath(xchesscc_path))
         xchesscc_path = os.path.dirname(xchesscc_bin_path)
-        os.environ["AIETOOLS"] = xchesscc_path
-        print("Found xchesscc at " + xchesscc_path)
+        print(f"Found xchesscc at {xchesscc_path}")
         os.environ["PATH"] = os.pathsep.join([os.environ["PATH"], xchesscc_bin_path])
-        opts.aietools_path = xchesscc_path
+        if opts.aietools_path is None:
+            opts.aietools_path = xchesscc_path
     else:
         print("xchesscc not found.")
 
@@ -1202,7 +1216,6 @@ def run(mlir_module, args=None):
 
     os.environ["AIETOOLS"] = opts.aietools_path
 
-    # This path should be generated from cmake
     aie_path = aie.compiler.aiecc.configure.install_path()
     peano_path = os.path.join(opts.peano_install_dir, "bin")
     os.environ["PATH"] = os.pathsep.join([aie_path, os.environ["PATH"]])

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML>=5.3.1, <=6.0.1
 aiofiles
-cmake==3.27.9
+cmake>=3.29
 dataclasses>=0.6, <=0.8
 filelock==3.13.1
 lit

--- a/test/generate-mmap/allocation_error_chess.mlir
+++ b/test/generate-mmap/allocation_error_chess.mlir
@@ -1,4 +1,4 @@
-//===- allocation_error.mlir -----------------------------------*- MLIR -*-===//
+//===- allocation_error_chess.mlir -----------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/tools/chess-clang/xchesscc_wrapper
+++ b/tools/chess-clang/xchesscc_wrapper
@@ -7,10 +7,19 @@
 # (c) Copyright 2021 Xilinx Inc.
 # (c) Copyright 2022-2024 Advanced Micro Devices, Inc.
 
-AIETOOLS=`realpath $(dirname $(which xchesscc))/../`
-
 TARGET=${1^^}
 shift
+
+# check to see if the next command line argument is -aietools
+if [ "$1" == "-aietools" ]
+  then
+    AIETOOLS=$2
+    shift
+    shift
+fi
+
+AIETOOLS_PATH=`realpath $(dirname $(which xchesscc))/../`
+AIETOOLS="${AIETOOLS:-${AIETOOLS_PATH}}"
 
 if [ $TARGET != "AIE" -a $TARGET != "AIE2" ]
   then
@@ -35,6 +44,7 @@ if [ -z "$AIETOOLS" ]
 fi
 
 LIBDIR=${AIETOOLS}/data/${AIETARGET}/lib
+INCDIR=${AIETOOLS}/include
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-xchesscc --aiearch ${AIEARCH} -p me -C Release_LLVM -D__AIENGINE__ $EXTRA_DEFS -P $LIBDIR -d -f $@
+xchesscc --aiearch ${AIEARCH} -p me -C Release_LLVM -D__AIENGINE__ $EXTRA_DEFS -I $INCDIR -P $LIBDIR -d -f $@


### PR DESCRIPTION
Add CI testing for building with aietools from [Ryzen AI Software](https://www.amd.com/en/developer/resources/ryzen-ai-software.html). The tests currently run in an Ubuntu 22 docker with xrt and xdna-driver pre-installed. Ryzen AI Software pre-download into the docker and is installed as part of the build process. It is not pre-installed because I read [somewhere ](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#troubleshooting) that docker layers are limited to 10GB.

* aiecc.py: Add detection of aietools installed via Ryzen AI Software.
* `xchesscc_wrapper`: Add `-aietools` flag to override default aietools path (which is derived from xchesscc path). 
* bump cmake in `requirements.txt` to >= 3.29 to be compatible with venv created by Ryzen AI Software installer