### PR TITLE
Update aiert based targets to use burst length from target model

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -49,11 +49,15 @@ struct SkipAccessibilityCheckTrait
     : mlir::OpTrait::TraitBase<ConcreteType, SkipAccessibilityCheckTrait> {};
 
 class TileOp;
-} // namespace xilinx::AIE
 
-namespace xilinx::AIE {
+uint32_t getShimBurstLengthBytes(const AIE::AIETargetModel &tm,
+                                 uint32_t burstLength);
+uint32_t getShimBurstLengthEncoding(const AIE::AIETargetModel &tm,
+                                    uint32_t burstLength);
+
 mlir::LogicalResult
 verifyOffsetSizeAndStrideOp(mlir::OffsetSizeAndStrideOpInterface op);
+
 } // namespace xilinx::AIE
 
 /// Include the generated interface declarations.
@@ -247,16 +251,16 @@ parseObjectFifoProducerTile(mlir::OpAsmParser &parser,
 
 void printObjectFifoProducerTile(mlir::OpAsmPrinter &printer,
                                  mlir::Operation *op, mlir::Value tile,
-                                 mlir::Attribute dimensions);
+                                 BDDimLayoutArrayAttr dimensions);
 
 mlir::ParseResult parseObjectFifoConsumerTiles(
     mlir::OpAsmParser &parser,
-    llvm::SmallVector<mlir::OpAsmParser::UnresolvedOperand> &tiles,
+    llvm::SmallVectorImpl<mlir::OpAsmParser::UnresolvedOperand> &tiles,
     BDDimLayoutArrayArrayAttr &dimensions);
 
 void printObjectFifoConsumerTiles(mlir::OpAsmPrinter &printer,
                                   mlir::Operation *op, mlir::OperandRange tiles,
-                                  mlir::Attribute dimensions);
+                                  BDDimLayoutArrayArrayAttr dimensions);
 
 int32_t getBufferBaseAddress(mlir::Operation *bufOp);
 

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -271,7 +271,7 @@ public:
   // Returns the list of possible burst encodings (first) and
   // their corresponding lengths in bytes (second).
   virtual std::vector<std::pair<uint32_t, uint32_t>>
-  getBurstEncodingsAndLengths() const = 0;
+  getShimBurstEncodingsAndLengths() const = 0;
 };
 
 class AIE1TargetModel : public AIETargetModel {
@@ -343,7 +343,7 @@ public:
   }
 
   std::vector<std::pair<uint32_t, uint32_t>>
-  getBurstEncodingsAndLengths() const override;
+  getShimBurstEncodingsAndLengths() const override;
 };
 
 class AIE2TargetModel : public AIETargetModel {
@@ -432,7 +432,7 @@ public:
   }
 
   std::vector<std::pair<uint32_t, uint32_t>>
-  getBurstEncodingsAndLengths() const override;
+  getShimBurstEncodingsAndLengths() const override;
 };
 
 class VC1902TargetModel : public AIE1TargetModel {
@@ -632,7 +632,7 @@ public:
   }
 
   std::vector<std::pair<uint32_t, uint32_t>>
