### PR TITLE
Quick install script cleanups

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -155,12 +155,16 @@ jobs:
           # quick_setup changes directory to programming_examples, so we need to return to mlir-aie
           cd ..
 
+          VERSION=$(utils/clone-llvm.sh --get-wheel-version)
+          pip -q download mlir==$VERSION \
+            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
+          unzip -q mlir-*.whl
           # I have no clue why but the system clock on GHA containers is like 12 hours ahead.
           # That means wheels have file with time stamps in the future which makes ninja loop
           # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
-          find my_install/mlir -exec touch -a -m -t 201108231405.14 {} \;
+          find mlir -exec touch -a -m -t 201108231405.14 {} \;
 
-          ./utils/build-mlir-aie-from-wheels.sh ./my_install/mlir build install ./my_install/llvm-aie
+          ./utils/build-mlir-aie-from-wheels.sh ./mlir build install ${PEANO_INSTALL_DIR} 
 
           # build is created by the build-mlir-aie-from-wheels.sh script
           pushd build

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
    ```
 
 1. Source `utils/quick_setup.sh` to setup the prerequisites and
-   install the mlir-aie and llvm compiler tools from whls.
+   install the mlir-aie compiler tools from whls.
 
 ## Build an IRON Design for AIEs in the AMD Ryzen™ AI NPU
 
@@ -196,7 +196,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 > ```
 >   source /opt/xilinx/xrt/setup.sh
 >   source ironenv/bin/activate
->   source utils/env_setup.sh my_install/mlir_aie my_install/mlir my_install/llvm-aie
+>   source utils/env_setup.sh my_install/mlir_aie  
 >   source yourVitisSetupScript.sh
 >   export LM_LICENSE_FILE=/opt/Xilinx.lic
 > ```

--- a/docs/buildHostLin.md
+++ b/docs/buildHostLin.md
@@ -89,7 +89,7 @@ You will...
         export LM_LICENSE_FILE=/opt/Xilinx.lic
        ```
       
-#### Option B - Supporting AMD Ryzen™ AI and AMD Versal™ with AIE and AIE-ML/XDNA™ (AIE2): Install AMD Vitis™ 2023.2 
+#### Option B - Supporting AMD Ryzen™ AI and AMD Versal™ with AIE and AIE-ML/XDNA™ (AIE2): Install AMD Vitis™ 2024.2 
 
 1. Install Vitis™ under from [Xilinx Downloads](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vitis.html). You will need to run the installer as root. We will assume you use the default installation directory, `/tools/Xilinx`.
 
@@ -108,7 +108,7 @@ You will...
         #################################################################################
         # Setup Vitis (which is just for aietools)
         #################################################################################
-        export MYXILINX_VER=2023.2
+        export MYXILINX_VER=2024.2
         export MYXILINX_BASE=/tools/Xilinx
         export XILINX_LOC=$MYXILINX_BASE/Vitis/$MYXILINX_VER
         export AIETOOLS_ROOT=$XILINX_LOC/aietools
@@ -332,7 +332,7 @@ You will...
    ````
 
 1. Source `utils/quick_setup.sh` to setup the prerequisites and
