### PR TITLE
[programming_examples] Fix typo in basic/vector_scalar_mul

### DIFF
--- a/programming_examples/basic/vector_scalar_mul/README.md
+++ b/programming_examples/basic/vector_scalar_mul/README.md
@@ -10,7 +10,7 @@
 
 # Vector Scalar Multiplication:
 
-This IRON design flow example, called "Vector Scalar Multiplication", demonstrates a simple AIE implementation for vectorized vector scalar multiply on a vector of integers. In this design, a single AIE core performs the vector scalar multiply operation on a vector with a default length `4096`. The kernel is configured to work on `1024` element-sized subvectors, and is invoked multiple times to complete the full scaling. The example consists of two primary design files: `aie2.py` and `scale.cc`, and a testbench `test.cpp` or `test.py`.
+This IRON design flow example, called "Vector Scalar Multiplication", demonstrates a simple AIE implementation for vectorized vector scalar multiply on a vector of integers. In this design, a single AIE core performs the vector scalar multiply operation on a vector with a default length `4096`. The kernel is configured to work on `1024` element-sized subvectors, and is invoked multiple times to complete the full scaling. The example consists of two primary design files: `vector_scalar_mul.py` and `scale.cc`, and a testbench `test.cpp` or `test.py`.
 
 ## Source Files Overview
 
@@ -70,7 +70,7 @@ This design performs a memcpy operation on a vector of input data. The AIE desig
 
 1. **Vectorized Scaling:** The `scale_vectorized()` function processes multiple data elements simultaneously, taking advantage of AIE vector datapath capabilities to load, multiply and store data elements.
 
-1. **C-style Wrapper Functions:** `vector_scalar_mul_aie_scalar()` and `vector_scalar_mul_aie()` are two C-style wrapper functions to call the templated `scale_vectorized()` and `scale_scalar()` implementations inside the AIE design implemented in `aie2.py`. The functions are provided for `int32_t`.
+1. **C-style Wrapper Functions:** `vector_scalar_mul_aie_scalar()` and `vector_scalar_mul_aie()` are two C-style wrapper functions to call the templated `scale_vectorized()` and `scale_scalar()` implementations inside the AIE design implemented in `vector_scalar_mul.py`. The functions are provided for `int32_t`.
 
 ## Usage
 


### PR DESCRIPTION
Hello!

I'm a doctoral student at ETH Zurich, supervised by Prof. Luca Benini. We are currently collaborating with AMD to set up an exercise for his _Systems-on-Chip for Data Analytics and Machine Learning_ course at ETH. The goal is to follow a similar structure to the [AMD MLIR tutorial](https://www.amd.com/content/dam/amd/en/documents/products/processors/ryzen/ai/iron-for-ryzen-ai-tutorial-micro-2024.pdf).

While preparing the exercise, I noticed a small typo referencing `aie2.py` instead of `vector_scalar_mul.py` in the task description. This PR fixes it!

I’ll follow up with any additional changes that may come up as we move to a more recent version of the toolchain and repository on the JupyterHub setup.

Thank you for your time and for reviewing this PR!

Best regards,
Viviane