### PR TITLE
Minor comment fixes in ukernels for B in col-maj

### DIFF
--- a/aie_kernels/aie2/mm_b_col_maj.cc
+++ b/aie_kernels/aie2/mm_b_col_maj.cc
@@ -33,13 +33,29 @@
  * below). This expansion helps with accumulator registers usage, which leads in
  * attaining high kernel efficiency (SIMD utilization).
  *
- * Data within each tile (rxs, sxt and rxt) are assumed to be in col-major
- * order. Also, the entire tiles themselves are stored in col-major order, as
- * shown in the example below for matrix A:
+ *
+ * For matrix A and C, data within each tile (rxs and rxt) are assumed to
+ * be in row-major order. Also, the entire tiles themselves are stored in
+ * row-major order, as shown in the example below for matrix A:
  *
  *      <-s->
  *    _  ________________________
- * 	  r |  1 |  y | ...
+ * 	  r |  1 |  2 |  3 | ...
+ * 	  _ |____|____|____|
+ * 	    |  x | x+1| x+2| ...
+ * 	    |____|____|____|
+ * 	    |.
+ * 	    |.
+ * 	    |.
+ *
+ *
+ * However, for matrix B, the data within each tile (sxt) are
+ * assumed to be in col-major order. Also, the entire tiles themselves are
+ * stored in col-major order, as shown below:
+ *
+ *      <-t->
+ *    _  ________________________
+ * 	  s |  1 |  y | ...
  * 	  _ |____|____|
  * 	    |  2 | y+1| ...
  * 	    |____|____|
@@ -49,6 +65,7 @@
  * 	    | .    .
  * 	    | .    .
  */
+
 template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
           unsigned colB, unsigned r, unsigned s, unsigned t>
 static inline void

--- a/aie_kernels/aie2p/mm_b_col_maj.cc
+++ b/aie_kernels/aie2p/mm_b_col_maj.cc
@@ -33,13 +33,29 @@
  * below). This expansion helps with accumulator registers usage, which leads in
  * attaining high kernel efficiency (SIMD utilization).
  *
- * Data within each tile (rxs, sxt and rxt) are assumed to be in col-major
- * order. Also, the entire tiles themselves are stored in col-major order, as
- * shown in the example below for matrix A:
+ *
+ * For matrix A and C, data within each tile (rxs and rxt) are assumed to
+ * be in row-major order. Also, the entire tiles themselves are stored in
+ * row-major order, as shown in the example below for matrix A:
  *
  *      <-s->
  *    _  ________________________
- * 	  r |  1 |  y | ...
+ * 	  r |  1 |  2 |  3 | ...
+ * 	  _ |____|____|____|
+ * 	    |  x | x+1| x+2| ...
+ * 	    |____|____|____|
+ * 	    |.
+ * 	    |.
+ * 	    |.
+ *
+ *
+ * However, for matrix B, the data within each tile (sxt) are
+ * assumed to be in col-major order. Also, the entire tiles themselves are
+ * stored in col-major order, as shown below:
+ *
+ *      <-t->
+ *    _  ________________________
+ * 	  s |  1 |  y | ...
  * 	  _ |____|____|
  * 	    |  2 | y+1| ...
  * 	    |____|____|
@@ -49,6 +65,7 @@
  * 	    | .    .
  * 	    | .    .
  */
+
 template <typename T_in, typename T_out, unsigned rowA, unsigned colA,
           unsigned colB, unsigned r, unsigned s, unsigned t>
 static inline void


### PR DESCRIPTION
Fixes useful comment in ukernels regarding data layouts of matrices A, B and C.