### PR TITLE
Add support for unranked memref in `aiex.npu.dma_memcpy_nd`

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -559,7 +559,7 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
   let arguments = (
     ins I64Attr:$x,
         I64Attr:$y,
-        AnyMemRef:$memref,
+        AnyRankedOrUnrankedMemRef:$memref,
         // NOTE: these are in reverse order: offset3, offset2, ...
         Variadic<I64>:$offsets,
         Variadic<I64>:$sizes,

--- a/include/aie/Dialect/AIEX/IR/AIEXDialect.h
+++ b/include/aie/Dialect/AIEX/IR/AIEXDialect.h
@@ -27,15 +27,15 @@ namespace AIEX {
 uint64_t getBufferDescriptorAddressRegisterAddress(
     const AIE::AIETargetModel &tm, unsigned bd_id, unsigned col, unsigned row);
 void getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
-                             mlir::MemRefType referencedBufType,
+                             mlir::BaseMemRefType referencedBufType,
                              llvm::SmallVector<int64_t, 4> inputSizes,
                              llvm::SmallVector<int64_t, 4> inputStrides,
                              llvm::SmallVector<int64_t, 4> &sizes,
                              llvm::SmallVector<int64_t, 4> &strides);
 mlir::LogicalResult
-verifyStridesWraps(mlir::Operation *forOp, mlir::MemRefType referencedBufType,
-                   int tileCol, int tileRow,
-                   llvm::SmallVector<int64_t, 4> inputSizes,
+verifyStridesWraps(mlir::Operation *forOp,
+                   mlir::BaseMemRefType referencedBufType, int tileCol,
+                   int tileRow, llvm::SmallVector<int64_t, 4> inputSizes,
                    llvm::SmallVector<int64_t, 4> inputStrides,
                    llvm::SmallVector<int64_t, 4> hardwareSizes,
                    llvm::SmallVector<int64_t, 4> hardwareStrides,

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -77,7 +77,7 @@ uint64_t AIEX::getBufferDescriptorAddressRegisterAddress(
   hardware does not support a 0 stride (repeat).
   */
 void AIEX::getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
-                                   mlir::MemRefType referencedBufType,
+                                   mlir::BaseMemRefType referencedBufType,
                                    llvm::SmallVector<int64_t, 4> inputSizes,
                                    llvm::SmallVector<int64_t, 4> inputStrides,
                                    llvm::SmallVector<int64_t, 4> &sizes,
@@ -146,7 +146,7 @@ void AIEX::getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
 
 mlir::LogicalResult
 AIEX::verifyStridesWraps(mlir::Operation *forOp,
-                         mlir::MemRefType referencedBufType, int tileCol,
+                         mlir::BaseMemRefType referencedBufType, int tileCol,
                          int tileRow, llvm::SmallVector<int64_t, 4> inputSizes,
                          llvm::SmallVector<int64_t, 4> inputStrides,
                          llvm::SmallVector<int64_t, 4> hardwareSizes,
@@ -307,7 +307,7 @@ int64_t AIEX::NpuDmaMemcpyNdOp::getOffsetInBytes() {
         return getConstantIntValue(s).value();
       });
   size_t offset = 0;
-  MemRefType my_memref = getMemref().getType();
+  BaseMemRefType my_memref = getMemref().getType();
   size_t R = offsets.size();
   size_t el_bit_width = my_memref.getElementTypeBitWidth();
   assert(el_bit_width % 8 == 0 &&
@@ -336,7 +336,7 @@ bool AIEX::NpuDmaMemcpyNdOp::isLinearTransferWithoutTransformation() {
 }
 
 LogicalResult AIEX::NpuDmaMemcpyNdOp::verify() {
-  MemRefType buffer = getMemref().getType();
+  BaseMemRefType buffer = getMemref().getType();
   const auto &targetModel = AIE::getTargetModel(*this);
   auto addressGranularity = targetModel.getAddressGenGranularity();
 

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -285,7 +285,7 @@ public:
   matchAndRewrite(NpuDmaMemcpyNdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     const auto &targetModel = AIE::getTargetModel(op);
-    MemRefType bufferType = op.getMemref().getType();
+    BaseMemRefType bufferType = op.getMemref().getType();
     auto *ctx = op->getContext();
     auto i32ty = IntegerType::get(ctx, 32);
     auto zero = IntegerAttr::get(i32ty, 0);

--- a/lib/Targets/AIETargetHSA.cpp
+++ b/lib/Targets/AIETargetHSA.cpp
@@ -142,7 +142,7 @@ mlir::LogicalResult AIETranslateToHSA(ModuleOp module, raw_ostream &output) {
     // buffer_offset
     size_t stride = 1;
     size_t offset = 0;
-    MemRefType my_memref = op.getMemref().getType();
+    BaseMemRefType my_memref = op.getMemref().getType();
     auto shape = my_memref.getShape();
     size_t R = shape.size();
     size_t el_bit_width = my_memref.getElementTypeBitWidth();


### PR DESCRIPTION
Previously, this op requires the memref to have type `MemRefType`. This type, however, actually strictly means ranked memref; unranked memref's type is called `UnrankedMemRefType`.

The `aiex.npu.dma_memcpy_nd` which is a host-to-device dma memcpy op, should work regardless of whether the memref is ranked or unranked---in fact the memref shape is irrelevant and only the memory pointer and element type matter.

This PR attempts to support unranked memref by changing some type castings from `MemRefType` to `BaseMemRefType`, which is the base type to both ranked and unranked memref type.