### PR TITLE
Passing arguments through iron.jit decorator

### DIFF
--- a/programming_examples/basic/vector_vector_add/run_placed.lit
+++ b/programming_examples/basic/vector_vector_add/run_placed.lit
@@ -1,6 +1,6 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai, peano
 //
-// RUN: %run_on_npu python3 %S/vector_vector_add_placed.py --device=npu --column=0
+// RUN: %run_on_npu python3 %S/vector_vector_add_placed.py --device=npu

--- a/programming_examples/basic/vector_vector_add/run_strix_placed.lit
+++ b/programming_examples/basic/vector_vector_add/run_strix_placed.lit
@@ -1,6 +1,6 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai, peano
 //
-// RUN: %run_on_2npu python3 %S/vector_vector_add_placed.py --device=npu2 --column=0
+// RUN: %run_on_2npu python3 %S/vector_vector_add_placed.py --device=npu2

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -9,8 +9,8 @@
 import argparse
 import sys
 import numpy as np
+import aie.iron as iron
 
-from aie import iron
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
 from aie.iron.device import NPU1Col1, NPU2Col1

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -112,8 +112,8 @@ def main():
 
     # Construct two input random tensors and an output zeroed tensor
     # The three tensor are in memory accessible to the NPU
-    input0 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
-    input1 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
+    input0 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device=args.device)
+    input1 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device=args.device)
     output = iron.zeros_like(input0)
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -4,78 +4,29 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
-import numpy as np
-import sys
-import argparse
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 
+import argparse
+import sys
+import numpy as np
+
+from aie import iron
 from aie.iron import ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU1Col1, NPU2Col1, XCVC1902
+from aie.iron.device import NPU1Col1, NPU2Col1
 from aie.iron.controlflow import range_
-
-import aie.iron as iron
-
-# The JIT-compiled kernel relies on inputs from the command line.
-# Because of that, we need to parse the arguments before the JIT is invoked.
-parser = argparse.ArgumentParser()
-parser.add_argument(
-    "-v", "--verbose", action="store_true", help="Enable verbose output"
-)
-parser.add_argument(
-    "-d",
-    "--device",
-    choices=["npu", "npu2"],
-    default="npu",
-    help="Target device",
-)
-parser.add_argument(
-    "-c", "--column", type=int, default=0, help="Column index (default: 0)"
-)
-parser.add_argument(
-    "-n",
-    "--num-elements",
-    type=int,
-    default=32,
-    help="Number of elements (default: 32)",
-)
-args = parser.parse_args()
-
-device_map = {
-    "npu": NPU1Col1(),
-    "npu2": NPU2Col1(),
-}
-device = device_map[args.device]
-
-# Construct two input random tensors and an output zeroed tensor
-# The three tensor are in memory accessible to the NPU
-input0 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
-input1 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
-output = iron.zeros_like(input0)
 
 
 @iron.jit(is_placed=False)
-def vector_vector_add(
-    # input0, input1, output
-):
+def vector_vector_add(device, input0, input1, output):
     if input0.shape != input1.shape:
         raise ValueError(
             f"Input shapes are not the equal ({input0.shape} != {input1.shape})."
         )
-    if input0.dtype != input1.dtype:
-        raise ValueError(
-            f"Input data types are not the same ({input0.dtype} != {input1.dtype})."
-        )
-
     if input0.shape != output.shape:
         raise ValueError(
             f"Input and output shapes are not the equal ({input0.shape} != {output.shape})."
         )
-    if input0.dtype != output.dtype:
-        raise ValueError(
-            f"Input and output data types are not the same ({input0.dtype} != {output.dtype})."
-        )
-
     if len(np.shape(input0)) != 1:
         raise ValueError("Function only supports vectors.")
     num_elements = np.size(input0)
@@ -85,6 +36,15 @@ def vector_vector_add(
             f"Number of elements ({num_elements}) must be a multiple of {n}."
         )
     N_div_n = num_elements // n
+
+    if input0.dtype != input1.dtype:
+        raise ValueError(
+            f"Input data types are not the same ({input0.dtype} != {input1.dtype})."
+        )
+    if input0.dtype != output.dtype:
+        raise ValueError(
+            f"Input and output data types are not the same ({input0.dtype} != {output.dtype})."
+        )
     dtype = input0.dtype
 
     # Define tensor types
