### PR TITLE
Set build target in util/build... scripts.

### DIFF
--- a/utils/build-llvm-local.sh
+++ b/utils/build-llvm-local.sh
@@ -15,12 +15,14 @@
 # <llvm dir>    - optional, default is 'llvm'
 # <build dir>   - optional, default is 'build' (for llvm/build)
 # <install dir> - optional, default is 'install' (for llvm/install)
+# <target>      - optional, default is 'X86'
 #
 ##===----------------------------------------------------------------------===##
 
 LLVM_DIR=${1:-"llvm"}
 BUILD_DIR=${2:-"build"}
 INSTALL_DIR=${3:-"install"}
+BUILD_TARGET=${4:-"X86"}
 
 mkdir -p $LLVM_DIR/$BUILD_DIR
 mkdir -p $LLVM_DIR/$INSTALL_DIR
@@ -44,7 +46,7 @@ CMAKE_CONFIGS="\
   -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
   -DCMAKE_INSTALL_PREFIX=../$INSTALL_DIR \
   -DLLVM_ENABLE_PROJECTS=mlir \
-  -DLLVM_TARGETS_TO_BUILD:STRING=X86;ARM;AArch64 \
+  -DLLVM_TARGETS_TO_BUILD:STRING=$BUILD_TARGET \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON \
   -DCMAKE_VISIBILITY_INLINES_HIDDEN=ON \

--- a/utils/build-mlir-aie.sh
+++ b/utils/build-mlir-aie.sh
@@ -15,6 +15,7 @@
 #
 # <build dir>    - optional, mlir-aie/build dir name, default is 'build'
 # <install dir>  - optional, mlir-aie/install dir name, default is 'install'
+# <target>       - optional, target to build for, default is 'x86_64'
 #
 ##===----------------------------------------------------------------------===##
 
@@ -31,6 +32,7 @@ echo "LLVM BUILD DIR: $LLVM_BUILD_DIR"
 
 BUILD_DIR=${2:-"build"}
 INSTALL_DIR=${3:-"install"}
+BUILD_TARGET=${4:-"x86_64"}
 LLVM_ENABLE_RTTI=${LLVM_ENABLE_RTTI:OFF}
 
 mkdir -p $BUILD_DIR
@@ -52,9 +54,9 @@ CMAKE_CONFIGS="\
     -DCMAKE_CXX_VISIBILITY_PRESET=hidden \
     -DLLVM_ENABLE_ASSERTIONS=ON \
     -DLLVM_ENABLE_RTTI=$LLVM_ENABLE_RTTI \
-    -DAIE_RUNTIME_TARGETS=x86_64;aarch64 \
+    -DAIE_RUNTIME_TARGETS=$BUILD_TARGET \
     -DAIE_ENABLE_PYTHON_PASSES=OFF \
-    -DAIE_RUNTIME_TEST_TARGET=aarch64"
+    -DAIE_RUNTIME_TEST_TARGET=$BUILD_TARGET"
 
 if [ -x "$(command -v lld)" ]; then
   CMAKE_CONFIGS="${CMAKE_CONFIGS} -DLLVM_USE_LINKER=lld"


### PR DESCRIPTION
Setting the target explicitly saves time (not building things you don't need, particularly in the context of llvm).

Explicitly setting the target also helps address https://github.com/Xilinx/mlir-aie/issues/1849