### PR TITLE
Fix typo in lit file for mat mul whole array test

### DIFF
--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
@@ -7,5 +7,5 @@
 // RUN: cd test_1_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=1 make -f %S/Makefile 
-// RUN: %run_on_npu env n_aie_cols=2 make -f %S/Makefile run | FileCheck %s
+// RUN: %run_on_npu env n_aie_cols=1 make -f %S/Makefile run | FileCheck %s
 // CHECK: PASS!


### PR DESCRIPTION
I don't think this typo affected the tests in any way, but it still seems best to be correct.