### PR TITLE
Remove aie-only-generate-npu aiecc option, cleanup aie-generate-cdo use

### DIFF
--- a/programming_examples/basic/dma_transpose/Makefile
+++ b/programming_examples/basic/dma_transpose/Makefile
@@ -43,9 +43,9 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_examples/basic/matrix_multiplication/makefile-common
+++ b/programming_examples/basic/matrix_multiplication/makefile-common
@@ -104,19 +104,19 @@ ${trace_mlir_target}: ${srcdir}/${aie_py_src}
 
 ${xclbin_target}: ${mlir_target} ${kernels:%=build/%.o}
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --alloc-scheme=${buffer_aloc_flag} --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --alloc-scheme=${buffer_aloc_flag} --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				$(if $(shell [ $(CHESS) != true ] && echo true), \
 					--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR}, \
 				) \
-				--aie-generate-npu --npu-insts-name=${insts_target:build/%=%} $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=${insts_target:build/%=%} $(<:%=../%)
 
 ${trace_xclbin_target}: ${trace_mlir_target} ${kernels:%=build/%.o}
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --alloc-scheme=${buffer_aloc_flag} --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --alloc-scheme=${buffer_aloc_flag} --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				$(if $(shell [ $(CHESS) != true ] && echo true), \
 					--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR}, \
 				) \
-				--aie-generate-npu --npu-insts-name=${insts_target:build/%=%} $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=${insts_target:build/%=%} $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp ${srcdir}/../test.cpp ${srcdir}/../common.h
 	rm -rf _build

--- a/programming_examples/basic/matrix_scalar_add/Makefile
+++ b/programming_examples/basic/matrix_scalar_add/Makefile
@@ -29,7 +29,7 @@ all: build/final.xclbin
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/basic/packet_switch/Makefile
+++ b/programming_examples/basic/packet_switch/Makefile
@@ -95,7 +95,7 @@ else
 	echo "Device type not supported"
 endif
 
-# Build bitstream
+# Build xclbin
 ${XCLBIN_TARGET}: ${XCLBIN_MLIR_SRCS} ${KERNEL_OBJS}
 ifeq ($(DEVICE),npu1)
 	sed -i 's/npu2/npu1_1col/' $<
@@ -105,7 +105,7 @@ else
 	echo "Device type not supported"
 endif
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host \
 		--xclbin-name=${@F} $(<:${HOME_DIR}/kernel/%=../../kernel/%)
 	cp ${XCLBIN_TARGET} ./final.xclbin
 
@@ -120,7 +120,7 @@ else
 	echo "Device type not supported"
 endif
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-only-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-npu-insts --no-compile-host \
 		--npu-insts-name=${@:${BITSTREAM_O_DIR}/%=%} $(<:${HOME_DIR}/kernel/%=../../kernel/%) 
 	cp $@ ./
 

--- a/programming_examples/basic/passthrough_dmas/Makefile
+++ b/programming_examples/basic/passthrough_dmas/Makefile
@@ -12,7 +12,7 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-all: build/final.xclbin build/insts.txt
+all: build/final.xclbin
 
 devicename ?= $(if $(NPU2),npu2,npu)
 targetname = passthrough_dmas
@@ -29,19 +29,11 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< ${LENGTH} ${devicename} ${col} > $@
 
-.PHONY: inst/insts.txt
-inst/insts.txt: ${srcdir}/${aie_py_src}
-	rm -rf inst
-	mkdir -p inst 
-	python3 $< ${LENGTH} > inst/aie.mlir
-	pushd inst && aiecc.py --aie-only-generate-npu --npu-insts-name=insts.txt aie.mlir && popd
-	${powershell} ./build/${targetname}.exe -x build/final.xclbin -i inst/insts.txt -k MLIR_AIE -l ${LENGTH}
-
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 		--no-xchesscc --no-xbridge \
-		--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+		--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_examples/basic/passthrough_kernel/Makefile
+++ b/programming_examples/basic/passthrough_kernel/Makefile
@@ -50,13 +50,13 @@ endif
 	
 build/final_${data_size}.xclbin: build/aie2_lineBased_8b_${data_size}.mlir build/passThrough.cc.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
 
 build/final_trace_${data_size}.xclbin: build/aie2_trace_lineBased_8b_${data_size}.mlir build/passThrough.cc.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
 

--- a/programming_examples/basic/passthrough_pykernel/Makefile
+++ b/programming_examples/basic/passthrough_pykernel/Makefile
@@ -35,7 +35,7 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final_${data_size}.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
 

--- a/programming_examples/basic/passthrough_pykernel/passthrough_pykernel.ipynb
+++ b/programming_examples/basic/passthrough_pykernel/passthrough_pykernel.ipynb
@@ -161,7 +161,7 @@
    "outputs": [],
    "source": [
     "!mkdir notebook_build\n",
-    "!cd notebook_build && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --no-xchesscc --no-xbridge --xclbin-name=notebook.xclbin --npu-insts-name=notebook_insts.txt ../notebook_aie.mlir"
+    "!cd notebook_build && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --no-xchesscc --no-xbridge --xclbin-name=notebook.xclbin --npu-insts-name=notebook_insts.txt ../notebook_aie.mlir"
    ]
   },
   {

--- a/programming_examples/basic/row_wise_bias_add/Makefile
+++ b/programming_examples/basic/row_wise_bias_add/Makefile
@@ -62,9 +62,9 @@ ${mlir_target}: ${srcdir}/${aie_py_src}
 
 ${xclbin_target}: ${mlir_target} build/kernel.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py -v --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py -v --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=${insts_target:build/%=%} ${<:%=../%}
+				--aie-generate-npu-insts --npu-insts-name=${insts_target:build/%=%} ${<:%=../%}
 
 ${host_target}: ${srcdir}/test.cpp ${xclbin_target}
 	mkdir -p ${@D}

--- a/programming_examples/basic/tiling_exploration/per_tile/Makefile
+++ b/programming_examples/basic/tiling_exploration/per_tile/Makefile
@@ -29,7 +29,7 @@ build/aie_${data_str}.mlir: ${srcdir}/${aie_py_src}
 
 build/final_${data_str}.xclbin: build/aie_${data_str}.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts_${data_str}.txt $(<:%=../%)
 

--- a/programming_examples/basic/tiling_exploration/tile_group/Makefile
+++ b/programming_examples/basic/tiling_exploration/tile_group/Makefile
@@ -29,7 +29,7 @@ build/aie_${data_str}.mlir: ${srcdir}/${aie_py_src}
 
 build/final_${data_str}.xclbin: build/aie_${data_str}.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts_${data_str}.txt $(<:%=../%)
 

--- a/programming_examples/basic/vector_exp/Makefile
+++ b/programming_examples/basic/vector_exp/Makefile
@@ -42,9 +42,9 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/kernels.a
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_examples/basic/vector_reduce_add/Makefile
+++ b/programming_examples/basic/vector_reduce_add/Makefile
@@ -41,9 +41,9 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/reduce_add.cc.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     	--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR} \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_examples/basic/vector_reduce_max/Makefile
+++ b/programming_examples/basic/vector_reduce_max/Makefile
@@ -43,9 +43,9 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/reduce_max.cc.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     			--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR} \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_examples/basic/vector_reduce_min/Makefile
+++ b/programming_examples/basic/vector_reduce_min/Makefile
@@ -41,9 +41,9 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/reduce_min.cc.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     			--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR} \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_examples/basic/vector_scalar_add/Makefile
+++ b/programming_examples/basic/vector_scalar_add/Makefile
@@ -30,7 +30,7 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 		

