### PR TITLE
Create alternative programming examples that use `dma_task` method for runtime sequence operations

### DIFF
--- a/programming_examples/basic/matrix_multiplication/single_core/aie2_alt.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/aie2_alt.py
@@ -286,16 +286,11 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str, trace_size):
                         )
                         with bds(c_task) as bd:
                             with bd[0]:
-                                dma_bd(
+                                shim_dma_bd(
                                     C,
                                     offset=C_row_offset,
-                                    len=N * m,
-                                    dimensions=[
-                                        (num_tile_rows, m_x_N),
-                                        (N_div_n, n),
-                                        (m, N),
-                                        (n, 1),
-                                    ],
+                                    sizes=[num_tile_rows, N_div_n, m, n],
+                                    strides=[m_x_N, n, N, 1],
                                 )
                                 EndOp()
                         dma_start_task(c_task)
@@ -309,16 +304,11 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str, trace_size):
                             )
                             with bds(a_task) as bd:
                                 with bd[0]:
-                                    dma_bd(
+                                    shim_dma_bd(
                                         A,
                                         offset=A_row_offset,
-                                        len=m * K,
-                                        dimensions=[
-                                            (1, 0),  # repeat/wrap w/o stride
-                                            (K_div_k, k),
-                                            (m, K),
-                                            (k, 1),
-                                        ],
+                                        sizes=[1, K_div_k, m, k],
+                                        strides=[0, k, K, 1],
                                     )
                                     EndOp()
                             dma_start_task(a_task)
@@ -330,16 +320,11 @@ def my_matmul(M, K, N, m, k, n, dtype_in_str, dtype_out_str, trace_size):
                             )
                             with bds(b_task) as bd:
                                 with bd[0]:
-                                    dma_bd(
+                                    shim_dma_bd(
                                         B,
                                         offset=0,
-                                        len=K * n,
-                                        dimensions=[
-                                            (N_div_n, n),
-                                            (K_div_k, k_x_N),
-                                            (k, N),
-                                            (n, 1),
-                                        ],
+                                        sizes=[N_div_n, K_div_k, k, n],
+                                        strides=[n, k_x_N, N, 1],
                                     )
                                     EndOp()
                             dma_start_task(b_task)

--- a/programming_examples/basic/row_wise_bias_add/Makefile
+++ b/programming_examples/basic/row_wise_bias_add/Makefile
@@ -37,6 +37,13 @@ N=2304
 m=96
 n=32
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 .PHONY: all
 all: ${xclbin_target} ${host_target}
 
@@ -44,7 +51,7 @@ build/kernel.o: ${srcdir}/kernel.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -DDIM_m=$m -DDIM_n=$n -c $< -o ${@F}
 
-${mlir_target}: ${srcdir}/aie2.py
+${mlir_target}: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< $M $N $m $n > $@
 

--- a/programming_examples/basic/row_wise_bias_add/aie2_alt.py
+++ b/programming_examples/basic/row_wise_bias_add/aie2_alt.py
@@ -1,0 +1,86 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 AMD Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+
+def row_wise_bias_add(M, N, m, n):
+
+    assert M % m == 0
+    assert N % n == 0
+
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+
+        tensor_ty = np.ndarray[(m * n,), np.dtype[np.float32]]
+        bias_ty = np.ndarray[(n,), np.dtype[np.float32]]
+
+        kernel_func = external_func(
+            f"row_wise_bias_add_f32_f32", inputs=[tensor_ty, bias_ty, tensor_ty]
+        )
+
+        shim_tile = tile(0, 0)
+        compute_tile = tile(0, 2)
+
+        in_fifo = object_fifo("in_fifo", shim_tile, compute_tile, 2, tensor_ty)
+        bias_fifo = object_fifo("bias_fifo", shim_tile, compute_tile, 2, bias_ty)
+        out_fifo = object_fifo("out_fifo", compute_tile, shim_tile, 2, tensor_ty)
+
+        @core(compute_tile, "kernel.o")
+        def core_body():
+            for _ in range_(0xFFFFFFFF):
+                for _ in range_(N // n):
+                    elem_bias = bias_fifo.acquire(ObjectFifoPort.Consume, 1)
+                    for _ in range_(M // m):
+                        elem_in = in_fifo.acquire(ObjectFifoPort.Consume, 1)
+                        elem_out = out_fifo.acquire(ObjectFifoPort.Produce, 1)
+                        kernel_func(elem_in, elem_bias, elem_out)
+                        out_fifo.release(ObjectFifoPort.Produce, 1)
+                        in_fifo.release(ObjectFifoPort.Consume, 1)
+                    bias_fifo.release(ObjectFifoPort.Consume, 1)
+
+        @runtime_sequence(tensor_ty, bias_ty, tensor_ty)
+        def sequence(inp, bias, out):
+
+            in_task = dma_configure_task_for(in_fifo)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(inp, sizes=[1, N // n, M, n], strides=[0, n, N, 1])
+                    EndOp()
+
+            bias_task = dma_configure_task_for(bias_fifo)
+            with bds(bias_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(bias, sizes=[1, 1, N // n, n], strides=[0, 0, n, 1])
+                    EndOp()
+
+            out_task = dma_configure_task_for(out_fifo, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(out, sizes=[1, N // n, M, n], strides=[0, n, N, 1])
+                    EndOp()
+
+            dma_start_task(in_task, bias_task, out_task)
+            dma_await_task(out_task)
+            dma_free_task(in_task, bias_task)
+
+
+# Declares that subsequent code is in mlir-aie context
+with mlir_mod_ctx() as ctx:
+    row_wise_bias_add(
+        int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+    )
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/row_wise_bias_add/run_makefile_alt.lit
+++ b/programming_examples/basic/row_wise_bias_add/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_exp/Makefile
+++ b/programming_examples/basic/vector_exp/Makefile
@@ -14,6 +14,13 @@ include ${srcdir}/../../makefile-common
 
 targetname = testExp
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin build/insts.txt
 
 VPATH := ${srcdir}/../../../aie_kernels/aie2
@@ -29,7 +36,7 @@ build/lut_based_ops.o: ${srcdir}/../../../aie_runtime_lib/AIE2/lut_based_ops.cpp
 build/kernels.a: build/exp.o build/lut_based_ops.o
 	ar rvs $@ $+
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 

--- a/programming_examples/basic/vector_exp/aie2_alt.py
+++ b/programming_examples/basic/vector_exp/aie2_alt.py
@@ -1,0 +1,134 @@
+# vector_exp/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+from ml_dtypes import bfloat16
+
+from aie.dialects.aie import *  # primary mlir-aie dialect definitions
+from aie.extras.context import mlir_mod_ctx  # mlir ctx wrapper
+
+from aie.dialects.aiex import *  # extended mlir-aie dialect definitions
+from aie.helpers.dialects.ext.scf import (
+    _for as range_,
+)  # scf (structured control flow) dialect
+from aie.helpers.util import np_ndarray_type_get_shape
+
+
+# AI Engine structural design function
+def my_eltwise_exp():
+
+    N = 65536
+
+    # Tile sizes
+    n = 1024
+    N_div_n = N // n
+
+    n_cores = 4
+    tiles = N_div_n // n_cores
+    buffer_depth = 2
+
+    # Device declaration - aie2 device NPU (aka Ryzen AI)
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the tile memory
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the memory tile which aggregates across the 4 cores
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+
+        # AIE Core Function declarations
+
+        exp_bf16_1024 = external_func("exp_bf16_1024", inputs=[tile_ty, tile_ty])
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+
+        MemTile = tile(0, 1)
+        cores = [tile(0, 2 + i) for i in range(n_cores)]
+
+        inA_fifos = []
+        outC_fifos = []
+
+        # AIE-array data movement with object fifos
+        # Input A
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
+        for i in range(n_cores):
+            inA_fifos.append(
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
+            )
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(inA, inA_fifos, [], of_offsets)
+
+        # Output C
+        for i in range(n_cores):
+            outC_fifos.append(
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
+            )
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(outC_fifos, outC, of_offsets, [])
+
+        # Compute tile bodies
+        for i in range(n_cores):
+            # Compute tile i
+            @core(cores[i], "kernels.a")
+            def core_body():
+                for _ in range_(0xFFFFFFFF):
+                    for _ in range_(tiles):
+                        elem_out = outC_fifos[i].acquire(ObjectFifoPort.Produce, 1)
+                        elem_in_a = inA_fifos[i].acquire(ObjectFifoPort.Consume, 1)
+
+                        exp_bf16_1024(elem_in_a, elem_out)
+
+                        inA_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        outC_fifos[i].release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
+
+        @runtime_sequence(tensor_ty, tensor_ty)
+        def sequence(A, C):
+            in_task = dma_configure_task_for(inA, issue_token=True)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            out_task = dma_configure_task_for(outC, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            dma_start_task(in_task, out_task)
+            dma_await_task(in_task, out_task)
+
+
+with mlir_mod_ctx() as ctx:
+    my_eltwise_exp()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_exp/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_exp/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_reduce_add/Makefile
+++ b/programming_examples/basic/vector_reduce_add/Makefile
@@ -16,6 +16,13 @@ targetname = reduce_add
 devicename = npu
 col = 0
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin build/insts.txt
 
 VPATH := ${srcdir}/../../../aie_kernels/aie2
@@ -24,7 +31,7 @@ build/%.cc.o: %.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS}  -c $< -o ${@F}
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${devicename} ${col} > $@
 

--- a/programming_examples/basic/vector_reduce_add/aie2_alt.py
+++ b/programming_examples/basic/vector_reduce_add/aie2_alt.py
@@ -1,0 +1,88 @@
+# vector_reduce_add/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+
+def my_reduce_add():
+    N = 1024
+
+    buffer_depth = 2
+
+    if len(sys.argv) != 3:
+        raise ValueError("[ERROR] Need 2 command line arguments (Device name, Col)")
+
+    if sys.argv[1] == "npu":
+        dev = AIEDevice.npu1_1col
+    elif sys.argv[1] == "xcvc1902":
+        dev = AIEDevice.xcvc1902
+    else:
+        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[1]))
+
+    @device(dev)
+    def device_body():
+        in_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        out_ty = np.ndarray[(1,), np.dtype[np.int32]]
+
+        # AIE Core Function declarations
+        reduce_add_vector = external_func(
+            "reduce_add_vector", inputs=[in_ty, out_ty, np.int32]
+        )
+
+        # Tile declarations
+        ShimTile = tile(int(sys.argv[2]), 0)
+        ComputeTile2 = tile(int(sys.argv[2]), 2)
+
+        # AIE-array data movement with object fifos
+        of_in = object_fifo("in", ShimTile, ComputeTile2, buffer_depth, in_ty)
+        of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, out_ty)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2, "reduce_add.cc.o")
+        def core_body():
+            for _ in range_(0xFFFFFFFF):
+                elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
+                elem_in = of_in.acquire(ObjectFifoPort.Consume, 1)
+                reduce_add_vector(elem_in, elem_out, N)
+                of_in.release(ObjectFifoPort.Consume, 1)
+                of_out.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(in_ty, out_ty)
+        def sequence(A, C):
+            in_task = dma_configure_task_for(of_in)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, 1])
+                    EndOp()
+
+            dma_start_task(in_task, out_task)
+            dma_await_task(out_task)
+            dma_free_task(in_task)
+
+
+with mlir_mod_ctx() as ctx:
+    my_reduce_add()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_reduce_add/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_reduce_add/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_reduce_max/Makefile
+++ b/programming_examples/basic/vector_reduce_max/Makefile
@@ -18,6 +18,13 @@ targetname = reduce_max
 devicename = npu
 col = 0
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin build/insts.txt
 
 VPATH := ${srcdir}/../../../aie_kernels/aie2
@@ -26,7 +33,7 @@ build/%.cc.o: %.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${devicename} ${col} > $@
 

--- a/programming_examples/basic/vector_reduce_max/aie2_alt.py
+++ b/programming_examples/basic/vector_reduce_max/aie2_alt.py
@@ -1,0 +1,87 @@
+# vector_reduce_max/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+
+def my_reduce_max():
+    N = 1024
+
+    buffer_depth = 2
+
+    if len(sys.argv) != 3:
+        raise ValueError("[ERROR] Need 2 command line arguments (Device name, Col)")
+
+    if sys.argv[1] == "npu":
+        dev = AIEDevice.npu1_1col
+    elif sys.argv[1] == "xcvc1902":
+        dev = AIEDevice.xcvc1902
+    else:
+        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[1]))
+
+    @device(dev)
+    def device_body():
+        in_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        out_ty = np.ndarray[(1,), np.dtype[np.int32]]
+
+        # AIE Core Function declarations
+        reduce_max_vector = external_func(
+            "reduce_max_vector", inputs=[in_ty, out_ty, np.int32]
+        )
+
+        # Tile declarations
+        ShimTile = tile(int(sys.argv[2]), 0)
+        ComputeTile2 = tile(int(sys.argv[2]), 2)
+
+        # AIE-array data movement with object fifos
+        of_in = object_fifo("in", ShimTile, ComputeTile2, buffer_depth, in_ty)
+        of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, out_ty)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2, "reduce_max.cc.o")
+        def core_body():
+            for _ in range_(0xFFFFFFFF):
+                elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
+                elem_in = of_in.acquire(ObjectFifoPort.Consume, 1)
+                reduce_max_vector(elem_in, elem_out, N)
+                of_in.release(ObjectFifoPort.Consume, 1)
+                of_out.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(in_ty, out_ty)
+        def sequence(A, C):
+            in_task = dma_configure_task_for(of_in, issue_token=True)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, 1])
+                    EndOp()
+
+            dma_start_task(in_task, out_task)
+            dma_await_task(in_task, out_task)
+
+
+with mlir_mod_ctx() as ctx:
+    my_reduce_max()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_reduce_max/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_reduce_max/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_reduce_min/Makefile
+++ b/programming_examples/basic/vector_reduce_min/Makefile
@@ -16,6 +16,13 @@ targetname = reduce_min
 devicename = npu
 col = 0
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin build/insts.txt
 
 VPATH := ${srcdir}/../../../aie_kernels/aie2
@@ -24,7 +31,7 @@ build/%.cc.o: %.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${devicename} ${col} > $@
 

--- a/programming_examples/basic/vector_reduce_min/aie2_alt.py
+++ b/programming_examples/basic/vector_reduce_min/aie2_alt.py
@@ -1,0 +1,88 @@
+# vector_reduce_min/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+
+def my_reduce_min():
+    N = 1024
+
+    buffer_depth = 2
+
+    if len(sys.argv) != 3:
+        raise ValueError("[ERROR] Need 2 command line arguments (Device name, Col)")
+
+    if sys.argv[1] == "npu":
+        dev = AIEDevice.npu1_1col
+    elif sys.argv[1] == "xcvc1902":
+        dev = AIEDevice.xcvc1902
+    else:
+        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[1]))
+
+    @device(dev)
+    def device_body():
+        in_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        out_ty = np.ndarray[(1,), np.dtype[np.int32]]
+
+        # AIE Core Function declarations
+        reduce_min_vector = external_func(
+            "reduce_min_vector", inputs=[in_ty, out_ty, np.int32]
+        )
+
+        # Tile declarations
+        ShimTile = tile(int(sys.argv[2]), 0)
+        ComputeTile2 = tile(int(sys.argv[2]), 2)
+
+        # AIE-array data movement with object fifos
+        of_in = object_fifo("in", ShimTile, ComputeTile2, buffer_depth, in_ty)
+        of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, out_ty)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2, "reduce_min.cc.o")
+        def core_body():
+            for _ in range_(0xFFFFFFFF):
+                elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
+                elem_in = of_in.acquire(ObjectFifoPort.Consume, 1)
+                reduce_min_vector(elem_in, elem_out, N)
+                of_in.release(ObjectFifoPort.Consume, 1)
+                of_out.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(in_ty, out_ty)
+        def sequence(A, C):
+            in_task = dma_configure_task_for(of_in)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, 1])
+                    EndOp()
+
+            dma_start_task(in_task, out_task)
+            dma_await_task(out_task)
+            dma_free_task(in_task)
+
+
+with mlir_mod_ctx() as ctx:
+    my_reduce_min()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_reduce_min/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_reduce_min/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_scalar_add/Makefile
+++ b/programming_examples/basic/vector_scalar_add/Makefile
@@ -16,7 +16,14 @@ all: build/final.xclbin
 
 targetname = vectorScalarAdd
 
-build/aie.mlir: ${srcdir}/aie2.py
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 

--- a/programming_examples/basic/vector_scalar_add/aie2_alt.py
+++ b/programming_examples/basic/vector_scalar_add/aie2_alt.py
@@ -1,0 +1,84 @@
+# vector_scalar_add/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+PROBLEM_SIZE = 1024
+MEM_TILE_WIDTH = 64
+AIE_TILE_WIDTH = 32
+
+
+def my_vector_bias_add():
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+        mem_tile_ty = np.ndarray[(AIE_TILE_WIDTH,), np.dtype[np.int32]]
+        aie_tile_ty = np.ndarray[(AIE_TILE_WIDTH,), np.dtype[np.int32]]
+        all_data_ty = np.ndarray[(PROBLEM_SIZE,), np.dtype[np.int32]]
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+        MemTile = tile(0, 1)
+        ComputeTile2 = tile(0, 2)
+
+        # AIE-array data movement with object fifos
+        # Input
+        of_in0 = object_fifo("in0", ShimTile, MemTile, 2, mem_tile_ty)
+        of_in1 = object_fifo("in1", MemTile, ComputeTile2, 2, aie_tile_ty)
+        object_fifo_link(of_in0, of_in1)
+
+        # Output
+        of_out0 = object_fifo("out0", MemTile, ShimTile, 2, mem_tile_ty)
+        of_out1 = object_fifo("out1", ComputeTile2, MemTile, 2, aie_tile_ty)
+        object_fifo_link(of_out1, of_out0)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2)
+        def core_body():
+            # Effective while(1)
+            for _ in range_(sys.maxsize):
+                elem_in = of_in1.acquire(ObjectFifoPort.Consume, 1)
+                elem_out = of_out1.acquire(ObjectFifoPort.Produce, 1)
+                for i in range_(AIE_TILE_WIDTH):
+                    elem_out[i] = elem_in[i] + 1
+                of_in1.release(ObjectFifoPort.Consume, 1)
+                of_out1.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(all_data_ty, all_data_ty)
+        def sequence(inTensor, outTensor):
+            in_task = dma_configure_task_for(of_in0, issue_token=True)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(inTensor, sizes=[1, 1, 1, PROBLEM_SIZE])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out0, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(outTensor, sizes=[1, 1, 1, PROBLEM_SIZE])
+                    EndOp()
+
+            dma_start_task(in_task, out_task)
+            dma_await_task(in_task, out_task)
+
+
+# Declares that subsequent code is in mlir-aie context
+with mlir_mod_ctx() as ctx:
+    my_vector_bias_add()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_scalar_add/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_scalar_add/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_scalar_add_runlist/Makefile
+++ b/programming_examples/basic/vector_scalar_add_runlist/Makefile
@@ -16,7 +16,14 @@ all: build/final.xclbin
 
 targetname = vectorScalarAdd
 
-build/aie.mlir: ${srcdir}/aie2.py
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 

--- a/programming_examples/basic/vector_scalar_add_runlist/aie2_alt.py
+++ b/programming_examples/basic/vector_scalar_add_runlist/aie2_alt.py
@@ -1,0 +1,85 @@
+# vector_scalar_add/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+PROBLEM_SIZE = 1024
+MEM_TILE_WIDTH = 64
+AIE_TILE_WIDTH = 32
+
+
+def my_vector_bias_add():
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+        mem_tile_ty = np.ndarray[(MEM_TILE_WIDTH,), np.dtype[np.int32]]
+        aie_tile_ty = np.ndarray[(AIE_TILE_WIDTH,), np.dtype[np.int32]]
+        all_data_ty = np.ndarray[(PROBLEM_SIZE,), np.dtype[np.int32]]
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+        MemTile = tile(0, 1)
+        ComputeTile2 = tile(0, 2)
+
+        # AIE-array data movement with object fifos
+        # Input
+        of_in0 = object_fifo("in0", ShimTile, MemTile, 2, mem_tile_ty)
+        of_in1 = object_fifo("in1", MemTile, ComputeTile2, 2, aie_tile_ty)
+        object_fifo_link(of_in0, of_in1)
+
+        # Output
+        of_out0 = object_fifo("out0", MemTile, ShimTile, 2, mem_tile_ty)
+        of_out1 = object_fifo("out1", ComputeTile2, MemTile, 2, aie_tile_ty)
+        object_fifo_link(of_out1, of_out0)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2)
+        def core_body():
+            # Effective while(1)
+            for _ in range_(sys.maxsize):
+                elem_in = of_in1.acquire(ObjectFifoPort.Consume, 1)
+                elem_out = of_out1.acquire(ObjectFifoPort.Produce, 1)
+                for i in range_(AIE_TILE_WIDTH):
+                    elem_out[i] = elem_in[i] + 1
+                of_in1.release(ObjectFifoPort.Consume, 1)
+                of_out1.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(all_data_ty, all_data_ty)
+        def sequence(inTensor, outTensor):
+            in_task = dma_configure_task_for(of_in0)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(inTensor, sizes=[1, 1, 1, PROBLEM_SIZE])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out0, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(outTensor, sizes=[1, 1, 1, PROBLEM_SIZE])
+                    EndOp()
+
+            dma_start_task(in_task, out_task)
+            dma_await_task(out_task)
+            dma_free_task(in_task)
+
+
+# Declares that subsequent code is in mlir-aie context
+with mlir_mod_ctx() as ctx:
+    my_vector_bias_add()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_scalar_add_runlist/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_scalar_add_runlist/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_scalar_mul/Makefile
+++ b/programming_examples/basic/vector_scalar_mul/Makefile
@@ -19,6 +19,13 @@ data_size = 4096
 trace_size = 8192
 CHESS ?= true
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final_${data_size}.xclbin build/insts_${data_size}.txt
 
 kristof: build/insts_${data_size}.txt
