### PR TITLE
Filter tests based on available Vitis cmake components

### DIFF
--- a/mlir_tutorials/CMakeLists.txt
+++ b/mlir_tutorials/CMakeLists.txt
@@ -119,11 +119,6 @@ set(CONFIG_ENABLE_BOARD_TESTS 1)
 else()
 set(CONFIG_ENABLE_BOARD_TESTS 0)
 endif()
-if(LibXAIE_FOUND)
-set(CONFIG_HAS_LIBXAIE 1)
-else()
-set(CONFIG_HAS_LIBXAIE 0)
-endif()
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/mlir_tutorials/lit.local.cfg
+++ b/mlir_tutorials/lit.local.cfg
@@ -5,7 +5,5 @@
 #
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
 
-config.unsupported = []
-
-if not config.has_libxaie:
-    config.unsupported = ['tutorials']
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True

--- a/mlir_tutorials/lit.site.cfg.py.in
+++ b/mlir_tutorials/lit.site.cfg.py.in
@@ -9,6 +9,7 @@
 @LIT_SITE_CFG_IN_HEADER@
 
 import sys
+import lit.util
 
 config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@TARGET_TRIPLE@"
@@ -49,10 +50,15 @@ config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"
 config.aieInstallPrefix = "@CMAKE_INSTALL_PREFIX@"
+
+config.vitis_components = []
+if lit.util.pythonize_bool("@AIETools_AIE_FOUND@"):
+    config.vitis_components.append("AIE")
+if lit.util.pythonize_bool("@AIETools_AIE2_FOUND@"):
+    config.vitis_components.append("AIE2")
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -120,11 +120,6 @@ set(CONFIG_ENABLE_BOARD_TESTS 1)
 else()
 set(CONFIG_ENABLE_BOARD_TESTS 0)
 endif()
-if(LibXAIE_FOUND)
-set(CONFIG_HAS_LIBXAIE 1)
-else()
-set(CONFIG_HAS_LIBXAIE 0)
-endif()
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/programming_examples/basic/lit.local.cfg
+++ b/programming_examples/basic/lit.local.cfg
@@ -6,4 +6,6 @@
 # (c) Copyright 2023 AMD Inc.
 
 config.suffixes = ['.lit']
-config.unsupported = []
+
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -247,9 +247,10 @@ try:
 except Exception as e:
     print("Peano not found, but expected at ", config.peano_tools_dir)
 
-print("Looking for Chess...")
-# test if LM_LICENSE_FILE valid
-if config.enable_chess_tests:
+if not config.enable_chess_tests:
+    print("Chess tests disabled")
+else:
+    print("Looking for Chess...")
     result = None
     if config.vitis_root:
         result = shutil.which("xchesscc")
@@ -265,6 +266,7 @@ if config.enable_chess_tests:
         if xilinxd_license_file != None:
             llvm_config.with_environment("XILINXD_LICENSE_FILE", xilinxd_license_file)
 
+        # test if LM_LICENSE_FILE valid
         validate_chess = False
         if validate_chess:
             import subprocess
@@ -287,6 +289,14 @@ if config.enable_chess_tests:
         )
     else:
         print("Chess not found")
+
+# look for aiesimulator
+result = shutil.which("aiesimulator")
+if result != None:
+    print("aiesimulator found: " + result)
+    config.available_features.add("aiesimulator")
+else:
+    print("aiesimulator not found")
 
 # add vitis components as available features
 for c in config.vitis_components:

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -288,6 +288,10 @@ if config.enable_chess_tests:
     else:
         print("Chess not found")
 
