### PR TITLE
Fix website tab format and add links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ For your design of interest, for instance from [programming_examples](../program
 
 [MLIR Dialect and Compiler Documentation](https://xilinx.github.io/mlir-aie/)
 
+Interested in contributing MLIR-AIE? [Information for developers](./CONTRIBUTING.md)
+
 -----
 
 <p align="center">Copyright&copy; 2019-2024 Advanced Micro Devices, Inc</p>

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ For your design of interest, for instance from [programming_examples](../program
 
 1. Continue to the [IRON AIE Application Programming Guide](programming_guide)
 
+2. Some MLIR-AIE documentation is available on the [website](https://xilinx.github.io/mlir-aie/)
+
 # Detailed Getting Started Guides and Documentation: 
 
 [Getting Started on a Versal™ board](docs/Building.md)

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ For your design of interest, for instance from [programming_examples](../program
 
 1. Continue to the [IRON AIE Application Programming Guide](programming_guide)
 
-2. Some MLIR-AIE documentation is available on the [website](https://xilinx.github.io/mlir-aie/)
+1. Some MLIR-AIE documentation is available on the [website](https://xilinx.github.io/mlir-aie/)
 
 # Detailed Getting Started Guides and Documentation: 
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -37,9 +37,9 @@
             <li class="listedpages"><a style="color:white;" href="ADFDialect.html">ADF Dialect</a></li>
             <li class="listedpages"><a style="color:white;" href="doxygen/html/index.html">Doxygen Docs</a></li>
             <li><label for="btn-4 " class="show ">IRON Docs</label></li>
-            <li class="listedpages"><a style="color:white;" href="python/html/namespaceiron.html">IRON API Docs</a></li>
-            <li class="listedpages"><a style="color:white;" href="python/html/namespacetaplib.html">Tensor Access Pattern (taplib) Docs</a></li>
-            <li class="listedpages"><a style="color:white;" href="python/html/index.html">All Docs</a></li>
+            <li class="listedpages"><a style="color:white;" href="python/html/namespaceiron.html">IRON API</a></li>
+            <li class="listedpages"><a style="color:white;" href="python/html/namespacetaplib.html">Tensor Access Pattern</a></li>
+            <li class="listedpages"><a style="color:white;" href="python/html/index.html">All</a></li>
             <li><label for="btn-4 " class="show ">Resources </label></li>
             <li class="listedpages"><a style="color:white;" href="Presentations.html">Presentations</a></li>
         </ul>


### PR DESCRIPTION
In a previous PR, I added some links to doxygen-generate documentation to the gihub pages site (https://xilinx.github.io/mlir-aie/).

This works well! However, one of the titles in the sidebar I added was too long, and the formatting was funky. This PR shortens those headings.

I also added a link to the webpage in the README.