@@ -125,10 +85,40 @@ def vector_vector_add(
 
 
 def main():
+    device_map = {
+        "npu": NPU1Col1(),
+        "npu2": NPU2Col1(),
+    }
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose output"
+    )
+    parser.add_argument(
+        "-d",
+        "--device",
+        choices=["npu", "npu2"],
+        default="npu",
+        help="Target device",
+    )
+    parser.add_argument(
+        "-n",
+        "--num-elements",
+        type=int,
+        default=32,
+        help="Number of elements (default: 32)",
+    )
+    args = parser.parse_args()
+
+    # Construct two input random tensors and an output zeroed tensor
+    # The three tensor are in memory accessible to the NPU
+    input0 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
+    input1 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
+    output = iron.zeros_like(input0)
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
-    vector_vector_add(input0, input1, output)
+    vector_vector_add(device_map[args.device], input0, input1, output)
 
     # Check the correctness of the result
     e = np.equal(input0.numpy() + input1.numpy(), output.numpy())
@@ -148,11 +138,11 @@ def main():
     # Otherwise, exit with a failure code
     if not errors:
         print("\nPASS!\n")
-        exit(0)
+        sys.exit(0)
     else:
         print("\nError count: ", errors)
         print("\nFailed.\n")
-        exit(-1)
+        sys.exit(-1)
 
 
 if __name__ == "__main__":

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -81,7 +81,7 @@ def vector_vector_add(config, input0, input1, output):
         rt.drain(of_out.cons(), C, wait=True)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(config['device'], rt).resolve_program(SequentialPlacer())
+    return Program(config["device"], rt).resolve_program(SequentialPlacer())
 
 
 def main():
@@ -112,13 +112,17 @@ def main():
 
     # Construct two input random tensors and an output zeroed tensor
     # The three tensor are in memory accessible to the NPU
-    input0 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device=args.device)
-    input1 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device=args.device)
+    input0 = iron.randint(
+        0, 100, (args.num_elements,), dtype=np.int32, device=args.device
+    )
+    input1 = iron.randint(
+        0, 100, (args.num_elements,), dtype=np.int32, device=args.device
+    )
     output = iron.zeros_like(input0)
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
-    vector_vector_add({'device': device_map[args.device]}, input0, input1, output)
+    vector_vector_add({"device": device_map[args.device]}, input0, input1, output)
 
     # Check the correctness of the result
     e = np.equal(input0.numpy() + input1.numpy(), output.numpy())

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -112,12 +112,8 @@ def main():
 
     # Construct two input random tensors and an output zeroed tensor
     # The three tensor are in memory accessible to the NPU
-    input0 = iron.randint(
-        0, 100, (args.num_elements,), dtype=np.int32, device=args.device
-    )
-    input1 = iron.randint(
-        0, 100, (args.num_elements,), dtype=np.int32, device=args.device
-    )
+    input0 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device="npu")
+    input1 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device="npu")
     output = iron.zeros_like(input0)
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -18,7 +18,7 @@ from aie.iron.controlflow import range_
 
 
 @iron.jit(is_placed=False)
