### PR TITLE
Update `upload-artifact` and `download-artifact` to v4

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -34,14 +34,6 @@ description: ''
 runs:
   using: "composite"
   steps:
-    - name: Set unified TZ
-      uses: szenius/set-timezone@v2.0
-      with:
-        # this is an arbitrary choice
-        timezoneLinux: "Asia/Singapore"
-        timezoneMacos: "Asia/Singapore"
-        timezoneWindows: "Singapore Standard Time"
-    
     - name: Setup tmate session
       if: ${{ inputs.DEBUG_ENABLED && inputs.DEBUG_OS == inputs.MATRIX_OS && inputs.DEBUG_ARCH == inputs.MATRIX_ARCH }}
       uses: mxschmitt/action-tmate@v3
@@ -73,9 +65,9 @@ runs:
         large-packages: true
         swap-storage: false # This frees space on the wrong partition.
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.10'
 
     - name: Install Ninja
       uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c # Jan 17
@@ -87,29 +79,35 @@ runs:
         
         sudo apt-get update
         sudo apt-get install -y binutils-aarch64-linux-gnu \
-          g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+          g++-aarch64-linux-gnu gcc-aarch64-linux-gnu openssl libssl-dev
 
     - name: pip install standard tools
       shell: bash
       run: pip install cibuildwheel wheel
 
     - name: install rename
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-13' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
       shell: bash
       run: |
         
-        if [ x"${{ inputs.MATRIX_OS }}" == x"macos-13" ]; then
+        if [ x"${{ inputs.MATRIX_OS }}" == x"macos-12" ] || [ x"${{ inputs.MATRIX_OS }}" == x"macos-14" ]; then
           brew install rename
         else
           sudo apt-get install -y rename
         fi
 
+    # why all this? two reasons:
+    # 1. because the windows runner have not enough space on D, which is also the checkout location (why????)
+    # see https://github.com/actions/runner-images/issues/1341
+    # 2. because windows has a command length limit even in 2023 of 8192 characeters (or something like that). how
+    # do we hit that during anything we're doing here? during the linking phase of MLIR-C.dll, which links together
+    # absolutely all the libs in MLIR using their full/abs paths.
     - run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
       if: ${{ inputs.MATRIX_OS == 'windows-2019' }}
       shell: pwsh
 
     - run: echo "TEMP=/tmp" >> $GITHUB_ENV
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-13' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
       shell: bash
 
     - name: Set workspace root
@@ -123,13 +121,15 @@ runs:
         else
           WORKSPACE_ROOT=$GITHUB_WORKSPACE
         fi
-        mkdir -p "$WORKSPACE_ROOT"
         
         if [[ -d "$WORKSPACE_ROOT" ]]; then
           ls -la "$WORKSPACE_ROOT"
+          rm -rf "$WORKSPACE_ROOT"
         fi 
         
-        # working-directory is "executed" in powershell
+        git clone --recursive -b ${{ github.head_ref || github.ref_name }} https://github.com/${{ github.repository }}.git "$WORKSPACE_ROOT"
+        ls "$WORKSPACE_ROOT"
+        
         if [ x"${{ inputs.MATRIX_OS }}" == x"windows-2019" ]; then
           WORKSPACE_ROOT="C:\a"
         fi
@@ -137,7 +137,6 @@ runs:
         echo "WORKSPACE_ROOT=$WORKSPACE_ROOT" | tee -a $GITHUB_OUTPUT
 
     - name: Docker prune
-      working-directory: ${{ env.TEMP }}
       if: contains(inputs.MATRIX_OS, 'ubuntu')
       shell: bash
       run: |

--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -34,6 +34,14 @@ description: ''
 runs:
   using: "composite"
   steps:
+    - name: Set unified TZ
+      uses: szenius/set-timezone@v2.0
+      with:
+        # this is an arbitrary choice
+        timezoneLinux: "Asia/Singapore"
+        timezoneMacos: "Asia/Singapore"
+        timezoneWindows: "Singapore Standard Time"
+    
     - name: Setup tmate session
       if: ${{ inputs.DEBUG_ENABLED && inputs.DEBUG_OS == inputs.MATRIX_OS && inputs.DEBUG_ARCH == inputs.MATRIX_ARCH }}
       uses: mxschmitt/action-tmate@v3
@@ -65,9 +73,9 @@ runs:
         large-packages: true
         swap-storage: false # This frees space on the wrong partition.
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install Ninja
       uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c # Jan 17
@@ -79,35 +87,29 @@ runs:
         
         sudo apt-get update
         sudo apt-get install -y binutils-aarch64-linux-gnu \
-          g++-aarch64-linux-gnu gcc-aarch64-linux-gnu openssl libssl-dev
+          g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
 
     - name: pip install standard tools
       shell: bash
       run: pip install cibuildwheel wheel
 
     - name: install rename
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-13' }}
       shell: bash
       run: |
         
-        if [ x"${{ inputs.MATRIX_OS }}" == x"macos-12" ] || [ x"${{ inputs.MATRIX_OS }}" == x"macos-14" ]; then
+        if [ x"${{ inputs.MATRIX_OS }}" == x"macos-13" ]; then
           brew install rename
         else
           sudo apt-get install -y rename
         fi
 
