### PR TITLE
Add llvm rtti support in AIETargetModel

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -53,8 +53,31 @@ using TileID = struct TileID {
 };
 
 class AIETargetModel {
+
 public:
-  AIETargetModel() = default;
+  enum TargetModelKind {
+    TK_AIE1_VC1902,
+    TK_AIE1_Last,
+    TK_AIE2_VE2302,
+    TK_AIE2_VE2802,
+    TK_AIE2_NPU1,
+    TK_AIE2_NPU1_1Col,
+    TK_AIE2_NPU1_2Col,
+    TK_AIE2_NPU1_3Col,
+    TK_AIE2_NPU1_4Col,
+    TK_AIE2_NPU1_Last,
+    TK_AIE2_NPU2 = TK_AIE2_NPU1_Last,
+    TK_AIE2_NPU2_Last,
+    TK_AIE2_Last = TK_AIE2_NPU2_Last,
+  };
+
+private:
+  const TargetModelKind kind;
+
+public:
+  TargetModelKind getKind() const { return kind; }
+
+  AIETargetModel(TargetModelKind k) : kind(k) {}
 
   virtual ~AIETargetModel();
 
@@ -226,7 +249,7 @@ public:
 
 class AIE1TargetModel : public AIETargetModel {
 public:
-  AIE1TargetModel() = default;
+  AIE1TargetModel(TargetModelKind k) : AIETargetModel(k) {}
 
   bool isCoreTile(int col, int row) const override { return row > 0; }
   bool isMemTile(int col, int row) const override { return false; }
@@ -286,11 +309,16 @@ public:
 
   uint32_t getColumnShift() const override { return 23; }
   uint32_t getRowShift() const override { return 18; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() >= TK_AIE1_VC1902 &&
+           model->getKind() < TK_AIE1_Last;
+  }
 };
 
 class AIE2TargetModel : public AIETargetModel {
 public:
-  AIE2TargetModel() = default;
+  AIE2TargetModel(TargetModelKind k) : AIETargetModel(k) {}
 
   AIEArch getTargetArch() const override;
 
@@ -363,6 +391,11 @@ public:
 
   uint32_t getColumnShift() const override { return 25; }
   uint32_t getRowShift() const override { return 20; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() >= TK_AIE2_VE2302 &&
+           model->getKind() < TK_AIE2_Last;
+  }
 };
 
 class VC1902TargetModel : public AIE1TargetModel {
@@ -370,7 +403,7 @@ class VC1902TargetModel : public AIE1TargetModel {
       2, 3, 6, 7, 10, 11, 18, 19, 26, 27, 34, 35, 42, 43, 46, 47};
 
 public:
-  VC1902TargetModel() = default;
+  VC1902TargetModel() : AIE1TargetModel(TK_AIE1_VC1902) {}
 
   uint32_t getAddressGenGranularity() const override { return 32; }
 
@@ -389,13 +422,17 @@ public:
   bool isShimNOCorPLTile(int col, int row) const override {
     return isShimNOCTile(col, row) || isShimPLTile(col, row);
   }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() == TK_AIE1_VC1902;
+  }
 };
 
 class VE2302TargetModel : public AIE2TargetModel {
   llvm::SmallDenseSet<unsigned, 8> nocColumns = {2, 3, 6, 7, 10, 11};
 
 public:
-  VE2302TargetModel() = default;
+  VE2302TargetModel() : AIE2TargetModel(TK_AIE2_VE2302) {}
 
   int columns() const override { return 17; }
 
@@ -419,6 +456,10 @@ public:
   }
 
   uint32_t getNumMemTileRows() const override { return 1; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() == TK_AIE2_VE2302;
+  }
 };
 
 class VE2802TargetModel : public AIE2TargetModel {
@@ -426,7 +467,7 @@ class VE2802TargetModel : public AIE2TargetModel {
                                                   22, 23, 30, 31, 34, 35};
 
 public:
-  VE2802TargetModel() = default;
+  VE2802TargetModel() : AIE2TargetModel(TK_AIE2_VE2802) {}
 
   int columns() const override { return 38; }
 
@@ -453,11 +494,15 @@ public:
   }
 
   uint32_t getNumMemTileRows() const override { return 2; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() == TK_AIE2_VE2802;
+  }
 };
 
 class BaseNPUTargetModel : public AIE2TargetModel {
 public:
-  BaseNPUTargetModel() = default;
+  BaseNPUTargetModel(TargetModelKind k) : AIE2TargetModel(k) {}
 
   int rows() const override {
     return 6; /* 1 Shim row, 1 memtile row, and 4 Core rows. */
@@ -481,12 +526,17 @@ public:
   virtual bool isVirtualized() const = 0;
 
   virtual bool isNPU() const override { return true; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() >= TK_AIE2_NPU1 &&
+           model->getKind() < TK_AIE2_NPU2_Last;
+  }
 };
 
 // The full Phoenix NPU
 class NPUTargetModel : public BaseNPUTargetModel {
 public:
-  NPUTargetModel() = default;
+  NPUTargetModel() : BaseNPUTargetModel(TK_AIE2_NPU1) {}
 
   int columns() const override { return 5; }
 
@@ -500,6 +550,10 @@ public:
   }
 
   bool isVirtualized() const override { return false; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() == TK_AIE2_NPU1;
+  }
 };
 
 // A sub-portion of the NPU