@@ -31,11 +38,11 @@ else
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}; 
 endif
 
-build/aie_${data_size}.mlir: ${srcdir}/aie2.py
+build/aie_${data_size}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${data_size} 0 > $@
 
-build/aie_trace_${data_size}.mlir: ${srcdir}/aie2.py
+build/aie_trace_${data_size}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${data_size} ${trace_size} > $@
 

--- a/programming_examples/basic/vector_scalar_mul/aie2_alt.py
+++ b/programming_examples/basic/vector_scalar_mul/aie2_alt.py
@@ -1,0 +1,117 @@
+# vector_scalar_mul/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+import aie.utils.trace as trace_utils
+
+
+def my_vector_scalar(vector_size, trace_size):
+    N = vector_size
+    N_in_bytes = N * 2
+    N_div_n = 4  # chop input vector into 4 sub-vectors
+    n = N // N_div_n
+
+    buffer_depth = 2
+
+    vectorized = True
+
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+        tensor_ty = np.ndarray[(N,), np.dtype[np.int16]]
+        tile_ty = np.ndarray[(n,), np.dtype[np.int16]]
+        scalar_ty = np.ndarray[(1,), np.dtype[np.int32]]
+
+        # AIE Core Function declarations
+
+        func_type = "vector" if vectorized else "scalar"
+        scale = external_func(
+            f"vector_scalar_mul_int16_{func_type}",
+            inputs=[tile_ty, tile_ty, scalar_ty, np.int32],
+        )
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+        ComputeTile2 = tile(0, 2)
+
+        # AIE-array data movement with object fifos
+        of_in = object_fifo("in", ShimTile, ComputeTile2, buffer_depth, tile_ty)
+        of_factor = object_fifo(
+            "infactor", ShimTile, ComputeTile2, buffer_depth, scalar_ty
+        )
+        of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, tile_ty)
+
+        # Set up a packet-switched flow from core to shim for tracing information
+        tiles_to_trace = [ComputeTile2]
+        if trace_size > 0:
+            trace_utils.configure_packet_tracing_flow(tiles_to_trace, ShimTile)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2, "scale.o")
+        def core_body():
+            # Effective while(1)
+            for _ in range_(sys.maxsize):
+                elem_factor = of_factor.acquire(ObjectFifoPort.Consume, 1)
+                # Number of sub-vector "tile" iterations
+                for _ in range_(N_div_n):
+                    elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
+                    elem_in = of_in.acquire(ObjectFifoPort.Consume, 1)
+                    scale(elem_in, elem_out, elem_factor, n)
+                    of_in.release(ObjectFifoPort.Consume, 1)
+                    of_out.release(ObjectFifoPort.Produce, 1)
+                of_factor.release(ObjectFifoPort.Consume, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(tensor_ty, scalar_ty, tensor_ty)
+        def sequence(A, F, C):
+
+            if trace_size > 0:
+                trace_utils.configure_packet_tracing_aie2(
+                    tiles_to_trace, ShimTile, trace_size, N_in_bytes
+                )
+
+            in_task = dma_configure_task_for(of_in, issue_token=True)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            in_factor_task = dma_configure_task_for(of_factor, issue_token=True)
+            with bds(in_factor_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(F)
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            dma_start_task(in_task, in_factor_task, out_task)
+            dma_await_task(in_task, in_factor_task, out_task)
+
+
+try:
+    vector_size = int(sys.argv[1])
+    if vector_size % 64 != 0 or vector_size < 512:
+        print("Vector size must be a multiple of 64 and greater than or equal to 512")
+        raise ValueError
+    trace_size = 0 if (len(sys.argv) != 3) else int(sys.argv[2])
+except ValueError:
+    print("Argument has inappropriate value")
+with mlir_mod_ctx() as ctx:
+    my_vector_scalar(vector_size, trace_size)
+    print(ctx.module)

--- a/programming_examples/basic/vector_scalar_mul/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env CHESS=true use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_vector_add/Makefile
+++ b/programming_examples/basic/vector_vector_add/Makefile
@@ -16,9 +16,16 @@ targetname = vectorAdd
 devicename = npu
 col = 0
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${devicename} ${col} > $@
 

--- a/programming_examples/basic/vector_vector_add/aie2_alt.py
+++ b/programming_examples/basic/vector_vector_add/aie2_alt.py
@@ -1,0 +1,100 @@
+# vector_vector_add/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+
+def my_vector_add():
+    N = 256
+    n = 16
+    N_div_n = N // n
+
+    buffer_depth = 2
+
+    if len(sys.argv) != 3:
+        raise ValueError("[ERROR] Need 2 command line arguments (Device name, Col)")
+
+    if sys.argv[1] == "npu":
+        dev = AIEDevice.npu1_1col
+    elif sys.argv[1] == "xcvc1902":
+        dev = AIEDevice.xcvc1902
+    else:
+        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[1]))
+
+    @device(dev)
+    def device_body():
+        tensor_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        tile_ty = np.ndarray[(n,), np.dtype[np.int32]]
+
+        # AIE Core Function declarations
+
+        # Tile declarations
+        ShimTile = tile(int(sys.argv[2]), 0)
+        ComputeTile2 = tile(int(sys.argv[2]), 2)
+
+        # AIE-array data movement with object fifos
+        of_in1 = object_fifo("in1", ShimTile, ComputeTile2, buffer_depth, tile_ty)
+        of_in2 = object_fifo("in2", ShimTile, ComputeTile2, buffer_depth, tile_ty)
+        of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, tile_ty)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2)
+        def core_body():
+            # Effective while(1)
+            for _ in range_(sys.maxsize):
+                # Number of sub-vector "tile" iterations
+                for _ in range_(N_div_n):
+                    elem_in1 = of_in1.acquire(ObjectFifoPort.Consume, 1)
+                    elem_in2 = of_in2.acquire(ObjectFifoPort.Consume, 1)
+                    elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
+                    for i in range_(n):
+                        elem_out[i] = elem_in1[i] + elem_in2[i]
+                    of_in1.release(ObjectFifoPort.Consume, 1)
+                    of_in2.release(ObjectFifoPort.Consume, 1)
+                    of_out.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
+        def sequence(A, B, C):
+            in1_task = dma_configure_task_for(of_in1)
+            with bds(in1_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            in2_task = dma_configure_task_for(of_in2)
+            with bds(in2_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(B, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            dma_start_task(in1_task, in2_task, out_task)
+            dma_await_task(out_task)
+            dma_free_task(in1_task, in2_task)
+
+
+with mlir_mod_ctx() as ctx:
+    my_vector_add()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_vector_add/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_vector_add/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_vector_modulo/Makefile
+++ b/programming_examples/basic/vector_vector_modulo/Makefile
@@ -16,9 +16,16 @@ targetname = vectorModulo
 devicename = npu
 col = 0
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${devicename} ${col} > $@
 

--- a/programming_examples/basic/vector_vector_modulo/aie2_alt.py
+++ b/programming_examples/basic/vector_vector_modulo/aie2_alt.py
@@ -1,0 +1,99 @@
+# vector_vector_add/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+
+def my_vector_add():
+    N = 256
+    n = 16
+    N_div_n = N // n
+
+    buffer_depth = 2
+
+    if len(sys.argv) != 3:
+        raise ValueError("[ERROR] Need 2 command line arguments (Device name, Col)")
+
+    if sys.argv[1] == "npu":
+        dev = AIEDevice.npu1_1col
+    elif sys.argv[1] == "xcvc1902":
+        dev = AIEDevice.xcvc1902
+    else:
+        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[1]))
+
+    @device(dev)
+    def device_body():
+        tensor_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        tile_ty = np.ndarray[(n,), np.dtype[np.int32]]
+
+        # AIE Core Function declarations
+
+        # Tile declarations
+        ShimTile = tile(int(sys.argv[2]), 0)
+        ComputeTile2 = tile(int(sys.argv[2]), 2)
+
+        # AIE-array data movement with object fifos
+        of_in1 = object_fifo("in1", ShimTile, ComputeTile2, buffer_depth, tile_ty)
+        of_in2 = object_fifo("in2", ShimTile, ComputeTile2, buffer_depth, tile_ty)
+        of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, tile_ty)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2)
+        def core_body():
+            # Effective while(1)
+            for _ in range_(sys.maxsize):
+                # Number of sub-vector "tile" iterations
+                for _ in range_(N_div_n):
+                    elem_in1 = of_in1.acquire(ObjectFifoPort.Consume, 1)
+                    elem_in2 = of_in2.acquire(ObjectFifoPort.Consume, 1)
+                    elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
+                    for i in range_(n):
+                        elem_out[i] = elem_in1[i] % elem_in2[i]
+                    of_in1.release(ObjectFifoPort.Consume, 1)
+                    of_in2.release(ObjectFifoPort.Consume, 1)
+                    of_out.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
+        def sequence(A, B, C):
+            in1_task = dma_configure_task_for(of_in1, issue_token=True)
+            with bds(in1_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            in2_task = dma_configure_task_for(of_in2, issue_token=True)
+            with bds(in2_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(B, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            dma_start_task(in1_task, in2_task, out_task)
+            dma_await_task(in1_task, in2_task, out_task)
+
+
+with mlir_mod_ctx() as ctx:
+    my_vector_add()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_vector_modulo/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_vector_modulo/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/basic/vector_vector_mul/Makefile
+++ b/programming_examples/basic/vector_vector_mul/Makefile
@@ -16,9 +16,16 @@ targetname = vectorMult
 devicename = npu
 col = 0
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${devicename} ${col} > $@
 

--- a/programming_examples/basic/vector_vector_mul/aie2_alt.py
+++ b/programming_examples/basic/vector_vector_mul/aie2_alt.py
@@ -1,0 +1,101 @@
+# vector_vector_mul/aie2.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+
+def my_vector_mul():
+    N = 256
+    n = 16
+    N_div_n = N // n
+
+    buffer_depth = 2
+
+    if len(sys.argv) != 3:
+        raise ValueError("[ERROR] Need 2 command line arguments (Device name, Col)")
+
+    if sys.argv[1] == "npu":
+        dev = AIEDevice.npu1_1col
+    elif sys.argv[1] == "xcvc1902":
+        dev = AIEDevice.xcvc1902
+    else:
+        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[1]))
+
+    @device(dev)
+    def device_body():
+        tensor_ty = np.ndarray[(N,), np.dtype[np.int32]]
+        tile_ty = np.ndarray[(n,), np.dtype[np.int32]]
+
+        # AIE Core Function declarations
+
+        # Tile declarations
+        ShimTile = tile(int(sys.argv[2]), 0)
+        ComputeTile2 = tile(int(sys.argv[2]), 2)
+
+        # AIE-array data movement with object fifos
+        of_in1 = object_fifo("in1", ShimTile, ComputeTile2, buffer_depth, tile_ty)
+        of_in2 = object_fifo("in2", ShimTile, ComputeTile2, buffer_depth, tile_ty)
+        of_out = object_fifo("out", ComputeTile2, ShimTile, buffer_depth, tile_ty)
+
+        # Set up compute tiles
+
+        # Compute tile 2
+        @core(ComputeTile2)
+        def core_body():
+            # Effective while(1)
+            for _ in range_(sys.maxsize):
+                # Number of sub-vector "tile" iterations
+                for _ in range_(N_div_n):
+                    elem_in1 = of_in1.acquire(ObjectFifoPort.Consume, 1)
+                    elem_in2 = of_in2.acquire(ObjectFifoPort.Consume, 1)
+                    elem_out = of_out.acquire(ObjectFifoPort.Produce, 1)
+                    for i in range_(n):
+                        elem_out[i] = elem_in1[i] * elem_in2[i]
+                    of_in1.release(ObjectFifoPort.Consume, 1)
+                    of_in2.release(ObjectFifoPort.Consume, 1)
+                    of_out.release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
+        def sequence(A, B, C):
+            in1_task = dma_configure_task_for(of_in1)
+            with bds(in1_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            in2_task = dma_configure_task_for(of_in2)
+            with bds(in2_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(B, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            out_task = dma_configure_task_for(of_out, issue_token=True)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+
+            dma_start_task(in1_task, in2_task, out_task)
+            # out_task will only complete after in1_task and in2_task completes, so we just wait on of_out instead of all
+            dma_await_task(out_task)
+            dma_free_task(in1_task, in2_task)
+
+
+with mlir_mod_ctx() as ctx:
+    my_vector_mul()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/vector_vector_mul/run_makefile_alt.lit
+++ b/programming_examples/basic/vector_vector_mul/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/bottleneck/Makefile
+++ b/programming_examples/ml/bottleneck/Makefile
@@ -11,11 +11,18 @@ include ${srcdir}/../../makefile-common
 
 mlirFileName = aie
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
 all: build/conv2dk1.o build/conv2dk3.o build/conv2dk1_skip.o build/final.xclbin
 
-build/${mlirFileName}.mlir: ${srcdir}/aie2.py
+build/${mlirFileName}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 

--- a/programming_examples/ml/bottleneck/aie2_alt.py
+++ b/programming_examples/ml/bottleneck/aie2_alt.py
@@ -1,0 +1,581 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.helpers.util import np_ndarray_type_get_shape
+
+# tracing definitions
+trace_sz_in_bytes = 8192
+trace_sz_in_i32s = trace_sz_in_bytes // 4
+enableTrace = False
+
+# Define bottleneck layer sizes
+
+tensorInW = 32
+tensorInH = 32
+tensorInC = 256
+
+tensorL1InC = tensorInC
+tensorL1OutC = tensorL1InC // 4
+
+tensorL2InC = tensorL1OutC
+tensorL2OutC = tensorL2InC
+
+tensorL3InC = tensorL2OutC
+tensorL3OutC = tensorL3InC * 4
+
+activationsIn = tensorInW * tensorInH * tensorInC
+acitivationsOut = activationsIn
+totalWeights = (
+    tensorL1InC * tensorL1OutC
+    + 3 * 3 * tensorL2InC * tensorL2OutC
+    + tensorL3InC * tensorL3OutC
+)
+
+
+def bottleneck4AIEs():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def deviceBody():
+
+            # define types
+            activationsInL3_ty = np.ndarray[(activationsIn,), np.dtype[np.int8]]
+            weightsInL3_ty = np.ndarray[(totalWeights,), np.dtype[np.uint8]]
+            weightsAll_ty = np.ndarray[(totalWeights,), np.dtype[np.int8]]
+
+            tensorLayer1In_ty = np.ndarray[
+                (tensorInW, 1, tensorL1InC), np.dtype[np.int8]
+            ]
+            weightsLayer1_ty = np.ndarray[
+                (tensorL1InC * tensorL1OutC,), np.dtype[np.int8]
+            ]
+            tensorLayer1Out_ty = np.ndarray[
+                (tensorInW, 1, tensorL1OutC), np.dtype[np.uint8]
+            ]
+
+            tensorLayer2In_ty = np.ndarray[
+                (tensorInW, 1, tensorL2InC), np.dtype[np.uint8]
+            ]
+            weightsLayer2_ty = np.ndarray[
+                (3 * 3 * tensorL2InC * tensorL2OutC,), np.dtype[np.int8]
+            ]
+            tensorLayer2Out_ty = np.ndarray[
+                (tensorInW, 1, tensorL2OutC // 2), np.dtype[np.uint8]
+            ]
+
+            tensorLayer3In_ty = np.ndarray[
+                (tensorInW, 1, tensorL3InC // 2), np.dtype[np.uint8]
+            ]
+            weightsLayer3_ty = np.ndarray[
+                (tensorL3InC * tensorL3OutC,), np.dtype[np.int8]
+            ]
+            tensorLayer3Out_ty = np.ndarray[
+                (tensorInW, 1, tensorL3OutC), np.dtype[np.uint8]
+            ]
+
+            # kernel definitions
+            conv2dk1 = external_func(
+                "conv2dk1_i8",
+                inputs=[
+                    tensorLayer1In_ty,
+                    weightsLayer1_ty,
+                    tensorLayer1Out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+            conv2dk3 = external_func(
+                "conv2dk3_ui8",
+                inputs=[
+                    tensorLayer2In_ty,
+                    tensorLayer2In_ty,
+                    tensorLayer2In_ty,
+                    weightsLayer2_ty,
+                    tensorLayer2Out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+            conv2dk1_skip = external_func(
+                "conv2dk1_skip_i8",
+                inputs=[
+                    tensorLayer3In_ty,
+                    tensorLayer3In_ty,
+                    weightsLayer3_ty,
+                    tensorLayer3Out_ty,
+                    tensorLayer1In_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+
+            ShimTile = tile(0, 0)
+            MemTile = tile(0, 1)
+            ComputeTile2 = tile(0, 2)
+            ComputeTile3 = tile(0, 3)
+            ComputeTile4 = tile(0, 4)
+            ComputeTile5 = tile(0, 5)
+
+            if enableTrace:
+                flow(ComputeTile4, WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
+
+            # runtime parameters
+
+            rtpComputeTile2 = buffer(
+                ComputeTile2,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile2",
+                use_write_rtp=True,
+            )
+            rtpComputeTile3 = buffer(
+                ComputeTile3,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile3",
+                use_write_rtp=True,
+            )
+            rtpComputeTile4 = buffer(
+                ComputeTile4,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile4",
+                use_write_rtp=True,
+            )
+            rtpComputeTile5 = buffer(
+                ComputeTile5,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile5",
+                use_write_rtp=True,
+            )
+
+            # set up data movement with OFs
+            # input tensor (with broadcast for skip connection)
+            of_inOF_act_L3L2 = object_fifo(
+                "inOF_act_L3L2",
+                ShimTile,
+                [ComputeTile2, MemTile],
+                [2, 2, 4],
+                tensorLayer1In_ty,
+            )
+            of_skip_buf = object_fifo(
+                "skip_buf", MemTile, ComputeTile4, 2, tensorLayer1In_ty
+            )
+            object_fifo_link(of_inOF_act_L3L2, of_skip_buf)
+
+            # weights
+            inOF_wts_0_L3L2 = object_fifo(
+                "inOF_wts_0_L3L2", ShimTile, MemTile, 1, weightsAll_ty
+            )
+            of_wts_buf_00 = object_fifo(
+                "wts_buf_00", MemTile, ComputeTile2, 1, weightsLayer1_ty
+            )
+            wts_buf_01 = object_fifo(
+                "wts_buf_01",
+                MemTile,
+                [ComputeTile3, ComputeTile5],
+                1,
+                weightsLayer2_ty,
+            )
+            wts_buf_02 = object_fifo(
+                "wts_buf_02", MemTile, ComputeTile4, 1, weightsLayer3_ty
+            )
+            of_offsets = [
+                0,
+                np.prod(np_ndarray_type_get_shape(weightsLayer1_ty)),
+                np.prod(np_ndarray_type_get_shape(weightsLayer1_ty))
+                + np.prod(np_ndarray_type_get_shape(weightsLayer2_ty)),
+            ]
+            object_fifo_link(
+                inOF_wts_0_L3L2, [of_wts_buf_00, wts_buf_01, wts_buf_02], [], of_offsets
+            )
+
+            # activation tensor
+            of_act_2_3_5 = object_fifo(
+                "act_2_3_5",
+                ComputeTile2,
+                [ComputeTile3, ComputeTile5],
+                [2, 4, 4],
+                tensorLayer1Out_ty,
+            )  # 1x1 -> 3x3
+            act_3_4 = object_fifo(
+                "act_3_4", ComputeTile3, ComputeTile4, 2, tensorLayer2Out_ty
+            )  # 3x3 -> 1x1
+            act_5_4 = object_fifo(
+                "act_5_4", ComputeTile5, ComputeTile4, 2, tensorLayer2Out_ty
+            )  # 3x3 -> 1x1
+
+            # output tensor
+            outOFL2L3 = object_fifo(
+                "outOFL2L3", ComputeTile4, ShimTile, 2, tensorLayer3Out_ty
+            )
+
+            # 1x1 conv2d
+            @core(ComputeTile2, "conv2dk1.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    # acquire weights once
+                    element0Weights = of_wts_buf_00.acquire(ObjectFifoPort.Consume, 1)
+                    scale = rtpComputeTile2[0]
+                    for _ in range_(tensorInH):
+                        element0ActivactionsIn = of_inOF_act_L3L2.acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
+                        element0ActivactionsOut = of_act_2_3_5.acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+                        conv2dk1(
+                            element0ActivactionsIn,
+                            element0Weights,
+                            element0ActivactionsOut,
+                            tensorInW,
+                            tensorL1InC,
+                            tensorL1OutC,
+                            scale,
+                        )
+                        of_inOF_act_L3L2.release(ObjectFifoPort.Consume, 1)
+                        of_act_2_3_5.release(ObjectFifoPort.Produce, 1)
+                    of_wts_buf_00.release(ObjectFifoPort.Consume, 1)
+
+            # 3x3 conv2d OFM 0-31
+            @core(ComputeTile3, "conv2dk3.o")
+            def core_body():
+                scale = 11
+                for _ in range_(sys.maxsize):
+
+                    # acquire weights and rtps once
+                    element0Weights = wts_buf_01.acquire(ObjectFifoPort.Consume, 1)
+                    # scale = memref.load(rtpComputeTile3, 0)
+
+                    # pre-amble: top row
+                    elementActivactionsIn = of_act_2_3_5.acquire(
+                        ObjectFifoPort.Consume, 2
+                    )
+                    element0ActivactionsOut = act_3_4.acquire(ObjectFifoPort.Produce, 1)
+                    conv2dk3(
+                        elementActivactionsIn[0],
+                        elementActivactionsIn[0],
+                        elementActivactionsIn[1],
+                        element0Weights,
+                        element0ActivactionsOut,
+                        tensorInW,
+                        tensorL2InC,
+                        tensorL2OutC,
+                        3,
+                        3,
+                        0,
+                        scale,
+                        0,
+                    )
+                    act_3_4.release(ObjectFifoPort.Produce, 1)
+
+                    # middle
+                    for _ in range_(tensorInH - 2):
+                        elementActivactionsIn = of_act_2_3_5.acquire(
+                            ObjectFifoPort.Consume, 3
+                        )
+                        element0ActivactionsOut = act_3_4.acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+                        conv2dk3(
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[1],
+                            elementActivactionsIn[2],
+                            element0Weights,
+                            element0ActivactionsOut,
+                            tensorInW,
+                            tensorL2InC,
+                            tensorL2OutC,
+                            3,
+                            3,
+                            1,
+                            scale,
+                            0,
+                        )
+                        of_act_2_3_5.release(ObjectFifoPort.Consume, 1)
+                        act_3_4.release(ObjectFifoPort.Produce, 1)
+
+                    # last part
+                    elementActivactionsIn = of_act_2_3_5.acquire(
+                        ObjectFifoPort.Consume, 2
+                    )
+                    element0ActivactionsOut = act_3_4.acquire(ObjectFifoPort.Produce, 1)
+                    conv2dk3(
+                        elementActivactionsIn[0],
+                        elementActivactionsIn[1],
+                        elementActivactionsIn[1],
+                        element0Weights,
+                        element0ActivactionsOut,
+                        tensorInW,
+                        tensorL2InC,
+                        tensorL2OutC,
+                        3,
+                        3,
+                        2,
+                        scale,
+                        0,
+                    )
+
+                    of_act_2_3_5.release(ObjectFifoPort.Consume, 2)
+                    act_3_4.release(ObjectFifoPort.Produce, 1)
+                    wts_buf_01.release(ObjectFifoPort.Consume, 1)
+
+            # 3x3 conv2d OFM 32-63
+            @core(ComputeTile5, "conv2dk3.o")
+            def core_body():
+                scale = 11
+                for _ in range_(sys.maxsize):
+
+                    # acquire weights and rtps once
+                    element0Weights = wts_buf_01.acquire(ObjectFifoPort.Consume, 1)
+                    # scale = memref.load(rtpComputeTile5, 0)
+
+                    # pre-amble: top row
+                    elementActivactionsIn = of_act_2_3_5.acquire(
+                        ObjectFifoPort.Consume, 2
+                    )
+                    element0ActivactionsOut = act_5_4.acquire(ObjectFifoPort.Produce, 1)
+                    conv2dk3(
+                        elementActivactionsIn[0],
+                        elementActivactionsIn[0],
+                        elementActivactionsIn[1],
+                        element0Weights,
+                        element0ActivactionsOut,
+                        tensorInW,
+                        tensorL2InC,
+                        tensorL2OutC,
+                        3,
+                        3,
+                        0,
+                        scale,
+                        tensorL2OutC // 2,
+                    )
+                    act_5_4.release(ObjectFifoPort.Produce, 1)
+
+                    # middle
+                    for _ in range_(tensorInH - 2):
+                        elementActivactionsIn = of_act_2_3_5.acquire(
+                            ObjectFifoPort.Consume, 3
+                        )
+                        element0ActivactionsOut = act_5_4.acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+                        conv2dk3(
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[1],
+                            elementActivactionsIn[2],
+                            element0Weights,
+                            element0ActivactionsOut,
+                            tensorInW,
+                            tensorL2InC,
+                            tensorL2OutC,
+                            3,
+                            3,
+                            1,
+                            scale,
+                            tensorL2OutC // 2,
+                        )
+                        of_act_2_3_5.release(ObjectFifoPort.Consume, 1)
+                        act_5_4.release(ObjectFifoPort.Produce, 1)
+
+                    # last part
+                    elementActivactionsIn = of_act_2_3_5.acquire(
+                        ObjectFifoPort.Consume, 2
+                    )
+                    element0ActivactionsOut = act_5_4.acquire(ObjectFifoPort.Produce, 1)
+                    conv2dk3(
+                        elementActivactionsIn[0],
+                        elementActivactionsIn[1],
+                        elementActivactionsIn[1],
+                        element0Weights,
+                        element0ActivactionsOut,
+                        tensorInW,
+                        tensorL2InC,
+                        tensorL2OutC,
+                        3,
+                        3,
+                        2,
+                        scale,
+                        tensorL2OutC // 2,
+                    )
+                    of_act_2_3_5.release(ObjectFifoPort.Consume, 2)
+                    act_5_4.release(ObjectFifoPort.Produce, 1)
+                    wts_buf_01.release(ObjectFifoPort.Consume, 1)
+
+            # # 1x1 conv2d and add skip
+            @core(ComputeTile4, "conv2dk1_skip.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+
+                    # acquire weights and rtps once
+                    element0Weights = wts_buf_02.acquire(ObjectFifoPort.Consume, 1)
+                    scale = rtpComputeTile4[0]
+                    skipScale = rtpComputeTile4[1]
+
+                    for _ in range_(tensorInH):
+                        element0ActivactionsIn = act_3_4.acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
+                        element1ActivactionsIn = act_5_4.acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
+                        elementSkipsIn = of_skip_buf.acquire(ObjectFifoPort.Consume, 1)
+                        elementActivactionsOut = outOFL2L3.acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+
+                        conv2dk1_skip(
+                            element0ActivactionsIn,
+                            element1ActivactionsIn,
+                            element0Weights,
+                            elementActivactionsOut,
+                            elementSkipsIn,
+                            tensorInW,
+                            tensorL3InC,
+                            tensorL3OutC,
+                            scale,
+                            skipScale,
+                        )
+                        outOFL2L3.release(ObjectFifoPort.Produce, 1)
+                        act_3_4.release(ObjectFifoPort.Consume, 1)
+                        act_5_4.release(ObjectFifoPort.Consume, 1)
+                        of_skip_buf.release(ObjectFifoPort.Consume, 1)
+                    wts_buf_02.release(ObjectFifoPort.Consume, 1)
+
+            # instruction stream generation
+            @runtime_sequence(activationsInL3_ty, weightsInL3_ty, activationsInL3_ty)
+            def sequence(inputFromL3, weightsFromL3, outputToL3):
+
+                if enableTrace:
+                    # Trace output
+
+                    # Trace_Event0, Trace_Event1: Select which events to trace.
+                    # Note that the event buffers only appear to be transferred to DDR in
+                    # bursts of 256 bytes. If less than 256 bytes are written, you may not
+                    # see trace output, or only see it on the next iteration of your
+                    # kernel invocation, as the buffer gets filled up. Note that, even
+                    # though events are encoded as 4 byte words, it may take more than 64
+                    # events to fill the buffer to 256 bytes and cause a flush, since
+                    # multiple repeating events can be 'compressed' by the trace mechanism.
+                    # In order to always generate sufficient events, we add the "assert
+                    # TRUE" event to one slot, which fires every cycle, and thus fills our
+                    # buffer quickly.
+
+                    # Some events:
+                    # TRUE                       (0x01)
+                    # STREAM_STALL               (0x18)
+                    # LOCK_STALL                 (0x1A)
+                    # EVENTS_CORE_INSTR_EVENT_1  (0x22)
+                    # EVENTS_CORE_INSTR_EVENT_0  (0x21)
+                    # INSTR_VECTOR               (0x25)  Core executes a vecotr MAC, ADD or compare instruction
+                    # INSTR_LOCK_ACQUIRE_REQ     (0x2C)  Core executes a lock .acquire instruction
+                    # INSTR_LOCK_.release_REQ     (0x2D)  Core executes a lock .release instruction
+                    # EVENTS_CORE_PORT_RUNNING_1 (0x4F)
+                    # EVENTS_CORE_PORT_RUNNING_0 (0x4B)
+
+                    # Trace_Event0  (4 slots)
+                    npu_write32(0, 4, 0x340E0, 0x4B222125)
+                    # Trace_Event1  (4 slots)
+                    npu_write32(0, 4, 0x340E4, 0x2D2C1A4F)
+
+                    # Event slots as configured above:
+                    # 0: Kernel executes vector instruction
+                    # 1: Event 0 -- Kernel starts
+                    # 2: Event 1 -- Kernel done
+                    # 3: Port_Running_0
+                    # 4: Port_Running_1
+                    # 5: Lock Stall
+                    # 6: Lock .acquire Instr
+                    # 7: Lock .release Instr
+
+                    # Stream_Switch_Event_Port_Selection_0
+                    # This is necessary to capture the Port_Running_0 and Port_Running_1 events
+                    npu_write32(0, 4, 0x3FF00, 0x121)
+
+                    # Trace_Control0: Define trace start and stop triggers. Set start event TRUE.
+                    npu_write32(0, 4, 0x340D0, 0x10000)
+
+                    # Start trace copy out.
+                    npu_writebd(
+                        bd_id=3,
+                        buffer_length=trace_sz_in_i32s,
+                        buffer_offset=acitivationsOut,
+                        enable_packet=0,
+                        out_of_order_id=0,
+                        packet_id=0,
+                        packet_type=0,
+                        column=0,
+                        row=0,
+                        d0_stepsize=0,
+                        d0_wrap=0,
+                        d1_stepsize=0,
+                        d1_wrap=0,
+                        d2_stepsize=0,
+                        iteration_current=0,
+                        iteration_stepsize=0,
+                        iteration_wrap=0,
+                        lock_acq_enable=0,
+                        lock_acq_id=0,
+                        lock_acq_val=0,
+                        lock_rel_id=0,
+                        lock_rel_val=0,
+                        next_bd=0,
+                        use_next_bd=0,
+                        valid_bd=1,
+                    )
+                    npu_write32(0, 2, 0x1D20C, 0x3)
+
+                # write RTP parameters
+                rtpComputeTile2[0] = 1  # scale
+                rtpComputeTile3[0] = 1  # scale
+                rtpComputeTile5[0] = 1  # scale
+                # scale: conv1x1 with the same scale as the input so we match the scaling factor of output after conv1x1 and the initial input
+                rtpComputeTile4[0] = 1
+                rtpComputeTile4[1] = 0  # skip_scale
+
+                in_act_task = dma_configure_task_for(of_inOF_act_L3L2)
+                with bds(in_act_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(inputFromL3, sizes=[1, 1, 1, activationsIn])
+                        EndOp()
+                dma_start_task(in_act_task)
+
+                in_wts_task = dma_configure_task_for(inOF_wts_0_L3L2)
+                with bds(in_wts_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(weightsFromL3, sizes=[1, 1, 1, totalWeights])
+                        EndOp()
+                dma_start_task(in_wts_task)
+
+                out_task = dma_configure_task_for(outOFL2L3)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(outputToL3, sizes=[1, 1, 1, acitivationsOut])
+                        EndOp()
+                dma_start_task(out_task)
+
+                dma_await_task(out_task)
+                dma_free_task(in_act_task, in_wts_task)
+
+    print(ctx.module)
+
+
+bottleneck4AIEs()

--- a/programming_examples/ml/bottleneck/aie2_alt.py
+++ b/programming_examples/ml/bottleneck/aie2_alt.py
@@ -556,21 +556,19 @@ def bottleneck4AIEs():
                     with bd[0]:
                         shim_dma_bd(inputFromL3, sizes=[1, 1, 1, activationsIn])
                         EndOp()
-                dma_start_task(in_act_task)
 
                 in_wts_task = dma_configure_task_for(inOF_wts_0_L3L2)
                 with bds(in_wts_task) as bd:
                     with bd[0]:
                         shim_dma_bd(weightsFromL3, sizes=[1, 1, 1, totalWeights])
                         EndOp()
-                dma_start_task(in_wts_task)
 
-                out_task = dma_configure_task_for(outOFL2L3)
+                out_task = dma_configure_task_for(outOFL2L3, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
                         shim_dma_bd(outputToL3, sizes=[1, 1, 1, acitivationsOut])
                         EndOp()
-                dma_start_task(out_task)
+                dma_start_task(in_act_task, in_wts_task, out_task)
 
                 dma_await_task(out_task)
                 dma_free_task(in_act_task, in_wts_task)

--- a/programming_examples/ml/bottleneck/run_makefile_alt.lit
+++ b/programming_examples/ml/bottleneck/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, torch
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run_py | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/conv2d/Makefile
+++ b/programming_examples/ml/conv2d/Makefile
@@ -13,13 +13,20 @@ mlirFileName = aie
 
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/conv2dk1_i8.o build/final.xclbin
 
 build/conv2dk1_i8.o: conv2dk1_i8.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang ${PEANOWRAP2_FLAGS} -DINT8_ACT -c $< -o ${@F}
 
-build/${mlirFileName}.mlir: ${srcdir}/aie2.py
+build/${mlirFileName}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 

--- a/programming_examples/ml/conv2d/aie2_alt.py
+++ b/programming_examples/ml/conv2d/aie2_alt.py
@@ -127,7 +127,6 @@ def conv2dk1():
                     with bd[0]:
                         shim_dma_bd(I, sizes=[1, 1, 1, tensorSize])
                         EndOp()
-                dma_start_task(in_act_task)
 
                 in_wts_task = dma_configure_task_for(
                     of_inOF_wts_0_L3L2, issue_token=True
@@ -136,15 +135,14 @@ def conv2dk1():
                     with bd[0]:
                         shim_dma_bd(W, sizes=[1, 1, 1, weights])
                         EndOp()
-                dma_start_task(in_wts_task)
 
-                out_task = dma_configure_task_for(of_inOF_wts_0_L3L2)
+                out_task = dma_configure_task_for(of_inOF_wts_0_L3L2, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
                         shim_dma_bd(O, sizes=[1, 1, 1, tensorSize])
                         EndOp()
-                dma_start_task(out_task)
 
+                dma_start_task(in_act_task, in_wts_task, out_task)
                 dma_await_task(in_act_task, in_wts_task, out_task)
 
     #    print(ctx.module.operation.verify())

--- a/programming_examples/ml/conv2d/aie2_alt.py
+++ b/programming_examples/ml/conv2d/aie2_alt.py
@@ -1,0 +1,154 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+width = 32
+height = 32
+in_channels = 64
+out_channels = 64
+
+if len(sys.argv) == 3:
+    width = int(sys.argv[1])
+    height = int(sys.argv[2])
+
+
+actIn = width * in_channels  # 32*64 = 2048
+bufIn = actIn * 2  # double buffer
+
+weights = in_channels * out_channels
+
+actOut = width * out_channels  # 32*64 = 2048
+bufOut = actOut * 2  # double buffer
+
+tensorSize = width * height * in_channels
+
+
+def conv2dk1():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def device_body():
+
+            actIn_ty = np.ndarray[(actIn,), np.dtype[np.int8]]
+            bufIn_ty = np.ndarray[(bufIn,), np.dtype[np.int8]]
+
+            weights_ty = np.ndarray[(weights,), np.dtype[np.int8]]
+
+            out_ty = np.ndarray[(actOut,), np.dtype[np.int8]]
+            bufOut_ty = np.ndarray[(bufOut,), np.dtype[np.int8]]
+            tensor_ty = np.ndarray[(tensorSize,), np.dtype[np.int8]]
+
+            # AIE Core Function declarations
+            conv2dk1_i8 = external_func(
+                "conv2dk1_i8",
+                inputs=[
+                    actIn_ty,
+                    weights_ty,
+                    out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+            MemTile = tile(0, 1)
+            ComputeTile2 = tile(0, 2)
+
+            # AIE-array data movement with object fifos
+            # Input
+            of_inOF_act_L3L2 = object_fifo(
+                "inOF_act_L3L2", ShimTile, MemTile, 2, bufIn_ty
+            )
+            of_act_L2_02 = object_fifo("act_L2_02", MemTile, ComputeTile2, 2, actIn_ty)
+            object_fifo_link(of_inOF_act_L3L2, of_act_L2_02)
+
+            # wts
+            of_inOF_wts_0_L3L2 = object_fifo(
+                "inOF_wts_0_L3L2", ShimTile, [ComputeTile2], 1, weights_ty
+            )
+
+            # Output
+            of_out_02_L2 = object_fifo("out_02_L2", ComputeTile2, [MemTile], 2, out_ty)
+            of_outOFL2L3 = object_fifo("outOFL2L3", MemTile, [ShimTile], 2, bufOut_ty)
+            object_fifo_link(of_out_02_L2, of_outOFL2L3)
+
+            # Set up compute tiles
+
+            rtp2 = buffer(
+                ComputeTile2,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtp2",
+                use_write_rtp=True,
+            )
+
+            # Compute tile 2
+            @core(ComputeTile2, "conv2dk1_i8.o")
+            def core_body():
+                y_dim = 32
+                x_dim = 32
+                ci = 64
+                co = 64
+
+                for _ in range_(0xFFFFFFFF):
+                    elemWts = of_inOF_wts_0_L3L2.acquire(ObjectFifoPort.Consume, 1)
+
+                    scale = rtp2[0]
+                    # scale = memref.load(rtpComputeTile2, [0])
+
+                    for _ in range_(y_dim):
+                        elemIn = of_act_L2_02.acquire(ObjectFifoPort.Consume, 1)
+                        elemOut0 = of_out_02_L2.acquire(ObjectFifoPort.Produce, 1)
+
+                        conv2dk1_i8(elemIn, elemWts, elemOut0, x_dim, ci, co, scale)
+                        of_act_L2_02.release(ObjectFifoPort.Consume, 1)
+                        of_out_02_L2.release(ObjectFifoPort.Produce, 1)
+                    of_inOF_wts_0_L3L2.release(ObjectFifoPort.Consume, 1)
+
+            # To/from AIE-array data movement
+            @runtime_sequence(tensor_ty, weights_ty, tensor_ty)
+            def sequence(I, W, O):
+                rtp2[0] = 10
+
+                in_act_task = dma_configure_task_for(of_inOF_act_L3L2, issue_token=True)
+                with bds(in_act_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(I, sizes=[1, 1, 1, tensorSize])
+                        EndOp()
+                dma_start_task(in_act_task)
+
+                in_wts_task = dma_configure_task_for(
+                    of_inOF_wts_0_L3L2, issue_token=True
+                )
+                with bds(in_wts_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(W, sizes=[1, 1, 1, weights])
+                        EndOp()
+                dma_start_task(in_wts_task)
+
+                out_task = dma_configure_task_for(of_inOF_wts_0_L3L2)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(O, sizes=[1, 1, 1, tensorSize])
+                        EndOp()
+                dma_start_task(out_task)
+
+                dma_await_task(in_act_task, in_wts_task, out_task)
+
+    #    print(ctx.module.operation.verify())
+    print(ctx.module)
+
+
+conv2dk1()

--- a/programming_examples/ml/conv2d/run_makefile_alt.lit
+++ b/programming_examples/ml/conv2d/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, torch
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run_py | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/conv2d_fused_relu/Makefile
+++ b/programming_examples/ml/conv2d_fused_relu/Makefile
@@ -13,9 +13,17 @@ mlirFileName = aieWithTrace_1core
 
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
+
 all: build/conv2dk1.o build/final.xclbin
 
-build/${mlirFileName}.mlir: ${srcdir}/aie2.py
+build/${mlirFileName}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 

--- a/programming_examples/ml/conv2d_fused_relu/aie2_alt.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2_alt.py
@@ -1,0 +1,261 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+width = 32
+height = 32
+in_channels = 64
+out_channels = 64
+
+if len(sys.argv) == 3:
+    width = int(sys.argv[1])
+    height = int(sys.argv[2])
+
+
+actIn = width * in_channels  # 32*64 = 2048
+bufIn = actIn * 2  # double buffer
+
+weights = in_channels * out_channels
+
+actOut = width * out_channels  # 32*64 = 2048
+bufOut = actOut * 2  # double buffer
+
+tensorSize = width * height * in_channels
+
+enableTrace = False
+trace_size = 16384
+traceSizeInInt32s = trace_size // 4
+
+
+def conv2dk1():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def device_body():
+
+            actIn_ty = np.ndarray[(actIn,), np.dtype[np.int8]]
+            bufIn_ty = np.ndarray[(bufIn,), np.dtype[np.int8]]
+
+            weights_ty = np.ndarray[(weights,), np.dtype[np.int8]]
+
+            out_ty = np.ndarray[(actOut,), np.dtype[np.int8]]
+            bufOut_ty = np.ndarray[(bufOut,), np.dtype[np.int8]]
+
+            tensor_ty = np.ndarray[(tensorSize,), np.dtype[np.int8]]
+
+            # AIE Core Function declarations
+            conv2dk1_i8 = external_func(
+                "conv2dk1_i8",
+                inputs=[
+                    actIn_ty,
+                    weights_ty,
+                    out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+            MemTile = tile(0, 1)
+            ComputeTile2 = tile(0, 2)
+            compute_tile2_col, compute_tile2_row = 0, 2
+
+            if enableTrace:
+                flow(ComputeTile2, WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
+
+            # AIE-array data movement with object fifos
+            # Input
+            of_inOF_act_L3L2 = object_fifo(
+                "inOF_act_L3L2", ShimTile, MemTile, 2, bufIn_ty
+            )
+            of_act_L2_02 = object_fifo("act_L2_02", MemTile, ComputeTile2, 2, actIn_ty)
+            object_fifo_link(of_inOF_act_L3L2, of_act_L2_02)
+
+            # wts
+            of_inOF_wts_0_L3L2 = object_fifo(
+                "inOF_wts_0_L3L2", ShimTile, [ComputeTile2], 1, weights_ty
+            )
+
+            # Output
+            of_out_02_L2 = object_fifo("out_02_L2", ComputeTile2, [MemTile], 2, out_ty)
+            of_outOFL2L3 = object_fifo("outOFL2L3", MemTile, [ShimTile], 2, bufOut_ty)
+            object_fifo_link(of_out_02_L2, of_outOFL2L3)
+
+            # Set up compute tiles
+
+            rtp2 = buffer(
+                ComputeTile2, T.memref(16, T.i32()), "rtp2", use_write_rtp=True
+            )
+
+            # Compute tile 2
+            @core(ComputeTile2, "conv2dk1.o")
+            def core_body():
+                y_dim = 32
+                x_dim = 32
+                ci = 64
+                co = 64
+
+                for _ in range_(0xFFFFFFFF):
+                    elemWts = of_inOF_wts_0_L3L2.acquire(ObjectFifoPort.Consume, 1)
+
+                    scale = rtp2[0]
+                    # scale = memref.load(rtpComputeTile2, [0])
+
+                    for _ in range_(y_dim):
+                        elemIn = of_act_L2_02.acquire(ObjectFifoPort.Consume, 1)
+                        elemOut0 = of_out_02_L2.acquire(ObjectFifoPort.Produce, 1)
+
+                        conv2dk1_i8(elemIn, elemWts, elemOut0, x_dim, ci, co, scale)
+
+                        of_act_L2_02.release(ObjectFifoPort.Consume, 1)
+                        of_out_02_L2.release(ObjectFifoPort.Produce, 1)
+                    of_inOF_wts_0_L3L2.release(ObjectFifoPort.Consume, 1)
+
+            # To/from AIE-array data movement
+
+            @runtime_sequence(tensor_ty, weights_ty, tensor_ty)
+            def sequence(I, W, O):
+                if enableTrace:
+                    # 0x340D0: Trace Control 0
+                    #          0xAABB---C
+                    #            AA        <- Event to stop trace capture
+                    #              BB      <- Event to start trace capture
+                    #                   C  <- Trace mode, 00=event=time, 01=event-PC, 10=execution
+                    # Configure so that "Event 1" (always true) causes tracing to start
+                    npu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340D0,
+                        value=0x00010000,
+                    )
+                    # 0x340D4: Trace Control 1
+                    npu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340D4,
+                        value=0x00000000,
+                    )
+                    # 0x340E0: Trace Event Group 1  (Which events to trace)
+                    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
+                    npu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340E0,
+                        value=0x4B222125,
+                    )
+                    # 0x340E4: Trace Event Group 2  (Which events to trace)
+                    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
+                    npu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x340E4,
+                        value=0x2D2C1A4F,
+                    )
+
+                    npu_write32(
+                        column=compute_tile2_col,
+                        row=compute_tile2_row,
+                        address=0x3FF00,
+                        value=0x00000121,
+                    )
+
+                    # Configure a buffer descriptor to write tracing information that has been routed into this shim tile
+                    # out to host DDR memory
+                    trace_bd_id = 13  # use BD 13 for writing trace output from compute tile to DDR host memory
+                    output_size = bufOut
+                    npu_writebd(
+                        bd_id=trace_bd_id,
+                        buffer_length=trace_size,
+                        buffer_offset=output_size,
+                        enable_packet=0,
+                        out_of_order_id=0,
+                        packet_id=0,
+                        packet_type=0,
+                        column=0,
+                        column_num=1,
+                        d0_size=0,
+                        d0_stride=0,
+                        d1_size=0,
+                        d1_stride=0,
+                        d2_stride=0,
+                        iteration_current=0,
+                        iteration_size=0,
+                        iteration_stride=0,
+                        lock_acq_enable=0,
+                        lock_acq_id=0,
+                        lock_acq_val=0,
+                        lock_rel_id=0,
+                        lock_rel_val=0,
+                        next_bd=0,
+                        use_next_bd=0,
+                        valid_bd=1,
+                    )
+                    # Set start BD to our shim bd_Id (3)
+                    npu_write32(column=0, row=0, address=0x1D20C, value=trace_bd_id)
+
+                rtp2[0] = 1
+
+                npu_dma_memcpy_nd(
+                    metadata=of_inOF_act_L3L2,
+                    bd_id=0,
+                    mem=I,
+                    sizes=[1, 1, 1, tensorSize],
+                )
+                npu_dma_memcpy_nd(
+                    metadata=of_outOFL2L3,
+                    bd_id=2,
+                    mem=O,
+                    sizes=[1, 1, 1, tensorSize],
+                )
+                npu_dma_memcpy_nd(
+                    metadata=of_inOF_wts_0_L3L2,
+                    bd_id=2,
+                    mem=W,
+                    sizes=[1, 1, 1, weights],
+                )
+                # of_outOFL2L3 will only complete after of_inOF_wts_0_L3L2 and of_inOF_act_L3L2 complete, so we just wait on of_outOFL2L3 instead of all
+                dma_wait(of_outOFL2L3)
+
+                in_act_task = dma_configure_task_for(of_inOF_act_L3L2)
+                with bds(in_act_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(I, sizes=[1, 1, 1, tensorSize])
+                        EndOp()
+                dma_start_task(in_act_task)
+
+                in_wts_task = dma_configure_task_for(of_inOF_wts_0_L3L2)
+                with bds(in_wts_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(W, sizes=[1, 1, 1, weights])
+                        EndOp()
+                dma_start_task(in_wts_task)
+
+                out_task = dma_configure_task_for(of_inOF_wts_0_L3L2)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(O, sizes=[1, 1, 1, tensorSize])
+                        EndOp()
+                dma_start_task(out_task)
+
+                # out_task will only complete after in_act_task and in_wts_task complete, so we just wait on out_task instead of all
+                dma_await_task(out_task)
+                dma_free_task(in_act_task, in_wts_task)
+
+    #    print(ctx.module.operation.verify())
+    print(ctx.module)
+
+
+conv2dk1()

--- a/programming_examples/ml/conv2d_fused_relu/aie2_alt.py
+++ b/programming_examples/ml/conv2d_fused_relu/aie2_alt.py
@@ -243,13 +243,13 @@ def conv2dk1():
                         EndOp()
                 dma_start_task(in_wts_task)
 
-                out_task = dma_configure_task_for(of_inOF_wts_0_L3L2)
+                out_task = dma_configure_task_for(of_inOF_wts_0_L3L2, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
                         shim_dma_bd(O, sizes=[1, 1, 1, tensorSize])
                         EndOp()
-                dma_start_task(out_task)
 
+                dma_start_task(in_act_task, in_wts_task, out_task)
                 # out_task will only complete after in_act_task and in_wts_task complete, so we just wait on out_task instead of all
                 dma_await_task(out_task)
                 dma_free_task(in_act_task, in_wts_task)

--- a/programming_examples/ml/conv2d_fused_relu/run_makefile_alt.lit
+++ b/programming_examples/ml/conv2d_fused_relu/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, torch
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run_py | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/eltwise_add/Makefile
+++ b/programming_examples/ml/eltwise_add/Makefile
@@ -17,17 +17,24 @@ all: build/final.xclbin
 targetname = myEltwiseAdd
 trace_size = 8192
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
 build/%.o: %.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< 0 > $@
 
-build/aie_trace.mlir: ${srcdir}/aie2.py
+build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${trace_size} > $@
 

--- a/programming_examples/ml/eltwise_add/aie2_alt.py
+++ b/programming_examples/ml/eltwise_add/aie2_alt.py
@@ -150,22 +150,20 @@ def my_eltwise_add(trace_size):
                 with bd[0]:
                     shim_dma_bd(A, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(in_a_task)
 
             in_b_task = dma_configure_task_for(inB, issue_token=True)
             with bds(in_b_task) as bd:
                 with bd[0]:
                     shim_dma_bd(B, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(in_b_task)
 
-            out_task = dma_configure_task_for(outC)
+            out_task = dma_configure_task_for(outC, issue_token=True)
             with bds(out_task) as bd:
                 with bd[0]:
                     shim_dma_bd(C, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(out_task)
 
+            dma_start_task(in_a_task, in_b_task, out_task)
             # outC will only complete after in_a_task and in_b_task complete, so we just wait on outC instead of all
             dma_await_task(in_a_task, in_b_task, out_task)
 

--- a/programming_examples/ml/eltwise_add/aie2_alt.py
+++ b/programming_examples/ml/eltwise_add/aie2_alt.py
@@ -1,0 +1,183 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 AMD Inc.
+from ml_dtypes import bfloat16
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.helpers.util import np_ndarray_type_get_shape
+
+
+import aie.utils.trace as trace_utils
+
+
+def my_eltwise_add(trace_size):
+
+    word_size_in = 2
+    N = 65536
+    N_in_bytes = N * word_size_in
+
+    # Tile sizes
+    n = 1024
+    N_div_n = N // n
+
+    n_cores = 2
+    tiles = N_div_n // n_cores
+    buffer_depth = 2
+
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the tile memory
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        B_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the memory tile which aggregates across the 2 cores
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        B_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+
+        # AIE Core Function declarations
+
+        eltwise_add_bf16_scalar = external_func(
+            "eltwise_add_bf16_scalar", inputs=[tile_ty, tile_ty, tile_ty]
+        )
+        eltwise_add_bf16_vector = external_func(
+            "eltwise_add_bf16_vector", inputs=[tile_ty, tile_ty, tile_ty]
+        )
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+
+        MemTile = tile(0, 1)
+        cores = [tile(0, 2 + i) for i in range(n_cores)]
+
+        # Set up a circuit-switched flow from core to shim for tracing information
+        if trace_size > 0:
+            flow(cores[0], WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
+
+        inA_fifos = []
+        inB_fifos = []
+        outC_fifos = []
+
+        # AIE-array data movement with object fifos
+        # Input A
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
+        for i in range(n_cores):
+            inA_fifos.append(
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
+            )
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(inA, inA_fifos, [], of_offsets)
+
+        # Input B
+        inB = object_fifo("inB", ShimTile, MemTile, buffer_depth, B_memTile_ty)
+        for i in range(n_cores):
+            inB_fifos.append(
+                object_fifo(f"memB{i}", MemTile, cores[i], buffer_depth, B_ty)
+            )
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(B_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(inB, inB_fifos, [], of_offsets)
+
+        # Output C
+        for i in range(n_cores):
+            outC_fifos.append(
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
+            )
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(outC_fifos, outC, of_offsets, [])
+
+        # Set up compute tiles
+        for i in range(n_cores):
+            # Compute tile i
+            @core(cores[i], "add.o")
+            def core_body():
+                for _ in range_(0xFFFFFFFF):
+                    for _ in range_(tiles):
+                        elem_out = outC_fifos[i].acquire(ObjectFifoPort.Produce, 1)
+                        elem_in_a = inA_fifos[i].acquire(ObjectFifoPort.Consume, 1)
+                        elem_in_b = inB_fifos[i].acquire(ObjectFifoPort.Consume, 1)
+                        eltwise_add_bf16_vector(elem_in_a, elem_in_b, elem_out)
+                        inA_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        inB_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        outC_fifos[i].release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
+
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
+        def sequence(A, B, C):
+
+            if trace_size > 0:
+                trace_utils.configure_simple_tracing_aie2(
+                    cores[0],
+                    ShimTile,
+                    ddr_id=2,
+                    size=trace_size,
+                    offset=N_in_bytes,
+                )
+
+            in_a_task = dma_configure_task_for(inA, issue_token=True)
+            with bds(in_a_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(in_a_task)
+
+            in_b_task = dma_configure_task_for(inB, issue_token=True)
+            with bds(in_b_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(B, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(in_b_task)
+
+            out_task = dma_configure_task_for(outC)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(out_task)
+
+            # outC will only complete after in_a_task and in_b_task complete, so we just wait on outC instead of all
+            dma_await_task(in_a_task, in_b_task, out_task)
+
+
+try:
+    trace_size = 0 if (len(sys.argv) < 2) else int(sys.argv[1])
+except ValueError:
+    print("Argument is not an integer")
+with mlir_mod_ctx() as ctx:
+    my_eltwise_add(trace_size)
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/ml/eltwise_add/run_makefile_alt.lit
+++ b/programming_examples/ml/eltwise_add/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/eltwise_mul/Makefile
+++ b/programming_examples/ml/eltwise_mul/Makefile
@@ -17,17 +17,25 @@ all: build/final.xclbin
 targetname = myEltwiseMul
 trace_size = 8192
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
+
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
 build/%.o: %.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 
-build/aie_trace.mlir: ${srcdir}/aie2.py
+build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${trace_size} > $@
 

--- a/programming_examples/ml/eltwise_mul/aie2_alt.py
+++ b/programming_examples/ml/eltwise_mul/aie2_alt.py
@@ -154,22 +154,20 @@ def my_eltwise_mul(trace_size):
                 with bd[0]:
                     shim_dma_bd(A, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(in_a_task)
 
             in_b_task = dma_configure_task_for(inB)
             with bds(in_b_task) as bd:
                 with bd[0]:
                     shim_dma_bd(B, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(in_b_task)
 
-            out_task = dma_configure_task_for(outC)
+            out_task = dma_configure_task_for(outC, issue_token=True)
             with bds(out_task) as bd:
                 with bd[0]:
                     shim_dma_bd(C, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(out_task)
 
+            dma_start_task(in_a_task, in_b_task, out_task)
             # outC will only complete after in_a_task and in_b_task complete, so we just wait on outC instead of all
             dma_await_task(out_task)
             dma_free_task(in_a_task, in_b_task)

--- a/programming_examples/ml/eltwise_mul/aie2_alt.py
+++ b/programming_examples/ml/eltwise_mul/aie2_alt.py
@@ -1,0 +1,189 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 AMD Inc.
+from ml_dtypes import bfloat16
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.helpers.util import np_ndarray_type_get_shape
+
+import aie.utils.trace as trace_utils
+
+
+def my_eltwise_mul(trace_size):
+
+    word_size_in = 2
+    N = 65536
+    N_in_bytes = N * word_size_in
+
+    # Tile sizes
+    n = 1024
+    N_div_n = N // n
+
+    n_cores = 2
+    tiles = N_div_n // n_cores
+    buffer_depth = 2
+
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the tile memory
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        B_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the memory tile which aggregates across the 4 cores
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        B_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+
+        # AIE Core Function declarations
+
+        eltwise_mul_bf16_scalar = external_func(
+            "eltwise_mul_bf16_scalar", inputs=[tile_ty, tile_ty, tile_ty]
+        )
+        eltwise_mul_bf16_vector = external_func(
+            "eltwise_mul_bf16_vector", inputs=[tile_ty, tile_ty, tile_ty]
+        )
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+
+        MemTile = tile(0, 1)
+        cores = [tile(0, 2 + i) for i in range(n_cores)]
+
+        # Set up a circuit-switched flow from core to shim for tracing information
+        if trace_size > 0:
+            flow(cores[0], WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
+
+        inA_fifos = []
+        inB_fifos = []
+        outC_fifos = []
+
+        # AIE-array data movement with object fifos
+        # Input A
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
+        for i in range(n_cores):
+            inA_fifos.append(
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
+            )
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(inA, inA_fifos, [], of_offsets)
+
+        # Input B
+        inB = object_fifo("inB", ShimTile, MemTile, buffer_depth, B_memTile_ty)
+        for i in range(n_cores):
+            inB_fifos.append(
+                object_fifo(f"memB{i}", MemTile, cores[i], buffer_depth, B_ty)
+            )
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(B_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(inB, inB_fifos, [], of_offsets)
+
+        # Output C
+        for i in range(n_cores):
+            outC_fifos.append(
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
+            )
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(outC_fifos, outC, of_offsets, [])
+
+        # Set up compute tiles
+        for i in range(n_cores):
+            # Compute tile i
+            @core(cores[i], "mul.o")
+            def core_body():
+                for _ in range_(0xFFFFFFFF):
+                    for _ in range_(tiles):
+                        elem_out = outC_fifos[i].acquire(ObjectFifoPort.Produce, 1)
+                        elem_in_a = inA_fifos[i].acquire(ObjectFifoPort.Consume, 1)
+                        elem_in_b = inB_fifos[i].acquire(ObjectFifoPort.Consume, 1)
+                        eltwise_mul_bf16_vector(elem_in_a, elem_in_b, elem_out)
+                        inA_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        inB_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        outC_fifos[i].release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
+
+        @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
+        def sequence(A, B, C):
+
+            if trace_size > 0:
+                trace_utils.configure_simple_tracing_aie2(
+                    cores[0],
+                    ShimTile,
+                    ddr_id=2,
+                    size=trace_size,
+                    offset=N_in_bytes,
+                )
+            npu_dma_memcpy_nd(metadata=inA, bd_id=1, mem=A, sizes=[1, 1, 1, N])
+            npu_dma_memcpy_nd(metadata=inB, bd_id=2, mem=B, sizes=[1, 1, 1, N])
+            npu_dma_memcpy_nd(metadata=outC, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+            # outC will only complete after inA and inB complete, so we just wait on outC instead of all
+            dma_wait(outC)
+
+            in_a_task = dma_configure_task_for(inA)
+            with bds(in_a_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(in_a_task)
+
+            in_b_task = dma_configure_task_for(inB)
+            with bds(in_b_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(B, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(in_b_task)
+
+            out_task = dma_configure_task_for(outC)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(out_task)
+
+            # outC will only complete after in_a_task and in_b_task complete, so we just wait on outC instead of all
+            dma_await_task(out_task)
+            dma_free_task(in_a_task, in_b_task)
+
+
+try:
+    trace_size = 0 if (len(sys.argv) < 2) else int(sys.argv[1])
+except ValueError:
+    print("Argument is not an integer")
+
+with mlir_mod_ctx() as ctx:
+    my_eltwise_mul(trace_size)
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/ml/eltwise_mul/run_makefile_alt.lit
+++ b/programming_examples/ml/eltwise_mul/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/relu/Makefile
+++ b/programming_examples/ml/relu/Makefile
@@ -17,17 +17,24 @@ all: build/final.xclbin
 targetname = myReLU
 trace_size = 8192
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
 build/%.o: %.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 
-build/aie_trace.mlir: ${srcdir}/aie2.py
+build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${trace_size} > $@
 

--- a/programming_examples/ml/relu/aie2_alt.py
+++ b/programming_examples/ml/relu/aie2_alt.py
@@ -126,14 +126,13 @@ def my_relu(trace_size):
                 with bd[0]:
                     shim_dma_bd(A, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(in_task)
 
-            out_task = dma_configure_task_for(outC)
+            out_task = dma_configure_task_for(outC, issue_token=True)
             with bds(out_task) as bd:
                 with bd[0]:
                     shim_dma_bd(C, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(out_task)
+            dma_start_task(in_task, out_task)
             dma_await_task(in_task, out_task)
 
 

--- a/programming_examples/ml/relu/aie2_alt.py
+++ b/programming_examples/ml/relu/aie2_alt.py
@@ -1,0 +1,151 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 AMD Inc.
+from ml_dtypes import bfloat16
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.helpers.util import np_ndarray_type_get_shape
+
+import aie.utils.trace as trace_utils
+
+
+def my_relu(trace_size):
+
+    word_size_in = 2
+    N = 65536
+    N_in_bytes = N * word_size_in
+
+    # Tile sizes
+    n = 1024
+    N_div_n = N // n
+
+    n_cores = 2
+    tiles = N_div_n // n_cores
+    buffer_depth = 2
+
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the tile memory
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the memory tile which aggregates across the 4 cores
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+
+        # AIE Core Function declarations
+
+        relu = external_func("bf16_relu", inputs=[tile_ty, tile_ty])
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+
+        MemTile = tile(0, 1)
+        cores = [tile(0, 2 + i) for i in range(n_cores)]
+
+        inA_fifos = []
+        outC_fifos = []
+
+        # AIE-array data movement with object fifos
+        # Input A
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
+        for i in range(n_cores):
+            inA_fifos.append(
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
+            )
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(inA, inA_fifos, [], of_offsets)
+
+        # Output C
+        for i in range(n_cores):
+            outC_fifos.append(
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
+            )
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
+        if n_cores > 1:
+            of_offsets = [
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_offsets = []
+        object_fifo_link(outC_fifos, outC, of_offsets, [])
+
+        # Set up a circuit-switched flow from core to shim for tracing information
+        if trace_size > 0:
+            flow(cores[0], WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
+
+        # Set up compute tiles
+        for i in range(n_cores):
+            # Compute tile i
+            @core(cores[i], "relu.o")
+            def core_body():
+                for _ in range_(0xFFFFFFFF):
+                    for _ in range_(tiles):
+                        elem_out = outC_fifos[i].acquire(ObjectFifoPort.Produce, 1)
+                        elem_in_a = inA_fifos[i].acquire(ObjectFifoPort.Consume, 1)
+
+                        relu(elem_in_a, elem_out)
+
+                        inA_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        outC_fifos[i].release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
+
+        @runtime_sequence(tensor_ty, tensor_ty)
+        def sequence(A, C):
+
+            if trace_size > 0:
+                trace_utils.configure_simple_tracing_aie2(
+                    cores[0],
+                    ShimTile,
+                    ddr_id=1,
+                    size=trace_size,
+                    offset=N_in_bytes,
+                )
+
+            in_task = dma_configure_task_for(inA, issue_token=True)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(in_task)
+
+            out_task = dma_configure_task_for(outC)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(out_task)
+            dma_await_task(in_task, out_task)
+
+
+try:
+    trace_size = 0 if (len(sys.argv) != 2) else int(sys.argv[1])
+except ValueError:
+    print("Argument is not an integer")
+
+with mlir_mod_ctx() as ctx:
+    my_relu(trace_size)
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/ml/relu/run_makefile_alt.lit
+++ b/programming_examples/ml/relu/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano 
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/resnet/layers_conv2_x/Makefile
+++ b/programming_examples/ml/resnet/layers_conv2_x/Makefile
@@ -16,9 +16,16 @@ mlirFileName = aie
 
 VPATH := ${srcdir}/../../../../aie_kernels/aie2
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/conv2dk1_i8.o build/conv2dk1_skip_init.o build/conv2dk3.o build/conv2dk1_skip.o build/conv2dk1_ui8.o build/final.xclbin
 
-build/${mlirFileName}.mlir: ${srcdir}/aie2.py
+build/${mlirFileName}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 

--- a/programming_examples/ml/resnet/layers_conv2_x/aie2_alt.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie2_alt.py
@@ -1,0 +1,949 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (C) 2024, Advanced Micro Devices, Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.helpers.util import np_ndarray_type_get_shape
+
+# tracing definitions
+trace_sz_in_bytes = 8192
+trace_sz_in_i32s = trace_sz_in_bytes // 4
+enableTrace = False
+
+# Define bottleneck layer sizes
+tensorInW = 32
+tensorInH = 32
+tensorInCInit = 64
+tensorInCRest = 4 * tensorInCInit
+n_cols = 3
+repeat = 2
+
+activationsIn = tensorInW * tensorInH * tensorInCInit
+acitivationsOut = tensorInW * tensorInH * tensorInCRest
+
+totalWeights_init = (
+    tensorInCInit * tensorInCInit
+    + 3 * 3 * tensorInCInit * tensorInCInit
+    + 2 * tensorInCInit * tensorInCRest
+)
+
+totalWeights_rest = (
+    tensorInCInit * tensorInCRest
+    + 3 * 3 * tensorInCInit * tensorInCInit
+    + tensorInCInit * tensorInCRest
+)
+
+totalWeights_complete = totalWeights_init + repeat * totalWeights_rest
+
+
+def resnet_conv_x():
+
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_3col)
+        def deviceBody():
+
+            # define types
+            tensorLayer1In_ty_init = np.ndarray[
+                (tensorInW, 1, tensorInCInit), np.dtype[np.int8]
+            ]
+            tensorLayer1In_ty_rest = np.ndarray[
+                (tensorInW, 1, tensorInCRest), np.dtype[np.uint8]
+            ]
+            weightsLayer1_ty_init = np.ndarray[
+                (tensorInCInit * tensorInCInit,), np.dtype[np.int8]
+            ]
+            weightsLayer1_ty_rest = np.ndarray[
+                (tensorInCRest * tensorInCInit,), np.dtype[np.int8]
+            ]
+
+            tensorLayer1Out_ty = np.ndarray[
+                (tensorInW, 1, tensorInCInit), np.dtype[np.uint8]
+            ]
+
+            tensorLayer2In_ty = np.ndarray[
+                (
+                    tensorInW,
+                    1,
+                    tensorInCInit,
+                ),
+                np.dtype[np.uint8],
+            ]
+            weightsLayer2_ty = np.ndarray[
+                (3 * 3 * tensorInCInit * tensorInCInit,), np.dtype[np.int8]
+            ]
+            tensorLayer2Out_ty = np.ndarray[
+                (tensorInW, 1, tensorInCInit // 2), np.dtype[np.uint8]
+            ]
+
+            tensorLayer3In_ty = np.ndarray[
+                (tensorInW, 1, tensorInCInit // 2), np.dtype[np.uint8]
+            ]
+            weightsLayer3_ty_init = np.ndarray[
+                (2 * tensorInCInit * tensorInCRest,), np.dtype[np.int8]
+            ]
+            weightsLayer3_ty_rest = np.ndarray[
+                (tensorInCRest // 4 * tensorInCRest,), np.dtype[np.int8]
+            ]
+
+            tensorLayer3Out_ty = np.ndarray[
+                (tensorInW, 1, tensorInCRest), np.dtype[np.uint8]
+            ]
+
+            allWeights_ty_init = np.ndarray[
+                (
+                    tensorInCInit * tensorInCInit
+                    + 3 * 3 * tensorInCInit * tensorInCInit
+                    + tensorInCInit * tensorInCRest
+                    + tensorInCInit * tensorInCRest,
+                ),
+                np.dtype[np.int8],
+            ]
+
+            allWeights_ty_rest = np.ndarray[
+                (
+                    tensorInCRest * tensorInCInit
+                    + 3 * 3 * tensorInCInit * tensorInCInit
+                    + tensorInCInit * tensorInCRest,
+                ),
+                np.dtype[np.int8],
+            ]
+
+            activationsInL3_ty = np.ndarray[(activationsIn,), np.dtype[np.int8]]
+            activationsOutL3_ty = np.ndarray[(acitivationsOut,), np.dtype[np.int8]]
+
+            weightsInL3_ty_complete = np.ndarray[
+                (totalWeights_complete,), np.dtype[np.int8]
+            ]
+
+            # kernel definitions
+            conv2dk1_i8 = external_func(
+                "conv2dk1_i8",
+                inputs=[
+                    tensorLayer1In_ty_init,
+                    weightsLayer1_ty_init,
+                    tensorLayer1Out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+            conv2dk3 = external_func(
+                "conv2dk3_ui8",
+                inputs=[
+                    tensorLayer2In_ty,
+                    tensorLayer2In_ty,
+                    tensorLayer2In_ty,
+                    weightsLayer2_ty,
+                    tensorLayer2Out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+            conv2dk1_skip_init_i8 = external_func(
+                "conv2dk1_skip_init_i8",
+                inputs=[
+                    tensorLayer3In_ty,
+                    tensorLayer3In_ty,
+                    weightsLayer3_ty_init,
+                    tensorLayer3Out_ty,
+                    tensorLayer1In_ty_init,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+            conv2dk1_ui8 = external_func(
+                "conv2dk1_ui8",
+                inputs=[
+                    tensorLayer3Out_ty,
+                    weightsLayer1_ty_rest,
+                    tensorLayer1Out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+
+            conv2dk1_skip_ui8 = external_func(
+                "conv2dk1_skip_ui8",
+                inputs=[
+                    tensorLayer3In_ty,
+                    tensorLayer3In_ty,
+                    weightsLayer3_ty_rest,
+                    tensorLayer3Out_ty,
+                    tensorLayer3Out_ty,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                    np.int32,
+                ],
+            )
+
+            ShimTile00 = tile(0, 0)
+            MemTile01 = tile(0, 1)
+            ComputeTile02 = tile(0, 2)
+            ComputeTile03 = tile(0, 3)
+            ComputeTile04 = tile(0, 4)
+            ComputeTile05 = tile(0, 5)
+
+            ShimTile10 = tile(1, 0)
+            MemTile11 = tile(1, 1)
+            ComputeTile12 = tile(1, 2)
+            ComputeTile13 = tile(1, 3)
+            ComputeTile14 = tile(1, 4)
+            ComputeTile15 = tile(1, 5)
+
+            ShimTile20 = tile(2, 0)
+            MemTile21 = tile(2, 1)
+            ComputeTile22 = tile(2, 2)
+            ComputeTile23 = tile(2, 3)
+            ComputeTile24 = tile(2, 4)
+            ComputeTile25 = tile(2, 5)
+
+            shims = [ShimTile00, ShimTile10, ShimTile20]
+            mems = [MemTile01, MemTile11, MemTile21]
+            wts_sizes = [allWeights_ty_init, allWeights_ty_rest, allWeights_ty_rest]
+            layer1_wts_sizes = [
+                weightsLayer1_ty_init,
+                weightsLayer1_ty_rest,
+                weightsLayer1_ty_rest,
+            ]
+            laye1_act_sizes = [
+                tensorLayer1In_ty_init,
+                tensorLayer1In_ty_rest,
+                tensorLayer1In_ty_rest,
+            ]
+            layer3_wts_sizes = [
+                weightsLayer3_ty_init,
+                weightsLayer3_ty_rest,
+                weightsLayer3_ty_rest,
+            ]
+
+            cores = [
+                [ComputeTile02, ComputeTile03, ComputeTile04, ComputeTile05],
+                [ComputeTile15, ComputeTile14, ComputeTile13, ComputeTile12],
+                [ComputeTile22, ComputeTile23, ComputeTile24, ComputeTile25],
+            ]
+
+            if enableTrace:
+                flow(ComputeTile04, WireBundle.Trace, 0, ShimTile00, WireBundle.DMA, 1)
+
+            # runtime parameters
+
+            rtpComputeTile02 = buffer(
+                ComputeTile02,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile02",
+                use_write_rtp=True,
+            )
+            rtpComputeTile03 = buffer(
+                ComputeTile03,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile03",
+                use_write_rtp=True,
+            )
+            rtpComputeTile04 = buffer(
+                ComputeTile05,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile04",
+                use_write_rtp=True,
+            )
+            rtpComputeTile05 = buffer(
+                ComputeTile04,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile05",
+                use_write_rtp=True,
+            )
+
+            rtpComputeTile12 = buffer(
+                ComputeTile12,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile12",
+                use_write_rtp=True,
+            )
+            rtpComputeTile13 = buffer(
+                ComputeTile13,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile13",
+                use_write_rtp=True,
+            )
+            rtpComputeTile14 = buffer(
+                ComputeTile14,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile14",
+                use_write_rtp=True,
+            )
+            rtpComputeTile15 = buffer(
+                ComputeTile15,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile15",
+                use_write_rtp=True,
+            )
+
+            rtpComputeTile22 = buffer(
+                ComputeTile22,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile22",
+                use_write_rtp=True,
+            )
+            rtpComputeTile23 = buffer(
+                ComputeTile23,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile23",
+                use_write_rtp=True,
+            )
+            rtpComputeTile24 = buffer(
+                ComputeTile24,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile24",
+                use_write_rtp=True,
+            )
+            rtpComputeTile25 = buffer(
+                ComputeTile25,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile25",
+                use_write_rtp=True,
+            )
+
+            rtp = [
+                [
+                    rtpComputeTile02,
+                    rtpComputeTile03,
+                    rtpComputeTile04,
+                    rtpComputeTile05,
+                ],
+                [
+                    rtpComputeTile15,
+                    rtpComputeTile14,
+                    rtpComputeTile13,
+                    rtpComputeTile12,
+                ],
+                [
+                    rtpComputeTile22,
+                    rtpComputeTile23,
+                    rtpComputeTile24,
+                    rtpComputeTile25,
+                ],
+            ]
+
+            # set up data movement with OFs
+            conv1_kernels = ["conv2dk1_i8.o", "conv2dk1_ui8.o", "conv2dk1_ui8.o"]
+            conv1_kernels_call = [conv2dk1_i8, conv2dk1_ui8, conv2dk1_ui8]
+
+            conv3_kernels = [
+                "conv2dk1_skip_init.o",
+                "conv2dk1_skip.o",
+                "conv2dk1_skip.o",
+            ]
+            conv3_kernels_call = [
+                conv2dk1_skip_init_i8,
+                conv2dk1_skip_ui8,
+                conv2dk1_skip_ui8,
+            ]
+
+            # input tensor (with broadcast for skip connection)
+            act1_fifo_names = ["act1_00_02_01", "act1_04_15_11", "act1_13_22_21"]
+            act1_fifos = []
+
+            skip_fifos = []
+
+            act1_fifos.append(
+                object_fifo(
+                    act1_fifo_names[0],
+                    shims[0],
+                    [cores[0][0], mems[0]],
+                    [2, 2, 4],
+                    laye1_act_sizes[0],
+                )
+            )
+            skip_fifos.append(
+                object_fifo("skip_0", mems[0], cores[0][2], 2, laye1_act_sizes[0])
+            )
+            object_fifo_link(act1_fifos[0], skip_fifos[0])
+
+            for i in range(1, repeat + 1):
+                if i == 1:
+                    act1_fifos.append(
+                        object_fifo(
+                            act1_fifo_names[i],
+                            cores[i - 1][2],
+                            [cores[i][0], mems[i - 1]],
+                            [2, 2, 4],
+                            laye1_act_sizes[i],
+                        )
+                    )
+                    skip_fifos.append(
+                        object_fifo(
+                            f"skip_{i}",
+                            mems[i - 1],
+                            cores[i][2],
+                            2,
+                            laye1_act_sizes[i],
+                        )
+                    )
+                    object_fifo_link(act1_fifos[i], skip_fifos[i])
+                else:
+                    act1_fifos.append(
+                        object_fifo(
+                            act1_fifo_names[i],
+                            cores[i - 1][2],
+                            [cores[i][0], mems[i]],
+                            [2, 2, 4],
+                            laye1_act_sizes[i],
+                        )
+                    )
+                    skip_fifos.append(
+                        object_fifo(
+                            f"skip_{i}",
+                            mems[i],
+                            cores[i][2],
+                            2,
+                            laye1_act_sizes[i],
+                        )
+                    )
+                    object_fifo_link(act1_fifos[i], skip_fifos[i])
+
+            act2_fifo_names = ["act2_02_03_05", "act2_15_12_14", "act2_22_23_25"]
+            act2_fifos = []
+
+            act3_fifo_names_1 = ["act3_03_04", "act3_14_13", "act3_23_24"]
+            act3_fifos_1 = []
+
+            act3_fifo_names_2 = ["act3_05_04", "act3_12_13", "act3_25_24"]
+            act3_fifos_2 = []
+
+            for i in range(n_cols):
+                if i == 1:
+                    # 1x1 -> 3x3
+                    act2_fifos.append(
+                        object_fifo(
+                            act2_fifo_names[i],
+                            cores[i][0],
+                            [cores[i][3], cores[i][1]],
+                            4,
+                            tensorLayer1Out_ty,
+                        )
+                    )
+
+                    # 3x3 -> 1x1
+                    act3_fifos_1.append(
+                        object_fifo(
+                            act3_fifo_names_1[i],
+                            cores[i][1],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
+                    )
+                    # 3x3 -> 1x1
+                    act3_fifos_2.append(
+                        object_fifo(
+                            act3_fifo_names_2[i],
+                            cores[i][3],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
+                    )
+                else:
+                    # 1x1 -> 3x3
+                    act2_fifos.append(
+                        object_fifo(
+                            act2_fifo_names[i],
+                            cores[i][0],
+                            [cores[i][1], cores[i][3]],
+                            4,
+                            tensorLayer1Out_ty,
+                        )
+                    )
+
+                    # 3x3 -> 1x1
+                    act3_fifos_1.append(
+                        object_fifo(
+                            act3_fifo_names_1[i],
+                            cores[i][1],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
+                    )
+                    # 3x3 -> 1x1
+                    act3_fifos_2.append(
+                        object_fifo(
+                            act3_fifo_names_2[i],
+                            cores[i][3],
+                            cores[i][2],
+                            2,
+                            tensorLayer2Out_ty,
+                        )
+                    )
+            wts_fifos = []
+            wts_sub_fifos = [[], [], []]
+
+            for i in range(n_cols):
+
+                wts_fifos.append(
+                    object_fifo(f"wts_{i}_L3L2", shims[i], mems[i], 1, wts_sizes[i])
+                )
+                wts_sub_fifos[i].append(
+                    object_fifo(
+                        f"wts_buf_{i}0",
+                        mems[i],
+                        cores[i][0],
+                        1,
+                        layer1_wts_sizes[i],
+                    )
+                )
+                if i == 1:
+                    wts_sub_fifos[i].append(
+                        object_fifo(
+                            f"wts_buf_{i}1",
+                            mems[i],
+                            [cores[i][3], cores[i][1]],
+                            1,
+                            weightsLayer2_ty,
+                        )
+                    )
+                else:
+                    wts_sub_fifos[i].append(
+                        object_fifo(
+                            f"wts_buf_{i}1",
+                            mems[i],
+                            [cores[i][1], cores[i][3]],
+                            1,
+                            weightsLayer2_ty,
+                        )
+                    )
+                wts_sub_fifos[i].append(
+                    object_fifo(
+                        f"wts_buf_{i}2",
+                        mems[i],
+                        cores[i][2],
+                        1,
+                        layer3_wts_sizes[i],
+                    )
+                )
+                object_fifo_link(
+                    wts_fifos[i],
+                    wts_sub_fifos[i],
+                    [],
+                    [
+                        0,
+                        np.prod(np_ndarray_type_get_shape(layer1_wts_sizes[i])),
+                        np.prod(np_ndarray_type_get_shape(layer1_wts_sizes[i]))
+                        + np.prod(np_ndarray_type_get_shape(weightsLayer2_ty)),
+                    ],
+                )
+            # output tensor
+            outOFL2L3 = object_fifo(
+                "outOFL2L3", cores[2][2], shims[1], 2, tensorLayer3Out_ty
+            )
+            conv3_out_fifos = [
+                act1_fifos[1],
+                act1_fifos[2],
+                outOFL2L3,
+            ]
+            # # 1x1 conv2d
+            for i in range(n_cols):
+
+                @core(cores[i][0], conv1_kernels[i])
+                def core_body():
+                    for _ in range_(sys.maxsize):
+
+                        # acquire weights once
+                        element0Weights = wts_sub_fifos[i][0].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
+                        scale = rtp[i][0][0]
+                        for _ in range_(tensorInH):
+                            element0ActivactionsIn = act1_fifos[i].acquire(
+                                ObjectFifoPort.Consume, 1
+                            )
+                            element0ActivactionsOut = act2_fifos[i].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
+                            if i == 0:
+                                conv1_kernels_call[i](
+                                    element0ActivactionsIn,
+                                    element0Weights,
+                                    element0ActivactionsOut,
+                                    tensorInW,
+                                    tensorInCInit,
+                                    tensorInCInit,
+                                    scale,
+                                )
+                            else:
+                                conv1_kernels_call[i](
+                                    element0ActivactionsIn,
+                                    element0Weights,
+                                    element0ActivactionsOut,
+                                    tensorInW,
+                                    tensorInCRest,
+                                    tensorInCInit,
+                                    scale,
+                                )
+
+                            act1_fifos[i].release(ObjectFifoPort.Consume, 1)
+                            act2_fifos[i].release(ObjectFifoPort.Produce, 1)
+                        wts_sub_fifos[i][0].release(ObjectFifoPort.Consume, 1)
+
+            # 3x3 conv2d OFM 0-31
+            for i in range(n_cols):
+
+                @core(cores[i][1], "conv2dk3.o")
+                def core_body():
+                    scale = 1
+                    for _ in range_(sys.maxsize):
+
+                        # acquire weights and rtps once
+                        element0Weights = wts_sub_fifos[i][1].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
+                        # scale = memref.load(rtpComputeTile03, 0)
+
+                        # pre-amble: top row
+                        elementActivactionsIn = act2_fifos[i].acquire(
+                            ObjectFifoPort.Consume, 2
+                        )
+                        element0ActivactionsOut = act3_fifos_1[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+                        conv2dk3(
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[1],
+                            element0Weights,
+                            element0ActivactionsOut,
+                            tensorInW,
+                            tensorInCInit,
+                            tensorInCInit // 2,
+                            3,
+                            3,
+                            0,
+                            scale,
+                            0,
+                        )
+                        act3_fifos_1[i].release(ObjectFifoPort.Produce, 1)
+
+                        # middle
+                        for _ in range_(tensorInH - 2):
+                            elementActivactionsIn = act2_fifos[i].acquire(
+                                ObjectFifoPort.Consume, 3
+                            )
+                            element0ActivactionsOut = act3_fifos_1[i].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
+                            conv2dk3(
+                                elementActivactionsIn[0],
+                                elementActivactionsIn[1],
+                                elementActivactionsIn[2],
+                                element0Weights,
+                                element0ActivactionsOut,
+                                tensorInW,
+                                tensorInCInit,
+                                tensorInCInit // 2,
+                                3,
+                                3,
+                                1,
+                                scale,
+                                0,
+                            )
+
+                            act2_fifos[i].release(ObjectFifoPort.Consume, 1)
+                            act3_fifos_1[i].release(ObjectFifoPort.Produce, 1)
+
+                        # last part
+                        elementActivactionsIn = act2_fifos[i].acquire(
+                            ObjectFifoPort.Consume, 2
+                        )
+                        element0ActivactionsOut = act3_fifos_1[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+                        conv2dk3(
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[1],
+                            elementActivactionsIn[1],
+                            element0Weights,
+                            element0ActivactionsOut,
+                            tensorInW,
+                            tensorInCInit,
+                            tensorInCInit // 2,
+                            3,
+                            3,
+                            2,
+                            scale,
+                            0,
+                        )
+                        act2_fifos[i].release(ObjectFifoPort.Consume, 2)
+                        act3_fifos_1[i].release(ObjectFifoPort.Produce, 1)
+                        wts_sub_fifos[i][1].release(ObjectFifoPort.Consume, 1)
+
+            # 3x3 conv2d OFM 32-63
+
+            for i in range(n_cols):
+
+                @core(cores[i][3], "conv2dk3.o")
+                def core_body():
+                    scale = 1
+                    for _ in range_(sys.maxsize):
+
+                        # acquire weights and rtps once
+                        element0Weights = wts_sub_fifos[i][1].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
+                        # scale = memref.load(rtpComputeTile05, 0)
+
+                        # pre-amble: top row
+                        elementActivactionsIn = act2_fifos[i].acquire(
+                            ObjectFifoPort.Consume, 2
+                        )
+                        element0ActivactionsOut = act3_fifos_2[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+                        conv2dk3(
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[1],
+                            element0Weights,
+                            element0ActivactionsOut,
+                            tensorInW,
+                            tensorInCInit,
+                            tensorInCInit // 2,
+                            3,
+                            3,
+                            0,
+                            scale,
+                            tensorInCInit // 2,
+                        )
+
+                        act3_fifos_2[i].release(ObjectFifoPort.Produce, 1)
+
+                        # middle
+                        for _ in range_(tensorInH - 2):
+                            elementActivactionsIn = act2_fifos[i].acquire(
+                                ObjectFifoPort.Consume, 3
+                            )
+                            element0ActivactionsOut = act3_fifos_2[i].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
+                            conv2dk3(
+                                elementActivactionsIn[0],
+                                elementActivactionsIn[1],
+                                elementActivactionsIn[2],
+                                element0Weights,
+                                element0ActivactionsOut,
+                                tensorInW,
+                                tensorInCInit,
+                                tensorInCInit // 2,
+                                3,
+                                3,
+                                1,
+                                scale,
+                                tensorInCInit // 2,
+                            )
+
+                            act2_fifos[i].release(ObjectFifoPort.Consume, 1)
+                            act3_fifos_2[i].release(ObjectFifoPort.Produce, 1)
+
+                        # last part
+                        elementActivactionsIn = act2_fifos[i].acquire(
+                            ObjectFifoPort.Consume, 2
+                        )
+                        element0ActivactionsOut = act3_fifos_2[i].acquire(
+                            ObjectFifoPort.Produce, 1
+                        )
+                        conv2dk3(
+                            elementActivactionsIn[0],
+                            elementActivactionsIn[1],
+                            elementActivactionsIn[1],
+                            element0Weights,
+                            element0ActivactionsOut,
+                            tensorInW,
+                            tensorInCInit,
+                            tensorInCInit // 2,
+                            3,
+                            3,
+                            2,
+                            scale,
+                            tensorInCInit // 2,
+                        )
+                        act2_fifos[i].release(ObjectFifoPort.Consume, 2)
+                        act3_fifos_2[i].release(ObjectFifoPort.Produce, 1)
+                        wts_sub_fifos[i][1].release(ObjectFifoPort.Consume, 1)
+
+            # # 1x1 conv2d and add skip
+            for i in range(n_cols):
+
+                @core(cores[i][2], conv3_kernels[i])
+                def core_body():
+                    for _ in range_(sys.maxsize):
+
+                        # acquire weights and rtps once
+                        element0Weights = wts_sub_fifos[i][2].acquire(
+                            ObjectFifoPort.Consume, 1
+                        )
+                        if i == 0:
+                            scale = rtp[0][3][0]
+                            skipScale = rtp[0][3][1]
+                            skipConvScale = rtp[0][3][2]
+                        else:
+                            scale = rtp[i][2][0]
+                            skipScale = rtp[i][2][1]
+
+                        for _ in range_(tensorInH):
+                            element0ActivactionsIn = act3_fifos_1[i].acquire(
+                                ObjectFifoPort.Consume, 1
+                            )
+                            element1ActivactionsIn = act3_fifos_2[i].acquire(
+                                ObjectFifoPort.Consume, 1
+                            )
+
+                            elementActivactionsOut = conv3_out_fifos[i].acquire(
+                                ObjectFifoPort.Produce, 1
+                            )
+                            elementSkipsIn = skip_fifos[i].acquire(
+                                ObjectFifoPort.Consume, 1
+                            )
+                            if i == 0:
+                                conv3_kernels_call[0](
+                                    element0ActivactionsIn,
+                                    element1ActivactionsIn,
+                                    element0Weights,
+                                    elementActivactionsOut,
+                                    elementSkipsIn,
+                                    tensorInW,
+                                    tensorInCInit,
+                                    tensorInCRest,
+                                    tensorInCInit,
+                                    scale,
+                                    skipScale,
+                                    skipConvScale,
+                                )
+                            else:
+                                conv3_kernels_call[i](
+                                    element0ActivactionsIn,
+                                    element1ActivactionsIn,
+                                    element0Weights,
+                                    elementActivactionsOut,
+                                    elementSkipsIn,
+                                    tensorInW,
+                                    tensorInCInit,
+                                    tensorInCRest,
+                                    scale,
+                                    skipScale,
+                                )
+                            act3_fifos_1[i].release(ObjectFifoPort.Consume, 1)
+                            act3_fifos_2[i].release(ObjectFifoPort.Consume, 1)
+                            conv3_out_fifos[i].release(ObjectFifoPort.Produce, 1)
+                            skip_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        wts_sub_fifos[i][2].release(ObjectFifoPort.Consume, 1)
+
+            # instruction stream generation
+            @runtime_sequence(
+                activationsInL3_ty, weightsInL3_ty_complete, activationsOutL3_ty
+            )
+            def sequence(inputFromL3, weightsFromL3, outputToL3):
+
+                rtpComputeTile02[0] = 1
+                rtpComputeTile03[0] = 1
+                rtpComputeTile04[0] = 1
+                rtpComputeTile05[0] = 1
+                rtpComputeTile05[1] = 0
+                rtpComputeTile05[2] = 1
+
+                rtpComputeTile15[0] = 1
+                rtpComputeTile14[0] = 1
+                rtpComputeTile12[0] = 1
+                rtpComputeTile13[0] = 1
+                rtpComputeTile13[1] = 0
+
+                rtpComputeTile22[0] = 1
+                rtpComputeTile23[0] = 1
+                rtpComputeTile25[0] = 1
+                rtpComputeTile24[0] = 1
+                rtpComputeTile24[1] = 0
+
+                act1_0_task = dma_configure_task_for(act1_fifos[0])
+                with bds(act1_0_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(inputFromL3, sizes=[1, 1, 1, activationsIn])
+                        EndOp()
+                dma_start_task(act1_0_task)
+
+                wts_0_task = dma_configure_task_for(wts_fifos[0])
+                with bds(wts_0_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(weightsFromL3, sizes=[1, 1, 1, totalWeights_init])
+                        EndOp()
+                dma_start_task(wts_0_task)
+
+                wts_1_task = dma_configure_task_for(wts_fifos[1])
+                with bds(wts_1_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            weightsFromL3,
+                            offsets=[0, 0, 0, totalWeights_init],
+                            sizes=[1, 1, 1, totalWeights_rest],
+                        )
+                        EndOp()
+                dma_start_task(wts_1_task)
+
+                wts_2_task = dma_configure_task_for(wts_fifos[2])
+                with bds(wts_2_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            weightsFromL3,
+                            offsets=[0, 0, 0, totalWeights_init + totalWeights_rest],
+                            sizes=[1, 1, 1, totalWeights_rest],
+                        )
+                        EndOp()
+                dma_start_task(wts_2_task)
+
+                npu_dma_memcpy_nd(
+                    metadata=outOFL2L3,
+                    bd_id=2,
+                    mem=outputToL3,
+                    sizes=[1, 1, 1, acitivationsOut],
+                )
+
+                out_task = dma_configure_task_for(outOFL2L3)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(outputToL3, sizes=[1, 1, 1, acitivationsOut])
+                        EndOp()
+                dma_start_task(out_task)
+
+                # out_task will only complete after inputs complete, so we just wait on out_task instead of all
+                dma_await_task(out_task)
+                dma_free_task(act1_0_task, wts_0_task, wts_1_task, wts_2_task)
+
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)
+
+
+resnet_conv_x()

--- a/programming_examples/ml/resnet/layers_conv2_x/run_makefile_alt.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, torch
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run_py | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/ml/softmax/Makefile
+++ b/programming_examples/ml/softmax/Makefile
@@ -15,6 +15,13 @@ include ${srcdir}/../../makefile-common
 targetname = testSoftmax
 trace_size = 8192
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
 all: build/final.xclbin build/insts.txt
 
 build/dut.cc: ${srcdir}/bf16_softmax.mlir
@@ -35,11 +42,11 @@ build/softmax.o: ${srcdir}/softmax.cc
 build/kernels.a: build/softmax.o build/lut_based_ops.o build/dut.o
 	ar rvs $@ $+
 
-build/aie.mlir: ${srcdir}/aie2.py
+build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 
-build/aie_trace.mlir: ${srcdir}/aie2.py
+build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${trace_size} > $@
 

--- a/programming_examples/ml/softmax/aie2_alt.py
+++ b/programming_examples/ml/softmax/aie2_alt.py
@@ -1,0 +1,150 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 AMD Inc.
+from ml_dtypes import bfloat16
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.helpers.util import np_ndarray_type_get_shape
+
+import aie.utils.trace as trace_utils
+
+
+def vector_softmax(trace_size):
+
+    word_size_in = 2
+    N = 262144  # *1024
+    N_in_bytes = N * word_size_in
+
+    # Tile sizes
+    n = 1024
+    N_div_n = N // n
+
+    n_cores = 2
+    tiles = N_div_n // n_cores
+    buffer_depth = 2
+
+    @device(AIEDevice.npu1_1col)
+    def device_body():
+        tile_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the tile memory
+        A_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+        C_ty = np.ndarray[(n,), np.dtype[bfloat16]]
+
+        # Type used in the memory tile which aggregates across the 4 cores
+        A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+        C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[bfloat16]]
+
+        # AIE Core Function declarations
+
+        softmax_bf16_vector = external_func(
+            "softmax_bf16_vector", inputs=[tile_ty, tile_ty]
+        )
+
+        # Tile declarations
+        ShimTile = tile(0, 0)
+
+        MemTile = tile(0, 1)
+        cores = [tile(0, 2 + i) for i in range(n_cores)]
+
+        inA_fifos = []
+        outC_fifos = []
+
+        # AIE-array data movement with object fifos
+        # Input A and Output C
+        inA = object_fifo("inA", ShimTile, MemTile, buffer_depth, A_memTile_ty)
+        outC = object_fifo("outC", MemTile, ShimTile, buffer_depth, C_memTile_ty)
+
+        for i in range(n_cores):
+            inA_fifos.append(
+                object_fifo(f"memA{i}", MemTile, cores[i], buffer_depth, A_ty)
+            )
+            outC_fifos.append(
+                object_fifo(f"memC{i}", cores[i], MemTile, buffer_depth, C_ty)
+            )
+
+        if n_cores > 1:
+            of_a_offsets = [
+                (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+            of_c_offsets = [
+                (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+                for i in range(n_cores)
+            ]
+        else:
+            of_a_offsets = []
+            of_c_offsets = []
+        object_fifo_link(inA, inA_fifos, [], of_a_offsets)
+        object_fifo_link(outC_fifos, outC, of_c_offsets, [])
+
+        # Set up a circuit-switched flow from core to shim for tracing information
+        if trace_size > 0:
+            flow(cores[0], WireBundle.Trace, 0, ShimTile, WireBundle.DMA, 1)
+
+        # Set up compute tiles
+        for i in range(n_cores):
+            # Compute tile i
+            @core(cores[i], "kernels.a")
+            def core_body():
+                for _ in range_(0xFFFFFFFF):
+                    for _ in range_(tiles):
+                        elem_out = outC_fifos[i].acquire(ObjectFifoPort.Produce, 1)
+                        elem_in_a = inA_fifos[i].acquire(ObjectFifoPort.Consume, 1)
+
+                        softmax_bf16_vector(elem_in_a, elem_out)
+
+                        inA_fifos[i].release(ObjectFifoPort.Consume, 1)
+                        outC_fifos[i].release(ObjectFifoPort.Produce, 1)
+
+        # To/from AIE-array data movement
+        tensor_ty = np.ndarray[(N,), np.dtype[bfloat16]]
+
+        @runtime_sequence(tensor_ty, tensor_ty)
+        def sequence(A, C):
+
+            if trace_size > 0:
+                trace_utils.configure_simple_tracing_aie2(
+                    cores[0],
+                    ShimTile,
+                    ddr_id=1,
+                    size=trace_size,
+                    offset=N_in_bytes,
+                )
+
+            in_task = dma_configure_task_for(inA)
+            with bds(in_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(A, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(in_task)
+
+            out_task = dma_configure_task_for(outC)
+            with bds(out_task) as bd:
+                with bd[0]:
+                    shim_dma_bd(C, sizes=[1, 1, 1, N])
+                    EndOp()
+            dma_start_task(out_task)
+            dma_await_task(in_task, out_task)
+
+
+try:
+    trace_size = 0 if (len(sys.argv) != 2) else int(sys.argv[1])
+except ValueError:
+    print("Argument is not an integer")
+
+with mlir_mod_ctx() as ctx:
+    vector_softmax(trace_size)
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/ml/softmax/aie2_alt.py
+++ b/programming_examples/ml/softmax/aie2_alt.py
@@ -120,19 +120,18 @@ def vector_softmax(trace_size):
                     offset=N_in_bytes,
                 )
 
-            in_task = dma_configure_task_for(inA)
+            in_task = dma_configure_task_for(inA, issue_token=True)
             with bds(in_task) as bd:
                 with bd[0]:
                     shim_dma_bd(A, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(in_task)
 
-            out_task = dma_configure_task_for(outC)
+            out_task = dma_configure_task_for(outC, issue_token=True)
             with bds(out_task) as bd:
                 with bd[0]:
                     shim_dma_bd(C, sizes=[1, 1, 1, N])
                     EndOp()
-            dma_start_task(out_task)
+            dma_start_task(in_task, out_task)
             dma_await_task(in_task, out_task)
 
 

--- a/programming_examples/ml/softmax/run_makefile_alt.lit
+++ b/programming_examples/ml/softmax/run_makefile_alt.lit
@@ -1,0 +1,13 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, chess
+// XFAIL: *
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/vision/color_detect/Makefile
+++ b/programming_examples/vision/color_detect/Makefile
@@ -23,6 +23,13 @@ targetname = colorDetect
 #COLORDETECT_WIDTH = 640
 #COLORDETECT_HEIGHT = 480
 
+aie_py_src=aie2_colorDetect.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_colorDetect_alt.py
+endif
+
 all: build/final_${COLORDETECT_WIDTH}.xclbin
 
 mlir: build/aie2_lineBased_8b_${COLORDETECT_WIDTH}.mlir
@@ -35,7 +42,7 @@ build/combined_bitwiseOR_gray2rgba_bitwiseAND.a: build/bitwiseOR.cc.o build/gray
 	mkdir -p ${@D}
 	ar rvs $@ $< $(word 2,$^) $(word 3,$^)
 
-build/aie2_lineBased_8b_${COLORDETECT_WIDTH}.mlir: ${srcdir}/aie2_colorDetect.py
+build/aie2_lineBased_8b_${COLORDETECT_WIDTH}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${COLORDETECT_WIDTH} ${COLORDETECT_HEIGHT} > $@
 

--- a/programming_examples/vision/color_detect/aie2_colorDetect_alt.py
+++ b/programming_examples/vision/color_detect/aie2_colorDetect_alt.py
@@ -1,0 +1,241 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 Xilinx Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+width = 64
+height = 36
+if len(sys.argv) == 3:
+    width = int(sys.argv[1])
+    height = int(sys.argv[2])
+
+lineWidth = width
+lineWidthInBytes = width * 4
+tensorSize = width * height * 4  # 4 channels
+
+enableTrace = False
+traceSize = 1024
+
+
+def color_detect():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def deviceBody():
+            line_bytes_ty = np.ndarray[(lineWidthInBytes,), np.dtype[np.uint8]]
+            line_ty = np.ndarray[(lineWidth,), np.dtype[np.uint8]]
+
+            tensor_ty = np.ndarray[(tensorSize,), np.dtype[np.int8]]
+            tensor_16x16_ty = np.ndarray[(16, 16), np.dtype[np.int32]]
+
+            # AIE Core Function declarations
+            rgba2hueLine = external_func(
+                "rgba2hueLine", inputs=[line_bytes_ty, line_ty, np.int32]
+            )
+            thresholdLine = external_func(
+                "thresholdLine",
+                inputs=[line_ty, line_ty, np.int32, np.int16, np.int16, np.int8],
+            )
+            bitwiseORLine = external_func(
+                "bitwiseORLine", inputs=[line_ty, line_ty, line_ty, np.int32]
+            )
+            gray2rgbaLine = external_func(
+                "gray2rgbaLine", inputs=[line_ty, line_bytes_ty, np.int32]
+            )
+            bitwiseANDLine = external_func(
+                "bitwiseANDLine",
+                inputs=[line_bytes_ty, line_bytes_ty, line_bytes_ty, np.int32],
+            )
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+            MemTile = tile(0, 1)
+            ComputeTile2 = tile(0, 2)
+            ComputeTile3 = tile(0, 3)
+            ComputeTile4 = tile(0, 4)
+            ComputeTile5 = tile(0, 5)
+
+            # AIE-array data movement with object fifos
+
+            # Input
+            inOF_L3L2 = object_fifo(
+                "inOF_L3L2",
+                ShimTile,
+                [ComputeTile2, MemTile],
+                [2, 2, 6],
+                line_bytes_ty,
+            )
+            inOF_L2L1 = object_fifo(
+                "inOF_L2L1", MemTile, ComputeTile5, 6, line_bytes_ty
+            )
+            object_fifo_link(inOF_L3L2, inOF_L2L1)
+
+            # Output
+            outOF_L2L3 = object_fifo("outOF_L2L3", MemTile, ShimTile, 2, line_bytes_ty)
+            outOF_L1L2 = object_fifo(
+                "outOF_L1L2", ComputeTile5, MemTile, 2, line_bytes_ty
+            )
+            object_fifo_link(outOF_L1L2, outOF_L2L3)
+
+            # Intermediate
+            OF_2to34 = object_fifo(
+                "OF_2to34", ComputeTile2, [ComputeTile3, ComputeTile4], 2, line_ty
+            )
+            OF_3to3 = object_fifo("OF_3to3", ComputeTile3, ComputeTile3, 1, line_ty)
+            OF_3to5 = object_fifo("OF_3to5", ComputeTile3, ComputeTile5, 2, line_ty)
+            OF_4to4 = object_fifo("OF_4to4", ComputeTile4, ComputeTile4, 1, line_ty)
+            OF_4to5 = object_fifo("OF_4to5", ComputeTile4, ComputeTile5, 2, line_ty)
+            OF_5to5a = object_fifo("OF_5to5a", ComputeTile5, ComputeTile5, 1, line_ty)
+            OF_5to5b = object_fifo(
+                "OF_5to5b", ComputeTile5, ComputeTile5, 1, line_bytes_ty
+            )
+
+            # Set up compute tiles
+
+            # Compute tile 2
+            @core(ComputeTile2, "rgba2hue.cc.o")
+            def coreBody():
+                for _ in range_(sys.maxsize):
+                    elemIn = inOF_L3L2.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = OF_2to34.acquire(ObjectFifoPort.Produce, 1)
+                    rgba2hueLine(elemIn, elemOut, lineWidth)
+                    inOF_L3L2.release(ObjectFifoPort.Consume, 1)
+                    OF_2to34.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 3
+            @core(ComputeTile3, "threshold.cc.o")
+            def coreBody():
+                thresholdValueUpper1 = 40
+                thresholdValueLower1 = 30
+                thresholdMaxvalue = 255
+                thresholdModeToZeroInv = 4
+                thresholdModeBinary = 0
+                for _ in range_(sys.maxsize):
+                    elemIn = OF_2to34.acquire(ObjectFifoPort.Consume, 1)
+                    elemOutTmp = OF_3to3.acquire(ObjectFifoPort.Produce, 1)
+                    thresholdLine(
+                        elemIn,
+                        elemOutTmp,
+                        lineWidth,
+                        thresholdValueUpper1,
+                        thresholdMaxvalue,
+                        thresholdModeToZeroInv,
+                    )
+                    OF_2to34.release(ObjectFifoPort.Consume, 1)
+                    OF_3to3.release(ObjectFifoPort.Produce, 1)
+                    elemInTmp = OF_3to3.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = OF_3to5.acquire(ObjectFifoPort.Produce, 1)
+                    thresholdLine(
+                        elemInTmp,
+                        elemOut,
+                        lineWidth,
+                        thresholdValueLower1,
+                        thresholdMaxvalue,
+                        thresholdModeBinary,
+                    )
+                    OF_3to3.release(ObjectFifoPort.Consume, 1)
+                    OF_3to5.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 4
+            @core(ComputeTile4, "threshold.cc.o")
+            def coreBody():
+                thresholdValueUpper1 = 160
+                thresholdValueLower1 = 90
+                thresholdMaxvalue = 255
+                thresholdModeToZeroInv = 4
+                thresholdModeBinary = 0
+                for _ in range_(sys.maxsize):
+                    elemIn = OF_2to34.acquire(ObjectFifoPort.Consume, 1)
+                    elemOutTmp = OF_4to4.acquire(ObjectFifoPort.Produce, 1)
+                    thresholdLine(
+                        elemIn,
+                        elemOutTmp,
+                        lineWidth,
+                        thresholdValueUpper1,
+                        thresholdMaxvalue,
+                        thresholdModeToZeroInv,
+                    )
+                    OF_2to34.release(ObjectFifoPort.Consume, 1)
+                    OF_4to4.release(ObjectFifoPort.Produce, 1)
+                    elemInTmp = OF_4to4.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = OF_4to5.acquire(ObjectFifoPort.Produce, 1)
+                    thresholdLine(
+                        elemInTmp,
+                        elemOut,
+                        lineWidth,
+                        thresholdValueLower1,
+                        thresholdMaxvalue,
+                        thresholdModeBinary,
+                    )
+                    OF_4to4.release(ObjectFifoPort.Consume, 1)
+                    OF_4to5.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 5
+            @core(ComputeTile5, "combined_bitwiseOR_gray2rgba_bitwiseAND.a")
+            def coreBody():
+                for _ in range_(sys.maxsize):
+                    # bitwise OR
+                    elemIn1 = OF_3to5.acquire(ObjectFifoPort.Consume, 1)
+                    elemIn2 = OF_4to5.acquire(ObjectFifoPort.Consume, 1)
+                    elemOutTmpA = OF_5to5a.acquire(ObjectFifoPort.Produce, 1)
+                    bitwiseORLine(elemIn1, elemIn2, elemOutTmpA, lineWidth)
+                    OF_3to5.release(ObjectFifoPort.Consume, 1)
+                    OF_4to5.release(ObjectFifoPort.Consume, 1)
+                    OF_5to5a.release(ObjectFifoPort.Produce, 1)
+                    # gray2rgba
+                    elemInTmpA = OF_5to5a.acquire(ObjectFifoPort.Consume, 1)
+                    elemOutTmpB = OF_5to5b.acquire(ObjectFifoPort.Produce, 1)
+                    gray2rgbaLine(elemInTmpA, elemOutTmpB, lineWidth)
+                    OF_5to5a.release(ObjectFifoPort.Consume, 1)
+                    OF_5to5b.release(ObjectFifoPort.Produce, 1)
+                    # bitwise AND
+                    elemInTmpB1 = OF_5to5b.acquire(ObjectFifoPort.Consume, 1)
+                    elemInTmpB2 = inOF_L2L1.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = outOF_L1L2.acquire(ObjectFifoPort.Produce, 1)
+                    bitwiseANDLine(elemInTmpB1, elemInTmpB2, elemOut, lineWidthInBytes)
+                    OF_5to5b.release(ObjectFifoPort.Consume, 1)
+                    inOF_L2L1.release(ObjectFifoPort.Consume, 1)
+                    outOF_L1L2.release(ObjectFifoPort.Produce, 1)
+
+            # To/from AIE-array data movement
+            @runtime_sequence(tensor_ty, tensor_16x16_ty, tensor_ty)
+            def sequence(I, B, O):
+                in_task = dma_configure_task_for(inOF_L3L2)
+                with bds(in_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            I,
+                            sizes=[1, 1, 1, height * lineWidthInBytes],
+                            strides=[0, 0, 0, 1],
+                        )
+                        EndOp()
+                dma_start_task(in_task)
+
+                out_task = dma_configure_task_for(outOF_L2L3)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            O,
+                            sizes=[1, 1, 1, height * lineWidthInBytes],
+                            strides=[0, 0, 0, 1],
+                        )
+                        EndOp()
+                dma_start_task(out_task)
+
+                # outOF_L2L3 will only complete after inOF_L3L2 completes, so we just wait on outOF_L2L3 instead of all
+                dma_await_task(out_task)
+                dma_free_task(in_task)
+
+    print(ctx.module)
+
+
+color_detect()

--- a/programming_examples/vision/color_detect/aie2_colorDetect_alt.py
+++ b/programming_examples/vision/color_detect/aie2_colorDetect_alt.py
@@ -215,7 +215,6 @@ def color_detect():
                         shim_dma_bd(
                             I,
                             sizes=[1, 1, 1, height * lineWidthInBytes],
-                            strides=[0, 0, 0, 1],
                         )
                         EndOp()
                 dma_start_task(in_task)
@@ -226,7 +225,6 @@ def color_detect():
                         shim_dma_bd(
                             O,
                             sizes=[1, 1, 1, height * lineWidthInBytes],
-                            strides=[0, 0, 0, 1],
                         )
                         EndOp()
                 dma_start_task(out_task)

--- a/programming_examples/vision/color_detect/aie2_colorDetect_alt.py
+++ b/programming_examples/vision/color_detect/aie2_colorDetect_alt.py
@@ -217,9 +217,8 @@ def color_detect():
                             sizes=[1, 1, 1, height * lineWidthInBytes],
                         )
                         EndOp()
-                dma_start_task(in_task)
 
-                out_task = dma_configure_task_for(outOF_L2L3)
+                out_task = dma_configure_task_for(outOF_L2L3, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
                         shim_dma_bd(
@@ -227,8 +226,8 @@ def color_detect():
                             sizes=[1, 1, 1, height * lineWidthInBytes],
                         )
                         EndOp()
-                dma_start_task(out_task)
 
+                dma_start_task(in_task, out_task)
                 # outOF_L2L3 will only complete after inOF_L3L2 completes, so we just wait on outOF_L2L3 instead of all
                 dma_await_task(out_task)
                 dma_free_task(in_task)

--- a/programming_examples/vision/color_detect/run_makefile_alt.lit
+++ b/programming_examples/vision/color_detect/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, opencv
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/vision/color_threshold/Makefile
+++ b/programming_examples/vision/color_threshold/Makefile
@@ -20,6 +20,13 @@ COLORTHRESHOLD_HEIGHT = 1080
 
 targetname = colorThreshold
 
+aie_py_src=aie2_colorThreshold.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_colorThreshold_alt.py
+endif
+
 all: build/final_${COLORTHRESHOLD_WIDTH}.xclbin
 
 mlir: build/aie2_${COLORTHRESHOLD_WIDTH}.mlir
@@ -28,7 +35,7 @@ build/%.cc.o: %.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -DBIT_WIDTH=8 -c $< -o ${@F}
 	
-build/aie2_${COLORTHRESHOLD_WIDTH}.mlir: ${srcdir}/aie2_colorThreshold.py
+build/aie2_${COLORTHRESHOLD_WIDTH}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${COLORTHRESHOLD_WIDTH} ${COLORTHRESHOLD_HEIGHT} > $@
 

--- a/programming_examples/vision/color_threshold/aie2_colorThreshold_alt.py
+++ b/programming_examples/vision/color_threshold/aie2_colorThreshold_alt.py
@@ -257,9 +257,8 @@ def color_threshold():
                             sizes=[1, 1, 1, tensorSize],
                         )
                         EndOp()
-                dma_start_task(in_task)
 
-                out_task = dma_configure_task_for(outOOB_L2L3)
+                out_task = dma_configure_task_for(outOOB_L2L3, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
                         shim_dma_bd(
@@ -267,8 +266,7 @@ def color_threshold():
                             sizes=[1, 1, 1, tensorSize],
                         )
                         EndOp()
-                dma_start_task(out_task)
-
+                dma_start_task(in_task, out_task)
                 dma_await_task(in_task, out_task)
 
     # print(ctx.module.operation.verify())

--- a/programming_examples/vision/color_threshold/aie2_colorThreshold_alt.py
+++ b/programming_examples/vision/color_threshold/aie2_colorThreshold_alt.py
@@ -1,0 +1,278 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2021 Xilinx Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.dialects.ext import arith
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.util import np_ndarray_type_get_shape
+from aie.helpers.dialects.ext.scf import _for as range_
+
+width = 512
+height = 9
+if len(sys.argv) == 3:
+    width = int(sys.argv[1])
+    height = int(sys.argv[2])
+
+lineWidth = width
+lineWidthChannels = width * 4  # 4 channels
+tensorSize = width * height
+
+enableTrace = False
+traceSizeInBytes = 8192
+traceSizeInInt32s = traceSizeInBytes // 4
+
+
+def color_threshold():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def device_body():
+            line_channels_ty = np.ndarray[(lineWidthChannels,), np.dtype[np.uint8]]
+            line_ty = np.ndarray[(lineWidth,), np.dtype[np.uint8]]
+
+            # AIE Core Function declarations
+            thresholdLine = external_func(
+                "thresholdLine",
+                inputs=[line_ty, line_ty, np.int32, np.int16, np.int16, np.int8],
+            )
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+            MemTile = tile(0, 1)
+            ComputeTile2 = tile(0, 2)
+            ComputeTile3 = tile(0, 3)
+            ComputeTile4 = tile(0, 4)
+            ComputeTile5 = tile(0, 5)
+
+            # AIE-array data movement with object fifos
+
+            # Input RGBA broadcast + memtile for skip
+            inOOB_L3L2 = object_fifo(
+                "inOOB_L3L2", ShimTile, MemTile, 2, line_channels_ty
+            )
+            inOOB_L2L1_0 = object_fifo(
+                "inOOB_L2L1_0", MemTile, ComputeTile2, 2, line_ty
+            )
+            inOOB_L2L1_1 = object_fifo(
+                "inOOB_L2L1_1", MemTile, ComputeTile3, 2, line_ty
+            )
+            inOOB_L2L1_2 = object_fifo(
+                "inOOB_L2L1_2", MemTile, ComputeTile4, 2, line_ty
+            )
+            inOOB_L2L1_3 = object_fifo(
+                "inOOB_L2L1_3", MemTile, ComputeTile5, 2, line_ty
+            )
+            of_offsets = [
+                np.prod(np_ndarray_type_get_shape(line_ty)) * i for i in range(4)
+            ]
+            object_fifo_link(
+                inOOB_L3L2,
+                [inOOB_L2L1_0, inOOB_L2L1_1, inOOB_L2L1_2, inOOB_L2L1_3],
+                [],
+                of_offsets,
+            )
+
+            # Output RGBA
+            outOOB_L2L3 = object_fifo(
+                "outOOB_L2L3", MemTile, ShimTile, 2, line_channels_ty
+            )
+            outOOB_L1L2_0 = object_fifo(
+                "outOOB_L1L2_0", ComputeTile2, MemTile, 2, line_ty
+            )
+            outOOB_L1L2_1 = object_fifo(
+                "outOOB_L1L2_1", ComputeTile3, MemTile, 2, line_ty
+            )
+            outOOB_L1L2_2 = object_fifo(
+                "outOOB_L1L2_2", ComputeTile4, MemTile, 2, line_ty
+            )
+            outOOB_L1L2_3 = object_fifo(
+                "outOOB_L1L2_3", ComputeTile5, MemTile, 2, line_ty
+            )
+            object_fifo_link(
+                [outOOB_L1L2_0, outOOB_L1L2_1, outOOB_L1L2_2, outOOB_L1L2_3],
+                outOOB_L2L3,
+                of_offsets,
+                [],
+            )
+
+            # Runtime parameters
+            rtpComputeTile2 = buffer(
+                ComputeTile2,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile2",
+                use_write_rtp=True,
+            )
+            rtpComputeTile3 = buffer(
+                ComputeTile3,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile3",
+                use_write_rtp=True,
+            )
+            rtpComputeTile4 = buffer(
+                ComputeTile4,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile4",
+                use_write_rtp=True,
+            )
+            rtpComputeTile5 = buffer(
+                ComputeTile5,
+                np.ndarray[(16,), np.dtype[np.int32]],
+                "rtpComputeTile5",
+                use_write_rtp=True,
+            )
+
+            # Set up compute tiles
+
+            # Compute tile 2
+            @core(ComputeTile2, "threshold.cc.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    elemIn = inOOB_L2L1_0.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = outOOB_L1L2_0.acquire(ObjectFifoPort.Produce, 1)
+
+                    # RTPs written from the instruction stream must be read right before the kernel
+                    # after the ObjectFIFO acquires
+                    thresholdValue = arith.trunci(T.i16(), rtpComputeTile2[0])
+                    maxValue = arith.trunci(T.i16(), rtpComputeTile2[1])
+                    thresholdType = arith.trunci(T.i8(), rtpComputeTile2[2])
+                    thresholdLine(
+                        elemIn,
+                        elemOut,
+                        lineWidth,
+                        thresholdValue,
+                        maxValue,
+                        thresholdType,
+                    )
+
+                    inOOB_L2L1_0.release(ObjectFifoPort.Consume, 1)
+                    outOOB_L1L2_0.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 3
+            @core(ComputeTile3, "threshold.cc.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    elemIn = inOOB_L2L1_1.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = outOOB_L1L2_1.acquire(ObjectFifoPort.Produce, 1)
+                    # RTPs written from the instruction stream must be read right before the kernel
+                    # after the ObjectFIFO acquires
+                    thresholdValue = arith.trunci(T.i16(), rtpComputeTile3[0])
+                    maxValue = arith.trunci(T.i16(), rtpComputeTile3[1])
+                    thresholdType = arith.trunci(T.i8(), rtpComputeTile3[2])
+                    thresholdLine(
+                        elemIn,
+                        elemOut,
+                        lineWidth,
+                        thresholdValue,
+                        maxValue,
+                        thresholdType,
+                    )
+
+                    inOOB_L2L1_1.release(ObjectFifoPort.Consume, 1)
+                    outOOB_L1L2_1.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 4
+            @core(ComputeTile4, "threshold.cc.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    elemIn = inOOB_L2L1_2.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = outOOB_L1L2_2.acquire(ObjectFifoPort.Produce, 1)
+
+                    # RTPs written from the instruction stream must be read right before the kernel
+                    # after the ObjectFIFO acquires
+                    thresholdValue = arith.trunci(T.i16(), rtpComputeTile4[0])
+                    maxValue = arith.trunci(T.i16(), rtpComputeTile4[1])
+                    thresholdType = arith.trunci(T.i8(), rtpComputeTile4[2])
+                    thresholdLine(
+                        elemIn,
+                        elemOut,
+                        lineWidth,
+                        thresholdValue,
+                        maxValue,
+                        thresholdType,
+                    )
+
+                    inOOB_L2L1_2.release(ObjectFifoPort.Consume, 1)
+                    outOOB_L1L2_2.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 5
+            @core(ComputeTile5, "threshold.cc.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    elemIn = inOOB_L2L1_3.acquire(ObjectFifoPort.Consume, 1)
+                    elemOut = outOOB_L1L2_3.acquire(ObjectFifoPort.Produce, 1)
+
+                    # RTPs written from the instruction stream must be read right before the kernel
+                    # after the ObjectFIFO acquires
+                    thresholdValue = arith.trunci(T.i16(), rtpComputeTile5[0])
+                    maxValue = arith.trunci(T.i16(), rtpComputeTile5[1])
+                    thresholdType = arith.trunci(T.i8(), rtpComputeTile5[2])
+                    thresholdLine(
+                        elemIn,
+                        elemOut,
+                        lineWidth,
+                        thresholdValue,
+                        maxValue,
+                        thresholdType,
+                    )
+
+                    inOOB_L2L1_3.release(ObjectFifoPort.Consume, 1)
+                    outOOB_L1L2_3.release(ObjectFifoPort.Produce, 1)
+
+            # To/from AIE-array data movement
+            @runtime_sequence(
+                np.ndarray[(tensorSize,), np.dtype[np.int8]],
+                np.ndarray[(32,), np.dtype[np.int32]],  # not used
+                np.ndarray[(tensorSize,), np.dtype[np.int8]],
+            )
+            def sequence(inTensor, notUsed, outTensor):
+                # thresholdValue, maxValue, thresholdType
+                rtpComputeTile2[0] = 50
+                rtpComputeTile2[1] = 255
+                rtpComputeTile2[2] = 0
+
+                rtpComputeTile3[0] = 50
+                rtpComputeTile3[1] = 255
+                rtpComputeTile3[2] = 0
+
+                rtpComputeTile4[0] = 50
+                rtpComputeTile4[1] = 255
+                rtpComputeTile4[2] = 0
+
+                rtpComputeTile5[0] = 50
+                rtpComputeTile5[1] = 255
+                rtpComputeTile5[2] = 0
+
+                in_task = dma_configure_task_for(inOOB_L3L2, issue_token=True)
+                with bds(in_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            inTensor,
+                            sizes=[1, 1, 1, tensorSize],
+                        )
+                        EndOp()
+                dma_start_task(in_task)
+
+                out_task = dma_configure_task_for(outOOB_L2L3)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            outTensor,
+                            sizes=[1, 1, 1, tensorSize],
+                        )
+                        EndOp()
+                dma_start_task(out_task)
+
+                dma_await_task(in_task, out_task)
+
+    # print(ctx.module.operation.verify())
+    print(ctx.module)
+
+
+color_threshold()

--- a/programming_examples/vision/color_threshold/run_makefile_alt.lit
+++ b/programming_examples/vision/color_threshold/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, opencv
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/vision/edge_detect/Makefile
+++ b/programming_examples/vision/edge_detect/Makefile
@@ -23,6 +23,13 @@ EDGEDETECT_HEIGHT = 1080
 
 targetname = edgeDetect
 
+aie_py_src=aie2_edgeDetect.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_edgeDetect_alt.py
+endif
+
 all: build/final_${EDGEDETECT_WIDTH}.xclbin
 
 mlir: build/aie2_lineBased_8b_${EDGEDETECT_WIDTH}.mlir
@@ -35,7 +42,7 @@ build/combined_gray2rgba_addWeighted.a: build/gray2rgba.cc.o build/addWeighted.c
 	mkdir -p ${@D}
 	ar rvs $@ $< $(word 2,$^)
 
-build/aie2_lineBased_8b_${EDGEDETECT_WIDTH}.mlir: ${srcdir}/aie2_edgeDetect.py
+build/aie2_lineBased_8b_${EDGEDETECT_WIDTH}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${EDGEDETECT_WIDTH} ${EDGEDETECT_HEIGHT} > $@
 

--- a/programming_examples/vision/edge_detect/aie2_edgeDetect_alt.py
+++ b/programming_examples/vision/edge_detect/aie2_edgeDetect_alt.py
@@ -1,0 +1,297 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2021 Xilinx Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.helpers.dialects.ext.scf import _for as range_
+from aie.extras.context import mlir_mod_ctx
+
+width = 64
+height = 36
+if len(sys.argv) == 3:
+    width = int(sys.argv[1])
+    height = int(sys.argv[2])
+
+heightMinus1 = height - 1
+lineWidth = width
+lineWidthInBytes = width * 4
+tensorSize = width * height * 4  # 4 channels
+
+enableTrace = False
+traceSizeInBytes = 8192
+traceSizeInInt32s = traceSizeInBytes // 4
+
+
+def edge_detect():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def device_body():
+            line_bytes_ty = np.ndarray[(lineWidthInBytes,), np.dtype[np.uint8]]
+            line_ty = np.ndarray[(lineWidth,), np.dtype[np.uint8]]
+            tensor_3x3_ty = np.ndarray[(3, 3), np.dtype[np.int16]]
+
+            tensor_ty = np.ndarray[(tensorSize,), np.dtype[np.int8]]
+            tensor_16x16_ty = np.ndarray[(16, 16), np.dtype[np.int32]]
+
+            # AIE Core Function declarations
+            rgba2gray_line = external_func(
+                "rgba2grayLine", inputs=[line_bytes_ty, line_ty, np.int32]
+            )
+            filter2d_line = external_func(
+                "filter2dLine",
+                inputs=[line_ty, line_ty, line_ty, line_ty, np.int32, tensor_3x3_ty],
+            )
+            threshold_line = external_func(
+                "thresholdLine",
+                inputs=[line_ty, line_ty, np.int32, np.int16, np.int16, np.int8],
+            )
+            gray2rgba_line = external_func(
+                "gray2rgbaLine", inputs=[line_ty, line_bytes_ty, np.int32]
+            )
+            add_weighted_line = external_func(
+                "addWeightedLine",
+                inputs=[
+                    line_bytes_ty,
+                    line_bytes_ty,
+                    line_bytes_ty,
+                    np.int32,
+                    np.int16,
+                    np.int16,
+                    np.int8,
+                ],
+            )
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+            MemTile = tile(0, 1)
+            ComputeTile2 = tile(0, 2)
+            ComputeTile3 = tile(0, 3)
+            ComputeTile4 = tile(0, 4)
+            ComputeTile5 = tile(0, 5)
+
+            # AIE-array data movement with object fifos
+            # Input
+            inOF_L3L2 = object_fifo(
+                "inOF_L3L2",
+                ShimTile,
+                [ComputeTile2, MemTile],
+                [2, 2, 7],
+                line_bytes_ty,
+            )
+            inOF_L2L1 = object_fifo(
+                "inOF_L2L1",
+                MemTile,
+                ComputeTile5,
+                7,
+                line_bytes_ty,
+            )
+            object_fifo_link(inOF_L3L2, inOF_L2L1)
+
+            # Output
+            outOF_L2L3 = object_fifo(
+                "outOF_L2L3",
+                MemTile,
+                ShimTile,
+                2,
+                line_bytes_ty,
+            )
+            outOF_L1L2 = object_fifo(
+                "outOF_L1L2",
+                ComputeTile5,
+                MemTile,
+                2,
+                line_bytes_ty,
+            )
+            object_fifo_link(outOF_L1L2, outOF_L2L3)
+
+            # Intermediate
+            OF_2to3 = object_fifo(
+                "OF_2to3",
+                ComputeTile2,
+                ComputeTile3,
+                4,
+                line_ty,
+            )
+            OF_3to4 = object_fifo(
+                "OF_3to4",
+                ComputeTile3,
+                ComputeTile4,
+                2,
+                line_ty,
+            )
+            OF_4to5 = object_fifo(
+                "OF_4to5",
+                ComputeTile4,
+                ComputeTile5,
+                2,
+                line_ty,
+            )
+            OF_5to5 = object_fifo(
+                "OF_5to5",
+                ComputeTile5,
+                ComputeTile5,
+                1,
+                line_bytes_ty,
+            )
+
+            # Set up compute tiles
+
+            # Compute tile 2
+            @core(ComputeTile2, "rgba2gray.cc.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    elem_in = inOF_L3L2.acquire(ObjectFifoPort.Consume, 1)
+                    elem_out = OF_2to3.acquire(ObjectFifoPort.Produce, 1)
+
+                    rgba2gray_line(elem_in, elem_out, lineWidth)
+
+                    inOF_L3L2.release(ObjectFifoPort.Consume, 1)
+                    OF_2to3.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 3
+            @core(ComputeTile3, "filter2d.cc.o")
+            def core_body():
+                v0 = 0
+                v1 = 4096
+                v_minus4 = -16384
+                initial_value = np.array(
+                    [[v0, v1, v0], [v1, v_minus4, v1], [v0, v1, v0]], dtype=np.int16
+                )
+                kernel = buffer(
+                    ComputeTile3,
+                    np.ndarray[(3, 3), np.dtype[np.int16]],
+                    "kernel",
+                    initial_value=initial_value,
+                )
+
+                for _ in range_(sys.maxsize):
+                    # Preamble : Top Border
+                    elems_in_pre = OF_2to3.acquire(ObjectFifoPort.Consume, 2)
+                    elem_pre_out = OF_3to4.acquire(ObjectFifoPort.Produce, 1)
+                    filter2d_line(
+                        elems_in_pre[0],
+                        elems_in_pre[0],
+                        elems_in_pre[1],
+                        elem_pre_out,
+                        lineWidth,
+                        kernel,
+                    )
+                    OF_3to4.release(ObjectFifoPort.Produce, 1)
+
+                    # Steady State : Middle
+                    for _ in range_(1, heightMinus1):
+                        elems_in = OF_2to3.acquire(ObjectFifoPort.Consume, 3)
+                        elem_out = OF_3to4.acquire(ObjectFifoPort.Produce, 1)
+                        filter2d_line(
+                            elems_in[0],
+                            elems_in[1],
+                            elems_in[2],
+                            elem_out,
+                            lineWidth,
+                            kernel,
+                        )
+                        OF_2to3.release(ObjectFifoPort.Consume, 1)
+                        OF_3to4.release(ObjectFifoPort.Produce, 1)
+
+                    # Postamble : Bottom Border
+                    elems_in_post = OF_2to3.acquire(ObjectFifoPort.Consume, 2)
+                    elem_post_out = OF_3to4.acquire(ObjectFifoPort.Produce, 1)
+                    filter2d_line(
+                        elems_in_post[0],
+                        elems_in_post[1],
+                        elems_in_post[1],
+                        elem_post_out,
+                        lineWidth,
+                        kernel,
+                    )
+                    OF_2to3.release(ObjectFifoPort.Consume, 2)
+                    OF_3to4.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 4
+            @core(ComputeTile4, "threshold.cc.o")
+            def core_body():
+                v_thr = 10
+                v_max = 255
+                v_typ = 0
+
+                for _ in range_(sys.maxsize):
+                    elem_in = OF_3to4.acquire(ObjectFifoPort.Consume, 1)
+                    elem_out = OF_4to5.acquire(ObjectFifoPort.Produce, 1)
+
+                    threshold_line(elem_in, elem_out, lineWidth, v_thr, v_max, v_typ)
+
+                    OF_3to4.release(ObjectFifoPort.Consume, 1)
+                    OF_4to5.release(ObjectFifoPort.Produce, 1)
+
+            # Compute tile 5
+            @core(ComputeTile5, "combined_gray2rgba_addWeighted.a")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    elem_in = OF_4to5.acquire(ObjectFifoPort.Consume, 1)
+                    elem_out = OF_5to5.acquire(ObjectFifoPort.Produce, 1)
+
+                    gray2rgba_line(elem_in, elem_out, lineWidth)
+
+                    OF_4to5.release(ObjectFifoPort.Consume, 1)
+                    OF_5to5.release(ObjectFifoPort.Produce, 1)
+
+                    elem_in1 = OF_5to5.acquire(ObjectFifoPort.Consume, 1)
+                    elem_in2 = inOF_L2L1.acquire(ObjectFifoPort.Consume, 1)
+                    elem_out2 = outOF_L1L2.acquire(ObjectFifoPort.Produce, 1)
+
+                    alpha = 16384
+                    beta = 16384
+                    gamma = 0
+
+                    add_weighted_line(
+                        elem_in1,
+                        elem_in2,
+                        elem_out2,
+                        lineWidthInBytes,
+                        alpha,
+                        beta,
+                        gamma,
+                    )
+
+                    OF_5to5.release(ObjectFifoPort.Consume, 1)
+                    inOF_L2L1.release(ObjectFifoPort.Consume, 1)
+                    outOF_L1L2.release(ObjectFifoPort.Produce, 1)
+
+            # To/from AIE-array data movement
+            @runtime_sequence(tensor_ty, tensor_16x16_ty, tensor_ty)
+            def sequence(I, B, O):
+                in_task = dma_configure_task_for(inOF_L3L2)
+                with bds(in_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            I,
+                            sizes=[1, 1, 1, tensorSize],
+                        )
+                        EndOp()
+                dma_start_task(in_task)
+
+                out_task = dma_configure_task_for(outOF_L2L3)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            O,
+                            sizes=[1, 1, 1, tensorSize],
+                        )
+                        EndOp()
+                dma_start_task(out_task)
+
+                dma_await_task(out_task)
+                dma_free_task(in_task)
+
+    #    print(ctx.module.operation.verify())
+    print(ctx.module)
+
+
+edge_detect()

--- a/programming_examples/vision/edge_detect/aie2_edgeDetect_alt.py
+++ b/programming_examples/vision/edge_detect/aie2_edgeDetect_alt.py
@@ -277,7 +277,7 @@ def edge_detect():
                         EndOp()
                 dma_start_task(in_task)
 
-                out_task = dma_configure_task_for(outOF_L2L3)
+                out_task = dma_configure_task_for(outOF_L2L3, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
                         shim_dma_bd(
@@ -285,8 +285,8 @@ def edge_detect():
                             sizes=[1, 1, 1, tensorSize],
                         )
                         EndOp()
-                dma_start_task(out_task)
 
+                dma_start_task(in_task, out_task)
                 dma_await_task(out_task)
                 dma_free_task(in_task)
 

--- a/programming_examples/vision/edge_detect/run_makefile_alt.lit
+++ b/programming_examples/vision/edge_detect/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, opencv
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/programming_examples/vision/vision_passthrough/Makefile
+++ b/programming_examples/vision/vision_passthrough/Makefile
@@ -20,11 +20,19 @@ PASSTHROUGH_HEIGHT = 1080
 
 targetname = passThrough
 
+aie_py_src=aie2.py
+use_alt?=0
+
+ifeq (${use_alt}, 1)
+aie_py_src=aie2_alt.py
+endif
+
+
 .PHONY: all template clean
 
 all: build/final_${PASSTHROUGH_WIDTH}.xclbin
 
-build/aie2_lineBased_8b_${PASSTHROUGH_WIDTH}.mlir: ${srcdir}/aie2.py
+build/aie2_lineBased_8b_${PASSTHROUGH_WIDTH}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${PASSTHROUGH_WIDTH} ${PASSTHROUGH_HEIGHT} > $@
 

--- a/programming_examples/vision/vision_passthrough/aie2_alt.py
+++ b/programming_examples/vision/vision_passthrough/aie2_alt.py
@@ -147,7 +147,7 @@ def passThroughAIE2():
                     )
                     NpuWrite32(0, 0, 0x1D20C, 0x3)
 
-                in_task = dma_configure_task_for(of_in)
+                in_task = dma_configure_task_for(of_in, issue_token=True)
                 with bds(in_task) as bd:
                     with bd[0]:
                         shim_dma_bd(
@@ -155,9 +155,8 @@ def passThroughAIE2():
                             sizes=[1, 1, 1, tensorSize],
                         )
                         EndOp()
-                dma_start_task(in_task)
 
-                out_task = dma_configure_task_for(of_out)
+                out_task = dma_configure_task_for(of_out, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
                         shim_dma_bd(
@@ -165,8 +164,8 @@ def passThroughAIE2():
                             sizes=[1, 1, 1, tensorSize],
                         )
                         EndOp()
-                dma_start_task(out_task)
 
+                dma_start_task(in_task, out_task)
                 dma_await_task(in_task, out_task)
 
     print(ctx.module)

--- a/programming_examples/vision/vision_passthrough/aie2_alt.py
+++ b/programming_examples/vision/vision_passthrough/aie2_alt.py
@@ -1,0 +1,175 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2023 AMD Inc.
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+width = 512  # 1920 // 8
+height = 9  # 1080 // 8
+if len(sys.argv) == 3:
+    width = int(sys.argv[1])
+    height = int(sys.argv[2])
+
+lineWidthInBytes = width
+tensorSize = width * height
+
+enableTrace = False
+traceSizeInBytes = 8192
+traceSizeInInt32s = traceSizeInBytes // 4
+
+
+def passThroughAIE2():
+    with mlir_mod_ctx() as ctx:
+
+        @device(AIEDevice.npu1_1col)
+        def device_body():
+            # define types
+            tensor_ty = np.ndarray[(tensorSize,), np.dtype[np.int8]]
+            line_ty = np.ndarray[(lineWidthInBytes,), np.dtype[np.uint8]]
+
+            # AIE Core Function declarations
+            passThroughLine = external_func(
+                "passThroughLine", inputs=[line_ty, line_ty, np.int32]
+            )
+
+            # Tile declarations
+            ShimTile = tile(0, 0)
+            ComputeTile2 = tile(0, 2)
+
+            if enableTrace:
+                flow(ComputeTile2, "Trace", 0, ShimTile, "DMA", 1)
+
+            # AIE-array data movement with object fifos
+            of_in = object_fifo("in", ShimTile, ComputeTile2, 2, line_ty)
+            of_out = object_fifo("out", ComputeTile2, ShimTile, 2, line_ty)
+
+            # Set up compute tiles
+
+            # Compute tile 2
+            @core(ComputeTile2, "passThrough.cc.o")
+            def core_body():
+                for _ in range_(sys.maxsize):
+                    for _ in range_(height):
+                        elemOut = of_out.acquire(ObjectFifoPort.Produce, 1)
+                        elemIn = of_in.acquire(ObjectFifoPort.Consume, 1)
+                        passThroughLine(elemIn, elemOut, width)
+                        of_in.release(ObjectFifoPort.Consume, 1)
+                        of_out.release(ObjectFifoPort.Produce, 1)
+
+            #    print(ctx.module.operation.verify())
+
+            @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
+            def sequence(inTensor, notUsed, outTensor):
+                if enableTrace:
+                    # Trace output
+
+                    # Trace_Event0, Trace_Event1: Select which events to trace.
+                    # Note that the event buffers only appear to be transferred to DDR in
+                    # bursts of 256 bytes. If less than 256 bytes are written, you may not
+                    # see trace output, or only see it on the next iteration of your
+                    # kernel invocation, as the buffer gets filled up. Note that, even
+                    # though events are encoded as 4 byte words, it may take more than 64
+                    # events to fill the buffer to 256 bytes and cause a flush, since
+                    # multiple repeating events can be 'compressed' by the trace mechanism.
+                    # In order to always generate sufficient events, we add the "assert
+                    # TRUE" event to one slot, which fires every cycle, and thus fills our
+                    # buffer quickly.
+
+                    # Some events:
+                    # TRUE                       (0x01)
+                    # STREAM_STALL               (0x18)
+                    # LOCK_STALL                 (0x1A)
+                    # EVENTS_CORE_INSTR_EVENT_1  (0x22)
+                    # EVENTS_CORE_INSTR_EVENT_0  (0x21)
+                    # INSTR_VECTOR               (0x25)  Core executes a vecotr MAC, ADD or compare instruction
+                    # INSTR_LOCK_ACQUIRE_REQ     (0x2C)  Core executes a lock acquire instruction
+                    # INSTR_LOCK_RELEASE_REQ     (0x2D)  Core executes a lock release instruction
+                    # EVENTS_CORE_PORT_RUNNING_1 (0x4F)
+                    # EVENTS_CORE_PORT_RUNNING_0 (0x4B)
+
+                    # Trace_Event0  (4 slots)
+                    NpuWrite32(0, 2, 0x340E0, 0x4B222125)
+                    # Trace_Event1  (4 slots)
+                    NpuWrite32(0, 2, 0x340E4, 0x2D2C1A4F)
+
+                    # Event slots as configured above:
+                    # 0: Kernel executes vector instruction
+                    # 1: Event 0 -- Kernel starts
+                    # 2: Event 1 -- Kernel done
+                    # 3: Port_Running_0
+                    # 4: Port_Running_1
+                    # 5: Lock Stall
+                    # 6: Lock Acquire Instr
+                    # 7: Lock Release Instr
+
+                    # Stream_Switch_Event_Port_Selection_0
+                    # This is necessary to capture the Port_Running_0 and Port_Running_1 events
+                    NpuWrite32(0, 2, 0x3FF00, 0x121)
+
+                    # Trace_Control0: Define trace start and stop triggers. Set start event TRUE.
+                    NpuWrite32(0, 2, 0x340D0, 0x10000)
+
+                    # Start trace copy out.
+                    NpuWriteBdShimTile(
+                        bd_id=3,
+                        buffer_length=traceSizeInBytes,
+                        buffer_offset=tensorSize,
+                        enable_packet=0,
+                        out_of_order_id=0,
+                        packet_id=0,
+                        packet_type=0,
+                        column=0,
+                        column_num=1,
+                        d0_stride=0,
+                        d0_wrap=0,
+                        d1_stride=0,
+                        d1_wrap=0,
+                        d2_stride=0,
+                        iteration_current=0,
+                        iteration_stride=0,
+                        iteration_wrap=0,
+                        lock_acq_enable=0,
+                        lock_acq_id=0,
+                        lock_acq_val=0,
+                        lock_rel_id=0,
+                        lock_rel_val=0,
+                        next_bd=0,
+                        use_next_bd=0,
+                        valid_bd=1,
+                    )
+                    NpuWrite32(0, 0, 0x1D20C, 0x3)
+
+                in_task = dma_configure_task_for(of_in)
+                with bds(in_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            inTensor,
+                            sizes=[1, 1, 1, tensorSize],
+                        )
+                        EndOp()
+                dma_start_task(in_task)
+
+                out_task = dma_configure_task_for(of_out)
+                with bds(out_task) as bd:
+                    with bd[0]:
+                        shim_dma_bd(
+                            outTensor,
+                            sizes=[1, 1, 1, tensorSize],
+                        )
+                        EndOp()
+                dma_start_task(out_task)
+
+                dma_await_task(in_task, out_task)
+
+    print(ctx.module)
+
+
+passThroughAIE2()

--- a/programming_examples/vision/vision_passthrough/run_makefile_alt.lit
+++ b/programming_examples/vision/vision_passthrough/run_makefile_alt.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai, peano, opencv
+//
+// RUN: mkdir -p test_alt
+// RUN: cd test_alt
+// RUN: make -f %S/Makefile clean
+// RUN: env use_alt=1 make -f %S/Makefile 
+// RUN: %run_on_npu make -f %S/Makefile run | FileCheck %s
+// CHECK: PASS!
+  

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -861,3 +861,39 @@ def shim_dma_bd(
             transfer_len = np.prod(sizes)
     dimensions = list(zip(sizes, strides))
     dma_bd(mem, offset=offset, len=transfer_len, dimensions=dimensions)
+
+
+_orig_dma_await_task = dma_await_task
+
+
+def dma_await_task(*args: DMAConfigureTaskForOp):
+    if len(args) == 0:
+        raise ValueError(
+            "dma_await_task must receive at least one DMAConfigureTaskForOp to wait for"
+        )
+    for dma_task in args:
+        _orig_dma_await_task(dma_task)
+
+
+_orig_dma_free_task = dma_free_task
+
+
+def dma_free_task(*args: DMAConfigureTaskForOp):
+    if len(args) == 0:
+        raise ValueError(
+            "dma_free_task must receive at least one DMAConfigureTaskForOp to free"
+        )
+    for dma_task in args:
+        _orig_dma_free_task(dma_task)
+
+
+_orig_dma_start_task = dma_start_task
+
+
+def dma_start_task(*args: DMAConfigureTaskForOp):
+    if len(args) == 0:
+        raise ValueError(
+            "dma_start_task must receive at least one DMAConfigureTaskForOp to free"
+        )
+    for dma_task in args:
+        _orig_dma_start_task(dma_task)


### PR DESCRIPTION
This PR is an incremental step towards implementation of my IRON augmentations (found here: https://github.com/Xilinx/mlir-aie/pull/1732).

The IRON extensions/augmentations generate runtime sequences using dma tasks. However, I noticed that the dma task infrastructure does not seem to work out of the box for all examples. Thus, enabling the programming examples to use dma tasks is a necessary preliminary step before I can merge my other work.

While having alternative versions of the program examples will slow down the CI, I believe this is a temporary step until we are ready to deprecate examples using the current IRON syntax. I plan to replace the alt versions with jupyter notebooks eventually.