### PR TITLE
In python bindings, make runtime_sequence take the sym_name of the python function by default

### DIFF
--- a/test/python/aiex_ops.py
+++ b/test/python/aiex_ops.py
@@ -3,7 +3,8 @@
 
 # RUN: %PYTHON %s | FileCheck %s
 
-from aie.dialects.aiex import GetTileOp
+from aie.dialects.aiex import *
+from aie.dialects.aie import device, AIEDevice
 from aie.extras.dialects.ext import arith
 from aie.extras import types as T
 from util import construct_and_print_module
@@ -16,3 +17,17 @@ def getTileOp():
     four = arith.constant(4, index=True)
     two = arith.constant(2, index=True)
     GetTileOp(T.index(), four, two)
+
+# CHECK-LABEL: runtimeSeq
+# CHECK: aiex.runtime_sequence @sequence0()
+# CHECK: aiex.runtime_sequence @seq1()
+@construct_and_print_module
+def runtimeSeq():
+    @device(AIEDevice.npu1_4col)
+    def device_body():
+        @runtime_sequence()
+        def sequence0():
+            npu_write32(0xffff, 0xeeee)
+        @runtime_sequence(sym_name="seq1")
+        def sequence1():
+            npu_write32(0x1111, 0x2222)


### PR DESCRIPTION
Given a runtime sequence like this,
```python
@runtime_sequence()
def sequence0():
    ...
```
The emitted MLIR will be:
```mlir
// new behavior
aiex.runtime_sequence @sequence0() {
```
instead of,
```mlir
// old behavior
aiex.runtime_sequence() {
```
Override of the name is also allowed, so this,
```python
@runtime_sequence(sym_name="foobar")
def sequence1():
    ...
```
will generate,
```mlir
aiex.runtime_sequence @foobar()
```