### PR TITLE
Cleanup extra code in headers

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.h
@@ -11,27 +11,8 @@
 #ifndef AIE_ASSIGN_BUFFER_DESCRIPTOR_IDS_H
 #define AIE_ASSIGN_BUFFER_DESCRIPTOR_IDS_H
 
-#include <optional>
+#include "aie/Dialect/AIE/IR/AIETargetModel.h"
 
-#include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIE/Transforms/AIEAssignBufferDescriptorIDs.h"
-#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
-
-#include "mlir/Pass/Pass.h"
-
-using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::AIE;
-
-#include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
-
-#include "mlir/Pass/Pass.h"
-
-#define DEBUG_TYPE "aie-assign-bd-ids"
-
-using namespace mlir;
-using namespace xilinx;
 using namespace xilinx::AIE;
 
 struct BdIdGenerator {

--- a/include/aie/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.h
@@ -27,7 +27,7 @@ DenseMap<int, int> getRowToShimChanMap(const AIETargetModel &targetModel,
 
 // AIE arch-specific tile id to controller id mapping. Users can use those
 // packet ids for design but run into risk of deadlocking control packet flows.
-DenseMap<AIE::TileID, int>
+DenseMap<TileID, int>
 getTileToControllerIdMap(bool clColumnWiseUniqueIDs,
                          const AIETargetModel &targetModel);
 

--- a/include/aie/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.h
@@ -11,26 +11,9 @@
 #ifndef AIE_ASSIGN_BUFFER_DESCRIPTOR_IDS_H
 #define AIE_ASSIGN_BUFFER_DESCRIPTOR_IDS_H
 
-#include <optional>
-
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
-
-#include "mlir/Pass/Pass.h"
 
 using namespace mlir;
-using namespace xilinx;
-using namespace xilinx::AIE;
-
-#include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIE/Transforms/AIEPasses.h"
-
-#include "mlir/Pass/Pass.h"
-
-#define DEBUG_TYPE "aie-generate-column-control-overlay"
-
-using namespace mlir;
-using namespace xilinx;
 using namespace xilinx::AIE;
 
 // Populate column control streaming interconnect overlay


### PR DESCRIPTION
Cleanup some extra code in a couple header files. I bumped into this because of some compiler warnings regarding redefinition of `DEBUG_TYPE`, which shouldn't be in header files anyway.