### PR TITLE
Rename aie-translate's aie-npu-instgen flag to aie-npu-to-binary be more descriptive 

### DIFF
--- a/include/aie-c/Translation.h
+++ b/include/aie-c/Translation.h
@@ -21,7 +21,7 @@ extern "C" {
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateAIEVecToCpp(MlirOperation op,
                                                          bool aie2);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateModuleToLLVMIR(MlirOperation op);
-MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToNPU(MlirOperation op);
+MLIR_CAPI_EXPORTED MlirStringRef aieTranslateNpuToBinary(MlirOperation op, MlirStringRef name);
 MLIR_CAPI_EXPORTED MlirStringRef
 aieTranslateControlPacketsToUI32Vec(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToXAIEV2(MlirOperation op);

--- a/include/aie-c/Translation.h
+++ b/include/aie-c/Translation.h
@@ -21,7 +21,8 @@ extern "C" {
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateAIEVecToCpp(MlirOperation op,
                                                          bool aie2);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateModuleToLLVMIR(MlirOperation op);
-MLIR_CAPI_EXPORTED MlirStringRef aieTranslateNpuToBinary(MlirOperation op, MlirStringRef name);
+MLIR_CAPI_EXPORTED MlirStringRef aieTranslateNpuToBinary(MlirOperation op,
+                                                         MlirStringRef name);
 MLIR_CAPI_EXPORTED MlirStringRef
 aieTranslateControlPacketsToUI32Vec(MlirOperation op);
 MLIR_CAPI_EXPORTED MlirStringRef aieTranslateToXAIEV2(MlirOperation op);

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -35,10 +35,11 @@ mlir::LogicalResult AIETranslateShimSolution(mlir::ModuleOp module,
 mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
                                          llvm::raw_ostream &);
 mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp module,
-                                      llvm::raw_ostream &output,
-                                      llvm::StringRef sequenceName = "");
-mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp, std::vector<uint32_t> &,
-                                      llvm::StringRef sequenceName = "");
+                                            llvm::raw_ostream &output,
+                                            llvm::StringRef sequenceName = "");
+mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp,
+                                            std::vector<uint32_t> &,
+                                            llvm::StringRef sequenceName = "");
 mlir::LogicalResult
 AIETranslateControlPacketsToUI32Vec(mlir::ModuleOp module,
                                     llvm::raw_ostream &output,

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -34,10 +34,10 @@ mlir::LogicalResult AIETranslateShimSolution(mlir::ModuleOp module,
                                              llvm::raw_ostream &);
 mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
                                          llvm::raw_ostream &);
-mlir::LogicalResult AIETranslateToNPU(mlir::ModuleOp module,
+mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp module,
                                       llvm::raw_ostream &output,
                                       llvm::StringRef sequenceName = "");