-    # why all this? two reasons:
-    # 1. because the windows runner have not enough space on D, which is also the checkout location (why????)
-    # see https://github.com/actions/runner-images/issues/1341
-    # 2. because windows has a command length limit even in 2023 of 8192 characeters (or something like that). how
-    # do we hit that during anything we're doing here? during the linking phase of MLIR-C.dll, which links together
-    # absolutely all the libs in MLIR using their full/abs paths.
     - run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
       if: ${{ inputs.MATRIX_OS == 'windows-2019' }}
       shell: pwsh
 
     - run: echo "TEMP=/tmp" >> $GITHUB_ENV
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-13' }}
       shell: bash
 
     - name: Set workspace root
@@ -121,15 +123,13 @@ runs:
         else
           WORKSPACE_ROOT=$GITHUB_WORKSPACE
         fi
+        mkdir -p "$WORKSPACE_ROOT"
         
         if [[ -d "$WORKSPACE_ROOT" ]]; then
           ls -la "$WORKSPACE_ROOT"
-          rm -rf "$WORKSPACE_ROOT"
         fi 
         
-        git clone --recursive -b ${{ github.head_ref || github.ref_name }} https://github.com/${{ github.repository }}.git "$WORKSPACE_ROOT"
-        ls "$WORKSPACE_ROOT"
-        
+        # working-directory is "executed" in powershell
         if [ x"${{ inputs.MATRIX_OS }}" == x"windows-2019" ]; then
           WORKSPACE_ROOT="C:\a"
         fi
@@ -137,6 +137,7 @@ runs:
         echo "WORKSPACE_ROOT=$WORKSPACE_ROOT" | tee -a $GITHUB_OUTPUT
 
     - name: Docker prune
+      working-directory: ${{ env.TEMP }}
       if: contains(inputs.MATRIX_OS, 'ubuntu')
       shell: bash
       run: |

--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -121,10 +121,10 @@ runs:
         else
           WORKSPACE_ROOT=$GITHUB_WORKSPACE
         fi
+        mkdir -p "$WORKSPACE_ROOT"
         
         if [[ -d "$WORKSPACE_ROOT" ]]; then
           ls -la "$WORKSPACE_ROOT"
-          rm -rf "$WORKSPACE_ROOT"
         fi 
         
         git clone --recursive -b ${{ github.head_ref || github.ref_name }} https://github.com/${{ github.repository }}.git "$WORKSPACE_ROOT"
@@ -137,6 +137,7 @@ runs:
         echo "WORKSPACE_ROOT=$WORKSPACE_ROOT" | tee -a $GITHUB_OUTPUT
 
     - name: Docker prune
+      working-directory: ${{ env.TEMP }}
       if: contains(inputs.MATRIX_OS, 'ubuntu')
       shell: bash
       run: |

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -221,7 +221,7 @@ jobs:
 
             auditwheel repair -w $WHEELHOUSE_DIR/repaired_wheel $WHEELHOUSE_DIR/aie_python_bindings*whl --plat manylinux_2_35_x86_64
 
-      - uses: geekyeggo/delete-artifact@v4
+      - uses: geekyeggo/delete-artifact@v3
         if: github.event_name == 'pull_request'
         with:
           name: mlir_aie

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -112,7 +112,7 @@ jobs:
             mv "$WHL_FN" "`echo $WHL_FN | sed "s/cp310-cp310/py3-none/"`"
 
       - name: Upload mlir_aie
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/repaired_wheel/mlir_aie*whl
           name: mlir_aie
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 2
           submodules: "true"
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir
@@ -228,7 +228,7 @@ jobs:
 
       - name: Upload wheels
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/repaired_wheel/aie_python_bindings*.whl
           name: ryzen_ai_wheel

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -146,7 +146,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: clang-format.diff
-          name: format_diffs
+          name: clang_format_diffs
 
       - name: Check C/C++ format
         uses: reviewdog/action-suggester@v1
@@ -168,7 +168,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: black-format.diff
-          name: format_diffs
+          name: black_format_diffs
 
       - name: Check Python format
         if: success() || failure()

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload clang-tidy fixes
         if: ${{ steps.clang-tidy-fixes.outputs.FIXES }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: fixes.yml
           name: clang-tidy-fixes.yml
@@ -143,7 +143,7 @@ jobs:
           cat clang-format.diff
 
       - name: Upload clang-format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: clang-format.diff
           name: format_diffs
@@ -165,7 +165,7 @@ jobs:
           cat black-format.diff
 
       - name: Upload black-format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: black-format.diff
           name: format_diffs

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -313,7 +313,7 @@ jobs:
         ls wheelhouse/mlir_aie*whl | Rename-Item -NewName {$_ -replace 'cp310-cp310', 'py3-none' }
 
     - name: Upload distro wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}/wheelhouse/*.whl
         name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
@@ -363,7 +363,7 @@ jobs:
             python/requirements.txt
             python/requirements_extras.txt
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
           path: dist
@@ -446,7 +446,7 @@ jobs:
 #            ENABLE_RTTI: OFF
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -352,7 +352,7 @@ jobs:
 
     - name: Upload wheels
       if: github.event_name != 'schedule'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}/wheelhouse/*.whl
         name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
@@ -395,7 +395,7 @@ jobs:
           #   ENABLE_RTTI: OFF
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
           path: dist
@@ -471,7 +471,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           # unpacks default artifact into dist/
           # if `name: artifact` is omitted, the action will create extra parent dir


### PR DESCRIPTION
V3 is scheduled to deprecate on 30th Jan. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/