### PR TITLE
Make pre-allocated buffers work again

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -175,7 +175,7 @@ checkAndAddBufferWithAddress(BufferOp buffer, int numBanks,
   int addr = addrAttr.getInt();
   for (int i = 0; i < numBanks; i++) {
     // if the address is not within the bank, continue
-    if (addr < bankLimits[i].startAddr && addr >= bankLimits[i].endAddr)
+    if (addr < bankLimits[i].startAddr || addr >= bankLimits[i].endAddr)
       continue;
 
     // if the allocator already overwrote this address, fail

--- a/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEAssignBuffers.cpp
@@ -100,7 +100,7 @@ LogicalResult basicAllocation(TileOp tile) {
     address += stacksize;
   }
 
-  // As the next address to allocate is assigned, skip over any buffers with the
+  // As the next address to allocate is assigned, skip over any buffers
   // from the allocated_buffers list.
   auto current_alloc = allocated_buffers.begin();
   for (auto buffer : buffers) {

--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -147,7 +147,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--alloc-scheme",
         dest="alloc_scheme",
-        default=None,
+        default="bank-aware",
         help="Allocation scheme for AIE buffers: basic-sequential, bank-aware (default).",
     )
     parser.add_argument(

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -34,32 +34,30 @@ from aie.dialects import aie as aiedialect
 from aie.ir import Context, Location, Module
 from aie.passmanager import PassManager
 
-INPUT_WITH_ADDRESSES_PIPELINE = (
-    lambda scheme, dynamic_objFifos, ctrl_pkt_overlay : (
+INPUT_WITH_ADDRESSES_PIPELINE = lambda scheme, dynamic_objFifos, ctrl_pkt_overlay: (
+    Pipeline()
+    .lower_affine()
+    .add_pass("aie-canonicalize-device")
+    .Nested(
+        "aie.device",
         Pipeline()
-        .lower_affine()
-        .add_pass("aie-canonicalize-device")
-        .Nested(
-            "aie.device",
-            Pipeline()
-            .add_pass("aie-assign-lock-ids")
-            .add_pass("aie-register-objectFifos")
-            .add_pass(
-                "aie-objectFifo-stateful-transform", dynamic_objFifos=dynamic_objFifos
-            )
-            .add_pass("aie-assign-bd-ids")
-            .add_pass("aie-lower-cascade-flows")
-            .add_pass("aie-lower-broadcast-packet")
-            .add_pass("aie-lower-multicast")
-            .add_pass("aie-assign-tile-controller-ids")
-            .add_pass(
-                "aie-generate-column-control-overlay",
-                route_shim_to_tile_ctrl=ctrl_pkt_overlay,
-            )
-            .add_pass("aie-assign-buffer-addresses", alloc_scheme=scheme),
+        .add_pass("aie-assign-lock-ids")
+        .add_pass("aie-register-objectFifos")
+        .add_pass(
+            "aie-objectFifo-stateful-transform", dynamic_objFifos=dynamic_objFifos
         )
-        .convert_scf_to_cf()
+        .add_pass("aie-assign-bd-ids")
+        .add_pass("aie-lower-cascade-flows")
+        .add_pass("aie-lower-broadcast-packet")
+        .add_pass("aie-lower-multicast")
+        .add_pass("aie-assign-tile-controller-ids")
+        .add_pass(
+            "aie-generate-column-control-overlay",
+            route_shim_to_tile_ctrl=ctrl_pkt_overlay,
+        )
+        .add_pass("aie-assign-buffer-addresses", alloc_scheme=scheme),
     )
+    .convert_scf_to_cf()
 )
 
 LOWER_TO_LLVM_PIPELINE = (

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -339,7 +339,7 @@ def run_passes(pass_pipeline, mlir_module_str, outputfile=None, verbose=False):
             pm.run(module.operation)
         except Exception as e:
             print("Error running pass pipeline: ", pass_pipeline, e)
-            raise(e)
+            raise e
         mlir_module_str = str(module)
         if outputfile:
             with open(outputfile, "w") as g:

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -334,7 +334,12 @@ def run_passes(pass_pipeline, mlir_module_str, outputfile=None, verbose=False):
         print("Running:", pass_pipeline)
     with Context() as ctx, Location.unknown():
         module = Module.parse(mlir_module_str)
-        PassManager.parse(pass_pipeline).run(module.operation)
+        pm = PassManager.parse(pass_pipeline)
+        try:
+            pm.run(module.operation)
+        except Exception as e:
+            print("Error running pass pipeline: ", pass_pipeline, e)
+            raise(e)
         mlir_module_str = str(module)
         if outputfile:
             with open(outputfile, "w") as g:

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -35,7 +35,7 @@ from aie.ir import Context, Location, Module
 from aie.passmanager import PassManager
 
 INPUT_WITH_ADDRESSES_PIPELINE = (
-    lambda scheme="", dynamic_objFifos=False, ctrl_pkt_overlay=False: (
+    lambda scheme, dynamic_objFifos, ctrl_pkt_overlay : (
         Pipeline()
         .lower_affine()
         .add_pass("aie-canonicalize-device")
@@ -1067,12 +1067,9 @@ class FlowRunner:
 
             file_with_addresses = self.prepend_tmp("input_with_addresses.mlir")
 
-            if opts.alloc_scheme:
-                pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE(
-                    opts.alloc_scheme, opts.dynamic_objFifos, opts.ctrl_pkt_overlay
-                ).materialize(module=True)
-            else:
-                pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE().materialize(module=True)
+            pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE(
+                opts.alloc_scheme, opts.dynamic_objFifos, opts.ctrl_pkt_overlay
+            ).materialize(module=True)
 
             run_passes(
                 pass_pipeline,

--- a/test/assign-buffer-addresses/bank_aware_alloc_error.mlir
+++ b/test/assign-buffer-addresses/bank_aware_alloc_error.mlir
@@ -1,4 +1,4 @@
-//===- bank_aware_alloc_error.mlir ---------------------------------------------*- MLIR -*-===//
+//===- bank_aware_alloc_error.mlir -----------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -26,18 +26,18 @@
 // CHECK:         bank : 3        0x6000-0x7FFF
 
 module @test {
- aie.device(xcvc1902) {
-  %0 = aie.tile(3, 3)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
-  %1 = aie.buffer(%0) { sym_name = "b" } : memref<8192xi32>
-  %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
-  %3 = aie.tile(4, 4)
-  %4 = aie.buffer(%3) : memref<500xi32>
-  aie.core(%0) {
-    aie.end
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
+    %1 = aie.buffer(%0) { sym_name = "b" } : memref<8192xi32>
+    %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
+    %3 = aie.tile(4, 4)
+    %4 = aie.buffer(%3) : memref<500xi32>
+    aie.core(%0) {
+      aie.end
+    }
+    aie.core(%3) {
+      aie.end
+    }
   }
-  aie.core(%3) {
-    aie.end
-  }
- }
 }

--- a/test/assign-buffer-addresses/bank_aware_alloc_memory_exhausted.mlir
+++ b/test/assign-buffer-addresses/bank_aware_alloc_memory_exhausted.mlir
@@ -1,4 +1,4 @@
-//===- bank_aware_alloc_memory_exhausted.mlir ---------------------------------------------*- MLIR -*-===//
+//===- bank_aware_alloc_memory_exhausted.mlir ------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/test/assign-buffer-addresses/bank_aware_alloc_memtile_error.mlir
+++ b/test/assign-buffer-addresses/bank_aware_alloc_memtile_error.mlir
@@ -1,4 +1,4 @@
-//===- bank_aware_alloc_memtile_error.mlir ---------------------------------------*- MLIR -*-===//
+//===- bank_aware_alloc_memtile_error.mlir ---------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -29,13 +29,12 @@
 // CHECK:         bank : 6        0x60000-0x6FFFF
 // CHECK:         bank : 7        0x70000-0x7FFFF
 
-
 module @test {
- aie.device(xcve2302) {
-  %0 = aie.tile(3, 1)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<132000xi32>
-  aie.memtile_dma(%0) {
-    aie.end
+  aie.device(xcve2302) {
+    %0 = aie.tile(3, 1)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<132000xi32>
+    aie.memtile_dma(%0) {
+      aie.end
+    }
   }
- }
 }

--- a/test/assign-buffer-addresses/bank_aware_alloc_memtile_simple.mlir
+++ b/test/assign-buffer-addresses/bank_aware_alloc_memtile_simple.mlir
@@ -1,4 +1,4 @@
-//===- bank_aware_alloc_memtile_simple.mlir --------------------------------------*- MLIR -*-===//
+//===- bank_aware_alloc_memtile_simple.mlir --------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,11 +12,11 @@
 // CHECK:       %a = aie.buffer(%tile_3_1) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "a"} : memref<16384xi32> 
 
 module @test {
- aie.device(xcve2302) {
-  %0 = aie.tile(3, 1)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16384xi32>
-  aie.memtile_dma(%0) {
-    aie.end
+  aie.device(xcve2302) {
+    %0 = aie.tile(3, 1)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16384xi32>
+    aie.memtile_dma(%0) {
+      aie.end
+    }
   }
- }
 }

--- a/test/assign-buffer-addresses/bank_aware_alloc_simple.mlir
+++ b/test/assign-buffer-addresses/bank_aware_alloc_simple.mlir
@@ -1,4 +1,4 @@
-//===- bank_aware_alloc_simple.mlir ---------------------------------------------*- MLIR -*-===//
+//===- bank_aware_alloc_simple.mlir ----------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -17,18 +17,18 @@
 
 
 module @test {
- aie.device(xcvc1902) {
-  %0 = aie.tile(3, 3)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
-  %1 = aie.buffer(%0) { sym_name = "b" } : memref<512xi32>
-  %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
-  %3 = aie.tile(4, 4)
-  %4 = aie.buffer(%3) : memref<500xi32>
-  aie.core(%0) {
-    aie.end
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
+    %1 = aie.buffer(%0) { sym_name = "b" } : memref<512xi32>
+    %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
+    %3 = aie.tile(4, 4)
+    %4 = aie.buffer(%3) : memref<500xi32>
+    aie.core(%0) {
+      aie.end
+    }
+    aie.core(%3) {
+      aie.end
+    }
   }
-  aie.core(%3) {
-    aie.end
-  }
- }
 }

--- a/test/assign-buffer-addresses/bank_aware_prealloc_error.mlir
+++ b/test/assign-buffer-addresses/bank_aware_prealloc_error.mlir
@@ -8,15 +8,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --verify-diagnostics --aie-assign-buffer-addresses %s
+// RUN: aie-opt --verify-diagnostics --aie-assign-buffer-addresses='alloc-scheme=bank-aware' %s
 
 module @test {
   aie.device(npu1) {
     %tile44 = aie.tile(4, 4)
     %buf0 = aie.buffer(%tile44) : memref<200xi32>
     %buf1 = aie.buffer(%tile44) : memref<100xi32>
-    // expected-error@+1 {{'aie.buffer' op would override allocated address}}
     %buf2 = aie.buffer(%tile44) { sym_name = "b", address = 4096 : i32 } : memref<1024xi32>
+    // expected-error@+1 {{'aie.buffer' op would override allocated address}}
     %buf3 = aie.buffer(%tile44) { sym_name = "c", address = 12288 : i32 } : memref<1024xi32>
     %buf4 = aie.buffer(%tile44) { sym_name = "d", address = 20000 : i32 } : memref<1024xi32>
     %buf5 = aie.buffer(%tile44) : memref<800xi32>

--- a/test/assign-buffer-addresses/bank_aware_prealloc_error.mlir
+++ b/test/assign-buffer-addresses/bank_aware_prealloc_error.mlir
@@ -8,17 +8,28 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --verify-diagnostics --aie-assign-buffer-addresses='alloc-scheme=bank-aware' %s
+// RUN: aie-opt --split-input-file --verify-diagnostics --aie-assign-buffer-addresses='alloc-scheme=bank-aware' %s
 
-module @test {
+module @test0 {
   aie.device(npu1) {
     %tile44 = aie.tile(4, 4)
     %buf0 = aie.buffer(%tile44) : memref<200xi32>
     %buf1 = aie.buffer(%tile44) : memref<100xi32>
     %buf2 = aie.buffer(%tile44) { sym_name = "b", address = 4096 : i32 } : memref<1024xi32>
-    // expected-error@+1 {{'aie.buffer' op would override allocated address}}
+    // expected-error@+1 {{'aie.buffer' op would override existing mem_bank}}
     %buf3 = aie.buffer(%tile44) { sym_name = "c", address = 12288 : i32 } : memref<1024xi32>
     %buf4 = aie.buffer(%tile44) { sym_name = "d", address = 20000 : i32 } : memref<1024xi32>
     %buf5 = aie.buffer(%tile44) : memref<800xi32>
+  }
+}
+
+// -----
+
+module @test1 {
+  aie.device(npu1) {
+    %tile44 = aie.tile(4, 4)
+    %buf0 = aie.buffer(%tile44) { sym_name = "a", address = 0 : i32 } : memref<1024xi32>
+    // expected-error@+1 {{'aie.buffer' op would override allocated address}}
+    %buf2 = aie.buffer(%tile44) { sym_name = "b", address = 1024 : i32 } : memref<1024xi32>
   }
 }

--- a/test/assign-buffer-addresses/bank_aware_prealloc_error.mlir
+++ b/test/assign-buffer-addresses/bank_aware_prealloc_error.mlir
@@ -1,0 +1,24 @@
+//===- bank_aware_prealloc_error.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --verify-diagnostics --aie-assign-buffer-addresses %s
+
+module @test {
+  aie.device(npu1) {
+    %tile44 = aie.tile(4, 4)
+    %buf0 = aie.buffer(%tile44) : memref<200xi32>
+    %buf1 = aie.buffer(%tile44) : memref<100xi32>
+    // expected-error@+1 {{'aie.buffer' op would override allocated address}}
+    %buf2 = aie.buffer(%tile44) { sym_name = "b", address = 4096 : i32 } : memref<1024xi32>
+    %buf3 = aie.buffer(%tile44) { sym_name = "c", address = 12288 : i32 } : memref<1024xi32>
+    %buf4 = aie.buffer(%tile44) { sym_name = "d", address = 20000 : i32 } : memref<1024xi32>
+    %buf5 = aie.buffer(%tile44) : memref<800xi32>
+  }
+}

--- a/test/assign-buffer-addresses/basic_alloc_error.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_error.mlir
@@ -1,4 +1,4 @@
-//===- basic_alloc_error.mlir ---------------------------------------------*- MLIR -*-===//
+//===- basic_alloc_error.mlir ----------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -16,18 +16,18 @@
 // CHECK:   a       : 0x8420-0x842F         (16 bytes)
 
 module @test {
- aie.device(xcvc1902) {
-  %0 = aie.tile(3, 3)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
-  %1 = aie.buffer(%0) { sym_name = "b" } : memref<8192xi32>
-  %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
-  %3 = aie.tile(4, 4)
-  %4 = aie.buffer(%3) : memref<500xi32>
-  aie.core(%0) {
-    aie.end
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
+    %1 = aie.buffer(%0) { sym_name = "b" } : memref<8192xi32>
+    %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
+    %3 = aie.tile(4, 4)
+    %4 = aie.buffer(%3) : memref<500xi32>
+    aie.core(%0) {
+      aie.end
+    }
+    aie.core(%3) {
+      aie.end
+    }
   }
-  aie.core(%3) {
-    aie.end
-  }
- }
 }

--- a/test/assign-buffer-addresses/basic_alloc_memtile_error.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_memtile_error.mlir
@@ -1,4 +1,4 @@
-//===- basic_alloc_memtile_error.mlir ---------------------------------------*- MLIR -*-===//
+//===- basic_alloc_memtile_error.mlir --------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,11 +12,11 @@
 // CHECK:   error: 'aie.tile' op allocated buffers exceeded available memory
 
 module @test {
- aie.device(xcve2302) {
-  %0 = aie.tile(3, 1)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<132000xi32>
-  aie.memtile_dma(%0) {
-    aie.end
+  aie.device(xcve2302) {
+    %0 = aie.tile(3, 1)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<132000xi32>
+    aie.memtile_dma(%0) {
+      aie.end
+    }
   }
- }
 }

--- a/test/assign-buffer-addresses/basic_alloc_memtile_simple.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_memtile_simple.mlir
@@ -1,4 +1,4 @@
-//===- basic_+alloc_memtile_simple.mlir ------------------------*- MLIR -*-===//
+//===- basic_alloc_memtile_simple.mlir -------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/test/assign-buffer-addresses/basic_alloc_memtile_simple.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_memtile_simple.mlir
@@ -1,4 +1,4 @@
-//===- basic_alloc_memtile_simple.mlir --------------------------------------*- MLIR -*-===//
+//===- basic_+alloc_memtile_simple.mlir ------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -19,11 +19,11 @@
 // CHECK:   }
 // CHECK: }
 module @test {
- aie.device(xcve2302) {
-  %0 = aie.tile(3, 1)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<65536xi32>
-  aie.memtile_dma(%0) {
-    aie.end
+  aie.device(xcve2302) {
+    %0 = aie.tile(3, 1)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<65536xi32>
+    aie.memtile_dma(%0) {
+      aie.end
+    }
   }
- }
 }

--- a/test/assign-buffer-addresses/basic_alloc_simple.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_simple.mlir
@@ -1,4 +1,4 @@
-//===- basic_alloc_simple.mlir ---------------------------------------------*- MLIR -*-===//
+//===- basic_alloc_simple.mlir ---------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -15,18 +15,18 @@
 // CHECK:   {{.*}} aie.buffer({{.*}}) {address = 1024 : i32, sym_name = "_anonymous0"} : memref<500xi32>
 
 module @test {
- aie.device(xcvc1902) {
-  %0 = aie.tile(3, 3)
-  %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
-  %1 = aie.buffer(%0) { sym_name = "b" } : memref<512xi32>
-  %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
-  %3 = aie.tile(4, 4)
-  %4 = aie.buffer(%3) : memref<500xi32>
-  aie.core(%0) {
-    aie.end
+  aie.device(xcvc1902) {
+    %0 = aie.tile(3, 3)
+    %b1 = aie.buffer(%0) { sym_name = "a" } : memref<16xi8>
+    %1 = aie.buffer(%0) { sym_name = "b" } : memref<512xi32>
+    %b2 = aie.buffer(%0) { sym_name = "c" } : memref<16xi16>
+    %3 = aie.tile(4, 4)
+    %4 = aie.buffer(%3) : memref<500xi32>
+    aie.core(%0) {
+      aie.end
+    }
+    aie.core(%3) {
+      aie.end
+    }
   }
-  aie.core(%3) {
-    aie.end
-  }
- }
 }

--- a/test/assign-buffer-addresses/basic_prealloc.mlir
+++ b/test/assign-buffer-addresses/basic_prealloc.mlir
@@ -1,4 +1,4 @@
-//===- basic_prealloc.mlir ---------------------------------------------*- MLIR -*-===//
+//===- basic_prealloc.mlir -------------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/test/assign-buffer-addresses/basic_prealloc.mlir
+++ b/test/assign-buffer-addresses/basic_prealloc.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-assign-buffer-addresses='basic-alloc' %s | FileCheck %s
+// RUN: aie-opt --aie-assign-buffer-addresses='alloc-scheme=basic-sequential' %s | FileCheck %s
 
 // CHECK: aie.buffer(%{{.*}}) {address = 4096 : i32, sym_name = "b"} : memref<1024xi32>
 // CHECK: aie.buffer(%{{.*}}) {address = 12288 : i32, sym_name = "c"} : memref<1024xi32>

--- a/test/assign-buffer-addresses/basic_prealloc.mlir
+++ b/test/assign-buffer-addresses/basic_prealloc.mlir
@@ -1,0 +1,28 @@
+//===- basic_prealloc.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-assign-buffer-addresses='basic-alloc' %s | FileCheck %s
+
+// CHECK: aie.buffer(%{{.*}}) {address = 4096 : i32, sym_name = "b"} : memref<1024xi32>
+// CHECK: aie.buffer(%{{.*}}) {address = 12288 : i32, sym_name = "c"} : memref<1024xi32>
+// CHECK: aie.buffer(%{{.*}}) {address = 20000 : i32, sym_name = "d"} : memref<1024xi32>
+
+module @test {
+  aie.device(npu1) {
+    %tile22 = aie.tile(2, 2)
+
+    %buf0 = aie.buffer(%tile22) : memref<200xi32>
+    %buf1 = aie.buffer(%tile22) : memref<100xi32>
+    %buf2 = aie.buffer(%tile22) { sym_name = "b", address = 4096 : i32 } : memref<1024xi32>
+    %buf3 = aie.buffer(%tile22) { sym_name = "c", address = 12288 : i32 } : memref<1024xi32>
+    %buf4 = aie.buffer(%tile22) { sym_name = "d", address = 20000 : i32 } : memref<1024xi32>
+    %buf5 = aie.buffer(%tile22) : memref<800xi32>
+  }
+}

--- a/test/unit_tests/aie2/00_itsalive/aie.mlir
+++ b/test/unit_tests/aie2/00_itsalive/aie.mlir
@@ -15,7 +15,7 @@ module @test00_itsalive {
   aie.device(xcve2802) {
     %tile12 = aie.tile(1, 3)
 
-    %buf12_0 = aie.buffer(%tile12) { sym_name = "a", address = 0 : i32 } : memref<256xi32>
+    %buf12_0 = aie.buffer(%tile12) : memref<256xi32>
 
     %core12 = aie.core(%tile12) {
       %val1 = arith.constant 1 : i32


### PR DESCRIPTION
I ran into problems on a branch where I was trying to manually set the address of buffers and the bank aware allocator silently failed and unexpectedly overwrote the manually set addresses. This PR fixes the problem by,

* Fail, don't warn, when bank aware buffer allocation conflicts with buffers with 'address' attribute set.
* Make basic buffer allocation scheme aware of 'address' attributes
* Small aiecc update to print errors to user when python bindings are used to run pass pipeline. For example during buffer allocation.
* I also snuck in a comment and indentation fixup for most of the other allocation tests