-mlir::LogicalResult AIETranslateToNPU(mlir::ModuleOp, std::vector<uint32_t> &,
+mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp, std::vector<uint32_t> &,
                                       llvm::StringRef sequenceName = "");
 mlir::LogicalResult
 AIETranslateControlPacketsToUI32Vec(mlir::ModuleOp module,

--- a/lib/CAPI/Translation.cpp
+++ b/lib/CAPI/Translation.cpp
@@ -93,7 +93,7 @@ MlirOperation aieTranslateBinaryToTxn(MlirContext ctx, MlirStringRef binary) {
 }
 
 MlirStringRef aieTranslateNpuToBinary(MlirOperation moduleOp,
-                                MlirStringRef sequenceName) {
+                                      MlirStringRef sequenceName) {
   std::string npu;
   llvm::raw_string_ostream os(npu);
   ModuleOp mod = llvm::cast<ModuleOp>(unwrap(moduleOp));

--- a/lib/CAPI/Translation.cpp
+++ b/lib/CAPI/Translation.cpp
@@ -92,11 +92,13 @@ MlirOperation aieTranslateBinaryToTxn(MlirContext ctx, MlirStringRef binary) {
   return wrap(mod->getOperation());
 }
 
-MlirStringRef aieTranslateToNPU(MlirOperation moduleOp) {
+MlirStringRef aieTranslateNpuToBinary(MlirOperation moduleOp,
+                                MlirStringRef sequenceName) {
   std::string npu;
   llvm::raw_string_ostream os(npu);
   ModuleOp mod = llvm::cast<ModuleOp>(unwrap(moduleOp));
-  if (failed(AIETranslateToNPU(mod, os)))
+  llvm::StringRef name(sequenceName.data, sequenceName.length);
+  if (failed(AIETranslateNpuToBinary(mod, os, name)))
     return mlirStringRefCreate(nullptr, 0);
   char *cStr = static_cast<char *>(malloc(npu.size()));
   npu.copy(cStr, npu.size());

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -187,8 +187,8 @@ void appendBlockWrite(std::vector<uint32_t> &instructions, NpuBlockWriteOp op) {
 
 LogicalResult
 xilinx::AIE::AIETranslateNpuToBinary(ModuleOp module,
-                               std::vector<uint32_t> &instructions,
-                               StringRef sequenceName) {
+                                     std::vector<uint32_t> &instructions,
+                                     StringRef sequenceName) {
 
   auto words = reserveAndGetTail(instructions, 4);
 
@@ -243,8 +243,8 @@ xilinx::AIE::AIETranslateNpuToBinary(ModuleOp module,
 }
 
 LogicalResult xilinx::AIE::AIETranslateNpuToBinary(ModuleOp module,
-                                             raw_ostream &output,
-                                             StringRef sequenceName) {
+                                                   raw_ostream &output,
+                                                   StringRef sequenceName) {
   std::vector<uint32_t> instructions;
   auto r = AIETranslateNpuToBinary(module, instructions, sequenceName);
   if (failed(r))

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -186,7 +186,7 @@ void appendBlockWrite(std::vector<uint32_t> &instructions, NpuBlockWriteOp op) {
 } // namespace
 
 LogicalResult
-xilinx::AIE::AIETranslateToNPU(ModuleOp module,
+xilinx::AIE::AIETranslateNpuToBinary(ModuleOp module,
                                std::vector<uint32_t> &instructions,
                                StringRef sequenceName) {
 
@@ -242,11 +242,11 @@ xilinx::AIE::AIETranslateToNPU(ModuleOp module,
   return success();
 }
 
-LogicalResult xilinx::AIE::AIETranslateToNPU(ModuleOp module,
+LogicalResult xilinx::AIE::AIETranslateNpuToBinary(ModuleOp module,
                                              raw_ostream &output,
                                              StringRef sequenceName) {
   std::vector<uint32_t> instructions;
-  auto r = AIETranslateToNPU(module, instructions, sequenceName);
+  auto r = AIETranslateNpuToBinary(module, instructions, sequenceName);
   if (failed(r))
     return r;
   for (auto w : instructions)

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -157,7 +157,7 @@ void registerAIETranslations() {
       "aie-output-binary", llvm::cl::init(false),
       llvm::cl::desc(
           "Select binary (true) or text (false) output for supported "
-          "translations. e.g. aie-npu-instgen, aie-ctrlpkt-to-bin"));
+          "translations. e.g. aie-npu-to-binary, aie-ctrlpkt-to-bin"));
 
   static llvm::cl::opt<std::string> sequenceName(
       "aie-sequence-name", llvm::cl::init(""),
@@ -344,18 +344,18 @@ void registerAIETranslations() {
       },
       registerDialects);
   TranslateFromMLIRRegistration registrationNPU(
-      "aie-npu-instgen", "Translate npu instructions to binary",
+      "aie-npu-to-binary", "Translate npu instructions to binary",
       [](ModuleOp module, raw_ostream &output) {
         if (outputBinary == true) {
           std::vector<uint32_t> instructions;
-          auto r = AIETranslateToNPU(module, instructions, sequenceName);
+          auto r = AIETranslateNpuToBinary(module, instructions, sequenceName);
           if (failed(r))
             return r;
           output.write(reinterpret_cast<const char *>(instructions.data()),
                        instructions.size() * sizeof(uint32_t));
           return success();
         }
-        return AIETranslateToNPU(module, output, sequenceName);
+        return AIETranslateNpuToBinary(module, output, sequenceName);
       },
       registerDialects);
   TranslateFromMLIRRegistration registrationCtrlPkt(

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -132,7 +132,7 @@ NB_MODULE(_aie, m) {
           individualInstructions[i] = individualInstructions[i].attr("strip")();
         return individualInstructions;
       },
-      "module"_a, "sequence_name"_a);
+      "module"_a, "sequence_name"_a = "");
 
   m.def(
       "generate_control_packets",

--- a/python/AIEMLIRModule.cpp
+++ b/python/AIEMLIRModule.cpp
@@ -122,16 +122,17 @@ NB_MODULE(_aie, m) {
       "ctx"_a, "binary"_a);
 
   m.def(
-      "npu_instgen",
-      [&stealCStr](MlirOperation op) {
-        nb::str npuInstructions = stealCStr(aieTranslateToNPU(op));
+      "translate_npu_to_binary",
+      [&stealCStr](MlirOperation op, const std::string &sequence_name) {
+        nb::str npuInstructions = stealCStr(aieTranslateNpuToBinary(
+            op, {sequence_name.data(), sequence_name.size()}));
         auto individualInstructions =
             nb::cast<nb::list>(npuInstructions.attr("split")());
         for (size_t i = 0; i < individualInstructions.size(); ++i)
           individualInstructions[i] = individualInstructions[i].attr("strip")();
         return individualInstructions;
       },
-      "module"_a);
+      "module"_a, "sequence_name"_a);
 
   m.def(
       "generate_control_packets",

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1121,22 +1121,22 @@ class FlowRunner:
                         await read_file_async(file_with_addresses)
                     )
                     pass_pipeline = NPU_LOWERING_PIPELINE.materialize(module=True)
-                    generated_npu_insts_file = (
+                    npu_insts_file = (
                         self.prepend_tmp("npu_insts.mlir")
                         if self.opts.verbose
                         else None
                     )
-                    generated_insts_mlir_module = run_passes_module(
+                    npu_insts_module = run_passes_module(
                         pass_pipeline,
                         file_with_addresses_module,
-                        generated_npu_insts_file,
+                        npu_insts_file,
                         self.opts.verbose,
                     )
-                    insts = aiedialect.translate_npu_to_binary(
-                        generated_insts_mlir_module.operation
+                    npu_insts = aiedialect.translate_npu_to_binary(
+                        npu_insts_module.operation
                     )
                     with open(opts.insts_name, "w") as f:
-                        for inst in insts:
+                        for inst in npu_insts:
                             f.write(f"{inst}\n")
                 if opts.only_npu:
                     return

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1116,11 +1116,14 @@ class FlowRunner:
                 # read file_with_addresses as mlir module
                 with Context(), Location.unknown():
                     file_with_addresses_module = Module.parse(
-                        await read_file_async(file_with_addresses)
+                        await read_file_async(generated_insts_mlir)
                     )
-                    bin = aiedialect.translate_npu_to_binary(file_with_addresses_module)
+                    insts = aiedialect.translate_npu_to_binary(
+                        file_with_addresses_module.operation
+                    )
                     with open(opts.insts_name, "w") as f:
-                        f.write(bin)
+                        for inst in insts:
+                            f.write(f"{inst}\n")
                 if opts.only_npu:
                     return
 

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1113,16 +1113,14 @@ class FlowRunner:
                         generated_insts_mlir,
                     ],
                 )
-                await self.do_call(
-                    progress_bar.task,
-                    [
-                        "aie-translate",
-                        "--aie-npu-instgen",
-                        generated_insts_mlir,
-                        "-o",
-                        opts.insts_name,
-                    ],
-                )
+                # read file_with_addresses as mlir module
+                with Context(), Location.unknown():
+                    file_with_addresses_module = Module.parse(
+                        await read_file_async(file_with_addresses)
+                    )
+                    bin = aiedialect.translate_npu_to_binary(file_with_addresses_module)
+                    with open(opts.insts_name, "w") as f:
+                        f.write(bin)
                 if opts.only_npu:
                     return
 

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -33,7 +33,7 @@ from .._mlir_libs._aie import (
     generate_cdo,
     generate_xaie,
     generate_control_packets,
-    npu_instgen,
+    translate_npu_to_binary,
     register_dialect,
     translate_aie_vec_to_cpp,
     translate_mlir_to_llvmir,

--- a/test/Targets/NPU/npu_blockwrite_instgen.mlir
+++ b/test/Targets/NPU/npu_blockwrite_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-dma-to-npu %s | aie-translate --aie-npu-instgen | FileCheck %s
+// RUN: aie-opt --aie-dma-to-npu %s | aie-translate --aie-npu-to-binary | FileCheck %s
 module {
   aie.device(npu1_4col) {
     aiex.runtime_sequence(%arg0: memref<16xf32>, %arg1: memref<16xf32>) {

--- a/test/Targets/NPU/npu_instgen.mlir
+++ b/test/Targets/NPU/npu_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-npu-instgen %s | FileCheck %s
+// RUN: aie-translate --aie-npu-to-binary %s | FileCheck %s
 module {
   aie.device(npu1) {
     memref.global "private" constant @write_data : memref<8xi32> = dense<[100, 101, 102, 103, 104 ,105, 106, 107]>

--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -93,6 +93,18 @@ module {
     %02 = aie.tile(0, 2)
     %12 = aie.tile(1, 2)
     %22 = aie.tile(2, 2)
+    memref.global "public" @in0 : memref<1024xi32>
+    memref.global "public" @in1 : memref<1024xi32>
+    memref.global "public" @in2 : memref<1024xi32>
+    memref.global "public" @out0 : memref<1024xi32>
+    memref.global "public" @out1 : memref<1024xi32>
+    memref.global "public" @out2 : memref<1024xi32>
+    aie.shim_dma_allocation @in0 (S2MM, 0, 0)
+    aie.shim_dma_allocation @in1(S2MM, 1, 0)
+    aie.shim_dma_allocation @in2(S2MM, 2, 0)
+    aie.shim_dma_allocation @out0(MM2S, 0, 0)
+    aie.shim_dma_allocation @out1(MM2S, 1, 0)
+    aie.shim_dma_allocation @out2(MM2S, 2, 0)
     aiex.runtime_sequence(%arg0: memref<1024xi32>, %arg1: memref<1024xi32>, %arg2: memref<1024xi32>, %arg3: memref<1024xi32>, %arg4: memref<1024xi32>, %arg5: memref<1024xi32>) {
       aiex.npu.dma_memcpy_nd (0, 0, %arg0[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 0 : i64, metadata = @in0} : memref<1024xi32>
       aiex.npu.dma_memcpy_nd (0, 0, %arg1[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 1 : i64, metadata = @out0} : memref<1024xi32>

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -6,5 +6,5 @@
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.txt %S/aie1.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-txn --aie-generate-npu --no-compile-host --npu-insts-name=add_two_insts.txt %S/aie2.mlir
-// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true -aie-sequence-name=configure aie2.mlir.prj/txn.mlir -o add_two_cfg.bin
+// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true -aie-sequence-name=configure aie2.mlir.prj/txn.mlir -o add_two_cfg.bin
 // RUN: %run_on_npu ./test.exe -x add_one.xclbin -i add_one_insts.txt -c add_two_cfg.bin -j add_two_insts.txt

--- a/test/npu-xrt/ctrl_packet_reconfig/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig/run.lit
@@ -12,7 +12,7 @@
 // RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
 //
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-instgen -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
@@ -12,7 +12,7 @@
 // RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
 //
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-instgen -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
@@ -12,7 +12,7 @@
 // RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
 //
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-instgen -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe

--- a/test/txn2mlir/roundtrip_npu1_1col.mlir
+++ b/test/txn2mlir/roundtrip_npu1_1col.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true %s -o ./roundtrip_npu1_1col_cfg.bin
+// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true %s -o ./roundtrip_npu1_1col_cfg.bin
 // RUN: %python txn2mlir.py -f ./roundtrip_npu1_1col_cfg.bin | FileCheck %s
 
 // CHECK: aie.device(npu1_1col)

--- a/test/txn2mlir/roundtrip_npu1_4col.mlir
+++ b/test/txn2mlir/roundtrip_npu1_4col.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate -aie-npu-instgen -aie-output-binary=true %s -o ./roundtrip_npu1_4col_cfg.bin
+// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true %s -o ./roundtrip_npu1_4col_cfg.bin
 // RUN: %python txn2mlir.py -f ./roundtrip_npu1_4col_cfg.bin | FileCheck %s
 
 // CHECK: aie.device(npu1_4col)


### PR DESCRIPTION
* Rename the `aie-translate` flag `aie-npu-instgen` to `aie-npu-to-binary` to better reflect what it does, which is to translate `aiex.npu.*` ops to their binary representation. At the same time rename the related internal APIs from `AIETranslateToNPU` to `AIETranslateNpuToBinary`.  NFC for this part.

* Rename the corresponding python binding from `npu_instgen` to `translate_npu_to_binary` and use it in aiecc instead of running `aie-translate`.

* Add sequence name parameter to `translate_npu_to_binary` to specify which `runtime_sequence` to translate. This just exposes to python the functionality already present in the underlying C++ and already usable with `aie-translate --aie-npu-instgen --aie-sequence-name=<string> ...`
