### PR TITLE
Don't pollute source tree during lit testing

### DIFF
--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile.lit
@@ -3,6 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
+// RUN: mkdir -p test
+// RUN: cd test
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
 // RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_chess.lit
@@ -3,6 +3,8 @@
 //
 // REQUIRES: ryzen_ai, chess 
 //
+// RUN: mkdir -p test_chess
+// RUN: cd test_chess
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess
 // RUN: %run_on_npu make -f %S/Makefile.chess run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_1
-// RUN: cd %S/test_1
+// RUN: mkdir -p test_1
+// RUN: cd test_1
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
 // RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_1.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_1.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_2
-// RUN: cd %S/test_2
+// RUN: mkdir -p test_2
+// RUN: cd test_2
 // RUN: make -f %S/Makefile clean
 // RUN: env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile 
 // RUN: %run_on_npu env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_alt.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_alt.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_alt
-// RUN: cd %S/test_alt
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
 // RUN: make -f %S/Makefile clean
 // RUN: env use_alt=1 make -f %S/Makefile 
 // RUN: %run_on_npu env use_alt=1 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_chess.lit
@@ -3,6 +3,8 @@
 //
 // REQUIRES: ryzen_ai, chess 
 //
+// RUN: mkdir -p test_chess
+// RUN: cd test_chess
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess
 // RUN: %run_on_npu make -f %S/Makefile.chess run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_i8.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_i8.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_i8
-// RUN: cd %S/test_i8
+// RUN: mkdir -p test_i8
+// RUN: cd test_i8
 // RUN: make -f %S/Makefile clean
 // RUN: env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile 
 // RUN: %run_on_npu env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_1_col
-// RUN: cd %S/test_1_col
+// RUN: mkdir -p test_1_col
+// RUN: cd test_1_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=1 make -f %S/Makefile 
 // RUN: %run_on_npu env n_aie_cols=2 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_2_col
-// RUN: cd %S/test_2_col
+// RUN: mkdir -p test_2_col
+// RUN: cd test_2_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=2 make -f %S/Makefile 
 // RUN: %run_on_npu env n_aie_cols=2 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_4_col
-// RUN: cd %S/test_4_col
+// RUN: mkdir -p test_4_col
+// RUN: cd test_4_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=4 make -f %S/Makefile 
 // RUN: %run_on_npu env n_aie_cols=4 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_4_col_i8
-// RUN: cd %S/test_4_col_i8
+// RUN: mkdir -p test_4_col_i8
+// RUN: cd test_4_col_i8
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile 
 // RUN: %run_on_npu env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_chess.lit
@@ -3,6 +3,8 @@
 //
 // REQUIRES: ryzen_ai, chess 
 //
+// RUN: mkdir -p test_chess
+// RUN: cd test_chess
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess
 // RUN: %run_on_npu make -f %S/Makefile.chess run | FileCheck %s

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: mkdir -p %S/test_b_col_maj
-// RUN: cd %S/test_b_col_maj
+// RUN: mkdir -p test_b_col_maj
+// RUN: cd test_b_col_maj
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=4 b_col_maj=1 dtype_in=bf16 dtype_out=f32 M=256 K=256 N=256 m=32 k=32 n=32 make -f %S/Makefile 
 // RUN: %run_on_npu env n_aie_cols=4 b_col_maj=1 dtype_in=bf16 dtype_out=f32 M=256 K=256 N=256 m=32 k=32 n=32 make -f %S/Makefile run | FileCheck %s


### PR DESCRIPTION
avoiding this,
```
$ git clean -xfd
Removing basic/matrix_multiplication/single_core/test_1/
Removing basic/matrix_multiplication/single_core/test_2/
Removing basic/matrix_multiplication/single_core/test_alt/
Removing basic/matrix_multiplication/single_core/test_i8/
Removing basic/matrix_multiplication/whole_array/test_1_col/
Removing basic/matrix_multiplication/whole_array/test_2_col/
Removing basic/matrix_multiplication/whole_array/test_4_col/
Removing basic/matrix_multiplication/whole_array/test_4_col_i8/
Removing basic/matrix_multiplication/whole_array/test_b_col_maj/
```
Also fix some rare collisions where tests run in the same directory, e.g. in `matrix_multiplication/matrix_vector`.