-def vector_vector_add(device, input0, input1, output):
+def vector_vector_add(config, input0, input1, output):
     if input0.shape != input1.shape:
         raise ValueError(
             f"Input shapes are not the equal ({input0.shape} != {input1.shape})."
@@ -81,7 +81,7 @@ def vector_vector_add(device, input0, input1, output):
         rt.drain(of_out.cons(), C, wait=True)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(device, rt).resolve_program(SequentialPlacer())
+    return Program(config['device'], rt).resolve_program(SequentialPlacer())
 
 
 def main():
@@ -118,7 +118,7 @@ def main():
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
-    vector_vector_add(device_map[args.device], input0, input1, output)
+    vector_vector_add({'device': device_map[args.device]}, input0, input1, output)
 
     # Check the correctness of the result
     e = np.equal(input0.numpy() + input1.numpy(), output.numpy())

--- a/programming_examples/basic/vector_vector_add/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add.py
@@ -18,7 +18,7 @@ from aie.iron.controlflow import range_
 
 
 @iron.jit(is_placed=False)
-def vector_vector_add(config, input0, input1, output):
+def vector_vector_add(input0, input1, output):
     if input0.shape != input1.shape:
         raise ValueError(
             f"Input shapes are not the equal ({input0.shape} != {input1.shape})."
@@ -81,7 +81,7 @@ def vector_vector_add(config, input0, input1, output):
         rt.drain(of_out.cons(), C, wait=True)
 
     # Place program components (assign them resources on the device) and generate an MLIR module
-    return Program(config["device"], rt).resolve_program(SequentialPlacer())
+    return Program(iron.get_current_device(), rt).resolve_program(SequentialPlacer())
 
 
 def main():
@@ -116,9 +116,11 @@ def main():
     input1 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device="npu")
     output = iron.zeros_like(input0)
 
+    iron.set_current_device(device_map[args.device])
+
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
-    vector_vector_add({"device": device_map[args.device]}, input0, input1, output)
+    vector_vector_add(input0, input1, output)
 
     # Check the correctness of the result
     e = np.equal(input0.numpy() + input1.numpy(), output.numpy())

--- a/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
@@ -48,7 +48,7 @@ def vector_vector_add(config, input0, input1, output):
 
     buffer_depth = 2
 
-    @device(config['device'])
+    @device(config["device"])
     def device_body():
         tensor_ty = np.ndarray[(num_elements,), np.dtype[dtype]]
         tile_ty = np.ndarray[(n,), np.dtype[dtype]]
@@ -56,8 +56,8 @@ def vector_vector_add(config, input0, input1, output):
         # AIE Core Function declarations
 
         # Tile declarations
-        ShimTile = tile(config['column_id'], 0)
-        ComputeTile2 = tile(config['column_id'], 2)
+        ShimTile = tile(config["column_id"], 0)
+        ComputeTile2 = tile(config["column_id"], 2)
 
         # AIE-array data movement with object fifos
         of_in1 = object_fifo("in1", ShimTile, ComputeTile2, buffer_depth, tile_ty)

--- a/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
@@ -9,8 +9,8 @@
 import argparse
 import sys
 import numpy as np
+import aie.iron as iron
 
-from aie import iron
 from aie.dialects.aie import *
 from aie.dialects.aiex import *
 from aie.helpers.dialects.ext.scf import _for as range_

--- a/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
@@ -128,12 +128,8 @@ def main():
 
     # Construct two input random tensors and an output zeroed tensor
     # The three tensor are in memory accessible to the NPU
-    input0 = iron.randint(
-        0, 100, (args.num_elements,), dtype=np.int32, device=args.device
-    )
-    input1 = iron.randint(
-        0, 100, (args.num_elements,), dtype=np.int32, device=args.device
-    )
+    input0 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device="npu")
+    input1 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device="npu")
     output = iron.zeros_like(input0)
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls

--- a/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
+++ b/programming_examples/basic/vector_vector_add/vector_vector_add_placed.py
@@ -128,8 +128,8 @@ def main():
 
     # Construct two input random tensors and an output zeroed tensor
     # The three tensor are in memory accessible to the NPU
-    input0 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
-    input1 = iron.rand((args.num_elements,), dtype=np.int32, device=args.device)
+    input0 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device=args.device)
+    input1 = iron.randint(0, 100, (args.num_elements,), dtype=np.int32, device=args.device)
     output = iron.zeros_like(input0)
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls

--- a/programming_guide/mini_tutorial/aie2p.py
+++ b/programming_guide/mini_tutorial/aie2p.py
@@ -16,10 +16,6 @@ from aie.iron.controlflow import range_
 
 import aie.iron as iron
 
-# The device on which the Program will be executed. Should match available hardware architecture.
-# You can see a list of available devices in python/iron/device/__init__.py
-dev = NPU2()
-
 # Define tensor types
 # These represent the size and datatype of the data tensors on which we do compute or move
 # with the ObjectFifo primitive.
@@ -34,7 +30,7 @@ tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
 #     - is_placed (bool): Whether the kernel is using explicit or deferred placement API. Defaults to True.
 #     - use_cache (bool): Use cached MLIR module if available. Defaults to True.
 @iron.jit(is_placed=False)
-def aie2p():
+def aie2p(input0, output):
     # Dataflow with ObjectFifos
     # ObjectFifos represent a dataflow connection between endpoints in the AIE array.
     # The IRON placement step relies on ObjectFifoHandles to infer the endpoints of ObjectFifos.
@@ -77,7 +73,7 @@ def aie2p():
         rt.drain(of_out.cons(), c_out, wait=True)
 
     # Create the program from the device type and runtime
