### PR TITLE
aiecc argument handling updates

### DIFF
--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -58,7 +58,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--no-xbridge",
         dest="xbridge",
-        default=not aie_link_with_xchesscc,
+        default=aie_link_with_xchesscc,
         action="store_false",
         help="Link using peano",
     )
@@ -86,7 +86,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--no-xchesscc",
         dest="xchesscc",
-        default=not aie_compile_with_xchesscc,
+        default=aie_compile_with_xchesscc,
         action="store_false",
         help="Compile using peano",
     )
@@ -106,7 +106,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--no-compile",
         dest="compile",
-        default=aie_disable_compile,
+        default=not aie_disable_compile,
         action="store_false",
         help="Disable compiling of AIE code",
     )
@@ -126,7 +126,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--no-compile-host",
         dest="compile_host",
-        default=host_disable_compile,
+        default=not host_disable_compile,
         action="store_false",
         help="Disable compiling of the host program",
     )
@@ -140,7 +140,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--no-link",
         dest="link",
-        default=aie_disable_link,
+        default=not aie_disable_link,
         action="store_false",
         help="Disable linking of AIE code",
     )
@@ -201,7 +201,7 @@ def parse_args(args=None):
     parser.add_argument(
         "--no-unified",
         dest="unified",
-        default=not aie_unified_compile,
+        default=aie_unified_compile,
         action="store_false",
         help="Compile cores independently in separate processes",
     )
@@ -247,7 +247,13 @@ def parse_args(args=None):
         default=False,
         action="store_const",
         const=True,
