### PR TITLE
Remove CallableOpInterface from MemOp and MemTileOp

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1046,8 +1046,6 @@ def AIE_DMAOp: AIE_Op<"dma", [
   }];
 }
 
-// MemOps are not actually Callable, but we want to inline code into them, so we have to
-// implement CallableOpInterface
 def AIE_MemOp: AIE_Op<"mem", [
     TileElement, FlowEndPoint,
     IsCoreTile, HasValidBDs, HasValidDMAChannels,
@@ -1088,8 +1086,6 @@ def AIE_MemOp: AIE_Op<"mem", [
   }];
 }
 
-// This op is not actually Callable, but we want to inline code into them, so we have to
-// implement CallableOpInterface
 def AIE_MemTileDMAOp: AIE_Op<"memtile_dma", [
     TileElement, FlowEndPoint,
     IsMemTile, HasValidBDs, HasValidDMAChannels,

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1049,7 +1049,7 @@ def AIE_DMAOp: AIE_Op<"dma", [
 // MemOps are not actually Callable, but we want to inline code into them, so we have to
 // implement CallableOpInterface
 def AIE_MemOp: AIE_Op<"mem", [
-    TileElement, FlowEndPoint, CallableOpInterface,
+    TileElement, FlowEndPoint,
     IsCoreTile, HasValidBDs, HasValidDMAChannels,
     DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]>, Results<(outs Index)> {
@@ -1084,11 +1084,6 @@ def AIE_MemOp: AIE_Op<"mem", [
     int colIndex();
     int rowIndex();
     TileOp getTileOp();
-    int maxSizeInBytes() { return 32768; }
-    // CallableOpInterface
-    mlir::Region *getCallableRegion();
-    llvm::ArrayRef<mlir::Type> getArgumentTypes() { return getOperand().getType(); }
-    llvm::ArrayRef<mlir::Type> getResultTypes() { return getType(); }
     using ::xilinx::AIE::TileElement::Trait<MemOp>::getAsmResultNames;
   }];
 }
@@ -1096,7 +1091,7 @@ def AIE_MemOp: AIE_Op<"mem", [
 // This op is not actually Callable, but we want to inline code into them, so we have to
 // implement CallableOpInterface
 def AIE_MemTileDMAOp: AIE_Op<"memtile_dma", [
-    TileElement, FlowEndPoint, CallableOpInterface,
+    TileElement, FlowEndPoint,
     IsMemTile, HasValidBDs, HasValidDMAChannels,
     DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]>, Results<(outs Index)> {
@@ -1135,10 +1130,6 @@ def AIE_MemTileDMAOp: AIE_Op<"memtile_dma", [
     int colIndex();
     int rowIndex();
     TileOp getTileOp();
-    // CallableOpInterface
-    mlir::Region *getCallableRegion();
-    llvm::ArrayRef<mlir::Type> getArgumentTypes() { return getOperand().getType(); }
-    llvm::ArrayRef<mlir::Type> getResultTypes() { return getType(); }
     using ::xilinx::AIE::TileElement::Trait<MemTileDMAOp>::getAsmResultNames;
   }];
 }

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1500,11 +1500,6 @@ int MemOp::colIndex() { return getTileOp().colIndex(); }
 
 int MemOp::rowIndex() { return getTileOp().rowIndex(); }
 
-/// Returns the region on the current operation that is callable. This may
-/// return nullptr in the case of an external callable object, e.g. an external
-/// function.
-Region *MemOp::getCallableRegion() { return &getBody(); }
-
 //===----------------------------------------------------------------------===//
 // MemTileDMAOp
 //===----------------------------------------------------------------------===//
@@ -1938,11 +1933,6 @@ TileOp MemTileDMAOp::getTileOp() {
 int MemTileDMAOp::colIndex() { return getTileOp().colIndex(); }
 
 int MemTileDMAOp::rowIndex() { return getTileOp().rowIndex(); }
-
-/// Returns the region on the current operation that is callable. This may
-/// return nullptr in the case of an external callable object, e.g. an
-/// external function.
-Region *MemTileDMAOp::getCallableRegion() { return &getBody(); }
 
 //===----------------------------------------------------------------------===//
 // SwitchboxOp

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -31,7 +31,12 @@ void AIEXDialect::initialize() {
       >();
 }
 
-uint64_t getBufferDescriptorAddressRegisterAddress(
+} // namespace
+
+#define GET_OP_CLASSES
+#include "aie/Dialect/AIEX/IR/AIEX.cpp.inc"
+
+uint64_t AIEX::getBufferDescriptorAddressRegisterAddress(
     const AIE::AIETargetModel &tm, unsigned bd_id, unsigned col, unsigned row) {
   assert(bd_id < tm.getNumBDs(col, row));
   return ((col & 0xff) << tm.getColumnShift()) |
@@ -71,7 +76,7 @@ uint64_t getBufferDescriptorAddressRegisterAddress(
   Note: strides are expressed offset by one from user input strides, because the
   hardware does not support a 0 stride (repeat).
   */
-void getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
+void AIEX::getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
                              mlir::MemRefType referencedBufType,
                              llvm::SmallVector<int64_t, 4> inputSizes,
                              llvm::SmallVector<int64_t, 4> inputStrides,
@@ -140,7 +145,7 @@ void getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
 }
 
 mlir::LogicalResult
-verifyStridesWraps(mlir::Operation *forOp, mlir::MemRefType referencedBufType,
+AIEX::verifyStridesWraps(mlir::Operation *forOp, mlir::MemRefType referencedBufType,
                    int tileCol, int tileRow,
                    llvm::SmallVector<int64_t, 4> inputSizes,
                    llvm::SmallVector<int64_t, 4> inputStrides,
@@ -243,11 +248,6 @@ verifyStridesWraps(mlir::Operation *forOp, mlir::MemRefType referencedBufType,
 
   return success();
 }
-
-} // namespace xilinx::AIEX
-
-#define GET_OP_CLASSES
-#include "aie/Dialect/AIEX/IR/AIEX.cpp.inc"
 
 //===----------------------------------------------------------------------===//
 // UseTokenOp


### PR DESCRIPTION
This PR removes `CallableOpInterface` from `MemOp` and `MemTileOp`.

`MemOp` and `MemTileOp` implement the `CallableOpInterface` but the way it's implemented is problematic, because the implementation returns pointers to the stack, for example:
```
llvm::ArrayRef<mlir::Type> getArgumentTypes() { return getOperand().getType(); }
```
This could be resolved by stashing a `FunctionType` as an attribute, as the various flavors of `FuncOp` do, and safely returning the types. But it also appears that the comment explaining why the ops have `CallableOpInterface`:
```
// MemOps are not actually Callable, but we want to inline code into them, so we have to
// implement CallableOpInterface
```
is not accurate, because I can remove the `CallableOpInterface` from these two ops completely and nothing seems to break.
