### PR TITLE
Use cmake versions <4.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML>=5.3.1, <=6.0.1
 aiofiles
-cmake>=3.29
+cmake>=3.29, <4.0
 dataclasses>=0.6, <=0.8
 filelock==3.13.1
 lit


### PR DESCRIPTION
cmake 4.0 is introducing errors in our C++ programming example and npu-xrt host program compilation