### PR TITLE
Cleanup import path for IRON `range_` import

### DIFF
--- a/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector_iron.py
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector_iron.py
@@ -9,8 +9,8 @@ import numpy as np
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col4
+from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorTiler2D
-from aie.helpers.dialects.ext.scf import _for as range_
 
 
 def my_matmul():

--- a/programming_examples/basic/matrix_multiplication/single_core/single_core_iron.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/single_core_iron.py
@@ -11,8 +11,8 @@ import numpy as np
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col4
+from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorAccessSequence, TensorTiler2D
-from aie.helpers.dialects.ext.scf import _for as range_
 
 dtype_map = {
     "bf16": bfloat16,

--- a/programming_examples/basic/matrix_multiplication/whole_array/whole_array_iron.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/whole_array_iron.py
@@ -11,8 +11,8 @@ import numpy as np
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, NPU1Col2, NPU1Col4, Tile
+from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorAccessSequence, TensorTiler2D
-from aie.helpers.dialects.ext.scf import _for as range_
 
 dtype_map = {
     "bf16": bfloat16,

--- a/programming_examples/basic/matrix_scalar_add/matrix_scalar_add.py
+++ b/programming_examples/basic/matrix_scalar_add/matrix_scalar_add.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, XCVC1902
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorTiler2D
 
 # Size of the entire matrix

--- a/programming_examples/basic/passthrough_pykernel/passthrough_pykernel.py
+++ b/programming_examples/basic/passthrough_pykernel/passthrough_pykernel.py
@@ -11,8 +11,8 @@ import sys
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
+from aie.iron.controlflow import range_
 from aie.helpers.dialects.ext.func import func
-from aie.helpers.dialects.ext.scf import _for as range_
 
 try:
     vector_size = int(sys.argv[1])

--- a/programming_examples/basic/row_wise_bias_add/row_wise_bias_add.py
+++ b/programming_examples/basic/row_wise_bias_add/row_wise_bias_add.py
@@ -10,8 +10,8 @@ import sys
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
+from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorTiler2D
-from aie.helpers.dialects.ext.scf import _for as range_
 
 
 def row_wise_bias_add(M, N, m, n):

--- a/programming_examples/basic/tiling_exploration/per_tile/per_tile.py
+++ b/programming_examples/basic/tiling_exploration/per_tile/per_tile.py
@@ -12,8 +12,8 @@ import sys
 from aie.iron import LocalBuffer, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
+from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorTiler2D
-from aie.helpers.dialects.ext.scf import _for as range_
 
 
 def generate_module(

--- a/programming_examples/basic/tiling_exploration/tile_group/tile_group.py
+++ b/programming_examples/basic/tiling_exploration/tile_group/tile_group.py
@@ -12,7 +12,7 @@ from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
 from aie.helpers.taplib import TensorTiler2D
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 import aie.extras.dialects.ext.arith as arith
 from aie.helpers.util import np_dtype_to_mlir_type
 

--- a/programming_examples/basic/vector_exp/vector_exp.py
+++ b/programming_examples/basic/vector_exp/vector_exp.py
@@ -11,7 +11,7 @@ from ml_dtypes import bfloat16
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 
 def my_eltwise_exp():

--- a/programming_examples/basic/vector_scalar_add/vector_scalar_add.py
+++ b/programming_examples/basic/vector_scalar_add/vector_scalar_add.py
@@ -10,7 +10,7 @@ import numpy as np
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 PROBLEM_SIZE = 1024
 MEM_TILE_WIDTH = 64

--- a/programming_examples/basic/vector_scalar_add_runlist/vector_scalar_add.py
+++ b/programming_examples/basic/vector_scalar_add_runlist/vector_scalar_add.py
@@ -10,7 +10,7 @@ import numpy as np
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 PROBLEM_SIZE = 1024
 MEM_TILE_WIDTH = 64

--- a/programming_examples/basic/vector_scalar_mul/vector_scalar_mul.py
+++ b/programming_examples/basic/vector_scalar_mul/vector_scalar_mul.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, NPU2
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 
 def my_vector_scalar(dev, vector_size, trace_size):

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, XCVC1902
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 
 def my_vector_add():

--- a/programming_examples/basic/vector_vector_modulo/vector_vector_modulo.py
+++ b/programming_examples/basic/vector_vector_modulo/vector_vector_modulo.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, XCVC1902
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 
 def my_vector_mod():

--- a/programming_examples/basic/vector_vector_mul/vector_vector_mul.py
+++ b/programming_examples/basic/vector_vector_mul/vector_vector_mul.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, XCVC1902
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 
 def my_vector_mul():

--- a/programming_examples/ml/bottleneck/bottleneck.py
+++ b/programming_examples/ml/bottleneck/bottleneck.py
@@ -9,7 +9,7 @@ import numpy as np
 from aie.iron import GlobalBuffer, Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import AnyMemTile, NPU1Col1, Tile
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 # Define bottleneck layer sizes
 

--- a/programming_examples/ml/conv2d/conv2d.py
+++ b/programming_examples/ml/conv2d/conv2d.py
@@ -10,7 +10,7 @@ import sys
 from aie.iron import GlobalBuffer, Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 width = 32
 height = 32

--- a/programming_examples/ml/conv2d_fused_relu/conv2d_fused_relu.py
+++ b/programming_examples/ml/conv2d_fused_relu/conv2d_fused_relu.py
@@ -10,7 +10,7 @@ import sys
 from aie.iron import GlobalBuffer, Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 width = 32
 height = 32

--- a/programming_examples/ml/eltwise_add/eltwise_add.py
+++ b/programming_examples/ml/eltwise_add/eltwise_add.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 from aie.helpers.util import np_ndarray_type_get_shape
 
 

--- a/programming_examples/ml/eltwise_mul/eltwise_mul.py
+++ b/programming_examples/ml/eltwise_mul/eltwise_mul.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 from aie.helpers.util import np_ndarray_type_get_shape
 
 

--- a/programming_examples/ml/relu/relu.py
+++ b/programming_examples/ml/relu/relu.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 from aie.helpers.util import np_ndarray_type_get_shape
 
 

--- a/programming_examples/ml/resnet/layers_conv2_x/resnet.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/resnet.py
@@ -9,7 +9,7 @@ import numpy as np
 from aie.iron import GlobalBuffer, Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col3, Tile
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 from aie.helpers.util import np_ndarray_type_get_shape
 from aie.helpers.taplib import TensorAccessPattern
 

--- a/programming_examples/ml/softmax/softmax.py
+++ b/programming_examples/ml/softmax/softmax.py
@@ -11,7 +11,7 @@ import sys
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 
 def vector_softmax(trace_size):

--- a/programming_examples/vision/edge_detect/edge_detect.py
+++ b/programming_examples/vision/edge_detect/edge_detect.py
@@ -10,7 +10,7 @@ import sys
 from aie.iron import LocalBuffer, Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, NPU2
-from aie.helpers.dialects.ext.scf import _for as range_
+from aie.iron.controlflow import range_
 
 
 def edge_detect(dev, width, height):

--- a/python/iron/controlflow.py
+++ b/python/iron/controlflow.py
@@ -1,0 +1,1 @@
+from aie.helpers.dialects.ext.scf import _for as range_


### PR DESCRIPTION
Previously, even new-style IRON designs needed to reach into a dialect-specific import path to get a handle to the `range_` function, which is used for looping. I reimported this function with a simpler path, `from aie.iron.controlflow import range_`