### PR TITLE
Reduce duplicate global data in aie-dma-to-npu pass

### DIFF
--- a/test/Targets/NPU/npu_dma_memcpy.mlir
+++ b/test/Targets/NPU/npu_dma_memcpy.mlir
@@ -10,7 +10,7 @@
 
 // RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
 
-// CHECK: memref.global "private" constant {{.*}} : memref<8xi32> = dense<[2048, 16384, 0, 33554432, -2113929153, 2047, 0, 33554432]>
+// CHECK: memref.global "private" constant {{.*}} : memref<8xi32> = dense<[2048, 0, 0, 33554432, -2113929153, 2047, 0, 33554432]>
 // CHECK: aiex.runtime_sequence
 // CHECK:   %[[VALUE:.*]] = memref.get_global {{.*}} : memref<8xi32>
 // CHECK:   aiex.npu.blockwrite(%[[VALUE]]) {address = 118784 : ui32} : memref<8xi32>


### PR DESCRIPTION
This adds an optimization in the `WriteBdToBlockWritePattern` of the `aie-dma-to-npu` lowering pass to look for existing constant global data before emitting new constant global data. This helps with program sequences repeatedly writing the same pattern. For example `test/npu-xrt/ctrl_packet_reconfig_1x4_cores` generates ~575 small shim dma transfers and this reduces the number of global constant ops from 600 to 41.

I'll note I tried to do this as a simple rewrite pattern to cleanup after the fact but found it extremely slow, with slowdown measured in seconds. I think it was from the lookup and manipulation of things in the symbol table with upstream apis like replaceAllSymbolUses and getSymbolUses.