@@ -507,7 +561,11 @@ class VirtualizedNPUTargetModel : public BaseNPUTargetModel {
   int cols;
 
 public:
-  VirtualizedNPUTargetModel(int _cols) : cols(_cols) {}
+  VirtualizedNPUTargetModel(int _cols)
+      : BaseNPUTargetModel(static_cast<TargetModelKind>(
+            static_cast<std::underlying_type_t<TargetModelKind>>(TK_AIE2_NPU1) +
+            _cols)),
+        cols(_cols) {}
 
   uint32_t getAddressGenGranularity() const override { return 32; }
 
@@ -516,12 +574,17 @@ public:
   bool isShimNOCTile(int col, int row) const override { return row == 0; }
 
   bool isVirtualized() const override { return true; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() >= TK_AIE2_NPU1_1Col &&
+           model->getKind() < TK_AIE2_NPU1_Last;
+  }
 };
 
 // The full Strix. NPU
 class NPU2TargetModel : public BaseNPUTargetModel {
 public:
-  NPU2TargetModel() = default;
+  NPU2TargetModel() : BaseNPUTargetModel(TK_AIE2_NPU2) {}
 
   AIEArch getTargetArch() const override;
 
@@ -532,6 +595,10 @@ public:
   bool isShimPLTile(int col, int row) const override { return false; }
 
   bool isVirtualized() const override { return false; }
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() == TK_AIE2_NPU2;
+  }
 };
 
 } // namespace xilinx::AIE

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1000,8 +1000,7 @@ LogicalResult ConfigureCascadeOp::verify() {
   if (t.isMemTile(tile.colIndex(), tile.rowIndex()))
     return emitOpError("memTile row has no cascade stream interface");
 
-  if ((t.getTargetArch() == AIEArch::AIE2) ||
-      (t.getTargetArch() == AIEArch::AIE2p)) {
+  if (isa<AIE2TargetModel>(t)) {
     if (inputDir == CascadeDir::South || inputDir == CascadeDir::East) {
       return emitOpError("input direction of cascade must be North or West on ")
              << stringifyAIEArch(t.getTargetArch());
@@ -1044,11 +1043,10 @@ LogicalResult GetCascadeOp::verify() {
   Type type = getCascadeValue().getType();
   DataLayout dataLayout = DataLayout::closest(*this);
   auto bits = dataLayout.getTypeSizeInBits(type);
-  if (targetModel.getTargetArch() == AIEArch::AIE1) {
+  if (isa<AIE1TargetModel>(targetModel)) {
     if (bits != 384)
       return emitOpError("must be a 384-bit type");
-  } else if ((targetModel.getTargetArch() == AIEArch::AIE2) ||
-             (targetModel.getTargetArch() == AIEArch::AIE2p)) {
+  } else if (isa<AIE2TargetModel>(targetModel)) {
     if (bits != 512)
       return emitOpError("must be a 512-bit type");
   } else

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -283,8 +283,7 @@ struct AIEPutCascadeToStdLowering : OpConversionPattern<PutCascadeOp> {
              << funcName;
     SmallVector<Value, 2> args;
     args.push_back(op.getCascadeValue());
-    if ((targetModel.getTargetArch() == AIEArch::AIE2) ||
-        (targetModel.getTargetArch() == AIEArch::AIE2p))
+    if (isa<AIE2TargetModel>(targetModel))
       args.push_back(rewriter.create<arith::ConstantOp>(
           op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(1))); // enable
@@ -318,8 +317,7 @@ struct AIEGetCascadeToStdLowering : OpConversionPattern<GetCascadeOp> {
       return op.emitOpError("Could not find the intrinsic function ")
              << funcName;
     SmallVector<Value, 2> args;
-    if ((targetModel.getTargetArch() == AIEArch::AIE2) ||
-        (targetModel.getTargetArch() == AIEArch::AIE2p))
+    if (isa<AIE2TargetModel>(targetModel))
       args.push_back(rewriter.create<arith::ConstantOp>(
           op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(1))); // enable

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -1134,8 +1134,7 @@ struct AIEObjectFifoStatefulTransformPass
         target = objFifoLinks[*linkOp];
 
     auto dev = op->getParentOfType<DeviceOp>();
-    if (auto &targetArch = dev.getTargetModel();
-        targetArch.getTargetArch() == AIEArch::AIE1) {
+    if (isa<AIE1TargetModel>(dev.getTargetModel())) {
 
       if (locksPerFifo[target].size() == 0) {
         for (int i = 0; i < numLocks; i++) {

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -539,8 +539,7 @@ LogicalResult AIERTControl::configureSwitches(DeviceOp &targetOp) {
   }
 
   // Cascade configuration
-  if ((targetModel.getTargetArch() == AIEArch::AIE2) ||
-      (targetModel.getTargetArch() == AIEArch::AIE2p)) {
+  if (isa<AIE2TargetModel>(targetModel)) {
     for (auto configOp : targetOp.getOps<ConfigureCascadeOp>()) {
       TileOp tile = cast<TileOp>(configOp.getTile().getDefiningOp());
       auto tileLoc = XAie_TileLoc(tile.getCol(), tile.getRow());

--- a/lib/Targets/AIETargetAirbin.cpp
+++ b/lib/Targets/AIETargetAirbin.cpp
@@ -1061,8 +1061,7 @@ static void configureSwitchBoxes(DeviceOp &targetOp) {
 
 static void configureCascade(DeviceOp &targetOp) {
   const auto &target_model = xilinx::AIE::getTargetModel(targetOp);
-  if ((targetModel.getTargetArch() == AIEArch::AIE2) ||
-      (targetModel.getTargetArch() == AIEArch::AIE2p)) {
+  if (isa<AIE2TargetModel>(targetModel)) {
     for (auto configOp : targetOp.getOps<ConfigureCascadeOp>()) {
       TileOp tile = cast<TileOp>(configOp.getTile().getDefiningOp());
       auto inputDir = stringifyCascadeDir(configOp.getInputDir()).upper();

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -125,8 +125,7 @@ mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
     }
 
     if (0 != ndims)
-      if ((AIEArch::AIE2 != targetModel.getTargetArch()) &&
-          (AIEArch::AIE2p != targetModel.getTargetArch()))
+      if (isa<AIE1TargetModel>(targetModel))
         return memOp.emitOpError("DMA contains at least one multi-dimensional "
                                  "buffer descriptor. This is currently only "
                                  "supported for AIE-ML and later devices.");

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -119,3 +119,5 @@ add_lit_testsuite(check-aie "Running the aie regression tests"
   ARGS "-sv --timeout 600"
 )
 set_target_properties(check-aie PROPERTIES FOLDER "Tests")
+
+add_subdirectory(CppTests)

--- a/test/CppTests/CMakeLists.txt
+++ b/test/CppTests/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (C) 2023, Xilinx Inc. All rights reserved.
+# Copyright (C) 2023, Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+set(CMAKE_CXX_STANDARD 17)
+
+include(CTest)
+
+add_executable(target_model_rtti  target_model_rtti.cpp)
+add_test(NAME TargetModelRtti COMMAND target_model_rtti)
+
+add_custom_target(check-aie-cpp COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS target_model_rtti)
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+target_link_libraries(target_model_rtti
+                      PUBLIC
+                      AIE
+                      ${dialect_libs})
+
+add_dependencies(check-aie check-aie-cpp)

--- a/test/CppTests/target_model_rtti.cpp
+++ b/test/CppTests/target_model_rtti.cpp
@@ -1,0 +1,138 @@
+//===- target_model_rtti.cpp ------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/IR/AIETargetModel.h"
+
+#include <stdexcept>
+
+using namespace xilinx;
+
+void test() {
+
+  // AIEDevice::xcvc1902
+  if (!llvm::isa<AIE::VC1902TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcvc1902))) {
+    throw std::runtime_error("Failed xcvc1902 isa<VC1902TargetModel>");
+  }
+  if (!llvm::isa<AIE::AIE1TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcvc1902))) {
+    throw std::runtime_error("Failed xcvc1902 isa<AIE1TargetModel>");
+  }
+  if (llvm::isa<AIE::AIE2TargetModel, AIE::VE2302TargetModel,
+                AIE::VE2802TargetModel, AIE::BaseNPUTargetModel,
+                AIE::NPUTargetModel, AIE::VirtualizedNPUTargetModel,
+                AIE::NPU2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcvc1902))) {
+    throw std::runtime_error("Failed xcvc1902 !isa<>");
+  }
+
+  // AIEDevice::xcve2302
+  if (!llvm::isa<AIE::VE2302TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve2302))) {
+    throw std::runtime_error("Failed xcvc1902 isa<VC1902TargetModel>");
+  }
+  if (!llvm::isa<AIE::AIE2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve2302))) {
+    throw std::runtime_error("Failed xcve2302 isa<AIE2TargetModel>");
+  }
+  if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
+                AIE::VE2802TargetModel, AIE::BaseNPUTargetModel,
+                AIE::NPUTargetModel, AIE::VirtualizedNPUTargetModel,
+                AIE::NPU2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve2302))) {
+    throw std::runtime_error("Failed xcve2302 !isa<>");
+  }
+
+  // AIEDevice::xcve2802
+  if (!llvm::isa<AIE::VE2802TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve2802))) {
+    throw std::runtime_error("Failed xcvc1902 isa<VC1902TargetModel>");
+  }
+  if (!llvm::isa<AIE::AIE2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve2802))) {
+    throw std::runtime_error("Failed xcve2802 isa<AIE2TargetModel>");
+  }
+  if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
+                AIE::VE2302TargetModel, AIE::BaseNPUTargetModel,
+                AIE::NPUTargetModel, AIE::VirtualizedNPUTargetModel,
+                AIE::NPU2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::xcve2802))) {
+    throw std::runtime_error("Failed xcve2802 !isa<>");
+  }
+
+  // AIEDevice::npu1
+  if (!llvm::isa<AIE::AIE2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu1))) {
+    throw std::runtime_error("Failed npu1 isa<AIE2TargetModel>");
+  }
+  if (!llvm::isa<AIE::BaseNPUTargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu1))) {
+    throw std::runtime_error("Failed npu1 isa<BaseNPUTargetModel>");
+  }
+  if (!llvm::isa<AIE::NPUTargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu1))) {
+    throw std::runtime_error("Failed npu1 isa<BaseNPUTargetModel>");
+  }
+  if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
+                AIE::VE2302TargetModel, AIE::VE2802TargetModel,
+                AIE::VirtualizedNPUTargetModel, AIE::NPU2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu1))) {
+    throw std::runtime_error("Failed npu1 isa<NPUTargetModel>");
+  }
+
+  // AIEDevice::npu_1col, npu_2col, npu_3col, npu_4col
+  llvm::SmallVector<AIE::AIEDevice> npu1_devs = {
+      AIE::AIEDevice::npu1_1col, AIE::AIEDevice::npu1_2col,
+      AIE::AIEDevice::npu1_3col, AIE::AIEDevice::npu1_4col};
+  for (auto dev : npu1_devs) {
+    if (!llvm::isa<AIE::AIE2TargetModel>(AIE::getTargetModel(dev))) {
+      throw std::runtime_error("Failed npu1_col isa<AIE2TargetModel>");
+    }
+    if (!llvm::isa<AIE::VirtualizedNPUTargetModel>(AIE::getTargetModel(dev))) {
+      throw std::runtime_error(
+          "Failed npu1_col isa<VirtualizedNPUTargetModel>");
+    }
+    if (!llvm::isa<AIE::BaseNPUTargetModel>(AIE::getTargetModel(dev))) {
+      throw std::runtime_error("Failed npu1_col isa<BaseNPUTargetModel>");
+    }
+    if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
+                  AIE::VE2302TargetModel, AIE::VE2802TargetModel,
+                  AIE::NPUTargetModel, AIE::NPU2TargetModel>(
+            AIE::getTargetModel(dev))) {
+      throw std::runtime_error("Failed npu1_1col !isa<>");
+    }
+  }
+
+  // AIEDevice::npu2
+  if (!llvm::isa<AIE::AIE2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu2))) {
+    throw std::runtime_error("Failed npu2 isa<AIE2TargetModel>");
+  }
+  if (!llvm::isa<AIE::BaseNPUTargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu2))) {
+    throw std::runtime_error("Failed npu2 isa<BaseNPUTargetModel>");
+  }
+  if (!llvm::isa<AIE::NPU2TargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu2))) {
+    throw std::runtime_error("Failed npu2 isa<NPU2TargetModel>");
+  }
+  if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
+                AIE::VE2302TargetModel, AIE::VE2802TargetModel,
+                AIE::VirtualizedNPUTargetModel, AIE::NPUTargetModel>(
+          AIE::getTargetModel(AIE::AIEDevice::npu2))) {
+    throw std::runtime_error("Failed npu2 !isa<>");
+  }
+}
+
+int main() {
+  test();
+  return 0;
+}

