### PR TITLE
Check equivalence of all ops across two blocks, to improve code generality

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1978,7 +1978,7 @@ static LogicalResult FoldDMAStartOp(DMAStartOp op, PatternRewriter &rewriter) {
   unsigned idx = 0;
   while (patternIt != reachable.end()) {
     // BD repetition found. Check if repeating pattern.
-    if (!areIdenticalBDs(*patternIt, uniquePattern[idx]))
+    if (!areEquivalentBDs(*patternIt, uniquePattern[idx]))
       return failure();
     patternIt++;
     idx = (++idx) % uniquePattern.size();


### PR DESCRIPTION
Instead of only checking for equivalence of `UseLockOp` and `DMABDOp`, switch to checking all operations across the two blocks, except for the terminators.