### PR TITLE
Allow IRON users to bypass Vitis installation step for XDNA1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
        ```bash
        cd $XDNA_SRC_DIR/xrt/build/Release
-       sudo apt reinstall ./xrt_202510.2.19.0_22.04-amd64-npu.deb
+       sudo apt reinstall ./xrt_202510.2.19.0_24.10-amd64-npu.deb
        ```
 
        > **An error might occur during this proces.** If so, do the following steps.
@@ -122,9 +122,9 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
        ```bash
        cd $XDNA_SRC_DIR/xrt/build/Release
        sudo apt remove xrt-npu
-       sudo dpkg -i --force-overwrite ./xrt_202510.2.19.0_22.04-amd64-npu.deb
+       sudo dpkg -i --force-overwrite ./xrt_202510.2.19.0_24.10-amd64-npu.deb
        sudo apt -f install
-       sudo apt reinstall ./xrt_202510.2.19.0_22.04-amd64-npu.deb
+       sudo apt reinstall ./xrt_202510.2.19.0_24.10-amd64-npu.deb
        ```      
 
 1. Build XDNA-Driver. Below steps are adapted from [here](https://github.com/amd/xdna-driver).
@@ -139,7 +139,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
     ```bash
     cd $XDNA_SRC_DIR/build/Release
-    sudo apt reinstall ./xrt_plugin.2.19.0_ubuntu22.04-x86_64-amdxdna.deb
+    sudo apt reinstall ./xrt_plugin.2.19.0_ubuntu24.10-x86_64-amdxdna.deb
     ```
     
 1. Check that the NPU is working if the device appears with xrt-smi:
@@ -175,7 +175,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
    sudo apt install libopencv-dev python3-opencv
    ```
 
-1. Remember to source the Vitis™ AIE Essentials setup script from [above](#install-aietools).
+1. Remember to source the Vitis™ AIE Essentials setup script, if required, from [above](#install-aietools).
    
 1. Remember to source the XRT setup script: `source /opt/xilinx/xrt/setup.sh`
 
@@ -192,13 +192,13 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
 ## Build an IRON Design for AIEs in the AMD Ryzen™ AI NPU
 
-> Remember to set up your environment including Vitis™ AIE Essentials, your license, XRT, and IRON
+> Remember to set up your environment including IRON, and XRT, (and if required Vitis™ AIE Essentials, and your license)
 > ```
->   source yourVitisSetupScript.sh
->   export LM_LICENSE_FILE=/opt/Xilinx.lic
 >   source /opt/xilinx/xrt/setup.sh
 >   source ironenv/bin/activate
 >   source utils/env_setup.sh my_install/mlir_aie my_install/mlir my_install/llvm-aie
+>   source yourVitisSetupScript.sh
+>   export LM_LICENSE_FILE=/opt/Xilinx.lic
 > ```
 
 For your design of interest, for instance from [programming_examples](../programming_examples/), 2 steps are needed: (i) build the AIE design and then (ii) build the host code.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
 #### Supporting AMD Ryzen™ AI with AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P): Install AMD Vitis™ AIE Essentials 
 
+> You may skip the Vitis™ installation step, and proceed to [Install the XDNA™ Driver](#install-the-xdna-driver), if you intend to only target AMD XDNA™/AIE-ML (AIE2) using our open-source single core compiler [Peano](https://github.com/Xilinx/llvm-aie). AMD XDNA™ 2 (AIE2P) is not currently supported without installing AMD Vitis™ AIE Essentials. 
+
 1. Install Vitis™ AIE Essentials from [Ryzen AI Software 1.3 Early Accesss](https://account.amd.com/en/member/ryzenai-sw-ea.html#tabs-a5e122f973-item-4757898120-tab). We will assume you use the installation directory, `/tools/ryzen_ai-1.3.0/vitis_aie_essentials`.
 
    > This is an early access lounge, you must register and be granted access at this time.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
 ### Install AIETools
 
-#### Supporting AMD Ryzen™ AI with AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P): Install AMD Vitis™ AIE Essentials 
+> You may skip the Vitis™ installation step, and proceed to step: [Install the XDNA™ Driver](#install-the-xdna-driver), if you intend to only target AMD XDNA™/AIE-ML (AIE2) using our open-source single-core compiler [Peano](https://github.com/Xilinx/llvm-aie). AMD XDNA™ 2 (AIE2P) is not currently supported without installing AMD Vitis™ AIE Essentials. 
 
-> You may skip the Vitis™ installation step, and proceed to [Install the XDNA™ Driver](#install-the-xdna-driver), if you intend to only target AMD XDNA™/AIE-ML (AIE2) using our open-source single core compiler [Peano](https://github.com/Xilinx/llvm-aie). AMD XDNA™ 2 (AIE2P) is not currently supported without installing AMD Vitis™ AIE Essentials. 
+#### Supporting AMD Ryzen™ AI with AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P): Install AMD Vitis™ AIE Essentials 
 
 1. Install Vitis™ AIE Essentials from [Ryzen AI Software 1.3 Early Accesss](https://account.amd.com/en/member/ryzenai-sw-ea.html#tabs-a5e122f973-item-4757898120-tab). We will assume you use the installation directory, `/tools/ryzen_ai-1.3.0/vitis_aie_essentials`.
 

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -53,49 +53,51 @@ rm -rf my_install
 $my_python -m venv ironenv
 source ironenv/bin/activate
 python3 -m pip install --upgrade pip
+mkdir -p my_install
+pushd my_install
+pip download mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
+unzip -q mlir_aie-*_x86_64.whl
+pushd mlir_aie/python
+pip download aie_python_bindings -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
+unzip -q -o aie_python_bindings*.whl
+rm *.whl
+popd
+pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
+unzip -q mlir-*_x86_64.whl
+pip -q download llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+unzip -q llvm_aie*.whl
+rm -rf mlir*.whl
+rm -rf llvm_aie*.whl
+export PEANO_INSTALL_DIR=`realpath llvm-aie`
+popd
+python3 -m pip install -r python/requirements.txt
+
+# This installs the pre-commit hooks defined in .pre-commit-config.yaml
+pre-commit install
+
+HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r python/requirements_extras.txt
+python3 -m pip install -r python/requirements_ml.txt
+source utils/env_setup.sh my_install/mlir_aie my_install/mlir
+
+# This creates an ipykernel (for use in notebooks) using the ironenv venv
+python3 -m ipykernel install --user --name ironenv
+
+# right now, mlir-aie install dire is generally captures in the $PYTHONPATH by the setup_env script.
+# However, jupyter notebooks don't always get access to the PYTHONPATH (e.g. if they are run with
+# vscode) so we save the ${MLIR_AIE_INSTALL_DIR}/python in a .pth file in the site packages dir of the
+# ironenv venv; this allows the iron ipykernel to find the install dir regardless of if PYTHONPATH is
+# available or not.
+venv_site_packages=`python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'`
+echo ${MLIR_AIE_INSTALL_DIR}/python > $venv_site_packages/mlir-aie.pth
+
+pushd programming_examples
+echo "PATH              : $PATH"
+echo "LD_LIBRARY_PATH   : $LD_LIBRARY_PATH"
+echo "PYTHONPATH        : $PYTHONPATH"
 VPP=`which xchesscc`
 if test -f "$VPP"; then
-  mkdir -p my_install
-  pushd my_install
-  pip download mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
-  unzip -q mlir_aie-*_x86_64.whl
-  pushd mlir_aie/python
-  pip download aie_python_bindings -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels/
-  unzip -q -o aie_python_bindings*.whl
-  rm *.whl
-  popd
-  pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
-  unzip -q mlir-*_x86_64.whl
-  pip -q download llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-  unzip -q llvm_aie*.whl
-  rm -rf mlir*.whl
-  rm -rf llvm_aie*.whl
-  export PEANO_INSTALL_DIR=`realpath llvm-aie`
-  popd
-  python3 -m pip install -r python/requirements.txt
-
-  # This installs the pre-commit hooks defined in .pre-commit-config.yaml
-  pre-commit install
-
-  HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r python/requirements_extras.txt
-  python3 -m pip install -r python/requirements_ml.txt
-  source utils/env_setup.sh my_install/mlir_aie my_install/mlir
-
-  # This creates an ipykernel (for use in notebooks) using the ironenv venv
-  python3 -m ipykernel install --user --name ironenv
-
-  # right now, mlir-aie install dire is generally captures in the $PYTHONPATH by the setup_env script.
-  # However, jupyter notebooks don't always get access to the PYTHONPATH (e.g. if they are run with
-  # vscode) so we save the ${MLIR_AIE_INSTALL_DIR}/python in a .pth file in the site packages dir of the
-  # ironenv venv; this allows the iron ipykernel to find the install dir regardless of if PYTHONPATH is
-  # available or not.
-  venv_site_packages=`python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])'`
-  echo ${MLIR_AIE_INSTALL_DIR}/python > $venv_site_packages/mlir-aie.pth
-
-  pushd programming_examples
-  echo "PATH              : $PATH"
-  echo "LD_LIBRARY_PATH   : $LD_LIBRARY_PATH"
-  echo "PYTHONPATH        : $PYTHONPATH"
+  echo "Vitis Found     : $VPP"
 else
-  echo "Vitis not found! Exiting..."
+  echo "Warning: Strix Point XDNA2 NPUs are NOT currently supported without a Vitis installation."
 fi
+


### PR DESCRIPTION
Modifies the `quick_setup.sh` script to not require Vitis before installing the rest of the tools, instead printing a warning that it was not found in the user's environment. This allows developers to use IRON without Vitis to target XDNA1/AIE-ML parts using Peano as the single-core compiler.