### PR TITLE
Update MLIR-AIE doc on `aie.dma_bd` by removing comment on 4th/5th dimension as being repeat dimension

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -856,10 +856,6 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
           // access/store element at/to index (i * 16 /*stride_2*/ + j * 1 /*stride_1*/ + k * 2 /*stride_0*/)
     ```
 
-    Note that an additional dimension of sizes/strides is accepted (5th dimension for memtiles, 4th otherwise);
-    the additional size value is interpreted as a repeat count whereas the additional stride value is
-    interpreted as an iteration stride.
-
     #### Important gotcha regarding strides
 
     All strides are expressed in multiples of the element width (just like `len` and `offset`)


### PR DESCRIPTION
Each `aie.dma_bd` op represents a BD, not a BD task. As of AIE2, a BD task can be enqueued with a repeat count; an individual BD cannot repeat itself with a repeat count, except for being the only BD within a BD task that repeats.