### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/tools/aie-translate/CMakeLists.txt
+++ b/tools/aie-translate/CMakeLists.txt
@@ -6,22 +6,15 @@
 # (c) Copyright 2021 Xilinx Inc.
 # (c) Copyright 2024 Advanced Micro Devices Inc.
 
-set(LLVM_LINK_COMPONENTS Support)
+llvm_map_components_to_libnames(llvm_libs support)
+
+add_llvm_tool(aie-translate aie-translate.cpp)
+llvm_update_compile_flags(aie-translate)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS)
 
-add_mlir_tool(aie-translate
-  aie-translate.cpp
-)
-install(TARGETS aie-translate
-EXPORT AIETargets
-RUNTIME DESTINATION ${LLVM_TOOLS_INSTALL_DIR}
-COMPONENT aie-translate)
-
-llvm_update_compile_flags(aie-translate)
-target_link_libraries(aie-translate
-  PRIVATE
+set(LIBS
   ${dialect_libs}
   ${translation_libs}
   AIE
@@ -40,3 +33,5 @@ target_link_libraries(aie-translate
   MLIRTargetLLVMIRExport
   MLIRTargetLLVMIRImport
 )
+
+target_link_libraries(aie-translate PRIVATE ${LIBS})


### PR DESCRIPTION
Make `aie-translate` `CMakeLists.txt` look like `aie-opt` `CMakeLists.txt`. This fixes an issue where `aie-translate` was getting added to both `AIETargets.cmake` and `MLIRTargets.cmake` leading to [errors like](https://github.com/Xilinx/mlir-aie/actions/runs/12401449320/job/34621590046?pr=1994#step:4:1133):
```
    CMake Error at /__w/mlir-aie/mlir-aie/mlir_aie/lib/cmake/aie/MLIRTargets.cmake:42 (message):
      Some (but not all) targets in this export set were already defined.
  
      Targets Defined: aie-translate
  
      Targets not yet defined: MLIRTargetAIEVecCpp, AIERT, obj.AIERT, AIETargets,
      obj.AIETargets, ADF, AIE, AIETransforms, AIEX, AIEXTransforms, AIEXUtils,
      MLIRAIEVecDialect, MLIRAIEVecAIE1Dialect, MLIRAIEVecTransforms,
      MLIRAIEVecTransformOps, MLIRAIEVecUtils, MLIRXLLVMDialect, AIECAPI,
      obj.AIECAPI, MLIRAIEToConfiguration, MLIRAIEVecToLLVM,
      MLIRXLLVMToLLVMIRTranslation, AIEPythonSources, AIEPythonExtensions,
      AIEPythonSources.Dialects, AIEPythonSources.Util, AIEPythonSources.Utils,
      AIEPythonSources.Helpers, AIEPythonSources.Iron,
      AIEPythonSources.Dialects.aie, AIEPythonSources.Dialects.aie.ops_gen,
      AIEPythonSources.Dialects.aiex, AIEPythonSources.Dialects.aiex.ops_gen,
      AIEPythonSources.Dialects.aievec, AIEPythonSources.Dialects.aievec.ops_gen,
      AIEPythonSources.Compiler, AIEPythonSources.XRT, AIEPythonSources.AIERT,
      AIEPythonExtensions.MLIR, AIEPythonExtensions.XRT,
      AIEPythonExtensions.AIERT
  
    Call Stack (most recent call first):
      /__w/mlir-aie/mlir-aie/mlir_aie/lib/cmake/aie/AIEConfig.cmake:39 (include)
      CMakeLists.txt:44 (find_package)
```
