### PR TITLE
Update reset_npu.sh

### DIFF
--- a/utils/reset_npu.sh
+++ b/utils/reset_npu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-NUMBER=$(lspci -D | grep "\[AMD\] Device 1502" | cut -d ' ' -f1)
+NUMBER=$(lspci -D | grep "\[AMD\] AMD IPU Device" | cut -d ' ' -f1)
 
 if [ x"$NUMBER" != x"" ]; then
   sudo modprobe -r amdxdna


### PR DESCRIPTION
NPU name change as seen in lspci 

![image](https://github.com/user-attachments/assets/f728236e-af12-4e43-ad8d-5816497dd790)

tested on AMD Ryzen 7 7840HS