-   install the mlir-aie and llvm compiler tools from whls.
+   install the mlir-aie compiler tools from whls.
 
 1. Jump ahead to [Build Device AIE Part](#build-device-aie-part) step 2 below.
 
@@ -361,7 +361,7 @@ export PATH="${NEW_CMAKE_DIR}/bin":"${PATH}"
 
 cd ${MLIR_AIE_BUILD_DIR}
 source ${MLIR_AIE_BUILD_DIR}/ironenv/bin/activate
-source ${MLIR_AIE_BUILD_DIR}/utils/env_setup.sh ${MLIR_AIE_BUILD_DIR}/my_install/mlir_aie ${MLIR_AIE_BUILD_DIR}/my_install/mlir ${MLIR_AIE_BUILD_DIR}/my_install/llvm-aie
+source ${MLIR_AIE_BUILD_DIR}/utils/env_setup.sh ${MLIR_AIE_BUILD_DIR}/my_install/mlir_aie
 ```
 
 > Replace `${MLIR_AIE_BUILD_DIR}` with the directory in which you *built* mlir-aie above. Replace `${NEW_CMAKE_DIR}` with the directory in which you installed CMake 3.28 above. Instead of search and replace, you can also define these values as environment variables.
@@ -374,7 +374,7 @@ source ${MLIR_AIE_BUILD_DIR}/utils/env_setup.sh ${MLIR_AIE_BUILD_DIR}/my_install
 cd ${MLIR_AIE_BUILD_DIR}
 source ${MLIR_AIE_BUILD_DIR}/sandbox/bin/activate
 source /opt/xilinx/xrt/setup.sh
-source ${MLIR_AIE_BUILD_DIR}/utils/env_setup.sh ${MLIR_AIE_BUILD_DIR}/install ${MLIR_AIE_BUILD_DIR}/llvm/install
+source ${MLIR_AIE_BUILD_DIR}/utils/env_setup.sh ${MLIR_AIE_BUILD_DIR}/install
 ```
 
 > Replace `${MLIR_AIE_BUILD_DIR}` with the directory in which you *built* mlir-aie above. Instead of search and replace, you can also define `MLIR_AIE_BUILD_DIR` as an environment variable.

--- a/docs/buildHostWin.md
+++ b/docs/buildHostWin.md
@@ -102,7 +102,7 @@ All steps in WSL Ubuntu terminal.
           #################################################################################
           # Setup Vitis (which is just for aietools)
           #################################################################################
-          export MYXILINX_VER=2023.2
+          export MYXILINX_VER=2024.2
           export MYXILINX_BASE=/tools/Xilinx
           export XILINX_LOC=$MYXILINX_BASE/Vitis/$MYXILINX_VER
           export AIETOOLS_ROOT=$XILINX_LOC/aietools
@@ -119,8 +119,7 @@ All steps in WSL Ubuntu terminal.
      ```
      source utils/quick_setup.sh
      # NOTE: this will install mlir-aie in my_install/mlir_aie
-     # and llvm in my_install/mlir. Be sure to account for this
-     # using utils/env_setup.sh later on.
+     # Be sure to account for this using utils/env_setup.sh later on.
      ```
 
    * [Optional] Build from source following regular get started instructions [https://xilinx.github.io/mlir-aie/Building.html](https://xilinx.github.io/mlir-aie/Building.html)
@@ -147,7 +146,7 @@ All steps in Win11 (powershell where needed).
     - Note: If you run into an error during the compilation phase, see [here](https://stackoverflow.com/questions/78835588/cannot-build-boost-library-on-windows-11) for suggestions on a workaround. This involves modifying the `tools/build/src/tools/msvc.jam` file and run `.\b2.exe --reconfigure install`
 1. Optional (only needed for vision examples): install [opencv](https://docs.opencv.org/4.x/d3/d52/tutorial_windows_install.html) and add this install to your PATH environmental variable, for instance `C:\Technical\thirdParty\opencv\build\x64\vc16\bin`
 
-1. Clone [https://github.com/Xilinx/XRT](https://github.com/Xilinx/XRT) for instance under `C:\Technical` and `git checkout 2023.2`
+1. Clone [https://github.com/Xilinx/XRT](https://github.com/Xilinx/XRT) for instance under `C:\Technical` and `git checkout 2024.2`
 1. Create a .lib file from the .dll shipping with the driver
     - In wsl, generate a .def file (see above)
     - Start a x86 Native Tools Command Prompt (installed as part of VS17), go to the folder `C:\Technical\xrtNPUfromDLL` and run command: 
@@ -169,7 +168,7 @@ If you used the quick setup script (precompiled mlir-aie binaries), use this set
 cd <yourPathToDesignsWithMLIR-AIE>
 source <yourPathToBuildMLIR-AIE>/ironenv/bin/activate
 source yourVitisSetupScript (example shown above)
-source <yourPathToBuildMLIR-AIE>/utils/env_setup.sh <yourPathToBuildMLIR-AIE>/my_install/mlir_aie <yourPathToBuildMLIR-AIE>/my_install/mlir
+source <yourPathToBuildMLIR-AIE>/utils/env_setup.sh <yourPathToBuildMLIR-AIE>/my_install/mlir_aie
 ```
 
 ### `setup.sh` - Option B - Built from Source
@@ -178,7 +177,7 @@ source <yourPathToBuildMLIR-AIE>/utils/env_setup.sh <yourPathToBuildMLIR-AIE>/my
 cd <yourPathToDesignsWithMLIR-AIE>
 source <yourPathToBuildMLIR-AIE>/sandbox/bin/activate
 source yourVitisSetupScript (example shown above)
-source <yourPathToBuildMLIR-AIE>/utils/env_setup.sh <yourPathToBuildMLIR-AIE>/install <yourPathToBuildMLIR-AIE>/llvm/install
+source <yourPathToBuildMLIR-AIE>/utils/env_setup.sh <yourPathToBuildMLIR-AIE>/install
 ```
 
 

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -12,40 +12,28 @@
 # 
 #
 # source env_setup.sh <mlir-aie install dir> 
-#                     <llvm install dir> 
 #                     <llvm-aie/peano install dir>
 #
 # e.g. source env_setup.sh /scratch/mlir-aie/install 
-#                          /scratch/llvm/install
 #                          /scratch/llvm-aie/install
 #
 ##===----------------------------------------------------------------------===##
 
-if [ "$#" -lt 2 ]; then
-    echo "ERROR: Needs 2 arguments for <mlir-aie install dir> and <llvm install dir>"
+if [ "$#" -lt 1 ]; then
+    echo "ERROR: Needs an argument for <mlir-aie install dir>."
     return 1
 fi
 
 export MLIR_AIE_INSTALL_DIR=`realpath $1`
-export LLVM_INSTALL_DIR=`realpath $2`
-if [ "$#" -eq 3 ]; then
-    export PEANO_INSTALL_DIR=`realpath $3`
+if [ "$#" -eq 2 ]; then
+    export PEANO_INSTALL_DIR=`realpath $2`
 fi
 
 if [[ $PEANO_INSTALL_DIR == "" ]]; then
-  mkdir -p my_install
-  if [ ! -d "my_install/llvm-aie" ]; then
-    pushd my_install
-    pip -q download llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-    unzip -q llvm_aie*.whl
-    rm -rf llvm_aie*.whl
-    export PEANO_INSTALL_DIR=`realpath llvm-aie`
-    popd
-  else
-    export PEANO_INSTALL_DIR=`realpath my_install/llvm-aie`
-  fi
+  python3 -m pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+  export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 fi
 
-export PATH=${PEANO_INSTALL_DIR}/bin:${MLIR_AIE_INSTALL_DIR}/bin:${LLVM_INSTALL_DIR}/bin:${PATH} 
+export PATH=${MLIR_AIE_INSTALL_DIR}/bin:${PATH} 
 export PYTHONPATH=${MLIR_AIE_INSTALL_DIR}/python:${PYTHONPATH}
-export LD_LIBRARY_PATH=${PEANO_INSTALL_DIR}/bin:${MLIR_AIE_INSTALL_DIR}/lib:${LLVM_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=${MLIR_AIE_INSTALL_DIR}/lib:${LD_LIBRARY_PATH}

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -62,14 +62,12 @@ pip download aie_python_bindings -f https://github.com/Xilinx/mlir-aie/releases/
 unzip -q -o aie_python_bindings*.whl
 rm *.whl
 popd
-pip download mlir -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro/
-unzip -q mlir-*_x86_64.whl
-pip -q download llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
-unzip -q llvm_aie*.whl
 rm -rf mlir*.whl
-rm -rf llvm_aie*.whl
-export PEANO_INSTALL_DIR=`realpath llvm-aie`
 popd
+
+python3 -m pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
+
 python3 -m pip install -r python/requirements.txt
 
 # This installs the pre-commit hooks defined in .pre-commit-config.yaml
@@ -77,7 +75,8 @@ pre-commit install
 
 HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie python3 -m pip install -r python/requirements_extras.txt
 python3 -m pip install -r python/requirements_ml.txt
-source utils/env_setup.sh my_install/mlir_aie my_install/mlir
+
+source utils/env_setup.sh my_install/mlir_aie
 
 # This creates an ipykernel (for use in notebooks) using the ironenv venv
 python3 -m ipykernel install --user --name ironenv


### PR DESCRIPTION
Remove llvm/mlir installation from the script as it is not needed. 
Use pip install for Peano. 
Update the `env_setup.sh` for changes

TODO:
- [x] Update READMEs for these changes
- [x] Fix GHA workflows