### PR TITLE
Update buildAndTestRyzenAI.yml for utils/scripts updates

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -155,16 +155,7 @@ jobs:
           # quick_setup changes directory to programming_examples, so we need to return to mlir-aie
           cd ..
 
-          VERSION=$(utils/clone-llvm.sh --get-wheel-version)
-          pip -q download mlir==$VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
-          unzip -q mlir-*.whl
-          # I have no clue why but the system clock on GHA containers is like 12 hours ahead.
-          # That means wheels have file with time stamps in the future which makes ninja loop
-          # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
-          find mlir -exec touch -a -m -t 201108231405.14 {} \;
-
-          ./utils/build-mlir-aie-from-wheels.sh ./mlir build install ${PEANO_INSTALL_DIR} 
+          ./utils/build-mlir-aie-from-wheels.sh
 
           # build is created by the build-mlir-aie-from-wheels.sh script
           pushd build


### PR DESCRIPTION
Let the `utils/build-mlir-aie-from-wheels.sh` script manage mlir and llvm-aie installation from wheels.