### PR TITLE
Remove redundant includes

### DIFF
--- a/mlir_tutorials/CMakeLists.txt
+++ b/mlir_tutorials/CMakeLists.txt
@@ -98,7 +98,6 @@ set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
 list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 
-include(TableGen)
 include(AddLLVM)
 include(AddMLIR)
 include(HandleLLVMOptions)

--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -99,7 +99,6 @@ set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
 list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 
-include(TableGen)
 include(AddLLVM)
 include(AddMLIR)
 include(HandleLLVMOptions)

--- a/programming_guide/CMakeLists.txt
+++ b/programming_guide/CMakeLists.txt
@@ -99,7 +99,6 @@ set(LLVM_LIT_ARGS "${LIT_ARGS_DEFAULT}" CACHE STRING "Default options for lit")
 list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 
-include(TableGen)
 include(AddLLVM)
 include(AddMLIR)
 include(HandleLLVMOptions)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,7 +87,6 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 
-include(TableGen)
 include(AddLLVM)
 include(AddMLIR)
 include(HandleLLVMOptions)


### PR DESCRIPTION
This is a small proposal to remove these redundant includes (since this include is already in a parent cmake file, at the root of the project). The reason is that these redundant calls erase the tablegen_compile_commands.yml needed by the [TableGen LSP Language Server](https://mlir.llvm.org/docs/Tools/MLIRLSP/#tablegen-lsp-language-server--tblgen-lsp-server).