### PR TITLE
Slightly reorganize npu TargetModels to prevent missing overrides

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -574,9 +574,9 @@ public:
   }
 };
 
-class BaseNPUTargetModel : public AIE2TargetModel {
+class BaseNPU1TargetModel : public AIE2TargetModel {
 public:
-  BaseNPUTargetModel(TargetModelKind k) : AIE2TargetModel(k) {
+  BaseNPU1TargetModel(TargetModelKind k) : AIE2TargetModel(k) {
     // Device properties initialization
     addModelProperty(AIETargetModel::IsNPU);
   }
@@ -600,14 +600,14 @@ public:
 
   static bool classof(const AIETargetModel *model) {
     return model->getKind() >= TK_AIE2_NPU1 &&
-           model->getKind() < TK_AIE2_NPU2_Last;
+           model->getKind() < TK_AIE2_NPU1_Last;
   }
 };
 
 // The full Phoenix NPU
-class NPUTargetModel : public BaseNPUTargetModel {
+class NPU1TargetModel : public BaseNPU1TargetModel {
 public:
-  NPUTargetModel() : BaseNPUTargetModel(TK_AIE2_NPU1) {}
+  NPU1TargetModel() : BaseNPU1TargetModel(TK_AIE2_NPU1) {}
 
   int columns() const override { return 5; }
 
@@ -626,20 +626,18 @@ public:
 };
 
 // A sub-portion of the Phoenix NPU
-class VirtualizedNPUTargetModel : public BaseNPUTargetModel {
+class VirtualizedNPU1TargetModel : public BaseNPU1TargetModel {
   int cols;
 
 public:
-  VirtualizedNPUTargetModel(int _cols)
-      : BaseNPUTargetModel(static_cast<TargetModelKind>(
+  VirtualizedNPU1TargetModel(int _cols)
+      : BaseNPU1TargetModel(static_cast<TargetModelKind>(
             static_cast<std::underlying_type_t<TargetModelKind>>(TK_AIE2_NPU1) +
             _cols)),
         cols(_cols) {
     // Device properties initialization
     addModelProperty(AIETargetModel::IsVirtualized);
   }
-
-  uint32_t getAddressGenGranularity() const override { return 32; }
 
   int columns() const override { return cols; }
 
@@ -651,34 +649,62 @@ public:
   }
 };
 
-// The full Strix NPU
-class NPU2TargetModel : public BaseNPUTargetModel {
+class BaseNPU2TargetModel : public AIE2TargetModel {
 public:
-  NPU2TargetModel() : BaseNPUTargetModel(TK_AIE2_NPU2) {}
+  BaseNPU2TargetModel(TargetModelKind k) : AIE2TargetModel(k) {
+    // Device properties initialization
+    addModelProperty(AIETargetModel::IsNPU);
+  }
 
   AIEArch getTargetArch() const override;
 
-  int columns() const override { return 8; }
+  int rows() const override {
+    return 6; /* 1 Shim row, 1 memtile row, and 4 Core rows. */
+  }
+
+  bool isCoreTile(int col, int row) const override { return row > 1; }
+  bool isMemTile(int col, int row) const override { return row == 1; }
+
+  bool isShimPLTile(int col, int row) const override {
+    return false; // No PL tiles
+  }
 
   bool isShimNOCTile(int col, int row) const override { return row == 0; }
 
-  bool isShimPLTile(int col, int row) const override { return false; }
+  bool isShimNOCorPLTile(int col, int row) const override {
+    return isShimNOCTile(col, row);
+  }
+
+  uint32_t getNumMemTileRows() const override { return 1; }
+
+  std::vector<std::pair<uint32_t, uint32_t>>
+  getShimBurstEncodingsAndLengths() const override;
+
+  static bool classof(const AIETargetModel *model) {
+    return model->getKind() >= TK_AIE2_NPU2 &&
+           model->getKind() < TK_AIE2_NPU2_Last;
+  }
+};
+
+// The full Strix NPU
+class NPU2TargetModel : public BaseNPU2TargetModel {
+public:
+  NPU2TargetModel() : BaseNPU2TargetModel(TK_AIE2_NPU2) {}
+
+  int columns() const override { return 8; }
 
   static bool classof(const AIETargetModel *model) {
     return model->getKind() == TK_AIE2_NPU2;
   }
-
-  std::vector<std::pair<uint32_t, uint32_t>>
-  getShimBurstEncodingsAndLengths() const override;
 };
 
 // A sub-portion of the Strix NPU
-class VirtualizedNPU2TargetModel : public BaseNPUTargetModel {
+class VirtualizedNPU2TargetModel : public BaseNPU2TargetModel {
   int cols;
 
 public:
   VirtualizedNPU2TargetModel(int _cols)
-      : BaseNPUTargetModel(static_cast<TargetModelKind>(
+      : BaseNPU2TargetModel(static_cast<TargetModelKind>(
             static_cast<std::underlying_type_t<TargetModelKind>>(TK_AIE2_NPU2) +
             _cols)),
         cols(_cols) {
@@ -686,11 +712,7 @@ public:
     addModelProperty(AIETargetModel::IsVirtualized);
   }
 
-  uint32_t getAddressGenGranularity() const override { return 32; }
-
   int columns() const override { return cols; }
-
-  bool isShimNOCTile(int col, int row) const override { return row == 0; }
 
   static bool classof(const AIETargetModel *model) {
     return model->getKind() >= TK_AIE2_NPU2_1Col &&

--- a/include/aie/Targets/AIERT.h
+++ b/include/aie/Targets/AIERT.h
@@ -187,9 +187,9 @@ namespace xilinx::AIE {
 struct AIERTControl {
   XAie_Config configPtr;
   XAie_DevInst devInst;
-  const BaseNPUTargetModel &targetModel;
+  const AIETargetModel &targetModel;
 
-  AIERTControl(const xilinx::AIE::BaseNPUTargetModel &tm);
+  AIERTControl(const xilinx::AIE::AIETargetModel &tm);
 
   mlir::LogicalResult setIOBackend(bool aieSim, bool xaieDebug);
   mlir::LogicalResult configureBdInBlock(XAie_DmaDesc &dmaTileBd,

--- a/lib/CAPI/Translation.cpp
+++ b/lib/CAPI/Translation.cpp
@@ -166,8 +166,8 @@ DEFINE_C_API_PTR_METHODS(AieRtControl, xilinx::AIE::AIERTControl)
 
 AieRtControl getAieRtControl(AieTargetModel tm) {
   // unwrap the target model
-  const BaseNPUTargetModel &targetModel =
-      *reinterpret_cast<const BaseNPUTargetModel *>(tm.d);
+  const AIETargetModel &targetModel =
+      *reinterpret_cast<const AIETargetModel *>(tm.d);
   AIERTControl *ctl = new AIERTControl(targetModel);
   return wrap(ctl);
 }

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -447,8 +447,8 @@ static LogicalResult convertAIEToConfiguration(AIE::DeviceOp device,
                                                StringRef clElfDir,
                                                OutputType outputType) {
 
-  const BaseNPUTargetModel &targetModel =
-      (const BaseNPUTargetModel &)device.getTargetModel();
+  const AIETargetModel &targetModel =
+      (const AIETargetModel &)device.getTargetModel();
 
   if (!targetModel.hasProperty(AIETargetModel::IsNPU))
     return failure();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -202,11 +202,11 @@ xilinx::AIE::myVerifyOffsetSizeAndStrideOp(OffsetSizeAndStrideOpInterface op) {
 static VC1902TargetModel VC1902model;
 static VE2302TargetModel VE2302model;
 static VE2802TargetModel VE2802model;
-static NPUTargetModel NPUmodel;
-static VirtualizedNPUTargetModel NPUmodel1col(1);
-static VirtualizedNPUTargetModel NPUmodel2col(2);
-static VirtualizedNPUTargetModel NPUmodel3col(3);
-static VirtualizedNPUTargetModel NPUmodel4col(4);
+static NPU1TargetModel NPUmodel;
+static VirtualizedNPU1TargetModel NPUmodel1col(1);
+static VirtualizedNPU1TargetModel NPUmodel2col(2);
+static VirtualizedNPU1TargetModel NPUmodel3col(3);
+static VirtualizedNPU1TargetModel NPUmodel4col(4);
 static NPU2TargetModel NPU2model;
 static VirtualizedNPU2TargetModel NPU2model1col(1);
 static VirtualizedNPU2TargetModel NPU2model2col(2);

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -799,10 +799,10 @@ AIETargetModel::getMemLocalBaseAddress(int localCol, int localRow, int memCol,
   return std::nullopt;
 }
 
-AIEArch NPU2TargetModel::getTargetArch() const { return AIEArch::AIE2p; }
+AIEArch BaseNPU2TargetModel::getTargetArch() const { return AIEArch::AIE2p; }
 
 std::vector<std::pair<uint32_t, uint32_t>>
-NPU2TargetModel::getShimBurstEncodingsAndLengths() const {
+BaseNPU2TargetModel::getShimBurstEncodingsAndLengths() const {
   return {std::pair(0, 64), std::pair(1, 128), std::pair(2, 256),
           std::pair(3, 512)};
 }

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -54,8 +54,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 
 namespace xilinx::AIE {
 
-AIERTControl::AIERTControl(const AIE::BaseNPUTargetModel &tm)
-    : targetModel(tm) {
+AIERTControl::AIERTControl(const AIE::AIETargetModel &tm) : targetModel(tm) {
   // The first column in the NPU lacks a shim tile.  AIE-RT exposes some of
   // the internals about how this is modeled in a somewhat awkward way.
   size_t partitionStartCol =

--- a/lib/Targets/AIETargetCDODirect.cpp
+++ b/lib/Targets/AIETargetCDODirect.cpp
@@ -137,8 +137,8 @@ translateToCDODirect(ModuleOp m, llvm::StringRef workDirPath,
   assert(llvm::range_size(devOps) == 1 &&
          "only exactly 1 device op supported.");
   DeviceOp targetOp = *devOps.begin();
-  const BaseNPUTargetModel &targetModel =
-      (const BaseNPUTargetModel &)targetOp.getTargetModel();
+  const AIETargetModel &targetModel =
+      (const AIETargetModel &)targetOp.getTargetModel();
 
   // things like XAIE_MEM_TILE_ROW_START and the missing
   // shim dma on tile (0,0) are hard-coded assumptions about NPU...

--- a/test/CppTests/target_model_rtti.cpp
+++ b/test/CppTests/target_model_rtti.cpp
@@ -27,9 +27,10 @@ void test() {
     throw std::runtime_error("Failed xcvc1902 isa<AIE1TargetModel>");
   }
   if (llvm::isa<AIE::AIE2TargetModel, AIE::VE2302TargetModel,
-                AIE::VE2802TargetModel, AIE::BaseNPUTargetModel,
-                AIE::NPUTargetModel, AIE::VirtualizedNPUTargetModel,
-                AIE::NPU2TargetModel, AIE::VirtualizedNPU2TargetModel>(
+                AIE::VE2802TargetModel, AIE::BaseNPU1TargetModel,
+                AIE::BaseNPU2TargetModel, AIE::NPU1TargetModel,
+                AIE::VirtualizedNPU1TargetModel, AIE::NPU2TargetModel,
+                AIE::VirtualizedNPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::xcvc1902))) {
     throw std::runtime_error("Failed xcvc1902 !isa<>");
   }
@@ -44,9 +45,10 @@ void test() {
     throw std::runtime_error("Failed xcve2302 isa<AIE2TargetModel>");
   }
   if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
-                AIE::VE2802TargetModel, AIE::BaseNPUTargetModel,
-                AIE::NPUTargetModel, AIE::VirtualizedNPUTargetModel,
-                AIE::NPU2TargetModel, AIE::VirtualizedNPU2TargetModel>(
+                AIE::VE2802TargetModel, AIE::BaseNPU1TargetModel,
+                AIE::BaseNPU2TargetModel, AIE::NPU1TargetModel,
+                AIE::VirtualizedNPU1TargetModel, AIE::NPU2TargetModel,
+                AIE::VirtualizedNPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::xcve2302))) {
     throw std::runtime_error("Failed xcve2302 !isa<>");
   }
@@ -61,9 +63,10 @@ void test() {
     throw std::runtime_error("Failed xcve2802 isa<AIE2TargetModel>");
   }
   if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
-                AIE::VE2302TargetModel, AIE::BaseNPUTargetModel,
-                AIE::NPUTargetModel, AIE::VirtualizedNPUTargetModel,
-                AIE::NPU2TargetModel, AIE::VirtualizedNPU2TargetModel>(
+                AIE::VE2302TargetModel, AIE::BaseNPU1TargetModel,
+                AIE::BaseNPU2TargetModel, AIE::NPU1TargetModel,
+                AIE::VirtualizedNPU1TargetModel, AIE::NPU2TargetModel,
+                AIE::VirtualizedNPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::xcve2802))) {
     throw std::runtime_error("Failed xcve2802 !isa<>");
   }
@@ -73,18 +76,18 @@ void test() {
           AIE::getTargetModel(AIE::AIEDevice::npu1))) {
     throw std::runtime_error("Failed npu1 isa<AIE2TargetModel>");
   }
-  if (!llvm::isa<AIE::BaseNPUTargetModel>(
+  if (!llvm::isa<AIE::BaseNPU1TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu1))) {
-    throw std::runtime_error("Failed npu1 isa<BaseNPUTargetModel>");
+    throw std::runtime_error("Failed npu1 isa<BaseNPU1TargetModel>");
   }
-  if (!llvm::isa<AIE::NPUTargetModel>(
+  if (!llvm::isa<AIE::NPU1TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu1))) {
-    throw std::runtime_error("Failed npu1 isa<NPUTargetModel>");
+    throw std::runtime_error("Failed npu1 isa<NPU1TargetModel>");
   }
   if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
                 AIE::VE2302TargetModel, AIE::VE2802TargetModel,
-                AIE::VirtualizedNPUTargetModel, AIE::NPU2TargetModel,
-                AIE::VirtualizedNPU2TargetModel>(
+                AIE::VirtualizedNPU1TargetModel, AIE::BaseNPU2TargetModel,
+                AIE::NPU2TargetModel, AIE::VirtualizedNPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu1))) {
     throw std::runtime_error("Failed npu1 !isa<>");
   }
@@ -97,17 +100,18 @@ void test() {
     if (!llvm::isa<AIE::AIE2TargetModel>(AIE::getTargetModel(dev))) {
       throw std::runtime_error("Failed npu1_col isa<AIE2TargetModel>");
     }
-    if (!llvm::isa<AIE::VirtualizedNPUTargetModel>(AIE::getTargetModel(dev))) {
+    if (!llvm::isa<AIE::VirtualizedNPU1TargetModel>(AIE::getTargetModel(dev))) {
       throw std::runtime_error(
-          "Failed npu1_col isa<VirtualizedNPUTargetModel>");
+          "Failed npu1_col isa<VirtualizedNPU1TargetModel>");
     }
-    if (!llvm::isa<AIE::BaseNPUTargetModel>(AIE::getTargetModel(dev))) {
-      throw std::runtime_error("Failed npu1_col isa<BaseNPUTargetModel>");
+    if (!llvm::isa<AIE::BaseNPU1TargetModel>(AIE::getTargetModel(dev))) {
+      throw std::runtime_error("Failed npu1_col isa<BaseNPU1TargetModel>");
     }
     if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
                   AIE::VE2302TargetModel, AIE::VE2802TargetModel,
-                  AIE::NPUTargetModel, AIE::NPU2TargetModel,
-                  AIE::VirtualizedNPU2TargetModel>(AIE::getTargetModel(dev))) {
+                  AIE::NPU1TargetModel, AIE::BaseNPU2TargetModel,
+                  AIE::NPU2TargetModel, AIE::VirtualizedNPU2TargetModel>(
+            AIE::getTargetModel(dev))) {
       throw std::runtime_error("Failed npu1_col !isa<>");
     }
   }
@@ -117,9 +121,9 @@ void test() {
           AIE::getTargetModel(AIE::AIEDevice::npu2))) {
     throw std::runtime_error("Failed npu2 isa<AIE2TargetModel>");
   }
-  if (!llvm::isa<AIE::BaseNPUTargetModel>(
+  if (!llvm::isa<AIE::BaseNPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu2))) {
-    throw std::runtime_error("Failed npu2 isa<BaseNPUTargetModel>");
+    throw std::runtime_error("Failed npu2 isa<BaseNPU1TargetModel>");
   }
   if (!llvm::isa<AIE::NPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu2))) {
@@ -127,8 +131,8 @@ void test() {
   }
   if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
                 AIE::VE2302TargetModel, AIE::VE2802TargetModel,
-                AIE::VirtualizedNPUTargetModel, AIE::NPUTargetModel,
-                AIE::VirtualizedNPU2TargetModel>(
+                AIE::VirtualizedNPU1TargetModel, AIE::BaseNPU1TargetModel,
+                AIE::NPU1TargetModel, AIE::VirtualizedNPU2TargetModel>(
           AIE::getTargetModel(AIE::AIEDevice::npu2))) {
     throw std::runtime_error("Failed npu2 !isa<>");
   }
@@ -148,13 +152,14 @@ void test() {
       throw std::runtime_error(
           "Failed npu2_col isa<VirtualizedNPU2TargetModel>");
     }
-    if (!llvm::isa<AIE::BaseNPUTargetModel>(AIE::getTargetModel(dev))) {
-      throw std::runtime_error("Failed npu2_col isa<BaseNPUTargetModel>");
+    if (!llvm::isa<AIE::BaseNPU2TargetModel>(AIE::getTargetModel(dev))) {
+      throw std::runtime_error("Failed npu2_col isa<BaseNPU1TargetModel>");
     }
     if (llvm::isa<AIE::AIE1TargetModel, AIE::VC1902TargetModel,
                   AIE::VE2302TargetModel, AIE::VE2802TargetModel,
-                  AIE::NPUTargetModel, AIE::VirtualizedNPUTargetModel,
-                  AIE::NPU2TargetModel>(AIE::getTargetModel(dev))) {
+                  AIE::BaseNPU1TargetModel, AIE::NPU1TargetModel,
+                  AIE::VirtualizedNPU1TargetModel, AIE::NPU2TargetModel>(
+            AIE::getTargetModel(dev))) {
       throw std::runtime_error("Failed npu2_col !isa<>");
     }
   }

--- a/test/Targets/AIEGenerateTargetArch/aie2.mlir
+++ b/test/Targets/AIEGenerateTargetArch/aie2.mlir
@@ -4,15 +4,18 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-translate --aie-generate-target-arch %s | FileCheck --match-full-lines %s
-// CHECK: AIE2
+// RUN: echo 'aie.device(npu1){aie.end}' | aie-translate -aie-generate-target-arch | FileCheck --check-prefix=NPU10 --match-full-lines %s
+// NPU10: AIE2
 
-module {
-  aie.device(xcve2802) {
-    %01 = aie.tile(0, 1)
-  }
-}
+// RUN: echo 'aie.device(npu1_4col){aie.end}' | aie-translate -aie-generate-target-arch | FileCheck --check-prefix=NPU14 --match-full-lines %s
+// NPU14: AIE2
+
+// RUN: echo 'aie.device(npu2){aie.end}' | aie-translate -aie-generate-target-arch | FileCheck --check-prefix=NPU20 --match-full-lines %s
+// NPU20: AIE2p
+
+// RUN: echo 'aie.device(npu2_4col){aie.end}' | aie-translate -aie-generate-target-arch | FileCheck --check-prefix=NPU24 --match-full-lines %s
+// NPU24: AIE2p


### PR DESCRIPTION
While porting some code to strix I encountered some odd compilation errors using aiecc, and it was insisting on compiling some things for aie2, which led me to the discovery of this:
```sh
$ echo 'aie.device(npu2_4col){aie.end}' | aie-translate -aie-generate-target-arch
AIE2
```
which is incorrect. While this one was correct:
```sh
$ echo 'aie.device(npu2){aie.end}' | aie-translate -aie-generate-target-arch
AIE2p
```
The error is from missing overrides on the npu2 virtual device AIETargetModel classes. The way the AIETargetModel hierarchy is set up, the NPU base classes are generic AIE2 devices, and the npu1 and npu2 device classes inherit from these same base classes. This reduces code because npu1 and npu2 are similar. But this also means any npu2 leaf class must separately implement any npu2/aie2p overrides. This does not reduce code and can lead to missing overrides causing the error(s) I observed.

This PR attempts to fix the situation by adding a npu2 specific `BaseNPU2TargetModel` base class for implementing aie2p overrides in one place. And the npu1 classes are renamed from "NPU" to "NPU1".