+# add vitis components as available features
+for c in config.vitis_components:
+    config.available_features.add(f"aietools_{c.lower()}")
+
 tool_dirs = [config.aie_tools_dir, config.peano_tools_dir, config.llvm_tools_dir]
 tools = [
     "aie-opt",

--- a/programming_examples/lit.local.cfg
+++ b/programming_examples/lit.local.cfg
@@ -4,8 +4,3 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
-
-config.unsupported = []
-
-if not config.has_libxaie:
-    config.unsupported = ["programming_examples"]

--- a/programming_examples/lit.site.cfg.py.in
+++ b/programming_examples/lit.site.cfg.py.in
@@ -60,10 +60,15 @@ config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"
 config.aieInstallPrefix = "@CMAKE_INSTALL_PREFIX@"
+
+config.vitis_components = []
+if lit.util.pythonize_bool("@AIETools_AIE_FOUND@"):
+    config.vitis_components.append("AIE")
+if lit.util.pythonize_bool("@AIETools_AIE2_FOUND@"):
+    config.vitis_components.append("AIE2")
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/programming_examples/ml/lit.local.cfg
+++ b/programming_examples/ml/lit.local.cfg
@@ -6,7 +6,6 @@
 # (c) Copyright 2023 AMD Inc.
 
 config.suffixes = ['.lit']
-config.unsupported = []
 
-if not config.has_libxaie:
-    config.unsupported = ['ml']
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True

--- a/programming_examples/mlir/horizontal_diffusion/lit.local.cfg
+++ b/programming_examples/mlir/horizontal_diffusion/lit.local.cfg
@@ -5,4 +5,4 @@
 #
 # (c) Copyright 2023 AMD Inc.
 
-config.unsupported = ['horizontal_diffusion']
+config.unsupported = True

--- a/programming_examples/mlir/lit.local.cfg
+++ b/programming_examples/mlir/lit.local.cfg
@@ -6,7 +6,6 @@
 # (c) Copyright 2023 AMD Inc.
 
 config.suffixes = ['.lit']
-config.unsupported = []
 
-if not config.has_libxaie:
-    config.unsupported = ['mlir']
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True

--- a/programming_examples/mlir/prime_sieve_large/lit.local.cfg
+++ b/programming_examples/mlir/prime_sieve_large/lit.local.cfg
@@ -5,4 +5,4 @@
 #
 # (c) Copyright 2023 AMD Inc.
 
-config.unsupported = ['prime_sieve_large']
+config.unsupported = True

--- a/programming_examples/vision/lit.local.cfg
+++ b/programming_examples/vision/lit.local.cfg
@@ -6,7 +6,6 @@
 # (c) Copyright 2023 AMD Inc.
 
 config.suffixes = ['.lit']
-config.unsupported = []
 
-if not config.has_libxaie:
-    config.unsupported = ['vision']
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True

--- a/programming_guide/CMakeLists.txt
+++ b/programming_guide/CMakeLists.txt
@@ -120,11 +120,6 @@ set(CONFIG_ENABLE_BOARD_TESTS 1)
 else()
 set(CONFIG_ENABLE_BOARD_TESTS 0)
 endif()
-if(LibXAIE_FOUND)
-set(CONFIG_HAS_LIBXAIE 1)
-else()
-set(CONFIG_HAS_LIBXAIE 0)
-endif()
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -247,9 +247,10 @@ try:
 except Exception as e:
     print("Peano not found, but expected at ", config.peano_tools_dir)
 
-print("Looking for Chess...")
-# test if LM_LICENSE_FILE valid
-if config.enable_chess_tests:
+if not config.enable_chess_tests:
+    print("Chess tests disabled")
+else:
+    print("Looking for Chess...")
     result = None
     if config.vitis_root:
         result = shutil.which("xchesscc")
@@ -265,6 +266,7 @@ if config.enable_chess_tests:
         if xilinxd_license_file != None:
             llvm_config.with_environment("XILINXD_LICENSE_FILE", xilinxd_license_file)
 
+        # test if LM_LICENSE_FILE valid
         validate_chess = False
         if validate_chess:
             import subprocess
@@ -287,6 +289,14 @@ if config.enable_chess_tests:
         )
     else:
         print("Chess not found")
+
+# look for aiesimulator
+result = shutil.which("aiesimulator")
+if result != None:
+    print("aiesimulator found: " + result)
+    config.available_features.add("aiesimulator")
+else:
+    print("aiesimulator not found")
 
 # add vitis components as available features
 for c in config.vitis_components:

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -288,6 +288,10 @@ if config.enable_chess_tests:
     else:
         print("Chess not found")
 
