### PR TITLE
Programming examples small fixes

### DIFF
--- a/programming_examples/basic/vector_scalar_mul/vector_scalar_mul.py
+++ b/programming_examples/basic/vector_scalar_mul/vector_scalar_mul.py
@@ -51,6 +51,7 @@ def my_vector_scalar(dev, vector_size, trace_size):
             scale_fn(elem_in, elem_out, elem_factor, n)
             of_in.release(1)
             of_out.release(1)
+        of_factor.release(1)
 
     # Create a worker to run the task on a compute tile
     worker = Worker(

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -63,7 +63,7 @@ def my_vector_add():
         rt.drain(of_out.cons(), C, wait=True)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(NPU1Col1(), rt).resolve_program(SequentialPlacer())
+    return Program(dev, rt).resolve_program(SequentialPlacer())
 
 
 module = my_vector_add()

--- a/programming_examples/basic/vector_vector_mul/vector_vector_mul.py
+++ b/programming_examples/basic/vector_vector_mul/vector_vector_mul.py
@@ -63,7 +63,7 @@ def my_vector_mul():
         rt.drain(of_out.cons(), C, wait=True)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(NPU1Col1(), rt).resolve_program(SequentialPlacer())
+    return Program(dev, rt).resolve_program(SequentialPlacer())
 
 
 module = my_vector_mul()


### PR DESCRIPTION
While I was working with the programming examples, I found a few bugs in the new versions of designs I had added previously. They were:
* In mat mul single core, overshadowing `A_taps`, `C_taps`
* In `vector_vector_add` and `vector_vector_mul` device is created from user args but is never used.
* In `vector_scalar_mul` new design - do not release an object in one of the ObjectFifos

This PR fixes these bugs.