### PR TITLE
Add tensor unittests

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -85,7 +85,7 @@ jobs:
           pip install -r python/requirements.txt
           HOST_MLIR_PYTHON_PACKAGE_PREFIX=aie pip install -r python/requirements_extras.txt
           pip install -r python/requirements_ml.txt
-          pip install jupyter
+          pip install jupyter pytest
           sed -i.bak 's/OUTPUT_TIMEOUT = 10/OUTPUT_TIMEOUT = 100/g' \
             $(python -c 'import site; print(site.getsitepackages()[0])')/jupyter_client/runapp.py
 

--- a/test/python/lit.local.cfg
+++ b/test/python/lit.local.cfg
@@ -18,4 +18,4 @@ if config.has_mlir_runtime_libraries:
 
 config.excludes.add("util.py")
 
-config.substitutions.append(("%pytest", "CI=1 pytest -rA"))
+config.substitutions.append(("%pytest", "pytest -rA"))

--- a/test/python/lit.local.cfg
+++ b/test/python/lit.local.cfg
@@ -17,3 +17,5 @@ if config.has_mlir_runtime_libraries:
     config.available_features.add("has_mlir_runtime_libraries")
 
 config.excludes.add("util.py")
+
+config.substitutions.append(("%pytest", "CI=1 pytest -rA"))

--- a/test/python/tensor.py
+++ b/test/python/tensor.py
@@ -4,12 +4,11 @@
 #
 # (c) Copyright 2025 AMD Inc.
 
-# RUN: %pytest %s
+# RUN: %run_on_npu %pytest %s
 
 import pytest
 import numpy as np
 import aie.iron as iron
-
 
 @pytest.mark.parametrize("dtype", [np.float32, np.int32])
 def test_tensor_creation(dtype):

--- a/test/python/tensor.py
+++ b/test/python/tensor.py
@@ -1,0 +1,69 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2025 AMD Inc.
+
+# RUN: %pytest %s
+
+import pytest
+import numpy as np
+import aie.iron as iron
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int32])
+def test_tensor_creation(dtype):
+    t = iron.tensor((2, 2), dtype=dtype, device="npu")
+    expected = np.zeros((2, 2), dtype=dtype)
+    assert np.allclose(t, expected)
+    assert t.shape == (2, 2)
+    assert str(t.device) == "npu"
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int32])
+def test_to_device(dtype):
+    t = iron.ones((2, 2), dtype=dtype, device="cpu")
+    t.to("npu")
+    t.to("cpu")
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int32])
+def test_zeros(dtype):
+    assert np.allclose(iron.zeros(2, 3, dtype=dtype), np.zeros((2, 3), dtype=dtype))
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.int32])
+def test_ones(dtype):
+    assert np.allclose(iron.ones((2, 2), dtype=dtype), np.ones((2, 2), dtype=dtype))
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.uint32])
+def test_random_with_bounds(dtype):
+    t = iron.randint(0, 32, (2, 4), dtype=dtype, device="npu")
+    assert t.shape == (2, 4)
+    arr = t.numpy()
+    assert np.all((arr >= 0) & (arr < 32))
+
+
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_rand(dtype):
+    t = iron.rand(2, 2, dtype=dtype, device="npu")
+    arr = t.numpy()
+    assert np.all((arr >= 0) & (arr < 1.0))
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.uint32])
+def test_arange_integer(dtype):
+    assert np.array_equal(iron.arange(3, 9, dtype=dtype), np.arange(3, 9, dtype=dtype))
+
+
+def test_arange_floats():
+    assert np.allclose(iron.arange(1.0, 5.0, 1.5), np.arange(1.0, 5.0, 1.5))
+
+
+@pytest.mark.parametrize("dtype", [np.int32, np.float32])
+def test_zeros_like(dtype):
+    t = iron.tensor([[1, 2], [3, 4]], dtype=dtype)
+    z = iron.zeros_like(t)
+    expected = np.zeros_like(t)
+    assert np.array_equal(z, expected)

--- a/test/python/tensor.py
+++ b/test/python/tensor.py
@@ -5,6 +5,7 @@
 # (c) Copyright 2025 AMD Inc.
 
 # RUN: %run_on_npu %pytest %s
+# RUN: %run_on_2npu %pytest %s
 
 import pytest
 import numpy as np

--- a/test/python/tensor.py
+++ b/test/python/tensor.py
@@ -10,6 +10,7 @@ import pytest
 import numpy as np
 import aie.iron as iron
 
+
 @pytest.mark.parametrize("dtype", [np.float32, np.int32])
 def test_tensor_creation(dtype):
     t = iron.tensor((2, 2), dtype=dtype, device="npu")


### PR DESCRIPTION
This PR adds `pytest`-based unittests for tensor class.

Also, it adds/installs pytest in RyzenAI CI. Let me know if I should be adding pytest to one of the requirement files.