### PR TITLE
Add worker stack size to python bindings

### DIFF
--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -245,10 +245,11 @@ Device = DeviceOp
 
 class Core(CoreOp):
     # Until https://github.com/llvm/llvm-project/pull/73620 gets figured out.
-    def __init__(self, tile, link_with=None, dynamic_objfifo_lowering=None):
+    def __init__(self, tile, link_with=None, dynamic_objfifo_lowering=None, stack_size=None):
         super().__init__(
             result=T.index(),
             tile=tile,
+            stack_size=stack_size,
             link_with=link_with,
             dynamic_objfifo_lowering=dynamic_objfifo_lowering,
         )

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -50,6 +50,19 @@ def coreOp():
     with InsertionPoint(bb):
         end()
 
+# CHECK-LABEL: coreOpParameters
+# CHECK: %[[VAL1:.*]] = aie.tile(1, 1)
+# CHECK: %[[VAL2:.*]] = aie.core(%[[VAL1]]) {
+# CHECK:   aie.end
+# CHECK: } {dynamic_objfifo_lowering = false, link_with = "test.elf", stack_size = 2048 : i32}
+@construct_and_print_module
+def coreOpParameters():
+    t = tile(col=1, row=1)
+    c = Core(t, link_with="test.elf", dynamic_objfifo_lowering=False, stack_size=2048)
+    bb = Block.create_at_start(c.body)
+    with InsertionPoint(bb):
+        end()
+
 
 # CHECK-LABEL: memOp
 # CHECK: %[[VAL1:.*]] = aie.tile(2, 2)

--- a/test/python/stack_size_definition.py
+++ b/test/python/stack_size_definition.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2023, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s | FileCheck %s
+
+from aie.iron import Program, Runtime, Worker
+from aie.iron.placers import SequentialPlacer
+from aie.iron.device import NPU1Col4
+
+# CHECK: {stack_size = 2048 : i32}
+
+my_worker = Worker(None, stack_size=2048, while_true=False)
+
+rt = Runtime()
+with rt.sequence():
+    rt.start(my_worker)
+
+my_program = Program(NPU1Col4(), rt)
+
+module = my_program.resolve_program(SequentialPlacer())
+
+print(module)
+
+
+# CHECK: {stack_size = 512 : i32}
+
+from aie.dialects.aie import *
+from aie.extras.context import mlir_mod_ctx
+
+def mlir_aie_design():
+
+    @device(AIEDevice.npu1)
+    def device_body():
+
+        ComputeTile1 = tile(0, 2)
+
+        @core(ComputeTile1, stack_size=512)
+        def core_body():
+            pass
+
+
+with mlir_mod_ctx() as ctx:
+    mlir_aie_design()
+    print(ctx.module)


### PR DESCRIPTION
Closes #2045

Note that the order of the positional arguments does not correspond to the order used in mlir. I did not change this to avoid breaking all previous tests using positional arguments when declaring a core.