--- a/programming_examples/basic/vector_scalar_add_runlist/Makefile
+++ b/programming_examples/basic/vector_scalar_add_runlist/Makefile
@@ -30,7 +30,7 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/basic/vector_scalar_mul/Makefile
+++ b/programming_examples/basic/vector_scalar_mul/Makefile
@@ -63,23 +63,23 @@ build/aie_trace_${data_size}.mlir: ${srcdir}/${aie_py_src}
 build/final_${data_size}.xclbin: build/aie_${data_size}.mlir build/scale.o
 	mkdir -p ${@D}
 ifeq ($(CHESS), true)
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
-				--aie-generate-npu --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
+				--aie-generate-npu-insts --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
 else
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     	  --no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
 endif
 
 build/final_trace_${data_size}.xclbin: build/aie_trace_${data_size}.mlir build/scale.o
 	mkdir -p ${@D}
 ifeq ($(CHESS), true)
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
-				--aie-generate-npu --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
+				--aie-generate-npu-insts --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
 else
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     		--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts_${data_size}.txt $(<:%=../%)
 endif
 
 ${targetname}_${data_size}.exe: ${srcdir}/test.cpp

--- a/programming_examples/basic/vector_vector_add/Makefile
+++ b/programming_examples/basic/vector_vector_add/Makefile
@@ -31,7 +31,7 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/Makefile
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/Makefile
@@ -26,7 +26,7 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/basic/vector_vector_modulo/Makefile
+++ b/programming_examples/basic/vector_vector_modulo/Makefile
@@ -31,7 +31,7 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/basic/vector_vector_mul/Makefile
+++ b/programming_examples/basic/vector_vector_mul/Makefile
@@ -31,7 +31,7 @@ build/aie.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/ml/bottleneck/Makefile
+++ b/programming_examples/ml/bottleneck/Makefile
@@ -26,9 +26,6 @@ build/${mlirFileName}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 
-insts.txt: build/${mlirFileName}.mlir
-	aiecc.py -v --aie-only-generate-npu --npu-insts-name=$@ $<
-
 build/conv2dk1.o: conv2dk1.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang ${PEANOWRAP2_FLAGS} -DINT8_ACT -c $< -o ${@F}
@@ -43,7 +40,7 @@ build/conv2dk1_skip.o: conv2dk1_skip.cc
 
 build/final.xclbin: build/${mlirFileName}.mlir build/conv2dk1.o build/conv2dk3.o build/conv2dk1_skip.o  
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py -v --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py -v --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--alloc-scheme=basic-sequential \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%) 

--- a/programming_examples/ml/conv2d/Makefile
+++ b/programming_examples/ml/conv2d/Makefile
@@ -66,22 +66,22 @@ build/${mlirFileName}_trace.mlir: ${srcdir}/${aie_py_trace_src}
 build/final.xclbin: build/${mlirFileName}.mlir build/conv2dk1_i8.o 
 	mkdir -p ${@D} 
 ifeq ($(device),npu)
-	cd ${@D} && aiecc.py -v --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py -v --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%)
 else
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 endif
 
 build/final_trace.xclbin: build/${mlirFileName}_trace.mlir build/conv2dk1_i8.o 
 	mkdir -p ${@D} 
 ifeq ($(device),npu)
-	cd ${@D} && aiecc.py -v --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py -v --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts_trace.txt $(<:%=../%)
 else
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--xclbin-name=${@F} --npu-insts-name=insts_trace.txt ${<F}
 endif
 

--- a/programming_examples/ml/conv2d_fused_relu/Makefile
+++ b/programming_examples/ml/conv2d_fused_relu/Makefile
@@ -26,17 +26,13 @@ build/${mlirFileName}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
 	python3 $< > $@
 
-
-insts.txt: build/${mlirFileName}.mlir
-	aiecc.py -v --aie-only-generate-npu --npu-insts-name=$@ $<
-
 build/conv2dk1.o: conv2dk1.cc
 	mkdir -p ${@D}
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang ${PEANOWRAP2_FLAGS} -DINT8_ACT -c $< -o$ ${@F} 
 
 build/final.xclbin: build/${mlirFileName}.mlir build/conv2dk1.o  
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py -v --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py -v --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%) 
 

--- a/programming_examples/ml/eltwise_add/Makefile
+++ b/programming_examples/ml/eltwise_add/Makefile
@@ -47,13 +47,13 @@ build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/add.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 
 build/final_trace.xclbin: build/aie_trace.mlir build/add.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/ml/eltwise_mul/Makefile
+++ b/programming_examples/ml/eltwise_mul/Makefile
@@ -47,13 +47,13 @@ build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/mul.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 
 build/final_trace.xclbin: build/aie_trace.mlir build/mul.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/ml/relu/Makefile
+++ b/programming_examples/ml/relu/Makefile
@@ -47,13 +47,13 @@ build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/relu.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 	--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 
 build/final_trace.xclbin: build/aie_trace.mlir build/relu.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 	--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt ${<F}
 