-    my_program = Program(dev, rt)
+    my_program = Program(iron.get_current_device(), rt)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     # The placer will use available information, such as the ObjectFifoHandles, to place the components.
@@ -94,6 +90,10 @@ def main():
     # The two tensors are in memory accessible to the NPU
     input0 = iron.arange(num_elements, dtype=data_type, device="npu")
     output = iron.zeros_like(input0)
+
+    # The device on which the Program will be executed. Should match available hardware architecture.
+    # You can see a list of available devices in python/iron/device/__init__.py
+    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
@@ -114,11 +114,11 @@ def main():
     # Otherwise, exit with a failure code
     if not errors:
         print("\nPASS!\n")
-        exit(0)
+        sys.exit(0)
     else:
         print("\nError count: ", errors)
         print("\nfailed.\n")
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/programming_guide/mini_tutorial/aie2p.py
+++ b/programming_guide/mini_tutorial/aie2p.py
@@ -11,7 +11,6 @@ import sys
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU2
 from aie.iron.controlflow import range_
 
 import aie.iron as iron
@@ -90,10 +89,6 @@ def main():
     # The two tensors are in memory accessible to the NPU
     input0 = iron.arange(num_elements, dtype=data_type, device="npu")
     output = iron.zeros_like(input0)
-
-    # The device on which the Program will be executed. Should match available hardware architecture.
-    # You can see a list of available devices in python/iron/device/__init__.py
-    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects

--- a/programming_guide/mini_tutorial/exercise_1/exercise_1.py
+++ b/programming_guide/mini_tutorial/exercise_1/exercise_1.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo, GlobalBuffer
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU2
 from aie.iron.controlflow import range_
 
 import aie.iron as iron
@@ -64,8 +63,6 @@ def main():
     # The two tensors are in memory accessible to the NPU
     input0 = iron.arange(num_elements, dtype=data_type, device="npu")
     output = iron.zeros_like(input0)
-
-    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects

--- a/programming_guide/mini_tutorial/exercise_1/exercise_1.py
+++ b/programming_guide/mini_tutorial/exercise_1/exercise_1.py
@@ -16,8 +16,6 @@ from aie.iron.controlflow import range_
 
 import aie.iron as iron
 
-dev = NPU2()
-
 # Define tensor types
 num_elements = 48
 data_type = np.int32
@@ -25,7 +23,7 @@ tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
 
 
 @iron.jit(is_placed=False)
-def exercise_1():
+def exercise_1(input0, output):
     # Dataflow with ObjectFifos
     of_out = ObjectFifo(tile_ty, name="out")
 
@@ -52,7 +50,7 @@ def exercise_1():
         rt.drain(of_out.cons(), c_out, wait=True)
 
     # Create the program from the device type and runtime
-    my_program = Program(dev, rt)
+    my_program = Program(iron.get_current_device(), rt)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return my_program.resolve_program(SequentialPlacer())
@@ -65,9 +63,11 @@ def main():
     input0 = iron.arange(num_elements, dtype=data_type, device="npu")
     output = iron.zeros_like(input0)
 
+    iron.set_current_device(NPU2())
+
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
-    exercise_1(output)
+    exercise_1(input0, output)
 
     # Check the correctness of the result
     e = np.equal(input0.numpy(), output.numpy())
@@ -84,11 +84,11 @@ def main():
     # Otherwise, exit with a failure code
     if not errors:
         print("\nPASS!\n")
-        exit(0)
+        sys.exit(0)
     else:
         print("\nError count: ", errors)
         print("\nfailed.\n")
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/programming_guide/mini_tutorial/exercise_1/exercise_1.py
+++ b/programming_guide/mini_tutorial/exercise_1/exercise_1.py
@@ -6,8 +6,8 @@
 #
 # (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 
-import numpy as np
 import sys
+import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo, GlobalBuffer
 from aie.iron.placers import SequentialPlacer
@@ -16,14 +16,13 @@ from aie.iron.controlflow import range_
 
 import aie.iron as iron
 
-# Define tensor types
-num_elements = 48
-data_type = np.int32
-tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
-
 
 @iron.jit(is_placed=False)
 def exercise_1(output):
+    num_elements = output.numel()
+    data_type = output.dtype
+    tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
+
     # Dataflow with ObjectFifos
     of_out = ObjectFifo(tile_ty, name="out")
 
@@ -57,6 +56,9 @@ def exercise_1(output):
 
 
 def main():
+    # Define tensor shapes and data types
+    num_elements = 48
+    data_type = np.int32
 
     # Construct an input tensor and an output zeroed tensor
     # The two tensors are in memory accessible to the NPU