-  getBurstEncodingsAndLengths() const override;
+  getShimBurstEncodingsAndLengths() const override;
 };
 
 } // namespace xilinx::AIE

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -74,11 +74,11 @@ struct AIEDialectFoldInterface : DialectFoldInterface {
 //  pair. An object of this class is invalidated if, for any symbol_name, a
 //  ShimDMAAllocationOp that uses it changes, as the cache is not updated in
 //  this case.
-namespace xilinx::AIE {
+
 // Return the first ShimDMAAllocationOp nested inside the DeviceOp 'dev' that
 // uses the symbol 'sym_name'
-std::optional<AIE::ShimDMAAllocationOp>
-ShimDMAllocationGetter::get(DeviceOp dev, StringRef sym_name) {
+std::optional<xilinx::AIE::ShimDMAAllocationOp>
+xilinx::AIE::ShimDMAllocationGetter::get(DeviceOp dev, StringRef sym_name) {
   auto key = std::make_pair(dev, sym_name);
   auto it = allocGetter.find(key);
   if (it != allocGetter.end()) {
@@ -100,8 +100,9 @@ ShimDMAllocationGetter::get(DeviceOp dev, StringRef sym_name) {
 // can be slow when the symbol is used in many places. This version of the
 // function is only called when the cache does not have a ShimDMAAllocationOp
 // stored from a previous lookup.
-std::optional<AIE::ShimDMAAllocationOp>
-ShimDMAllocationGetter::cachelessGet(DeviceOp dev, mlir::StringRef sym_name) {
+std::optional<xilinx::AIE::ShimDMAAllocationOp>
+xilinx::AIE::ShimDMAllocationGetter::cachelessGet(DeviceOp dev,
+                                                  mlir::StringRef sym_name) {
   auto *sym = dev.lookupSymbol(sym_name);
   if (!sym)
     return std::nullopt;
@@ -111,11 +112,46 @@ ShimDMAllocationGetter::cachelessGet(DeviceOp dev, mlir::StringRef sym_name) {
       return infoOp;
   return std::nullopt;
 }
-} // namespace xilinx::AIE
 
-namespace xilinx::AIE {
+// Helper methods to retrieve the encoding associated to a burst length,
+// or to find the highest available burst length if the requested one is 0
+// (default value).
 
-LogicalResult myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
+static std::pair<uint32_t, uint32_t>
+getShimBurstLength(const xilinx::AIE::AIETargetModel &tm,
+                   uint32_t burstLength) {
+
+  std::vector<std::pair<uint32_t, uint32_t>> bel =
+      tm.getShimBurstEncodingsAndLengths();
+
+  // If we have the default burst length (no burst length was specified),
+  // use the highest one available on our target model
+  if (burstLength == 0) {
+    return *std::max_element(
+        bel.begin(), bel.end(),
+        [](auto pair1, auto pair2) { return pair1.second < pair2.second; });
+  }
+
+  // Note that if we are given a burst size, we are checking its existence in
+  // the pass verification already, so we can safely assume it exists.
+  return *std::find_if(bel.begin(), bel.end(),
+                       [=](auto p) { return p.second == burstLength; });
+}
+
+uint32_t xilinx::AIE::getShimBurstLengthBytes(const AIE::AIETargetModel &tm,
+                                              uint32_t burstLength) {
+
+  return getShimBurstLength(tm, burstLength).second;
+}
+
+uint32_t xilinx::AIE::getShimBurstLengthEncoding(const AIE::AIETargetModel &tm,
+                                                 uint32_t burstLength) {
+
+  return getShimBurstLength(tm, burstLength).first;
+}
+
+LogicalResult
+xilinx::AIE::myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
   std::array<unsigned, 3> maxRanks = op.getArrayAttrMaxRanks();
   if (!(op.getMixedOffsets().size() == 1 && maxRanks[0] == 1) && // NOLINT
       op.getMixedOffsets().size() != op.getMixedSizes().size())
@@ -154,7 +190,7 @@ static VirtualizedNPUTargetModel NPUmodel3col(3);
 static VirtualizedNPUTargetModel NPUmodel4col(4);
 static NPU2TargetModel NPU2model;
 
-const AIETargetModel &getTargetModel(Operation *op) {
+const AIETargetModel &xilinx::AIE::getTargetModel(Operation *op) {
   if (auto t = dyn_cast<AIETarget>(op))
     return t.getTargetModel();
   if (auto t = op->getParentOfType<AIETarget>())
@@ -165,7 +201,7 @@ const AIETargetModel &getTargetModel(Operation *op) {
   return VC1902model;
 }
 
-const AIETargetModel &getTargetModel(AIEDevice device) {
+const AIETargetModel &xilinx::AIE::getTargetModel(AIEDevice device) {
   switch (device) {
   case AIEDevice::xcvc1902:
     return VC1902model;
@@ -200,6 +236,8 @@ static TileElement getParentTileElement(Operation *op) {
   }
   return llvm::dyn_cast<TileElement>(parent);
 }
+
+namespace {
 
 struct UsesAreAccessible {
   static LogicalResult verifyTrait(Operation *op) {
@@ -243,7 +281,9 @@ struct UsesAreAccessible {
   }
 };
 
-namespace detail {
+} // namespace
+
+namespace xilinx::AIE::detail {
 /// This class represents the internal storage of the AIE `ObjectFifoType`.
 struct AIEObjectFifoTypeStorage : TypeStorage {
   /// The `KeyTy` is a required type that provides an interface for the storage
@@ -271,27 +311,26 @@ struct AIEObjectFifoTypeStorage : TypeStorage {
 
   MemRefType elementType;
 };
-} // namespace detail
+} // namespace xilinx::AIE::detail
 
-AIEObjectFifoType AIEObjectFifoType::get(MemRefType elementType) {
+AIEObjectFifoType xilinx::AIE::AIEObjectFifoType::get(MemRefType elementType) {
   // Call into a helper 'get' method in 'TypeBase' to get an uniqued instance
   // of this type.
   MLIRContext *ctx = elementType.getContext();
   return Base::get(ctx, elementType);
 }
 
-LogicalResult
-AIEObjectFifoType::verify(function_ref<InFlightDiagnostic()> emitError,
-                          MemRefType elementType) {
+LogicalResult xilinx::AIE::AIEObjectFifoType::verify(
+    function_ref<InFlightDiagnostic()> emitError, MemRefType elementType) {
   return success();
 }
 
-mlir::MemRefType AIEObjectFifoType::getElementType() {
+mlir::MemRefType xilinx::AIE::AIEObjectFifoType::getElementType() {
   // 'getImpl' returns a pointer to the internal storage instance.
   return getImpl()->elementType;
 }
 
-namespace detail {
+namespace xilinx::AIE::detail {
 /// This class represents the internal storage of the AIE
 /// `ObjectFifoSubviewType`.
 struct AIEObjectFifoSubviewTypeStorage : TypeStorage {
@@ -321,9 +360,10 @@ struct AIEObjectFifoSubviewTypeStorage : TypeStorage {
 
   MemRefType elementType;
 };
-} // namespace detail
+} // namespace xilinx::AIE::detail
 
-AIEObjectFifoSubviewType AIEObjectFifoSubviewType::get(MemRefType elementType) {
+AIEObjectFifoSubviewType
+xilinx::AIE::AIEObjectFifoSubviewType::get(MemRefType elementType) {
   // Call into a helper 'get' method in 'TypeBase' to get a uniqued instance
   // of this type.
   MLIRContext *ctx = elementType.getContext();
@@ -331,13 +371,12 @@ AIEObjectFifoSubviewType AIEObjectFifoSubviewType::get(MemRefType elementType) {
 }
 
 /// This method is used to verify the construction invariants.
-LogicalResult
-AIEObjectFifoSubviewType::verify(function_ref<InFlightDiagnostic()> emitError,
-                                 MemRefType elementType) {
+LogicalResult xilinx::AIE::AIEObjectFifoSubviewType::verify(
+    function_ref<InFlightDiagnostic()> emitError, MemRefType elementType) {
   return success();
 }
 
-MemRefType AIEObjectFifoSubviewType::getElementType() {
+MemRefType xilinx::AIE::AIEObjectFifoSubviewType::getElementType() {
   return getImpl()->elementType;
 }
 
@@ -447,8 +486,6 @@ void AIEDialect::initialize() {
       >();
   addInterfaces<AIEInlinerInterface, AIEDialectFoldInterface>();
 }
-
-} // namespace xilinx::AIE
 
 // Check that the operation only contains terminators in
 // TerminatorOpTypes.
@@ -578,11 +615,9 @@ TileOp ObjectFifoCreateOp::getProducerTileOp() {
   return cast<TileOp>(getProducerTile().getDefiningOp());
 }
 
-namespace xilinx::AIE {
-
-ParseResult parseObjectFifoProducerTile(OpAsmParser &parser,
-                                        OpAsmParser::UnresolvedOperand &operand,
-                                        BDDimLayoutArrayAttr &dimensions) {
+ParseResult xilinx::AIE::parseObjectFifoProducerTile(
+    OpAsmParser &parser, OpAsmParser::UnresolvedOperand &operand,
+    BDDimLayoutArrayAttr &dimensions) {
   std::vector<BDDimLayoutAttr> emptyDims = {};
   if (parser.parseOperand(operand))
     return failure();
@@ -598,9 +633,9 @@ ParseResult parseObjectFifoProducerTile(OpAsmParser &parser,
   return success();
 }
 
-void printObjectFifoProducerTile(OpAsmPrinter &printer, Operation *op,
-                                 Value operand,
-                                 BDDimLayoutArrayAttr dimensions) {
+void xilinx::AIE::printObjectFifoProducerTile(OpAsmPrinter &printer,
+                                              Operation *op, Value operand,
+                                              BDDimLayoutArrayAttr dimensions) {
   printer << operand;
   if (!dimensions.empty()) {
     printer << " dimensionsToStream ";
@@ -608,7 +643,7 @@ void printObjectFifoProducerTile(OpAsmPrinter &printer, Operation *op,
   }
 }
 
-ParseResult parseObjectFifoConsumerTiles(
+ParseResult xilinx::AIE::parseObjectFifoConsumerTiles(
     OpAsmParser &parser, SmallVectorImpl<OpAsmParser::UnresolvedOperand> &tiles,
     BDDimLayoutArrayArrayAttr &dimensions) {
   // parseCommaSeparatedList doesn't handle the missing case for "none",
@@ -644,9 +679,9 @@ ParseResult parseObjectFifoConsumerTiles(
   return success();
 }
 
-void printObjectFifoConsumerTiles(OpAsmPrinter &printer, Operation *op,
-                                  OperandRange tiles,
-                                  BDDimLayoutArrayArrayAttr dimsPerTileAttr) {
+void xilinx::AIE::printObjectFifoConsumerTiles(
+    OpAsmPrinter &printer, Operation *op, OperandRange tiles,
+    BDDimLayoutArrayArrayAttr dimsPerTileAttr) {
   size_t tileIdx = 0;
   for (auto tile : tiles) {
     printer << tile;
@@ -714,8 +749,6 @@ static ParseResult parseObjectFifoInitValues(OpAsmParser &parser,
 
   return success();
 }
-
-} // namespace xilinx::AIE
 
 //===----------------------------------------------------------------------===//
 // ObjectFifoLinkOp
@@ -1882,10 +1915,9 @@ LogicalResult DMABDOp::verify() {
         return emitOpError()
                << "Invalid step size; must be a positive integer.";
       if (dim.getStride() > buffer.getNumElements())
-        return emitOpError()
-               << "Step size " << std::to_string(dim.getStride()) << " "
-               << "exceeds memref size "
-               << std::to_string(buffer.getNumElements());
+        return emitOpError() << "Step size " << std::to_string(dim.getStride())
+                             << " exceeds memref size "
+                             << std::to_string(buffer.getNumElements());
       if (dim.getSize() >= (1UL << 9) + 1)
         return emitOpError() << "Size may not exceed 1023.";
       if (dim.getStride() >= (1UL << 19))
@@ -2319,8 +2351,6 @@ LogicalResult UseLockOp::verify() {
 #define GET_OP_CLASSES
 #include "aie/Dialect/AIE/IR/AIEOps.cpp.inc"
 
-namespace xilinx::AIE {
-
 size_t SwitchboxOp::getNumSourceConnections(WireBundle bundle) {
   auto tile = getTileOp();
   const auto &targetModel = getTargetModel(*this);
@@ -2335,7 +2365,7 @@ size_t SwitchboxOp::getNumDestConnections(WireBundle bundle) {
                                                     tile.getRow(), bundle);
 }
 
-WireBundle getConnectingBundle(WireBundle dir) {
+WireBundle xilinx::AIE::getConnectingBundle(WireBundle dir) {
   switch (dir) {
   case WireBundle::North:
     return WireBundle::South;
@@ -2349,8 +2379,6 @@ WireBundle getConnectingBundle(WireBundle dir) {
     return dir;
   }
 }
-
-} // namespace xilinx::AIE
 
 //===----------------------------------------------------------------------===//
 // BDChainOp

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -291,9 +291,8 @@ bool AIE1TargetModel::isLegalTileConnection(int col, int row,
 }
 
 std::vector<std::pair<uint32_t, uint32_t>>
-AIE1TargetModel::getBurstEncodingsAndLengths() const {
-  return {std::pair(0x00000000, 64), std::pair(0x40000000, 128),
-          std::pair(0x80000000, 256)};
+AIE1TargetModel::getShimBurstEncodingsAndLengths() const {
+  return {std::pair(0, 64), std::pair(1, 128), std::pair(2, 256)};
 }
 
 ///
@@ -657,9 +656,8 @@ bool AIE2TargetModel::isLegalTileConnection(int col, int row,
 }
 
 std::vector<std::pair<uint32_t, uint32_t>>
-AIE2TargetModel::getBurstEncodingsAndLengths() const {
-  return {std::pair(0x00000000, 64), std::pair(0x40000000, 128),
-          std::pair(0x80000000, 256)};
+AIE2TargetModel::getShimBurstEncodingsAndLengths() const {
+  return {std::pair(0, 64), std::pair(1, 128), std::pair(2, 256)};
 }
 
 void AIETargetModel::validate() const {
@@ -723,9 +721,9 @@ void AIETargetModel::validate() const {
 AIEArch NPU2TargetModel::getTargetArch() const { return AIEArch::AIE2p; }
 
 std::vector<std::pair<uint32_t, uint32_t>>
-NPU2TargetModel::getBurstEncodingsAndLengths() const {
-  return {std::pair(0x00000000, 64), std::pair(0x40000000, 128),
-          std::pair(0x80000000, 256), std::pair(0xC0000000, 512)};
+NPU2TargetModel::getShimBurstEncodingsAndLengths() const {
+  return {std::pair(0, 64), std::pair(1, 128), std::pair(2, 256),
+          std::pair(3, 512)};
 }
 
 } // namespace AIE

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -346,7 +346,7 @@ static std::optional<std::string>
 checkBurstLength(const xilinx::AIE::AIETargetModel &targetModel,
                  uint32_t requestedBurstLength) {
   if (requestedBurstLength != 0) {
-    auto bel = targetModel.getBurstEncodingsAndLengths();
+    auto bel = targetModel.getShimBurstEncodingsAndLengths();
     auto pair = std::find_if(bel.begin(), bel.end(),
                              [=](const std::pair<uint32_t, uint32_t> &p) {
                                return p.second == requestedBurstLength;

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -209,14 +209,14 @@ LogicalResult AIERTControl::configureBdInBlock(XAie_DmaDesc &dmaTileBd,
 
   if (targetModel.isShimNOCTile(tileLoc.Col, tileLoc.Row)) {
     // write them out like this so they show up with names in debug prints
-    size_t smid = 0;
-    size_t burstLen = 16; // (10):BLEN=16 (256Byte) (corresponds to
-                          // 0x800000000 from target)
-    size_t qOs = 0;
-    size_t cache = 0;
-    size_t secure = 0;
-    TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAxi, &dmaTileBd, smid, burstLen,
-                            qOs, cache, secure);
+    uint8_t smid = 0;
+    uint32_t burstLen =
+        getShimBurstLengthBytes(targetModel, bdOp.getBurstLength());
+    uint8_t qOs = 0;
+    uint8_t cache = 0;
+    uint8_t secure = 0;
+    TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetAxi, &dmaTileBd, smid,
+                            burstLen / 16, qOs, cache, secure);
   }
 
   // get address from BufferOp (core,mem) or ExternalBufferOp (shim)

--- a/test/Targets/AIETargetCDODirect/oneshim.mlir
+++ b/test/Targets/AIETargetCDODirect/oneshim.mlir
@@ -19,7 +19,8 @@
 // CHECK:     Address: 0x000000000001D014  Data@ {{0x[0-9a-z]+}} is: 0x00000000 
 // CHECK:     Address: 0x000000000001D018  Data@ {{0x[0-9a-z]+}} is: 0x00000000 
 // CHECK:     Address: 0x000000000001D01C  Data@ {{0x[0-9a-z]+}} is: 0x02000000 
-
+// check that burst length is set to 128B
+// CHECK:     Address: 0x000000000001D030  Data@ {{0x[0-9a-z]+}} is: 0x40000000
 // CHECK: (Write64): Address:  0x000000000001D204 Data:  0x80000000  
 // CHECK: (MaskWrite64): Address: 0x000000000001D200  Mask: 0x00000000  Data: 0x00000001 
 
@@ -28,9 +29,14 @@ module {
   %buffer = aie.external_buffer { sym_name = "buf" } : memref<16 x f32>
   %t00 = aie.tile(0, 0)
   aie.shim_dma(%t00)  {
-      aie.dma_start(S2MM, 0, ^bd0, ^end)
+      aie.dma_start(S2MM, 0, ^bd0, ^bd1)
     ^bd0:
       aie.dma_bd(%buffer : memref<16 x f32>, 0, 4)  {bd_id = 0 : i32}
+      aie.next_bd ^end
+    ^bd1:
+      aie.dma_start(S2MM, 1, ^bd2, ^end)
+    ^bd2:
+      aie.dma_bd(%buffer : memref<16 x f32>, 0, 4)  {bd_id = 1 : i32, burst_length = 128 : i32}
       aie.next_bd ^end
     ^end:
       aie.end


### PR DESCRIPTION
This PR updates the `AIRRTControl` class to use the shim burst length api introduced in https://github.com/Xilinx/mlir-aie/pull/2130. The helper functions to compute burst length are also updated to live in AIEDialect.cpp and to return length in bytes (for interfacing with aie-rt) as well the register encodings.

Mixed in is a minor cleanup of `namespece xilinx::AIE` blocks in AIEDialect.cpp which revealed some declaration errors.