### PR TITLE
Fix CI error for buildAndTestRyzenAI Examples

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -139,6 +139,12 @@ jobs:
           source utils/quick_setup.sh
           # quick_setup changes directory to programming_examples, so we need to return to mlir-aie
           cd ..
+
+          # I have no clue why but the system clock on GHA containers is like 12 hours ahead.
+          # That means wheels have file with time stamps in the future which makes ninja loop
+          # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
+          find my_install/mlir -exec touch -a -m -t 201108231405.14 {} \;
+
           ./utils/build-mlir-aie-from-wheels.sh ./my_install/mlir build install ./my_install/llvm-aie
 
           # build is created by the build-mlir-aie-from-wheels.sh script


### PR DESCRIPTION
This PR applies a timestamp fix which is supposed to stop ninja from looping indefinitely after mlir is downloaded. In another PR, I was seeing CI jobs for the buildAndTestRyzenAI Run Examples task with error:
```
ninja: error: manifest 'build.ninja' still dirty after 100 tries
```

This is already applied in other CI actions, but does not apply after my changes to the buildAndTestRyzenAI Examples task, which was recently changed to use the `quick_setup` script.