--- a/programming_guide/mini_tutorial/exercise_1/exercise_1.py
+++ b/programming_guide/mini_tutorial/exercise_1/exercise_1.py
@@ -23,7 +23,7 @@ tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
 
 
 @iron.jit(is_placed=False)
-def exercise_1(input0, output):
+def exercise_1(output):
     # Dataflow with ObjectFifos
     of_out = ObjectFifo(tile_ty, name="out")
 
@@ -67,7 +67,7 @@ def main():
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
-    exercise_1(input0, output)
+    exercise_1(output)
 
     # Check the correctness of the result
     e = np.equal(input0.numpy(), output.numpy())

--- a/programming_guide/mini_tutorial/exercise_1/run.lit
+++ b/programming_guide/mini_tutorial/exercise_1/run.lit
@@ -3,4 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
+// RUN: %run_on_npu python3 %S/exercise_1.py
 // RUN: %run_on_2npu python3 %S/exercise_1.py

--- a/programming_guide/mini_tutorial/exercise_2/exercise_2.py
+++ b/programming_guide/mini_tutorial/exercise_2/exercise_2.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU2
 from aie.iron.controlflow import range_
 
 import aie.iron as iron
@@ -62,8 +61,6 @@ def main():
     # The two tensors are in memory accessible to the NPU
     input0 = iron.arange(num_elements, dtype=data_type, device="npu")
     output = iron.zeros_like(input0)
-
-    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects

--- a/programming_guide/mini_tutorial/exercise_2/exercise_2.py
+++ b/programming_guide/mini_tutorial/exercise_2/exercise_2.py
@@ -6,8 +6,8 @@
 #
 # (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 
-import numpy as np
 import sys
+import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo
 from aie.iron.placers import SequentialPlacer
@@ -16,14 +16,13 @@ from aie.iron.controlflow import range_
 
 import aie.iron as iron
 
-# Define tensor types
-num_elements = 48
-data_type = np.int32
-tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
-
 
 @iron.jit(is_placed=False)
 def exercise_2(input0, output):
+    num_elements = output.numel()
+    data_type = output.dtype
+    tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
+
     # Dataflow with ObjectFifos
     of_in = ObjectFifo(tile_ty, name="in")
     of_out = ObjectFifo(tile_ty, name="out")
@@ -55,6 +54,9 @@ def exercise_2(input0, output):
 
 
 def main():
+    # Define tensor shapes and data types
+    num_elements = 48
+    data_type = np.int32
 
     # Construct an input tensor and an output zeroed tensor
     # The two tensors are in memory accessible to the NPU

--- a/programming_guide/mini_tutorial/exercise_2/exercise_2.py
+++ b/programming_guide/mini_tutorial/exercise_2/exercise_2.py
@@ -16,8 +16,6 @@ from aie.iron.controlflow import range_
 
 import aie.iron as iron
 
-dev = NPU2()
-
 # Define tensor types
 num_elements = 48
 data_type = np.int32
@@ -25,7 +23,7 @@ tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
 
 
 @iron.jit(is_placed=False)
-def exercise_2():
+def exercise_2(input0, output):
     # Dataflow with ObjectFifos
     of_in = ObjectFifo(tile_ty, name="in")
     of_out = ObjectFifo(tile_ty, name="out")
@@ -50,7 +48,7 @@ def exercise_2():
         rt.drain(of_out.cons(), c_out, wait=True)
 
     # Create the program from the device type and runtime
-    my_program = Program(dev, rt)
+    my_program = Program(iron.get_current_device(), rt)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return my_program.resolve_program(SequentialPlacer())
@@ -62,6 +60,8 @@ def main():
     # The two tensors are in memory accessible to the NPU
     input0 = iron.arange(num_elements, dtype=data_type, device="npu")
     output = iron.zeros_like(input0)
+
+    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects
@@ -82,11 +82,11 @@ def main():
     # Otherwise, exit with a failure code
     if not errors:
         print("\nPASS!\n")
-        exit(0)
+        sys.exit(0)
     else:
         print("\nError count: ", errors)
         print("\nfailed.\n")
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/programming_guide/mini_tutorial/exercise_2/run.lit
+++ b/programming_guide/mini_tutorial/exercise_2/run.lit
@@ -3,4 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
+// RUN: %run_on_npu python3 %S/exercise_2.py
 // RUN: %run_on_2npu python3 %S/exercise_2.py