--- a/programming_examples/ml/resnet/layers_conv2_x/Makefile
+++ b/programming_examples/ml/resnet/layers_conv2_x/Makefile
@@ -51,7 +51,7 @@ build/conv2dk1_skip.o: conv2dk1_skip.cc
 
 build/final.xclbin: build/${mlirFileName}.mlir build/conv2dk1_i8.o build/conv2dk1_skip_init.o build/conv2dk3.o build/conv2dk1_skip.o build/conv2dk1_ui8.o
 	mkdir -p ${@D}
-	cd ${@D} &&	aiecc.py --alloc-scheme=basic-sequential --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	cd ${@D} &&	aiecc.py --alloc-scheme=basic-sequential --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%)
 

--- a/programming_examples/ml/softmax/Makefile
+++ b/programming_examples/ml/softmax/Makefile
@@ -74,15 +74,15 @@ build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir build/kernels.a
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     	--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR} \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 build/final_trace.xclbin: build/aie_trace.mlir build/kernels.a
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     	--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR} \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_examples/vision/color_detect/Makefile
+++ b/programming_examples/vision/color_detect/Makefile
@@ -56,11 +56,11 @@ build/aie2_lineBased_8b_${COLORDETECT_WIDTH}.mlir: ${srcdir}/${aie_py_src}
 build/final_${COLORDETECT_WIDTH}.xclbin: build/aie2_lineBased_8b_${COLORDETECT_WIDTH}.mlir build/rgba2hue.cc.o build/threshold.cc.o build/combined_bitwiseOR_gray2rgba_bitwiseAND.a
 	mkdir -p ${@D}
 ifeq ($(device),npu)
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%)
 else
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%)
 endif
 

--- a/programming_examples/vision/color_threshold/Makefile
+++ b/programming_examples/vision/color_threshold/Makefile
@@ -48,7 +48,7 @@ build/aie2_${COLORTHRESHOLD_WIDTH}.mlir: ${srcdir}/${aie_py_src}
 
 build/final_${COLORTHRESHOLD_WIDTH}.xclbin: build/aie2_${COLORTHRESHOLD_WIDTH}.mlir build/threshold.cc.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%)
 

--- a/programming_examples/vision/edge_detect/Makefile
+++ b/programming_examples/vision/edge_detect/Makefile
@@ -55,7 +55,7 @@ build/aie2_lineBased_8b_${EDGEDETECT_WIDTH}.mlir: ${srcdir}/${aie_py_src}
 
 build/final_${EDGEDETECT_WIDTH}.xclbin: build/aie2_lineBased_8b_${EDGEDETECT_WIDTH}.mlir build/rgba2gray.cc.o build/gray2rgba.cc.o build/filter2d.cc.o build/threshold.cc.o build/addWeighted.cc.o build/combined_gray2rgba_addWeighted.a
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%)
 

--- a/programming_examples/vision/vision_passthrough/Makefile
+++ b/programming_examples/vision/vision_passthrough/Makefile
@@ -48,7 +48,7 @@ endif
 	
 build/final_${PASSTHROUGH_WIDTH}.xclbin: build/aie2_lineBased_8b_${PASSTHROUGH_WIDTH}.mlir build/passThrough.cc.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential \
 		--no-xchesscc --no-xbridge \
 		--xclbin-name=${@F} --npu-insts-name=insts.txt $(<:%=../%)
 

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/Makefile
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/Makefile
@@ -35,9 +35,9 @@ inst/insts.txt: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/Makefile
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/Makefile
@@ -33,9 +33,9 @@ inst/insts.txt: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/Makefile
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/Makefile
@@ -33,9 +33,9 @@ inst/insts.txt: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_guide/section-2/section-2f/05_join_L2/Makefile
+++ b/programming_guide/section-2/section-2f/05_join_L2/Makefile
@@ -33,9 +33,9 @@ inst/insts.txt: ${srcdir}/${aie_py_src}
 
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_guide/section-3/Makefile
+++ b/programming_guide/section-3/Makefile
@@ -24,9 +24,9 @@ build/scale.o: ${srcdir}/vector_scalar_mul.cc
 
 build/final.xclbin: build/aie.mlir build/scale.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_guide/section-4/section-4a/Makefile
+++ b/programming_guide/section-4/section-4a/Makefile
@@ -24,9 +24,9 @@ build/scale.o: ${srcdir}/vector_scalar_mul.cc
 
 build/final.xclbin: build/aie.mlir build/scale.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
 				--no-xchesscc --no-xbridge \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/programming_guide/section-4/section-4b/Makefile
+++ b/programming_guide/section-4/section-4b/Makefile
@@ -36,19 +36,19 @@ endif
 
 build/final.xclbin: build/aie.mlir build/scale.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     			$(if $(shell [ $(CHESS) != true ] && echo true), \
     			    --no-xchesscc --no-xbridge \
     			) \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 build/trace.xclbin: build/aie_trace.mlir build/scale.o
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py -v --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
+	cd ${@D} && aiecc.py -v --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
     			$(if $(shell [ $(CHESS) != true ] && echo true), \
     			    --no-xchesscc --no-xbridge \
     			) \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	echo $(powershell_srcdir)

--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -221,20 +221,12 @@ def parse_args(args=None):
         help="Show progress visualization",
     )
     parser.add_argument(
-        "--aie-generate-npu",
+        "--aie-generate-npu-insts",
         dest="npu",
         default=False,
         action="store_const",
         const=True,
-        help="Generate npu instruction stream",
-    )
-    parser.add_argument(
-        "--aie-only-generate-npu",
-        dest="only_npu",
-        default=False,
-        action="store_const",
-        const=True,
-        help="Generate npu instruction stream only",
+        help="Generate npu instruction stream from default runtime sequence",
     )
     parser.add_argument(
         "--npu-insts-name",
@@ -293,6 +285,20 @@ def parse_args(args=None):
         dest="xclbin_name",
         default="final.xclbin",
         help="Output xclbin filename for CDO/XCLBIN target",
+    )
+    parser.add_argument(
+        "--aie-generate-pdi",
+        dest="pdi",
+        default=False,
+        action="store_const",
+        const=True,
+        help="Generate pdi binary for configuration",
+    )
+    parser.add_argument(
+        "--pdi-name",
+        dest="pdi_name",
+        default="design.pdi",
+        help="Output pdi filename for PDI/CDO/XCLBIN target",
     )
     parser.add_argument(
         "--xclbin-kernel-name",

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1170,19 +1170,20 @@ class FlowRunner:
             )
 
             input_physical = self.prepend_tmp("input_physical.mlir")
