### PR TITLE
Minimal Example Showcasing Errors with ObjectFIFOs

### DIFF
--- a/programming_examples/basic/passthrough_kernel/Makefile
+++ b/programming_examples/basic/passthrough_kernel/Makefile
@@ -20,7 +20,7 @@ trace_size = 8192
 PASSTHROUGH_SIZE = ${data_size}
 
 aie_py_src=${targetname}.py
-use_alt?=0
+use_alt?=1
 
 ifeq (${use_alt}, 1)
 aie_py_src=${targetname}_alt.py


### PR DESCRIPTION
Minimal Example Showcasing Errors with ObjectFIFOs @ programming_examples/basic/passthough_kernel. The Passthough Kernel alternative times out when the design is modified to link two objectFIFOs with different sizes with tranformations. This problem only problematic when objectFIFOs with different sizes are linked with tranformations. Without transformation works as expected. Documented the BD design output for reference. 