-        help="Generate txn binary for configuration",
+        help="Generate transaction binary mlir for configuration",
+    )
+    parser.add_argument(
+        "--txn-name",
+        dest="txn_name",
+        default="transaction.mlir",
+        help="Output filename for transaction binary mlir",
     )
     parser.add_argument(
         "--aie-generate-ctrlpkt",

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -207,7 +207,7 @@ mem_topology = {
 }
 
 
-def emit_partition(mlir_module_str, pdi_name, kernel_id="0x901"):
+def emit_partition(mlir_module_str, kernel_id="0x901"):
     with Context(), Location.unknown():
         module = Module.parse(mlir_module_str)
     device = find_ops(
@@ -242,7 +242,7 @@ def emit_partition(mlir_module_str, pdi_name, kernel_id="0x901"):
             "PDIs": [
                 {
                     "uuid": str(pdi_uuid),
-                    "file_name": pdi_name,
+                    "file_name": "./design.pdi",
                     "cdo_groups": [
                         {
                             "name": "DPU",
@@ -600,6 +600,10 @@ class FlowRunner:
                 self.prepend_tmp("txn.mlir"),
                 self.opts.verbose,
             )
+            tmp = self.prepend_tmp("txn.mlir")
+            if opts.verbose:
+                print(f"copy {tmp} to {opts.txn_name}")
+            shutil.copy(tmp, opts.txn_name)
 
     async def process_ctrlpkt(self, module_str):
         with Context(), Location.unknown():
@@ -616,7 +620,7 @@ class FlowRunner:
 
         await write_file_async(
             emit_design_bif(self.tmpdirname),
-            self.prepend_tmp(opts.pdi_name + ".bif"),
+            self.prepend_tmp("design.bif"),
         )
 
         await self.do_call(
@@ -626,12 +630,17 @@ class FlowRunner:
                 "-arch",
                 "versal",
                 "-image",
-                self.prepend_tmp(opts.pdi_name + ".bif"),
+                self.prepend_tmp("design.bif"),
                 "-o",
-                self.prepend_tmp(opts.pdi_name),
+                self.prepend_tmp('design.pdi'),
                 "-w",
             ],
         )
+        if opts.pdi:
+            tmp = self.prepend_tmp("design.pdi")
+            if opts.verbose:
+                print(f"copy {tmp} to {opts.pdi_name}")
+            shutil.copy(tmp, opts.pdi_name)
 
     # generate an xclbin. The inputs are self.mlir_module_str and the cdo
     # binaries from the process_cdo step.
@@ -658,7 +667,7 @@ class FlowRunner:
         processes.append(
             write_file_async(
                 json.dumps(
-                    emit_partition(self.mlir_module_str, opts.pdi_name, opts.kernel_id),
+                    emit_partition(self.mlir_module_str, opts.kernel_id),
                     indent=2,
                 ),
                 self.prepend_tmp("aie_partition.json"),

--- a/test/aiecc/generate_pdi.mlir
+++ b/test/aiecc/generate_pdi.mlir
@@ -1,4 +1,4 @@
-//===- simple.mlir ---------------------------------------------*- MLIR -*-===//
+//===- generate_pdi.mlir ---------------------------------------*- MLIR -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,14 +8,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %PYTHON aiecc.py -v --aie-generate-pdi --pdi-name=MlirAie.pdi --npu-insts-name=insts.txt %s | FileCheck %s
+// REQUIRES: chess
+// REQUIRES: peano
+
+// RUN: %python aiecc.py -v --xchesscc --xbridge --aie-generate-pdi --pdi-name=MlirAie0.pdi %s | FileCheck %s --check-prefix=XCHESSCC
+// RUN: %python aiecc.py -v --no-xchesscc --no-xbridge --aie-generate-pdi --pdi-name=MlirAie1.pdi %s | FileCheck %s --check-prefix=PEANO
+
 // RUN: ls | grep MlirAie.pdi | FileCheck %s --check-prefix=CHECK-FILE
 
-// Note that llc determines the architecture from the llvm IR.
-// CHECK: bootgen
-// CHECK: copy{{.*}} to MlirAie.pdi
-// CHECK-NOT: xclbinutil
-// CHECK-FILE: MlirAie.pdi
+// XCHESSCC: bootgen
+// XCHESSCC: copy{{.*}} to MlirAie0.pdi
+// XCHESSCC-NOT: xclbinutil
+
+// PEANO: bootgen
+// PEANO: copy{{.*}} to MlirAie1.pdi
+// PEANO-NOT: xclbinutil
+
+// CHECK-FILE: MlirAie0.pdi
+// CHECK-FILE: MlirAie1.pdi
 
 module {
   aie.device(npu1_4col) {

--- a/test/aiecc/simple_pdi.mlir
+++ b/test/aiecc/simple_pdi.mlir
@@ -1,0 +1,31 @@
+//===- simple.mlir ---------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %PYTHON aiecc.py -v --aie-generate-pdi --pdi-name=MlirAie.pdi --npu-insts-name=insts.txt %s | FileCheck %s
+// RUN: ls | grep MlirAie.pdi | FileCheck %s --check-prefix=CHECK-FILE
+
+// Note that llc determines the architecture from the llvm IR.
+// CHECK: bootgen
+// CHECK: copy{{.*}} to MlirAie.pdi
+// CHECK-NOT: xclbinutil
+// CHECK-FILE: MlirAie.pdi
+
+module {
+  aie.device(npu1_4col) {
+  %12 = aie.tile(1, 2)
+  %buf = aie.buffer(%12) : memref<256xi32>
+  %4 = aie.core(%12)  {
+    %0 = arith.constant 0 : i32
+    %1 = arith.constant 0 : index
+    memref.store %0, %buf[%1] : memref<256xi32>
+    aie.end
+  }
+  }
+}

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -5,6 +5,6 @@
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.txt %S/aie1.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-txn --aie-generate-npu-insts --no-compile-host --npu-insts-name=add_two_insts.txt %S/aie2.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true -aie-sequence-name=configure aie2.mlir.prj/txn.mlir -o add_two_cfg.bin
+// RUN: %python aiecc.py --no-aiesim --aie-generate-txn --txn-name=transaction.mlir --aie-generate-npu-insts --no-compile-host --npu-insts-name=add_two_insts.txt %S/aie2.mlir
+// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true -aie-sequence-name=configure transaction.mlir -o add_two_cfg.bin
 // RUN: %run_on_npu ./test.exe -x add_one.xclbin -i add_one_insts.txt -c add_two_cfg.bin -j add_two_insts.txt


### PR DESCRIPTION
This PR has three updates to aiecc command line handling:

1. Fix the handling of defaults for `--feature`/`--no-feature` style flags. These pairs of flags target the same argparse `dest` variable, so they need to set the default in the same way, which aiecc wasn't doing. The fix is to set the dest variable default correctly once or at least do it consistently. Here's a test showing how the existing behavior is broken wrt defaults: https://gist.github.com/fifield/9cc04f2df370af4846bf0ba86b7709be
2. Fix the `--aie-generate-pdi` and `--pdi-name` flags to actually work. Add a test.
3. Add `--txn-name` flag to go along with `--aie-generate-txn` flag and update a test to use it.