-            processes = [self.do_call(
-                None,
-                [
-                    "aie-opt",
-                    "--aie-create-pathfinder-flows",
-                    file_with_addresses,
-                    "-o",
-                    input_physical
-                ]
-            )]
-            await asyncio.gather(
-                *processes
-            )
+            processes = [
+                self.do_call(
+                    None,
+                    [
+                        "aie-opt",
+                        "--aie-create-pathfinder-flows",
+                        file_with_addresses,
+                        "-o",
+                        input_physical,
+                    ],
+                    force=True,
+                )
+            ]
+            await asyncio.gather(*processes)
 
             if len(opts.host_args) > 0:
                 await self.process_host_cgen(aie_target, input_physical)

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -489,6 +489,8 @@ class FlowRunner:
     # In order to run peano on modern ll code, we need a bunch of hacks.
     async def peanohack(self, llvmir):
         llvmir_peanohack = llvmir + "peanohack.ll"
+        if not self.opts.execute:
+            return llvmir_peanohack
 
         llvmir_ir = await read_file_async(llvmir)
         llvmir_hacked_ir = downgrade_ir_for_peano(llvmir_ir)
@@ -583,75 +585,56 @@ class FlowRunner:
                 self.progress_bar.update(task, advance=0, visible=False)
             # fmt: on
 
-    async def process_cdo(self):
-        from aie.dialects.aie import generate_cdo
-
+    async def process_cdo(self, module_str):
         with Context(), Location.unknown():
-            for elf in glob.glob("*.elf"):
-                try:
-                    shutil.copy(elf, self.tmpdirname)
-                except shutil.SameFileError:
-                    pass
-            for elf_map in glob.glob("*.elf.map"):
-                try:
-                    shutil.copy(elf_map, self.tmpdirname)
-                except shutil.SameFileError:
-                    pass
-            input_physical = Module.parse(
-                await read_file_async(self.prepend_tmp("input_physical.mlir"))
-            )
-            generate_cdo(input_physical.operation, self.tmpdirname)
+            input_physical = Module.parse(module_str)
+            aiedialect.generate_cdo(input_physical.operation, self.tmpdirname)
 
-    async def process_txn(self):
-
+    async def process_txn(self, module_str):
         with Context(), Location.unknown():
-            for elf in glob.glob("*.elf"):
-                try:
-                    shutil.copy(elf, self.tmpdirname)
-                except shutil.SameFileError:
-                    pass
-            for elf_map in glob.glob("*.elf.map"):
-                try:
-                    shutil.copy(elf_map, self.tmpdirname)
-                except shutil.SameFileError:
-                    pass
-            input_physical = await read_file_async(
-                self.prepend_tmp("input_physical.mlir")
-            )
             run_passes(
                 "builtin.module(aie.device(convert-aie-to-transaction{elf-dir="
                 + self.tmpdirname
                 + "}))",
-                input_physical,
+                module_str,
                 self.prepend_tmp("txn.mlir"),
                 self.opts.verbose,
             )
 
-    async def process_ctrlpkt(self):
-
+    async def process_ctrlpkt(self, module_str):
         with Context(), Location.unknown():
-            for elf in glob.glob("*.elf"):
-                try:
-                    shutil.copy(elf, self.tmpdirname)
-                except shutil.SameFileError:
-                    pass
-            for elf_map in glob.glob("*.elf.map"):
-                try:
-                    shutil.copy(elf_map, self.tmpdirname)
-                except shutil.SameFileError:
-                    pass
-            input_physical = await read_file_async(
-                self.prepend_tmp("input_physical.mlir")
-            )
             run_passes(
                 "builtin.module(aie.device(convert-aie-to-control-packets{elf-dir="
                 + self.tmpdirname
                 + "}))",
-                input_physical,
+                module_str,
                 self.prepend_tmp("ctrlpkt.mlir"),
                 self.opts.verbose,
             )
 
