### PR TITLE
[asm] Specialize tile SSA names according to the tile kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ lib/**/Makefile
 /platforms/vck190_bare/vivado/vck190_bare_proj
 utils/vitisVariables.config
 runtime_lib/xaiengine/src
+/ironenv
+/.cache

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -130,9 +130,18 @@ def AIE_TileOp: AIE_Op<"tile", [
   let extraClassDefinition = [{
     void $cppClass::getAsmResultNames(
         function_ref<void(::mlir::Value, ::llvm::StringRef)> setNameFn) {
-       std::string nameWithoutDialect =
+       std::string tileName =
              getOperationName().str().substr(getOperationName().find('.') + 1);
-       setNameFn(getResult(), nameWithoutDialect + "_" +
+       // Specialize the SSA value name according to the tile kind
+       if (isMemTile())
+         tileName = "mem_" + tileName;
+       else if (isShimNOCTile())
+         tileName = "shim_noc_" + tileName;
+       else if (isShimPLTile())
+         tileName = "shim_pl_" + tileName;
+       else if (isShimTile())
+         tileName = "shim_" + tileName;
+       setNameFn(getResult(), tileName + "_" +
                                   std::to_string(getCol()) + "_" +
                                   std::to_string(getRow()));
     }
@@ -642,13 +651,13 @@ def AIE_PacketFlowOp: AIE_Op<"packet_flow", [SingleBlockImplicitTerminator<"EndO
   let description = [{
     A logical packet-switched flow between tiles.  During place and
     route, this is replaced by MasterSets and PacketRules inside
-    switchboxes. 
-    
-    The optional attribute keep_pkt_header indicates whether each 
-    data packet's packet header gets preserved at the flow's 
+    switchboxes.
+
+    The optional attribute keep_pkt_header indicates whether each
+    data packet's packet header gets preserved at the flow's
     destination. The optional attribute priority_route indicates
-    whether the packet flow is routed in priority over other flows, 
-    so that they always get allocated with the same master, slave 
+    whether the packet flow is routed in priority over other flows,
+    so that they always get allocated with the same master, slave
     ports, arbiters and master selects (msel).
 
     Example:
@@ -864,9 +873,9 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
     ## DMA constant padding on AIE-ML Devices
 
     AIE-ML devices can apply constant padding at the buffer descriptor level, described with pairs of padding
-    counts before and after a dimension, to all dimensions in the data layout transformations. The padding 
-    counts can be supplied to the `dma_bd` through an optional argument, an array of "tuple-like" attributes 
-    `bd_pad_layout<const_pad_before, const_pad_after>`, followed by an optional argument `const_val` (default 
+    counts before and after a dimension, to all dimensions in the data layout transformations. The padding
+    counts can be supplied to the `dma_bd` through an optional argument, an array of "tuple-like" attributes
+    `bd_pad_layout<const_pad_before, const_pad_after>`, followed by an optional argument `const_val` (default
     is 0). All counts are expressed in multiples of the element width.
   }];
 
@@ -1004,7 +1013,7 @@ def AIE_DMAStartOp: AIE_Op<"dma_start", [
     bool isSend() { return getChannelDir() == DMAChannelDir::MM2S; }
     bool isRecv() { return getChannelDir() == DMAChannelDir::S2MM; }
   }];
-  
+
   let hasCanonicalizer = 1;
 }
 
@@ -1467,8 +1476,8 @@ def AIE_CascadeFlowOp: AIE_Op<"cascade_flow", []> {
   );
   let summary = "A cascade connection between tiles";
   let description = [{
-    The `aie.cascade_flow` operation represents a cascade connection between two `aie.tile` operations.  
-    During lowering, this is replaced by `aie.configure_cascade` operations for each `aie.tile` based on 
+    The `aie.cascade_flow` operation represents a cascade connection between two `aie.tile` operations.
+    During lowering, this is replaced by `aie.configure_cascade` operations for each `aie.tile` based on
     their relative placement to one another.
 
     Example:
@@ -1491,7 +1500,7 @@ def AIE_CascadeFlowOp: AIE_Op<"cascade_flow", []> {
 def AIE_ConfigureCascadeOp: AIE_Op<"configure_cascade", [HasParent<"DeviceOp">]> {
   let summary = "An op to configure the input and output directions of the cascade for a single AIE tile";
   let description = [{
-    An operation to configure the cascade on a single tile in both the input and the output 
+    An operation to configure the cascade on a single tile in both the input and the output
     directions.
 
     Example:
@@ -1666,7 +1675,7 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
         BDDimLayoutArrayArrayAttr:$dimensionsFromStreamPerConsumer,
         DefaultValuedAttr<BoolAttr, "false">:$via_DMA,
         DefaultValuedAttr<BoolAttr, "false">:$plio,
-        // disable_synchronization==true will skip lock generation for 
+        // disable_synchronization==true will skip lock generation for
         // objectfifo synchronous accesses
         DefaultValuedAttr<BoolAttr, "false">:$disable_synchronization,
         // via_shared_mem==0 means use producer tile's memory module
@@ -1915,7 +1924,7 @@ def AIE_ObjectFifoSubviewAccessOp : AIE_Op<"objectfifo.subview.access", []> {
   }];
 
   let arguments = (
-    ins AIE_ObjectFifoSubviewType:$subview, 
+    ins AIE_ObjectFifoSubviewType:$subview,
         ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>:$index
   );
 
@@ -2007,11 +2016,11 @@ def AIE_ObjectFifoRegisterProcessOp: AIE_Op<"objectfifo.register_process", []> {
 def AIE_BDChainOp: AIE_Op<"bd_chain", [Symbol, SkipAccessibilityCheckTrait]> {
   let summary = "Definition of a Parametrizable Chain of Buffer Descriptors";
   let description = [{
-    This operation allows you to define buffer descriptor chains with parametrizable inputs. 
+    This operation allows you to define buffer descriptor chains with parametrizable inputs.
     This is useful for common patterns such as double buffering (ping-pong) that may look identical but use different input/output buffers and locks.
     Currently, only buffers and locks are parametrizable.
 
-    Once defined, an abstract BD chain can be used elsewhere using AIEX ops in the runtime sequence. 
+    Once defined, an abstract BD chain can be used elsewhere using AIEX ops in the runtime sequence.
     In the future, abstract BD chains will also be usable elsewhere, inside the static configuration.
     At its usage sites, the abstract BD chain will be concretized with the given input arguments.
   }];

--- a/test/assign-buffer-addresses/bank_aware_alloc_memtile_simple.mlir
+++ b/test/assign-buffer-addresses/bank_aware_alloc_memtile_simple.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-assign-buffer-addresses="alloc-scheme=bank-aware" %s 2>&1 | FileCheck %s
-// CHECK:       %a = aie.buffer(%tile_3_1) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "a"} : memref<16384xi32> 
+// CHECK:       %a = aie.buffer(%{{.*}}_3_1) {address = 0 : i32, mem_bank = 0 : i32, sym_name = "a"} : memref<16384xi32>
 
 module @test {
   aie.device(xcve2302) {

--- a/test/assign-buffer-addresses/basic_alloc_memtile_simple.mlir
+++ b/test/assign-buffer-addresses/basic_alloc_memtile_simple.mlir
@@ -11,9 +11,9 @@
 // RUN: aie-opt --aie-assign-buffer-addresses="alloc-scheme=basic-sequential" %s 2>&1 | FileCheck %s
 // CHECK:   module @test {
 // CHECK:   aie.device(xcve2302) {
-// CHECK:     %tile_3_1 = aie.tile(3, 1)
-// CHECK:     %a = aie.buffer(%tile_3_1) {address = 0 : i32, sym_name = "a"} : memref<65536xi32> 
-// CHECK:     %memtile_dma_3_1 = aie.memtile_dma(%tile_3_1) {
+// CHECK:     %mem_tile_3_1 = aie.tile(3, 1)
+// CHECK:     %a = aie.buffer(%mem_tile_3_1) {address = 0 : i32, sym_name = "a"} : memref<65536xi32>
+// CHECK:     %memtile_dma_3_1 = aie.memtile_dma(%mem_tile_3_1) {
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:   }

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-1.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-1.mlir
@@ -26,9 +26,9 @@ module {
     }
 
     aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
-      %t1 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg2) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
-                                    on (%tile_0_0, MM2S, 0) 
-      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      %t1 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg2) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
+                                    on (%tile_0_0, MM2S, 0)
+      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%{{.*}}tile_0_0, MM2S, 0) {
       // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>]) {bd_id = 0 : i32}
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -39,9 +39,9 @@ module {
       // CHECK:   aie.end
       // CHECK: }
       // CHECK: aiex.dma_start_task(%[[task1]])
-      %t2 = aiex.dma_start_bd_chain @simple_chain(%arg2, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
-                                    on (%tile_0_0, MM2S, 1) 
-      // CHECK: %[[task2:.+]] = aiex.dma_configure_task(%tile_0_0, MM2S, 1) {
+      %t2 = aiex.dma_start_bd_chain @simple_chain(%arg2, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
+                                    on (%tile_0_0, MM2S, 1)
+      // CHECK: %[[task2:.+]] = aiex.dma_configure_task(%{{.*}}tile_0_0, MM2S, 1) {
       // CHECK:   aie.dma_bd(%arg2 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>]) {bd_id = 3 : i32}
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -52,9 +52,9 @@ module {
       // CHECK:   aie.end
       // CHECK: }
       // CHECK: aiex.dma_start_task(%[[task2]])
-      %t3 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
-                                    on (%tile_0_0, S2MM, 0) 
-      // CHECK: %[[task3:.+]] = aiex.dma_configure_task(%tile_0_0, S2MM, 0) {
+      %t3 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
+                                    on (%tile_0_0, S2MM, 0)
+      // CHECK: %[[task3:.+]] = aiex.dma_configure_task(%{{.*}}tile_0_0, S2MM, 0) {
       // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>]) {bd_id = 6 : i32}
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -69,4 +69,3 @@ module {
     }
   }
 }
-

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
@@ -17,10 +17,10 @@ module {
     %tile_0_0 = aie.tile(0, 0)
     %tile_0_1 = aie.tile(0, 1)
     %tile_0_2 = aie.tile(0, 2)
-    // CHECK: %{{.*}} = aie.buffer(%tile_0_1) {address = [[ADDR1:[0-9]+]] {{.*}}}
-    %buf0 = aie.buffer(%tile_0_1) : memref<32xi8> 
-    // CHECK: %{{.*}} = aie.buffer(%tile_0_1) {address = [[ADDR2:[0-9]+]] {{.*}}}
-    %buf1 = aie.buffer(%tile_0_1) : memref<32xi8> 
+    // CHECK: %{{.*}} = aie.buffer(%{{.*}}tile_0_1) {address = [[ADDR1:[0-9]+]] {{.*}}}
+    %buf0 = aie.buffer(%tile_0_1) : memref<32xi8>
+    // CHECK: %{{.*}} = aie.buffer(%{{.*}}tile_0_1) {address = [[ADDR2:[0-9]+]] {{.*}}}
+    %buf1 = aie.buffer(%tile_0_1) : memref<32xi8>
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
@@ -35,4 +35,3 @@ module {
     }
   }
 }
-

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-1.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-1.mlir
@@ -8,7 +8,7 @@
 // RUN: aie-opt --aie-materialize-bd-chains %s | FileCheck %s
 
 // This test ensures that a BD chains get lowered to correct `aiex.dma_configure_task`
-// operations at their usage sites. We particularly ensure that the input arguments 
+// operations at their usage sites. We particularly ensure that the input arguments
 // are correctly substituted.
 
 module {
@@ -28,9 +28,9 @@ module {
     }
 
     aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
-      %t1 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg2) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
-                                    on (%tile_0_0, MM2S, 0) 
-      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      %t1 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg2) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
+                                    on (%tile_0_0, MM2S, 0)
+      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%{{.*}}tile_0_0, MM2S, 0) {
       // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -41,9 +41,9 @@ module {
       // CHECK:   aie.end
       // CHECK: }
       // CHECK: aiex.dma_start_task(%[[task1]])
-      %t2 = aiex.dma_start_bd_chain @simple_chain(%arg2, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
-                                    on (%tile_0_0, MM2S, 1) 
-      // CHECK: %[[task2:.+]] = aiex.dma_configure_task(%tile_0_0, MM2S, 1) {
+      %t2 = aiex.dma_start_bd_chain @simple_chain(%arg2, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
+                                    on (%tile_0_0, MM2S, 1)
+      // CHECK: %[[task2:.+]] = aiex.dma_configure_task(%{{.*}}tile_0_0, MM2S, 1) {
       // CHECK:   aie.dma_bd(%arg2 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -54,9 +54,9 @@ module {
       // CHECK:   aie.end
       // CHECK: }
       // CHECK: aiex.dma_start_task(%[[task2]])
-      %t3 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
-                                    on (%tile_0_0, S2MM, 0) 
-      // CHECK: %[[task3:.+]] = aiex.dma_configure_task(%tile_0_0, S2MM, 0) {
+      %t3 = aiex.dma_start_bd_chain @simple_chain(%arg0, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
+                                    on (%tile_0_0, S2MM, 0)
+      // CHECK: %[[task3:.+]] = aiex.dma_configure_task(%{{.*}}tile_0_0, S2MM, 0) {
       // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -71,4 +71,3 @@ module {
     }
   }
 }
-

--- a/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/materialize-bd-chains/good-5.mlir
@@ -26,9 +26,9 @@ module {
     }
 
     aiex.runtime_sequence(%arg0: memref<8xi16>, %arg1: memref<12xi16>, %arg2: memref<8xi16>) {
-      %t1 = aiex.dma_start_bd_chain_for @simple_chain(%arg0, %arg1, %arg2) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
+      %t1 = aiex.dma_start_bd_chain_for @simple_chain(%arg0, %arg1, %arg2) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
                                         for @alloc0
-      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      // CHECK: %[[task1:.+]] = aiex.dma_configure_task(%{{.*}}tile_0_0, MM2S, 0) {
       // CHECK:   aie.dma_bd(%arg0 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -39,9 +39,9 @@ module {
       // CHECK:   aie.end
       // CHECK: }
       // CHECK: aiex.dma_start_task(%[[task1]])
-      %t2 = aiex.dma_start_bd_chain_for @simple_chain(%arg2, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)  
+      %t2 = aiex.dma_start_bd_chain_for @simple_chain(%arg2, %arg1, %arg0) : (memref<8xi16>, memref<12xi16>, memref<8xi16>)
                                         for @alloc1
-      // CHECK: %[[task2:.+]] = aiex.dma_configure_task(%tile_2_0, MM2S, 1) {
+      // CHECK: %[[task2:.+]] = aiex.dma_configure_task(%{{.*}}tile_2_0, MM2S, 1) {
       // CHECK:   aie.dma_bd(%arg2 : memref<8xi16>, 0, 8, [<size = 1, stride = 0>, <size = 2, stride = 2>, <size = 2, stride = 4>, <size = 2, stride = 1>])
       // CHECK:   aie.next_bd ^bb1
       // CHECK: ^bb1:
@@ -56,4 +56,3 @@ module {
     }
   }
 }
-

--- a/test/create-flows/fixed_connections.mlir
+++ b/test/create-flows/fixed_connections.mlir
@@ -10,23 +10,23 @@
 
 // RUN: aie-opt --aie-create-pathfinder-flows --split-input-file %s | FileCheck %s
 
-// CHECK: %tile_2_0 = aie.tile(2, 0)
-// CHECK: %tile_3_0 = aie.tile(3, 0)
-// CHECK: %tile_6_0 = aie.tile(6, 0)
-// CHECK: %tile_7_0 = aie.tile(7, 0)
-// CHECK: %switchbox_2_0 = aie.switchbox(%tile_2_0) {
+// CHECK: %{{.*}}tile_2_0 = aie.tile(2, 0)
+// CHECK: %{{.*}}tile_3_0 = aie.tile(3, 0)
+// CHECK: %{{.*}}tile_6_0 = aie.tile(6, 0)
+// CHECK: %{{.*}}tile_7_0 = aie.tile(7, 0)
+// CHECK: %switchbox_2_0 = aie.switchbox(%{{.*}}tile_2_0) {
 // CHECK:   aie.connect<North : 0, South : 2>
 // CHECK:   aie.connect<North : 1, South : 3>
 // CHECK: }
-// CHECK: %switchbox_3_0 = aie.switchbox(%tile_3_0) {
+// CHECK: %switchbox_3_0 = aie.switchbox(%{{.*}}tile_3_0) {
 // CHECK:   aie.connect<North : 0, South : 2>
 // CHECK:   aie.connect<North : 1, South : 3>
 // CHECK: }
-// CHECK: %switchbox_6_0 = aie.switchbox(%tile_6_0) {
+// CHECK: %switchbox_6_0 = aie.switchbox(%{{.*}}tile_6_0) {
 // CHECK:   aie.connect<North : 0, South : 2>
 // CHECK:   aie.connect<North : 1, South : 3>
 // CHECK: }
-// CHECK: %switchbox_7_0 = aie.switchbox(%tile_7_0) {
+// CHECK: %switchbox_7_0 = aie.switchbox(%{{.*}}tile_7_0) {
 // CHECK:   aie.connect<North : 0, South : 2>
 // CHECK:   aie.connect<North : 1, South : 3>
 // CHECK: }

--- a/test/find-flows/shim.mlir
+++ b/test/find-flows/shim.mlir
@@ -44,30 +44,30 @@ module {
 
 // -----
 
-// CHECK:  %tile_2_1 = aie.tile(2, 1)
-// CHECK:  %tile_2_0 = aie.tile(2, 0)
+// CHECK:  %{{.*}}tile_2_1 = aie.tile(2, 1)
+// CHECK:  %{{.*}}tile_2_0 = aie.tile(2, 0)
 // CHECK:  %core_2_1 = aie.core(%tile_2_1) {
 // CHECK:    aie.end
 // CHECK:  }
-// CHECK:  %switchbox_2_1 = aie.switchbox(%tile_2_1) {
+// CHECK:  %switchbox_2_1 = aie.switchbox(%{{.*}}tile_2_1) {
 // CHECK:    aie.connect<Core : 0, South : 0>
 // CHECK:  }
-// CHECK:  %switchbox_2_0 = aie.switchbox(%tile_2_0) {
+// CHECK:  %switchbox_2_0 = aie.switchbox(%{{.*}}tile_2_0) {
 // CHECK:    aie.connect<North : 0, South : 2>
 // CHECK:  }
-// CHECK:  %shim_mux_2_0 = aie.shim_mux(%tile_2_0) {
+// CHECK:  %shim_mux_2_0 = aie.shim_mux(%{{.*}}tile_2_0) {
 // CHECK:    aie.connect<North : 2, DMA : 0>
 // CHECK:  }
-// CHECK:  %shim_dma_2_0 = aie.shim_dma(%tile_2_0) {
+// CHECK:  %shim_dma_2_0 = aie.shim_dma(%{{.*}}tile_2_0) {
 // CHECK:    aie.end
 // CHECK:  }
 // CHECK:  aie.wire(%switchbox_2_1 : South, %switchbox_2_0 : North)
 // CHECK:  aie.wire(%switchbox_2_0 : South, %shim_mux_2_0 : North)
 // CHECK:  aie.wire(%shim_mux_2_0 : DMA, %shim_dma_2_0 : DMA)
-// CHECK:  aie.wire(%shim_mux_2_0 : South, %tile_2_0 : DMA)
+// CHECK:  aie.wire(%shim_mux_2_0 : South, %{{.*}}tile_2_0 : DMA)
 // CHECK:  aie.wire(%switchbox_2_1 : Core, %core_2_1 : Core)
-// CHECK:  aie.wire(%switchbox_2_1 : Core, %tile_2_1 : Core)
-// CHECK:  aie.flow(%tile_2_1, Core : 0, %shim_dma_2_0, DMA : 0)
+// CHECK:  aie.wire(%switchbox_2_1 : Core, %{{.*}}tile_2_1 : Core)
+// CHECK:  aie.flow(%{{.*}}tile_2_1, Core : 0, %shim_dma_2_0, DMA : 0)
 
 module {
   aie.device(xcvc1902) {

--- a/test/objectFifo-stateful-transform/dynamic_lowering_test.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering_test.mlir
@@ -18,25 +18,25 @@
 // CHECK:       func.func @add_10_i32(%arg0: memref<10xi32>, %arg1: memref<10xi32>, %arg2: memref<10xi32>) {
 // CHECK:         return
 // CHECK:       }
-// CHECK:       %tile_0_0 = aie.tile(0, 0)
-// CHECK:       %tile_0_2 = aie.tile(0, 2)
-// CHECK:       %output_fifo_cons_prod_lock = aie.lock(%tile_0_0, 2) {init = 1 : i32, sym_name = "output_fifo_cons_prod_lock"}
-// CHECK:       %output_fifo_cons_cons_lock = aie.lock(%tile_0_0, 3) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock"}
-// CHECK:       %output_fifo_buff_0 = aie.buffer(%tile_0_2) {sym_name = "output_fifo_buff_0"} : memref<10xi32> 
-// CHECK:       %output_fifo_buff_1 = aie.buffer(%tile_0_2) {sym_name = "output_fifo_buff_1"} : memref<10xi32> 
-// CHECK:       %output_fifo_prod_lock = aie.lock(%tile_0_2, 2) {init = 2 : i32, sym_name = "output_fifo_prod_lock"}
-// CHECK:       %output_fifo_cons_lock = aie.lock(%tile_0_2, 3) {init = 0 : i32, sym_name = "output_fifo_cons_lock"}
-// CHECK:       %input_fifo_cons_buff_0 = aie.buffer(%tile_0_2) {sym_name = "input_fifo_cons_buff_0"} : memref<10xi32> 
-// CHECK:       %input_fifo_cons_buff_1 = aie.buffer(%tile_0_2) {sym_name = "input_fifo_cons_buff_1"} : memref<10xi32> 
-// CHECK:       %input_fifo_cons_buff_2 = aie.buffer(%tile_0_2) {sym_name = "input_fifo_cons_buff_2"} : memref<10xi32> 
-// CHECK:       %input_fifo_cons_prod_lock = aie.lock(%tile_0_2, 0) {init = 3 : i32, sym_name = "input_fifo_cons_prod_lock"}
-// CHECK:       %input_fifo_cons_cons_lock = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock"}
-// CHECK:       %input_fifo_prod_lock = aie.lock(%tile_0_0, 0) {init = 1 : i32, sym_name = "input_fifo_prod_lock"}
-// CHECK:       %input_fifo_cons_lock = aie.lock(%tile_0_0, 1) {init = 0 : i32, sym_name = "input_fifo_cons_lock"}
-// CHECK:       aie.flow(%tile_0_0, DMA : 0, %tile_0_2, DMA : 0)
-// CHECK:       aie.flow(%tile_0_2, DMA : 0, %tile_0_0, DMA : 0)
-// CHECK:       %buffer_0_2 = aie.buffer(%tile_0_2) : memref<2xi32> 
-// CHECK:       %core_0_2 = aie.core(%tile_0_2) {
+// CHECK:       %{{.*}}tile_0_0 = aie.tile(0, 0)
+// CHECK:       %{{.*}}tile_0_2 = aie.tile(0, 2)
+// CHECK:       %output_fifo_cons_prod_lock = aie.lock(%{{.*}}tile_0_0, 2) {init = 1 : i32, sym_name = "output_fifo_cons_prod_lock"}
+// CHECK:       %output_fifo_cons_cons_lock = aie.lock(%{{.*}}tile_0_0, 3) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock"}
+// CHECK:       %output_fifo_buff_0 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "output_fifo_buff_0"} : memref<10xi32>
+// CHECK:       %output_fifo_buff_1 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "output_fifo_buff_1"} : memref<10xi32>
+// CHECK:       %output_fifo_prod_lock = aie.lock(%{{.*}}tile_0_2, 2) {init = 2 : i32, sym_name = "output_fifo_prod_lock"}
+// CHECK:       %output_fifo_cons_lock = aie.lock(%{{.*}}tile_0_2, 3) {init = 0 : i32, sym_name = "output_fifo_cons_lock"}
+// CHECK:       %input_fifo_cons_buff_0 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "input_fifo_cons_buff_0"} : memref<10xi32>
+// CHECK:       %input_fifo_cons_buff_1 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "input_fifo_cons_buff_1"} : memref<10xi32>
+// CHECK:       %input_fifo_cons_buff_2 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "input_fifo_cons_buff_2"} : memref<10xi32>
+// CHECK:       %input_fifo_cons_prod_lock = aie.lock(%{{.*}}tile_0_2, 0) {init = 3 : i32, sym_name = "input_fifo_cons_prod_lock"}
+// CHECK:       %input_fifo_cons_cons_lock = aie.lock(%{{.*}}tile_0_2, 1) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock"}
+// CHECK:       %input_fifo_prod_lock = aie.lock(%{{.*}}tile_0_0, 0) {init = 1 : i32, sym_name = "input_fifo_prod_lock"}
+// CHECK:       %input_fifo_cons_lock = aie.lock(%{{.*}}tile_0_0, 1) {init = 0 : i32, sym_name = "input_fifo_cons_lock"}
+// CHECK:       aie.flow(%{{.*}}tile_0_0, DMA : 0, %{{.*}}tile_0_2, DMA : 0)
+// CHECK:       aie.flow(%{{.*}}tile_0_2, DMA : 0, %{{.*}}tile_0_0, DMA : 0)
+// CHECK:       %buffer_0_2 = aie.buffer(%{{.*}}tile_0_2) : memref<2xi32>
+// CHECK:       %core_0_2 = aie.core(%{{.*}}tile_0_2) {
 // CHECK:         %c0_i32 = arith.constant 0 : i32
 // CHECK:         %c0 = arith.constant 0 : index
 // CHECK:         %c2_i32 = arith.constant 2 : i32
@@ -50,7 +50,7 @@
 // CHECK:         aie.use_lock(%output_fifo_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:         %0 = memref.load %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:         %1 = arith.index_cast %0 : i32 to index
-// CHECK:         %2 = scf.index_switch %1 -> memref<10xi32> 
+// CHECK:         %2 = scf.index_switch %1 -> memref<10xi32>
 // CHECK:         case 0 {
 // CHECK:           scf.yield %output_fifo_buff_0 : memref<10xi32>
 // CHECK:         }
@@ -63,7 +63,7 @@
 // CHECK:         aie.use_lock(%input_fifo_cons_cons_lock, AcquireGreaterEqual, 1)
 // CHECK:         %3 = memref.load %buffer_0_2[%c1] : memref<2xi32>
 // CHECK:         %4 = arith.index_cast %3 : i32 to index
-// CHECK:         %5 = scf.index_switch %4 -> memref<10xi32> 
+// CHECK:         %5 = scf.index_switch %4 -> memref<10xi32>
 // CHECK:         case 0 {
 // CHECK:           scf.yield %input_fifo_cons_buff_0 : memref<10xi32>
 // CHECK:         }
@@ -81,15 +81,15 @@
 // CHECK:         %6 = memref.load %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:         %c1_i32 = arith.constant 1 : i32
 // CHECK:         %7 = arith.addi %6, %c1_i32 : i32
-// CHECK:         %8 = arith.cmpi sge, %7, %c2_i32 : i32 
+// CHECK:         %8 = arith.cmpi sge, %7, %c2_i32 : i32
 // CHECK:         %9 = arith.subi %7, %c2_i32 : i32
-// CHECK:         %10 = arith.select %8, %9, %7 : i32 
+// CHECK:         %10 = arith.select %8, %9, %7 : i32
 // CHECK:         memref.store %10, %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:         scf.for %arg0 = %c0_0 to %c9 step %c1_1 {
 // CHECK:           aie.use_lock(%output_fifo_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:           %30 = memref.load %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:           %31 = arith.index_cast %30 : i32 to index
-// CHECK:           %32 = scf.index_switch %31 -> memref<10xi32> 
+// CHECK:           %32 = scf.index_switch %31 -> memref<10xi32>
 // CHECK:           case 0 {
 // CHECK:             scf.yield %output_fifo_buff_0 : memref<10xi32>
 // CHECK:           }
@@ -102,7 +102,7 @@
 // CHECK:           aie.use_lock(%input_fifo_cons_cons_lock, AcquireGreaterEqual, 1)
 // CHECK:           %33 = memref.load %buffer_0_2[%c1] : memref<2xi32>
 // CHECK:           %34 = arith.index_cast %33 : i32 to index
-// CHECK:           %35 = scf.index_switch %34 -> memref<10xi32> 
+// CHECK:           %35 = scf.index_switch %34 -> memref<10xi32>
 // CHECK:           case 0 {
 // CHECK:             scf.yield %input_fifo_cons_buff_0 : memref<10xi32>
 // CHECK:           }
@@ -117,7 +117,7 @@
 // CHECK:           }
 // CHECK:           %36 = memref.load %buffer_0_2[%c1] : memref<2xi32>
 // CHECK:           %37 = arith.index_cast %36 : i32 to index
-// CHECK:           %38 = scf.index_switch %37 -> memref<10xi32> 
+// CHECK:           %38 = scf.index_switch %37 -> memref<10xi32>
 // CHECK:           case 0 {
 // CHECK:             scf.yield %input_fifo_cons_buff_1 : memref<10xi32>
 // CHECK:           }
@@ -143,15 +143,15 @@
 // CHECK:           %44 = memref.load %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:           %c1_i32_5 = arith.constant 1 : i32
 // CHECK:           %45 = arith.addi %44, %c1_i32_5 : i32
-// CHECK:           %46 = arith.cmpi sge, %45, %c2_i32 : i32 
-// CHECK:           %47 = arith.subi %45, %c2_i32 : i32 
-// CHECK:           %48 = arith.select %46, %47, %45 : i32 
+// CHECK:           %46 = arith.cmpi sge, %45, %c2_i32 : i32
+// CHECK:           %47 = arith.subi %45, %c2_i32 : i32
+// CHECK:           %48 = arith.select %46, %47, %45 : i32
 // CHECK:           memref.store %48, %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:         }
 // CHECK:         aie.use_lock(%output_fifo_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:         %11 = memref.load %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:         %12 = arith.index_cast %11 : i32 to index
-// CHECK:         %13 = scf.index_switch %12 -> memref<10xi32> 
+// CHECK:         %13 = scf.index_switch %12 -> memref<10xi32>
 // CHECK:         case 0 {
 // CHECK:           scf.yield %output_fifo_buff_0 : memref<10xi32>
 // CHECK:         }
@@ -164,7 +164,7 @@
 // CHECK:         aie.use_lock(%input_fifo_cons_cons_lock, AcquireGreaterEqual, 1)
 // CHECK:         %14 = memref.load %buffer_0_2[%c1] : memref<2xi32>
 // CHECK:         %15 = arith.index_cast %14 : i32 to index
-// CHECK:         %16 = scf.index_switch %15 -> memref<10xi32> 
+// CHECK:         %16 = scf.index_switch %15 -> memref<10xi32>
 // CHECK:         case 0 {
 // CHECK:           scf.yield %input_fifo_cons_buff_0 : memref<10xi32>
 // CHECK:         }
@@ -179,7 +179,7 @@
 // CHECK:         }
 // CHECK:         %17 = memref.load %buffer_0_2[%c1] : memref<2xi32>
 // CHECK:         %18 = arith.index_cast %17 : i32 to index
-// CHECK:         %19 = scf.index_switch %18 -> memref<10xi32> 
+// CHECK:         %19 = scf.index_switch %18 -> memref<10xi32>
 // CHECK:         case 0 {
 // CHECK:           scf.yield %input_fifo_cons_buff_1 : memref<10xi32>
 // CHECK:         }
@@ -198,16 +198,16 @@
 // CHECK:         %c2_i32_2 = arith.constant 2 : i32
 // CHECK:         %21 = arith.addi %20, %c2_i32_2 : i32
 // CHECK:         %22 = arith.cmpi sge, %21, %c3_i32 : i32
-// CHECK:         %23 = arith.subi %21, %c3_i32 : i32 
-// CHECK:         %24 = arith.select %22, %23, %21 : i32 
+// CHECK:         %23 = arith.subi %21, %c3_i32 : i32
+// CHECK:         %24 = arith.select %22, %23, %21 : i32
 // CHECK:         memref.store %24, %buffer_0_2[%c1] : memref<2xi32>
 // CHECK:         aie.use_lock(%output_fifo_cons_lock, Release, 1)
-// CHECK:         %25 = memref.load %buffer_0_2[%c0] : memref<2xi32> 
+// CHECK:         %25 = memref.load %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:         %c1_i32_3 = arith.constant 1 : i32
-// CHECK:         %26 = arith.addi %25, %c1_i32_3 : i32 
-// CHECK:         %27 = arith.cmpi sge, %26, %c2_i32 : i32 
-// CHECK:         %28 = arith.subi %26, %c2_i32 : i32 
-// CHECK:         %29 = arith.select %27, %28, %26 : i32 
+// CHECK:         %26 = arith.addi %25, %c1_i32_3 : i32
+// CHECK:         %27 = arith.cmpi sge, %26, %c2_i32 : i32
+// CHECK:         %28 = arith.subi %26, %c2_i32 : i32
+// CHECK:         %29 = arith.select %27, %28, %26 : i32
 // CHECK:         memref.store %29, %buffer_0_2[%c0] : memref<2xi32>
 // CHECK:         aie.end
 // CHECK:       }

--- a/test/objectFifo-stateful-transform/link_test_distribute_offsets.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute_offsets.mlir
@@ -22,35 +22,35 @@
 // CHECK:     memref.global "public" @link2 : memref<4x4xi32>
 // CHECK:     memref.global "public" @link1_cons : memref<48xi32>
 // CHECK:     memref.global "public" @link1 : memref<48xi32>
-// CHECK:     %tile_2_0 = aie.tile(2, 0)
-// CHECK:     %tile_2_1 = aie.tile(2, 1)
-// CHECK:     %tile_2_2 = aie.tile(2, 2)
-// CHECK:     %tile_2_3 = aie.tile(2, 3)
-// CHECK:     %tile_3_3 = aie.tile(3, 3)
-// CHECK:     %link4_cons_buff_0 = aie.buffer(%tile_3_3) {sym_name = "link4_cons_buff_0"} : memref<12xi32> 
-// CHECK:     %link4_cons_buff_1 = aie.buffer(%tile_3_3) {sym_name = "link4_cons_buff_1"} : memref<12xi32> 
-// CHECK:     %link4_cons_prod_lock = aie.lock(%tile_3_3, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
-// CHECK:     %link4_cons_cons_lock = aie.lock(%tile_3_3, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
-// CHECK:     %link3_cons_buff_0 = aie.buffer(%tile_2_3) {sym_name = "link3_cons_buff_0"} : memref<20xi32> 
-// CHECK:     %link3_cons_buff_1 = aie.buffer(%tile_2_3) {sym_name = "link3_cons_buff_1"} : memref<20xi32> 
-// CHECK:     %link3_cons_prod_lock = aie.lock(%tile_2_3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
-// CHECK:     %link3_cons_cons_lock = aie.lock(%tile_2_3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
-// CHECK:     %link2_cons_buff_0 = aie.buffer(%tile_2_2) {sym_name = "link2_cons_buff_0"} : memref<4x4xi32> 
-// CHECK:     %link2_cons_buff_1 = aie.buffer(%tile_2_2) {sym_name = "link2_cons_buff_1"} : memref<4x4xi32> 
-// CHECK:     %link2_cons_prod_lock = aie.lock(%tile_2_2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
-// CHECK:     %link2_cons_cons_lock = aie.lock(%tile_2_2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
-// CHECK:     %link1_cons_buff_0 = aie.buffer(%tile_2_1) {sym_name = "link1_cons_buff_0"} : memref<48xi32> 
-// CHECK:     %link1_cons_buff_1 = aie.buffer(%tile_2_1) {sym_name = "link1_cons_buff_1"} : memref<48xi32> 
-// CHECK:     %link1_cons_prod_lock = aie.lock(%tile_2_1, 0) {init = 6 : i32, sym_name = "link1_cons_prod_lock"}
-// CHECK:     %link1_cons_cons_lock = aie.lock(%tile_2_1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
-// CHECK:     %link1_prod_lock = aie.lock(%tile_2_0, 0) {init = 1 : i32, sym_name = "link1_prod_lock"}
-// CHECK:     %link1_cons_lock = aie.lock(%tile_2_0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
-// CHECK:     aie.flow(%tile_2_0, DMA : 0, %tile_2_1, DMA : 0)
-// CHECK:     aie.flow(%tile_2_1, DMA : 0, %tile_2_2, DMA : 0)
-// CHECK:     aie.flow(%tile_2_1, DMA : 1, %tile_2_3, DMA : 0)
-// CHECK:     aie.flow(%tile_2_1, DMA : 2, %tile_3_3, DMA : 0)
+// CHECK:     %{{.*}}tile_2_0 = aie.tile(2, 0)
+// CHECK:     %{{.*}}tile_2_1 = aie.tile(2, 1)
+// CHECK:     %{{.*}}tile_2_2 = aie.tile(2, 2)
+// CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
+// CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
+// CHECK:     %link4_cons_buff_0 = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
+// CHECK:     %link4_cons_buff_1 = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
+// CHECK:     %link4_cons_prod_lock = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock"}
+// CHECK:     %link4_cons_cons_lock = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
+// CHECK:     %link3_cons_buff_0 = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
+// CHECK:     %link3_cons_buff_1 = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
+// CHECK:     %link3_cons_prod_lock = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
+// CHECK:     %link3_cons_cons_lock = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
+// CHECK:     %link2_cons_buff_0 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_0"} : memref<4x4xi32>
+// CHECK:     %link2_cons_buff_1 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_1"} : memref<4x4xi32>
+// CHECK:     %link2_cons_prod_lock = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
+// CHECK:     %link2_cons_cons_lock = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
+// CHECK:     %link1_cons_buff_0 = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
+// CHECK:     %link1_cons_buff_1 = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
+// CHECK:     %link1_cons_prod_lock = aie.lock(%{{.*}}tile_2_1, 0) {init = 6 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %link1_cons_cons_lock = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     %link1_prod_lock = aie.lock(%{{.*}}tile_2_0, 0) {init = 1 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %link1_cons_lock = aie.lock(%{{.*}}tile_2_0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 1, %{{.*}}tile_2_3, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 2, %{{.*}}tile_3_3, DMA : 0)
 // CHECK:     aie.shim_dma_allocation @link1(MM2S, 0, 2)
-// CHECK:     %memtile_dma_2_1 = aie.memtile_dma(%tile_2_1) {
+// CHECK:     %memtile_dma_2_1 = aie.memtile_dma(%{{.*}}tile_2_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link1_cons_prod_lock, AcquireGreaterEqual, 3)
@@ -101,7 +101,7 @@
 // CHECK:     ^bb12:  // pred: ^bb9
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_2_2 = aie.mem(%tile_2_2) {
+// CHECK:     %mem_2_2 = aie.mem(%{{.*}}tile_2_2) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link2_cons_prod_lock, AcquireGreaterEqual, 1)
@@ -116,7 +116,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_2_3 = aie.mem(%tile_2_3) {
+// CHECK:     %mem_2_3 = aie.mem(%{{.*}}tile_2_3) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link3_cons_prod_lock, AcquireGreaterEqual, 1)
@@ -131,7 +131,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_3_3 = aie.mem(%tile_3_3) {
+// CHECK:     %mem_3_3 = aie.mem(%{{.*}}tile_3_3) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link4_cons_prod_lock, AcquireGreaterEqual, 1)

--- a/test/objectFifo-stateful-transform/link_test_distribute_output_sizes.mlir
+++ b/test/objectFifo-stateful-transform/link_test_distribute_output_sizes.mlir
@@ -20,28 +20,28 @@
 // CHECK:     memref.global "public" @link2 : memref<16xi32>
 // CHECK:     memref.global "public" @link1_cons : memref<64xi32>
 // CHECK:     memref.global "public" @link1 : memref<64xi32>
-// CHECK:     %tile_2_0 = aie.tile(2, 0)
-// CHECK:     %tile_2_1 = aie.tile(2, 1)
-// CHECK:     %tile_2_2 = aie.tile(2, 2)
-// CHECK:     %tile_2_3 = aie.tile(2, 3)
-// CHECK:     %link3_cons_buff_0 = aie.buffer(%tile_2_3) {sym_name = "link3_cons_buff_0"} : memref<16xi32> 
-// CHECK:     %link3_cons_buff_1 = aie.buffer(%tile_2_3) {sym_name = "link3_cons_buff_1"} : memref<16xi32> 
-// CHECK:     %link3_cons_prod_lock = aie.lock(%tile_2_3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
-// CHECK:     %link3_cons_cons_lock = aie.lock(%tile_2_3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
-// CHECK:     %link2_cons_buff_0 = aie.buffer(%tile_2_2) {sym_name = "link2_cons_buff_0"} : memref<16xi32> 
-// CHECK:     %link2_cons_buff_1 = aie.buffer(%tile_2_2) {sym_name = "link2_cons_buff_1"} : memref<16xi32> 
-// CHECK:     %link2_cons_prod_lock = aie.lock(%tile_2_2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
-// CHECK:     %link2_cons_cons_lock = aie.lock(%tile_2_2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
-// CHECK:     %link1_cons_buff_0 = aie.buffer(%tile_2_1) {sym_name = "link1_cons_buff_0"} : memref<64xi32> 
-// CHECK:     %link1_cons_prod_lock = aie.lock(%tile_2_1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
-// CHECK:     %link1_cons_cons_lock = aie.lock(%tile_2_1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
-// CHECK:     %link1_prod_lock = aie.lock(%tile_2_0, 0) {init = 1 : i32, sym_name = "link1_prod_lock"}
-// CHECK:     %link1_cons_lock = aie.lock(%tile_2_0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
-// CHECK:     aie.flow(%tile_2_0, DMA : 0, %tile_2_1, DMA : 0)
-// CHECK:     aie.flow(%tile_2_1, DMA : 0, %tile_2_2, DMA : 0)
-// CHECK:     aie.flow(%tile_2_1, DMA : 1, %tile_2_3, DMA : 0)
+// CHECK:     %{{.*}}tile_2_0 = aie.tile(2, 0)
+// CHECK:     %{{.*}}tile_2_1 = aie.tile(2, 1)
+// CHECK:     %{{.*}}tile_2_2 = aie.tile(2, 2)
+// CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
+// CHECK:     %link3_cons_buff_0 = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_0"} : memref<16xi32>
+// CHECK:     %link3_cons_buff_1 = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_1"} : memref<16xi32>
+// CHECK:     %link3_cons_prod_lock = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock"}
+// CHECK:     %link3_cons_cons_lock = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock"}
+// CHECK:     %link2_cons_buff_0 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %link2_cons_buff_1 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %link2_cons_prod_lock = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock"}
+// CHECK:     %link2_cons_cons_lock = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock"}
+// CHECK:     %link1_cons_buff_0 = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link1_cons_buff_0"} : memref<64xi32>
+// CHECK:     %link1_cons_prod_lock = aie.lock(%{{.*}}tile_2_1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock"}
+// CHECK:     %link1_cons_cons_lock = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock"}
+// CHECK:     %link1_prod_lock = aie.lock(%{{.*}}tile_2_0, 0) {init = 1 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %link1_cons_lock = aie.lock(%{{.*}}tile_2_0, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 1, %{{.*}}tile_2_3, DMA : 0)
 // CHECK:     aie.shim_dma_allocation @link1(MM2S, 0, 2)
-// CHECK:     %memtile_dma_2_1 = aie.memtile_dma(%tile_2_1) {
+// CHECK:     %memtile_dma_2_1 = aie.memtile_dma(%{{.*}}tile_2_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%link1_cons_prod_lock, AcquireGreaterEqual, 2)
@@ -65,7 +65,7 @@
 // CHECK:     ^bb6:  // pred: ^bb4
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_2_2 = aie.mem(%tile_2_2) {
+// CHECK:     %mem_2_2 = aie.mem(%{{.*}}tile_2_2) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link2_cons_prod_lock, AcquireGreaterEqual, 1)
@@ -80,7 +80,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_2_3 = aie.mem(%tile_2_3) {
+// CHECK:     %mem_2_3 = aie.mem(%{{.*}}tile_2_3) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link3_cons_prod_lock, AcquireGreaterEqual, 1)

--- a/test/objectFifo-stateful-transform/link_test_join_offsets.mlir
+++ b/test/objectFifo-stateful-transform/link_test_join_offsets.mlir
@@ -22,34 +22,34 @@
 // CHECK:     memref.global "public" @link2 : memref<20xi32>
 // CHECK:     memref.global "public" @link1_cons : memref<4x4xi32>
 // CHECK:     memref.global "public" @link1 : memref<4x4xi32>
-// CHECK:     %tile_2_0 = aie.tile(2, 0)
-// CHECK:     %tile_2_1 = aie.tile(2, 1)
-// CHECK:     %tile_2_2 = aie.tile(2, 2)
-// CHECK:     %tile_2_3 = aie.tile(2, 3)
-// CHECK:     %tile_3_3 = aie.tile(3, 3)
-// CHECK:     %link4_cons_prod_lock = aie.lock(%tile_2_0, 0) {init = 1 : i32, sym_name = "link4_cons_prod_lock"}
-// CHECK:     %link4_cons_cons_lock = aie.lock(%tile_2_0, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
-// CHECK:     %link4_buff_0 = aie.buffer(%tile_2_1) {sym_name = "link4_buff_0"} : memref<48xi32> 
-// CHECK:     %link4_buff_1 = aie.buffer(%tile_2_1) {sym_name = "link4_buff_1"} : memref<48xi32> 
-// CHECK:     %link4_prod_lock = aie.lock(%tile_2_1, 0) {init = 6 : i32, sym_name = "link4_prod_lock"}
-// CHECK:     %link4_cons_lock = aie.lock(%tile_2_1, 1) {init = 0 : i32, sym_name = "link4_cons_lock"}
-// CHECK:     %link3_buff_0 = aie.buffer(%tile_3_3) {sym_name = "link3_buff_0"} : memref<12xi32> 
-// CHECK:     %link3_buff_1 = aie.buffer(%tile_3_3) {sym_name = "link3_buff_1"} : memref<12xi32> 
-// CHECK:     %link3_prod_lock = aie.lock(%tile_3_3, 0) {init = 2 : i32, sym_name = "link3_prod_lock"}
-// CHECK:     %link3_cons_lock = aie.lock(%tile_3_3, 1) {init = 0 : i32, sym_name = "link3_cons_lock"}
-// CHECK:     %link2_buff_0 = aie.buffer(%tile_2_3) {sym_name = "link2_buff_0"} : memref<20xi32> 
-// CHECK:     %link2_buff_1 = aie.buffer(%tile_2_3) {sym_name = "link2_buff_1"} : memref<20xi32> 
-// CHECK:     %link2_prod_lock = aie.lock(%tile_2_3, 0) {init = 2 : i32, sym_name = "link2_prod_lock"}
-// CHECK:     %link2_cons_lock = aie.lock(%tile_2_3, 1) {init = 0 : i32, sym_name = "link2_cons_lock"}
-// CHECK:     %link1_buff_0 = aie.buffer(%tile_2_2) {sym_name = "link1_buff_0"} : memref<4x4xi32> 
-// CHECK:     %link1_buff_1 = aie.buffer(%tile_2_2) {sym_name = "link1_buff_1"} : memref<4x4xi32> 
-// CHECK:     %link1_prod_lock = aie.lock(%tile_2_2, 0) {init = 2 : i32, sym_name = "link1_prod_lock"}
-// CHECK:     %link1_cons_lock = aie.lock(%tile_2_2, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
-// CHECK:     aie.flow(%tile_2_2, DMA : 0, %tile_2_1, DMA : 0)
-// CHECK:     aie.flow(%tile_2_3, DMA : 0, %tile_2_1, DMA : 1)
-// CHECK:     aie.flow(%tile_3_3, DMA : 0, %tile_2_1, DMA : 2)
-// CHECK:     aie.flow(%tile_2_1, DMA : 0, %tile_2_0, DMA : 0)
-// CHECK:     %mem_2_2 = aie.mem(%tile_2_2) {
+// CHECK:     %{{.*}}tile_2_0 = aie.tile(2, 0)
+// CHECK:     %{{.*}}tile_2_1 = aie.tile(2, 1)
+// CHECK:     %{{.*}}tile_2_2 = aie.tile(2, 2)
+// CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
+// CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
+// CHECK:     %link4_cons_prod_lock = aie.lock(%{{.*}}tile_2_0, 0) {init = 1 : i32, sym_name = "link4_cons_prod_lock"}
+// CHECK:     %link4_cons_cons_lock = aie.lock(%{{.*}}tile_2_0, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock"}
+// CHECK:     %link4_buff_0 = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link4_buff_0"} : memref<48xi32>
+// CHECK:     %link4_buff_1 = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link4_buff_1"} : memref<48xi32>
+// CHECK:     %link4_prod_lock = aie.lock(%{{.*}}tile_2_1, 0) {init = 6 : i32, sym_name = "link4_prod_lock"}
+// CHECK:     %link4_cons_lock = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "link4_cons_lock"}
+// CHECK:     %link3_buff_0 = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link3_buff_0"} : memref<12xi32>
+// CHECK:     %link3_buff_1 = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link3_buff_1"} : memref<12xi32>
+// CHECK:     %link3_prod_lock = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "link3_prod_lock"}
+// CHECK:     %link3_cons_lock = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "link3_cons_lock"}
+// CHECK:     %link2_buff_0 = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link2_buff_0"} : memref<20xi32>
+// CHECK:     %link2_buff_1 = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link2_buff_1"} : memref<20xi32>
+// CHECK:     %link2_prod_lock = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "link2_prod_lock"}
+// CHECK:     %link2_cons_lock = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "link2_cons_lock"}
+// CHECK:     %link1_buff_0 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link1_buff_0"} : memref<4x4xi32>
+// CHECK:     %link1_buff_1 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link1_buff_1"} : memref<4x4xi32>
+// CHECK:     %link1_prod_lock = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "link1_prod_lock"}
+// CHECK:     %link1_cons_lock = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "link1_cons_lock"}
+// CHECK:     aie.flow(%{{.*}}tile_2_2, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_2_3, DMA : 0, %{{.*}}tile_2_1, DMA : 1)
+// CHECK:     aie.flow(%{{.*}}tile_3_3, DMA : 0, %{{.*}}tile_2_1, DMA : 2)
+// CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 0, %{{.*}}tile_2_0, DMA : 0)
+// CHECK:     %mem_2_2 = aie.mem(%{{.*}}tile_2_2) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link1_cons_lock, AcquireGreaterEqual, 1)
@@ -64,7 +64,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %memtile_dma_2_1 = aie.memtile_dma(%tile_2_1) {
+// CHECK:     %memtile_dma_2_1 = aie.memtile_dma(%{{.*}}tile_2_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link4_prod_lock, AcquireGreaterEqual, 1)
@@ -115,7 +115,7 @@
 // CHECK:     ^bb12:  // pred: ^bb9
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_2_3 = aie.mem(%tile_2_3) {
+// CHECK:     %mem_2_3 = aie.mem(%{{.*}}tile_2_3) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link2_cons_lock, AcquireGreaterEqual, 1)
@@ -130,7 +130,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_3_3 = aie.mem(%tile_3_3) {
+// CHECK:     %mem_3_3 = aie.mem(%{{.*}}tile_3_3) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%link3_cons_lock, AcquireGreaterEqual, 1)

--- a/test/objectFifo-stateful-transform/link_via_shared_mem.mlir
+++ b/test/objectFifo-stateful-transform/link_via_shared_mem.mlir
@@ -18,32 +18,32 @@
 //CHECK:    memref.global "public" @of2 : memref<16xi32>
 //CHECK:    memref.global "public" @of1_cons : memref<16xi32>
 //CHECK:    memref.global "public" @of1 : memref<16xi32>
-//CHECK:    %tile_2_0 = aie.tile(2, 0)
-//CHECK:    %tile_1_2 = aie.tile(1, 2)
-//CHECK:    %tile_2_2 = aie.tile(2, 2)
-//CHECK:    %of2_cons_buff_0 = aie.buffer(%tile_2_2) {sym_name = "of2_cons_buff_0"} : memref<16xi32> 
-//CHECK:    %of2_cons_buff_1 = aie.buffer(%tile_2_2) {sym_name = "of2_cons_buff_1"} : memref<16xi32> 
-//CHECK:    %of2_cons_prod_lock = aie.lock(%tile_2_2, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock"}
-//CHECK:    %of2_cons_cons_lock = aie.lock(%tile_2_2, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock"}
-//CHECK:    %of1_cons_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32> 
-//CHECK:    %of1_cons_buff_1 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32> 
-//CHECK:    %of1_cons_prod_lock = aie.lock(%tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
-//CHECK:    %of1_cons_cons_lock = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
-//CHECK:    %of1_prod_lock = aie.lock(%tile_2_0, 0) {init = 1 : i32, sym_name = "of1_prod_lock"}
-//CHECK:    %of1_cons_lock = aie.lock(%tile_2_0, 1) {init = 0 : i32, sym_name = "of1_cons_lock"}
-//CHECK:    aie.flow(%tile_2_0, DMA : 0, %tile_1_2, DMA : 0)
-//CHECK:    aie.flow(%tile_1_2, DMA : 0, %tile_2_2, DMA : 0)
+//CHECK:    %{{.*}}tile_2_0 = aie.tile(2, 0)
+//CHECK:    %{{.*}}tile_1_2 = aie.tile(1, 2)
+//CHECK:    %{{.*}}tile_2_2 = aie.tile(2, 2)
+//CHECK:    %of2_cons_buff_0 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
+//CHECK:    %of2_cons_buff_1 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
+//CHECK:    %of2_cons_prod_lock = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock"}
+//CHECK:    %of2_cons_cons_lock = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock"}
+//CHECK:    %of1_cons_buff_0 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
+//CHECK:    %of1_cons_buff_1 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
+//CHECK:    %of1_cons_prod_lock = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
+//CHECK:    %of1_cons_cons_lock = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
+//CHECK:    %of1_prod_lock = aie.lock(%{{.*}}tile_2_0, 0) {init = 1 : i32, sym_name = "of1_prod_lock"}
+//CHECK:    %of1_cons_lock = aie.lock(%{{.*}}tile_2_0, 1) {init = 0 : i32, sym_name = "of1_cons_lock"}
+//CHECK:    aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
+//CHECK:    aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
 //CHECK:    func.func @some_work(%arg0: memref<16xi32>) {
 //CHECK:      return
 //CHECK:    }
-//CHECK:    %core_2_2 = aie.core(%tile_2_2) {
+//CHECK:    %core_2_2 = aie.core(%{{.*}}tile_2_2) {
 //CHECK:      aie.use_lock(%of2_cons_cons_lock, AcquireGreaterEqual, 1)
 //CHECK:      func.call @some_work(%of2_cons_buff_0) : (memref<16xi32>) -> ()
 //CHECK:      aie.use_lock(%of2_cons_prod_lock, Release, 1)
 //CHECK:      aie.end
 //CHECK:    }
 //CHECK:    aie.shim_dma_allocation @of1(MM2S, 0, 2)
-//CHECK:    %mem_1_2 = aie.mem(%tile_1_2) {
+//CHECK:    %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 //CHECK:      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 //CHECK:    ^bb1:
 //CHECK:      aie.use_lock(%of1_cons_prod_lock, AcquireGreaterEqual, 1)
@@ -70,7 +70,7 @@
 //CHECK:    ^bb6:
 //CHECK:      aie.end
 //CHECK:    }
-//CHECK:    %mem_2_2 = aie.mem(%tile_2_2) {
+//CHECK:    %mem_2_2 = aie.mem(%{{.*}}tile_2_2) {
 //CHECK:      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 //CHECK:    ^bb1:
 //CHECK:      aie.use_lock(%of2_cons_prod_lock, AcquireGreaterEqual, 1)
@@ -101,7 +101,7 @@ module @link_AIE2 {
         func.func @some_work(%lineOut : memref<16xi32>) -> () {
             return
         }
-        
+
         %core22 = aie.core(%tile22) {
             %subview = aie.objectfifo.acquire @of2 (Consume, 1) : !aie.objectfifosubview<memref<16xi32>>
             %elem0 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>

--- a/test/objectFifo-stateful-transform/link_via_shared_mem3.mlir
+++ b/test/objectFifo-stateful-transform/link_via_shared_mem3.mlir
@@ -15,29 +15,29 @@
 // CHECK:    memref.global "public" @of2 : memref<16xi32>
 // CHECK:    memref.global "public" @of1_cons : memref<16xi32>
 // CHECK:    memref.global "public" @of1 : memref<16xi32>
-// CHECK:    %tile_2_0 = aie.tile(2, 0)
-// CHECK:    %tile_1_2 = aie.tile(1, 2)
-// CHECK:    %tile_2_2 = aie.tile(2, 2)
-// CHECK:    %of1_cons_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32> 
-// CHECK:    %of1_cons_buff_1 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32> 
-// CHECK:    %of1_cons_prod_lock = aie.lock(%tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
-// CHECK:    %of1_cons_cons_lock = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
-// CHECK:    %of1_prod_lock = aie.lock(%tile_2_0, 0) {init = 1 : i32, sym_name = "of1_prod_lock"}
-// CHECK:    %of1_cons_lock = aie.lock(%tile_2_0, 1) {init = 0 : i32, sym_name = "of1_cons_lock"}
-// CHECK:    aie.flow(%tile_2_0, DMA : 0, %tile_1_2, DMA : 0)
-// CHECK:    %mem_1_2 = aie.mem(%tile_1_2) {
+// CHECK:    %{{.*}}tile_2_0 = aie.tile(2, 0)
+// CHECK:    %{{.*}}tile_1_2 = aie.tile(1, 2)
+// CHECK:    %{{.*}}tile_2_2 = aie.tile(2, 2)
+// CHECK:    %of1_cons_buff_0 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
+// CHECK:    %of1_cons_buff_1 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
+// CHECK:    %of1_cons_prod_lock = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
+// CHECK:    %of1_cons_cons_lock = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
+// CHECK:    %of1_prod_lock = aie.lock(%{{.*}}tile_2_0, 0) {init = 1 : i32, sym_name = "of1_prod_lock"}
+// CHECK:    %of1_cons_lock = aie.lock(%{{.*}}tile_2_0, 1) {init = 0 : i32, sym_name = "of1_cons_lock"}
+// CHECK:    aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
+// CHECK:    %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
-// CHECK:    ^bb1:  
+// CHECK:    ^bb1:
 // CHECK:      aie.use_lock(%of1_cons_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:      aie.dma_bd(%of1_cons_buff_0 : memref<16xi32>, 0, 16)
 // CHECK:      aie.use_lock(%of1_cons_cons_lock, Release, 1)
 // CHECK:      aie.next_bd ^bb2
-// CHECK:    ^bb2:  
+// CHECK:    ^bb2:
 // CHECK:      aie.use_lock(%of1_cons_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:      aie.dma_bd(%of1_cons_buff_1 : memref<16xi32>, 0, 16)
 // CHECK:      aie.use_lock(%of1_cons_cons_lock, Release, 1)
 // CHECK:      aie.next_bd ^bb1
-// CHECK:    ^bb3:  
+// CHECK:    ^bb3:
 // CHECK:      aie.end
 // CHECK:    }
 // CHECK:  }

--- a/test/objectFifo-stateful-transform/link_via_shared_mem_diff_memref.mlir
+++ b/test/objectFifo-stateful-transform/link_via_shared_mem_diff_memref.mlir
@@ -17,36 +17,36 @@
 // CHECK:    memref.global "public" @of2 : memref<16xi32>
 // CHECK:    memref.global "public" @of1_cons : memref<32xi32>
 // CHECK:    memref.global "public" @of1 : memref<32xi32>
-// CHECK:    %tile_2_0 = aie.tile(2, 0)
-// CHECK:    %tile_1_2 = aie.tile(1, 2)
-// CHECK:    %tile_2_2 = aie.tile(2, 2)
-// CHECK:    %of2_cons_buff_0 = aie.buffer(%tile_2_2) {sym_name = "of2_cons_buff_0"} : memref<16xi32> 
-// CHECK:    %of2_cons_buff_1 = aie.buffer(%tile_2_2) {sym_name = "of2_cons_buff_1"} : memref<16xi32> 
-// CHECK:    %of2_cons_prod_lock = aie.lock(%tile_2_2, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock"}
-// CHECK:    %of2_cons_cons_lock = aie.lock(%tile_2_2, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock"}
-// CHECK:    %of1_cons_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<32xi32> 
-// CHECK:    %of1_cons_buff_1 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<32xi32> 
-// CHECK:    %of1_cons_prod_lock = aie.lock(%tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
-// CHECK:    %of1_cons_cons_lock = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
-// CHECK:    %of1_prod_lock = aie.lock(%tile_2_0, 0) {init = 1 : i32, sym_name = "of1_prod_lock"}
-// CHECK:    %of1_cons_lock = aie.lock(%tile_2_0, 1) {init = 0 : i32, sym_name = "of1_cons_lock"}
-// CHECK:    aie.flow(%tile_2_0, DMA : 0, %tile_1_2, DMA : 0)
-// CHECK:    aie.flow(%tile_1_2, DMA : 0, %tile_2_2, DMA : 0)
-// CHECK:    %mem_1_2 = aie.mem(%tile_1_2) {
+// CHECK:    %{{.*}}tile_2_0 = aie.tile(2, 0)
+// CHECK:    %{{.*}}tile_1_2 = aie.tile(1, 2)
+// CHECK:    %{{.*}}tile_2_2 = aie.tile(2, 2)
+// CHECK:    %of2_cons_buff_0 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
+// CHECK:    %of2_cons_buff_1 = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
+// CHECK:    %of2_cons_prod_lock = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock"}
+// CHECK:    %of2_cons_cons_lock = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock"}
+// CHECK:    %of1_cons_buff_0 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<32xi32>
+// CHECK:    %of1_cons_buff_1 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<32xi32>
+// CHECK:    %of1_cons_prod_lock = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
+// CHECK:    %of1_cons_cons_lock = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
+// CHECK:    %of1_prod_lock = aie.lock(%{{.*}}tile_2_0, 0) {init = 1 : i32, sym_name = "of1_prod_lock"}
+// CHECK:    %of1_cons_lock = aie.lock(%{{.*}}tile_2_0, 1) {init = 0 : i32, sym_name = "of1_cons_lock"}
+// CHECK:    aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
+// CHECK:    aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
+// CHECK:    %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
-// CHECK:    ^bb1:  
+// CHECK:    ^bb1:
 // CHECK:      aie.use_lock(%of1_cons_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:      aie.dma_bd(%of1_cons_buff_0 : memref<32xi32>, 0, 32)
 // CHECK:      aie.use_lock(%of1_cons_cons_lock, Release, 1)
 // CHECK:      aie.next_bd ^bb2
-// CHECK:    ^bb2: 
+// CHECK:    ^bb2:
 // CHECK:      aie.use_lock(%of1_cons_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:      aie.dma_bd(%of1_cons_buff_1 : memref<32xi32>, 0, 32)
 // CHECK:      aie.use_lock(%of1_cons_cons_lock, Release, 1)
 // CHECK:      aie.next_bd ^bb1
-// CHECK:    ^bb3: 
+// CHECK:    ^bb3:
 // CHECK:      %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
-// CHECK:    ^bb4: 
+// CHECK:    ^bb4:
 // CHECK:      aie.use_lock(%of1_cons_cons_lock, AcquireGreaterEqual, 1)
 // CHECK:      aie.dma_bd(%of1_cons_buff_0 : memref<32xi32>, 0, 16)
 // CHECK:      aie.use_lock(%of1_cons_prod_lock, Release, 1)
@@ -56,12 +56,12 @@
 // CHECK:      aie.dma_bd(%of1_cons_buff_1 : memref<32xi32>, 0, 16)
 // CHECK:      aie.use_lock(%of1_cons_prod_lock, Release, 1)
 // CHECK:      aie.next_bd ^bb4
-// CHECK:    ^bb6: 
+// CHECK:    ^bb6:
 // CHECK:      aie.end
 // CHECK:    }
-// CHECK:    %mem_2_2 = aie.mem(%tile_2_2) {
+// CHECK:    %mem_2_2 = aie.mem(%{{.*}}tile_2_2) {
 // CHECK:      %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
-// CHECK:    ^bb1:  
+// CHECK:    ^bb1:
 // CHECK:      aie.use_lock(%of2_cons_prod_lock, AcquireGreaterEqual, 1)
 // CHECK:      aie.dma_bd(%of2_cons_buff_0 : memref<16xi32>, 0, 16)
 // CHECK:      aie.use_lock(%of2_cons_cons_lock, Release, 1)
@@ -71,7 +71,7 @@
 // CHECK:      aie.dma_bd(%of2_cons_buff_1 : memref<16xi32>, 0, 16)
 // CHECK:      aie.use_lock(%of2_cons_cons_lock, Release, 1)
 // CHECK:      aie.next_bd ^bb1
-// CHECK:    ^bb3: 
+// CHECK:    ^bb3:
 // CHECK:      aie.end
 // CHECK:    }
 // CHECK:  }

--- a/test/objectFifo-stateful-transform/memtile_padding_test.mlir
+++ b/test/objectFifo-stateful-transform/memtile_padding_test.mlir
@@ -5,38 +5,38 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// 
+//
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
-    // CHECK: %tile_0_0 = aie.tile(0, 0)
-    // CHECK: %tile_0_1 = aie.tile(0, 1)
-    // CHECK: %tile_0_2 = aie.tile(0, 2)
-    // CHECK: %objFifo_out0_cons_prod_lock = aie.lock(%tile_0_0, 2) {init = 1 : i32, sym_name = "objFifo_out0_cons_prod_lock"}
-    // CHECK: %objFifo_out0_cons_cons_lock = aie.lock(%tile_0_0, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_cons_lock"}
-    // CHECK: %objFifo_out1_cons_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out1_cons_buff_0"} : memref<64x64xi8> 
-    // CHECK: %objFifo_out1_cons_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_out1_cons_buff_1"} : memref<64x64xi8> 
-    // CHECK: %objFifo_out1_cons_prod_lock = aie.lock(%tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock"}
-    // CHECK: %objFifo_out1_cons_cons_lock = aie.lock(%tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock"}
-    // CHECK: %objFifo_out1_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_0"} : memref<64x64xi8> 
-    // CHECK: %objFifo_out1_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_out1_buff_1"} : memref<64x64xi8> 
-    // CHECK: %objFifo_out1_prod_lock = aie.lock(%tile_0_2, 2) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock"}
-    // CHECK: %objFifo_out1_cons_lock = aie.lock(%tile_0_2, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_lock"}
-    // CHECK: %objFifo_in1_cons_buff_0 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_0"} : memref<64x64xi8> 
-    // CHECK: %objFifo_in1_cons_buff_1 = aie.buffer(%tile_0_2) {sym_name = "objFifo_in1_cons_buff_1"} : memref<64x64xi8> 
-    // CHECK: %objFifo_in1_cons_prod_lock = aie.lock(%tile_0_2, 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock"}
-    // CHECK: %objFifo_in1_cons_cons_lock = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock"}
-    // CHECK: %objFifo_in1_buff_0 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in1_buff_0"} : memref<64x64xi8> 
-    // CHECK: %objFifo_in1_buff_1 = aie.buffer(%tile_0_1) {sym_name = "objFifo_in1_buff_1"} : memref<64x64xi8> 
-    // CHECK: %objFifo_in1_prod_lock = aie.lock(%tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in1_prod_lock"}
-    // CHECK: %objFifo_in1_cons_lock = aie.lock(%tile_0_1, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_lock"}
-    // CHECK: %objFifo_in0_prod_lock = aie.lock(%tile_0_0, 0) {init = 1 : i32, sym_name = "objFifo_in0_prod_lock"}
-    // CHECK: %objFifo_in0_cons_lock = aie.lock(%tile_0_0, 1) {init = 0 : i32, sym_name = "objFifo_in0_cons_lock"}
-    // CHECK: aie.flow(%tile_0_0, DMA : 0, %tile_0_1, DMA : 0)
-    // CHECK: aie.flow(%tile_0_1, DMA : 0, %tile_0_2, DMA : 0)
-    // CHECK: aie.flow(%tile_0_2, DMA : 0, %tile_0_1, DMA : 1)
-    // CHECK: aie.flow(%tile_0_1, DMA : 1, %tile_0_0, DMA : 0)
-    // CHECK: %core_0_2 = aie.core(%tile_0_2) {
+    // CHECK: %{{.*}}tile_0_0 = aie.tile(0, 0)
+    // CHECK: %{{.*}}tile_0_1 = aie.tile(0, 1)
+    // CHECK: %{{.*}}tile_0_2 = aie.tile(0, 2)
+    // CHECK: %objFifo_out0_cons_prod_lock = aie.lock(%{{.*}}tile_0_0, 2) {init = 1 : i32, sym_name = "objFifo_out0_cons_prod_lock"}
+    // CHECK: %objFifo_out0_cons_cons_lock = aie.lock(%{{.*}}tile_0_0, 3) {init = 0 : i32, sym_name = "objFifo_out0_cons_cons_lock"}
+    // CHECK: %objFifo_out1_cons_buff_0 = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_0"} : memref<64x64xi8>
+    // CHECK: %objFifo_out1_cons_buff_1 = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_1"} : memref<64x64xi8>
+    // CHECK: %objFifo_out1_cons_prod_lock = aie.lock(%{{.*}}tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock"}
+    // CHECK: %objFifo_out1_cons_cons_lock = aie.lock(%{{.*}}tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock"}
+    // CHECK: %objFifo_out1_buff_0 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_out1_buff_0"} : memref<64x64xi8>
+    // CHECK: %objFifo_out1_buff_1 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_out1_buff_1"} : memref<64x64xi8>
+    // CHECK: %objFifo_out1_prod_lock = aie.lock(%{{.*}}tile_0_2, 2) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock"}
+    // CHECK: %objFifo_out1_cons_lock = aie.lock(%{{.*}}tile_0_2, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_lock"}
+    // CHECK: %objFifo_in1_cons_buff_0 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_in1_cons_buff_0"} : memref<64x64xi8>
+    // CHECK: %objFifo_in1_cons_buff_1 = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_in1_cons_buff_1"} : memref<64x64xi8>
+    // CHECK: %objFifo_in1_cons_prod_lock = aie.lock(%{{.*}}tile_0_2, 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock"}
+    // CHECK: %objFifo_in1_cons_cons_lock = aie.lock(%{{.*}}tile_0_2, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock"}
+    // CHECK: %objFifo_in1_buff_0 = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_in1_buff_0"} : memref<64x64xi8>
+    // CHECK: %objFifo_in1_buff_1 = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_in1_buff_1"} : memref<64x64xi8>
+    // CHECK: %objFifo_in1_prod_lock = aie.lock(%{{.*}}tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in1_prod_lock"}
+    // CHECK: %objFifo_in1_cons_lock = aie.lock(%{{.*}}tile_0_1, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_lock"}
+    // CHECK: %objFifo_in0_prod_lock = aie.lock(%{{.*}}tile_0_0, 0) {init = 1 : i32, sym_name = "objFifo_in0_prod_lock"}
+    // CHECK: %objFifo_in0_cons_lock = aie.lock(%{{.*}}tile_0_0, 1) {init = 0 : i32, sym_name = "objFifo_in0_cons_lock"}
+    // CHECK: aie.flow(%{{.*}}tile_0_0, DMA : 0, %{{.*}}tile_0_1, DMA : 0)
+    // CHECK: aie.flow(%{{.*}}tile_0_1, DMA : 0, %{{.*}}tile_0_2, DMA : 0)
+    // CHECK: aie.flow(%{{.*}}tile_0_2, DMA : 0, %{{.*}}tile_0_1, DMA : 1)
+    // CHECK: aie.flow(%{{.*}}tile_0_1, DMA : 1, %{{.*}}tile_0_0, DMA : 0)
+    // CHECK: %core_0_2 = aie.core(%{{.*}}tile_0_2) {
     // CHECK:   aie.use_lock(%objFifo_in1_cons_cons_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.use_lock(%objFifo_out1_prod_lock, AcquireGreaterEqual, 1)
     // CHECK:   %c0 = arith.constant 0 : index
@@ -60,14 +60,14 @@
     // CHECK:   aiex.npu.dma_wait {symbol = @objFifo_out0}
     // CHECK: }
     // CHECK: aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
-    // CHECK: %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
+    // CHECK: %memtile_dma_0_1 = aie.memtile_dma(%{{.*}}tile_0_1) {
     // CHECK:   %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
-    // CHECK: ^bb1: 
+    // CHECK: ^bb1:
     // CHECK:   aie.use_lock(%objFifo_in1_prod_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_in1_buff_0 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_in1_cons_lock, Release, 1)
     // CHECK:   aie.next_bd ^bb2
-    // CHECK: ^bb2: 
+    // CHECK: ^bb2:
     // CHECK:   aie.use_lock(%objFifo_in1_prod_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_in1_buff_1 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_in1_cons_lock, Release, 1)
@@ -79,14 +79,14 @@
     // CHECK:   aie.dma_bd(%objFifo_in1_buff_0 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_in1_prod_lock, Release, 1)
     // CHECK:   aie.next_bd ^bb5
-    // CHECK: ^bb5: 
+    // CHECK: ^bb5:
     // CHECK:   aie.use_lock(%objFifo_in1_cons_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_in1_buff_1 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_in1_prod_lock, Release, 1)
     // CHECK:   aie.next_bd ^bb4
-    // CHECK: ^bb6: 
+    // CHECK: ^bb6:
     // CHECK:   %2 = aie.dma_start(S2MM, 1, ^bb7, ^bb9)
-    // CHECK: ^bb7: 
+    // CHECK: ^bb7:
     // CHECK:   aie.use_lock(%objFifo_out1_cons_prod_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_out1_cons_buff_0 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_out1_cons_cons_lock, Release, 1)
@@ -98,7 +98,7 @@
     // CHECK:   aie.next_bd ^bb7
     // CHECK: ^bb9:
     // CHECK:   %3 = aie.dma_start(MM2S, 1, ^bb10, ^bb12)
-    // CHECK: ^bb10: 
+    // CHECK: ^bb10:
     // CHECK:   aie.use_lock(%objFifo_out1_cons_cons_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_out1_cons_buff_0 : memref<64x64xi8>, 0, 4096, [<size = 61, stride = 56>, <size = 56, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>, <const_pad_before = 4, const_pad_after = 4>])
     // CHECK:   aie.use_lock(%objFifo_out1_cons_prod_lock, Release, 1)
@@ -111,9 +111,9 @@
     // CHECK: ^bb12:
     // CHECK:   aie.end
     // CHECK: }
-    // CHECK: %mem_0_2 = aie.mem(%tile_0_2) {
+    // CHECK: %mem_0_2 = aie.mem(%{{.*}}tile_0_2) {
     // CHECK:   %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
-    // CHECK: ^bb1: 
+    // CHECK: ^bb1:
     // CHECK:   aie.use_lock(%objFifo_in1_cons_prod_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_in1_cons_buff_0 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
@@ -123,14 +123,14 @@
     // CHECK:   aie.dma_bd(%objFifo_in1_cons_buff_1 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_in1_cons_cons_lock, Release, 1)
     // CHECK:   aie.next_bd ^bb1
-    // CHECK: ^bb3: 
+    // CHECK: ^bb3:
     // CHECK:   %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
-    // CHECK: ^bb4: 
+    // CHECK: ^bb4:
     // CHECK:   aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_out1_buff_0 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
     // CHECK:   aie.next_bd ^bb5
-    // CHECK: ^bb5: 
+    // CHECK: ^bb5:
     // CHECK:   aie.use_lock(%objFifo_out1_cons_lock, AcquireGreaterEqual, 1)
     // CHECK:   aie.dma_bd(%objFifo_out1_buff_1 : memref<64x64xi8>, 0, 4096)
     // CHECK:   aie.use_lock(%objFifo_out1_prod_lock, Release, 1)
@@ -156,7 +156,7 @@ module {
       %subview1 = aie.objectfifo.acquire @objFifo_out1 (Produce, 1) : !aie.objectfifosubview<memref<64x64xi8>>
       %elem = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<64x64xi8>> -> memref<64x64xi8>
       %elem1 = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<64x64xi8>> -> memref<64x64xi8>
-      
+
       %c0 = arith.constant 0 : index
       %c1 = arith.constant 1 : index
       %c64 = arith.constant 64 : index

--- a/test/objectFifo-stateful-transform/memtile_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/memtile_repeat_count_test.mlir
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// 
+//
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
@@ -18,29 +18,29 @@
 // CHECK:     memref.global "public" @of1 : memref<16xi32>
 // CHECK:     memref.global "public" @of0_cons : memref<32xi32>
 // CHECK:     memref.global "public" @of0 : memref<32xi32>
-// CHECK:     %tile_1_0 = aie.tile(1, 0)
-// CHECK:     %tile_1_1 = aie.tile(1, 1)
-// CHECK:     %tile_1_2 = aie.tile(1, 2)
-// CHECK:     %tile_3_3 = aie.tile(3, 3)
-// CHECK:     %of2_cons_buff_0 = aie.buffer(%tile_3_3) {sym_name = "of2_cons_buff_0"} : memref<16xi32> 
-// CHECK:     %of2_cons_buff_1 = aie.buffer(%tile_3_3) {sym_name = "of2_cons_buff_1"} : memref<16xi32> 
-// CHECK:     %of2_cons_prod_lock = aie.lock(%tile_3_3, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock"}
-// CHECK:     %of2_cons_cons_lock = aie.lock(%tile_3_3, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock"}
-// CHECK:     %of1_cons_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32> 
-// CHECK:     %of1_cons_buff_1 = aie.buffer(%tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32> 
-// CHECK:     %of1_cons_prod_lock = aie.lock(%tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
-// CHECK:     %of1_cons_cons_lock = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
-// CHECK:     %of0_cons_buff_0 = aie.buffer(%tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<32xi32> 
-// CHECK:     %of0_cons_buff_1 = aie.buffer(%tile_1_1) {sym_name = "of0_cons_buff_1"} : memref<32xi32> 
-// CHECK:     %of0_cons_prod_lock = aie.lock(%tile_1_1, 0) {init = 12 : i32, sym_name = "of0_cons_prod_lock"}
-// CHECK:     %of0_cons_cons_lock = aie.lock(%tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock"}
-// CHECK:     %of0_prod_lock = aie.lock(%tile_1_0, 0) {init = 1 : i32, sym_name = "of0_prod_lock"}
-// CHECK:     %of0_cons_lock = aie.lock(%tile_1_0, 1) {init = 0 : i32, sym_name = "of0_cons_lock"}
-// CHECK:     aie.flow(%tile_1_0, DMA : 0, %tile_1_1, DMA : 0)
-// CHECK:     aie.flow(%tile_1_1, DMA : 0, %tile_1_2, DMA : 0)
-// CHECK:     aie.flow(%tile_1_1, DMA : 1, %tile_3_3, DMA : 0)
+// CHECK:     %{{.*}}tile_1_0 = aie.tile(1, 0)
+// CHECK:     %{{.*}}tile_1_1 = aie.tile(1, 1)
+// CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
+// CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
+// CHECK:     %of2_cons_buff_0 = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
+// CHECK:     %of2_cons_buff_1 = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
+// CHECK:     %of2_cons_prod_lock = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock"}
+// CHECK:     %of2_cons_cons_lock = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock"}
+// CHECK:     %of1_cons_buff_0 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %of1_cons_buff_1 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
+// CHECK:     %of1_cons_prod_lock = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock"}
+// CHECK:     %of1_cons_cons_lock = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
+// CHECK:     %of0_cons_buff_0 = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<32xi32>
+// CHECK:     %of0_cons_buff_1 = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_1"} : memref<32xi32>
+// CHECK:     %of0_cons_prod_lock = aie.lock(%{{.*}}tile_1_1, 0) {init = 12 : i32, sym_name = "of0_cons_prod_lock"}
+// CHECK:     %of0_cons_cons_lock = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock"}
+// CHECK:     %of0_prod_lock = aie.lock(%{{.*}}tile_1_0, 0) {init = 1 : i32, sym_name = "of0_prod_lock"}
+// CHECK:     %of0_cons_lock = aie.lock(%{{.*}}tile_1_0, 1) {init = 0 : i32, sym_name = "of0_cons_lock"}
+// CHECK:     aie.flow(%{{.*}}tile_1_0, DMA : 0, %{{.*}}tile_1_1, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 1, %{{.*}}tile_3_3, DMA : 0)
 // CHECK:     aie.shim_dma_allocation @of0(MM2S, 0, 1)
-// CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%tile_1_1) {
+// CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%of0_cons_prod_lock, AcquireGreaterEqual, 6)
@@ -79,7 +79,7 @@
 // CHECK:     ^bb9:  // pred: ^bb6
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_1_2 = aie.mem(%tile_1_2) {
+// CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%of1_cons_prod_lock, AcquireGreaterEqual, 1)
@@ -94,7 +94,7 @@
 // CHECK:     ^bb3:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_3_3 = aie.mem(%tile_3_3) {
+// CHECK:     %mem_3_3 = aie.mem(%{{.*}}tile_3_3) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb2
 // CHECK:       aie.use_lock(%of2_cons_prod_lock, AcquireGreaterEqual, 1)

--- a/test/objectFifo-stateful-transform/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count_test.mlir
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// 
+//
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
@@ -16,24 +16,24 @@
 // CHECK:     memref.global "public" @of1 : memref<16xi32>
 // CHECK:     memref.global "public" @of0_cons : memref<16xi32>
 // CHECK:     memref.global "public" @of0 : memref<16xi32>
-// CHECK:     %tile_1_1 = aie.tile(1, 1)
-// CHECK:     %tile_1_2 = aie.tile(1, 2)
-// CHECK:     %tile_1_3 = aie.tile(1, 3)
-// CHECK:     %of1_cons_buff_0 = aie.buffer(%tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32> 
-// CHECK:     %of1_cons_prod_lock = aie.lock(%tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock"}
-// CHECK:     %of1_cons_cons_lock = aie.lock(%tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
-// CHECK:     %of1_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32> 
-// CHECK:     %of1_prod_lock = aie.lock(%tile_1_2, 2) {init = 3 : i32, sym_name = "of1_prod_lock"}
-// CHECK:     %of1_cons_lock = aie.lock(%tile_1_2, 3) {init = 0 : i32, sym_name = "of1_cons_lock"}
-// CHECK:     %of0_cons_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of0_cons_buff_0"} : memref<16xi32> 
-// CHECK:     %of0_cons_prod_lock = aie.lock(%tile_1_2, 0) {init = 1 : i32, sym_name = "of0_cons_prod_lock"}
-// CHECK:     %of0_cons_cons_lock = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock"}
-// CHECK:     %of0_buff_0 = aie.buffer(%tile_1_1) {sym_name = "of0_buff_0"} : memref<16xi32> 
-// CHECK:     %of0_prod_lock = aie.lock(%tile_1_1, 0) {init = 1 : i32, sym_name = "of0_prod_lock"}
-// CHECK:     %of0_cons_lock = aie.lock(%tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_lock"}
-// CHECK:     aie.flow(%tile_1_1, DMA : 0, %tile_1_2, DMA : 0)
-// CHECK:     aie.flow(%tile_1_2, DMA : 0, %tile_1_3, DMA : 0)
-// CHECK:     %core_1_2 = aie.core(%tile_1_2) {
+// CHECK:     %{{.*}}tile_1_1 = aie.tile(1, 1)
+// CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
+// CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
+// CHECK:     %of1_cons_buff_0 = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
+// CHECK:     %of1_cons_prod_lock = aie.lock(%{{.*}}tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock"}
+// CHECK:     %of1_cons_cons_lock = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock"}
+// CHECK:     %of1_buff_0 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32>
+// CHECK:     %of1_prod_lock = aie.lock(%{{.*}}tile_1_2, 2) {init = 3 : i32, sym_name = "of1_prod_lock"}
+// CHECK:     %of1_cons_lock = aie.lock(%{{.*}}tile_1_2, 3) {init = 0 : i32, sym_name = "of1_cons_lock"}
+// CHECK:     %of0_cons_buff_0 = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_cons_buff_0"} : memref<16xi32>
+// CHECK:     %of0_cons_prod_lock = aie.lock(%{{.*}}tile_1_2, 0) {init = 1 : i32, sym_name = "of0_cons_prod_lock"}
+// CHECK:     %of0_cons_cons_lock = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock"}
+// CHECK:     %of0_buff_0 = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_buff_0"} : memref<16xi32>
+// CHECK:     %of0_prod_lock = aie.lock(%{{.*}}tile_1_1, 0) {init = 1 : i32, sym_name = "of0_prod_lock"}
+// CHECK:     %of0_cons_lock = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_lock"}
+// CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
+// CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
+// CHECK:     %core_1_2 = aie.core(%{{.*}}tile_1_2) {
 // CHECK:       %c0 = arith.constant 0 : index
 // CHECK:       %c1 = arith.constant 1 : index
 // CHECK:       %c12 = arith.constant 12 : index
@@ -45,7 +45,7 @@
 // CHECK:       }
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%tile_1_1) {
+// CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%of0_cons_lock, AcquireGreaterEqual, 1)
@@ -55,7 +55,7 @@
 // CHECK:     ^bb2:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_1_2 = aie.mem(%tile_1_2) {
+// CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%of0_cons_prod_lock, AcquireGreaterEqual, 1)
@@ -72,7 +72,7 @@
 // CHECK:     ^bb4:  // pred: ^bb2
 // CHECK:       aie.end
 // CHECK:     }
-// CHECK:     %mem_1_3 = aie.mem(%tile_1_3) {
+// CHECK:     %mem_1_3 = aie.mem(%{{.*}}tile_1_3) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%of1_cons_prod_lock, AcquireGreaterEqual, 1)

--- a/test/python/code_region.py
+++ b/test/python/code_region.py
@@ -21,13 +21,13 @@ from util import construct_and_print_module
 # CHECK:  module {
 # CHECK:    aie.device(xcve2802) {
 # CHECK:      func.func private @test_func(memref<8x8xi32>) -> i32
-# CHECK:      %tile_0_2 = aie.tile(0, 2)
-# CHECK:      %tile_1_2 = aie.tile(1, 2)
-# CHECK:      %tile_3_3 = aie.tile(3, 3)
-# CHECK:      aie.objectfifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
-# CHECK:      aie.objectfifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !aie.objectfifo<memref<8x8xi32>>
+# CHECK:      %{{.*}}tile_0_2 = aie.tile(0, 2)
+# CHECK:      %{{.*}}tile_1_2 = aie.tile(1, 2)
+# CHECK:      %{{.*}}tile_3_3 = aie.tile(3, 3)
+# CHECK:      aie.objectfifo @of0(%{{.*}}tile_0_2, {%{{.*}}tile_1_2}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
+# CHECK:      aie.objectfifo @of1(%{{.*}}tile_1_2, {%{{.*}}tile_3_3}, 2 : i32) : !aie.objectfifo<memref<8x8xi32>>
 # CHECK:      aie.objectfifo.link [@of0] -> [@of1]([] [])
-# CHECK:      %core_3_3 = aie.core(%tile_3_3) {
+# CHECK:      %core_3_3 = aie.core(%{{.*}}tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index

--- a/test/python/core_ext_kernel.py
+++ b/test/python/core_ext_kernel.py
@@ -24,13 +24,13 @@ from util import construct_and_print_module
 # CHECK:  module {
 # CHECK:    aie.device(xcve2802) {
 # CHECK:      func.func private @test_func(memref<8x8xi32>, i32) -> i32
-# CHECK:      %tile_0_2 = aie.tile(0, 2)
-# CHECK:      %tile_1_2 = aie.tile(1, 2)
-# CHECK:      %tile_3_3 = aie.tile(3, 3)
-# CHECK:      aie.objectfifo @of0(%tile_0_2, {%tile_1_2}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
-# CHECK:      aie.objectfifo @of1(%tile_1_2, {%tile_3_3}, 2 : i32) : !aie.objectfifo<memref<8x8xi32>>
+# CHECK:      %{{.*}}tile_0_2 = aie.tile(0, 2)
+# CHECK:      %{{.*}}tile_1_2 = aie.tile(1, 2)
+# CHECK:      %{{.*}}tile_3_3 = aie.tile(3, 3)
+# CHECK:      aie.objectfifo @of0(%{{.*}}tile_0_2, {%{{.*}}tile_1_2}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
+# CHECK:      aie.objectfifo @of1(%{{.*}}tile_1_2, {%{{.*}}tile_3_3}, 2 : i32) : !aie.objectfifo<memref<8x8xi32>>
 # CHECK:      aie.objectfifo.link [@of0] -> [@of1]([] [])
-# CHECK:      %core_3_3 = aie.core(%tile_3_3) {
+# CHECK:      %core_3_3 = aie.core(%{{.*}}tile_3_3) {
 # CHECK:        %c0 = arith.constant 0 : index
 # CHECK:        %c10 = arith.constant 10 : index
 # CHECK:        %c1 = arith.constant 1 : index

--- a/test/python/objFifo.py
+++ b/test/python/objFifo.py
@@ -19,14 +19,14 @@ from util import construct_and_print_module
 
 # CHECK:  module {
 # CHECK:    aie.device(xcve2302) {
-# CHECK:      %tile_0_0 = aie.tile(0, 0)
-# CHECK:      %tile_0_1 = aie.tile(0, 1)
-# CHECK:      %tile_1_2 = aie.tile(1, 2)
-# CHECK:      %tile_1_3 = aie.tile(1, 3)
-# CHECK:      aie.objectfifo @of0(%tile_0_0, {%tile_1_2}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
-# CHECK:      aie.objectfifo @of1(%tile_0_1, {%tile_1_2}, 2 : i32) {repeat_count = 4 : i32} : !aie.objectfifo<memref<256xi32>>
-# CHECK:      aie.objectfifo @of2(%tile_1_2, {%tile_1_3}, 2 : i32) {via_shared_mem = 1 : i32} : !aie.objectfifo<memref<256xi32>>
-# CHECK:      %core_1_2 = aie.core(%tile_1_2) {
+# CHECK:      %{{.*}}tile_0_0 = aie.tile(0, 0)
+# CHECK:      %{{.*}}tile_0_1 = aie.tile(0, 1)
+# CHECK:      %{{.*}}tile_1_2 = aie.tile(1, 2)
+# CHECK:      %{{.*}}tile_1_3 = aie.tile(1, 3)
+# CHECK:      aie.objectfifo @of0(%{{.*}}tile_0_0, {%{{.*}}tile_1_2}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
+# CHECK:      aie.objectfifo @of1(%{{.*}}tile_0_1, {%{{.*}}tile_1_2}, 2 : i32) {repeat_count = 4 : i32} : !aie.objectfifo<memref<256xi32>>
+# CHECK:      aie.objectfifo @of2(%{{.*}}tile_1_2, {%{{.*}}tile_1_3}, 2 : i32) {via_shared_mem = 1 : i32} : !aie.objectfifo<memref<256xi32>>
+# CHECK:      %core_1_2 = aie.core(%{{.*}}tile_1_2) {
 # CHECK:        %0 = aie.objectfifo.acquire @of0(Consume, 1) : !aie.objectfifosubview<memref<256xi32>>
 # CHECK:        %1 = aie.objectfifo.subview.access %0[0] : !aie.objectfifosubview<memref<256xi32>> -> memref<256xi32>
 # CHECK:        %c0 = arith.constant 0 : index

--- a/test/python/objFifo_init_values.py
+++ b/test/python/objFifo_init_values.py
@@ -19,10 +19,10 @@ from util import construct_and_print_module
 
 # CHECK:  module {
 # CHECK:    aie.device(xcve2302) {
-# CHECK:      %tile_0_1 = aie.tile(0, 1)
-# CHECK:      %tile_1_3 = aie.tile(1, 3)
-# CHECK:      aie.objectfifo @of0(%tile_0_1, {%tile_1_3}, 2 : i32) : !aie.objectfifo<memref<2x2xi32>> = [dense<[{{\[}}0, 1], [2, 3]]> : memref<2x2xi32>, dense<[{{\[}}4, 5], [6, 7]]> : memref<2x2xi32>]
-# CHECK:      aie.objectfifo @of1(%tile_0_1, {%tile_1_3}, 2 : i32) : !aie.objectfifo<memref<4xi32>> = [dense<[0, 1, 2, 3]> : memref<4xi32>, dense<[4, 5, 6, 7]> : memref<4xi32>]
+# CHECK:      %{{.*}}tile_0_1 = aie.tile(0, 1)
+# CHECK:      %{{.*}}tile_1_3 = aie.tile(1, 3)
+# CHECK:      aie.objectfifo @of0(%{{.*}}tile_0_1, {%{{.*}}tile_1_3}, 2 : i32) : !aie.objectfifo<memref<2x2xi32>> = [dense<[{{\[}}0, 1], [2, 3]]> : memref<2x2xi32>, dense<[{{\[}}4, 5], [6, 7]]> : memref<2x2xi32>]
+# CHECK:      aie.objectfifo @of1(%{{.*}}tile_0_1, {%{{.*}}tile_1_3}, 2 : i32) : !aie.objectfifo<memref<4xi32>> = [dense<[0, 1, 2, 3]> : memref<4xi32>, dense<[4, 5, 6, 7]> : memref<4xi32>]
 # CHECK:    }
 # CHECK:  }
 

--- a/test/python/objFifo_link.py
+++ b/test/python/objFifo_link.py
@@ -20,17 +20,17 @@ from util import construct_and_print_module
 
 # CHECK:  module {
 # CHECK:    aie.device(xcve2802) {
-# CHECK:      %tile_0_0 = aie.tile(0, 0)
-# CHECK:      %tile_1_1 = aie.tile(1, 1)
-# CHECK:      %tile_2_2 = aie.tile(2, 2)
-# CHECK:      %tile_2_3 = aie.tile(2, 3)
-# CHECK:      aie.objectfifo @of0(%tile_0_0, {%tile_1_1}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
-# CHECK:      aie.objectfifo @of1(%tile_1_1, {%tile_2_2, %tile_2_3}, 2 : i32) : !aie.objectfifo<memref<64xi32>>
+# CHECK:      %{{.*}}tile_0_0 = aie.tile(0, 0)
+# CHECK:      %{{.*}}tile_1_1 = aie.tile(1, 1)
+# CHECK:      %{{.*}}tile_2_2 = aie.tile(2, 2)
+# CHECK:      %{{.*}}tile_2_3 = aie.tile(2, 3)
+# CHECK:      aie.objectfifo @of0(%{{.*}}tile_0_0, {%{{.*}}tile_1_1}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
+# CHECK:      aie.objectfifo @of1(%{{.*}}tile_1_1, {%{{.*}}tile_2_2, %{{.*}}tile_2_3}, 2 : i32) : !aie.objectfifo<memref<64xi32>>
 # CHECK:      aie.objectfifo.link [@of0] -> [@of1]([] [])
-# CHECK:      aie.objectfifo @of2(%tile_1_1 dimensionsToStream [<size = 1, stride = 2>], {%tile_2_2 dimensionsFromStream [<size = 1, stride = 2>], %tile_2_3 dimensionsFromStream [<size = 1, stride = 2>]}, [2 : i32, 2 : i32, 7 : i32]) : !aie.objectfifo<memref<256xui8>>
-# CHECK:      aie.objectfifo @of3(%tile_0_0, {%tile_1_1}, 1 : i32) : !aie.objectfifo<memref<256xi32>>
-# CHECK:      aie.objectfifo @of4(%tile_1_1, {%tile_2_2}, 2 : i32) : !aie.objectfifo<memref<64xi32>>
-# CHECK:      aie.objectfifo @of5(%tile_1_1, {%tile_2_3}, 2 : i32) : !aie.objectfifo<memref<64xi32>>
+# CHECK:      aie.objectfifo @of2(%{{.*}}tile_1_1 dimensionsToStream [<size = 1, stride = 2>], {%{{.*}}tile_2_2 dimensionsFromStream [<size = 1, stride = 2>], %{{.*}}tile_2_3 dimensionsFromStream [<size = 1, stride = 2>]}, [2 : i32, 2 : i32, 7 : i32]) : !aie.objectfifo<memref<256xui8>>
+# CHECK:      aie.objectfifo @of3(%{{.*}}tile_0_0, {%{{.*}}tile_1_1}, 1 : i32) : !aie.objectfifo<memref<256xi32>>
+# CHECK:      aie.objectfifo @of4(%{{.*}}tile_1_1, {%{{.*}}tile_2_2}, 2 : i32) : !aie.objectfifo<memref<64xi32>>
+# CHECK:      aie.objectfifo @of5(%{{.*}}tile_1_1, {%{{.*}}tile_2_3}, 2 : i32) : !aie.objectfifo<memref<64xi32>>
 # CHECK:      aie.objectfifo.link [@of3] -> [@of4, @of5]([] [0, 128])
 # CHECK:    }
 # CHECK:  }

--- a/test/python/tile_array.py
+++ b/test/python/tile_array.py
@@ -125,66 +125,66 @@ def broadcast(module):
 
         # CHECK: module {
         # CHECK:   aie.device(npu1) {
-        # CHECK:     %tile_0_0 = aie.tile(0, 0)
-        # CHECK:     %tile_0_1 = aie.tile(0, 1)
-        # CHECK:     %tile_0_2 = aie.tile(0, 2)
-        # CHECK:     %tile_0_3 = aie.tile(0, 3)
-        # CHECK:     %tile_0_4 = aie.tile(0, 4)
-        # CHECK:     %tile_0_5 = aie.tile(0, 5)
-        # CHECK:     %tile_1_0 = aie.tile(1, 0)
-        # CHECK:     %tile_1_1 = aie.tile(1, 1)
-        # CHECK:     %tile_1_2 = aie.tile(1, 2)
-        # CHECK:     %tile_1_3 = aie.tile(1, 3)
-        # CHECK:     %tile_1_4 = aie.tile(1, 4)
-        # CHECK:     %tile_1_5 = aie.tile(1, 5)
-        # CHECK:     %tile_2_0 = aie.tile(2, 0)
-        # CHECK:     %tile_2_1 = aie.tile(2, 1)
-        # CHECK:     %tile_2_2 = aie.tile(2, 2)
-        # CHECK:     %tile_2_3 = aie.tile(2, 3)
-        # CHECK:     %tile_2_4 = aie.tile(2, 4)
-        # CHECK:     %tile_2_5 = aie.tile(2, 5)
-        # CHECK:     %tile_3_0 = aie.tile(3, 0)
-        # CHECK:     %tile_3_1 = aie.tile(3, 1)
-        # CHECK:     %tile_3_2 = aie.tile(3, 2)
-        # CHECK:     %tile_3_3 = aie.tile(3, 3)
-        # CHECK:     %tile_3_4 = aie.tile(3, 4)
-        # CHECK:     %tile_3_5 = aie.tile(3, 5)
-        # CHECK:     %tile_4_0 = aie.tile(4, 0)
-        # CHECK:     %tile_4_1 = aie.tile(4, 1)
-        # CHECK:     %tile_4_2 = aie.tile(4, 2)
-        # CHECK:     %tile_4_3 = aie.tile(4, 3)
-        # CHECK:     %tile_4_4 = aie.tile(4, 4)
-        # CHECK:     %tile_4_5 = aie.tile(4, 5)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 0, %tile_0_1, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 1, %tile_0_3, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 1, %tile_0_4, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 1, %tile_0_5, DMA : 0)
-        # CHECK:     aie.flow(%tile_1_0, DMA : 0, %tile_1_3, DMA : 0)
-        # CHECK:     aie.flow(%tile_1_0, DMA : 0, %tile_1_4, DMA : 0)
-        # CHECK:     aie.flow(%tile_1_0, DMA : 0, %tile_1_5, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 2, %tile_1_0, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 2, %tile_1_1, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 2, %tile_1_2, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_2_1, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_2_2, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_2_3, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_2_4, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_2_5, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_3_1, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_3_2, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_3_3, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_3_4, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 3, %tile_3_5, DMA : 0)
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_2_1, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_2_2, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_2_3, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_2_4, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_2_5, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_3_1, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_3_2, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_3_3, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_3_4, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
-        # CHECK:     aie.flow(%tile_0_0, DMA : 4, %tile_3_5, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     %{{.*}}tile_0_0 = aie.tile(0, 0)
+        # CHECK:     %{{.*}}tile_0_1 = aie.tile(0, 1)
+        # CHECK:     %{{.*}}tile_0_2 = aie.tile(0, 2)
+        # CHECK:     %{{.*}}tile_0_3 = aie.tile(0, 3)
+        # CHECK:     %{{.*}}tile_0_4 = aie.tile(0, 4)
+        # CHECK:     %{{.*}}tile_0_5 = aie.tile(0, 5)
+        # CHECK:     %{{.*}}tile_1_0 = aie.tile(1, 0)
+        # CHECK:     %{{.*}}tile_1_1 = aie.tile(1, 1)
+        # CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
+        # CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
+        # CHECK:     %{{.*}}tile_1_4 = aie.tile(1, 4)
+        # CHECK:     %{{.*}}tile_1_5 = aie.tile(1, 5)
+        # CHECK:     %{{.*}}tile_2_0 = aie.tile(2, 0)
+        # CHECK:     %{{.*}}tile_2_1 = aie.tile(2, 1)
+        # CHECK:     %{{.*}}tile_2_2 = aie.tile(2, 2)
+        # CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
+        # CHECK:     %{{.*}}tile_2_4 = aie.tile(2, 4)
+        # CHECK:     %{{.*}}tile_2_5 = aie.tile(2, 5)
+        # CHECK:     %{{.*}}tile_3_0 = aie.tile(3, 0)
+        # CHECK:     %{{.*}}tile_3_1 = aie.tile(3, 1)
+        # CHECK:     %{{.*}}tile_3_2 = aie.tile(3, 2)
+        # CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
+        # CHECK:     %{{.*}}tile_3_4 = aie.tile(3, 4)
+        # CHECK:     %{{.*}}tile_3_5 = aie.tile(3, 5)
+        # CHECK:     %{{.*}}tile_4_0 = aie.tile(4, 0)
+        # CHECK:     %{{.*}}tile_4_1 = aie.tile(4, 1)
+        # CHECK:     %{{.*}}tile_4_2 = aie.tile(4, 2)
+        # CHECK:     %{{.*}}tile_4_3 = aie.tile(4, 3)
+        # CHECK:     %{{.*}}tile_4_4 = aie.tile(4, 4)
+        # CHECK:     %{{.*}}tile_4_5 = aie.tile(4, 5)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 0, %{{.*}}tile_0_1, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 1, %{{.*}}tile_0_3, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 1, %{{.*}}tile_0_4, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 1, %{{.*}}tile_0_5, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_1_0, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_1_0, DMA : 0, %{{.*}}tile_1_4, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_1_0, DMA : 0, %{{.*}}tile_1_5, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 2, %{{.*}}tile_1_0, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 2, %{{.*}}tile_1_1, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 2, %{{.*}}tile_1_2, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_2_1, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_2_2, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_2_3, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_2_4, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_2_5, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_3_1, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_3_2, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_3_3, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_3_4, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 3, %{{.*}}tile_3_5, DMA : 0)
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_2_1, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_2_2, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_2_3, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_2_4, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_2_5, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_3_1, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_3_2, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_3_3, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_3_4, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
+        # CHECK:     aie.flow(%{{.*}}tile_0_0, DMA : 4, %{{.*}}tile_3_5, DMA : 1) {dest_annot = {alice}, source_annot = {bob}}
         # CHECK:   }
         # CHECK: }
 
@@ -199,12 +199,12 @@ def lshift(module):
         tiles = TileArray()
 
         fls = tiles[2, 1] << tiles[0, [2, 3]]
-        # CHECK: aie.flow(%tile_0_2, DMA : 0, %tile_2_1, DMA : 0)
-        # CHECK: aie.flow(%tile_0_3, DMA : 0, %tile_2_1, DMA : 1)
+        # CHECK: aie.flow(%{{.*}}tile_0_2, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
+        # CHECK: aie.flow(%{{.*}}tile_0_3, DMA : 0, %{{.*}}tile_2_1, DMA : 1)
 
         fls = tiles[2, 1] << tiles[0, [2, 3]]
-        # CHECK: aie.flow(%tile_0_2, DMA : 1, %tile_2_1, DMA : 2)
-        # CHECK: aie.flow(%tile_0_3, DMA : 1, %tile_2_1, DMA : 3)
+        # CHECK: aie.flow(%{{.*}}tile_0_2, DMA : 1, %{{.*}}tile_2_1, DMA : 2)
+        # CHECK: aie.flow(%{{.*}}tile_0_3, DMA : 1, %{{.*}}tile_2_1, DMA : 3)
 
     print(npu)
 
@@ -217,7 +217,7 @@ def locks(module):
         tiles = TileArray()
 
         aie.lock(tiles[0, 1].tile)
-        # CHECK: %lock_0_1 = aie.lock(%tile_0_1)
+        # CHECK: %lock_0_1 = aie.lock(%{{.*}}tile_0_1)
         for l in tiles[0, 1].locks():
             print(l.owner)
 
@@ -226,12 +226,12 @@ def locks(module):
         aie.lock(tiles[0, 3].tile)
         aie.lock(tiles[0, 3].tile, annot="alice")
 
-        # CHECK: %lock_0_2 = aie.lock(%tile_0_2)
-        # CHECK: %lock_0_2_0 = aie.lock(%tile_0_2) {annot = {bob}}
+        # CHECK: %lock_0_2 = aie.lock(%{{.*}}tile_0_2)
+        # CHECK: %lock_0_2_0 = aie.lock(%{{.*}}tile_0_2) {annot = {bob}}
         # for l in tiles[0, 2].locks():
         #     print(l.owner)
 
-        # NOCHECK: %lock_0_2_0 = aie.lock(%tile_0_2) {annot = {bob}}
+        # NOCHECK: %lock_0_2_0 = aie.lock(%{{.*}}tile_0_2) {annot = {bob}}
         assert len(tiles[0, 2].locks(annot="bob"))
         # for l in tiles[0, 2].locks(annot="bob"):
         #     print(l.owner)
@@ -239,7 +239,7 @@ def locks(module):
         assert len(tiles[0, 2].locks(annot="alice")) == 0
 
         assert len(tiles[0, 3].locks(annot="alice")) == 1
-        # CHECK: %lock_0_3_1 = aie.lock(%tile_0_3) {annot = {alice}}
+        # CHECK: %lock_0_3_1 = aie.lock(%{{.*}}tile_0_3) {annot = {alice}}
         # for l in tiles[0, 3].locks(annot="alice"):
         #     print(l.owner)
 
@@ -290,12 +290,12 @@ def channels_basic(module):
             tiles[2, 2].tile, shape=(10, 10), dtype=np.int32, buffer_name="alice"
         )
 
-    # CHECK: %bob = aie.buffer(%tile_2_2) {sym_name = "bob"} : memref<10x10xi32>
-    # CHECK: %bob_producer_lock = aie.lock(%tile_2_2) {sym_name = "bob_producer_lock"}
-    # CHECK: %bob_consumer_lock = aie.lock(%tile_2_2) {sym_name = "bob_consumer_lock"}
-    # CHECK: %alice = aie.buffer(%tile_2_2) {sym_name = "alice"} : memref<10x10xi32>
-    # CHECK: %alice_producer_lock = aie.lock(%tile_2_2) {sym_name = "alice_producer_lock"}
-    # CHECK: %alice_consumer_lock = aie.lock(%tile_2_2) {sym_name = "alice_consumer_lock"}
+    # CHECK: %bob = aie.buffer(%{{.*}}tile_2_2) {sym_name = "bob"} : memref<10x10xi32>
+    # CHECK: %bob_producer_lock = aie.lock(%{{.*}}tile_2_2) {sym_name = "bob_producer_lock"}
+    # CHECK: %bob_consumer_lock = aie.lock(%{{.*}}tile_2_2) {sym_name = "bob_consumer_lock"}
+    # CHECK: %alice = aie.buffer(%{{.*}}tile_2_2) {sym_name = "alice"} : memref<10x10xi32>
+    # CHECK: %alice_producer_lock = aie.lock(%{{.*}}tile_2_2) {sym_name = "alice_producer_lock"}
+    # CHECK: %alice_consumer_lock = aie.lock(%{{.*}}tile_2_2) {sym_name = "alice_consumer_lock"}
     print(npu)
 
     # CHECK-LABEL: test-context-manager
@@ -322,15 +322,15 @@ def channels_basic(module):
                 # CHECK: %30 = "aie.buffer"(%14) <{sym_name = "alice"}> : (index) -> memref<10x10xi32>
                 print(buffer.owner)
 
-    # CHECK: %alice = aie.buffer(%tile_2_2) {sym_name = "alice"} : memref<10x10xi32>
-    # CHECK: %alice_producer_lock = aie.lock(%tile_2_2) {sym_name = "alice_producer_lock"}
-    # CHECK: %alice_consumer_lock = aie.lock(%tile_2_2) {sym_name = "alice_consumer_lock"}
-    # CHECK: %mem_2_2 = aie.mem(%tile_2_2) {
+    # CHECK: %alice = aie.buffer(%{{.*}}tile_2_2) {sym_name = "alice"} : memref<10x10xi32>
+    # CHECK: %alice_producer_lock = aie.lock(%{{.*}}tile_2_2) {sym_name = "alice_producer_lock"}
+    # CHECK: %alice_consumer_lock = aie.lock(%{{.*}}tile_2_2) {sym_name = "alice_consumer_lock"}
+    # CHECK: %mem_2_2 = aie.mem(%{{.*}}tile_2_2) {
     # CHECK:   aie.use_lock(%alice_producer_lock, AcquireGreaterEqual)
     # CHECK:   aie.use_lock(%alice_consumer_lock, Release)
     # CHECK:   aie.end
     # CHECK: }
-    # CHECK: %core_2_2 = aie.core(%tile_2_2) {
+    # CHECK: %core_2_2 = aie.core(%{{.*}}tile_2_2) {
     # CHECK:   aie.use_lock(%alice_consumer_lock, AcquireGreaterEqual)
     # CHECK:   aie.use_lock(%alice_producer_lock, Release)
     # CHECK:   aie.end

--- a/test/python/zero_pad.py
+++ b/test/python/zero_pad.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # RUN: %python %s | FileCheck %s
-# CHECK: aie.objectfifo @out(%tile_0_1 dimensionsToStream [<size = 5, stride = 5>, <size = 5, stride = 5>], {%tile_0_0}, 1 : i32) {padDimensions = #aie<bd_pad_layout_array[<const_pad_before = 2, const_pad_after = 0>, <const_pad_before = 3, const_pad_after = 0>]>} : !aie.objectfifo<memref<56xi32>>
+# CHECK: aie.objectfifo @out(%{{.*}}tile_0_1 dimensionsToStream [<size = 5, stride = 5>, <size = 5, stride = 5>], {%{{.*}}tile_0_0}, 1 : i32) {padDimensions = #aie<bd_pad_layout_array[<const_pad_before = 2, const_pad_after = 0>, <const_pad_before = 3, const_pad_after = 0>]>} : !aie.objectfifo<memref<56xi32>>
 import sys
 
 from aie.dialects.aie import *


### PR DESCRIPTION
Specialize the SSA value names of the tiles according to their real functions to make text assembly clearer, like:
    %tile_1_3 = aie.tile(1, 3)
    %shim_noc_tile_0_0 = aie.tile(0, 0)
    %mem_tile_0_1 = aie.tile(0, 1)