### PR TITLE
Deprecate ubuntu 20.04 from github ci runners

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Install cross-compilation toolchain
       shell: bash
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' && inputs.MATRIX_ARCH == 'aarch64' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-22.04' && inputs.MATRIX_ARCH == 'aarch64' }}
       run: |
         
         sudo apt-get update
@@ -86,7 +86,7 @@ runs:
       run: pip install cibuildwheel wheel
 
     - name: install rename
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-22.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
       shell: bash
       run: |
         
@@ -107,7 +107,7 @@ runs:
       shell: pwsh
 
     - run: echo "TEMP=/tmp" >> $GITHUB_ENV
-      if: ${{ inputs.MATRIX_OS == 'ubuntu-20.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
+      if: ${{ inputs.MATRIX_OS == 'ubuntu-22.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}
       shell: bash
 
     - name: Set workspace root

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
@@ -95,11 +95,11 @@ jobs:
 
 # disabled because openssl dep isn't being compiled from source
 # (and hence system openssl can't be linked against during cross-compile)
-#          - OS: ubuntu-20.04
+#          - OS: ubuntu-22.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
@@ -118,7 +118,7 @@ jobs:
 
 # disabled because openssl dep isn't being compiled from source
 # (and hence system openssl can't be linked against during cross-compile)
-#          - OS: ubuntu-20.04
+#          - OS: ubuntu-22.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: OFF
 
@@ -199,7 +199,7 @@ jobs:
     # build
 
     - name: build distro wheels
-      if: ${{ matrix.OS != 'ubuntu-20.04' || matrix.ARCH != 'aarch64' }}
+      if: ${{ matrix.OS != 'ubuntu-22.04' || matrix.ARCH != 'aarch64' }}
       shell: bash
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       run: |
@@ -216,7 +216,7 @@ jobs:
         cibuildwheel --output-dir wheelhouse
 
     - name: build aarch ubuntu wheel
-      if: ${{ matrix.OS == 'ubuntu-20.04' && matrix.ARCH == 'aarch64' }}
+      if: ${{ matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'aarch64' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -265,7 +265,7 @@ jobs:
         echo "MLIR_AIE_WHEEL_VERSION=$(python -c "import pkginfo; w = pkginfo.Wheel('$WHL'); print(w.version.split('+')[0] + '+' + w.version.split('+')[1].rsplit('.', 1)[-1])")" | tee -a $GITHUB_OUTPUT
 
     - name: Download cache from container ubuntu
-      if: (matrix.OS == 'ubuntu-20.04' && matrix.ARCH == 'x86_64') && (success() || failure())
+      if: (matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'x86_64') && (success() || failure())
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -295,14 +295,14 @@ jobs:
     # python version. With py3-none you can pip install them in any python venv. Unfortunately though this does
     # mean that the python bindings themselves will confusingly not work in other envs (!=3.10)
     - name: rename non-windows
-      if: ${{ matrix.OS == 'ubuntu-20.04' || matrix.OS == 'macos-12' || matrix.OS == 'macos-14' }}
+      if: ${{ matrix.OS == 'ubuntu-22.04' || matrix.OS == 'macos-12' || matrix.OS == 'macos-14' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
         
         rename 's/cp310-cp310/py3-none/' wheelhouse/mlir_aie*whl
         
-        if [ x"${{ matrix.OS }}" == x"ubuntu-20.04" ] && [ x"${{ matrix.ARCH }}" == x"aarch64" ]; then
+        if [ x"${{ matrix.OS }}" == x"ubuntu-22.04" ] && [ x"${{ matrix.ARCH }}" == x"aarch64" ]; then
           rename 's/x86_64/aarch64/' wheelhouse/mlir_aie*whl
         fi
 
@@ -329,7 +329,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
@@ -342,7 +342,7 @@ jobs:
 #            ARCH: x86_64
 #            ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
@@ -403,11 +403,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
-#          - OS: ubuntu-20.04
+#          - OS: ubuntu-22.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: ON
 
@@ -424,11 +424,11 @@ jobs:
 #            ARCH: arm64
 #            ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
-#          - OS: ubuntu-20.04
+#          - OS: ubuntu-22.04
 #            ARCH: aarch64
 #            ENABLE_RTTI: OFF
 

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -88,11 +88,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: aarch64
             ENABLE_RTTI: ON
 
@@ -108,11 +108,11 @@ jobs:
           #   ARCH: arm64
           #   ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: aarch64
             ENABLE_RTTI: OFF
 
@@ -208,7 +208,7 @@ jobs:
     # build
 
     - name: cibuildwheel
-      if: ${{ matrix.OS != 'ubuntu-20.04' || matrix.ARCH != 'aarch64' }}
+      if: ${{ matrix.OS != 'ubuntu-22.04' || matrix.ARCH != 'aarch64' }}
       shell: bash
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       run: |
@@ -224,7 +224,7 @@ jobs:
         cibuildwheel --output-dir wheelhouse
 
     - name: build aarch ubuntu wheel
-      if: ${{ matrix.OS == 'ubuntu-20.04' && matrix.ARCH == 'aarch64' }}
+      if: ${{ matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'aarch64' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -265,7 +265,7 @@ jobs:
         echo "MLIR_WHEEL_VERSION=$(python -c "import pkginfo; w = pkginfo.Wheel('$WHL'); print(w.version.split('+')[0] + '+' + w.version.split('+')[1].rsplit('.', 1)[-1])")" | tee -a $GITHUB_OUTPUT
 
     - name: Download cache from container ubuntu
-      if: (matrix.OS == 'ubuntu-20.04' && matrix.ARCH == 'x86_64') && (success() || failure())
+      if: (matrix.OS == 'ubuntu-22.04' && matrix.ARCH == 'x86_64') && (success() || failure())
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
@@ -295,14 +295,14 @@ jobs:
     # python version. With py3-none you can pip install them in any python venv. Unfortunately though this does
     # mean that the python bindings themselves will confusingly not work in other envs (!=3.10)
     - name: rename non-windows
-      if: ${{ matrix.OS == 'ubuntu-20.04' || matrix.OS == 'macos-12' || matrix.OS == 'macos-14' }}
+      if: ${{ matrix.OS == 'ubuntu-22.04' || matrix.OS == 'macos-12' || matrix.OS == 'macos-14' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
         
         rename 's/cp310-cp310/py3-none/' wheelhouse/mlir*whl
         
-        if [ x"${{ matrix.OS }}" == x"ubuntu-20.04" ] && [ x"${{ matrix.ARCH }}" == x"aarch64" ]; then
+        if [ x"${{ matrix.OS }}" == x"ubuntu-22.04" ] && [ x"${{ matrix.ARCH }}" == x"aarch64" ]; then
           rename 's/x86_64/aarch64/' wheelhouse/mlir*whl
         fi
 
@@ -330,7 +330,7 @@ jobs:
           unzip -j wheelhouse/mlir*whl "mlir/bin/$TOOL" -d native_tools/
         done
         
-        if [ x"${{ matrix.OS }}" == x"ubuntu-20.04" ]; then
+        if [ x"${{ matrix.OS }}" == x"ubuntu-22.04" ]; then
           PLAT="linux"
         elif [ x"${{ matrix.OS }}" == x"macos-12" ]; then
           PLAT="macosx_12_0"
@@ -370,7 +370,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
@@ -382,7 +382,7 @@ jobs:
           #   ARCH: x86_64
           #   ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
@@ -426,11 +426,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: aarch64
             ENABLE_RTTI: ON
 
@@ -446,11 +446,11 @@ jobs:
           #   ARCH: arm64
           #   ENABLE_RTTI: ON
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
-          - OS: ubuntu-20.04
+          - OS: ubuntu-22.04
             ARCH: aarch64
             ENABLE_RTTI: OFF
 


### PR DESCRIPTION
- Update wheel building CIs to use 22.04 instead.