### PR TITLE
Add a proper address attribute to aie.external_buffer

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1327,10 +1327,10 @@ def AIE_BufferOp: AIE_Op<"buffer", [
 
   let arguments = (
     ins Index:$tile,
-    OptionalAttr<StrAttr>:$sym_name,
-    OptionalAttr<AIEI32Attr>:$address,
-    OptionalAttr<ElementsAttr>:$initial_value,
-    OptionalAttr<AIEI32Attr>:$mem_bank
+        OptionalAttr<StrAttr>:$sym_name,
+        OptionalAttr<AIEI32Attr>:$address,
+        OptionalAttr<ElementsAttr>:$initial_value,
+        OptionalAttr<AIEI32Attr>:$mem_bank
   );
 
   let results = (outs AnyMemRef:$buffer);
@@ -1395,7 +1395,10 @@ def AIE_ExternalBufferOp: AIE_Op<"external_buffer", [
     This operation represents an external buffer.
   }];
 
-  let arguments = (ins OptionalAttr<StrAttr>:$sym_name);
+  let arguments = (
+    ins OptionalAttr<StrAttr>:$sym_name,
+        OptionalAttr<AIEI64Attr>:$address
+  );
 
   let results = (outs AnyMemRef:$buffer);
   let assemblyFormat = [{ attr-dict `:` type($buffer) }];

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -377,12 +377,14 @@ class external_buffer(MemRef):
         cls,
         datatype: MemRefType | type[np.ndarray],
         name: str | None = None,
+        address=None,
         loc=None,
         ip=None,
     ):
         my_buffer = ExternalBufferOp(
             buffer=try_convert_np_type_to_mlir_type(datatype),
             sym_name=name,
+            address=address,
             loc=loc,
             ip=ip,
         )

--- a/test/python/aie_ops.py
+++ b/test/python/aie_ops.py
@@ -116,9 +116,11 @@ def bufferOp():
 
 # CHECK-LABEL: externalBufferOp
 # CHECK: %[[VAL_0:.*]] = aie.external_buffer : memref<12xi32>
+# CHECK: %[[VAL_1:.*]] = aie.external_buffer {address = 209934011881080 : i64} : memref<13xi8>
 @construct_and_print_module
 def externalBufferOp():
     b = external_buffer(T.memref(12, T.i32()))
+    c = external_buffer(T.memref(13, T.i8()), address=0xBEEF12345678)
 
 
 # CHECK-LABEL: objFifo


### PR DESCRIPTION
* Add `address` as an optional `i64` attribute on external buffers
* Support external buffers with addresses in shim bd lowering
* Add address parameter to aie.external_buffer constructor in python binding