### PR TITLE
AIE To Standard for AIE2p

### DIFF
--- a/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.cpp
+++ b/aie_runtime_lib/AIE2P/chess_intrinsic_wrapper.cpp
@@ -19,10 +19,10 @@
 /// when parsing .ll code containing standard intrinsic names, so these symbols
 /// are defined that way.
 
-extern "C" void llvm___aie2___acquire(unsigned id, unsigned val) {
+extern "C" void llvm___aie2p___acquire(unsigned id, unsigned val) {
   acquire_equal(id, val);
 }
-extern "C" void llvm___aie2___release(unsigned id, unsigned val) {
+extern "C" void llvm___aie2p___release(unsigned id, unsigned val) {
   release(id, val);
 }
 extern "C" void llvm___aie___event0() { event0(); }

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -113,8 +113,12 @@ static auto getAIE2pIntrinsics(OpBuilder &builder) {
   Type accType = VectorType::get({16}, int32Type);
   IntrinsicDecls functions = {
       {"debug_i32", {int32Type}, {}},
-      {"llvm.aie2p.put.ms", {int32Type, int32Type}, {}}, //(%value, %tlast) -> ()
-      {"llvm.aie2p.get.ss", {}, {int32Type, int32Type}}, //() -> (%value, %tlast)
+      {"llvm.aie2p.put.ms",
+       {int32Type, int32Type},
+       {}}, //(%value, %tlast) -> ()
+      {"llvm.aie2p.get.ss",
+       {},
+       {int32Type, int32Type}}, //() -> (%value, %tlast)
       {"llvm.aie2p.mcd.write.vec",
        {accType, int32Type},
        {}}, // (%value, %enable) -> ()

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -108,6 +108,29 @@ static auto getAIE2Intrinsics(OpBuilder &builder) {
   return functions;
 }
 
+static auto getAIE2pIntrinsics(OpBuilder &builder) {
+  Type int32Type = IntegerType::get(builder.getContext(), 32);
+  Type accType = VectorType::get({16}, int32Type);
+  IntrinsicDecls functions = {
+      {"debug_i32", {int32Type}, {}},
+      {"llvm.aie2p.put.ms", {int32Type, int32Type}, {}}, //(%value, %tlast) -> ()
+      {"llvm.aie2p.get.ss", {}, {int32Type, int32Type}}, //() -> (%value, %tlast)
+      {"llvm.aie2p.mcd.write.vec",
+       {accType, int32Type},
+       {}}, // (%value, %enable) -> ()
+      {"llvm.aie2p.scd.read.vec",
+       {int32Type},
+       {accType}}, // (%enable) -> (%value)
+      {"llvm.aie2p.acquire",
+       {int32Type, int32Type},
+       {}}, //(%lock_id, %lock_val) -> ()
+      {"llvm.aie2p.release",
+       {int32Type, int32Type},
+       {}}, //(%lock_id, %lock_val) -> ()
+  };
+  return functions;
+}
+
 static void declareAIEIntrinsics(AIEArch arch, OpBuilder &builder) {
   auto registerIntrinsics = [&builder](IntrinsicDecls functions) {
     for (auto &i : functions) {
@@ -124,8 +147,10 @@ static void declareAIEIntrinsics(AIEArch arch, OpBuilder &builder) {
     registerIntrinsics(getAIE1Intrinsics(builder));
     return;
   case AIEArch::AIE2:
-  case AIEArch::AIE2p:
     registerIntrinsics(getAIE2Intrinsics(builder));
+    return;
+  case AIEArch::AIE2p:
+    registerIntrinsics(getAIE2pIntrinsics(builder));
     return;
   }
   llvm::report_fatal_error("unsupported arch");
@@ -188,8 +213,10 @@ struct AIEPutStreamToStdLowering : OpConversionPattern<PutStreamOp> {
     std::string funcName;
     if (targetModel.getTargetArch() == AIEArch::AIE1)
       funcName = "llvm.aie.put.";
-    else
+    else if (targetModel.getTargetArch() == AIEArch::AIE2)
       funcName = "llvm.aie2.put.";
+    else
+      funcName = "llvm.aie2p.put.";
 
     if (op.isWideStream())
       funcName += "wms";
@@ -234,8 +261,10 @@ struct AIEGetStreamToStdLowering : OpConversionPattern<GetStreamOp> {
     std::string funcName;
     if (targetModel.getTargetArch() == AIEArch::AIE1)
       funcName = "llvm.aie.get.";
-    else
+    else if (targetModel.getTargetArch() == AIEArch::AIE2)
       funcName = "llvm.aie2.get.";
+    else
+      funcName = "llvm.aie2p.get.";
 
     if (op.isWideStream())
       funcName += "wss";
@@ -275,8 +304,10 @@ struct AIEPutCascadeToStdLowering : OpConversionPattern<PutCascadeOp> {
     std::string funcName;
     if (targetModel.getTargetArch() == AIEArch::AIE1)
       funcName = "llvm.aie.put.mcd";
-    else
+    else if (targetModel.getTargetArch() == AIEArch::AIE2)
       funcName = "llvm.aie2.mcd.write.vec";
+    else
+      funcName = "llvm.aie2p.mcd.write.vec";
     auto putMCDFunc = module.lookupSymbol<func::FuncOp>(funcName);
     if (!putMCDFunc)
       return op.emitOpError("Could not find the intrinsic function ")
@@ -310,8 +341,10 @@ struct AIEGetCascadeToStdLowering : OpConversionPattern<GetCascadeOp> {
     std::string funcName;
     if (targetModel.getTargetArch() == AIEArch::AIE1)
       funcName = "llvm.aie.get.scd";
-    else
+    else if (targetModel.getTargetArch() == AIEArch::AIE2)
       funcName = "llvm.aie2.scd.read.vec";
+    else
+      funcName = "llvm.aie2p.scd.read.vec";
     auto getSCDFunc = module.lookupSymbol<func::FuncOp>(funcName);
     if (!getSCDFunc)
       return op.emitOpError("Could not find the intrinsic function ")
@@ -350,8 +383,10 @@ struct AIEUseLockToStdLowering : OpConversionPattern<UseLockOp> {
       std::string funcName;
       if (targetModel.getTargetArch() == AIEArch::AIE1)
         funcName = "llvm.aie.lock.";
-      else
+      else if (targetModel.getTargetArch() == AIEArch::AIE2)
         funcName = "llvm.aie2.";
+      else
+        funcName = "llvm.aie2p.";
       if (useLock.acquire() || useLock.acquireGE())
         funcName += "acquire";
       else if (useLock.release())

--- a/programming_examples/makefile-common
+++ b/programming_examples/makefile-common
@@ -15,6 +15,7 @@ CHESSCCWRAP1_FLAGS = aie -I ${AIETOOLS_DIR}/include
 CHESSCCWRAP2_FLAGS = aie2 -I ${AIETOOLS_DIR}/include
 CHESSCCWRAP2P_FLAGS = aie2p -I ${AIETOOLS_DIR}/include 
 PEANOWRAP2_FLAGS = -O2 -v -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include 
+PEANOWRAP2P_FLAGS = -O2 -v -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include 
 
 TEST_POWERSHELL := $(shell command -v powershell.exe >/dev/null 2>&1 && echo yes || echo no)
 ifeq ($(TEST_POWERSHELL),yes)

--- a/test/lower-to-standard/local_locks_aie2.mlir
+++ b/test/lower-to-standard/local_locks_aie2.mlir
@@ -1,0 +1,35 @@
+//===- local_locks_aie2.mlir -----------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-standard-lowering="tilecol=3 tilerow=3" %s | FileCheck --check-prefix=CHECK33 %s
+
+// CHECK33:  func.func @core_3_3() {
+// CHECK33:    %c56 = arith.constant 56 : index
+// CHECK33:    %0 = arith.index_cast %c56 : index to i32
+// CHECK33:    %c0_i32 = arith.constant 0 : i32
+// CHECK33:    call @llvm.aie2.acquire(%0, %c0_i32) : (i32, i32) -> ()
+// CHECK33:    %1 = arith.index_cast %c56 : index to i32
+// CHECK33:    %c1_i32 = arith.constant 1 : i32
+// CHECK33:    call @llvm.aie2.release(%1, %c1_i32) : (i32, i32) -> ()
+// CHECK33:    return
+// CHECK33:  }
+
+module @local_locks {
+ aie.device(xcve2302) {
+  %3 = aie.tile(3, 3)
+  %11 = aie.core(%3)  {
+    %c56 = arith.constant 56 : index
+    aie.use_lock(%c56, Acquire, 0)
+    aie.use_lock(%c56, Release, 1)
+    aie.end
+  }
+ }
+}
+

--- a/test/lower-to-standard/local_locks_aie2p.mlir
+++ b/test/lower-to-standard/local_locks_aie2p.mlir
@@ -1,0 +1,35 @@
+//===- local_locks_aie2p.mlir ----------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-standard-lowering="tilecol=3 tilerow=3" %s | FileCheck --check-prefix=CHECK33 %s
+
+// CHECK33:  func.func @core_3_3() {
+// CHECK33:    %c56 = arith.constant 56 : index
+// CHECK33:    %0 = arith.index_cast %c56 : index to i32
+// CHECK33:    %c0_i32 = arith.constant 0 : i32
+// CHECK33:    call @llvm.aie2p.acquire(%0, %c0_i32) : (i32, i32) -> ()
+// CHECK33:    %1 = arith.index_cast %c56 : index to i32
+// CHECK33:    %c1_i32 = arith.constant 1 : i32
+// CHECK33:    call @llvm.aie2p.release(%1, %c1_i32) : (i32, i32) -> ()
+// CHECK33:    return
+// CHECK33:  }
+
+module @local_locks {
+ aie.device(npu2) {
+  %3 = aie.tile(3, 3)
+  %11 = aie.core(%3)  {
+    %c56 = arith.constant 56 : index
+    aie.use_lock(%c56, Acquire, 0)
+    aie.use_lock(%c56, Release, 1)
+    aie.end
+  }
+ }
+}
+

--- a/test/lower-to-standard/useLock_in_func_aie2.mlir
+++ b/test/lower-to-standard/useLock_in_func_aie2.mlir
@@ -1,0 +1,42 @@
+//===- useLock_in_func_aie2.mlir --------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering="tilecol=1 tilerow=3" %s | FileCheck --check-prefix=CHECK %s
+
+// CHECK: module @test attributes {llvm.target_triple = "aie2"} {
+// CHECK:   func.func private @kernel(%arg0: index) {
+// CHECK-NEXT:     %0 = arith.index_cast %arg0 : index to i32
+// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:     call @llvm.aie2.acquire(%0, %c0_i32) : (i32, i32) -> ()
+// CHECK-NEXT:     return
+// CHECK:   }
+// CHECK:   func.func @core_1_3() {
+// CHECK:     %c48 = arith.constant 48 : index
+// CHECK:     call @kernel(%c48) : (index) -> ()
+// CHECK:     return
+// CHECK:   }
+// CHECK: }
+
+module @test {
+ aie.device(xcve2302) {
+  %tile13 = aie.tile(1, 3)
+  %lock13_3 = aie.lock(%tile13, 0)
+
+  func.func private @kernel(%lock : index) {
+    aie.use_lock(%lock, "Acquire", 0)
+    return
+  }
+
+  %core13 = aie.core(%tile13) {
+    func.call @kernel(%lock13_3) : (index) -> ()
+    aie.end
+  }
+ }
+}

--- a/test/lower-to-standard/useLock_in_func_aie2p.mlir
+++ b/test/lower-to-standard/useLock_in_func_aie2p.mlir
@@ -1,0 +1,42 @@
+//===- useLock_in_func_aie2p.mlir -------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering="tilecol=1 tilerow=3" %s | FileCheck --check-prefix=CHECK %s
+
+// CHECK: module @test attributes {llvm.target_triple = "aie2p"} {
+// CHECK:   func.func private @kernel(%arg0: index) {
+// CHECK-NEXT:     %0 = arith.index_cast %arg0 : index to i32
+// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:     call @llvm.aie2p.acquire(%0, %c0_i32) : (i32, i32) -> ()
+// CHECK-NEXT:     return
+// CHECK:   }
+// CHECK:   func.func @core_1_3() {
+// CHECK:     %c48 = arith.constant 48 : index
+// CHECK:     call @kernel(%c48) : (index) -> ()
+// CHECK:     return
+// CHECK:   }
+// CHECK: }
+
+module @test {
+ aie.device(npu2) {
+  %tile13 = aie.tile(1, 3)
+  %lock13_3 = aie.lock(%tile13, 0)
+
+  func.func private @kernel(%lock : index) {
+    aie.use_lock(%lock, "Acquire", 0)
+    return
+  }
+
+  %core13 = aie.core(%tile13) {
+    func.call @kernel(%lock13_3) : (index) -> ()
+    aie.end
+  }
+ }
+}


### PR DESCRIPTION
- Update AIE to Standard pass for AIE2p
- Add tests for AIE2 and AIE2p locks
- Add programming examples `makefile-common` for Peano AIE2p 