### PR TITLE
Revert "Enable buildAndTestRyzenAISw workflow for PRs (#1854)"

### DIFF
--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - ryzen-ai-sw-test
-  pull_request:
+#  pull_request:
   workflow_dispatch:
     inputs:
       AIE_COMMIT:


### PR DESCRIPTION
This reverts commit 717e85d8846338eaa20450c9a2b9226f0efffcaf.

We don't want to do this, because the github secrets used by the docker container are not usable by PRs from forks.