--- a/programming_guide/mini_tutorial/exercise_3/exercise_3.py
+++ b/programming_guide/mini_tutorial/exercise_3/exercise_3.py
@@ -6,8 +6,8 @@
 #
 # (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 
-import numpy as np
 import sys
+import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo, GlobalBuffer
 from aie.iron.placers import SequentialPlacer
@@ -20,14 +20,13 @@ from aie.dialects.aie import T
 
 import aie.iron as iron
 
-# Define tensor types
-num_elements = 48
-data_type = np.int32
-tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
-
 
 @iron.jit(is_placed=False)
 def exercise_3(output):
+    num_elements = output.numel()
+    data_type = output.dtype
+    tile_ty = np.ndarray[(num_elements,), np.dtype[data_type]]
+
     # Dataflow with ObjectFifos
     of_out = ObjectFifo(tile_ty, name="out")
 
@@ -74,6 +73,9 @@ def exercise_3(output):
 
 
 def main():
+    # Define tensor shapes and data types
+    num_elements = 48
+    data_type = np.int32
 
     # Construct an input tensor and an output zeroed tensor
     # The two tensors are in memory accessible to the NPU

--- a/programming_guide/mini_tutorial/exercise_3/exercise_3.py
+++ b/programming_guide/mini_tutorial/exercise_3/exercise_3.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo, GlobalBuffer
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU2
 from aie.iron.controlflow import range_
 
 from aie.extras.dialects.ext import arith
@@ -81,8 +80,6 @@ def main():
     # The two tensors are in memory accessible to the NPU
     input0 = iron.arange(num_elements, dtype=data_type, device="npu")
     output = iron.zeros_like(input0)
-
-    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects

--- a/programming_guide/mini_tutorial/exercise_3/run.lit
+++ b/programming_guide/mini_tutorial/exercise_3/run.lit
@@ -3,4 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
+// RUN: %run_on_npu python3 %S/exercise_3.py
 // RUN: %run_on_2npu python3 %S/exercise_3.py

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4a/exercise_4a.py
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4a/exercise_4a.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU2
 from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorAccessPattern
 
@@ -75,8 +74,6 @@ def main():
 
     # Generate reference pattern
     ref_vec = [k * 8 + j * 16 + i for k in range(2) for j in range(3) for i in range(8)]
-
-    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4a/exercise_4a.py
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4a/exercise_4a.py
@@ -6,6 +6,7 @@
 #
 # (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 
+import sys
 import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4a/exercise_4a.py
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4a/exercise_4a.py
@@ -17,20 +17,20 @@ from aie.helpers.taplib import TensorAccessPattern
 
 import aie.iron as iron
 
-# Define tensor types
-data_height = 3
-data_width = 16
-tile_height = 3
-tile_width = 8
-data_size = data_height * data_width
-tile_size = tile_height * tile_width
-element_type = np.int32
-data_ty = np.ndarray[(data_size,), np.dtype[element_type]]
-tile_ty = np.ndarray[(tile_size,), np.dtype[element_type]]
-
 
 @iron.jit(is_placed=False)
 def exercise_4a(input0, output):
+    # Define tile size
+    tile_height = 3
+    tile_width = 8
+    tile_size = tile_height * tile_width
+
+    data_size = input0.numel()
+    element_type = input0.dtype
+
+    data_ty = np.ndarray[(data_size,), np.dtype[element_type]]
+    tile_ty = np.ndarray[(tile_size,), np.dtype[element_type]]
+
     # Dataflow with ObjectFifos
     of_in = ObjectFifo(tile_ty, name="in")
     of_out = ObjectFifo(tile_ty, name="out")
@@ -62,6 +62,11 @@ def exercise_4a(input0, output):
 
 
 def main():
+    # Define tensor shapes and data types
+    data_height = 3
+    data_width = 16
+    data_size = data_height * data_width
+    element_type = np.int32
 
     # Construct an input tensor and an output zeroed tensor
     # The two tensors are in memory accessible to the NPU

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4a/run.lit
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4a/run.lit
@@ -3,4 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
+// RUN: %run_on_npu python3 %S/exercise_4a.py 
 // RUN: %run_on_2npu python3 %S/exercise_4a.py 

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4b/exercise_4b.py
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4b/exercise_4b.py
@@ -8,6 +8,7 @@
 
 import os
 import glob
