### PR TITLE
[programmin_examples] Fix Makefile command in dma_transpose

### DIFF
--- a/programming_examples/basic/dma_transpose/Makefile
+++ b/programming_examples/basic/dma_transpose/Makefile
@@ -63,7 +63,7 @@ run: ${targetname}.exe build/final.xclbin
 
 generate_access_map: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
-	python3 $< --generate-access-map ${devicename} ${M} ${K} 
+	python3 $< ${devicename} ${M} ${K} --generate-access-map
 
 clean:
 	rm -rf build _build inst ${targetname}.exe


### PR DESCRIPTION
Fixing a small issue in the `Makefile` of the `dma_transpose` programming example. The argument ordering resulted in an error, since the `device_name` and dimensions (`M`, `K`) must be placed after the `--generate-access-map` flag. 