+    async def process_pdi_gen(self):
+
+        await write_file_async(
+            emit_design_bif(self.tmpdirname),
+            self.prepend_tmp(opts.pdi_name + ".bif"),
+        )
+
+        await self.do_call(
+            None,
+            [
+                "bootgen",
+                "-arch",
+                "versal",
+                "-image",
+                self.prepend_tmp(opts.pdi_name + ".bif"),
+                "-o",
+                self.prepend_tmp(opts.pdi_name),
+                "-w",
+            ],
+        )
+
+    # generate an xclbin. The inputs are self.mlir_module_str and the cdo
+    # binaries from the process_cdo step.
     async def process_xclbin_gen(self):
         if opts.progress:
             task = self.progress_bar.add_task(
@@ -660,41 +643,71 @@ class FlowRunner:
         else:
             task = None
 
-        await write_file_async(
-            json.dumps(mem_topology, indent=2),
-            self.prepend_tmp("mem_topology.json"),
+        # collect the tasks to generate the inputs to xclbinutil
+        processes = []
+
+        # generate mem_topology.json
+        processes.append(
+            write_file_async(
+                json.dumps(mem_topology, indent=2),
+                self.prepend_tmp("mem_topology.json"),
+            )
         )
 
-        await write_file_async(
-            json.dumps(emit_partition(self.mlir_module_str, opts.kernel_id), indent=2),
-            self.prepend_tmp("aie_partition.json"),
-        )
-
-        buffer_arg_names = [f"bo{i}" for i in range(5)]
-        await write_file_async(
-            json.dumps(
-                emit_design_kernel_json(
-                    opts.kernel_name,
-                    opts.kernel_id,
-                    opts.instance_name,
-                    buffer_arg_names,
+        # generate aie_partition.json
+        processes.append(
+            write_file_async(
+                json.dumps(
+                    emit_partition(self.mlir_module_str, opts.kernel_id), indent=2
                 ),
-                indent=2,
-            ),
-            self.prepend_tmp("kernels.json"),
+                self.prepend_tmp("aie_partition.json"),
+            )
         )
 
-        await write_file_async(
-            emit_design_bif(self.tmpdirname),
-            self.prepend_tmp("design.bif"),
+        # generate kernels.json
+        buffer_arg_names = [f"bo{i}" for i in range(5)]
+        processes.append(
+            write_file_async(
+                json.dumps(
+                    emit_design_kernel_json(
+                        opts.kernel_name,
+                        opts.kernel_id,
+                        opts.instance_name,
+                        buffer_arg_names,
+                    ),
+                    indent=2,
+                ),
+                self.prepend_tmp("kernels.json"),
+            )
         )
+
+        # generate pdi
+        processes.append(self.process_pdi_gen())
+
+        # get partition info from input xclbin, if present
+        if opts.xclbin_input:
+            processes.append(
+                self.do_call(
+                    task,
+                    [
+                        "xclbinutil",
+                        "--dump-section",
+                        "AIE_PARTITION:JSON:"
+                        + self.prepend_tmp("aie_input_partition.json"),
+                        "--force",
+                        "--quiet",
+                        "--input",
+                        opts.xclbin_input,
+                    ],
+                )
+            )
+
+        # wait for all of the above to finish
+        await asyncio.gather(*processes)
 
         # fmt: off
-        await self.do_call(task, ["bootgen", "-arch", "versal", "-image", self.prepend_tmp("design.bif"), "-o", self.prepend_tmp("design.pdi"), "-w"])
         if opts.xclbin_input:
-            await self.do_call(task, ["xclbinutil",
-                                      "--dump-section", "AIE_PARTITION:JSON:" + self.prepend_tmp("aie_input_partition.json"),
-                                      "--force", "--quiet", "--input", opts.xclbin_input])
+            # patch the input partition json with the new partition information
             with open(self.prepend_tmp("aie_input_partition.json")) as f:
                 input_partition = json.load(f)
             with open(self.prepend_tmp("aie_partition.json")) as f:
@@ -706,13 +719,16 @@ class FlowRunner:
         else:
             flag = ["--add-replace-section", "MEM_TOPOLOGY:JSON:" + self.prepend_tmp("mem_topology.json")]
 
+        # run xclbinutil to generate the xclbin
         await self.do_call(task, ["xclbinutil"] + flag +
                                  ["--add-kernel", self.prepend_tmp("kernels.json"),
                                   "--add-replace-section", "AIE_PARTITION:JSON:" + self.prepend_tmp("aie_partition.json"),
                                   "--force", "--quiet", "--output", opts.xclbin_name])
         # fmt: on
 
-    async def process_host_cgen(self, aie_target, file_with_addresses):
+    async def process_host_cgen(self, aie_target, file_physical):
+        if len(opts.host_args) == 0:
+            return
         async with self.limit:
             if self.stopall:
                 return
@@ -723,19 +739,6 @@ class FlowRunner:
                 )
             else:
                 task = None
-
-            # Generate the included host interface
-            file_physical = self.prepend_tmp("input_physical.mlir")
-            await self.do_call(
-                task,
-                [
-                    "aie-opt",
-                    "--aie-create-pathfinder-flows",
-                    file_with_addresses,
-                    "-o",
-                    file_physical,
-                ],
-            )
 
             if opts.airbin:
                 file_airbin = self.prepend_tmp("air.bin")
@@ -874,7 +877,7 @@ class FlowRunner:
             if task:
                 self.progress_bar.update(task, advance=0, visible=False)
 
-    async def gen_sim(self, task, aie_target):
+    async def gen_sim(self, task, aie_target, file_physical):
         # For simulation, we need to additionally parse the 'remaining' options to avoid things
         # which conflict with the options below (e.g. -o)
         print(opts.host_args)
@@ -921,7 +924,6 @@ class FlowRunner:
             "include",
         )
         sim_genwrapper = os.path.join(runtime_simlib_path, "genwrapper_for_ps.cpp")
-        file_physical = self.prepend_tmp("input_physical.mlir")
         memory_allocator = os.path.join(
             runtime_testlib_path, "libmemory_allocator_sim_aie.a"
         )
@@ -1086,12 +1088,11 @@ class FlowRunner:
                 "[green] MLIR compilation:", total=1, command="1 Worker"
             )
 
-            file_with_addresses = self.prepend_tmp("input_with_addresses.mlir")
-
             pass_pipeline = INPUT_WITH_ADDRESSES_PIPELINE(
                 opts.alloc_scheme, opts.dynamic_objFifos, opts.ctrl_pkt_overlay
             ).materialize(module=True)
 
+            file_with_addresses = self.prepend_tmp("input_with_addresses.mlir")
             run_passes(
                 pass_pipeline,
                 self.mlir_module_str,
@@ -1118,7 +1119,7 @@ class FlowRunner:
             aie_peano_target = aie_target.lower() + "-none-elf"
 
             # Optionally generate insts.txt for NPU instruction stream
-            if opts.npu or opts.only_npu:
+            if opts.npu:
                 with Context(), Location.unknown():
                     file_with_addresses_module = Module.parse(
                         await read_file_async(file_with_addresses)
@@ -1141,8 +1142,6 @@ class FlowRunner:
                     with open(opts.insts_name, "w") as f:
                         for inst in npu_insts:
                             f.write(f"{inst}\n")
-                if opts.only_npu:
-                    return
 
             # fmt: off
             if opts.unified:
@@ -1170,13 +1169,31 @@ class FlowRunner:
                 command="%d Workers" % nworkers,
             )
 
-            processes = [self.process_host_cgen(aie_target, file_with_addresses)]
+            input_physical = self.prepend_tmp("input_physical.mlir")
+            processes = [self.do_call(
+                None,
+                [
+                    "aie-opt",
+                    "--aie-create-pathfinder-flows",
+                    file_with_addresses,
+                    "-o",
+                    input_physical
+                ]
+            )]
             await asyncio.gather(
                 *processes
-            )  # ensure that process_host_cgen finishes before running gen_sim
+            )
+
+            if len(opts.host_args) > 0:
+                await self.process_host_cgen(aie_target, input_physical)
+
+            input_physical_str = await read_file_async(input_physical)
+
             processes = []
             if opts.aiesim:
-                processes.append(self.gen_sim(progress_bar.task, aie_target))
+                processes.append(
+                    self.gen_sim(progress_bar.task, aie_target, input_physical)
+                )
             for core in cores:
                 processes.append(
                     self.process_core(
@@ -1188,18 +1205,36 @@ class FlowRunner:
                 )
             await asyncio.gather(*processes)
 
-            # Must have elfs, before we build the final binary assembly
-            if opts.cdo and opts.execute:
-                await self.process_cdo()
+            # copy the elfs left by proess_core to the tmpdir for process_cdo
+            for elf in glob.glob("*.elf"):
+                try:
+                    shutil.copy(elf, self.tmpdirname)
+                except shutil.SameFileError:
+                    pass
+            for elf_map in glob.glob("*.elf.map"):
+                try:
+                    shutil.copy(elf_map, self.tmpdirname)
+                except shutil.SameFileError:
+                    pass
 
-            if opts.cdo or opts.xcl:
-                await self.process_xclbin_gen()
+            if (opts.cdo or opts.xcl or opts.pdi) and opts.execute:
+                await self.process_cdo(input_physical_str)
+
+            processes = []
+            if opts.xcl:
+                processes.append(self.process_xclbin_gen())
+            # self.process_pdi_gen is called in process_xclbin_gen,
+            # so don't call it again if opts.xcl is set
+            elif opts.pdi:
+                processes.append(self.process_pdi_gen())
 
             if opts.txn and opts.execute:
-                await self.process_txn()
+                processes.append(self.process_txn(input_physical_str))
 
             if opts.ctrlpkt and opts.execute:
-                await self.process_ctrlpkt()
+                processes.append(self.process_ctrlpkt(input_physical_str))
+
+            await asyncio.gather(*processes)
 
     def dumpprofile(self):
         sortedruntimes = sorted(

--- a/python/iron/experimental/task_runner.py
+++ b/python/iron/experimental/task_runner.py
@@ -36,7 +36,7 @@ class TaskRunner:
     @classmethod
     def _aiecc_args(cls, xclbin, insts):
         return [
-            "--aie-generate-cdo",
+            "--aie-generate-xclbin",
             f"--xclbin-name={xclbin}",
             "--no-xchesscc",
             "--no-xbridge",

--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %PYTHON aiecc.py --no-compile --no-link -nv --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s 
+// RUN: %python aiecc.py --no-compile --no-link --aie-generate-xclbin %s
 // RUN: FileCheck %s --input-file=buffers_xclbin.mlir.prj/kernels.json
 
 // CHECK: {

--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %python aiecc.py --no-compile --no-link --aie-generate-xclbin %s
+// RUN: %python aiecc.py -n --no-compile --no-link --aie-generate-xclbin %s
 // RUN: FileCheck %s --input-file=buffers_xclbin.mlir.prj/kernels.json
 
 // CHECK: {

--- a/test/aiecc/simple_xclbin.mlir
+++ b/test/aiecc/simple_xclbin.mlir
@@ -11,8 +11,8 @@
 // REQUIRES: chess
 // REQUIRES: peano
 
-// RUN: %PYTHON aiecc.py --xchesscc --no-link -nv --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s | FileCheck %s --check-prefix=XCHESSCC
-// RUN: %PYTHON aiecc.py --no-xchesscc --no-link -nv --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s | FileCheck %s --check-prefix=PEANO
+// RUN: %PYTHON aiecc.py --xchesscc --no-link -nv --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %PYTHON aiecc.py --no-xchesscc --no-link -nv --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %s | FileCheck %s --check-prefix=PEANO
 
 // Note that llc determines the architecture from the llvm IR.
 // XCHESSCC-NOT: {{^[^ ]*llc}}

--- a/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin
 //

--- a/test/npu-xrt/add_21_i8_using_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_21_i8_using_dma_op_with_padding/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin

--- a/test/npu-xrt/add_256_using_dma_op_no_double_buffering/run.lit
+++ b/test/npu-xrt/add_256_using_dma_op_no_double_buffering/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin

--- a/test/npu-xrt/add_314_using_dma_op/run.lit
+++ b/test/npu-xrt/add_314_using_dma_op/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin
 

--- a/test/npu-xrt/add_378_i32_using_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_378_i32_using_dma_op_with_padding/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin
 

--- a/test/npu-xrt/add_blockwrite/run.lit
+++ b/test/npu-xrt/add_blockwrite/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 

--- a/test/npu-xrt/add_maskwrite/run.lit
+++ b/test/npu-xrt/add_maskwrite/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 

--- a/test/npu-xrt/add_one_ctrl_packet/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall -lrt -lstdc++ %xrt_flags %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --generate-ctrl-pkt-overlay --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --generate-ctrl-pkt-overlay --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/add_one_objFifo/run.lit
+++ b/test/npu-xrt/add_one_objFifo/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 

--- a/test/npu-xrt/add_one_two/run.lit
+++ b/test/npu-xrt/add_one_two/run.lit
@@ -3,8 +3,8 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=insts.txt %S/aie1.mlir
-// RUN: %python aiecc.py --xclbin-kernel-name=ADDTWO --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.txt %S/aie2.mlir
+// RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=insts.txt %S/aie1.mlir
+// RUN: %python aiecc.py --xclbin-kernel-name=ADDTWO --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.txt %S/aie2.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x add_two.xclbin -i insts.txt
 

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -4,7 +4,7 @@
 // REQUIRES: ryzen_ai
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-// RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.txt %S/aie1.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-txn --aie-generate-npu --no-compile-host --npu-insts-name=add_two_insts.txt %S/aie2.mlir
+// RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.txt %S/aie1.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-txn --aie-generate-npu-insts --no-compile-host --npu-insts-name=add_two_insts.txt %S/aie2.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true -aie-sequence-name=configure aie2.mlir.prj/txn.mlir -o add_two_cfg.bin
 // RUN: %run_on_npu ./test.exe -x add_one.xclbin -i add_one_insts.txt -c add_two_cfg.bin -j add_two_insts.txt

--- a/test/npu-xrt/add_one_using_dma/run.lit
+++ b/test/npu-xrt/add_one_using_dma/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 

--- a/test/npu-xrt/adjacent_memtile_access/three_memtiles/aie2.py
+++ b/test/npu-xrt/adjacent_memtile_access/three_memtiles/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 import numpy as np

--- a/test/npu-xrt/adjacent_memtile_access/two_memtiles/aie2.py
+++ b/test/npu-xrt/adjacent_memtile_access/two_memtiles/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 import numpy as np

--- a/test/npu-xrt/cascade_flows/run.lit
+++ b/test/npu-xrt/cascade_flows/run.lit
@@ -6,6 +6,6 @@
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel1.cc -o ./kernel1.o
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel2.cc -o ./kernel2.o
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel3.cc -o ./kernel3.o
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/column_specific/aie2.py
+++ b/test/npu-xrt/column_specific/aie2.py
@@ -10,7 +10,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: %run_on_npu ./test.exe -x final.xclbin -k MLIR_AIE -i insts.txt
 
 import numpy as np

--- a/test/npu-xrt/ctrl_packet_reconfig/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig/run.lit
@@ -4,10 +4,10 @@
 // REQUIRES: ryzen_ai
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie1.mlir -o aie1_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --npu-insts-name=aie2_run_seq.txt aie2_overlay.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.txt aie2_overlay.mlir
 //
 // RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
 //

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
@@ -4,10 +4,10 @@
 // REQUIRES: ryzen_ai
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie1.mlir -o aie1_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --npu-insts-name=aie2_run_seq.txt aie2_overlay.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.txt aie2_overlay.mlir
 //
 // RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
 //

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
@@ -4,10 +4,10 @@
 // REQUIRES: ryzen_ai
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie1.mlir -o aie1_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu --no-compile-host --npu-insts-name=aie2_run_seq.txt aie2_overlay.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.txt aie2_overlay.mlir
 //
 // RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
 //

--- a/test/npu-xrt/device_width/aie2.py
+++ b/test/npu-xrt/device_width/aie2.py
@@ -10,7 +10,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: %run_on_npu ./test.exe -x final.xclbin -k MLIR_AIE -i insts.txt
 
 import numpy as np

--- a/test/npu-xrt/dma_complex_dims/aie2.py
+++ b/test/npu-xrt/dma_complex_dims/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai, peano
 #
 # RUN: %python %S/aie2.py --m 8 --k 5 --K 20 --r 4 --s 5 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x final.xclbin -i insts.txt -k MLIR_AIE --m 8 --k 5 --K 20 --r 4 --s 5
 import argparse

--- a/test/npu-xrt/dma_task_large_linear/aie2.py
+++ b/test/npu-xrt/dma_task_large_linear/aie2.py
@@ -8,7 +8,7 @@
 # REQUIRES: ryzen_ai, peano
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test
 import numpy as np

--- a/test/npu-xrt/dmabd_task_queue/run.lit
+++ b/test/npu-xrt/dmabd_task_queue/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/dynamic_object_fifo/nested_loops/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/nested_loops/aie2.py
@@ -10,7 +10,7 @@
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: %run_on_npu ./test.exe -x final.xclbin -k MLIR_AIE -i insts.txt
 
 import numpy as np

--- a/test/npu-xrt/dynamic_object_fifo/ping_pong/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/ping_pong/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe
 import numpy as np

--- a/test/npu-xrt/dynamic_object_fifo/reduction/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/reduction/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe
 import numpy as np

--- a/test/npu-xrt/dynamic_object_fifo/sliding_window/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/sliding_window/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe
 

--- a/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/run.lit
+++ b/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/run.lit
@@ -4,6 +4,6 @@
 // REQUIRES: ryzen_ai, valid_xchess_license
 //
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x final.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/dynamic_object_fifo/two_core_sliding_window/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/two_core_sliding_window/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe
 

--- a/test/npu-xrt/e2e/util.py
+++ b/test/npu-xrt/e2e/util.py
@@ -62,7 +62,7 @@ def annot(op, annot):
 
 def aiecc_args(xclbin, insts):
     return [
-        "--aie-generate-cdo",
+        "--aie-generate-xclbin",
         f"--xclbin-name={xclbin}",
         "--no-xchesscc",
         "--no-xbridge",

--- a/test/npu-xrt/matrix_multiplication_using_cascade/run.lit
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/run.lit
@@ -6,11 +6,11 @@
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/mm.cc -o ./mm.o
 // RUN: g++-13 %S/test.cpp -o test.exe -std=c++23 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 //
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie2_plain.xclbin --npu-insts-name=insts2_plain.txt %S/aie_plainx4.mlir
+// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie2_plain.xclbin --npu-insts-name=insts2_plain.txt %S/aie_plainx4.mlir
 // RUN: %run_on_npu ./test.exe -x aie2_plain.xclbin -k MLIR_AIE -i insts2_plain.txt --trace_sz 32768
 //
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie2_buffer.xclbin --npu-insts-name=insts2_buffer.txt %S/aie_bufferx4.mlir
+// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie2_buffer.xclbin --npu-insts-name=insts2_buffer.txt %S/aie_bufferx4.mlir
 // RUN: %run_on_npu ./test.exe -x aie2_buffer.xclbin -k MLIR_AIE -i insts2_buffer.txt --trace_sz 32768
 //
-// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie2_cascade.xclbin --npu-insts-name=insts2_cascade.txt %S/aie_cascadex4.mlir
+// RUN: %python aiecc.py --xchesscc --xbridge --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie2_cascade.xclbin --npu-insts-name=insts2_cascade.txt %S/aie_cascadex4.mlir
 // RUN: %run_on_npu ./test.exe -x aie2_cascade.xclbin -k MLIR_AIE -i insts2_cascade.txt --trace_sz 32768

--- a/test/npu-xrt/matrix_transpose/aie2.py
+++ b/test/npu-xrt/matrix_transpose/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test
 import numpy as np

--- a/test/npu-xrt/memtile_dmas/blockwrite_using_locks/run.lit
+++ b/test/npu-xrt/memtile_dmas/blockwrite_using_locks/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai, chess
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/memtile_dmas/writebd/run.lit
+++ b/test/npu-xrt/memtile_dmas/writebd/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai, chess
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/memtile_dmas/writebd_tokens/run.lit
+++ b/test/npu-xrt/memtile_dmas/writebd_tokens/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai, chess
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/nd_memcpy_linear_repeat/aie2.py
+++ b/test/npu-xrt/nd_memcpy_linear_repeat/aie2.py
@@ -8,7 +8,7 @@
 # REQUIRES: ryzen_ai, valid_xchess_license
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe
 

--- a/test/npu-xrt/nd_memcpy_transforms/aie2.py
+++ b/test/npu-xrt/nd_memcpy_transforms/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test
 import numpy as np

--- a/test/npu-xrt/neighbor_tile_memory_access/aie2.py
+++ b/test/npu-xrt/neighbor_tile_memory_access/aie2.py
@@ -10,7 +10,7 @@
 # REQUIRES: ryzen_ai, chess
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x final.xclbin -k MLIR_AIE -i insts.txt
 import numpy as np

--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai, peano
 #
 # RUN: %python %S/aie2.py 4096 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x final.xclbin -i insts.txt -k MLIR_AIE -l 4096
 import numpy as np

--- a/test/npu-xrt/objectfifo_repeat/distribute_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/distribute_repeat/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai, peano
 #
 # RUN: %python %S/aie2.py 36 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x final.xclbin -i insts.txt -k MLIR_AIE -l 36
 import numpy as np

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/Makefile
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/Makefile
@@ -11,7 +11,7 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-all: build/final.xclbin build/insts.txt
+all: build/final.xclbin
 
 devicename ?= npu
 targetname = init_values_repeat
@@ -21,18 +21,10 @@ build/aie.mlir: ${srcdir}/aie2.py
 	mkdir -p ${@D}
 	python3 $< ${LENGTH} ${devicename} ${col} > $@
 
-.PHONY: inst/insts.txt
-inst/insts.txt: ${srcdir}/aie2.py
-	rm -rf inst
-	mkdir -p inst
-	python3 $< ${LENGTH} > inst/aie.mlir
-	pushd inst && aiecc.py --aie-only-generate-npu --npu-insts-name=insts.txt aie.mlir && popd
-	${powershell} ./build/${targetname}.exe -x build/final.xclbin -i inst/insts.txt -k MLIR_AIE -l ${LENGTH}
-
 build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-cdo --no-compile-host --xclbin-name=${@F} \
-				--aie-generate-npu --npu-insts-name=insts.txt $(<:%=../%)
+	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
+				--aie-generate-npu-insts --npu-insts-name=insts.txt $(<:%=../%)
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai, peano
 #
 # RUN: %python %S/aie2.py 4096 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x final.xclbin -i insts.txt -k MLIR_AIE -l 4096
 import numpy as np

--- a/test/npu-xrt/objectfifo_repeat/simple_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/simple_repeat/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai, peano
 #
 # RUN: %python %S/aie2.py 4096 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x final.xclbin -i insts.txt -k MLIR_AIE -l 4096
 import numpy as np

--- a/test/npu-xrt/packet_flow/run.lit
+++ b/test/npu-xrt/packet_flow/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin
 

--- a/test/npu-xrt/packet_flow_fanin/run.lit
+++ b/test/npu-xrt/packet_flow_fanin/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin
 

--- a/test/npu-xrt/packet_flow_fanout/run.lit
+++ b/test/npu-xrt/packet_flow_fanout/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe aie.xclbin
 

--- a/test/npu-xrt/static_L1_init/run.lit
+++ b/test/npu-xrt/static_L1_init/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/sync_task_complete_token/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token/aie2.py
@@ -8,7 +8,7 @@
 # REQUIRES: ryzen_ai
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test
 

--- a/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
@@ -8,7 +8,7 @@
 # REQUIRES: ryzen_ai
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.txt ./aie2.mlir
 # RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test
 

--- a/test/npu-xrt/two_col/Makefile
+++ b/test/npu-xrt/two_col/Makefile
@@ -4,14 +4,11 @@ VPATH := $(VISION_KERNELS_VPATH_BASE)/threshold
 
 all: final.xclbin
 
-insts.txt: aie.mlir
-	aiecc.py -v --aie-only-generate-npu --npu-insts-name=$@ $<
-
 threshold.o: threshold.cc
 	xchesscc -d ${CHESSCC2_FLAGS} -DBIT_WIDTH=8 -c $< -o $@
 	
 final.xclbin: aie.mlir threshold.o
-	aiecc.py -v --aie-generate-cdo --aie-generate-npu --no-compile-host \
+	aiecc.py -v --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
 		--xclbin-name=$@ --npu-insts-name=insts.txt $<
 
 clean:

--- a/test/npu-xrt/two_col/run.lit
+++ b/test/npu-xrt/two_col/run.lit
@@ -4,6 +4,6 @@
 // REQUIRES: ryzen_ai, chess
 //
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -DBIT_WIDTH=8 -c %S/threshold.cc -o ./threshold.o
-// RUN: %python aiecc.py --xchesscc --xbridge --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --xchesscc --xbridge --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/vec_vec_add_memtile_init/run.lit
+++ b/test/npu-xrt/vec_vec_add_memtile_init/run.lit
@@ -3,7 +3,7 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 

--- a/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
+++ b/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
@@ -9,7 +9,7 @@
 # REQUIRES: ryzen_ai, peano
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --no-xchesscc --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --no-xchesscc --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt
 import numpy as np

--- a/test/npu-xrt/vec_vec_add_tile_init/run.lit
+++ b/test/npu-xrt/vec_vec_add_tile_init/run.lit
@@ -3,6 +3,6 @@
 //
 // REQUIRES: ryzen_ai
 //
-// RUN: %python aiecc.py --no-aiesim --aie-generate-cdo --aie-generate-npu --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt

--- a/test/npu-xrt/vector_scalar_using_dma/run.lit
+++ b/test/npu-xrt/vector_scalar_using_dma/run.lit
@@ -4,6 +4,6 @@
 // REQUIRES: ryzen_ai, chess
 //
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/scale.cc -o ./scale.o
-// RUN: %python aiecc.py --xbridge --aie-generate-cdo --aie-generate-npu --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
+// RUN: %python aiecc.py --xbridge --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.txt %S/aie.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.txt


### PR DESCRIPTION
* Remove aiecc `aie-only-generate-npu` option. Other options like `--no-compile` can be used instead.
* Rename aiecc `--aie-generate-npu` to `--aie-generate-npu-insts`
* Update tests and examples to use aiecc `--aie-generate-xclbin` instead of `--aie-generate-cdo` where an xclbin is what's desired
* New aiecc options `--aie-generate-pdi` and `--pdi-name` for when pdi output is wanted, not cdo or xclbin. e.g. with rocr runtime