--- a/test/CppTests/target_model_rtti.cpp
+++ b/test/CppTests/target_model_rtti.cpp
@@ -37,7 +37,7 @@ void test() {
   // AIEDevice::xcve2302
   if (!llvm::isa<AIE::VE2302TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::xcve2302))) {
-    throw std::runtime_error("Failed xcvc1902 isa<VC1902TargetModel>");
+    throw std::runtime_error("Failed xcve2302 isa<VE2302TargetModel>");
   }
   if (!llvm::isa<AIE::AIE2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::xcve2302))) {
@@ -54,7 +54,7 @@ void test() {
   // AIEDevice::xcve2802
   if (!llvm::isa<AIE::VE2802TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::xcve2802))) {
-    throw std::runtime_error("Failed xcvc1902 isa<VC1902TargetModel>");
+    throw std::runtime_error("Failed xcvc1902 isa<VE2802TargetModel>");
   }
   if (!llvm::isa<AIE::AIE2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::xcve2802))) {
@@ -79,13 +79,13 @@ void test() {
   }
   if (!llvm::isa<AIE::NPUTargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu1))) {
-    throw std::runtime_error("Failed npu1 isa<BaseNPUTargetModel>");
+    throw std::runtime_error("Failed npu1 isa<NPUTargetModel>");
   }
   if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
                 AIE::VE2302TargetModel, AIE::VE2802TargetModel,
                 AIE::VirtualizedNPUTargetModel, AIE::NPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu1))) {
-    throw std::runtime_error("Failed npu1 isa<NPUTargetModel>");
+    throw std::runtime_error("Failed npu1 !isa<>");
   }
 
   // AIEDevice::npu_1col, npu_2col, npu_3col, npu_4col
@@ -107,7 +107,7 @@ void test() {
                   AIE::VE2302TargetModel, AIE::VE2802TargetModel,
                   AIE::NPUTargetModel, AIE::NPU2TargetModel>(
             AIE::getTargetModel(dev))) {
-      throw std::runtime_error("Failed npu1_1col !isa<>");
+      throw std::runtime_error("Failed npu1_col !isa<>");
     }
   }
 


### PR DESCRIPTION
Add [basic LLVM RTTI support](https://llvm.org/docs/HowToSetUpLLVMStyleRTTI.html) to AIETargetModel. This allows querying the target model object hierarchy in the llvm way with `isa<>`, etc., which is sometimes nicer than checking `AIETargetModel::getTargetArch()` or other properties. As someone who has spent time updating code for strix and beyond I think it is nice to have this option.