### PR TITLE
Extend `buildRyzenWheels` with more options

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -121,7 +121,7 @@ jobs:
 
             popd
 
-            auditwheel repair -w $WHEELHOUSE_DIR/repaired_wheel $WHEELHOUSE_DIR/mlir_aie-*.whl --plat manylinux_2_35_x86_64 --exclude libcdo_driver.so --exclude libmlir_float16_utils.so
+            auditwheel repair -w $WHEELHOUSE_DIR/repaired_wheel $WHEELHOUSE_DIR/mlir_aie*.whl --plat manylinux_2_35_x86_64 --exclude libcdo_driver.so --exclude libmlir_float16_utils.so
             # WHL_FN=$(ls $WHEELHOUSE_DIR/repaired_wheel/mlir_aie*whl)
             # mv "$WHL_FN" "`echo $WHL_FN | sed "s/cp310-cp310/py3-none/"`"
 

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -81,7 +81,6 @@ jobs:
             git config --global --add safe.directory $PWD
             MLIR_VERSION=$(git rev-parse --short HEAD)
             echo "Building mlir-aie version $MLIR_VERSION"
-            echo "ENABLE_RTTI=${{ inputs.ENABLE_RTTI }}" | tee -a $GITHUB_ENV
 
             python${{ matrix.python_version }} -m venv ${{ github.workspace }}/aie-venv
             source ${{ github.workspace }}/aie-venv/bin/activate
@@ -104,6 +103,7 @@ jobs:
             # forever when configuring. Set the time to some arbitrary stamp in the past just to be safe.
             find mlir -exec touch -a -m -t 201108231405.14 {} \;
 
+            export ENABLE_RTTI=${{ inputs.ENABLE_RTTI }}
             export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
             export MLIR_INSTALL_ABS_PATH=$PWD/mlir
             export MLIR_AIE_SOURCE_DIR=$PWD

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -9,6 +9,11 @@ on:
         type: boolean
         required: false
         default: true
+      AIE_COMMIT:
+        description: 'AIE commit to build'
+        type: string
+        required: false
+        default: ''
   merge_group:
 
   schedule:
@@ -110,7 +115,11 @@ jobs:
             export WHEELHOUSE_DIR=$PWD/wheelhouse
             export CMAKE_MODULE_PATH=$PWD/cmake/modulesXilinx
             export XRT_ROOT=/opt/xilinx/xrt
-            export AIE_PROJECT_COMMIT=$MLIR_VERSION
+            if [ x"${{ inputs.AIE_COMMIT }}" == x"" ]; then
+              export AIE_PROJECT_COMMIT=$MLIR_VERSION
+            else
+              export AIE_PROJECT_COMMIT="${{ inputs.AIE_COMMIT }}"
+            fi
             export AIE_VITIS_COMPONENTS='AIE2;AIE2P'
             export DATETIME=$(date +"%Y%m%d%H")
 

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -3,6 +3,12 @@ name: Build wheels for Ryzen AI
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      ENABLE_RTTI:
+        description: 'Run the build with rtti enabled'
+        type: boolean
+        required: false
+        default: true
   merge_group:
 
   schedule:
@@ -75,6 +81,7 @@ jobs:
             git config --global --add safe.directory $PWD
             MLIR_VERSION=$(git rev-parse --short HEAD)
             echo "Building mlir-aie version $MLIR_VERSION"
+            echo "ENABLE_RTTI=${{ inputs.ENABLE_RTTI }}" | tee -a $GITHUB_ENV
 
             python${{ matrix.python_version }} -m venv ${{ github.workspace }}/aie-venv
             source ${{ github.workspace }}/aie-venv/bin/activate


### PR DESCRIPTION
- ENABLE_RTTI option switches between building mlir-aie wheel with rtti enabled/disabled.
- AIE_COMMIT option allows for user to control over which mlir-aie commit to build wheel with.