+# add vitis components as available features
+for c in config.vitis_components:
+    config.available_features.add(f"aietools_{c.lower()}")
+
 tool_dirs = [config.aie_tools_dir, config.peano_tools_dir, config.llvm_tools_dir]
 tools = [
     "aie-opt",

--- a/programming_guide/lit.local.cfg
+++ b/programming_guide/lit.local.cfg
@@ -5,9 +5,7 @@
 #
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
 
-config.unsupported = []
-
 config.suffixes = ['.lit']
 
-if not config.has_libxaie:
-    config.unsupported = ["programming_guide"]
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True

--- a/programming_guide/lit.site.cfg.py.in
+++ b/programming_guide/lit.site.cfg.py.in
@@ -60,10 +60,15 @@ config.enable_board_tests = @CONFIG_ENABLE_BOARD_TESTS@
 config.vitis_root = "@VITIS_ROOT@"
 config.vitis_aietools_dir = "@VITIS_AIETOOLS_DIR@"
 config.vitis_sysroot = "@Sysroot@"
-config.has_libxaie = @CONFIG_HAS_LIBXAIE@
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"
 config.aieInstallPrefix = "@CMAKE_INSTALL_PREFIX@"
+
+config.vitis_components = []
+if lit.util.pythonize_bool("@AIETools_AIE_FOUND@"):
+    config.vitis_components.append("AIE")
+if lit.util.pythonize_bool("@AIETools_AIE2_FOUND@"):
+    config.vitis_components.append("AIE2")
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1194,7 +1194,13 @@ def run(mlir_module, args=None):
         os.environ["PATH"] = os.pathsep.join([os.environ["PATH"], xchesscc_bin_path])
         opts.aietools_path = xchesscc_path
     else:
-        print("xchesscc not found...")
+        print("xchesscc not found.")
+
+    if opts.aietools_path is None:
+        print("Could not find aietools from Vitis or Ryzen AI Software.")
+        opts.aietools_path = "<aietools not found>"
+
+    os.environ["AIETOOLS"] = opts.aietools_path
 
     # This path should be generated from cmake
     aie_path = aie.compiler.aiecc.configure.install_path()

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1183,7 +1183,7 @@ def run(mlir_module, args=None):
     if args is not None:
         opts = aie.compiler.aiecc.cl_arguments.parse_args(args)
 
-    opts.aietools_path = ""
+    opts.aietools_path = None
     # Try to find vitis in the path
     xchesscc_path = shutil.which("xchesscc")
     if xchesscc_path:

--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -8,8 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: chess
-// RUN: %PYTHON aiecc.py --xchesscc --no-link -nv --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s 
+// RUN: %PYTHON aiecc.py --no-compile --no-link -nv --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s 
 // RUN: FileCheck %s --input-file=buffers_xclbin.mlir.prj/kernels.json
 
 // CHECK: {

--- a/test/aiecc/simple.mlir
+++ b/test/aiecc/simple.mlir
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: chess
+// REQUIRES: peano
+
 // RUN: %PYTHON aiecc.py --compile --xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
 // RUN: %PYTHON aiecc.py --compile --no-xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
 // RUN: %PYTHON aiecc.py --no-compile --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE

--- a/test/aiecc/simple_aie2.mlir
+++ b/test/aiecc/simple_aie2.mlir
@@ -8,6 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// REQUIRES: chess
+// REQUIRES: peano
+
 // RUN: %PYTHON aiecc.py --compile --xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=XCHESSCC
 // RUN: %PYTHON aiecc.py --compile --no-xchesscc --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=PEANO
 // RUN: %PYTHON aiecc.py --no-compile --no-link -nv %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o test.elf | FileCheck %s --check-prefix=NOCOMPILE

--- a/test/benchmarks/lit.local.cfg
+++ b/test/benchmarks/lit.local.cfg
@@ -5,7 +5,8 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
-config.unsupported = []
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True
 
 if not config.enable_chess_tests:
     config.unsupported = True

--- a/test/generate-mmap/allocation_error_chess.mlir
+++ b/test/generate-mmap/allocation_error_chess.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: chess
+// REQUIRES: chess, aietools_aie
 // RUN: not aiecc.py --basic-alloc-scheme --xchesscc --xbridge %s 2>&1 | FileCheck %s --check-prefix=CHESS
 // CHESS: Error: could not find free space for SpaceSymbol x in memory DMb
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -294,6 +294,10 @@ if config.enable_chess_tests:
     else:
         print("Chess not found")
 
+# add vitis components as available features
+for c in config.vitis_components:
+    config.available_features.add(f"aietools_{c.lower()}")
+
 tools = [
     "aie-opt",
     "aie-translate",

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -253,9 +253,10 @@ try:
 except Exception as e:
     print("Peano not found, but expected at ", peano_tools_dir)
 
-print("Looking for Chess...")
-# test if LM_LICENSE_FILE valid
-if config.enable_chess_tests:
+if not config.enable_chess_tests:
+    print("Chess tests disabled")
+else:
+    print("Looking for Chess...")
     result = None
     if config.vitis_root:
         result = shutil.which("xchesscc")
@@ -271,6 +272,7 @@ if config.enable_chess_tests:
         if xilinxd_license_file != None:
             llvm_config.with_environment("XILINXD_LICENSE_FILE", xilinxd_license_file)
 
+        # test if LM_LICENSE_FILE valid
         validate_chess = False
         if validate_chess:
             import subprocess
@@ -293,6 +295,14 @@ if config.enable_chess_tests:
         )
     else:
         print("Chess not found")
+
+# look for aiesimulator
+result = shutil.which("aiesimulator")
+if result != None:
+    print("aiesimulator found: " + result)
+    config.available_features.add("aiesimulator")
+else:
+    print("aiesimulator not found")
 
 # add vitis components as available features
 for c in config.vitis_components:

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -58,7 +58,6 @@ config.enable_board_tests = lit.util.pythonize_bool("@ENABLE_BOARD_TESTS@")
 config.enable_python_tests = lit.util.pythonize_bool("@ENABLE_PYTHON_TESTS@")
 config.python_passes = lit.util.pythonize_bool("@AIE_ENABLE_PYTHON_PASSES@")
 config.xrt_python_bindings = lit.util.pythonize_bool("@AIE_ENABLE_XRT_PYTHON_BINDINGS@")
-config.has_libxaie = lit.util.pythonize_bool("@LibXAIE_FOUND@")
 config.has_mlir_runtime_libraries = lit.util.pythonize_bool("@HAS_MLIR_RUNTIME_LIBRARIES@")
 config.aie_enable_airbin = lit.util.pythonize_bool("@AIE_ENABLE_AIRBIN@")
 
@@ -69,6 +68,12 @@ config.vitis_sysroot = "@Sysroot@"
 config.extraAieCcFlags = "@extraAieCcFlags@"
 config.aieHostTarget = "@AIE_RUNTIME_TEST_TARGET@"
 config.aieInstallPrefix = "@CMAKE_INSTALL_PREFIX@"
+
+config.vitis_components = []
+if lit.util.pythonize_bool("@AIETools_AIE_FOUND@"):
+    config.vitis_components.append("AIE")
+if lit.util.pythonize_bool("@AIETools_AIE2_FOUND@"):
+    config.vitis_components.append("AIE2")
 
 # Support substitution of the tools_dir with user parameters. This is
 # used when we can't determine the tool dir at configuration time.

--- a/test/npu-xrt/lit.local.cfg
+++ b/test/npu-xrt/lit.local.cfg
@@ -6,9 +6,7 @@
 
 config.suffixes = [".lit", ".py"]
 
-# if "ryzen_ai" not in config.available_features:
-#     config.unsupported = ["npu-xrt"]
-# else:
-#     config.unsupported = []
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True
 
 config.excludes.add("util.py")

--- a/test/objectFifo_tests/lit.local.cfg
+++ b/test/objectFifo_tests/lit.local.cfg
@@ -6,7 +6,5 @@
 # Copyright (C) 2022, Xilinx Inc.
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
 
-config.unsupported = []
-
-if not config.has_libxaie:
-    config.unsupported = ['objectFifo_tests']
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True

--- a/test/python/aiecc_simple.py
+++ b/test/python/aiecc_simple.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2023, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+# REQUIRES: chess
+
 # RUN: %PYTHON %s --compile --xchesscc --no-link -nv | FileCheck %s
 
 # CHECK: xchesscc_wrapper aie

--- a/test/unit_tests/aie/29_aie2_nd_dma_even_odd/aie.mlir
+++ b/test/unit_tests/aie/29_aie2_nd_dma_even_odd/aie.mlir
@@ -23,7 +23,7 @@
 // The DMA receives this data and writes it to a buffer linearly, which is
 // checked from the host code to be correct.
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %extraAieCcFlags% %S/test.cpp -o test.elf
 // RUN: %run_on_vck5000 ./test.elf
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s

--- a/test/unit_tests/aie/30_aie2_nd_dma_transpose_repeat/aie.mlir
+++ b/test/unit_tests/aie/30_aie2_nd_dma_transpose_repeat/aie.mlir
@@ -11,7 +11,7 @@
 // This tests the multi-dimensional (n-D) address generation function of AIE2
 // buffer descriptors.
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %extraAieCcFlags% %S/test.cpp -o test.elf
 // RUN: %run_on_vck5000 ./test.elf
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s

--- a/test/unit_tests/aie/31_stream_core/aie.mlir
+++ b/test/unit_tests/aie/31_stream_core/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: peano, !hsa
+// REQUIRES: aiesimulator, peano, !hsa
 
 // RUN: %PYTHON aiecc.py --aiesim --no-xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/aie/lit.local.cfg
+++ b/test/unit_tests/aie/lit.local.cfg
@@ -1,7 +1,9 @@
+#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023 AMD Inc.
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
-config.unsupported = True
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True

--- a/test/unit_tests/aie2/lit.local.cfg
+++ b/test/unit_tests/aie2/lit.local.cfg
@@ -1,7 +1,9 @@
+#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023 AMD Inc.
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
-config.unsupported = True
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True

--- a/test/unit_tests/aievec_tests/aie/lit.local.cfg
+++ b/test/unit_tests/aievec_tests/aie/lit.local.cfg
@@ -1,0 +1,12 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
+
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True
+
+if 'aiesimulator' not in config.available_features:
+    config.unsupported = True

--- a/test/unit_tests/aievec_tests/aie2/lit.local.cfg
+++ b/test/unit_tests/aievec_tests/aie2/lit.local.cfg
@@ -5,5 +5,8 @@
 #
 # Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
-if 'AIE' not in config.vitis_components:
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True
+
+if 'aiesimulator' not in config.available_features:
     config.unsupported = True

--- a/test/unit_tests/aievec_tests/lit.local.cfg
+++ b/test/unit_tests/aievec_tests/lit.local.cfg
@@ -1,7 +1,9 @@
+#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023 AMD Inc.
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
-config.unsupported = True
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True

--- a/test/unit_tests/chess_compiler_tests/01_precompiled_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/01_precompiled_core_function/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py --aiesim --xbridge --xchesscc %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/chess_compiler_tests/02_precompiled_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/02_precompiled_kernel/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: xchesscc_wrapper aie +l aie.mlir.prj/core_1_3.bcf %S/kernel.cc -o custom_1_3.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/chess_compiler_tests/04_shared_memory/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shared_memory/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: !hsa
+// REQUIRES: aiesimulator, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %extraAieCcFlags% %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s

--- a/test/unit_tests/chess_compiler_tests/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shared_memory/aie_row.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: !hsa
+// REQUIRES: aiesimulator, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s %test_lib_flags %extraAieCcFlags% %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 // RUN: aie_row.mlir.prj/aiesim.sh | FileCheck %s

--- a/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: xchesscc_wrapper aie +l aie.mlir.prj/core_7_3.bcf %S/kernel.cc -o custom_7_3.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py --aiesim --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 //  clang -O2 --target=aie -c %S/kernel.cc
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf

--- a/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/08_tile_locks/aie.mlir
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %link_against_hsa% %s %test_lib_flags %S/test.cpp -o test.elf
 // RUN: %run_on_board ./test.elf
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s

--- a/test/unit_tests/chess_compiler_tests/lit.local.cfg
+++ b/test/unit_tests/chess_compiler_tests/lit.local.cfg
@@ -1,7 +1,9 @@
+#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023 AMD Inc.
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
-config.unsupported = True
+if 'AIE' not in config.vitis_components:
+    config.unsupported = True

--- a/test/unit_tests/chess_compiler_tests_aie2/01_precompiled_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/01_precompiled_core_function/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py -v --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s

--- a/test/unit_tests/chess_compiler_tests_aie2/02_precompiled_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/02_precompiled_kernel/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: xchesscc_wrapper aie2 +l aie.mlir.prj/core_1_3.bcf %S/kernel.cc -o custom_1_3.elf
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s

--- a/test/unit_tests/chess_compiler_tests_aie2/03_cascade_core_functions/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/03_cascade_core_functions/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s

--- a/test/unit_tests/chess_compiler_tests_aie2/03_simple/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/03_simple/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie.mlir
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge %s %test_lib_flags %S/test.cpp
 // RUN: aie.mlir.prj/aiesim.sh | FileCheck %s
 

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie_row.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shared_memory/aie_row.mlir
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: aie_row.mlir.prj/aiesim.sh | FileCheck %s
 

--- a/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/04_shim_dma_kernel/aie.mlir
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !!hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !!hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: xchesscc_wrapper aie2 +l aie.mlir.prj/core_7_3.bcf %S/kernel.cc -o custom_7_3.elf
 

--- a/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/05_shim_dma_core_function/aie.mlir
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 

--- a/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/07_shim_dma_core_function_with_loop/aie.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: xchesscc_wrapper aie2 -c %S/kernel.cc
 // RUN: %PYTHON aiecc.py --aiesim --chesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 

--- a/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/08_tile_locks/aie.mlir
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 

--- a/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests_aie2/09_memtile_locks/aie.mlir
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: valid_xchess_license, !hsa
+// REQUIRES: aiesimulator, valid_xchess_license, !hsa
 // RUN: %PYTHON aiecc.py --aiesim --xchesscc --xbridge --no-compile-host %s %test_lib_flags %S/test.cpp
 // RUN: sh -c 'aie.mlir.prj/aiesim.sh; exit 0' | FileCheck %s
 

--- a/test/unit_tests/chess_compiler_tests_aie2/lit.local.cfg
+++ b/test/unit_tests/chess_compiler_tests_aie2/lit.local.cfg
@@ -1,7 +1,9 @@
+#
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023 AMD Inc.
+# Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
 
-config.unsupported = True
+if 'AIE2' not in config.vitis_components:
+    config.unsupported = True

--- a/test/unit_tests/lit.local.cfg
+++ b/test/unit_tests/lit.local.cfg
@@ -5,14 +5,6 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
-config.unsupported = []
-
-if not config.has_libxaie:
-    config.unsupported = ['unit_tests']
-
-if not config.enable_chess_tests:
-    config.unsupported += 'unit_tests/aievec_tests'
-
 if config.enable_chess_tests:
     # args for using xchesscc_wrapper
     xchesscc_aie2_args = 'aie2 -f -g +s'
@@ -35,5 +27,3 @@ if "peano" in config.available_features:
     config.substitutions.append(('%vector-to-llvmir%', vector_to_aievec+' '+aievec_to_llvmir))
     config.substitutions.append(('%vector-to-generic-llvmir%', vector_to_generic_llvmir))
     config.substitutions.append(('%llvmir-to-ll%', llvmir_to_ll))
-
-


### PR DESCRIPTION
Not all aietools installations have support for every AIE architecture and not all installations contain `aiesimulator`. This PR adds lit test filtering based on which vitis cmake components are found (`AIE`, `AIE2`, `AIE2p`, etc), and adds filtering based on whether aiesimulator is installed.

For lit testsing each component found corresponds to an `"aietools_<lower case component>"` feature being available. For example if AIE2 support is found by cmake, then `aietools_aie2` will be an available feature. Available components are also stored in the `config.vitis_components` list. This PR generally filters test by entire test directories by querying `config.vitis_components` and setting `config.unsupported` where appropriate. 

Example lit script usage:
```
// REQUIRES: aiesimulator, aietools_aie2, chess
```

This PR also removes `config.has_libxaie` which seems to have overlapping but bit rotted functionality. 
This PR also fixes use of `config.unsupported` to match upstream usage by only setting it to `True` instead of to a directory name.
