### PR TITLE
Add Python Doxygen Docs to MLIR-AIE Website

### DIFF
--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -87,6 +87,9 @@ jobs:
             -DLLVM_EXTERNAL_LIT=$(which lit)
           make docs
           popd
+          pushd python
+          doxygen
+          popd
           cp -r docs/* build_release/docs
           dot -Tpng docs/dialects.dot > build_release/docs/dialects.png
           dot -Tsvg docs/dialects.dot > build_release/docs/dialects.svg

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -35,6 +35,11 @@
             <li class="listedpages"><a style="color:white;" href="AIEVecDialect.html">AIEVec Dialect</a></li>
             <li class="listedpages"><a style="color:white;" href="AIEVecPasses.html">AIEVec Passes</a></li>
             <li class="listedpages"><a style="color:white;" href="ADFDialect.html">ADF Dialect</a></li>
+            <li class="listedpages"><a style="color:white;" href="doxygen/html/index.html">Doxygen Docs</a></li>
+            <li><label for="btn-4 " class="show ">IRON Docs</label></li>
+            <li class="listedpages"><a style="color:white;" href="python/html/namespaceiron.html">IRON API Docs</a></li>
+            <li class="listedpages"><a style="color:white;" href="python/html/namespacetaplib.html">Tensor Access Pattern (taplib) Docs</a></li>
+            <li class="listedpages"><a style="color:white;" href="python/html/index.html">All Docs</a></li>
             <li><label for="btn-4 " class="show ">Resources </label></li>
             <li class="listedpages"><a style="color:white;" href="Presentations.html">Presentations</a></li>
         </ul>

--- a/python/Doxyfile
+++ b/python/Doxyfile
@@ -1,0 +1,39 @@
+# Example Doxyfile for a Python project
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+PROJECT_NAME           = "IRON"
+PROJECT_NUMBER         = "1.0"
+OUTPUT_DIRECTORY       = "../docs/python"
+CREATE_SUBDIRS         = NO
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = YES
+EXTRACT_STATIC         = YES
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+INPUT                  = helpers/taplib iron
+FILE_PATTERNS          = *.py
+RECURSIVE              = YES
+
+#---------------------------------------------------------------------------
+# Output related configuration options
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+GENERATE_MAN           = NO
+GENERATE_RTF           = NO
+GENERATE_XML           = NO
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_FILE_EXTENSION    = .html
+
+#---------------------------------------------------------------------------
+# Python specific configuration options
+#---------------------------------------------------------------------------
+OPTIMIZE_OUTPUT_FOR_C  = NO
+OPTIMIZE_OUTPUT_JAVA   = NO
+OPTIMIZE_FOR_FORTRAN   = NO
+OPTIMIZE_OUTPUT_VHDL   = NO
+EXTENSION_MAPPING      = py=Python


### PR DESCRIPTION
This PR adds doxygen-generated html docs for both `aie.iron` and `aie.helpers.taplib` to the MLIR-AIE website (https://xilinx.github.io/mlir-aie/). As a side note, you can already access doxygen docs for mlir-aie generally here: https://xilinx.github.io/mlir-aie/doxygen/html/index.html. I also added a link to this on the website.

The Python documents are generated from docstrings. In general, I created these docstrings using templates from the VSCode plugin "autoDocstring - Python Docstring Generator" and then filled them in. It should be pretty simple to add other Python classes outside of the two libraries I added by modifying the Python Doxyfile at `python/Doxyfile`. The documents will be generated even without docstrings, but they look a little odd/limited, so I've excluded other classes for now.

Note: I haven't tested if the links I added to the sidebar work, but I have tested that the docs generate.