### PR TITLE
Update pyproject.toml

### DIFF
--- a/utils/mlir_wheels/pyproject.toml
+++ b/utils/mlir_wheels/pyproject.toml
@@ -9,6 +9,7 @@ requires = [
     "numpy",
     "dataclasses",
     "mlir-native-tools",
+    "nanobind",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Add new llvm/mlir requirement `nanobind` to whl build dependencies. I'm not sure if this is the correct place to put it.