+import sys
 import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4b/exercise_4b.py
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4b/exercise_4b.py
@@ -13,7 +13,6 @@ import numpy as np
 
 from aie.iron import Program, Runtime, Worker, ObjectFifo
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU2
 from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorAccessPattern, TensorAccessSequence
 
@@ -100,8 +99,6 @@ def main():
     # The two tensors are in memory accessible to the NPU
     input0 = iron.arange(data_size, dtype=element_type, device="npu")
     output = iron.zeros(data_size, dtype=element_type, device="npu")
-
-    iron.set_current_device(NPU2())
 
     # JIT-compile the kernel then launches the kernel with the given arguments. Future calls
     # to the kernel will use the same compiled kernel and loaded code objects

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4b/exercise_4b.py
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4b/exercise_4b.py
@@ -19,20 +19,23 @@ from aie.helpers.taplib import TensorAccessPattern, TensorAccessSequence
 
 import aie.iron as iron
 
-# Define tensor types
+# Define tensor shape
 data_height = 3
 data_width = 16
-tile_height = 3
-tile_width = 8
-data_size = data_height * data_width
-tile_size = tile_height * tile_width
-element_type = np.int32
-data_ty = np.ndarray[(data_size,), np.dtype[element_type]]
-tile_ty = np.ndarray[(tile_size,), np.dtype[element_type]]
 
 
 @iron.jit(is_placed=False)
 def exercise_4b(input0, output):
