### PR TITLE
Change aie-translate runtime sequence default from text to binary

### DIFF
--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -154,7 +154,7 @@ void registerAIETranslations() {
       llvm::cl::desc("Enable cores in CDO"));
 
   static llvm::cl::opt<bool> outputBinary(
-      "aie-output-binary", llvm::cl::init(false),
+      "aie-output-binary", llvm::cl::init(true),
       llvm::cl::desc(
           "Select binary (true) or text (false) output for supported "
           "translations. e.g. aie-npu-to-binary, aie-ctrlpkt-to-bin"));

--- a/test/Targets/AIETargetCDODirect/control_packets.mlir
+++ b/test/Targets/AIETargetCDODirect/control_packets.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-ctrlpkt-to-bin %s |& FileCheck %s
+// RUN: aie-translate --aie-ctrlpkt-to-bin -aie-output-binary=false %s |& FileCheck %s
 
 // CHECK: 0001F000
 // CHECK: 00000002

--- a/test/Targets/NPU/npu2_instgen.mlir
+++ b/test/Targets/NPU/npu2_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-npu-to-binary %s | FileCheck %s
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false %s | FileCheck %s
 module {
   aie.device(npu2) {
     memref.global "private" constant @write_data : memref<8xi32> = dense<[100, 101, 102, 103, 104 ,105, 106, 107]>

--- a/test/Targets/NPU/npu_blockwrite_instgen.mlir
+++ b/test/Targets/NPU/npu_blockwrite_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-dma-to-npu -aie-output-binary=false %s | aie-translate --aie-npu-to-binary | FileCheck %s
+// RUN: aie-opt --aie-dma-to-npu %s | aie-translate --aie-npu-to-binary -aie-output-binary=false | FileCheck %s
 module {
   aie.device(npu1_4col) {
     aiex.runtime_sequence(%arg0: memref<16xf32>, %arg1: memref<16xf32>) {

--- a/test/Targets/NPU/npu_blockwrite_instgen.mlir
+++ b/test/Targets/NPU/npu_blockwrite_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-dma-to-npu %s | aie-translate --aie-npu-to-binary | FileCheck %s
+// RUN: aie-opt --aie-dma-to-npu -aie-output-binary=false %s | aie-translate --aie-npu-to-binary | FileCheck %s
 module {
   aie.device(npu1_4col) {
     aiex.runtime_sequence(%arg0: memref<16xf32>, %arg1: memref<16xf32>) {

--- a/test/Targets/NPU/npu_instgen.mlir
+++ b/test/Targets/NPU/npu_instgen.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-npu-to-binary %s | FileCheck %s
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false %s | FileCheck %s
 module {
   aie.device(npu1) {
     memref.global "private" constant @write_data : memref<8xi32> = dense<[100, 101, 102, 103, 104 ,105, 106, 107]>

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -6,5 +6,5 @@
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.bin %S/aie1.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-txn --txn-name=transaction.mlir --aie-generate-npu-insts --no-compile-host --npu-insts-name=add_two_insts.bin %S/aie2.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true -aie-sequence-name=configure transaction.mlir -o add_two_cfg.bin
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure transaction.mlir -o add_two_cfg.bin
 // RUN: %run_on_npu ./test.exe -x add_one.xclbin -i add_one_insts.bin -c add_two_cfg.bin -j add_two_insts.bin

--- a/test/npu-xrt/ctrl_packet_reconfig/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig/run.lit
@@ -9,10 +9,10 @@
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 //
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
 //
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig/test.cpp
@@ -35,10 +35,10 @@ int main(int argc, const char *argv[]) {
       test_utils::load_instr_binary("aie2_run_seq.bin");
   // AIE configuration as control packet streams
   std::vector<uint32_t> instr3_cfg_v =
-      test_utils::load_instr_sequence("ctrlpkt_dma_seq.txt");
+      test_utils::load_instr_binary("ctrlpkt_dma_seq.bin");
   // AIE configuration control packets' raw data
   std::vector<uint32_t> ctrlPackets =
-      test_utils::load_instr_sequence("ctrlpkt.txt");
+      test_utils::load_instr_binary("ctrlpkt.bin");
 
   // Start the XRT test code
   // Get a device handle

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
@@ -9,10 +9,10 @@
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 //
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
 //
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/test.cpp
@@ -30,9 +30,9 @@ int main(int argc, const char *argv[]) {
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary("aie2_run_seq.bin");
   std::vector<uint32_t> ctrlpkt_instr_v =
-      test_utils::load_instr_sequence("ctrlpkt_dma_seq.txt");
+      test_utils::load_instr_binary("ctrlpkt_dma_seq.bin");
   std::vector<uint32_t> ctrlPackets =
-      test_utils::load_instr_sequence("ctrlpkt.txt");
+      test_utils::load_instr_binary("ctrlpkt.bin");
 
   // Start the XRT test code
   // Get a device handle

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
@@ -9,10 +9,10 @@
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 //
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.txt
+// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
 //
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.txt
+// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/test.cpp
@@ -30,9 +30,9 @@ int main(int argc, const char *argv[]) {
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary("aie2_run_seq.bin");
   std::vector<uint32_t> ctrlpkt_instr_v =
-      test_utils::load_instr_sequence("ctrlpkt_dma_seq.txt");
+      test_utils::load_instr_binary("ctrlpkt_dma_seq.bin");
   std::vector<uint32_t> ctrlPackets =
-      test_utils::load_instr_sequence("ctrlpkt.txt");
+      test_utils::load_instr_binary("ctrlpkt.bin");
 
   // Start the XRT test code
   // Get a device handle

--- a/test/txn2mlir/roundtrip_npu1_1col.mlir
+++ b/test/txn2mlir/roundtrip_npu1_1col.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true %s -o ./roundtrip_npu1_1col_cfg.bin
+// RUN: aie-translate -aie-npu-to-binary %s -o ./roundtrip_npu1_1col_cfg.bin
 // RUN: %python txn2mlir.py -f ./roundtrip_npu1_1col_cfg.bin | FileCheck %s
 
 // CHECK: aie.device(npu1_1col)

--- a/test/txn2mlir/roundtrip_npu1_4col.mlir
+++ b/test/txn2mlir/roundtrip_npu1_4col.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate -aie-npu-to-binary -aie-output-binary=true %s -o ./roundtrip_npu1_4col_cfg.bin
+// RUN: aie-translate -aie-npu-to-binary %s -o ./roundtrip_npu1_4col_cfg.bin
 // RUN: %python txn2mlir.py -f ./roundtrip_npu1_4col_cfg.bin | FileCheck %s
 
 // CHECK: aie.device(npu1_4col)


### PR DESCRIPTION
Follow on to https://github.com/Xilinx/mlir-aie/pull/2128. The next step could be to remove the text support entirely.