### PR TITLE
Fix simulation host compilation bug -- aie_inc.cpp not found

### DIFF
--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1184,6 +1184,19 @@ class FlowRunner:
             ]
             await asyncio.gather(*processes)
 
+            if opts.compile_host or opts.aiesim:
+                file_inc_cpp = self.prepend_tmp("aie_inc.cpp")
+                await self.do_call(
+                    None,
+                    [
+                        "aie-translate",
+                        "--aie-generate-xaie",
+                        input_physical,
+                        "-o",
+                        file_inc_cpp,
+                    ],
+                )
+
             if opts.compile_host and len(opts.host_args) > 0:
                 await self.process_host_cgen(aie_target, input_physical)
 

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -751,18 +751,6 @@ class FlowRunner:
                         file_airbin,
                     ],
                 )
-            else:
-                file_inc_cpp = self.prepend_tmp("aie_inc.cpp")
-                await self.do_call(
-                    task,
-                    [
-                        "aie-translate",
-                        "--aie-generate-xaie",
-                        file_physical,
-                        "-o",
-                        file_inc_cpp,
-                    ],
-                )
 
             if opts.link_against_hsa:
                 file_inc_cpp = self.prepend_tmp("aie_data_movement.cpp")


### PR DESCRIPTION
Fix bug introduced in https://github.com/Xilinx/mlir-aie/pull/2075 found by internal CI where aie_inc.cpp is not generated for some aiesimulator use cases.