+    # Define tile size
+    tile_height = 3
+    tile_width = 8
+    tile_size = tile_height * tile_width
+
+    data_size = input0.numel()
+    element_type = input0.dtype
+    data_ty = np.ndarray[(data_size,), np.dtype[element_type]]
+    tile_ty = np.ndarray[(tile_size,), np.dtype[element_type]]
+
     # Define runtime tensor access pattern (tap)
     tensor_dims = (data_height, data_width)
     tap1 = TensorAccessPattern(
@@ -82,6 +85,10 @@ def exercise_4b(input0, output):
 
 
 def main():
+    # Define tensor shapes and data types
+    data_size = data_height * data_width
+    element_type = np.int32
+
     # Delete existing plot*.png files
     for file in glob.glob("plot*.png"):
         try:

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4b/run.lit
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4b/run.lit
@@ -3,4 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
+// RUN: %run_on_npu python3 %S/exercise_4b.py
 // RUN: %run_on_2npu python3 %S/exercise_4b.py

--- a/programming_guide/mini_tutorial/run.lit
+++ b/programming_guide/mini_tutorial/run.lit
@@ -3,4 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
+// RUN: %run_on_npu python3 %S/aie2p.py
 // RUN: %run_on_2npu python3 %S/aie2p.py

--- a/python/iron/__init__.py
+++ b/python/iron/__init__.py
@@ -12,7 +12,7 @@ try:
     # imports the .jit module.
     import pyxrt
     from .jit import jit
-    from .config import set_current_device, get_current_device
+    from .config import set_current_device, get_current_device, detect_npu_device
 
     from .tensor import (
         tensor,

--- a/python/iron/__init__.py
+++ b/python/iron/__init__.py
@@ -12,6 +12,7 @@ try:
     # imports the .jit module.
     import pyxrt
     from .jit import jit
+    from .config import set_current_device, get_current_device
 
     from .tensor import (
         tensor,

--- a/python/iron/config.py
+++ b/python/iron/config.py
@@ -10,6 +10,14 @@ config = {}
 
 
 def set_current_device(device):
+    """Sets the current device.
+
+    Args:
+        device: Device to set as the current device.
+
+    Returns:
+        The previously set device.
+    """
     global config
     previous_device = config.get("device")
     config["device"] = device
@@ -17,5 +25,10 @@ def set_current_device(device):
 
 
 def get_current_device():
+    """Gets the current device.
+
+    Returns:
+        The currently set device.
+    """
     global config
     return config["device"]

--- a/python/iron/config.py
+++ b/python/iron/config.py
@@ -1,0 +1,21 @@
+# config.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2025 Advanced Micro Devices, Inc.
+
+config = {}
+
+
+def set_current_device(device):
+    global config
+    previous_device = config.get("device")
+    config["device"] = device
+    return previous_device
+
+
+def get_current_device():
+    global config
+    return config["device"]

--- a/python/iron/jit.py
+++ b/python/iron/jit.py
@@ -81,7 +81,7 @@ class NPUKernel:
         self.__insts_buffer_bo.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
     # Blocking call.
-    def __call__(self, *args):
+    def __call__(self, config, *args):
         """
         Allows the kernel to be called as a function with the provided arguments.
 
@@ -101,7 +101,7 @@ class NPUKernel:
         h = self.__kernel(opcode, self.__insts_buffer_bo, self.__n_insts, *kernel_args)
         r = h.wait()
         if r != xrt.ert_cmd_state.ERT_CMD_STATE_COMPLETED:
-            raise Exception(f"Kernel returned {r}")
+            raise NPUKernel_Error(f"Kernel returned {r}")
 
     def __del__(self):
         """
@@ -169,7 +169,7 @@ def jit(function=None, is_placed=True, use_cache=True):
                 )
 
             kernel_name = "MLIR_AIE"
-            return NPUKernel(xclbin_path, inst_path, kernel_name=kernel_name)
+            return NPUKernel(xclbin_path, inst_path, kernel_name=kernel_name)(*args, **kwargs)
 
         return wrapped_function
 

--- a/python/iron/jit.py
+++ b/python/iron/jit.py
@@ -81,7 +81,7 @@ class NPUKernel:
         self.__insts_buffer_bo.sync(xrt.xclBOSyncDirection.XCL_BO_SYNC_BO_TO_DEVICE)
 
     # Blocking call.
-    def __call__(self, config, *args):
+    def __call__(self, *args):
         """
         Allows the kernel to be called as a function with the provided arguments.
 

--- a/python/iron/jit.py
+++ b/python/iron/jit.py
@@ -169,7 +169,9 @@ def jit(function=None, is_placed=True, use_cache=True):
                 )
 
             kernel_name = "MLIR_AIE"
-            return NPUKernel(xclbin_path, inst_path, kernel_name=kernel_name)(*args, **kwargs)
+            return NPUKernel(xclbin_path, inst_path, kernel_name=kernel_name)(
+                *args, **kwargs
+            )
 
         return wrapped_function
 

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -17,5 +17,6 @@ def main():
     device = iron.get_current_device()
     print(device)
 
+
 if __name__ == "__main__":
     main()

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -10,6 +10,7 @@ from aie.iron.device import NPU2
 
 import aie.iron as iron
 
+
 # CHECK: NPU2
 def main():
     iron.set_current_device(NPU2())

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -10,7 +10,7 @@ from aie.iron.device import NPU2
 
 import aie.iron as iron
 
-# CHECK NPU2
+# CHECK: NPU2
 def main():
     iron.set_current_device(NPU2())
     device = iron.get_current_device()

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -19,4 +19,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-  

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -7,7 +7,6 @@
 # RUN: %run_on_npu %pytest %s
 # RUN: %run_on_2npu %pytest %s
 
-import pytest
 import aie.iron as iron
 from aie.iron.device import NPU2
 

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -4,19 +4,16 @@
 #
 # (c) Copyright 2025 AMD Inc.
 
-# RUN: %python %s | FileCheck %s
+# RUN: %run_on_npu %pytest %s
+# RUN: %run_on_2npu %pytest %s
 
+import pytest
+import aie.iron as iron
 from aie.iron.device import NPU2
 
-import aie.iron as iron
 
-
-# CHECK: NPU2
-def main():
-    iron.set_current_device(NPU2())
-    device = iron.get_current_device()
-    print(type(device).__name__)
-
-
-if __name__ == "__main__":
-    main()
+def test_set_current_device():
+    device = NPU2()
+    iron.set_current_device(device)
+    current_device = iron.get_current_device()
+    assert current_device == device

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -15,7 +15,7 @@ import aie.iron as iron
 def main():
     iron.set_current_device(NPU2())
     device = iron.get_current_device()
-    print(device)
+    print(type(device).__name__)
 
 
 if __name__ == "__main__":

--- a/test/python/set_current_device.py
+++ b/test/python/set_current_device.py
@@ -1,0 +1,21 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2025 AMD Inc.
+
+# RUN: %python %s | FileCheck %s
+
+from aie.iron.device import NPU2
+
+import aie.iron as iron
+
+# CHECK NPU2
+def main():
+    iron.set_current_device(NPU2())
+    device = iron.get_current_device()
+    print(device)
+
+if __name__ == "__main__":
+    main()
+  


### PR DESCRIPTION
This PR allows to pass arguments through the `iron.jit` decorator to the called function.

Closes #2211 