### PR TITLE
Update downgrade_ir_for_chess after llvm update

### DIFF
--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -384,6 +384,7 @@ def downgrade_ir_for_chess(llvmir_chesslinked):
             "memory(argmem: write, inaccessiblemem: write)",
             "inaccessiblemem_or_argmemonly writeonly",
         )
+        .replace("captures(none)", "nocapture")
     )
     return llvmir_chesslinked
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/123181 replaces `nocapture` with `capture(none)`, which causes a problem for chess, giving errors like:
```
input.llchesshack.ll:74:52: error: expected ')' at end of argument list
declare <8 x float> @llvm.masked.load.v8f32.p0(ptr captures(none), i32 immarg, <8 x i1>, <8 x float>) #1
                                                   ^
```
For example https://github.com/Xilinx/mlir-aie/actions/runs/13077904662/job/36494451051