### PR TITLE
[CI] test rollback of setup-cpp action

### DIFF
--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -97,7 +97,7 @@ jobs:
           HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie pip install -r python/requirements_extras.txt
 
       - name: Setup Cpp
-        uses: aminya/setup-cpp@v1
+        uses: aminya/setup-cpp@1fd813945e55021261b381c59275db442da4082f
         with:
           compiler: ${{ matrix.COMPILER }}
           vcvarsall: ${{ contains(matrix.OS, 'windows') }}


### PR DESCRIPTION
Failures like https://github.com/Xilinx/mlir-aie/actions/runs/13007517333/job/36302736888?pr=2026 are caused by a problem with the setup-cpp action. `v1` of that action appears to track `main` and there have been recent breaking changes.  This PR fixes the action to a specific commit to avoid using setup-cpp `main`.

