### PR TITLE
Use `cxxopts` instead of Boost

### DIFF
--- a/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
+++ b/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
@@ -83,7 +83,7 @@ jobs:
                 | tee /etc/apt/preferences.d/rocm-pin-600
             apt update
             apt install -y rocm-hip-runtime-dev5.6.0 python3.10-venv \
-                           libboost-all-dev pkg-config libelf-dev elfutils \
+                           pkg-config libelf-dev elfutils \
                            libdwarf-dev libsysfs-dev clang libssl-dev uuid-dev
             apt-get clean
 
@@ -160,4 +160,4 @@ jobs:
             export LIT_OPTS="-sv --timeout 600 -j1 --filter-out Targets/AIEGenerateCDODirect"
             ninja check-aie
             ninja check-reference-designs
-            
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/build*
+build*
+_build*
+*.exe
 /install*
 /my_install*
 /sandbox*

--- a/docs/buildHostLin.md
+++ b/docs/buildHostLin.md
@@ -1,6 +1,6 @@
 # Linux Setup and Build Instructions
 
-These instructions will guide you through everything required for building and executing a program on the Ryzen™ AI NPU, starting from a fresh bare-bones **Ubuntu 22.04 LTS** install. Ubuntu 22.04 LTS, Ubuntu 24.04 LTS and Ubuntu 24.10 are supported by this toolchain. 
+These instructions will guide you through everything required for building and executing a program on the Ryzen™ AI NPU, starting from a fresh bare-bones **Ubuntu 22.04 LTS** install. Ubuntu 22.04 LTS, Ubuntu 24.04 LTS and Ubuntu 24.10 are supported by this toolchain.
 
 ## Initial Setup
 
@@ -8,9 +8,9 @@ These instructions will guide you through everything required for building and e
 
 Be sure you have the latest BIOS for your laptop or mini PC, this will ensure the NPU (sometimes referred to as IPU) is enabled in the system. You may need to manually enable the NPU:
 :
-   ```Advanced → CPU Configuration → IPU``` 
+   ```Advanced → CPU Configuration → IPU```
 
-> **NOTE:** Some manufacturers only provide Windows executables to update the BIOS, please do this before installing Ubuntu. 
+> **NOTE:** Some manufacturers only provide Windows executables to update the BIOS, please do this before installing Ubuntu.
 
 #### BIOS Settings:
 1. Turn off SecureBoot (Allows for unsigned drivers to be installed)
@@ -27,9 +27,9 @@ You will...
 1. Install the compiler toolchain, allowing you to compile your own NPU designs from source. As part of this, you will need to...
 
    1. [...install prerequisites.](#prerequisites)
-   
+
    1. ...install MLIR-AIE [from precompiled binaries (fast)](#option-a---quick-setup-for-ryzen-ai-application-development) or [from source (slow)](#option-b---build-mlir-aie-tools-from-source-for-development).
-  
+
 1. Install a driver for the Ryzen™ AI. As part of this, you will need to...
 
    1. [...install AIE Tools and obtain a license.](#install-aietools)
@@ -41,10 +41,10 @@ You will...
 1. Build and execute one of the example designs. This consists of...
 
    1. [...setting up your environment.](#setting-up-your-environment)
-   
+
    2. [...building device (NPU) code.](#build-device-aie-part)
-   
-   3. [...building and executing host (x86) code and device (NPU) code.](#build-and-run-host-part) 
+
+   3. [...building and executing host (x86) code and device (NPU) code.](#build-and-run-host-part)
 
 > Be advised that some of the potential steps (Linux kernel compilation and installing AIE Tools from Vitis™) may take hours. If you decide to build mlir-aie and/or LLVM from source, this will also take time, especially the LLVM build. Allocate enough time and patience. Once done, you will have an amazing toolchain allowing you to harness this great hardware at your hands.
 
@@ -52,14 +52,14 @@ You will...
 
 ### Install AIETools
 
-#### Option A - Supporting AMD Ryzen™ AI with AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P): Install AMD Vitis™ AIE Essentials 
+#### Option A - Supporting AMD Ryzen™ AI with AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P): Install AMD Vitis™ AIE Essentials
 
 1. Install Vitis™ AIE Essentials from [Ryzen AI Software 1.3 Early Accesss](https://account.amd.com/en/member/ryzenai-sw-ea.html#tabs-a5e122f973-item-4757898120-tab). We will assume you use the installation directory, `/tools/ryzen_ai-1.3.0/vitis_aie_essentials`.
 
    > This is an early access lounge, you must register and be granted access at this time.
 
     1. Download VAIML Installer for Linux based compilation: `ryzen_ai-1.3.0ea1.tgz`
- 
+
     1. Extract the required tools:
 
        ``` bash
@@ -76,7 +76,7 @@ You will...
     1. Get a local license for AI Engine tools from [https://www.xilinx.com/getlicense](https://www.xilinx.com/getlicense).
 
     1. Copy your license file (Xilinx.lic) to your preferred location, e.g. `/opt/Xilinx.lic`:
-       
+
     1. Setup your environment using the following script for Vitis for aietools:
 
        ```bash
@@ -88,8 +88,8 @@ You will...
         export PATH=$PATH:${AIETOOLS_ROOT}/bin
         export LM_LICENSE_FILE=/opt/Xilinx.lic
        ```
-      
-#### Option B - Supporting AMD Ryzen™ AI and AMD Versal™ with AIE and AIE-ML/XDNA™ (AIE2): Install AMD Vitis™ 2024.2 
+
+#### Option B - Supporting AMD Ryzen™ AI and AMD Versal™ with AIE and AIE-ML/XDNA™ (AIE2): Install AMD Vitis™ 2024.2
 
 1. Install Vitis™ under from [Xilinx Downloads](https://www.xilinx.com/support/download/index.html/content/xilinx/en/downloadNav/vitis.html). You will need to run the installer as root. We will assume you use the default installation directory, `/tools/Xilinx`.
 
@@ -100,7 +100,7 @@ You will...
     1. Get a local license for AI Engine tools from [https://www.xilinx.com/getlicense](https://www.xilinx.com/getlicense).
 
     1. Copy your license file (Xilinx.lic) to your preferred location, e.g. `/opt/Xilinx.lic`:
-       
+
     1. Setup your environment using the following script for Vitis™ for aietools:
 
        ```bash
@@ -116,7 +116,7 @@ You will...
         export LM_LICENSE_FILE=/opt/Xilinx.lic
        ```
    1. Vitis™ requires some python3.8 libraries:
-  
+
       ```bash
       sudo add-apt-repository ppa:deadsnakes/ppa
       sudo apt-get update
@@ -125,8 +125,8 @@ You will...
 
 ### Update Linux for Ubuntu 22.04 and 24.04
 
-> The reason we need to update the kernel is that the XDNA driver requires IOMMU SVA support. This step is required for Ubuntu 22.04 LTS. 
-> If you are using Ubuntu 24.04 you can install a prebuilt kernel from the [Ubuntu Mainline Kernel PPA](https://kernel.ubuntu.com/mainline/v6.11/). 
+> The reason we need to update the kernel is that the XDNA driver requires IOMMU SVA support. This step is required for Ubuntu 22.04 LTS.
+> If you are using Ubuntu 24.04 you can install a prebuilt kernel from the [Ubuntu Mainline Kernel PPA](https://kernel.ubuntu.com/mainline/v6.11/).
 >  ```bash
 >     wget https://kernel.ubuntu.com/mainline/v6.11/amd64/linux-headers-6.11.0-061100-generic_6.11.0-061100.202409151536_amd64.deb
 >     wget https://kernel.ubuntu.com/mainline/v6.11/amd64/linux-headers-6.11.0-061100_6.11.0-061100.202409151536_all.deb
@@ -146,7 +146,7 @@ You will...
 1. Install the following prerequisite packages for compiling Linux:
     ```bash
     sudo apt install \
-    build-essential debhelper flex bison libssl-dev libelf-dev libboost-all-dev libpython3.10-dev libsystemd-dev libtiff-dev libudev-dev
+    build-essential debhelper flex bison libssl-dev libelf-dev libpython3.10-dev libsystemd-dev libtiff-dev libudev-dev
     ```
 
 1. Pull the source for kernel version 6.10.
@@ -157,7 +157,7 @@ You will...
     ```
 
 1. Create a build directory and a configuration within it.
-    
+
     ```bash
     mkdir linux-build
     export LINUX_BUILD_DIR=$(realpath linux-build)
@@ -182,7 +182,7 @@ You will...
     ```
 
     > Compiling the linux kernel may take hours.
-    
+
     > Note that the final kernel `.deb` packages will be in the *parent* directory of `LINUX_BUILD_DIR`.
 
 1. Install the new Linux kernel and reboot.
@@ -196,7 +196,7 @@ You will...
 ### Install the XDNA™ Driver
 
 1. Install a more recent CMake, which is needed for building XRT.
-   
+
    1. Download CMake 3.28 binaries into `NEW_CMAKE_DIR`.
       ```bash
       mkdir cmake
@@ -214,7 +214,7 @@ You will...
       ```bash
       export PATH="${NEW_CMAKE_DIR}/bin":"${PATH}"
       ```
-   
+
    1. Verify the install of CMake was successful.
 
       ```bash
@@ -225,7 +225,7 @@ You will...
       > ```cmake version 3.28.3```
 
 1. Install the following prerequisite packages.
- 
+
    ```bash
    sudo apt install \
    libidn11-dev
@@ -245,7 +245,7 @@ You will...
 1. Install XRT. (Below steps are adapted from [here](https://xilinx.github.io/XRT/master/html/build.html).)
 
     1. Install XRT prerequisites.
-    
+
        ```bash
        cd $XDNA_SRC_DIR
        sudo ./tools/amdxdna_deps.sh
@@ -283,9 +283,9 @@ You will...
     cd $XDNA_SRC_DIR/build/Release
     sudo apt reinstall ./xrt_plugin.2.18.0_ubuntu22.04-x86_64-amdxdna.deb
     ```
-    
+
 1. Check that the NPU is working if the device appears with xrt-smi:
-   
+
    ```bash
    source /opt/xilinx/xrt/setup.sh
    xrt-smi examine
@@ -294,7 +294,7 @@ You will...
    > At the bottom of the output you should see:
    >  ```
    >  Devices present
-   >  BDF             :  Name             
+   >  BDF             :  Name
    > ------------------------------------
    >  [0000:66:00.1]  :  RyzenAI-npu1
    >  ```
@@ -323,9 +323,9 @@ You will...
 
 ### Option A - Quick Setup for Ryzen™ AI Application Development
 
-   > NOTE: Installing the mlir-aie tools from wheels via the quick setup path supports AIE-ML (AIE2) and AIE2P, it does NOT support Versal™ devices with AIE. 
+   > NOTE: Installing the mlir-aie tools from wheels via the quick setup path supports AIE-ML (AIE2) and AIE2P, it does NOT support Versal™ devices with AIE.
 
-1. Clone [the mlir-aie repository](https://github.com/Xilinx/mlir-aie.git), best under /home/username for speed (yourPathToBuildMLIR-AIE): 
+1. Clone [the mlir-aie repository](https://github.com/Xilinx/mlir-aie.git), best under /home/username for speed (yourPathToBuildMLIR-AIE):
    ```bash
    git clone https://github.com/Xilinx/mlir-aie.git
    cd mlir-aie
@@ -338,7 +338,7 @@ You will...
 
 ### Option B - Build mlir-aie Tools from Source for Development
 
-1. Clone [https://github.com/Xilinx/mlir-aie.git](https://github.com/Xilinx/mlir-aie.git) best under /home/username for speed (yourPathToBuildMLIR-AIE), with submodules: 
+1. Clone [https://github.com/Xilinx/mlir-aie.git](https://github.com/Xilinx/mlir-aie.git) best under /home/username for speed (yourPathToBuildMLIR-AIE), with submodules:
    ```bash
    git clone --recurse-submodules https://github.com/Xilinx/mlir-aie.git
    ````
@@ -391,7 +391,7 @@ For your design of interest, for instance from [programming_examples](../program
 
 ### Build and Run Host Part
 
-> Note that your design of interest might need an adapted `CMakeLists.txt` file. Also pay attention to accurately set the paths CMake parameters `BOOST_ROOT`, `XRT_INC_DIR` and `XRT_LIB_DIR` used in the `CMakeLists.txt`, either in the file or as CMake command line parameters.
+> Note that your design of interest might need an adapted `CMakeLists.txt` file. Also pay attention to accurately set the paths CMake parameters `XRT_INC_DIR` and `XRT_LIB_DIR` used in the `CMakeLists.txt`, either in the file or as CMake command line parameters.
 
 1. Build: Goto the same design of interest folder where the AIE design just got built (see above)
     ```bash
@@ -428,7 +428,7 @@ sudo modprobe -v amdxdna
 
 The `v++` compiler for the NPU device code requires a valid Vitis license. If you are getting errors related to this:
 
-1. You have obtained a valid license, as described [above](#prerequisites). 
+1. You have obtained a valid license, as described [above](#prerequisites).
 1. Make sure you have set the environment variable `LM_LICENSE_FILE` to point to your license file, see [above](#setting-up-your-environment).
 1. Make sure the ethernet interface whose MAC address you used to generate the license is still available on your machine. For example, if you used the MAC address of a removable USB Ethernet adapter, and then removed that adapter, the license check will fail. You can list MAC addresses of interfaces on your machine using `ip link`.
 

--- a/docs/buildHostWin.md
+++ b/docs/buildHostWin.md
@@ -1,6 +1,6 @@
 # Windows Setup and Build Instructions
 
-These instructions will guide you through everything required for building and executing a program on the Ryzen™ AI NPU on Windows. The instructions were tested on a ASUS Vivobook Pro 15. 
+These instructions will guide you through everything required for building and executing a program on the Ryzen™ AI NPU on Windows. The instructions were tested on a ASUS Vivobook Pro 15.
 
 You will set up a Windows subsystem for Linux (WSL) Ubuntu install, which will be used for building NPU device code. For building the host (x86) code, you will use MS Visual Code Community.
 
@@ -15,7 +15,7 @@ Be sure you have the latest BIOS for your laptop or mini PC, this will ensure th
 
   ```Advanced → CPU Configuration → IPU```
 
-> **NOTE:** Some manufacturers only provide Windows executables to update the BIOS. 
+> **NOTE:** Some manufacturers only provide Windows executables to update the BIOS.
 
 #### BIOS Settings:
 1. Turn off SecureBoot (Allows for unsigned drivers to be installed)
@@ -30,16 +30,15 @@ Be sure you have the latest BIOS for your laptop or mini PC, this will ensure th
 ## Prerequisites
 ### mlir-aie tools: WSL Ubuntu 22.04
 All steps in WSL Ubuntu terminal.
-1. Clone [https://github.com/Xilinx/mlir-aie.git](https://github.com/Xilinx/mlir-aie.git) best under /home/username for speed (yourPathToBuildMLIR-AIE), with submodules: 
+1. Clone [https://github.com/Xilinx/mlir-aie.git](https://github.com/Xilinx/mlir-aie.git) best under /home/username for speed (yourPathToBuildMLIR-AIE), with submodules:
    ```
    git clone --recurse-submodules https://github.com/Xilinx/mlir-aie.git
    ````
 1. Prepare WSL2 with Ubuntu 22.04:
     - Install packages (after apt-get update):
-      ``` 
+      ```
         sudo apt install \
         build-essential clang clang-14 lld lld-14 cmake \
-        libboost-all-dev \
         python3-venv python3-pip \
         libxrender1 libxtst6 libxi6 \
         mingw-w64-tools
@@ -52,7 +51,7 @@ All steps in WSL Ubuntu terminal.
 
 1. Install AIETools under WSL Ubuntu
 
-    1. Option A -  Supporting AMD Ryzen™ AI with AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P): Install AMD Vitis™ AIE Essentials under WSL Ubuntu from [Ryzen AI Software 1.3 Early Accesss](https://account.amd.com/en/member/ryzenai-sw-ea.html#tabs-a5e122f973-item-4757898120-tab). 
+    1. Option A -  Supporting AMD Ryzen™ AI with AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P): Install AMD Vitis™ AIE Essentials under WSL Ubuntu from [Ryzen AI Software 1.3 Early Accesss](https://account.amd.com/en/member/ryzenai-sw-ea.html#tabs-a5e122f973-item-4757898120-tab).
 
 
       > This is an early access lounge, you must register and be granted access at this time.
@@ -89,7 +88,7 @@ All steps in WSL Ubuntu terminal.
 
 
       - Install Vitis in WSL Ubuntu. We will assume you use the default installation directory, `/tools/Xilinx`.
-      - Get local license for AIE Engine tools from [https://www.xilinx.com/getlicense](https://www.xilinx.com/getlicense) providing your machine's MAC address (`ip -brief link show eth0`). Be sure to select License Type of `Node` instead of `Floating`. 
+      - Get local license for AIE Engine tools from [https://www.xilinx.com/getlicense](https://www.xilinx.com/getlicense) providing your machine's MAC address (`ip -brief link show eth0`). Be sure to select License Type of `Node` instead of `Floating`.
       - copy license file (Xilinx.lic) to your preferred location (licenseFilePath) and update your setup configuration accordingly, for instance
         ```
         export XILINXD_LICENSE_FILE=<licenseFilePath>/Xilinx.lic
@@ -114,7 +113,7 @@ All steps in WSL Ubuntu terminal.
 
    * Use quick setup script to install from whls:
 
-     >  NOTE: Installing the mlir-aie tools from wheels via the quick setup path supports AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P), it does NOT support Versal™ devices with AIE. 
+     >  NOTE: Installing the mlir-aie tools from wheels via the quick setup path supports AMD XDNA™/AIE-ML (AIE2) and AMD XDNA™ 2 (AIE2P), it does NOT support Versal™ devices with AIE.
 
      ```
      source utils/quick_setup.sh
@@ -140,20 +139,16 @@ All steps in Win11 (powershell where needed).
 1. Install [Microsoft Visual Studio 17 2022 Community Edition](https://visualstudio.microsoft.com/vs/community/) with package for C++ development.
 
 1. Install CMake on windows ([https://cmake.org/download/](https://cmake.org/download/))
-    - [Download](https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.zip) and [compile](https://www.boost.org/doc/libs/1_83_0/more/getting_started/windows.html) boost (current version 1.83). 
-    - Extract zip file into `C:\Technical\thirdParty`
-    - Run `bootstrap.bat` and after that `b2.exe`
-    - Note: If you run into an error during the compilation phase, see [here](https://stackoverflow.com/questions/78835588/cannot-build-boost-library-on-windows-11) for suggestions on a workaround. This involves modifying the `tools/build/src/tools/msvc.jam` file and run `.\b2.exe --reconfigure install`
 1. Optional (only needed for vision examples): install [opencv](https://docs.opencv.org/4.x/d3/d52/tutorial_windows_install.html) and add this install to your PATH environmental variable, for instance `C:\Technical\thirdParty\opencv\build\x64\vc16\bin`
 
 1. Clone [https://github.com/Xilinx/XRT](https://github.com/Xilinx/XRT) for instance under `C:\Technical` and `git checkout 2024.2`
 1. Create a .lib file from the .dll shipping with the driver
     - In wsl, generate a .def file (see above)
-    - Start a x86 Native Tools Command Prompt (installed as part of VS17), go to the folder `C:\Technical\xrtNPUfromDLL` and run command: 
+    - Start a x86 Native Tools Command Prompt (installed as part of VS17), go to the folder `C:\Technical\xrtNPUfromDLL` and run command:
       ```
       lib /def:xrt_coreutil.def /machine:x64 /out:xrt_coreutil.lib
       ```
-1. Clone [https://github.com/Xilinx/mlir-aie.git](https://github.com/Xilinx/mlir-aie.git) for instance under C:\Technical to be used to build designs (yourPathToDesignsWithMLIR-AIE) 
+1. Clone [https://github.com/Xilinx/mlir-aie.git](https://github.com/Xilinx/mlir-aie.git) for instance under C:\Technical to be used to build designs (yourPathToDesignsWithMLIR-AIE)
 
 ## Set up your environment
 
@@ -192,7 +187,7 @@ For your design of interest, for instance from [programming_examples](../program
 
 ### Build and run host part: PowerShell
 
-Note that your design of interest might need an adapted CMakelists.txt file. Also pay attention to accurately set the paths CMake parameters BOOST_ROOT, XRT_INC_DIR and XRT_LIB_DIR used in the CMakelists.txt, either in the file or as CMake command line parameters.
+Note that your design of interest might need an adapted CMakelists.txt file. Also pay attention to accurately set the paths CMake parameters XRT_INC_DIR and XRT_LIB_DIR used in the CMakelists.txt, either in the file or as CMake command line parameters.
 
 1. Build: Goto the same design of interest folder where the AIE design just got build (see above)
     ```
@@ -201,7 +196,7 @@ Note that your design of interest might need an adapted CMakelists.txt file. Als
     cmake .. -G "Visual Studio 17 2022"
     cmake --build . --config Release
     ```
-    
+
 1. Run (program arguments are just an example for add_one design)
    ```
     cd Release

--- a/programming_examples/basic/dma_transpose/CMakeLists.txt
+++ b/programming_examples/basic/dma_transpose/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -51,25 +46,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/dma_transpose/Makefile
+++ b/programming_examples/basic/dma_transpose/Makefile
@@ -59,7 +59,7 @@ else
 endif
 
 run: ${targetname}.exe build/final.xclbin
-	${powershell} ./$< -x build/final.xclbin -i build/insts.bin -k MLIR_AIE --M ${M} --K ${K}
+	${powershell} ./$< -x build/final.xclbin -i build/insts.bin -k MLIR_AIE -M ${M} -K ${K}
 
 generate_access_map: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}

--- a/programming_examples/basic/dma_transpose/test.cpp
+++ b/programming_examples/basic/dma_transpose/test.cpp
@@ -56,9 +56,6 @@ int main(int argc, const char *argv[]) {
     return 1;
   }
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/programming_examples/basic/dma_transpose/test.cpp
+++ b/programming_examples/basic/dma_transpose/test.cpp
@@ -22,7 +22,6 @@
 
 #include "cxxopts.hpp"
 
-
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
   cxxopts::Options options("DMA Transpose Test",

--- a/programming_examples/basic/dma_transpose/test.cpp
+++ b/programming_examples/basic/dma_transpose/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -22,42 +21,35 @@
 #include "xrt/xrt_kernel.h"
 
 #include "test_utils.h"
-
-namespace po = boost::program_options;
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
+  cxxopts::Options options("DMA Transpose Test", "Test the DMA Transpose kernel");
 
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "M", po::value<int>()->default_value(64),
-      "M, number of rows in the input matrix")(
-      "K", po::value<int>()->default_value(64),
-      "K, number of columns in the input matrix");
+  options.add_options()
+      ("help,h", "produce help message")
+      ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
+      ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
+      ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
+      ("instr,i", "path of file containing userspace instructions to be sent to the LX6", cxxopts::value<std::string>())
+      ("rows,M", "M, number of rows in the input matrix", cxxopts::value<int>()->default_value("64"))
+      ("cols,K", "K, number of columns in the input matrix", cxxopts::value<int>()->default_value("64"));
 
-  po::variables_map vm;
-
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+    auto vm = options.parse(argc, argv);
 
     if (vm.count("help")) {
-      std::cout << desc << std::endl;
+      std::cout << options.help() << std::endl;
       return 1;
     }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
+
+    // Check required options
+    if (!vm.count("xclbin") || !vm.count("kernel") || !vm.count("instr")) {
+      std::cerr << "Error: Required options missing\n\n";
+      std::cerr << "Usage:\n" << options.help() << std::endl;
+      return 1;
+    }
+
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/programming_examples/basic/dma_transpose/test.cpp
+++ b/programming_examples/basic/dma_transpose/test.cpp
@@ -20,36 +20,41 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-#include "test_utils.h"
 #include "cxxopts.hpp"
+
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  cxxopts::Options options("DMA Transpose Test", "Test the DMA Transpose kernel");
+  cxxopts::Options options("DMA Transpose Test",
+                           "Test the DMA Transpose kernel");
 
-  options.add_options()
-      ("help,h", "produce help message")
-      ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
-      ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
-      ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
-      ("instr,i", "path of file containing userspace instructions to be sent to the LX6", cxxopts::value<std::string>())
-      ("rows,M", "M, number of rows in the input matrix", cxxopts::value<int>()->default_value("64"))
-      ("cols,K", "K, number of columns in the input matrix", cxxopts::value<int>()->default_value("64"));
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions to be sent to the LX6",
+      cxxopts::value<std::string>())(
+      "rows,M", "M, number of rows in the input matrix",
+      cxxopts::value<int>()->default_value("64"))(
+      "cols,K", "K, number of columns in the input matrix",
+      cxxopts::value<int>()->default_value("64"));
 
-    auto vm = options.parse(argc, argv);
+  auto vm = options.parse(argc, argv);
 
-    if (vm.count("help")) {
-      std::cout << options.help() << std::endl;
-      return 1;
-    }
+  if (vm.count("help")) {
+    std::cout << options.help() << std::endl;
+    return 1;
+  }
 
-    // Check required options
-    if (!vm.count("xclbin") || !vm.count("kernel") || !vm.count("instr")) {
-      std::cerr << "Error: Required options missing\n\n";
-      std::cerr << "Usage:\n" << options.help() << std::endl;
-      return 1;
-    }
-
+  // Check required options
+  if (!vm.count("xclbin") || !vm.count("kernel") || !vm.count("instr")) {
+    std::cerr << "Error: Required options missing\n\n";
+    std::cerr << "Usage:\n" << options.help() << std::endl;
+    return 1;
+  }
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/programming_examples/basic/dma_transpose/test.cpp
+++ b/programming_examples/basic/dma_transpose/test.cpp
@@ -21,6 +21,7 @@
 #include "xrt/xrt_kernel.h"
 
 #include "cxxopts.hpp"
+#include "test_utils.h"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/programming_examples/basic/matrix_multiplication/CMakeLists.txt
+++ b/programming_examples/basic/matrix_multiplication/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -43,9 +40,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     ${subdir}/test.cpp
@@ -53,25 +47,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/matrix_multiplication/common.h
+++ b/programming_examples/basic/matrix_multiplication/common.h
@@ -75,9 +75,6 @@ void parse_options(int argc, const char *argv[], cxxopts::Options &options,
       std::exit(1);
     }
 
-    test_utils::check_arg_file_exists(result, "xclbin");
-    test_utils::check_arg_file_exists(result, "instr");
-
   } catch (const cxxopts::exceptions::parsing &e) {
     std::cerr << e.what() << "\n\n";
     std::cerr << "Usage:\n" << options.help() << "\n";

--- a/programming_examples/basic/matrix_multiplication/common.h
+++ b/programming_examples/basic/matrix_multiplication/common.h
@@ -27,54 +27,53 @@
 
 namespace matmul_common {
 
-namespace po = boost::program_options;
-
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
 
-void add_default_options(po::options_description &desc) {
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions sent to the NPU")(
-      "verify", po::value<bool>()->default_value(true),
-      "whether to verify the AIE computed output")(
-      "M,M", po::value<int>()->default_value(512), "Matrix size M")(
-      "K,K", po::value<int>()->default_value(512), "Matrix size K")(
-      "N,N", po::value<int>()->default_value(512),
-      "Matrix size N")("iters", po::value<int>()->default_value(1))(
-      "warmup", po::value<int>()->default_value(0))(
-      "trace_sz,t", po::value<int>()->default_value(0))(
-      "trace_file", po::value<std::string>()->default_value("trace.txt"),
-      "where to store trace output")("b_col_maj",
-                                     po::value<int>()->default_value(0),
-                                     "Is B matrix in colum-major format?");
+void add_default_options(cxxopts::Options& options) {
+  options.add_options()
+    ("help,h", "produce help message")
+    ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
+    ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
+    ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
+    ("instr,i", "path of file containing userspace instructions sent to the NPU", cxxopts::value<std::string>())
+    ("verify", "whether to verify the AIE computed output", cxxopts::value<bool>()->default_value("true"))
+    ("rows,M", "Matrix size M", cxxopts::value<int>()->default_value("512"))
+    ("inner,K", "Matrix size K", cxxopts::value<int>()->default_value("512"))
+    ("columns,N", "Matrix size N", cxxopts::value<int>()->default_value("512"))
+    ("iters", "number of iterations", cxxopts::value<int>()->default_value("1"))
+    ("warmup", "number of warmup iterations", cxxopts::value<int>()->default_value("0"))
+    ("trace_sz,t", "trace size", cxxopts::value<int>()->default_value("0"))
+    ("trace_file", "where to store trace output", cxxopts::value<std::string>()->default_value("trace.txt"))
+    ("b_col_maj", "Is B matrix in colum-major format?", cxxopts::value<int>()->default_value("0"));
 }
 
-void parse_options(int argc, const char *argv[], po::options_description &desc,
-                   po::variables_map &vm) {
+void parse_options(int argc, const char *argv[], cxxopts::Options& options,
+                   cxxopts::ParseResult& result) {
   try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+    result = options.parse(argc, argv);
 
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
+    if (result.count("help")) {
+      std::cout << options.help() << "\n";
       std::exit(1);
     }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
+
+    // Check required options
+    if (!result.count("xclbin") || !result.count("kernel") || !result.count("instr")) {
+      std::cerr << "Error: Required options missing\n\n";
+      std::cerr << "Usage:\n" << options.help() << "\n";
+      std::exit(1);
+    }
+
+    test_utils::check_arg_file_exists(result, "xclbin");
+    test_utils::check_arg_file_exists(result, "instr");
+
+  } catch (const cxxopts::exceptions::parsing& e) {
+    std::cerr << e.what() << "\n\n";
+    std::cerr << "Usage:\n" << options.help() << "\n";
     std::exit(1);
   }
-
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
 }
 
 // --------------------------------------------------------------------------

--- a/programming_examples/basic/matrix_multiplication/common.h
+++ b/programming_examples/basic/matrix_multiplication/common.h
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
 #include <cmath>
 #include <fstream>
 #include <optional>

--- a/programming_examples/basic/matrix_multiplication/common.h
+++ b/programming_examples/basic/matrix_multiplication/common.h
@@ -30,26 +30,35 @@ namespace matmul_common {
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
 
-void add_default_options(cxxopts::Options& options) {
-  options.add_options()
-    ("help,h", "produce help message")
-    ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
-    ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
-    ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
-    ("instr,i", "path of file containing userspace instructions sent to the NPU", cxxopts::value<std::string>())
-    ("verify", "whether to verify the AIE computed output", cxxopts::value<bool>()->default_value("true"))
-    ("rows,M", "Matrix size M", cxxopts::value<int>()->default_value("512"))
-    ("inner,K", "Matrix size K", cxxopts::value<int>()->default_value("512"))
-    ("columns,N", "Matrix size N", cxxopts::value<int>()->default_value("512"))
-    ("iters", "number of iterations", cxxopts::value<int>()->default_value("1"))
-    ("warmup", "number of warmup iterations", cxxopts::value<int>()->default_value("0"))
-    ("trace_sz,t", "trace size", cxxopts::value<int>()->default_value("0"))
-    ("trace_file", "where to store trace output", cxxopts::value<std::string>()->default_value("trace.txt"))
-    ("b_col_maj", "Is B matrix in colum-major format?", cxxopts::value<int>()->default_value("0"));
+void add_default_options(cxxopts::Options &options) {
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions sent to the NPU",
+      cxxopts::value<std::string>())(
+      "verify", "whether to verify the AIE computed output",
+      cxxopts::value<bool>()->default_value("true"))(
+      "rows,M", "Matrix size M", cxxopts::value<int>()->default_value("512"))(
+      "inner,K", "Matrix size K", cxxopts::value<int>()->default_value("512"))(
+      "columns,N", "Matrix size N",
+      cxxopts::value<int>()->default_value("512"))(
+      "iters", "number of iterations",
+      cxxopts::value<int>()->default_value("1"))(
+      "warmup", "number of warmup iterations",
+      cxxopts::value<int>()->default_value("0"))(
+      "trace_sz,t", "trace size", cxxopts::value<int>()->default_value("0"))(
+      "trace_file", "where to store trace output",
+      cxxopts::value<std::string>()->default_value("trace.txt"))(
+      "b_col_maj", "Is B matrix in colum-major format?",
+      cxxopts::value<int>()->default_value("0"));
 }
 
-void parse_options(int argc, const char *argv[], cxxopts::Options& options,
-                   cxxopts::ParseResult& result) {
+void parse_options(int argc, const char *argv[], cxxopts::Options &options,
+                   cxxopts::ParseResult &result) {
   try {
     result = options.parse(argc, argv);
 
@@ -59,7 +68,8 @@ void parse_options(int argc, const char *argv[], cxxopts::Options& options,
     }
 
     // Check required options
-    if (!result.count("xclbin") || !result.count("kernel") || !result.count("instr")) {
+    if (!result.count("xclbin") || !result.count("kernel") ||
+        !result.count("instr")) {
       std::cerr << "Error: Required options missing\n\n";
       std::cerr << "Usage:\n" << options.help() << "\n";
       std::exit(1);
@@ -68,7 +78,7 @@ void parse_options(int argc, const char *argv[], cxxopts::Options& options,
     test_utils::check_arg_file_exists(result, "xclbin");
     test_utils::check_arg_file_exists(result, "instr");
 
-  } catch (const cxxopts::exceptions::parsing& e) {
+  } catch (const cxxopts::exceptions::parsing &e) {
     std::cerr << e.what() << "\n\n";
     std::cerr << "Usage:\n" << options.help() << "\n";
     std::exit(1);

--- a/programming_examples/basic/matrix_multiplication/test.cpp
+++ b/programming_examples/basic/matrix_multiplication/test.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -54,16 +54,13 @@ constexpr int verify_stochastic_n_samples = 1000;
 float abs_tol = matmul_common::get_abs_tol<C_DATATYPE>();
 float rel_tol = matmul_common::get_rel_tol<C_DATATYPE>();
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  matmul_common::add_default_options(desc);
+  cxxopts::Options options("Matrix Matrix Multiplication Test");
+  cxxopts::ParseResult vm; 
+  matmul_common::add_default_options(options);
 
-  matmul_common::parse_options(argc, argv, desc, vm);
+  matmul_common::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();
@@ -77,8 +74,7 @@ int main(int argc, const char *argv[]) {
   int M = vm["M"].as<int>();
   int K = vm["K"].as<int>();
   int N = vm["N"].as<int>();
-  bool do_verify_stochastic =
-      (long long)M * N * K > verify_stochastic_threshold;
+  bool do_verify_stochastic = (long long)M * N * K > verify_stochastic_threshold;
 
   if (verbosity >= 1) {
     std::cout << "Matrix size " << M << "x" << K << "x" << N << std::endl;

--- a/programming_examples/basic/matrix_multiplication/test.cpp
+++ b/programming_examples/basic/matrix_multiplication/test.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>

--- a/programming_examples/basic/matrix_multiplication/test.cpp
+++ b/programming_examples/basic/matrix_multiplication/test.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <bits/stdc++.h>
 #include "cxxopts.hpp"
+#include <bits/stdc++.h>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -57,7 +57,7 @@ float rel_tol = matmul_common::get_rel_tol<C_DATATYPE>();
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
   cxxopts::Options options("Matrix Matrix Multiplication Test");
-  cxxopts::ParseResult vm; 
+  cxxopts::ParseResult vm;
   matmul_common::add_default_options(options);
 
   matmul_common::parse_options(argc, argv, options, vm);
@@ -74,7 +74,8 @@ int main(int argc, const char *argv[]) {
   int M = vm["M"].as<int>();
   int K = vm["K"].as<int>();
   int N = vm["N"].as<int>();
-  bool do_verify_stochastic = (long long)M * N * K > verify_stochastic_threshold;
+  bool do_verify_stochastic =
+      (long long)M * N * K > verify_stochastic_threshold;
 
   if (verbosity >= 1) {
     std::cout << "Matrix size " << M << "x" << K << "x" << N << std::endl;

--- a/programming_examples/basic/matrix_scalar_add/CMakeLists.txt
+++ b/programming_examples/basic/matrix_scalar_add/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -51,25 +46,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/matrix_scalar_add/test.cpp
+++ b/programming_examples/basic/matrix_scalar_add/test.cpp
@@ -35,12 +35,15 @@ int main(int argc, const char *argv[]) {
   cxxopts::Options options("Matrix Scalar Add Test");
   cxxopts::ParseResult vm;
 
-  options.add_options()
-    ("help,h", "produce help message")
-    ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
-    ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
-    ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
-    ("instr,i", "path of file containing userspace instructions to be sent to the LX6", cxxopts::value<std::string>());
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions to be sent to the LX6",
+      cxxopts::value<std::string>());
 
   try {
     vm = options.parse(argc, argv);
@@ -56,7 +59,7 @@ int main(int argc, const char *argv[]) {
       std::cerr << "Usage:\n" << options.help() << "\n";
       return 1;
     }
-  } catch (const cxxopts::exceptions::parsing& e) {
+  } catch (const cxxopts::exceptions::parsing &e) {
     std::cerr << e.what() << "\n\n";
     std::cerr << "Usage:\n" << options.help() << "\n";
     return 1;

--- a/programming_examples/basic/matrix_scalar_add/test.cpp
+++ b/programming_examples/basic/matrix_scalar_add/test.cpp
@@ -65,9 +65,6 @@ int main(int argc, const char *argv[]) {
     return 1;
   }
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/programming_examples/basic/matrix_scalar_add/test.cpp
+++ b/programming_examples/basic/matrix_scalar_add/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/packet_switch/Makefile
+++ b/programming_examples/basic/packet_switch/Makefile
@@ -41,7 +41,6 @@ CXXFLAGS += -c
 CXXFLAGS += -std=c++23
 CXXFLAGS += -ggdb
 CXXFLAGS += -I/opt/xilinx/xrt/include
-CXXFLAGS += -I/usr/include/boost
 CXXFLAGS += -I${HOME_DIR}/host
 CXXFLAGS += -I${HOME_DIR}/../../../runtime_lib/test_lib
 
@@ -49,13 +48,12 @@ LDFLAGS += -lm
 LDFLAGS += -L/opt/xilinx/xrt/lib
 LDFLAGS += -Wl,-rpath,/opt/xilinx/xrt/lib
 LDFLAGS += -lxrt_coreutil
-LDFLAGS += -lboost_program_options -lboost_filesystem
 
 .PHONY: all link bitstream host clean instructions
 all: ${XCLBIN_TARGET} ${INSTS_TARGET} ${HOST_C_TARGET}
 
 clean:
-	-@rm -rf build 
+	-@rm -rf build
 	-@rm -rf log
 	-@rm -rf ${HOST_C_TARGET}
 	-@rm -rf trace*
@@ -75,7 +73,7 @@ instructions: ${INSTS_TARGET}
 kernel: ${KERNEL_OBJS}
 
 
-link: ${MLIR_TARGET} 
+link: ${MLIR_TARGET}
 
 
 bitstream: ${XCLBIN_TARGET}
@@ -121,7 +119,7 @@ else
 endif
 	mkdir -p ${@D}
 	cd ${@D} && aiecc.py --aie-generate-npu-insts --no-compile-host \
-		--npu-insts-name=${@:${BITSTREAM_O_DIR}/%=%} $(<:${HOME_DIR}/kernel/%=../../kernel/%) 
+		--npu-insts-name=${@:${BITSTREAM_O_DIR}/%=%} $(<:${HOME_DIR}/kernel/%=../../kernel/%)
 	cp $@ ./
 
 ${HOST_C_TARGET}: ${HOST_OBJS}

--- a/programming_examples/basic/packet_switch/host/test.cpp
+++ b/programming_examples/basic/packet_switch/host/test.cpp
@@ -25,24 +25,22 @@ using IN_DATATYPE = int8_t;
 using OUT_DATATYPE = int8_t;
 
 int main(int argc, const char *argv[]) {
-    std::vector<uint32_t> instr_v;
-    int app_id = 1;
-    if (argc > 1){
-        app_id = atoi(argv[1]);
-    }
-    else{
-        app_id = 0;
-    }
+  std::vector<uint32_t> instr_v;
+  int app_id = 1;
+  if (argc > 1) {
+    app_id = atoi(argv[1]);
+  } else {
+    app_id = 0;
+  }
 
-    if (app_id == 0){
-      instr_v = test_utils::load_instr_binary("insts_add.txt");
-    }
-    else{
-      instr_v = test_utils::load_instr_binary("insts_mul.txt");
-    }
+  if (app_id == 0) {
+    instr_v = test_utils::load_instr_binary("insts_add.txt");
+  } else {
+    instr_v = test_utils::load_instr_binary("insts_mul.txt");
+  }
 
-    int IN_SIZE = 256;
-    int OUT_SIZE = 256;
+  int IN_SIZE = 256;
+  int OUT_SIZE = 256;
 
   // Start the XRT test code
   // Get a device handle
@@ -80,8 +78,8 @@ int main(int argc, const char *argv[]) {
 
   IN_DATATYPE *bufInA = bo_inA.map<IN_DATATYPE *>();
   std::vector<IN_DATATYPE> srcVecA(IN_SIZE);
-  for (int i = 0; i < IN_SIZE; i++){
-      srcVecA[i] = i % 10;
+  for (int i = 0; i < IN_SIZE; i++) {
+    srcVecA[i] = i % 10;
   }
 
   memcpy(bufInA, srcVecA.data(), (srcVecA.size() * sizeof(IN_DATATYPE)));
@@ -108,17 +106,18 @@ int main(int argc, const char *argv[]) {
 
   for (uint32_t i = 0; i < OUT_SIZE; i++) {
     uint32_t ref;
-    if(app_id == 1){
+    if (app_id == 1) {
       ref = srcVecA[i] * 2; // ref for the first input packet
-    }
-    else{
-        ref = srcVecA[i] + 2; // ref for the second input packet
+    } else {
+      ref = srcVecA[i] + 2; // ref for the second input packet
     }
     if (*(bufOut + i) != ref) {
-        if(errors < 10){
-            std::cout << "Error in output " << i << "; Input: " << srcVecA[i] << "; Output: " << *(bufOut + i) << " != reference:" << ref << std::endl;
-        }
-        errors++;
+      if (errors < 10) {
+        std::cout << "Error in output " << i << "; Input: " << srcVecA[i]
+                  << "; Output: " << *(bufOut + i) << " != reference:" << ref
+                  << std::endl;
+      }
+      errors++;
     }
   }
   if (!errors) {

--- a/programming_examples/basic/passthrough_dmas/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_dmas/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -51,25 +46,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/passthrough_dmas/test.cpp
+++ b/programming_examples/basic/passthrough_dmas/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -23,35 +23,36 @@
 
 #include "test_utils.h"
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t");
-  po::variables_map vm;
+  cxxopts::Options options("Passthrough DMAs Test");
+  cxxopts::ParseResult vm;
+
+  options.add_options()
+    ("help,h", "produce help message")
+    ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
+    ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
+    ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
+    ("instr,i", "path of file containing userspace instructions to be sent to the LX6", cxxopts::value<std::string>())
+    ("length,l", "the length of the transfer in int32_t", cxxopts::value<int>()->default_value("4096"));
 
   try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+    vm = options.parse(argc, argv);
 
     if (vm.count("help")) {
-      std::cout << desc << std::endl;
+      std::cout << options.help() << std::endl;
       return 1;
     }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
+
+    // Check required options
+    if (!vm.count("xclbin") || !vm.count("kernel") || !vm.count("instr")) {
+      std::cerr << "Error: Required options missing\n\n";
+      std::cerr << "Usage:\n" << options.help() << std::endl;
+      return 1;
+    }
+  } catch (const cxxopts::exceptions::parsing& e) {
+    std::cerr << e.what() << "\n\n";
+    std::cerr << "Usage:\n" << options.help() << std::endl;
     return 1;
   }
 

--- a/programming_examples/basic/passthrough_dmas/test.cpp
+++ b/programming_examples/basic/passthrough_dmas/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>

--- a/programming_examples/basic/passthrough_dmas/test.cpp
+++ b/programming_examples/basic/passthrough_dmas/test.cpp
@@ -28,13 +28,17 @@ int main(int argc, const char *argv[]) {
   cxxopts::Options options("Passthrough DMAs Test");
   cxxopts::ParseResult vm;
 
-  options.add_options()
-    ("help,h", "produce help message")
-    ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
-    ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
-    ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
-    ("instr,i", "path of file containing userspace instructions to be sent to the LX6", cxxopts::value<std::string>())
-    ("length,l", "the length of the transfer in int32_t", cxxopts::value<int>()->default_value("4096"));
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions to be sent to the LX6",
+      cxxopts::value<std::string>())(
+      "length,l", "the length of the transfer in int32_t",
+      cxxopts::value<int>()->default_value("4096"));
 
   try {
     vm = options.parse(argc, argv);
@@ -50,7 +54,7 @@ int main(int argc, const char *argv[]) {
       std::cerr << "Usage:\n" << options.help() << std::endl;
       return 1;
     }
-  } catch (const cxxopts::exceptions::parsing& e) {
+  } catch (const cxxopts::exceptions::parsing &e) {
     std::cerr << e.what() << "\n\n";
     std::cerr << "Usage:\n" << options.help() << std::endl;
     return 1;

--- a/programming_examples/basic/passthrough_dmas/test.cpp
+++ b/programming_examples/basic/passthrough_dmas/test.cpp
@@ -60,9 +60,6 @@ int main(int argc, const char *argv[]) {
     return 1;
   }
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/programming_examples/basic/passthrough_dmas_plio/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_dmas_plio/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -51,25 +46,16 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)
+

--- a/programming_examples/basic/passthrough_kernel/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_kernel/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2024 Xilinx Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -16,11 +15,9 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif ()
@@ -38,40 +35,28 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
     IN1_SIZE=${IN1_SIZE}
     OUT_SIZE=${OUT_SIZE}
-    DISABLE_ABI_CHECK=1 
+    DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/passthrough_pykernel/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_pykernel/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2024 Xilinx Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -16,11 +15,9 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif ()
@@ -37,39 +34,28 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         PASSTHROUGH_SIZE=${PASSTHROUGH_SIZE}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)
+

--- a/programming_examples/basic/passthrough_pykernel/test.cpp
+++ b/programming_examples/basic/passthrough_pykernel/test.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include "cxxopts.hpp"
 
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
@@ -24,16 +25,13 @@
 using DATATYPE = std::uint8_t;
 #endif
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Passthrough PyKernel Test", "Test the Passthrough PyKernel");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int trace_size = vm["trace_sz"].as<int>();
 

--- a/programming_examples/basic/passthrough_pykernel/test.cpp
+++ b/programming_examples/basic/passthrough_pykernel/test.cpp
@@ -8,11 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include "cxxopts.hpp"
 
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
@@ -27,7 +27,8 @@ using DATATYPE = std::uint8_t;
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  cxxopts::Options options("Passthrough PyKernel Test", "Test the Passthrough PyKernel");
+  cxxopts::Options options("Passthrough PyKernel Test",
+                           "Test the Passthrough PyKernel");
   cxxopts::ParseResult vm;
   test_utils::add_default_options(options);
 

--- a/programming_examples/basic/vector_exp/CMakeLists.txt
+++ b/programming_examples/basic/vector_exp/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -53,25 +48,15 @@ set_property(TARGET ${currentTarget} PROPERTY CXX_STANDARD 23)
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_exp/test.cpp
+++ b/programming_examples/basic/vector_exp/test.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <bits/stdc++.h>
 #include "cxxopts.hpp"
+#include <bits/stdc++.h>
 #include <cmath>
 #include <cstdint>
 #include <fstream>

--- a/programming_examples/basic/vector_exp/test.cpp
+++ b/programming_examples/basic/vector_exp/test.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cmath>
 #include <cstdint>
 #include <fstream>

--- a/programming_examples/basic/vector_exp/test.cpp
+++ b/programming_examples/basic/vector_exp/test.cpp
@@ -9,8 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cmath>
 #include <cstdint>
 #include <fstream>
@@ -30,8 +29,6 @@
 using INOUT0_DATATYPE = std::bfloat16_t;
 using INOUT1_DATATYPE = std::bfloat16_t;
 #endif
-
-namespace po = boost::program_options;
 
 // ----------------------------------------------------------------------------
 // Verify results (specific to our design example)
@@ -62,15 +59,14 @@ int verify(int CSize, std::vector<T> A, std::vector<T> C, int verbosity) {
 // Main
 // ----------------------------------------------------------------------------
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Exp Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();
@@ -184,7 +180,6 @@ int main(int argc, const char *argv[]) {
   // Main run loop
   // ------------------------------------------------------
   for (unsigned iter = 0; iter < num_iter; iter++) {
-
     if (verbosity >= 1) {
       std::cout << "Running Kernel.\n";
     }

--- a/programming_examples/basic/vector_reduce_add/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_add/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -16,11 +15,9 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -36,8 +33,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -46,26 +41,16 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_reduce_add/test.cpp
+++ b/programming_examples/basic/vector_reduce_add/test.cpp
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <bits/stdc++.h>
 #include "cxxopts.hpp"
+#include <bits/stdc++.h>
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_reduce_add/test.cpp
+++ b/programming_examples/basic/vector_reduce_add/test.cpp
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_reduce_add/test.cpp
+++ b/programming_examples/basic/vector_reduce_add/test.cpp
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -31,8 +31,6 @@ using INOUT0_DATATYPE = std::int32_t;
 using INOUT1_DATATYPE = std::int32_t;
 #endif
 
-namespace po = boost::program_options;
-
 // ----------------------------------------------------------------------------
 // Main
 // ----------------------------------------------------------------------------
@@ -41,11 +39,11 @@ int main(int argc, const char *argv[]) {
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Reduce Add Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/basic/vector_reduce_max/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_max/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2024 Xilinx Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -16,11 +15,9 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif ()
@@ -38,40 +35,28 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
     IN1_SIZE=${IN1_SIZE}
     OUT_SIZE=${OUT_SIZE}
-    DISABLE_ABI_CHECK=1 
+    DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_reduce_min/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_min/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -16,11 +15,9 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -36,9 +33,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -50,22 +44,12 @@ target_include_directories (${currentTarget} PUBLIC
     ../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_reduce_min/test.cpp
+++ b/programming_examples/basic/vector_reduce_min/test.cpp
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <bits/stdc++.h>
 #include "cxxopts.hpp"
+#include <bits/stdc++.h>
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_reduce_min/test.cpp
+++ b/programming_examples/basic/vector_reduce_min/test.cpp
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_reduce_min/test.cpp
+++ b/programming_examples/basic/vector_reduce_min/test.cpp
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -31,8 +31,6 @@ using INOUT0_DATATYPE = std::int32_t;
 using INOUT1_DATATYPE = std::int32_t;
 #endif
 
-namespace po = boost::program_options;
-
 // ----------------------------------------------------------------------------
 // Main
 // ----------------------------------------------------------------------------
@@ -41,11 +39,11 @@ int main(int argc, const char *argv[]) {
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Reduce Min Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/basic/vector_scalar_add/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_add/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_scalar_add/test.cpp
+++ b/programming_examples/basic/vector_scalar_add/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -22,18 +22,15 @@
 
 #include "test_utils.h"
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Scalar Add Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/basic/vector_scalar_add/test.cpp
+++ b/programming_examples/basic/vector_scalar_add/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_scalar_add_runlist/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_add_runlist/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_scalar_add_runlist/test.cpp
+++ b/programming_examples/basic/vector_scalar_add_runlist/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_scalar_add_runlist/test.cpp
+++ b/programming_examples/basic/vector_scalar_add_runlist/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -24,18 +24,15 @@
 
 #include "test_utils.h"
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Scalar Add Runlist Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -44,40 +41,28 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
     IN1_SIZE=${IN1_SIZE}
     IN2_SIZE=${IN2_SIZE}
     OUT_SIZE=${OUT_SIZE}
     DISABLE_ABI_CHECK=1
     )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2024 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/test.cpp
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/test.cpp
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -22,18 +22,15 @@
 
 #include "test_utils.h"
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Vector Add BDs Init Values Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/basic/vector_vector_modulo/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_modulo/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_vector_modulo/test.cpp
+++ b/programming_examples/basic/vector_vector_modulo/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -22,18 +22,15 @@
 
 #include "test_utils.h"
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Vector Modulo Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/basic/vector_vector_modulo/test.cpp
+++ b/programming_examples/basic/vector_vector_modulo/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_vector_mul/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_mul/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/basic/vector_vector_mul/test.cpp
+++ b/programming_examples/basic/vector_vector_mul/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/programming_examples/basic/vector_vector_mul/test.cpp
+++ b/programming_examples/basic/vector_vector_mul/test.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -22,18 +22,15 @@
 
 #include "test_utils.h"
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Vector Vector Mul Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/ml/bottleneck/CMakeLists.txt
+++ b/programming_examples/ml/bottleneck/CMakeLists.txt
@@ -5,7 +5,6 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -17,12 +16,10 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -43,7 +40,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -55,35 +51,25 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         EDGEDETECT_WIDTH=${EDGEDETECT_WIDTH}
         EDGEDETECT_HEIGHT=${EDGEDETECT_HEIGHT}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/ml/conv2d/CMakeLists.txt
+++ b/programming_examples/ml/conv2d/CMakeLists.txt
@@ -5,7 +5,6 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -17,12 +16,10 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -43,7 +40,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -55,35 +51,25 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         EDGEDETECT_WIDTH=${EDGEDETECT_WIDTH}
         EDGEDETECT_HEIGHT=${EDGEDETECT_HEIGHT}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/ml/conv2d_fused_relu/CMakeLists.txt
+++ b/programming_examples/ml/conv2d_fused_relu/CMakeLists.txt
@@ -5,7 +5,6 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -17,12 +16,10 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -43,7 +40,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -55,35 +51,25 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         EDGEDETECT_WIDTH=${EDGEDETECT_WIDTH}
         EDGEDETECT_HEIGHT=${EDGEDETECT_HEIGHT}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/ml/eltwise_add/CMakeLists.txt
+++ b/programming_examples/ml/eltwise_add/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -44,40 +41,28 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
     IN1_SIZE=${IN1_SIZE}
     IN2_SIZE=${IN2_SIZE}
     OUT_SIZE=${OUT_SIZE}
     DISABLE_ABI_CHECK=1
     )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/ml/eltwise_mul/CMakeLists.txt
+++ b/programming_examples/ml/eltwise_mul/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/ml/eltwise_mul/test.cpp
+++ b/programming_examples/ml/eltwise_mul/test.cpp
@@ -61,11 +61,11 @@ int main(int argc, const char *argv[]) {
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Eltwise Mul Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/programming_examples/ml/eltwise_mul/test.cpp
+++ b/programming_examples/ml/eltwise_mul/test.cpp
@@ -9,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -22,6 +21,7 @@
 #include "xrt/xrt_kernel.h"
 
 #include "test_utils.h"
+#include "cxxopts.hpp"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED
@@ -30,7 +30,6 @@ using INOUT1_DATATYPE = std::bfloat16_t;
 using INOUT2_DATATYPE = std::bfloat16_t;
 #endif
 
-namespace po = boost::program_options;
 
 // ----------------------------------------------------------------------------
 // Verify results (specific to our design example)

--- a/programming_examples/ml/eltwise_mul/test.cpp
+++ b/programming_examples/ml/eltwise_mul/test.cpp
@@ -20,8 +20,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-#include "test_utils.h"
 #include "cxxopts.hpp"
+#include "test_utils.h"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED
@@ -29,7 +29,6 @@ using INOUT0_DATATYPE = std::bfloat16_t;
 using INOUT1_DATATYPE = std::bfloat16_t;
 using INOUT2_DATATYPE = std::bfloat16_t;
 #endif
-
 
 // ----------------------------------------------------------------------------
 // Verify results (specific to our design example)

--- a/programming_examples/ml/relu/CMakeLists.txt
+++ b/programming_examples/ml/relu/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2024 Xilinx Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif ()
@@ -43,40 +40,29 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
     IN1_SIZE=${IN1_SIZE}
     OUT_SIZE=${OUT_SIZE}
-    DISABLE_ABI_CHECK=1 
+    DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/ml/relu/test.cpp
+++ b/programming_examples/ml/relu/test.cpp
@@ -12,7 +12,6 @@
 #include <cstdint>
 
 // #include <bits/stdc++.h>
-// #include <boost/program_options.hpp>
 // #include <cmath>
 // #include <cstdint>
 // #include <fstream>

--- a/programming_examples/ml/resnet/layers_conv2_x/CMakeLists.txt
+++ b/programming_examples/ml/resnet/layers_conv2_x/CMakeLists.txt
@@ -5,7 +5,6 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -17,12 +16,10 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -43,7 +40,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -55,35 +51,25 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         EDGEDETECT_WIDTH=${EDGEDETECT_WIDTH}
         EDGEDETECT_HEIGHT=${EDGEDETECT_HEIGHT}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../utils
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/ml/softmax/CMakeLists.txt
+++ b/programming_examples/ml/softmax/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_examples/ml/softmax/test.cpp
+++ b/programming_examples/ml/softmax/test.cpp
@@ -29,7 +29,6 @@ using INOUT0_DATATYPE = std::bfloat16_t;
 using INOUT1_DATATYPE = std::bfloat16_t;
 #endif
 
-
 // ----------------------------------------------------------------------------
 // Verify results (specific to our design example)
 // ----------------------------------------------------------------------------

--- a/programming_examples/ml/softmax/test.cpp
+++ b/programming_examples/ml/softmax/test.cpp
@@ -9,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -21,6 +20,7 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 
 #ifndef DATATYPES_USING_DEFINED
@@ -29,7 +29,6 @@ using INOUT0_DATATYPE = std::bfloat16_t;
 using INOUT1_DATATYPE = std::bfloat16_t;
 #endif
 
-namespace po = boost::program_options;
 
 // ----------------------------------------------------------------------------
 // Verify results (specific to our design example)

--- a/programming_examples/ml/softmax/test.cpp
+++ b/programming_examples/ml/softmax/test.cpp
@@ -72,11 +72,11 @@ int verify(int size, int tile_size, std::vector<T> A, std::vector<T> B,
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("Softmax Test");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
 
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();

--- a/programming_examples/vision/color_detect/CMakeLists.txt
+++ b/programming_examples/vision/color_detect/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Xilinx Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -17,12 +16,10 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -43,7 +40,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -55,36 +51,26 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         COLORDETECT_WIDTH=${COLORDETECT_WIDTH}
         COLORDETECT_HEIGHT=${COLORDETECT_HEIGHT}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/vision/color_detect/test.cpp
+++ b/programming_examples/vision/color_detect/test.cpp
@@ -20,8 +20,8 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "OpenCVUtils.h"
-#include "test_utils.h"
 #include "cxxopts.hpp"
+#include "test_utils.h"
 
 double epsilon = 2.0;
 

--- a/programming_examples/vision/color_detect/test.cpp
+++ b/programming_examples/vision/color_detect/test.cpp
@@ -21,6 +21,7 @@
 
 #include "OpenCVUtils.h"
 #include "test_utils.h"
+#include <cxxopts.hpp>
 
 double epsilon = 2.0;
 
@@ -29,8 +30,6 @@ constexpr int testImageHeight = COLORDETECT_HEIGHT;
 
 constexpr int testImageSize = testImageWidth * testImageHeight;
 constexpr int kernelSize = 3;
-
-namespace po = boost::program_options;
 
 void colorDetect(cv::Mat &inImage, cv::Mat &outImage) {
   cv::Mat imageHSV, imageHue, imageThreshold1u, imageThreshold1ul,
@@ -62,25 +61,17 @@ int main(int argc, const char *argv[]) {
    * Program arguments parsing
    ****************************************************************************
    */
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")("image,p", po::value<std::string>(),
-                               "the input image")(
-      "outfile,o",
-      po::value<std::string>()->default_value("colorDetectOut_test.jpg"),
-      "the output image")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "live,l", "capture from webcam")("video,m", po::value<std::string>(),
-                                       "optional video input file name");
-  po::variables_map vm;
-
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("color_detect");
+  test_utils::add_default_options(options);
+  options.add_options()("image,p", "the input image",
+                        cxxopts::value<std::string>())(
+      "outfile,o", "the output image",
+      cxxopts::value<std::string>()->default_value("colorDetectOut_test.jpg"))(
+      "live,l", "capture from webcam")("video,m",
+                                       "optional video input file name",
+                                       cxxopts::value<std::string>());
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   std::cout << "Running colorDetect for resolution: " << testImageWidth << "x"
             << testImageHeight << std::endl;

--- a/programming_examples/vision/color_detect/test.cpp
+++ b/programming_examples/vision/color_detect/test.cpp
@@ -21,7 +21,7 @@
 
 #include "OpenCVUtils.h"
 #include "test_utils.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 double epsilon = 2.0;
 

--- a/programming_examples/vision/color_threshold/CMakeLists.txt
+++ b/programming_examples/vision/color_threshold/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Xilinx Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -17,12 +16,10 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -43,7 +40,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -55,36 +51,26 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
 	COLORTHRESHOLD_WIDTH=${COLORTHRESHOLD_WIDTH}
 	COLORTHRESHOLD_HEIGHT=${COLORTHRESHOLD_HEIGHT}
 	DISABLE_ABI_CHECK=1
 )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/vision/color_threshold/test.cpp
+++ b/programming_examples/vision/color_threshold/test.cpp
@@ -139,7 +139,7 @@ int main(int argc, const char *argv[]) {
     if (srcVec[i] <= 50) { // Obviously change this back to 100
       if (*(bufOut + i) != 0) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint32_t)(uint8_t)*(bufOut + i) << " at "
+          std::cout << "Error: " << (uint32_t)(uint8_t) * (bufOut + i) << " at "
                     << i << " should be zero "
                     << " : input " << std::dec << (uint32_t)(uint8_t)srcVec[i]
                     << std::endl;
@@ -155,7 +155,7 @@ int main(int argc, const char *argv[]) {
     } else {
       if (*(bufOut + i) != UINT8_MAX) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint32_t)(uint8_t)*(bufOut + i) << " at "
+          std::cout << "Error: " << (uint32_t)(uint8_t) * (bufOut + i) << " at "
                     << i << " should be UINT8_MAX "
                     << " : input " << std::dec << (uint32_t)(uint8_t)srcVec[i]
                     << std::endl;

--- a/programming_examples/vision/color_threshold/test.cpp
+++ b/programming_examples/vision/color_threshold/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -45,8 +44,6 @@ constexpr int imageAreaOut = testImageWidth * testImageHeight;
 constexpr int IN_SIZE = (imageAreaIn * sizeof(uint8_t));
 constexpr int OUT_SIZE = (imageAreaOut * sizeof(uint8_t));
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
 
   /*
@@ -54,19 +51,10 @@ int main(int argc, const char *argv[]) {
    * Program arguments parsing
    ****************************************************************************
    */
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
-
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("color_threshold");
+  test_utils::add_default_options(options);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   /*
    ****************************************************************************
@@ -151,7 +139,7 @@ int main(int argc, const char *argv[]) {
     if (srcVec[i] <= 50) { // Obviously change this back to 100
       if (*(bufOut + i) != 0) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint32_t)(uint8_t) * (bufOut + i) << " at "
+          std::cout << "Error: " << (uint32_t)(uint8_t)*(bufOut + i) << " at "
                     << i << " should be zero "
                     << " : input " << std::dec << (uint32_t)(uint8_t)srcVec[i]
                     << std::endl;
@@ -167,7 +155,7 @@ int main(int argc, const char *argv[]) {
     } else {
       if (*(bufOut + i) != UINT8_MAX) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint32_t)(uint8_t) * (bufOut + i) << " at "
+          std::cout << "Error: " << (uint32_t)(uint8_t)*(bufOut + i) << " at "
                     << i << " should be UINT8_MAX "
                     << " : input " << std::dec << (uint32_t)(uint8_t)srcVec[i]
                     << std::endl;

--- a/programming_examples/vision/edge_detect/CMakeLists.txt
+++ b/programming_examples/vision/edge_detect/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Xilinx Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -17,12 +16,10 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -43,7 +40,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -55,36 +51,26 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         EDGEDETECT_WIDTH=${EDGEDETECT_WIDTH}
         EDGEDETECT_HEIGHT=${EDGEDETECT_HEIGHT}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/vision/edge_detect/test.cpp
+++ b/programming_examples/vision/edge_detect/test.cpp
@@ -20,8 +20,8 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "OpenCVUtils.h"
-#include "test_utils.h"
 #include "cxxopts.hpp"
+#include "test_utils.h"
 
 double epsilon = 2.0;
 

--- a/programming_examples/vision/edge_detect/test.cpp
+++ b/programming_examples/vision/edge_detect/test.cpp
@@ -21,6 +21,7 @@
 
 #include "OpenCVUtils.h"
 #include "test_utils.h"
+#include <cxxopts.hpp>
 
 double epsilon = 2.0;
 
@@ -29,8 +30,6 @@ constexpr int testImageHeight = EDGEDETECT_HEIGHT;
 
 constexpr int testImageSize = testImageWidth * testImageHeight;
 constexpr int kernelSize = 3;
-
-namespace po = boost::program_options;
 
 void edgeDetect(cv::Mat &inImage, cv::Mat &outImage) {
   cv::Mat inImageGray, imageFiltered, imageThreshold, imageThresholdBRG,
@@ -62,25 +61,17 @@ int main(int argc, const char *argv[]) {
    * Program arguments parsing
    ****************************************************************************
    */
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")("image,p", po::value<std::string>(),
-                               "the input image")(
-      "outfile,o",
-      po::value<std::string>()->default_value("edgeDetectOut_test.jpg"),
-      "the output image")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "live,l", "capture from webcam")("video,m", po::value<std::string>(),
-                                       "optional video input file name");
-  po::variables_map vm;
-
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("edge_detect");
+  test_utils::add_default_options(options);
+  options.add_options()("image,p", "the input image",
+                        cxxopts::value<std::string>())(
+      "outfile,o", "the output image",
+      cxxopts::value<std::string>()->default_value("edgeDetectOut_test.jpg"))(
+      "live,l", "capture from webcam")("video,m",
+                                       "optional video input file name",
+                                       cxxopts::value<std::string>());
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   std::cout << "Running edgeDetect for resolution: " << testImageWidth << "x"
             << testImageHeight << std::endl;

--- a/programming_examples/vision/edge_detect/test.cpp
+++ b/programming_examples/vision/edge_detect/test.cpp
@@ -21,7 +21,7 @@
 
 #include "OpenCVUtils.h"
 #include "test_utils.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 double epsilon = 2.0;
 

--- a/programming_examples/vision/vision_passthrough/CMakeLists.txt
+++ b/programming_examples/vision/vision_passthrough/CMakeLists.txt
@@ -5,7 +5,6 @@
 # Copyright (C) 2024, Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DOpenCV_DIR: Path to OpenCV install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
@@ -14,18 +13,16 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-#set(CMAKE_CXX_STANDARD 23) 
+#set(CMAKE_CXX_STANDARD 23)
 #set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
@@ -46,7 +43,6 @@ endif ()
 project(${ProjectName})
 
 # Find packages
-find_package(Boost REQUIRED)
 find_package(OpenCV REQUIRED)
 message("opencv library paht: ${OpenCV_LIB_PATH}")
 message("opencv libs: ${OpenCV_LIBS}")
@@ -58,36 +54,26 @@ add_executable(${currentTarget}
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
         PASSTHROUGH_WIDTH=${PASSTHROUGH_WIDTH}
         PASSTHROUGH_HEIGHT=${PASSTHROUGH_HEIGHT}
-        DISABLE_ABI_CHECK=1 
+        DISABLE_ABI_CHECK=1
         )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
     ${OpenCV_LIB_PATH}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        ${OpenCV_LIBS}
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+    ${OpenCV_LIBS}
+)

--- a/programming_examples/vision/vision_passthrough/test.cpp
+++ b/programming_examples/vision/vision_passthrough/test.cpp
@@ -21,7 +21,7 @@
 
 #include "OpenCVUtils.h"
 #include "test_utils.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int channels = 4;
 constexpr uint64_t testImageWidth = PASSTHROUGH_WIDTH;

--- a/programming_examples/vision/vision_passthrough/test.cpp
+++ b/programming_examples/vision/vision_passthrough/test.cpp
@@ -21,34 +21,24 @@
 
 #include "OpenCVUtils.h"
 #include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int channels = 4;
 constexpr uint64_t testImageWidth = PASSTHROUGH_WIDTH;
 constexpr uint64_t testImageHeight = PASSTHROUGH_HEIGHT;
 constexpr uint64_t testImageSize = testImageWidth * testImageHeight;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")("image,p", po::value<std::string>(),
-                               "the input image")(
-      "outfile,o",
-      po::value<std::string>()->default_value("passThroughOut_test.jpg"),
-      "the output image")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
-
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("vision_passthrough");
+  test_utils::add_default_options(options);
+  options.add_options()("image,p", "the input image",
+                        cxxopts::value<std::string>())(
+      "outfile,o", "the output image",
+      cxxopts::value<std::string>()->default_value("passThroughOut_test.jpg"));
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   // Read the input image or generate random one if no input file argument
   // provided

--- a/programming_examples/vision/vision_passthrough/test.cpp
+++ b/programming_examples/vision/vision_passthrough/test.cpp
@@ -20,8 +20,8 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include "OpenCVUtils.h"
-#include "test_utils.h"
 #include "cxxopts.hpp"
+#include "test_utils.h"
 
 constexpr int channels = 4;
 constexpr uint64_t testImageWidth = PASSTHROUGH_WIDTH;

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib/test_utils.cpp
@@ -51,25 +46,16 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
@@ -13,9 +13,9 @@
 #include <iostream>
 #include <sstream>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
-#include "cxxopts.hpp"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
@@ -15,7 +15,7 @@
 
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
@@ -15,22 +15,20 @@
 
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
+#include <cxxopts.hpp>
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED
 using DATATYPE = std::uint32_t; // Configure this to match your buffer data type
 #endif
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
-
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("single_double_buffer");
+  test_utils::add_default_options(options);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
 
   constexpr bool VERIFY = true;

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib/test_utils.cpp
@@ -51,25 +46,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/test.cpp
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/test.cpp
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/test.cpp
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,87 +15,25 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;
 
-namespace po = boost::program_options;
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_binary(std::string instr_path) {
-  // Open file in binary mode
-  std::ifstream instr_file(instr_path, std::ios::binary);
-  if (!instr_file.is_open()) {
-    throw std::runtime_error("Unable to open instruction file\n");
-  }
-
-  // Get the size of the file
-  instr_file.seekg(0, std::ios::end);
-  std::streamsize size = instr_file.tellg();
-  instr_file.seekg(0, std::ios::beg);
-
-  // Check that the file size is a multiple of 4 bytes (size of uint32_t)
-  if (size % 4 != 0) {
-    throw std::runtime_error("File size is not a multiple of 4 bytes\n");
-  }
-
-  // Allocate vector and read the binary data
-  std::vector<uint32_t> instr_v(size / 4);
-  if (!instr_file.read(reinterpret_cast<char *>(instr_v.data()), size)) {
-    throw std::runtime_error("Failed to read instruction file\n");
-  }
-  return instr_v;
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
-
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  cxxopts::Options options("external_mem_to_core");
+  test_utils::add_default_options(options);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   std::vector<uint32_t> instr_v =
-      load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/test.cpp
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/test.cpp
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;

--- a/programming_guide/section-2/section-2f/05_join_L2/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/05_join_L2/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,8 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib/test_utils.cpp
@@ -51,25 +46,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_guide/section-2/section-2f/05_join_L2/test.cpp
+++ b/programming_guide/section-2/section-2f/05_join_L2/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;

--- a/programming_guide/section-2/section-2f/05_join_L2/test.cpp
+++ b/programming_guide/section-2/section-2f/05_join_L2/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,87 +15,26 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;
 
-namespace po = boost::program_options;
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_binary(std::string instr_path) {
-  // Open file in binary mode
-  std::ifstream instr_file(instr_path, std::ios::binary);
-  if (!instr_file.is_open()) {
-    throw std::runtime_error("Unable to open instruction file\n");
-  }
-
-  // Get the size of the file
-  instr_file.seekg(0, std::ios::end);
-  std::streamsize size = instr_file.tellg();
-  instr_file.seekg(0, std::ios::beg);
-
-  // Check that the file size is a multiple of 4 bytes (size of uint32_t)
-  if (size % 4 != 0) {
-    throw std::runtime_error("File size is not a multiple of 4 bytes\n");
-  }
-
-  // Allocate vector and read the binary data
-  std::vector<uint32_t> instr_v(size / 4);
-  if (!instr_file.read(reinterpret_cast<char *>(instr_v.data()), size)) {
-    throw std::runtime_error("Failed to read instruction file\n");
-  }
-  return instr_v;
-}
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("join_L2");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   std::vector<uint32_t> instr_v =
-      load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/programming_guide/section-2/section-2f/05_join_L2/test.cpp
+++ b/programming_guide/section-2/section-2f/05_join_L2/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 48;
 constexpr int OUT_SIZE = 48;

--- a/programming_guide/section-3/CMakeLists.txt
+++ b/programming_guide/section-3/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,15 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_guide/section-3/test.cpp
+++ b/programming_guide/section-3/test.cpp
@@ -12,9 +12,14 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+#include <cxxopts.hpp>
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED
@@ -23,16 +28,13 @@ using DATATYPE = std::uint32_t; // Configure this to match your buffer data type
 
 const int scaleFactor = 3;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("section-3");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
 
   // Declaring design constants

--- a/programming_guide/section-3/test.cpp
+++ b/programming_guide/section-3/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED

--- a/programming_guide/section-3/test.cpp
+++ b/programming_guide/section-3/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED

--- a/programming_guide/section-4/section-4a/CMakeLists.txt
+++ b/programming_guide/section-4/section-4a/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -16,11 +15,9 @@ cmake_minimum_required(VERSION 3.1)
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -36,8 +33,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -46,27 +41,18 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ../../utils
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/programming_guide/section-4/section-4a/test.cpp
+++ b/programming_guide/section-4/section-4a/test.cpp
@@ -16,7 +16,7 @@
 
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED

--- a/programming_guide/section-4/section-4a/test.cpp
+++ b/programming_guide/section-4/section-4a/test.cpp
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <chrono>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -15,6 +16,7 @@
 
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
+#include <cxxopts.hpp>
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED
@@ -23,16 +25,13 @@ using DATATYPE = std::uint32_t; // Configure this to match your buffer data type
 
 const int scaleFactor = 3;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("section-4a");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();
@@ -127,7 +126,6 @@ int main(int argc, const char *argv[]) {
       continue;
     }
 
-    // Copy output results and verify they are correct
     // Copy output results and verify they are correct
     if (do_verify) {
       if (verbosity >= 1) {

--- a/programming_guide/section-4/section-4a/test.cpp
+++ b/programming_guide/section-4/section-4a/test.cpp
@@ -14,9 +14,9 @@
 #include <iostream>
 #include <sstream>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
-#include "cxxopts.hpp"
 
 #ifndef DATATYPES_USING_DEFINED
 #define DATATYPES_USING_DEFINED

--- a/programming_guide/section-4/section-4b/CMakeLists.txt
+++ b/programming_guide/section-4/section-4b/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -44,40 +41,27 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
 )
 
-target_compile_definitions(${currentTarget} PUBLIC 
+target_compile_definitions(${currentTarget} PUBLIC
     IN1_SIZE=${IN1_SIZE}
     IN2_SIZE=${IN2_SIZE}
     OUT_SIZE=${OUT_SIZE}
     DISABLE_ABI_CHECK=1
     )
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_LIB_PUBLIC_HEADERS
     test_library.h
     target.h
     hsa_ext_air.h
+    cxxopts.hpp
 )
 set_target_properties(test_lib PROPERTIES PUBLIC_HEADER "${TEST_LIB_PUBLIC_HEADERS}")
 target_compile_options(test_lib PRIVATE -fPIC)
@@ -57,7 +58,7 @@ if (${BUILD_TEST_UTILS})
 endif()
 
 # copy test_library and test_utils header files into build area
-set(headers target.h test_library.h test_utils.h memory_allocator.h hsa_ext_air.h)
+set(headers target.h test_library.h test_utils.h memory_allocator.h hsa_ext_air.h cxxopts.hpp)
 foreach(basefile ${headers})
     set(dest ${CMAKE_CURRENT_BINARY_DIR}/../include/${basefile})
     add_custom_target(aie-copy-runtime-libs-${basefile} ALL DEPENDS ${dest})

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -47,7 +47,7 @@ set(BUILD_TEST_UTILS ${XRT_FOUND} AND NOT ${AIE_RUNTIME_TARGET} STREQUAL "x86_64
 # test_utils library
 if (${BUILD_TEST_UTILS})
   add_library(test_utils STATIC test_utils.cpp)
-  set_target_properties(test_utils PROPERTIES PUBLIC_HEADER test_utils.h)
+  set_target_properties(test_utils PROPERTIES PUBLIC_HEADER "test_utils.h;cxxopts.hpp")
   target_compile_options(test_utils PRIVATE -fPIC)
 
   target_include_directories(test_utils PRIVATE

--- a/runtime_lib/test_lib/cxxopts.hpp
+++ b/runtime_lib/test_lib/cxxopts.hpp
@@ -1,0 +1,2930 @@
+/*
+
+Copyright (c) 2014-2022 Jarryd Beck
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// vim: ts=2:sw=2:expandtab
+
+#ifndef CXXOPTS_HPP_INCLUDED
+#define CXXOPTS_HPP_INCLUDED
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <initializer_list>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include <algorithm>
+#include <locale>
+
+#ifdef CXXOPTS_NO_EXCEPTIONS
+#include <iostream>
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+#  if (__GNUC__ * 10 + __GNUC_MINOR__) < 49
+#    define CXXOPTS_NO_REGEX true
+#  endif
+#endif
+#if defined(_MSC_VER) && !defined(__clang__)
+#define CXXOPTS_LINKONCE_CONST	__declspec(selectany) extern
+#define CXXOPTS_LINKONCE		__declspec(selectany) extern
+#else
+#define CXXOPTS_LINKONCE_CONST
+#define CXXOPTS_LINKONCE
+#endif
+
+#ifndef CXXOPTS_NO_REGEX
+#  include <regex>
+#endif  // CXXOPTS_NO_REGEX
+
+// Nonstandard before C++17, which is coincidentally what we also need for <optional>
+#ifdef __has_include
+#  if __has_include(<optional>)
+#    include <optional>
+#    ifdef __cpp_lib_optional
+#      define CXXOPTS_HAS_OPTIONAL
+#    endif
+#  endif
+#  if __has_include(<filesystem>)
+#    include <filesystem>
+#    ifdef __cpp_lib_filesystem
+#      define CXXOPTS_HAS_FILESYSTEM
+#    endif
+#  endif
+#endif
+
+#define CXXOPTS_FALLTHROUGH
+#ifdef __has_cpp_attribute
+  #if __has_cpp_attribute(fallthrough)
+    #undef CXXOPTS_FALLTHROUGH
+    #define CXXOPTS_FALLTHROUGH [[fallthrough]]
+  #endif
+#endif
+
+#if __cplusplus >= 201603L
+#define CXXOPTS_NODISCARD [[nodiscard]]
+#else
+#define CXXOPTS_NODISCARD
+#endif
+
+#ifndef CXXOPTS_VECTOR_DELIMITER
+#define CXXOPTS_VECTOR_DELIMITER ','
+#endif
+
+#define CXXOPTS__VERSION_MAJOR 3
+#define CXXOPTS__VERSION_MINOR 2
+#define CXXOPTS__VERSION_PATCH 1
+
+#if (__GNUC__ < 10 || (__GNUC__ == 10 && __GNUC_MINOR__ < 1)) && __GNUC__ >= 6
+  #define CXXOPTS_NULL_DEREF_IGNORE
+#endif
+
+#if defined(__GNUC__)
+#define DO_PRAGMA(x) _Pragma(#x)
+#define CXXOPTS_DIAGNOSTIC_PUSH DO_PRAGMA(GCC diagnostic push)
+#define CXXOPTS_DIAGNOSTIC_POP DO_PRAGMA(GCC diagnostic pop)
+#define CXXOPTS_IGNORE_WARNING(x) DO_PRAGMA(GCC diagnostic ignored x)
+#else
+// define other compilers here if needed
+#define CXXOPTS_DIAGNOSTIC_PUSH
+#define CXXOPTS_DIAGNOSTIC_POP
+#define CXXOPTS_IGNORE_WARNING(x)
+#endif
+
+#ifdef CXXOPTS_NO_RTTI
+#define CXXOPTS_RTTI_CAST static_cast
+#else
+#define CXXOPTS_RTTI_CAST dynamic_cast
+#endif
+
+namespace cxxopts {
+static constexpr struct {
+  uint8_t major, minor, patch;
+} version = {
+  CXXOPTS__VERSION_MAJOR,
+  CXXOPTS__VERSION_MINOR,
+  CXXOPTS__VERSION_PATCH
+};
+} // namespace cxxopts
+
+//when we ask cxxopts to use Unicode, help strings are processed using ICU,
+//which results in the correct lengths being computed for strings when they
+//are formatted for the help output
+//it is necessary to make sure that <unicode/unistr.h> can be found by the
+//compiler, and that icu-uc is linked in to the binary.
+
+#ifdef CXXOPTS_USE_UNICODE
+#include <unicode/unistr.h>
+
+namespace cxxopts {
+
+using String = icu::UnicodeString;
+
+inline
+String
+toLocalString(std::string s)
+{
+  return icu::UnicodeString::fromUTF8(std::move(s));
+}
+
+// GNU GCC with -Weffc++ will issue a warning regarding the upcoming class, we want to silence it:
+// warning: base class 'class std::enable_shared_from_this<cxxopts::Value>' has accessible non-virtual destructor
+CXXOPTS_DIAGNOSTIC_PUSH
+CXXOPTS_IGNORE_WARNING("-Wnon-virtual-dtor")
+// This will be ignored under other compilers like LLVM clang.
+class UnicodeStringIterator
+{
+  public:
+
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = int32_t;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  UnicodeStringIterator(const icu::UnicodeString* string, int32_t pos)
+  : s(string)
+  , i(pos)
+  {
+  }
+
+  value_type
+  operator*() const
+  {
+    return s->char32At(i);
+  }
+
+  bool
+  operator==(const UnicodeStringIterator& rhs) const
+  {
+    return s == rhs.s && i == rhs.i;
+  }
+
+  bool
+  operator!=(const UnicodeStringIterator& rhs) const
+  {
+    return !(*this == rhs);
+  }
+
+  UnicodeStringIterator&
+  operator++()
+  {
+    ++i;
+    return *this;
+  }
+
+  UnicodeStringIterator
+  operator+(int32_t v)
+  {
+    return UnicodeStringIterator(s, i + v);
+  }
+
+  private:
+  const icu::UnicodeString* s;
+  int32_t i;
+};
+CXXOPTS_DIAGNOSTIC_POP
+
+inline
+String&
+stringAppend(String&s, String a)
+{
+  return s.append(std::move(a));
+}
+
+inline
+String&
+stringAppend(String& s, std::size_t n, UChar32 c)
+{
+  for (std::size_t i = 0; i != n; ++i)
+  {
+    s.append(c);
+  }
+
+  return s;
+}
+
+template <typename Iterator>
+String&
+stringAppend(String& s, Iterator begin, Iterator end)
+{
+  while (begin != end)
+  {
+    s.append(*begin);
+    ++begin;
+  }
+
+  return s;
+}
+
+inline
+size_t
+stringLength(const String& s)
+{
+  return static_cast<size_t>(s.length());
+}
+
+inline
+std::string
+toUTF8String(const String& s)
+{
+  std::string result;
+  s.toUTF8String(result);
+
+  return result;
+}
+
+inline
+bool
+empty(const String& s)
+{
+  return s.isEmpty();
+}
+
+} // namespace cxxopts
+
+namespace std {
+
+inline
+cxxopts::UnicodeStringIterator
+begin(const icu::UnicodeString& s)
+{
+  return cxxopts::UnicodeStringIterator(&s, 0);
+}
+
+inline
+cxxopts::UnicodeStringIterator
+end(const icu::UnicodeString& s)
+{
+  return cxxopts::UnicodeStringIterator(&s, s.length());
+}
+
+} // namespace std
+
+//ifdef CXXOPTS_USE_UNICODE
+#else
+
+namespace cxxopts {
+
+using String = std::string;
+
+template <typename T>
+T
+toLocalString(T&& t)
+{
+  return std::forward<T>(t);
+}
+
+inline
+std::size_t
+stringLength(const String& s)
+{
+  return s.length();
+}
+
+inline
+String&
+stringAppend(String&s, const String& a)
+{
+  return s.append(a);
+}
+
+inline
+String&
+stringAppend(String& s, std::size_t n, char c)
+{
+  return s.append(n, c);
+}
+
+template <typename Iterator>
+String&
+stringAppend(String& s, Iterator begin, Iterator end)
+{
+  return s.append(begin, end);
+}
+
+template <typename T>
+std::string
+toUTF8String(T&& t)
+{
+  return std::forward<T>(t);
+}
+
+inline
+bool
+empty(const std::string& s)
+{
+  return s.empty();
+}
+
+} // namespace cxxopts
+
+//ifdef CXXOPTS_USE_UNICODE
+#endif
+
+namespace cxxopts {
+
+namespace {
+CXXOPTS_LINKONCE_CONST std::string LQUOTE("\'");
+CXXOPTS_LINKONCE_CONST std::string RQUOTE("\'");
+} // namespace
+
+// GNU GCC with -Weffc++ will issue a warning regarding the upcoming class, we
+// want to silence it: warning: base class 'class
+// std::enable_shared_from_this<cxxopts::Value>' has accessible non-virtual
+// destructor This will be ignored under other compilers like LLVM clang.
+CXXOPTS_DIAGNOSTIC_PUSH
+CXXOPTS_IGNORE_WARNING("-Wnon-virtual-dtor")
+
+// some older versions of GCC warn under this warning
+CXXOPTS_IGNORE_WARNING("-Weffc++")
+class Value : public std::enable_shared_from_this<Value>
+{
+  public:
+
+  virtual ~Value() = default;
+
+  virtual
+  std::shared_ptr<Value>
+  clone() const = 0;
+
+  virtual void
+  add(const std::string& text) const = 0;
+
+  virtual void
+  parse(const std::string& text) const = 0;
+
+  virtual void
+  parse() const = 0;
+
+  virtual bool
+  has_default() const = 0;
+
+  virtual bool
+  is_container() const = 0;
+
+  virtual bool
+  has_implicit() const = 0;
+
+  virtual std::string
+  get_default_value() const = 0;
+
+  virtual std::string
+  get_implicit_value() const = 0;
+
+  virtual std::shared_ptr<Value>
+  default_value(const std::string& value) = 0;
+
+  virtual std::shared_ptr<Value>
+  implicit_value(const std::string& value) = 0;
+
+  virtual std::shared_ptr<Value>
+  no_implicit_value() = 0;
+
+  virtual bool
+  is_boolean() const = 0;
+};
+
+CXXOPTS_DIAGNOSTIC_POP
+
+namespace exceptions {
+
+class exception : public std::exception
+{
+  public:
+  explicit exception(std::string  message)
+  : m_message(std::move(message))
+  {
+  }
+
+  CXXOPTS_NODISCARD
+  const char*
+  what() const noexcept override
+  {
+    return m_message.c_str();
+  }
+
+  private:
+  std::string m_message;
+};
+
+class specification : public exception
+{
+  public:
+
+  explicit specification(const std::string& message)
+  : exception(message)
+  {
+  }
+};
+
+class parsing : public exception
+{
+  public:
+  explicit parsing(const std::string& message)
+  : exception(message)
+  {
+  }
+};
+
+class option_already_exists : public specification
+{
+  public:
+  explicit option_already_exists(const std::string& option)
+  : specification("Option " + LQUOTE + option + RQUOTE + " already exists")
+  {
+  }
+};
+
+class invalid_option_format : public specification
+{
+  public:
+  explicit invalid_option_format(const std::string& format)
+  : specification("Invalid option format " + LQUOTE + format + RQUOTE)
+  {
+  }
+};
+
+class invalid_option_syntax : public parsing {
+  public:
+  explicit invalid_option_syntax(const std::string& text)
+  : parsing("Argument " + LQUOTE + text + RQUOTE +
+            " starts with a - but has incorrect syntax")
+  {
+  }
+};
+
+class no_such_option : public parsing
+{
+  public:
+  explicit no_such_option(const std::string& option)
+  : parsing("Option " + LQUOTE + option + RQUOTE + " does not exist")
+  {
+  }
+};
+
+class missing_argument : public parsing
+{
+  public:
+  explicit missing_argument(const std::string& option)
+  : parsing(
+      "Option " + LQUOTE + option + RQUOTE + " is missing an argument"
+    )
+  {
+  }
+};
+
+class option_requires_argument : public parsing
+{
+  public:
+  explicit option_requires_argument(const std::string& option)
+  : parsing(
+      "Option " + LQUOTE + option + RQUOTE + " requires an argument"
+    )
+  {
+  }
+};
+
+class gratuitous_argument_for_option : public parsing
+{
+  public:
+  gratuitous_argument_for_option
+  (
+    const std::string& option,
+    const std::string& arg
+  )
+  : parsing(
+      "Option " + LQUOTE + option + RQUOTE +
+      " does not take an argument, but argument " +
+      LQUOTE + arg + RQUOTE + " given"
+    )
+  {
+  }
+};
+
+class requested_option_not_present : public parsing
+{
+  public:
+  explicit requested_option_not_present(const std::string& option)
+  : parsing("Option " + LQUOTE + option + RQUOTE + " not present")
+  {
+  }
+};
+
+class option_has_no_value : public exception
+{
+  public:
+  explicit option_has_no_value(const std::string& option)
+  : exception(
+      !option.empty() ?
+      ("Option " + LQUOTE + option + RQUOTE + " has no value") :
+      "Option has no value")
+  {
+  }
+};
+
+class incorrect_argument_type : public parsing
+{
+  public:
+  explicit incorrect_argument_type
+  (
+    const std::string& arg
+  )
+  : parsing(
+      "Argument " + LQUOTE + arg + RQUOTE + " failed to parse"
+    )
+  {
+  }
+};
+
+} // namespace exceptions
+
+
+template <typename T>
+void throw_or_mimic(const std::string& text)
+{
+  static_assert(std::is_base_of<std::exception, T>::value,
+                "throw_or_mimic only works on std::exception and "
+                "deriving classes");
+
+#ifndef CXXOPTS_NO_EXCEPTIONS
+  // If CXXOPTS_NO_EXCEPTIONS is not defined, just throw
+  throw T{text};
+#else
+  // Otherwise manually instantiate the exception, print what() to stderr,
+  // and exit
+  T exception{text};
+  std::cerr << exception.what() << std::endl;
+  std::exit(EXIT_FAILURE);
+#endif
+}
+
+using OptionNames = std::vector<std::string>;
+
+namespace values {
+
+namespace parser_tool {
+
+struct IntegerDesc
+{
+  std::string negative = "";
+  std::string base     = "";
+  std::string value    = "";
+};
+struct ArguDesc {
+  std::string arg_name  = "";
+  bool        grouping  = false;
+  bool        set_value = false;
+  std::string value     = "";
+};
+
+#ifdef CXXOPTS_NO_REGEX
+inline IntegerDesc SplitInteger(const std::string &text)
+{
+  if (text.empty())
+  {
+    throw_or_mimic<exceptions::incorrect_argument_type>(text);
+  }
+  IntegerDesc desc;
+  const char *pdata = text.c_str();
+  if (*pdata == '-')
+  {
+    pdata += 1;
+    desc.negative = "-";
+  }
+  if (strncmp(pdata, "0x", 2) == 0)
+  {
+    pdata += 2;
+    desc.base = "0x";
+  }
+  if (*pdata != '\0')
+  {
+    desc.value = std::string(pdata);
+  }
+  else
+  {
+    throw_or_mimic<exceptions::incorrect_argument_type>(text);
+  }
+  return desc;
+}
+
+inline bool IsTrueText(const std::string &text)
+{
+  const char *pdata = text.c_str();
+  if (*pdata == 't' || *pdata == 'T')
+  {
+    pdata += 1;
+    if (strncmp(pdata, "rue\0", 4) == 0)
+    {
+      return true;
+    }
+  }
+  else if (strncmp(pdata, "1\0", 2) == 0)
+  {
+    return true;
+  }
+  return false;
+}
+
+inline bool IsFalseText(const std::string &text)
+{
+  const char *pdata = text.c_str();
+  if (*pdata == 'f' || *pdata == 'F')
+  {
+    pdata += 1;
+    if (strncmp(pdata, "alse\0", 5) == 0)
+    {
+      return true;
+    }
+  }
+  else if (strncmp(pdata, "0\0", 2) == 0)
+  {
+    return true;
+  }
+  return false;
+}
+
+inline OptionNames split_option_names(const std::string &text)
+{
+  OptionNames split_names;
+
+  std::string::size_type token_start_pos = 0;
+  auto length = text.length();
+
+  if (length == 0)
+  {
+    throw_or_mimic<exceptions::invalid_option_format>(text);
+  }
+
+  while (token_start_pos < length) {
+    const auto &npos = std::string::npos;
+    auto next_non_space_pos = text.find_first_not_of(' ', token_start_pos);
+    if (next_non_space_pos == npos) {
+      throw_or_mimic<exceptions::invalid_option_format>(text);
+    }
+    token_start_pos = next_non_space_pos;
+    auto next_delimiter_pos = text.find(',', token_start_pos);
+    if (next_delimiter_pos == token_start_pos) {
+      throw_or_mimic<exceptions::invalid_option_format>(text);
+    }
+    if (next_delimiter_pos == npos) {
+      next_delimiter_pos = length;
+    }
+    auto token_length = next_delimiter_pos - token_start_pos;
+    // validate the token itself matches the regex /([:alnum:][-_[:alnum:]]*/
+    {
+      const char* option_name_valid_chars =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz"
+        "0123456789"
+        "_-.?";
+
+      if (!std::isalnum(text[token_start_pos], std::locale::classic()) ||
+          text.find_first_not_of(option_name_valid_chars, token_start_pos) < next_delimiter_pos) {
+        throw_or_mimic<exceptions::invalid_option_format>(text);
+      }
+    }
+    split_names.emplace_back(text.substr(token_start_pos, token_length));
+    token_start_pos = next_delimiter_pos + 1;
+  }
+  return split_names;
+}
+
+inline ArguDesc ParseArgument(const char *arg, bool &matched)
+{
+  ArguDesc argu_desc;
+  const char *pdata = arg;
+  matched = false;
+  if (strncmp(pdata, "--", 2) == 0)
+  {
+    pdata += 2;
+    if (isalnum(*pdata, std::locale::classic()))
+    {
+      argu_desc.arg_name.push_back(*pdata);
+      pdata += 1;
+      while (isalnum(*pdata, std::locale::classic()) || *pdata == '-' || *pdata == '_')
+      {
+        argu_desc.arg_name.push_back(*pdata);
+        pdata += 1;
+      }
+      if (argu_desc.arg_name.length() > 1)
+      {
+        if (*pdata == '=')
+        {
+          argu_desc.set_value = true;
+          pdata += 1;
+          if (*pdata != '\0')
+          {
+            argu_desc.value = std::string(pdata);
+          }
+          matched = true;
+        }
+        else if (*pdata == '\0')
+        {
+          matched = true;
+        }
+      }
+    }
+  }
+  else if (strncmp(pdata, "-", 1) == 0)
+  {
+    pdata += 1;
+    argu_desc.grouping = true;
+    while (isalnum(*pdata, std::locale::classic()))
+    {
+      argu_desc.arg_name.push_back(*pdata);
+      pdata += 1;
+    }
+    matched = !argu_desc.arg_name.empty() && *pdata == '\0';
+  }
+  return argu_desc;
+}
+
+#else  // CXXOPTS_NO_REGEX
+
+namespace {
+CXXOPTS_LINKONCE
+const char* const integer_pattern =
+  "(-)?(0x)?([0-9a-zA-Z]+)|((0x)?0)";
+CXXOPTS_LINKONCE
+const char* const truthy_pattern =
+  "(t|T)(rue)?|1";
+CXXOPTS_LINKONCE
+const char* const falsy_pattern =
+  "(f|F)(alse)?|0";
+CXXOPTS_LINKONCE
+const char* const option_pattern =
+  "--([[:alnum:]][-_[:alnum:]\\.]+)(=(.*))?|-([[:alnum:]].*)";
+CXXOPTS_LINKONCE
+const char* const option_specifier_pattern =
+  "([[:alnum:]][-_[:alnum:]\\.]*)(,[ ]*[[:alnum:]][-_[:alnum:]]*)*";
+CXXOPTS_LINKONCE
+const char* const option_specifier_separator_pattern = ", *";
+
+} // namespace
+
+inline IntegerDesc SplitInteger(const std::string &text)
+{
+  static const std::basic_regex<char> integer_matcher(integer_pattern);
+
+  std::smatch match;
+  std::regex_match(text, match, integer_matcher);
+
+  if (match.length() == 0)
+  {
+    throw_or_mimic<exceptions::incorrect_argument_type>(text);
+  }
+
+  IntegerDesc desc;
+  desc.negative = match[1];
+  desc.base = match[2];
+  desc.value = match[3];
+
+  if (match.length(4) > 0)
+  {
+    desc.base = match[5];
+    desc.value = "0";
+    return desc;
+  }
+
+  return desc;
+}
+
+inline bool IsTrueText(const std::string &text)
+{
+  static const std::basic_regex<char> truthy_matcher(truthy_pattern);
+  std::smatch result;
+  std::regex_match(text, result, truthy_matcher);
+  return !result.empty();
+}
+
+inline bool IsFalseText(const std::string &text)
+{
+  static const std::basic_regex<char> falsy_matcher(falsy_pattern);
+  std::smatch result;
+  std::regex_match(text, result, falsy_matcher);
+  return !result.empty();
+}
+
+// Gets the option names specified via a single, comma-separated string,
+// and returns the separate, space-discarded, non-empty names
+// (without considering which or how many are single-character)
+inline OptionNames split_option_names(const std::string &text)
+{
+  static const std::basic_regex<char> option_specifier_matcher(option_specifier_pattern);
+  if (!std::regex_match(text.c_str(), option_specifier_matcher))
+  {
+    throw_or_mimic<exceptions::invalid_option_format>(text);
+  }
+
+  OptionNames split_names;
+
+  static const std::basic_regex<char> option_specifier_separator_matcher(option_specifier_separator_pattern);
+  constexpr int use_non_matches { -1 };
+  auto token_iterator = std::sregex_token_iterator(
+    text.begin(), text.end(), option_specifier_separator_matcher, use_non_matches);
+  std::copy(token_iterator, std::sregex_token_iterator(), std::back_inserter(split_names));
+  return split_names;
+}
+
+inline ArguDesc ParseArgument(const char *arg, bool &matched)
+{
+  static const std::basic_regex<char> option_matcher(option_pattern);
+  std::match_results<const char*> result;
+  std::regex_match(arg, result, option_matcher);
+  matched = !result.empty();
+
+  ArguDesc argu_desc;
+  if (matched) {
+    argu_desc.arg_name = result[1].str();
+    argu_desc.set_value = result[2].length() > 0;
+    argu_desc.value = result[3].str();
+    if (result[4].length() > 0)
+    {
+      argu_desc.grouping = true;
+      argu_desc.arg_name = result[4].str();
+    }
+  }
+
+  return argu_desc;
+}
+
+#endif  // CXXOPTS_NO_REGEX
+#undef CXXOPTS_NO_REGEX
+} // namespace parser_tool
+
+namespace detail {
+
+template <typename T, bool B>
+struct SignedCheck;
+
+template <typename T>
+struct SignedCheck<T, true>
+{
+  template <typename U>
+  void
+  operator()(bool negative, U u, const std::string& text)
+  {
+    if (negative)
+    {
+      if (u > static_cast<U>((std::numeric_limits<T>::min)()))
+      {
+        throw_or_mimic<exceptions::incorrect_argument_type>(text);
+      }
+    }
+    else
+    {
+      if (u > static_cast<U>((std::numeric_limits<T>::max)()))
+      {
+        throw_or_mimic<exceptions::incorrect_argument_type>(text);
+      }
+    }
+  }
+};
+
+template <typename T>
+struct SignedCheck<T, false>
+{
+  template <typename U>
+  void
+  operator()(bool, U, const std::string&) const {}
+};
+
+template <typename T, typename U>
+void
+check_signed_range(bool negative, U value, const std::string& text)
+{
+  SignedCheck<T, std::numeric_limits<T>::is_signed>()(negative, value, text);
+}
+
+} // namespace detail
+
+template <typename R, typename T>
+void
+checked_negate(R& r, T&& t, const std::string&, std::true_type)
+{
+  // if we got to here, then `t` is a positive number that fits into
+  // `R`. So to avoid MSVC C4146, we first cast it to `R`.
+  // See https://github.com/jarro2783/cxxopts/issues/62 for more details.
+  r = static_cast<R>(-static_cast<R>(t-1)-1);
+}
+
+template <typename R, typename T>
+void
+checked_negate(R&, T&&, const std::string& text, std::false_type)
+{
+  throw_or_mimic<exceptions::incorrect_argument_type>(text);
+}
+
+template <typename T>
+void
+integer_parser(const std::string& text, T& value)
+{
+  parser_tool::IntegerDesc int_desc = parser_tool::SplitInteger(text);
+
+  using US = typename std::make_unsigned<T>::type;
+  constexpr bool is_signed = std::numeric_limits<T>::is_signed;
+
+  const bool          negative    = int_desc.negative.length() > 0;
+  const uint8_t       base        = int_desc.base.length() > 0 ? 16 : 10;
+  const std::string & value_match = int_desc.value;
+
+  US result = 0;
+
+  for (char ch : value_match)
+  {
+    US digit = 0;
+
+    if (ch >= '0' && ch <= '9')
+    {
+      digit = static_cast<US>(ch - '0');
+    }
+    else if (base == 16 && ch >= 'a' && ch <= 'f')
+    {
+      digit = static_cast<US>(ch - 'a' + 10);
+    }
+    else if (base == 16 && ch >= 'A' && ch <= 'F')
+    {
+      digit = static_cast<US>(ch - 'A' + 10);
+    }
+    else
+    {
+      throw_or_mimic<exceptions::incorrect_argument_type>(text);
+    }
+
+    US limit = 0;
+    if (negative)
+    {
+      limit = static_cast<US>(std::abs(static_cast<intmax_t>((std::numeric_limits<T>::min)())));
+    }
+    else
+    {
+      limit = (std::numeric_limits<T>::max)();
+    }
+
+    if (base != 0 && result > limit / base)
+    {
+      throw_or_mimic<exceptions::incorrect_argument_type>(text);
+    }
+    if (result * base > limit - digit)
+    {
+      throw_or_mimic<exceptions::incorrect_argument_type>(text);
+    }
+
+    result = static_cast<US>(result * base + digit);
+  }
+
+  detail::check_signed_range<T>(negative, result, text);
+
+  if (negative)
+  {
+    checked_negate<T>(value, result, text, std::integral_constant<bool, is_signed>());
+  }
+  else
+  {
+    value = static_cast<T>(result);
+  }
+}
+
+template <typename T>
+void stringstream_parser(const std::string& text, T& value)
+{
+  std::stringstream in(text);
+  in >> value;
+  if (!in) {
+    throw_or_mimic<exceptions::incorrect_argument_type>(text);
+  }
+}
+
+template <typename T,
+         typename std::enable_if<std::is_integral<T>::value>::type* = nullptr
+         >
+void parse_value(const std::string& text, T& value)
+{
+    integer_parser(text, value);
+}
+
+inline
+void
+parse_value(const std::string& text, bool& value)
+{
+  if (parser_tool::IsTrueText(text))
+  {
+    value = true;
+    return;
+  }
+
+  if (parser_tool::IsFalseText(text))
+  {
+    value = false;
+    return;
+  }
+
+  throw_or_mimic<exceptions::incorrect_argument_type>(text);
+}
+
+inline
+void
+parse_value(const std::string& text, std::string& value)
+{
+  value = text;
+}
+
+// The fallback parser. It uses the stringstream parser to parse all types
+// that have not been overloaded explicitly.  It has to be placed in the
+// source code before all other more specialized templates.
+template <typename T,
+         typename std::enable_if<!std::is_integral<T>::value>::type* = nullptr
+         >
+void
+parse_value(const std::string& text, T& value) {
+  stringstream_parser(text, value);
+}
+
+#ifdef CXXOPTS_HAS_OPTIONAL
+template <typename T>
+void
+parse_value(const std::string& text, std::optional<T>& value)
+{
+  T result;
+  parse_value(text, result);
+  value = std::move(result);
+}
+#endif
+
+#ifdef CXXOPTS_HAS_FILESYSTEM
+inline
+void
+parse_value(const std::string& text, std::filesystem::path& value)
+{
+  value.assign(text);
+}
+#endif
+
+inline
+void parse_value(const std::string& text, char& c)
+{
+  if (text.length() != 1)
+  {
+    throw_or_mimic<exceptions::incorrect_argument_type>(text);
+  }
+
+  c = text[0];
+}
+
+template <typename T>
+void
+parse_value(const std::string& text, std::vector<T>& value)
+{
+  if (text.empty()) {
+    T v;
+    parse_value(text, v);
+    value.emplace_back(std::move(v));
+    return;
+  }
+  std::stringstream in(text);
+  std::string token;
+  while(!in.eof() && std::getline(in, token, CXXOPTS_VECTOR_DELIMITER)) {
+    T v;
+    parse_value(token, v);
+    value.emplace_back(std::move(v));
+  }
+}
+
+template <typename T>
+void
+add_value(const std::string& text, T& value)
+{
+  parse_value(text, value);
+}
+
+template <typename T>
+void
+add_value(const std::string& text, std::vector<T>& value)
+{
+  T v;
+  add_value(text, v);
+  value.emplace_back(std::move(v));
+}
+
+template <typename T>
+struct type_is_container
+{
+  static constexpr bool value = false;
+};
+
+template <typename T>
+struct type_is_container<std::vector<T>>
+{
+  static constexpr bool value = true;
+};
+
+template <typename T>
+class abstract_value : public Value
+{
+  using Self = abstract_value<T>;
+
+  public:
+  abstract_value()
+  : m_result(std::make_shared<T>())
+  , m_store(m_result.get())
+  {
+  }
+
+  explicit abstract_value(T* t)
+  : m_store(t)
+  {
+  }
+
+  ~abstract_value() override = default;
+
+  abstract_value& operator=(const abstract_value&) = default;
+
+  abstract_value(const abstract_value& rhs)
+  {
+    if (rhs.m_result)
+    {
+      m_result = std::make_shared<T>();
+      m_store = m_result.get();
+    }
+    else
+    {
+      m_store = rhs.m_store;
+    }
+
+    m_default = rhs.m_default;
+    m_implicit = rhs.m_implicit;
+    m_default_value = rhs.m_default_value;
+    m_implicit_value = rhs.m_implicit_value;
+  }
+
+  void
+  add(const std::string& text) const override
+  {
+    add_value(text, *m_store);
+  }
+
+  void
+  parse(const std::string& text) const override
+  {
+    parse_value(text, *m_store);
+  }
+
+  bool
+  is_container() const override
+  {
+    return type_is_container<T>::value;
+  }
+
+  void
+  parse() const override
+  {
+    parse_value(m_default_value, *m_store);
+  }
+
+  bool
+  has_default() const override
+  {
+    return m_default;
+  }
+
+  bool
+  has_implicit() const override
+  {
+    return m_implicit;
+  }
+
+  std::shared_ptr<Value>
+  default_value(const std::string& value) override
+  {
+    m_default = true;
+    m_default_value = value;
+    return shared_from_this();
+  }
+
+  std::shared_ptr<Value>
+  implicit_value(const std::string& value) override
+  {
+    m_implicit = true;
+    m_implicit_value = value;
+    return shared_from_this();
+  }
+
+  std::shared_ptr<Value>
+  no_implicit_value() override
+  {
+    m_implicit = false;
+    return shared_from_this();
+  }
+
+  std::string
+  get_default_value() const override
+  {
+    return m_default_value;
+  }
+
+  std::string
+  get_implicit_value() const override
+  {
+    return m_implicit_value;
+  }
+
+  bool
+  is_boolean() const override
+  {
+    return std::is_same<T, bool>::value;
+  }
+
+  const T&
+  get() const
+  {
+    if (m_store == nullptr)
+    {
+      return *m_result;
+    }
+    return *m_store;
+  }
+
+  protected:
+  std::shared_ptr<T> m_result{};
+  T* m_store{};
+
+  bool m_default = false;
+  bool m_implicit = false;
+
+  std::string m_default_value{};
+  std::string m_implicit_value{};
+};
+
+template <typename T>
+class standard_value : public abstract_value<T>
+{
+  public:
+  using abstract_value<T>::abstract_value;
+
+  CXXOPTS_NODISCARD
+  std::shared_ptr<Value>
+  clone() const override
+  {
+    return std::make_shared<standard_value<T>>(*this);
+  }
+};
+
+template <>
+class standard_value<bool> : public abstract_value<bool>
+{
+  public:
+  ~standard_value() override = default;
+
+  standard_value()
+  {
+    set_default_and_implicit();
+  }
+
+  explicit standard_value(bool* b)
+  : abstract_value(b)
+  {
+    m_implicit = true;
+    m_implicit_value = "true";
+  }
+
+  std::shared_ptr<Value>
+  clone() const override
+  {
+    return std::make_shared<standard_value<bool>>(*this);
+  }
+
+  private:
+
+  void
+  set_default_and_implicit()
+  {
+    m_default = true;
+    m_default_value = "false";
+    m_implicit = true;
+    m_implicit_value = "true";
+  }
+};
+
+} // namespace values
+
+template <typename T>
+std::shared_ptr<Value>
+value()
+{
+  return std::make_shared<values::standard_value<T>>();
+}
+
+template <typename T>
+std::shared_ptr<Value>
+value(T& t)
+{
+  return std::make_shared<values::standard_value<T>>(&t);
+}
+
+class OptionAdder;
+
+CXXOPTS_NODISCARD
+inline
+const std::string&
+first_or_empty(const OptionNames& long_names)
+{
+  static const std::string empty{""};
+  return long_names.empty() ? empty : long_names.front();
+}
+
+class OptionDetails
+{
+  public:
+  OptionDetails
+  (
+    std::string short_,
+    OptionNames long_,
+    String desc,
+    std::shared_ptr<const Value> val
+  )
+  : m_short(std::move(short_))
+  , m_long(std::move(long_))
+  , m_desc(std::move(desc))
+  , m_value(std::move(val))
+  , m_count(0)
+  {
+    m_hash = std::hash<std::string>{}(first_long_name() + m_short);
+  }
+
+  OptionDetails(const OptionDetails& rhs)
+  : m_desc(rhs.m_desc)
+  , m_value(rhs.m_value->clone())
+  , m_count(rhs.m_count)
+  {
+  }
+
+  OptionDetails(OptionDetails&& rhs) = default;
+
+  CXXOPTS_NODISCARD
+  const String&
+  description() const
+  {
+    return m_desc;
+  }
+
+  CXXOPTS_NODISCARD
+  const Value&
+  value() const {
+      return *m_value;
+  }
+
+  CXXOPTS_NODISCARD
+  std::shared_ptr<Value>
+  make_storage() const
+  {
+    return m_value->clone();
+  }
+
+  CXXOPTS_NODISCARD
+  const std::string&
+  short_name() const
+  {
+    return m_short;
+  }
+
+  CXXOPTS_NODISCARD
+  const std::string&
+  first_long_name() const
+  {
+    return first_or_empty(m_long);
+  }
+
+  CXXOPTS_NODISCARD
+  const std::string&
+  essential_name() const
+  {
+    return m_long.empty() ? m_short : m_long.front();
+  }
+
+  CXXOPTS_NODISCARD
+  const OptionNames &
+  long_names() const
+  {
+    return m_long;
+  }
+
+  std::size_t
+  hash() const
+  {
+    return m_hash;
+  }
+
+  private:
+  std::string m_short{};
+  OptionNames m_long{};
+  String m_desc{};
+  std::shared_ptr<const Value> m_value{};
+  int m_count;
+
+  std::size_t m_hash{};
+};
+
+struct HelpOptionDetails
+{
+  std::string s;
+  OptionNames l;
+  String desc;
+  bool has_default;
+  std::string default_value;
+  bool has_implicit;
+  std::string implicit_value;
+  std::string arg_help;
+  bool is_container;
+  bool is_boolean;
+};
+
+struct HelpGroupDetails
+{
+  std::string name{};
+  std::string description{};
+  std::vector<HelpOptionDetails> options{};
+};
+
+class OptionValue
+{
+  public:
+  void
+  add
+  (
+    const std::shared_ptr<const OptionDetails>& details,
+    const std::string& text
+  )
+  {
+    ensure_value(details);
+    ++m_count;
+    m_value->add(text);
+    m_long_names = &details->long_names();
+  }
+
+  void
+  parse
+  (
+    const std::shared_ptr<const OptionDetails>& details,
+    const std::string& text
+  )
+  {
+    ensure_value(details);
+    ++m_count;
+    m_value->parse(text);
+    m_long_names = &details->long_names();
+  }
+
+  void
+  parse_default(const std::shared_ptr<const OptionDetails>& details)
+  {
+    ensure_value(details);
+    m_default = true;
+    m_long_names = &details->long_names();
+    m_value->parse();
+  }
+
+  void
+  parse_no_value(const std::shared_ptr<const OptionDetails>& details)
+  {
+    m_long_names = &details->long_names();
+  }
+
+#if defined(CXXOPTS_NULL_DEREF_IGNORE)
+CXXOPTS_DIAGNOSTIC_PUSH
+CXXOPTS_IGNORE_WARNING("-Wnull-dereference")
+#endif
+
+  CXXOPTS_NODISCARD
+  std::size_t
+  count() const noexcept
+  {
+    return m_count;
+  }
+
+#if defined(CXXOPTS_NULL_DEREF_IGNORE)
+CXXOPTS_DIAGNOSTIC_POP
+#endif
+
+  // TODO: maybe default options should count towards the number of arguments
+  CXXOPTS_NODISCARD
+  bool
+  has_default() const noexcept
+  {
+    return m_default;
+  }
+
+  template <typename T>
+  const T&
+  as() const
+  {
+    if (m_value == nullptr) {
+        throw_or_mimic<exceptions::option_has_no_value>(
+            m_long_names == nullptr ? "" : first_or_empty(*m_long_names));
+    }
+
+    return CXXOPTS_RTTI_CAST<const values::standard_value<T>&>(*m_value).get();
+  }
+
+#ifdef CXXOPTS_HAS_OPTIONAL
+  template <typename T>
+  std::optional<T>
+  as_optional() const
+  {
+    if (m_value == nullptr) {
+      return std::nullopt;
+    }
+    return as<T>();
+  }
+#endif
+
+  private:
+  void
+  ensure_value(const std::shared_ptr<const OptionDetails>& details)
+  {
+    if (m_value == nullptr)
+    {
+      m_value = details->make_storage();
+    }
+  }
+
+
+  const OptionNames * m_long_names = nullptr;
+  // Holding this pointer is safe, since OptionValue's only exist in key-value pairs,
+  // where the key has the string we point to.
+  std::shared_ptr<Value> m_value{};
+  std::size_t m_count = 0;
+  bool m_default = false;
+};
+
+class KeyValue
+{
+  public:
+  KeyValue(std::string key_, std::string value_) noexcept
+  : m_key(std::move(key_))
+  , m_value(std::move(value_))
+  {
+  }
+
+  CXXOPTS_NODISCARD
+  const std::string&
+  key() const
+  {
+    return m_key;
+  }
+
+  CXXOPTS_NODISCARD
+  const std::string&
+  value() const
+  {
+    return m_value;
+  }
+
+  template <typename T>
+  T
+  as() const
+  {
+    T result;
+    values::parse_value(m_value, result);
+    return result;
+  }
+
+  private:
+  std::string m_key;
+  std::string m_value;
+};
+
+using ParsedHashMap = std::unordered_map<std::size_t, OptionValue>;
+using NameHashMap = std::unordered_map<std::string, std::size_t>;
+
+class ParseResult
+{
+  public:
+  class Iterator
+  {
+    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = KeyValue;
+    using difference_type = void;
+    using pointer = const KeyValue*;
+    using reference = const KeyValue&;
+
+    Iterator() = default;
+    Iterator(const Iterator&) = default;
+
+// GCC complains about m_iter not being initialised in the member
+// initializer list
+CXXOPTS_DIAGNOSTIC_PUSH
+CXXOPTS_IGNORE_WARNING("-Weffc++")
+    Iterator(const ParseResult *pr, bool end=false)
+    : m_pr(pr)
+    {
+      if (end)
+      {
+        m_sequential = false;
+        m_iter = m_pr->m_defaults.end();
+      }
+      else
+      {
+        m_sequential = true;
+        m_iter = m_pr->m_sequential.begin();
+
+        if (m_iter == m_pr->m_sequential.end())
+        {
+          m_sequential = false;
+          m_iter = m_pr->m_defaults.begin();
+        }
+      }
+    }
+CXXOPTS_DIAGNOSTIC_POP
+
+    Iterator& operator++()
+    {
+      ++m_iter;
+      if(m_sequential && m_iter == m_pr->m_sequential.end())
+      {
+        m_sequential = false;
+        m_iter = m_pr->m_defaults.begin();
+        return *this;
+      }
+      return *this;
+    }
+
+    Iterator operator++(int)
+    {
+      Iterator retval = *this;
+      ++(*this);
+      return retval;
+    }
+
+    bool operator==(const Iterator& other) const
+    {
+      return (m_sequential == other.m_sequential) && (m_iter == other.m_iter);
+    }
+
+    bool operator!=(const Iterator& other) const
+    {
+      return !(*this == other);
+    }
+
+    const KeyValue& operator*()
+    {
+      return *m_iter;
+    }
+
+    const KeyValue* operator->()
+    {
+      return m_iter.operator->();
+    }
+
+    private:
+    const ParseResult* m_pr;
+    std::vector<KeyValue>::const_iterator m_iter;
+    bool m_sequential = true;
+  };
+
+  ParseResult() = default;
+  ParseResult(const ParseResult&) = default;
+
+  ParseResult(NameHashMap&& keys, ParsedHashMap&& values, std::vector<KeyValue> sequential,
+          std::vector<KeyValue> default_opts, std::vector<std::string>&& unmatched_args)
+  : m_keys(std::move(keys))
+  , m_values(std::move(values))
+  , m_sequential(std::move(sequential))
+  , m_defaults(std::move(default_opts))
+  , m_unmatched(std::move(unmatched_args))
+  {
+  }
+
+  ParseResult& operator=(ParseResult&&) = default;
+  ParseResult& operator=(const ParseResult&) = default;
+
+  Iterator
+  begin() const
+  {
+    return Iterator(this);
+  }
+
+  Iterator
+  end() const
+  {
+    return Iterator(this, true);
+  }
+
+  std::size_t
+  count(const std::string& o) const
+  {
+    auto iter = m_keys.find(o);
+    if (iter == m_keys.end())
+    {
+      return 0;
+    }
+
+    auto viter = m_values.find(iter->second);
+
+    if (viter == m_values.end())
+    {
+      return 0;
+    }
+
+    return viter->second.count();
+  }
+
+  bool
+  contains(const std::string& o) const
+  {
+    return static_cast<bool>(count(o));
+  }
+
+  const OptionValue&
+  operator[](const std::string& option) const
+  {
+    auto iter = m_keys.find(option);
+
+    if (iter == m_keys.end())
+    {
+      throw_or_mimic<exceptions::requested_option_not_present>(option);
+    }
+
+    auto viter = m_values.find(iter->second);
+
+    if (viter == m_values.end())
+    {
+      throw_or_mimic<exceptions::requested_option_not_present>(option);
+    }
+
+    return viter->second;
+  }
+
+#ifdef CXXOPTS_HAS_OPTIONAL
+  template <typename T>
+  std::optional<T>
+  as_optional(const std::string& option) const
+  {
+    auto iter = m_keys.find(option);
+    if (iter != m_keys.end())
+    {
+      auto viter = m_values.find(iter->second);
+      if (viter != m_values.end())
+      {
+        return viter->second.as_optional<T>();
+      }
+    }
+    return std::nullopt;
+  }
+#endif
+
+  const std::vector<KeyValue>&
+  arguments() const
+  {
+    return m_sequential;
+  }
+
+  const std::vector<std::string>&
+  unmatched() const
+  {
+    return m_unmatched;
+  }
+
+  const std::vector<KeyValue>&
+  defaults() const
+  {
+    return m_defaults;
+  }
+
+  const std::string
+  arguments_string() const
+  {
+    std::string result;
+    for(const auto& kv: m_sequential)
+    {
+      result += kv.key() + " = " + kv.value() + "\n";
+    }
+    for(const auto& kv: m_defaults)
+    {
+      result += kv.key() + " = " + kv.value() + " " + "(default)" + "\n";
+    }
+    return result;
+  }
+
+  private:
+  NameHashMap m_keys{};
+  ParsedHashMap m_values{};
+  std::vector<KeyValue> m_sequential{};
+  std::vector<KeyValue> m_defaults{};
+  std::vector<std::string> m_unmatched{};
+};
+
+struct Option
+{
+  Option
+  (
+    std::string opts,
+    std::string desc,
+    std::shared_ptr<const Value>  value = ::cxxopts::value<bool>(),
+    std::string arg_help = ""
+  )
+  : opts_(std::move(opts))
+  , desc_(std::move(desc))
+  , value_(std::move(value))
+  , arg_help_(std::move(arg_help))
+  {
+  }
+
+  std::string opts_;
+  std::string desc_;
+  std::shared_ptr<const Value> value_;
+  std::string arg_help_;
+};
+
+using OptionMap = std::unordered_map<std::string, std::shared_ptr<OptionDetails>>;
+using PositionalList = std::vector<std::string>;
+using PositionalListIterator = PositionalList::const_iterator;
+
+class OptionParser
+{
+  public:
+  OptionParser(const OptionMap& options, const PositionalList& positional, bool allow_unrecognised)
+  : m_options(options)
+  , m_positional(positional)
+  , m_allow_unrecognised(allow_unrecognised)
+  {
+  }
+
+  ParseResult
+  parse(int argc, const char* const* argv);
+
+  bool
+  consume_positional(const std::string& a, PositionalListIterator& next);
+
+  void
+  checked_parse_arg
+  (
+    int argc,
+    const char* const* argv,
+    int& current,
+    const std::shared_ptr<OptionDetails>& value,
+    const std::string& name
+  );
+
+  void
+  add_to_option(const std::shared_ptr<OptionDetails>& value, const std::string& arg);
+
+  void
+  parse_option
+  (
+    const std::shared_ptr<OptionDetails>& value,
+    const std::string& name,
+    const std::string& arg = ""
+  );
+
+  void
+  parse_default(const std::shared_ptr<OptionDetails>& details);
+
+  void
+  parse_no_value(const std::shared_ptr<OptionDetails>& details);
+
+  private:
+
+  void finalise_aliases();
+
+  const OptionMap& m_options;
+  const PositionalList& m_positional;
+
+  std::vector<KeyValue> m_sequential{};
+  std::vector<KeyValue> m_defaults{};
+  bool m_allow_unrecognised;
+
+  ParsedHashMap m_parsed{};
+  NameHashMap m_keys{};
+};
+
+class Options
+{
+  public:
+
+  explicit Options(std::string program_name, std::string help_string = "")
+  : m_program(std::move(program_name))
+  , m_help_string(toLocalString(std::move(help_string)))
+  , m_custom_help("[OPTION...]")
+  , m_positional_help("positional parameters")
+  , m_show_positional(false)
+  , m_allow_unrecognised(false)
+  , m_width(76)
+  , m_tab_expansion(false)
+  , m_options(std::make_shared<OptionMap>())
+  {
+  }
+
+  Options&
+  positional_help(std::string help_text)
+  {
+    m_positional_help = std::move(help_text);
+    return *this;
+  }
+
+  Options&
+  custom_help(std::string help_text)
+  {
+    m_custom_help = std::move(help_text);
+    return *this;
+  }
+
+  Options&
+  show_positional_help()
+  {
+    m_show_positional = true;
+    return *this;
+  }
+
+  Options&
+  allow_unrecognised_options()
+  {
+    m_allow_unrecognised = true;
+    return *this;
+  }
+
+  Options&
+  set_width(std::size_t width)
+  {
+    m_width = width;
+    return *this;
+  }
+
+  Options&
+  set_tab_expansion(bool expansion=true)
+  {
+    m_tab_expansion = expansion;
+    return *this;
+  }
+
+  ParseResult
+  parse(int argc, const char* const* argv);
+
+  OptionAdder
+  add_options(std::string group = "");
+
+  void
+  add_options
+  (
+    const std::string& group,
+    std::initializer_list<Option> options
+  );
+
+  void
+  add_option
+  (
+    const std::string& group,
+    const Option& option
+  );
+
+  void
+  add_option
+  (
+    const std::string& group,
+    const std::string& s,
+    const OptionNames& l,
+    std::string desc,
+    const std::shared_ptr<const Value>& value,
+    std::string arg_help
+  );
+
+  void
+  add_option
+  (
+    const std::string& group,
+    const std::string& short_name,
+    const std::string& single_long_name,
+    std::string desc,
+    const std::shared_ptr<const Value>& value,
+    std::string arg_help
+  )
+  {
+    OptionNames long_names;
+    long_names.emplace_back(single_long_name);
+    add_option(group, short_name, long_names, desc, value, arg_help);
+  }
+
+  //parse positional arguments into the given option
+  void
+  parse_positional(std::string option);
+
+  void
+  parse_positional(std::vector<std::string> options);
+
+  void
+  parse_positional(std::initializer_list<std::string> options);
+
+  template <typename Iterator>
+  void
+  parse_positional(Iterator begin, Iterator end) {
+    parse_positional(std::vector<std::string>{begin, end});
+  }
+
+  std::string
+  help(const std::vector<std::string>& groups = {}, bool print_usage=true) const;
+
+  std::vector<std::string>
+  groups() const;
+
+  const HelpGroupDetails&
+  group_help(const std::string& group) const;
+
+  const std::string& program() const
+  {
+    return m_program;
+  }
+
+  private:
+
+  void
+  add_one_option
+  (
+    const std::string& option,
+    const std::shared_ptr<OptionDetails>& details
+  );
+
+  String
+  help_one_group(const std::string& group) const;
+
+  void
+  generate_group_help
+  (
+    String& result,
+    const std::vector<std::string>& groups
+  ) const;
+
+  void
+  generate_all_groups_help(String& result) const;
+
+  std::string m_program{};
+  String m_help_string{};
+  std::string m_custom_help{};
+  std::string m_positional_help{};
+  bool m_show_positional;
+  bool m_allow_unrecognised;
+  std::size_t m_width;
+  bool m_tab_expansion;
+
+  std::shared_ptr<OptionMap> m_options;
+  std::vector<std::string> m_positional{};
+  std::unordered_set<std::string> m_positional_set{};
+
+  //mapping from groups to help options
+  std::vector<std::string> m_group{};
+  std::map<std::string, HelpGroupDetails> m_help{};
+};
+
+class OptionAdder
+{
+  public:
+
+  OptionAdder(Options& options, std::string group)
+  : m_options(options), m_group(std::move(group))
+  {
+  }
+
+  OptionAdder&
+  operator()
+  (
+    const std::string& opts,
+    const std::string& desc,
+    const std::shared_ptr<const Value>& value
+      = ::cxxopts::value<bool>(),
+    std::string arg_help = ""
+  );
+
+  private:
+  Options& m_options;
+  std::string m_group;
+};
+
+namespace {
+constexpr std::size_t OPTION_LONGEST = 30;
+constexpr std::size_t OPTION_DESC_GAP = 2;
+
+String
+format_option
+(
+  const HelpOptionDetails& o
+)
+{
+  const auto& s = o.s;
+  const auto& l = first_or_empty(o.l);
+
+  String result = "  ";
+
+  if (!s.empty())
+  {
+    result += "-" + toLocalString(s);
+    if (!l.empty())
+    {
+      result += ",";
+    }
+  }
+  else
+  {
+    result += "   ";
+  }
+
+  if (!l.empty())
+  {
+    result += " --" + toLocalString(l);
+  }
+
+  auto arg = !o.arg_help.empty() ? toLocalString(o.arg_help) : "arg";
+
+  if (!o.is_boolean)
+  {
+    if (o.has_implicit)
+    {
+      result += " [=" + arg + "(=" + toLocalString(o.implicit_value) + ")]";
+    }
+    else
+    {
+      result += " " + arg;
+    }
+  }
+
+  return result;
+}
+
+String
+format_description
+(
+  const HelpOptionDetails& o,
+  std::size_t start,
+  std::size_t allowed,
+  bool tab_expansion
+)
+{
+  auto desc = o.desc;
+
+  if (o.has_default && (!o.is_boolean || o.default_value != "false"))
+  {
+    if(!o.default_value.empty())
+    {
+      desc += toLocalString(" (default: " + o.default_value + ")");
+    }
+    else
+    {
+      desc += toLocalString(" (default: \"\")");
+    }
+  }
+
+  String result;
+
+  if (tab_expansion)
+  {
+    String desc2;
+    auto size = std::size_t{ 0 };
+    for (auto c = std::begin(desc); c != std::end(desc); ++c)
+    {
+      if (*c == '\n')
+      {
+        desc2 += *c;
+        size = 0;
+      }
+      else if (*c == '\t')
+      {
+        auto skip = 8 - size % 8;
+        stringAppend(desc2, skip, ' ');
+        size += skip;
+      }
+      else
+      {
+        desc2 += *c;
+        ++size;
+      }
+    }
+    desc = desc2;
+  }
+
+  desc += " ";
+
+  auto current = std::begin(desc);
+  auto previous = current;
+  auto startLine = current;
+  auto lastSpace = current;
+
+  auto size = std::size_t{};
+
+  bool appendNewLine;
+  bool onlyWhiteSpace = true;
+
+  while (current != std::end(desc))
+  {
+    appendNewLine = false;
+    if (*previous == ' ' || *previous == '\t')
+    {
+      lastSpace = current;
+    }
+    if (*current != ' ' && *current != '\t')
+    {
+      onlyWhiteSpace = false;
+    }
+
+    while (*current == '\n')
+    {
+      previous = current;
+      ++current;
+      appendNewLine = true;
+    }
+
+    if (!appendNewLine && size >= allowed)
+    {
+      if (lastSpace != startLine)
+      {
+        current = lastSpace;
+        previous = current;
+      }
+      appendNewLine = true;
+    }
+
+    if (appendNewLine)
+    {
+      stringAppend(result, startLine, current);
+      startLine = current;
+      lastSpace = current;
+
+      if (*previous != '\n')
+      {
+        stringAppend(result, "\n");
+      }
+
+      stringAppend(result, start, ' ');
+
+      if (*previous != '\n')
+      {
+        stringAppend(result, lastSpace, current);
+      }
+
+      onlyWhiteSpace = true;
+      size = 0;
+    }
+
+    previous = current;
+    ++current;
+    ++size;
+  }
+
+  //append whatever is left but ignore whitespace
+  if (!onlyWhiteSpace)
+  {
+    stringAppend(result, startLine, previous);
+  }
+
+  return result;
+}
+
+} // namespace
+
+inline
+void
+Options::add_options
+(
+  const std::string &group,
+  std::initializer_list<Option> options
+)
+{
+ OptionAdder option_adder(*this, group);
+ for (const auto &option: options)
+ {
+   option_adder(option.opts_, option.desc_, option.value_, option.arg_help_);
+ }
+}
+
+inline
+OptionAdder
+Options::add_options(std::string group)
+{
+  return OptionAdder(*this, std::move(group));
+}
+
+inline
+OptionAdder&
+OptionAdder::operator()
+(
+  const std::string& opts,
+  const std::string& desc,
+  const std::shared_ptr<const Value>& value,
+  std::string arg_help
+)
+{
+  OptionNames option_names = values::parser_tool::split_option_names(opts);
+    // Note: All names will be non-empty; but we must separate the short
+    // (length-1) and longer names
+  std::string short_name {""};
+  auto first_short_name_iter =
+    std::partition(option_names.begin(), option_names.end(),
+      [&](const std::string& name) { return name.length() > 1; }
+    );
+  auto num_length_1_names = (option_names.end() - first_short_name_iter);
+  switch(num_length_1_names) {
+  case 1:
+    short_name = *first_short_name_iter;
+    option_names.erase(first_short_name_iter);
+    CXXOPTS_FALLTHROUGH;
+  case 0:
+    break;
+  default:
+    throw_or_mimic<exceptions::invalid_option_format>(opts);
+  };
+
+  m_options.add_option
+  (
+    m_group,
+    short_name,
+    option_names,
+    desc,
+    value,
+    std::move(arg_help)
+  );
+
+  return *this;
+}
+
+inline
+void
+OptionParser::parse_default(const std::shared_ptr<OptionDetails>& details)
+{
+  // TODO: remove the duplicate code here
+  auto& store = m_parsed[details->hash()];
+  store.parse_default(details);
+  m_defaults.emplace_back(details->essential_name(), details->value().get_default_value());
+}
+
+inline
+void
+OptionParser::parse_no_value(const std::shared_ptr<OptionDetails>& details)
+{
+  auto& store = m_parsed[details->hash()];
+  store.parse_no_value(details);
+}
+
+inline
+void
+OptionParser::parse_option
+(
+  const std::shared_ptr<OptionDetails>& value,
+  const std::string& /*name*/,
+  const std::string& arg
+)
+{
+  auto hash = value->hash();
+  auto& result = m_parsed[hash];
+  result.parse(value, arg);
+
+  m_sequential.emplace_back(value->essential_name(), arg);
+}
+
+inline
+void
+OptionParser::checked_parse_arg
+(
+  int argc,
+  const char* const* argv,
+  int& current,
+  const std::shared_ptr<OptionDetails>& value,
+  const std::string& name
+)
+{
+  if (current + 1 >= argc)
+  {
+    if (value->value().has_implicit())
+    {
+      parse_option(value, name, value->value().get_implicit_value());
+    }
+    else
+    {
+      throw_or_mimic<exceptions::missing_argument>(name);
+    }
+  }
+  else
+  {
+    if (value->value().has_implicit())
+    {
+      parse_option(value, name, value->value().get_implicit_value());
+    }
+    else
+    {
+      parse_option(value, name, argv[current + 1]);
+      ++current;
+    }
+  }
+}
+
+inline
+void
+OptionParser::add_to_option(const std::shared_ptr<OptionDetails>& value, const std::string& arg)
+{
+  auto hash = value->hash();
+  auto& result = m_parsed[hash];
+  result.add(value, arg);
+
+  m_sequential.emplace_back(value->essential_name(), arg);
+}
+
+inline
+bool
+OptionParser::consume_positional(const std::string& a, PositionalListIterator& next)
+{
+  while (next != m_positional.end())
+  {
+    auto iter = m_options.find(*next);
+    if (iter != m_options.end())
+    {
+      if (!iter->second->value().is_container())
+      {
+        auto& result = m_parsed[iter->second->hash()];
+        if (result.count() == 0)
+        {
+          add_to_option(iter->second, a);
+          ++next;
+          return true;
+        }
+        ++next;
+        continue;
+      }
+      add_to_option(iter->second, a);
+      return true;
+    }
+    throw_or_mimic<exceptions::no_such_option>(*next);
+  }
+
+  return false;
+}
+
+inline
+void
+Options::parse_positional(std::string option)
+{
+  parse_positional(std::vector<std::string>{std::move(option)});
+}
+
+inline
+void
+Options::parse_positional(std::vector<std::string> options)
+{
+  m_positional = std::move(options);
+
+  m_positional_set.insert(m_positional.begin(), m_positional.end());
+}
+
+inline
+void
+Options::parse_positional(std::initializer_list<std::string> options)
+{
+  parse_positional(std::vector<std::string>(options));
+}
+
+inline
+ParseResult
+Options::parse(int argc, const char* const* argv)
+{
+  OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
+
+  return parser.parse(argc, argv);
+}
+
+inline ParseResult
+OptionParser::parse(int argc, const char* const* argv)
+{
+  int current = 1;
+  bool consume_remaining = false;
+  auto next_positional = m_positional.begin();
+
+  std::vector<std::string> unmatched;
+
+  while (current != argc)
+  {
+    if (strcmp(argv[current], "--") == 0)
+    {
+      consume_remaining = true;
+      ++current;
+      break;
+    }
+    bool matched = false;
+    values::parser_tool::ArguDesc argu_desc =
+        values::parser_tool::ParseArgument(argv[current], matched);
+
+    if (!matched)
+    {
+      //not a flag
+
+      // but if it starts with a `-`, then it's an error
+      if (argv[current][0] == '-' && argv[current][1] != '\0') {
+        if (!m_allow_unrecognised) {
+          throw_or_mimic<exceptions::invalid_option_syntax>(argv[current]);
+        }
+      }
+
+      //if true is returned here then it was consumed, otherwise it is
+      //ignored
+      if (consume_positional(argv[current], next_positional))
+      {
+      }
+      else
+      {
+        unmatched.emplace_back(argv[current]);
+      }
+      //if we return from here then it was parsed successfully, so continue
+    }
+    else
+    {
+      //short or long option?
+      if (argu_desc.grouping)
+      {
+        const std::string& s = argu_desc.arg_name;
+
+        for (std::size_t i = 0; i != s.size(); ++i)
+        {
+          std::string name(1, s[i]);
+          auto iter = m_options.find(name);
+
+          if (iter == m_options.end())
+          {
+            if (m_allow_unrecognised)
+            {
+              unmatched.push_back(std::string("-") + s[i]);
+              continue;
+            }
+            //error
+            throw_or_mimic<exceptions::no_such_option>(name);
+          }
+
+          auto value = iter->second;
+
+          if (i + 1 == s.size())
+          {
+            //it must be the last argument
+            checked_parse_arg(argc, argv, current, value, name);
+          }
+          else if (value->value().has_implicit())
+          {
+            parse_option(value, name, value->value().get_implicit_value());
+          }
+          else if (i + 1 < s.size())
+          {
+            std::string arg_value = s.substr(i + 1);
+            parse_option(value, name, arg_value);
+            break;
+          }
+          else
+          {
+            //error
+            throw_or_mimic<exceptions::option_requires_argument>(name);
+          }
+        }
+      }
+      else if (argu_desc.arg_name.length() != 0)
+      {
+        const std::string& name = argu_desc.arg_name;
+
+        auto iter = m_options.find(name);
+
+        if (iter == m_options.end())
+        {
+          if (m_allow_unrecognised)
+          {
+            // keep unrecognised options in argument list, skip to next argument
+            unmatched.emplace_back(argv[current]);
+            ++current;
+            continue;
+          }
+          //error
+          throw_or_mimic<exceptions::no_such_option>(name);
+        }
+
+        auto opt = iter->second;
+
+        //equals provided for long option?
+        if (argu_desc.set_value)
+        {
+          //parse the option given
+
+          parse_option(opt, name, argu_desc.value);
+        }
+        else
+        {
+          //parse the next argument
+          checked_parse_arg(argc, argv, current, opt, name);
+        }
+      }
+
+    }
+
+    ++current;
+  }
+
+  for (auto& opt : m_options)
+  {
+    auto& detail = opt.second;
+    const auto& value = detail->value();
+
+    auto& store = m_parsed[detail->hash()];
+
+    if (value.has_default()) {
+      if (!store.count() && !store.has_default()) {
+        parse_default(detail);
+      }
+    }
+    else {
+      parse_no_value(detail);
+    }
+  }
+
+  if (consume_remaining)
+  {
+    while (current < argc)
+    {
+      if (!consume_positional(argv[current], next_positional)) {
+        break;
+      }
+      ++current;
+    }
+
+    //adjust argv for any that couldn't be swallowed
+    while (current != argc) {
+      unmatched.emplace_back(argv[current]);
+      ++current;
+    }
+  }
+
+  finalise_aliases();
+
+  ParseResult parsed(std::move(m_keys), std::move(m_parsed), std::move(m_sequential), std::move(m_defaults), std::move(unmatched));
+  return parsed;
+}
+
+inline
+void
+OptionParser::finalise_aliases()
+{
+  for (auto& option: m_options)
+  {
+    auto& detail = *option.second;
+    auto hash = detail.hash();
+    m_keys[detail.short_name()] = hash;
+    for(const auto& long_name : detail.long_names()) {
+      m_keys[long_name] = hash;
+    }
+
+    m_parsed.emplace(hash, OptionValue());
+  }
+}
+
+inline
+void
+Options::add_option
+(
+  const std::string& group,
+  const Option& option
+)
+{
+    add_options(group, {option});
+}
+
+inline
+void
+Options::add_option
+(
+  const std::string& group,
+  const std::string& s,
+  const OptionNames& l,
+  std::string desc,
+  const std::shared_ptr<const Value>& value,
+  std::string arg_help
+)
+{
+  auto stringDesc = toLocalString(std::move(desc));
+  auto option = std::make_shared<OptionDetails>(s, l, stringDesc, value);
+
+  if (!s.empty())
+  {
+    add_one_option(s, option);
+  }
+
+  for(const auto& long_name : l) {
+    add_one_option(long_name, option);
+  }
+
+  //add the help details
+
+  if (m_help.find(group) == m_help.end())
+  {
+    m_group.push_back(group);
+  }
+
+  auto& options = m_help[group];
+
+  options.options.emplace_back(HelpOptionDetails{s, l, stringDesc,
+      value->has_default(), value->get_default_value(),
+      value->has_implicit(), value->get_implicit_value(),
+      std::move(arg_help),
+      value->is_container(),
+      value->is_boolean()});
+}
+
+inline
+void
+Options::add_one_option
+(
+  const std::string& option,
+  const std::shared_ptr<OptionDetails>& details
+)
+{
+  auto in = m_options->emplace(option, details);
+
+  if (!in.second)
+  {
+    throw_or_mimic<exceptions::option_already_exists>(option);
+  }
+}
+
+inline
+String
+Options::help_one_group(const std::string& g) const
+{
+  using OptionHelp = std::vector<std::pair<String, String>>;
+
+  auto group = m_help.find(g);
+  if (group == m_help.end())
+  {
+    return "";
+  }
+
+  OptionHelp format;
+
+  std::size_t longest = 0;
+
+  String result;
+
+  if (!g.empty())
+  {
+    result += toLocalString(" " + g + " options:\n");
+  }
+
+  for (const auto& o : group->second.options)
+  {
+    if (o.l.size() &&
+        m_positional_set.find(o.l.front()) != m_positional_set.end() &&
+        !m_show_positional)
+    {
+      continue;
+    }
+
+    auto s = format_option(o);
+    longest = (std::max)(longest, stringLength(s));
+    format.push_back(std::make_pair(s, String()));
+  }
+  longest = (std::min)(longest, OPTION_LONGEST);
+
+  //widest allowed description -- min 10 chars for helptext/line
+  std::size_t allowed = 10;
+  if (m_width > allowed + longest + OPTION_DESC_GAP)
+  {
+    allowed = m_width - longest - OPTION_DESC_GAP;
+  }
+
+  auto fiter = format.begin();
+  for (const auto& o : group->second.options)
+  {
+    if (o.l.size() &&
+        m_positional_set.find(o.l.front()) != m_positional_set.end() &&
+        !m_show_positional)
+    {
+      continue;
+    }
+
+    auto d = format_description(o, longest + OPTION_DESC_GAP, allowed, m_tab_expansion);
+
+    result += fiter->first;
+    if (stringLength(fiter->first) > longest)
+    {
+      result += '\n';
+      result += toLocalString(std::string(longest + OPTION_DESC_GAP, ' '));
+    }
+    else
+    {
+      result += toLocalString(std::string(longest + OPTION_DESC_GAP -
+        stringLength(fiter->first),
+        ' '));
+    }
+    result += d;
+    result += '\n';
+
+    ++fiter;
+  }
+
+  return result;
+}
+
+inline
+void
+Options::generate_group_help
+(
+  String& result,
+  const std::vector<std::string>& print_groups
+) const
+{
+  for (std::size_t i = 0; i != print_groups.size(); ++i)
+  {
+    const String& group_help_text = help_one_group(print_groups[i]);
+    if (empty(group_help_text))
+    {
+      continue;
+    }
+    result += group_help_text;
+    if (i < print_groups.size() - 1)
+    {
+      result += '\n';
+    }
+  }
+}
+
+inline
+void
+Options::generate_all_groups_help(String& result) const
+{
+  generate_group_help(result, m_group);
+}
+
+inline
+std::string
+Options::help(const std::vector<std::string>& help_groups, bool print_usage) const
+{
+  String result = m_help_string;
+  if(print_usage)
+  {
+    result+= "\nUsage:\n  " + toLocalString(m_program);
+  }
+
+  if (!m_custom_help.empty())
+  {
+    result += " " + toLocalString(m_custom_help);
+  }
+
+  if (!m_positional.empty() && !m_positional_help.empty()) {
+    result += " " + toLocalString(m_positional_help);
+  }
+
+  result += "\n\n";
+
+  if (help_groups.empty())
+  {
+    generate_all_groups_help(result);
+  }
+  else
+  {
+    generate_group_help(result, help_groups);
+  }
+
+  return toUTF8String(result);
+}
+
+inline
+std::vector<std::string>
+Options::groups() const
+{
+  return m_group;
+}
+
+inline
+const HelpGroupDetails&
+Options::group_help(const std::string& group) const
+{
+  return m_help.at(group);
+}
+
+} // namespace cxxopts
+
+#endif //CXXOPTS_HPP_INCLUDED

--- a/runtime_lib/test_lib/cxxopts.hpp
+++ b/runtime_lib/test_lib/cxxopts.hpp
@@ -27,12 +27,14 @@ THE SOFTWARE.
 #ifndef CXXOPTS_HPP_INCLUDED
 #define CXXOPTS_HPP_INCLUDED
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <exception>
-#include <limits>
 #include <initializer_list>
+#include <limits>
+#include <locale>
 #include <map>
 #include <memory>
 #include <sstream>
@@ -41,52 +43,51 @@ THE SOFTWARE.
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <algorithm>
-#include <locale>
 
 #ifdef CXXOPTS_NO_EXCEPTIONS
 #include <iostream>
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__)
-#  if (__GNUC__ * 10 + __GNUC_MINOR__) < 49
-#    define CXXOPTS_NO_REGEX true
-#  endif
+#if (__GNUC__ * 10 + __GNUC_MINOR__) < 49
+#define CXXOPTS_NO_REGEX true
+#endif
 #endif
 #if defined(_MSC_VER) && !defined(__clang__)
-#define CXXOPTS_LINKONCE_CONST	__declspec(selectany) extern
-#define CXXOPTS_LINKONCE		__declspec(selectany) extern
+#define CXXOPTS_LINKONCE_CONST __declspec(selectany) extern
+#define CXXOPTS_LINKONCE __declspec(selectany) extern
 #else
 #define CXXOPTS_LINKONCE_CONST
 #define CXXOPTS_LINKONCE
 #endif
 
 #ifndef CXXOPTS_NO_REGEX
-#  include <regex>
-#endif  // CXXOPTS_NO_REGEX
+#include <regex>
+#endif // CXXOPTS_NO_REGEX
 
-// Nonstandard before C++17, which is coincidentally what we also need for <optional>
+// Nonstandard before C++17, which is coincidentally what we also need for
+// <optional>
 #ifdef __has_include
-#  if __has_include(<optional>)
-#    include <optional>
-#    ifdef __cpp_lib_optional
-#      define CXXOPTS_HAS_OPTIONAL
-#    endif
-#  endif
-#  if __has_include(<filesystem>)
-#    include <filesystem>
-#    ifdef __cpp_lib_filesystem
-#      define CXXOPTS_HAS_FILESYSTEM
-#    endif
-#  endif
+#if __has_include(<optional>)
+#include <optional>
+#ifdef __cpp_lib_optional
+#define CXXOPTS_HAS_OPTIONAL
+#endif
+#endif
+#if __has_include(<filesystem>)
+#include <filesystem>
+#ifdef __cpp_lib_filesystem
+#define CXXOPTS_HAS_FILESYSTEM
+#endif
+#endif
 #endif
 
 #define CXXOPTS_FALLTHROUGH
 #ifdef __has_cpp_attribute
-  #if __has_cpp_attribute(fallthrough)
-    #undef CXXOPTS_FALLTHROUGH
-    #define CXXOPTS_FALLTHROUGH [[fallthrough]]
-  #endif
+#if __has_cpp_attribute(fallthrough)
+#undef CXXOPTS_FALLTHROUGH
+#define CXXOPTS_FALLTHROUGH [[fallthrough]]
+#endif
 #endif
 
 #if __cplusplus >= 201603L
@@ -104,7 +105,7 @@ THE SOFTWARE.
 #define CXXOPTS__VERSION_PATCH 1
 
 #if (__GNUC__ < 10 || (__GNUC__ == 10 && __GNUC_MINOR__ < 1)) && __GNUC__ >= 6
-  #define CXXOPTS_NULL_DEREF_IGNORE
+#define CXXOPTS_NULL_DEREF_IGNORE
 #endif
 
 #if defined(__GNUC__)
@@ -128,18 +129,15 @@ THE SOFTWARE.
 namespace cxxopts {
 static constexpr struct {
   uint8_t major, minor, patch;
-} version = {
-  CXXOPTS__VERSION_MAJOR,
-  CXXOPTS__VERSION_MINOR,
-  CXXOPTS__VERSION_PATCH
-};
+} version = {CXXOPTS__VERSION_MAJOR, CXXOPTS__VERSION_MINOR,
+             CXXOPTS__VERSION_PATCH};
 } // namespace cxxopts
 
-//when we ask cxxopts to use Unicode, help strings are processed using ICU,
-//which results in the correct lengths being computed for strings when they
-//are formatted for the help output
-//it is necessary to make sure that <unicode/unistr.h> can be found by the
-//compiler, and that icu-uc is linked in to the binary.
+// when we ask cxxopts to use Unicode, help strings are processed using ICU,
+// which results in the correct lengths being computed for strings when they
+// are formatted for the help output
+// it is necessary to make sure that <unicode/unistr.h> can be found by the
+// compiler, and that icu-uc is linked in to the binary.
 
 #ifdef CXXOPTS_USE_UNICODE
 #include <unicode/unistr.h>
@@ -148,84 +146,59 @@ namespace cxxopts {
 
 using String = icu::UnicodeString;
 
-inline
-String
-toLocalString(std::string s)
-{
+inline String toLocalString(std::string s) {
   return icu::UnicodeString::fromUTF8(std::move(s));
 }
 
-// GNU GCC with -Weffc++ will issue a warning regarding the upcoming class, we want to silence it:
-// warning: base class 'class std::enable_shared_from_this<cxxopts::Value>' has accessible non-virtual destructor
+// GNU GCC with -Weffc++ will issue a warning regarding the upcoming class, we
+// want to silence it: warning: base class 'class
+// std::enable_shared_from_this<cxxopts::Value>' has accessible non-virtual
+// destructor
 CXXOPTS_DIAGNOSTIC_PUSH
 CXXOPTS_IGNORE_WARNING("-Wnon-virtual-dtor")
 // This will be ignored under other compilers like LLVM clang.
-class UnicodeStringIterator
-{
-  public:
-
+class UnicodeStringIterator {
+public:
   using iterator_category = std::forward_iterator_tag;
   using value_type = int32_t;
   using difference_type = std::ptrdiff_t;
-  using pointer = value_type*;
-  using reference = value_type&;
+  using pointer = value_type *;
+  using reference = value_type &;
 
-  UnicodeStringIterator(const icu::UnicodeString* string, int32_t pos)
-  : s(string)
-  , i(pos)
-  {
-  }
+  UnicodeStringIterator(const icu::UnicodeString *string, int32_t pos)
+      : s(string), i(pos) {}
 
-  value_type
-  operator*() const
-  {
-    return s->char32At(i);
-  }
+  value_type operator*() const { return s->char32At(i); }
 
-  bool
-  operator==(const UnicodeStringIterator& rhs) const
-  {
+  bool operator==(const UnicodeStringIterator &rhs) const {
     return s == rhs.s && i == rhs.i;
   }
 
-  bool
-  operator!=(const UnicodeStringIterator& rhs) const
-  {
+  bool operator!=(const UnicodeStringIterator &rhs) const {
     return !(*this == rhs);
   }
 
-  UnicodeStringIterator&
-  operator++()
-  {
+  UnicodeStringIterator &operator++() {
     ++i;
     return *this;
   }
 
-  UnicodeStringIterator
-  operator+(int32_t v)
-  {
+  UnicodeStringIterator operator+(int32_t v) {
     return UnicodeStringIterator(s, i + v);
   }
 
-  private:
-  const icu::UnicodeString* s;
+private:
+  const icu::UnicodeString *s;
   int32_t i;
 };
 CXXOPTS_DIAGNOSTIC_POP
 
-inline
-String&
-stringAppend(String&s, String a)
-{
+inline String &stringAppend(String &s, String a) {
   return s.append(std::move(a));
 }
 
-inline
-String&
-stringAppend(String& s, std::size_t n, UChar32 c)
-{
-  for (std::size_t i = 0; i != n; ++i)
-  {
+inline String &stringAppend(String &s, std::size_t n, UChar32 c) {
+  for (std::size_t i = 0; i != n; ++i) {
     s.append(c);
   }
 
@@ -233,11 +206,8 @@ stringAppend(String& s, std::size_t n, UChar32 c)
 }
 
 template <typename Iterator>
-String&
-stringAppend(String& s, Iterator begin, Iterator end)
-{
-  while (begin != end)
-  {
+String &stringAppend(String &s, Iterator begin, Iterator end) {
+  while (begin != end) {
     s.append(*begin);
     ++begin;
   }
@@ -245,51 +215,34 @@ stringAppend(String& s, Iterator begin, Iterator end)
   return s;
 }
 
-inline
-size_t
-stringLength(const String& s)
-{
+inline size_t stringLength(const String &s) {
   return static_cast<size_t>(s.length());
 }
 
-inline
-std::string
-toUTF8String(const String& s)
-{
+inline std::string toUTF8String(const String &s) {
   std::string result;
   s.toUTF8String(result);
 
   return result;
 }
 
-inline
-bool
-empty(const String& s)
-{
-  return s.isEmpty();
-}
+inline bool empty(const String &s) { return s.isEmpty(); }
 
 } // namespace cxxopts
 
 namespace std {
 
-inline
-cxxopts::UnicodeStringIterator
-begin(const icu::UnicodeString& s)
-{
+inline cxxopts::UnicodeStringIterator begin(const icu::UnicodeString &s) {
   return cxxopts::UnicodeStringIterator(&s, 0);
 }
 
-inline
-cxxopts::UnicodeStringIterator
-end(const icu::UnicodeString& s)
-{
+inline cxxopts::UnicodeStringIterator end(const icu::UnicodeString &s) {
   return cxxopts::UnicodeStringIterator(&s, s.length());
 }
 
 } // namespace std
 
-//ifdef CXXOPTS_USE_UNICODE
+// ifdef CXXOPTS_USE_UNICODE
 #else
 
 namespace cxxopts {
@@ -297,57 +250,33 @@ namespace cxxopts {
 using String = std::string;
 
 template <typename T>
-T
-toLocalString(T&& t)
-{
+T toLocalString(T &&t) {
   return std::forward<T>(t);
 }
 
-inline
-std::size_t
-stringLength(const String& s)
-{
-  return s.length();
-}
+inline std::size_t stringLength(const String &s) { return s.length(); }
 
-inline
-String&
-stringAppend(String&s, const String& a)
-{
-  return s.append(a);
-}
+inline String &stringAppend(String &s, const String &a) { return s.append(a); }
 
-inline
-String&
-stringAppend(String& s, std::size_t n, char c)
-{
+inline String &stringAppend(String &s, std::size_t n, char c) {
   return s.append(n, c);
 }
 
 template <typename Iterator>
-String&
-stringAppend(String& s, Iterator begin, Iterator end)
-{
+String &stringAppend(String &s, Iterator begin, Iterator end) {
   return s.append(begin, end);
 }
 
 template <typename T>
-std::string
-toUTF8String(T&& t)
-{
+std::string toUTF8String(T &&t) {
   return std::forward<T>(t);
 }
 
-inline
-bool
-empty(const std::string& s)
-{
-  return s.empty();
-}
+inline bool empty(const std::string &s) { return s.empty(); }
 
 } // namespace cxxopts
 
-//ifdef CXXOPTS_USE_UNICODE
+// ifdef CXXOPTS_USE_UNICODE
 #endif
 
 namespace cxxopts {
@@ -366,211 +295,135 @@ CXXOPTS_IGNORE_WARNING("-Wnon-virtual-dtor")
 
 // some older versions of GCC warn under this warning
 CXXOPTS_IGNORE_WARNING("-Weffc++")
-class Value : public std::enable_shared_from_this<Value>
-{
-  public:
-
+class Value : public std::enable_shared_from_this<Value> {
+public:
   virtual ~Value() = default;
 
-  virtual
-  std::shared_ptr<Value>
-  clone() const = 0;
+  virtual std::shared_ptr<Value> clone() const = 0;
 
-  virtual void
-  add(const std::string& text) const = 0;
+  virtual void add(const std::string &text) const = 0;
 
-  virtual void
-  parse(const std::string& text) const = 0;
+  virtual void parse(const std::string &text) const = 0;
 
-  virtual void
-  parse() const = 0;
+  virtual void parse() const = 0;
 
-  virtual bool
-  has_default() const = 0;
+  virtual bool has_default() const = 0;
 
-  virtual bool
-  is_container() const = 0;
+  virtual bool is_container() const = 0;
 
-  virtual bool
-  has_implicit() const = 0;
+  virtual bool has_implicit() const = 0;
 
-  virtual std::string
-  get_default_value() const = 0;
+  virtual std::string get_default_value() const = 0;
 
-  virtual std::string
-  get_implicit_value() const = 0;
+  virtual std::string get_implicit_value() const = 0;
 
-  virtual std::shared_ptr<Value>
-  default_value(const std::string& value) = 0;
+  virtual std::shared_ptr<Value> default_value(const std::string &value) = 0;
 
-  virtual std::shared_ptr<Value>
-  implicit_value(const std::string& value) = 0;
+  virtual std::shared_ptr<Value> implicit_value(const std::string &value) = 0;
 
-  virtual std::shared_ptr<Value>
-  no_implicit_value() = 0;
+  virtual std::shared_ptr<Value> no_implicit_value() = 0;
 
-  virtual bool
-  is_boolean() const = 0;
+  virtual bool is_boolean() const = 0;
 };
 
 CXXOPTS_DIAGNOSTIC_POP
 
 namespace exceptions {
 
-class exception : public std::exception
-{
-  public:
-  explicit exception(std::string  message)
-  : m_message(std::move(message))
-  {
-  }
+class exception : public std::exception {
+public:
+  explicit exception(std::string message) : m_message(std::move(message)) {}
 
   CXXOPTS_NODISCARD
-  const char*
-  what() const noexcept override
-  {
-    return m_message.c_str();
-  }
+  const char *what() const noexcept override { return m_message.c_str(); }
 
-  private:
+private:
   std::string m_message;
 };
 
-class specification : public exception
-{
-  public:
-
-  explicit specification(const std::string& message)
-  : exception(message)
-  {
-  }
+class specification : public exception {
+public:
+  explicit specification(const std::string &message) : exception(message) {}
 };
 
-class parsing : public exception
-{
-  public:
-  explicit parsing(const std::string& message)
-  : exception(message)
-  {
-  }
+class parsing : public exception {
+public:
+  explicit parsing(const std::string &message) : exception(message) {}
 };
 
-class option_already_exists : public specification
-{
-  public:
-  explicit option_already_exists(const std::string& option)
-  : specification("Option " + LQUOTE + option + RQUOTE + " already exists")
-  {
-  }
+class option_already_exists : public specification {
+public:
+  explicit option_already_exists(const std::string &option)
+      : specification("Option " + LQUOTE + option + RQUOTE +
+                      " already exists") {}
 };
 
-class invalid_option_format : public specification
-{
-  public:
-  explicit invalid_option_format(const std::string& format)
-  : specification("Invalid option format " + LQUOTE + format + RQUOTE)
-  {
-  }
+class invalid_option_format : public specification {
+public:
+  explicit invalid_option_format(const std::string &format)
+      : specification("Invalid option format " + LQUOTE + format + RQUOTE) {}
 };
 
 class invalid_option_syntax : public parsing {
-  public:
-  explicit invalid_option_syntax(const std::string& text)
-  : parsing("Argument " + LQUOTE + text + RQUOTE +
-            " starts with a - but has incorrect syntax")
-  {
-  }
+public:
+  explicit invalid_option_syntax(const std::string &text)
+      : parsing("Argument " + LQUOTE + text + RQUOTE +
+                " starts with a - but has incorrect syntax") {}
 };
 
-class no_such_option : public parsing
-{
-  public:
-  explicit no_such_option(const std::string& option)
-  : parsing("Option " + LQUOTE + option + RQUOTE + " does not exist")
-  {
-  }
+class no_such_option : public parsing {
+public:
+  explicit no_such_option(const std::string &option)
+      : parsing("Option " + LQUOTE + option + RQUOTE + " does not exist") {}
 };
 
-class missing_argument : public parsing
-{
-  public:
-  explicit missing_argument(const std::string& option)
-  : parsing(
-      "Option " + LQUOTE + option + RQUOTE + " is missing an argument"
-    )
-  {
-  }
+class missing_argument : public parsing {
+public:
+  explicit missing_argument(const std::string &option)
+      : parsing("Option " + LQUOTE + option + RQUOTE +
+                " is missing an argument") {}
 };
 
-class option_requires_argument : public parsing
-{
-  public:
-  explicit option_requires_argument(const std::string& option)
-  : parsing(
-      "Option " + LQUOTE + option + RQUOTE + " requires an argument"
-    )
-  {
-  }
+class option_requires_argument : public parsing {
+public:
+  explicit option_requires_argument(const std::string &option)
+      : parsing("Option " + LQUOTE + option + RQUOTE +
+                " requires an argument") {}
 };
 
-class gratuitous_argument_for_option : public parsing
-{
-  public:
-  gratuitous_argument_for_option
-  (
-    const std::string& option,
-    const std::string& arg
-  )
-  : parsing(
-      "Option " + LQUOTE + option + RQUOTE +
-      " does not take an argument, but argument " +
-      LQUOTE + arg + RQUOTE + " given"
-    )
-  {
-  }
+class gratuitous_argument_for_option : public parsing {
+public:
+  gratuitous_argument_for_option(const std::string &option,
+                                 const std::string &arg)
+      : parsing("Option " + LQUOTE + option + RQUOTE +
+                " does not take an argument, but argument " + LQUOTE + arg +
+                RQUOTE + " given") {}
 };
 
-class requested_option_not_present : public parsing
-{
-  public:
-  explicit requested_option_not_present(const std::string& option)
-  : parsing("Option " + LQUOTE + option + RQUOTE + " not present")
-  {
-  }
+class requested_option_not_present : public parsing {
+public:
+  explicit requested_option_not_present(const std::string &option)
+      : parsing("Option " + LQUOTE + option + RQUOTE + " not present") {}
 };
 
-class option_has_no_value : public exception
-{
-  public:
-  explicit option_has_no_value(const std::string& option)
-  : exception(
-      !option.empty() ?
-      ("Option " + LQUOTE + option + RQUOTE + " has no value") :
-      "Option has no value")
-  {
-  }
+class option_has_no_value : public exception {
+public:
+  explicit option_has_no_value(const std::string &option)
+      : exception(!option.empty()
+                      ? ("Option " + LQUOTE + option + RQUOTE + " has no value")
+                      : "Option has no value") {}
 };
 
-class incorrect_argument_type : public parsing
-{
-  public:
-  explicit incorrect_argument_type
-  (
-    const std::string& arg
-  )
-  : parsing(
-      "Argument " + LQUOTE + arg + RQUOTE + " failed to parse"
-    )
-  {
-  }
+class incorrect_argument_type : public parsing {
+public:
+  explicit incorrect_argument_type(const std::string &arg)
+      : parsing("Argument " + LQUOTE + arg + RQUOTE + " failed to parse") {}
 };
 
 } // namespace exceptions
 
-
 template <typename T>
-void throw_or_mimic(const std::string& text)
-{
+void throw_or_mimic(const std::string &text) {
   static_assert(std::is_base_of<std::exception, T>::value,
                 "throw_or_mimic only works on std::exception and "
                 "deriving classes");
@@ -593,94 +446,74 @@ namespace values {
 
 namespace parser_tool {
 
-struct IntegerDesc
-{
+struct IntegerDesc {
   std::string negative = "";
-  std::string base     = "";
-  std::string value    = "";
+  std::string base = "";
+  std::string value = "";
 };
 struct ArguDesc {
-  std::string arg_name  = "";
-  bool        grouping  = false;
-  bool        set_value = false;
-  std::string value     = "";
+  std::string arg_name = "";
+  bool grouping = false;
+  bool set_value = false;
+  std::string value = "";
 };
 
 #ifdef CXXOPTS_NO_REGEX
-inline IntegerDesc SplitInteger(const std::string &text)
-{
-  if (text.empty())
-  {
+inline IntegerDesc SplitInteger(const std::string &text) {
+  if (text.empty()) {
     throw_or_mimic<exceptions::incorrect_argument_type>(text);
   }
   IntegerDesc desc;
   const char *pdata = text.c_str();
-  if (*pdata == '-')
-  {
+  if (*pdata == '-') {
     pdata += 1;
     desc.negative = "-";
   }
-  if (strncmp(pdata, "0x", 2) == 0)
-  {
+  if (strncmp(pdata, "0x", 2) == 0) {
     pdata += 2;
     desc.base = "0x";
   }
-  if (*pdata != '\0')
-  {
+  if (*pdata != '\0') {
     desc.value = std::string(pdata);
-  }
-  else
-  {
+  } else {
     throw_or_mimic<exceptions::incorrect_argument_type>(text);
   }
   return desc;
 }
 
-inline bool IsTrueText(const std::string &text)
-{
+inline bool IsTrueText(const std::string &text) {
   const char *pdata = text.c_str();
-  if (*pdata == 't' || *pdata == 'T')
-  {
+  if (*pdata == 't' || *pdata == 'T') {
     pdata += 1;
-    if (strncmp(pdata, "rue\0", 4) == 0)
-    {
+    if (strncmp(pdata, "rue\0", 4) == 0) {
       return true;
     }
-  }
-  else if (strncmp(pdata, "1\0", 2) == 0)
-  {
+  } else if (strncmp(pdata, "1\0", 2) == 0) {
     return true;
   }
   return false;
 }
 
-inline bool IsFalseText(const std::string &text)
-{
+inline bool IsFalseText(const std::string &text) {
   const char *pdata = text.c_str();
-  if (*pdata == 'f' || *pdata == 'F')
-  {
+  if (*pdata == 'f' || *pdata == 'F') {
     pdata += 1;
-    if (strncmp(pdata, "alse\0", 5) == 0)
-    {
+    if (strncmp(pdata, "alse\0", 5) == 0) {
       return true;
     }
-  }
-  else if (strncmp(pdata, "0\0", 2) == 0)
-  {
+  } else if (strncmp(pdata, "0\0", 2) == 0) {
     return true;
   }
   return false;
 }
 
-inline OptionNames split_option_names(const std::string &text)
-{
+inline OptionNames split_option_names(const std::string &text) {
   OptionNames split_names;
 
   std::string::size_type token_start_pos = 0;
   auto length = text.length();
 
-  if (length == 0)
-  {
+  if (length == 0) {
     throw_or_mimic<exceptions::invalid_option_format>(text);
   }
 
@@ -701,14 +534,14 @@ inline OptionNames split_option_names(const std::string &text)
     auto token_length = next_delimiter_pos - token_start_pos;
     // validate the token itself matches the regex /([:alnum:][-_[:alnum:]]*/
     {
-      const char* option_name_valid_chars =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        "abcdefghijklmnopqrstuvwxyz"
-        "0123456789"
-        "_-.?";
+      const char *option_name_valid_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                            "abcdefghijklmnopqrstuvwxyz"
+                                            "0123456789"
+                                            "_-.?";
 
       if (!std::isalnum(text[token_start_pos], std::locale::classic()) ||
-          text.find_first_not_of(option_name_valid_chars, token_start_pos) < next_delimiter_pos) {
+          text.find_first_not_of(option_name_valid_chars, token_start_pos) <
+              next_delimiter_pos) {
         throw_or_mimic<exceptions::invalid_option_format>(text);
       }
     }
@@ -718,48 +551,37 @@ inline OptionNames split_option_names(const std::string &text)
   return split_names;
 }
 
-inline ArguDesc ParseArgument(const char *arg, bool &matched)
-{
+inline ArguDesc ParseArgument(const char *arg, bool &matched) {
   ArguDesc argu_desc;
   const char *pdata = arg;
   matched = false;
-  if (strncmp(pdata, "--", 2) == 0)
-  {
+  if (strncmp(pdata, "--", 2) == 0) {
     pdata += 2;
-    if (isalnum(*pdata, std::locale::classic()))
-    {
+    if (isalnum(*pdata, std::locale::classic())) {
       argu_desc.arg_name.push_back(*pdata);
       pdata += 1;
-      while (isalnum(*pdata, std::locale::classic()) || *pdata == '-' || *pdata == '_')
-      {
+      while (isalnum(*pdata, std::locale::classic()) || *pdata == '-' ||
+             *pdata == '_') {
         argu_desc.arg_name.push_back(*pdata);
         pdata += 1;
       }
-      if (argu_desc.arg_name.length() > 1)
-      {
-        if (*pdata == '=')
-        {
+      if (argu_desc.arg_name.length() > 1) {
+        if (*pdata == '=') {
           argu_desc.set_value = true;
           pdata += 1;
-          if (*pdata != '\0')
-          {
+          if (*pdata != '\0') {
             argu_desc.value = std::string(pdata);
           }
           matched = true;
-        }
-        else if (*pdata == '\0')
-        {
+        } else if (*pdata == '\0') {
           matched = true;
         }
       }
     }
-  }
-  else if (strncmp(pdata, "-", 1) == 0)
-  {
+  } else if (strncmp(pdata, "-", 1) == 0) {
     pdata += 1;
     argu_desc.grouping = true;
-    while (isalnum(*pdata, std::locale::classic()))
-    {
+    while (isalnum(*pdata, std::locale::classic())) {
       argu_desc.arg_name.push_back(*pdata);
       pdata += 1;
     }
@@ -768,38 +590,33 @@ inline ArguDesc ParseArgument(const char *arg, bool &matched)
   return argu_desc;
 }
 
-#else  // CXXOPTS_NO_REGEX
+#else // CXXOPTS_NO_REGEX
 
 namespace {
 CXXOPTS_LINKONCE
-const char* const integer_pattern =
-  "(-)?(0x)?([0-9a-zA-Z]+)|((0x)?0)";
+const char *const integer_pattern = "(-)?(0x)?([0-9a-zA-Z]+)|((0x)?0)";
 CXXOPTS_LINKONCE
-const char* const truthy_pattern =
-  "(t|T)(rue)?|1";
+const char *const truthy_pattern = "(t|T)(rue)?|1";
 CXXOPTS_LINKONCE
-const char* const falsy_pattern =
-  "(f|F)(alse)?|0";
+const char *const falsy_pattern = "(f|F)(alse)?|0";
 CXXOPTS_LINKONCE
-const char* const option_pattern =
-  "--([[:alnum:]][-_[:alnum:]\\.]+)(=(.*))?|-([[:alnum:]].*)";
+const char *const option_pattern =
+    "--([[:alnum:]][-_[:alnum:]\\.]+)(=(.*))?|-([[:alnum:]].*)";
 CXXOPTS_LINKONCE
-const char* const option_specifier_pattern =
-  "([[:alnum:]][-_[:alnum:]\\.]*)(,[ ]*[[:alnum:]][-_[:alnum:]]*)*";
+const char *const option_specifier_pattern =
+    "([[:alnum:]][-_[:alnum:]\\.]*)(,[ ]*[[:alnum:]][-_[:alnum:]]*)*";
 CXXOPTS_LINKONCE
-const char* const option_specifier_separator_pattern = ", *";
+const char *const option_specifier_separator_pattern = ", *";
 
 } // namespace
 
-inline IntegerDesc SplitInteger(const std::string &text)
-{
+inline IntegerDesc SplitInteger(const std::string &text) {
   static const std::basic_regex<char> integer_matcher(integer_pattern);
 
   std::smatch match;
   std::regex_match(text, match, integer_matcher);
 
-  if (match.length() == 0)
-  {
+  if (match.length() == 0) {
     throw_or_mimic<exceptions::incorrect_argument_type>(text);
   }
 
@@ -808,8 +625,7 @@ inline IntegerDesc SplitInteger(const std::string &text)
   desc.base = match[2];
   desc.value = match[3];
 
-  if (match.length(4) > 0)
-  {
+  if (match.length(4) > 0) {
     desc.base = match[5];
     desc.value = "0";
     return desc;
@@ -818,16 +634,14 @@ inline IntegerDesc SplitInteger(const std::string &text)
   return desc;
 }
 
-inline bool IsTrueText(const std::string &text)
-{
+inline bool IsTrueText(const std::string &text) {
   static const std::basic_regex<char> truthy_matcher(truthy_pattern);
   std::smatch result;
   std::regex_match(text, result, truthy_matcher);
   return !result.empty();
 }
 
-inline bool IsFalseText(const std::string &text)
-{
+inline bool IsFalseText(const std::string &text) {
   static const std::basic_regex<char> falsy_matcher(falsy_pattern);
   std::smatch result;
   std::regex_match(text, result, falsy_matcher);
@@ -837,28 +651,29 @@ inline bool IsFalseText(const std::string &text)
 // Gets the option names specified via a single, comma-separated string,
 // and returns the separate, space-discarded, non-empty names
 // (without considering which or how many are single-character)
-inline OptionNames split_option_names(const std::string &text)
-{
-  static const std::basic_regex<char> option_specifier_matcher(option_specifier_pattern);
-  if (!std::regex_match(text.c_str(), option_specifier_matcher))
-  {
+inline OptionNames split_option_names(const std::string &text) {
+  static const std::basic_regex<char> option_specifier_matcher(
+      option_specifier_pattern);
+  if (!std::regex_match(text.c_str(), option_specifier_matcher)) {
     throw_or_mimic<exceptions::invalid_option_format>(text);
   }
 
   OptionNames split_names;
 
-  static const std::basic_regex<char> option_specifier_separator_matcher(option_specifier_separator_pattern);
-  constexpr int use_non_matches { -1 };
+  static const std::basic_regex<char> option_specifier_separator_matcher(
+      option_specifier_separator_pattern);
+  constexpr int use_non_matches{-1};
   auto token_iterator = std::sregex_token_iterator(
-    text.begin(), text.end(), option_specifier_separator_matcher, use_non_matches);
-  std::copy(token_iterator, std::sregex_token_iterator(), std::back_inserter(split_names));
+      text.begin(), text.end(), option_specifier_separator_matcher,
+      use_non_matches);
+  std::copy(token_iterator, std::sregex_token_iterator(),
+            std::back_inserter(split_names));
   return split_names;
 }
 
-inline ArguDesc ParseArgument(const char *arg, bool &matched)
-{
+inline ArguDesc ParseArgument(const char *arg, bool &matched) {
   static const std::basic_regex<char> option_matcher(option_pattern);
-  std::match_results<const char*> result;
+  std::match_results<const char *> result;
   std::regex_match(arg, result, option_matcher);
   matched = !result.empty();
 
@@ -867,8 +682,7 @@ inline ArguDesc ParseArgument(const char *arg, bool &matched)
     argu_desc.arg_name = result[1].str();
     argu_desc.set_value = result[2].length() > 0;
     argu_desc.value = result[3].str();
-    if (result[4].length() > 0)
-    {
+    if (result[4].length() > 0) {
       argu_desc.grouping = true;
       argu_desc.arg_name = result[4].str();
     }
@@ -877,7 +691,7 @@ inline ArguDesc ParseArgument(const char *arg, bool &matched)
   return argu_desc;
 }
 
-#endif  // CXXOPTS_NO_REGEX
+#endif // CXXOPTS_NO_REGEX
 #undef CXXOPTS_NO_REGEX
 } // namespace parser_tool
 
@@ -887,23 +701,15 @@ template <typename T, bool B>
 struct SignedCheck;
 
 template <typename T>
-struct SignedCheck<T, true>
-{
+struct SignedCheck<T, true> {
   template <typename U>
-  void
-  operator()(bool negative, U u, const std::string& text)
-  {
-    if (negative)
-    {
-      if (u > static_cast<U>((std::numeric_limits<T>::min)()))
-      {
+  void operator()(bool negative, U u, const std::string &text) {
+    if (negative) {
+      if (u > static_cast<U>((std::numeric_limits<T>::min)())) {
         throw_or_mimic<exceptions::incorrect_argument_type>(text);
       }
-    }
-    else
-    {
-      if (u > static_cast<U>((std::numeric_limits<T>::max)()))
-      {
+    } else {
+      if (u > static_cast<U>((std::numeric_limits<T>::max)())) {
         throw_or_mimic<exceptions::incorrect_argument_type>(text);
       }
     }
@@ -911,91 +717,69 @@ struct SignedCheck<T, true>
 };
 
 template <typename T>
-struct SignedCheck<T, false>
-{
+struct SignedCheck<T, false> {
   template <typename U>
-  void
-  operator()(bool, U, const std::string&) const {}
+  void operator()(bool, U, const std::string &) const {}
 };
 
 template <typename T, typename U>
-void
-check_signed_range(bool negative, U value, const std::string& text)
-{
+void check_signed_range(bool negative, U value, const std::string &text) {
   SignedCheck<T, std::numeric_limits<T>::is_signed>()(negative, value, text);
 }
 
 } // namespace detail
 
 template <typename R, typename T>
-void
-checked_negate(R& r, T&& t, const std::string&, std::true_type)
-{
+void checked_negate(R &r, T &&t, const std::string &, std::true_type) {
   // if we got to here, then `t` is a positive number that fits into
   // `R`. So to avoid MSVC C4146, we first cast it to `R`.
   // See https://github.com/jarro2783/cxxopts/issues/62 for more details.
-  r = static_cast<R>(-static_cast<R>(t-1)-1);
+  r = static_cast<R>(-static_cast<R>(t - 1) - 1);
 }
 
 template <typename R, typename T>
-void
-checked_negate(R&, T&&, const std::string& text, std::false_type)
-{
+void checked_negate(R &, T &&, const std::string &text, std::false_type) {
   throw_or_mimic<exceptions::incorrect_argument_type>(text);
 }
 
 template <typename T>
-void
-integer_parser(const std::string& text, T& value)
-{
+void integer_parser(const std::string &text, T &value) {
   parser_tool::IntegerDesc int_desc = parser_tool::SplitInteger(text);
 
   using US = typename std::make_unsigned<T>::type;
   constexpr bool is_signed = std::numeric_limits<T>::is_signed;
 
-  const bool          negative    = int_desc.negative.length() > 0;
-  const uint8_t       base        = int_desc.base.length() > 0 ? 16 : 10;
-  const std::string & value_match = int_desc.value;
+  const bool negative = int_desc.negative.length() > 0;
+  const uint8_t base = int_desc.base.length() > 0 ? 16 : 10;
+  const std::string &value_match = int_desc.value;
 
   US result = 0;
 
-  for (char ch : value_match)
-  {
+  for (char ch : value_match) {
     US digit = 0;
 
-    if (ch >= '0' && ch <= '9')
-    {
+    if (ch >= '0' && ch <= '9') {
       digit = static_cast<US>(ch - '0');
-    }
-    else if (base == 16 && ch >= 'a' && ch <= 'f')
-    {
+    } else if (base == 16 && ch >= 'a' && ch <= 'f') {
       digit = static_cast<US>(ch - 'a' + 10);
-    }
-    else if (base == 16 && ch >= 'A' && ch <= 'F')
-    {
+    } else if (base == 16 && ch >= 'A' && ch <= 'F') {
       digit = static_cast<US>(ch - 'A' + 10);
-    }
-    else
-    {
+    } else {
       throw_or_mimic<exceptions::incorrect_argument_type>(text);
     }
 
     US limit = 0;
-    if (negative)
-    {
-      limit = static_cast<US>(std::abs(static_cast<intmax_t>((std::numeric_limits<T>::min)())));
-    }
-    else
-    {
+    if (negative) {
+      limit = static_cast<US>(
+          std::abs(static_cast<intmax_t>((std::numeric_limits<T>::min)())));
+    } else {
       limit = (std::numeric_limits<T>::max)();
     }
 
-    if (base != 0 && result > limit / base)
-    {
+    if (base != 0 && result > limit / base) {
       throw_or_mimic<exceptions::incorrect_argument_type>(text);
     }
-    if (result * base > limit - digit)
-    {
+    if (result * base > limit - digit) {
       throw_or_mimic<exceptions::incorrect_argument_type>(text);
     }
 
@@ -1004,19 +788,16 @@ integer_parser(const std::string& text, T& value)
 
   detail::check_signed_range<T>(negative, result, text);
 
-  if (negative)
-  {
-    checked_negate<T>(value, result, text, std::integral_constant<bool, is_signed>());
-  }
-  else
-  {
+  if (negative) {
+    checked_negate<T>(value, result, text,
+                      std::integral_constant<bool, is_signed>());
+  } else {
     value = static_cast<T>(result);
   }
 }
 
 template <typename T>
-void stringstream_parser(const std::string& text, T& value)
-{
+void stringstream_parser(const std::string &text, T &value) {
   std::stringstream in(text);
   in >> value;
   if (!in) {
@@ -1025,25 +806,18 @@ void stringstream_parser(const std::string& text, T& value)
 }
 
 template <typename T,
-         typename std::enable_if<std::is_integral<T>::value>::type* = nullptr
-         >
-void parse_value(const std::string& text, T& value)
-{
-    integer_parser(text, value);
+          typename std::enable_if<std::is_integral<T>::value>::type * = nullptr>
+void parse_value(const std::string &text, T &value) {
+  integer_parser(text, value);
 }
 
-inline
-void
-parse_value(const std::string& text, bool& value)
-{
-  if (parser_tool::IsTrueText(text))
-  {
+inline void parse_value(const std::string &text, bool &value) {
+  if (parser_tool::IsTrueText(text)) {
     value = true;
     return;
   }
 
-  if (parser_tool::IsFalseText(text))
-  {
+  if (parser_tool::IsFalseText(text)) {
     value = false;
     return;
   }
@@ -1051,29 +825,22 @@ parse_value(const std::string& text, bool& value)
   throw_or_mimic<exceptions::incorrect_argument_type>(text);
 }
 
-inline
-void
-parse_value(const std::string& text, std::string& value)
-{
+inline void parse_value(const std::string &text, std::string &value) {
   value = text;
 }
 
 // The fallback parser. It uses the stringstream parser to parse all types
 // that have not been overloaded explicitly.  It has to be placed in the
 // source code before all other more specialized templates.
-template <typename T,
-         typename std::enable_if<!std::is_integral<T>::value>::type* = nullptr
-         >
-void
-parse_value(const std::string& text, T& value) {
+template <typename T, typename std::enable_if<!std::is_integral<T>::value>::type
+                          * = nullptr>
+void parse_value(const std::string &text, T &value) {
   stringstream_parser(text, value);
 }
 
 #ifdef CXXOPTS_HAS_OPTIONAL
 template <typename T>
-void
-parse_value(const std::string& text, std::optional<T>& value)
-{
+void parse_value(const std::string &text, std::optional<T> &value) {
   T result;
   parse_value(text, result);
   value = std::move(result);
@@ -1081,19 +848,13 @@ parse_value(const std::string& text, std::optional<T>& value)
 #endif
 
 #ifdef CXXOPTS_HAS_FILESYSTEM
-inline
-void
-parse_value(const std::string& text, std::filesystem::path& value)
-{
+inline void parse_value(const std::string &text, std::filesystem::path &value) {
   value.assign(text);
 }
 #endif
 
-inline
-void parse_value(const std::string& text, char& c)
-{
-  if (text.length() != 1)
-  {
+inline void parse_value(const std::string &text, char &c) {
+  if (text.length() != 1) {
     throw_or_mimic<exceptions::incorrect_argument_type>(text);
   }
 
@@ -1101,9 +862,7 @@ void parse_value(const std::string& text, char& c)
 }
 
 template <typename T>
-void
-parse_value(const std::string& text, std::vector<T>& value)
-{
+void parse_value(const std::string &text, std::vector<T> &value) {
   if (text.empty()) {
     T v;
     parse_value(text, v);
@@ -1112,7 +871,7 @@ parse_value(const std::string& text, std::vector<T>& value)
   }
   std::stringstream in(text);
   std::string token;
-  while(!in.eof() && std::getline(in, token, CXXOPTS_VECTOR_DELIMITER)) {
+  while (!in.eof() && std::getline(in, token, CXXOPTS_VECTOR_DELIMITER)) {
     T v;
     parse_value(token, v);
     value.emplace_back(std::move(v));
@@ -1120,63 +879,45 @@ parse_value(const std::string& text, std::vector<T>& value)
 }
 
 template <typename T>
-void
-add_value(const std::string& text, T& value)
-{
+void add_value(const std::string &text, T &value) {
   parse_value(text, value);
 }
 
 template <typename T>
-void
-add_value(const std::string& text, std::vector<T>& value)
-{
+void add_value(const std::string &text, std::vector<T> &value) {
   T v;
   add_value(text, v);
   value.emplace_back(std::move(v));
 }
 
 template <typename T>
-struct type_is_container
-{
+struct type_is_container {
   static constexpr bool value = false;
 };
 
 template <typename T>
-struct type_is_container<std::vector<T>>
-{
+struct type_is_container<std::vector<T>> {
   static constexpr bool value = true;
 };
 
 template <typename T>
-class abstract_value : public Value
-{
+class abstract_value : public Value {
   using Self = abstract_value<T>;
 
-  public:
-  abstract_value()
-  : m_result(std::make_shared<T>())
-  , m_store(m_result.get())
-  {
-  }
+public:
+  abstract_value() : m_result(std::make_shared<T>()), m_store(m_result.get()) {}
 
-  explicit abstract_value(T* t)
-  : m_store(t)
-  {
-  }
+  explicit abstract_value(T *t) : m_store(t) {}
 
   ~abstract_value() override = default;
 
-  abstract_value& operator=(const abstract_value&) = default;
+  abstract_value &operator=(const abstract_value &) = default;
 
-  abstract_value(const abstract_value& rhs)
-  {
-    if (rhs.m_result)
-    {
+  abstract_value(const abstract_value &rhs) {
+    if (rhs.m_result) {
       m_result = std::make_shared<T>();
       m_store = m_result.get();
-    }
-    else
-    {
+    } else {
       m_store = rhs.m_store;
     }
 
@@ -1186,96 +927,55 @@ class abstract_value : public Value
     m_implicit_value = rhs.m_implicit_value;
   }
 
-  void
-  add(const std::string& text) const override
-  {
+  void add(const std::string &text) const override {
     add_value(text, *m_store);
   }
 
-  void
-  parse(const std::string& text) const override
-  {
+  void parse(const std::string &text) const override {
     parse_value(text, *m_store);
   }
 
-  bool
-  is_container() const override
-  {
-    return type_is_container<T>::value;
-  }
+  bool is_container() const override { return type_is_container<T>::value; }
 
-  void
-  parse() const override
-  {
-    parse_value(m_default_value, *m_store);
-  }
+  void parse() const override { parse_value(m_default_value, *m_store); }
 
-  bool
-  has_default() const override
-  {
-    return m_default;
-  }
+  bool has_default() const override { return m_default; }
 
-  bool
-  has_implicit() const override
-  {
-    return m_implicit;
-  }
+  bool has_implicit() const override { return m_implicit; }
 
-  std::shared_ptr<Value>
-  default_value(const std::string& value) override
-  {
+  std::shared_ptr<Value> default_value(const std::string &value) override {
     m_default = true;
     m_default_value = value;
     return shared_from_this();
   }
 
-  std::shared_ptr<Value>
-  implicit_value(const std::string& value) override
-  {
+  std::shared_ptr<Value> implicit_value(const std::string &value) override {
     m_implicit = true;
     m_implicit_value = value;
     return shared_from_this();
   }
 
-  std::shared_ptr<Value>
-  no_implicit_value() override
-  {
+  std::shared_ptr<Value> no_implicit_value() override {
     m_implicit = false;
     return shared_from_this();
   }
 
-  std::string
-  get_default_value() const override
-  {
-    return m_default_value;
-  }
+  std::string get_default_value() const override { return m_default_value; }
 
-  std::string
-  get_implicit_value() const override
-  {
-    return m_implicit_value;
-  }
+  std::string get_implicit_value() const override { return m_implicit_value; }
 
-  bool
-  is_boolean() const override
-  {
-    return std::is_same<T, bool>::value;
-  }
+  bool is_boolean() const override { return std::is_same<T, bool>::value; }
 
-  const T&
-  get() const
-  {
-    if (m_store == nullptr)
-    {
+  const T &get() const {
+    if (m_store == nullptr) {
       return *m_result;
     }
     return *m_store;
   }
 
-  protected:
+protected:
   std::shared_ptr<T> m_result{};
-  T* m_store{};
+  T *m_store{};
 
   bool m_default = false;
   bool m_implicit = false;
@@ -1285,48 +985,34 @@ class abstract_value : public Value
 };
 
 template <typename T>
-class standard_value : public abstract_value<T>
-{
-  public:
+class standard_value : public abstract_value<T> {
+public:
   using abstract_value<T>::abstract_value;
 
   CXXOPTS_NODISCARD
-  std::shared_ptr<Value>
-  clone() const override
-  {
+  std::shared_ptr<Value> clone() const override {
     return std::make_shared<standard_value<T>>(*this);
   }
 };
 
 template <>
-class standard_value<bool> : public abstract_value<bool>
-{
-  public:
+class standard_value<bool> : public abstract_value<bool> {
+public:
   ~standard_value() override = default;
 
-  standard_value()
-  {
-    set_default_and_implicit();
-  }
+  standard_value() { set_default_and_implicit(); }
 
-  explicit standard_value(bool* b)
-  : abstract_value(b)
-  {
+  explicit standard_value(bool *b) : abstract_value(b) {
     m_implicit = true;
     m_implicit_value = "true";
   }
 
-  std::shared_ptr<Value>
-  clone() const override
-  {
+  std::shared_ptr<Value> clone() const override {
     return std::make_shared<standard_value<bool>>(*this);
   }
 
-  private:
-
-  void
-  set_default_and_implicit()
-  {
+private:
+  void set_default_and_implicit() {
     m_default = true;
     m_default_value = "false";
     m_implicit = true;
@@ -1337,113 +1023,64 @@ class standard_value<bool> : public abstract_value<bool>
 } // namespace values
 
 template <typename T>
-std::shared_ptr<Value>
-value()
-{
+std::shared_ptr<Value> value() {
   return std::make_shared<values::standard_value<T>>();
 }
 
 template <typename T>
-std::shared_ptr<Value>
-value(T& t)
-{
+std::shared_ptr<Value> value(T &t) {
   return std::make_shared<values::standard_value<T>>(&t);
 }
 
 class OptionAdder;
 
 CXXOPTS_NODISCARD
-inline
-const std::string&
-first_or_empty(const OptionNames& long_names)
-{
+inline const std::string &first_or_empty(const OptionNames &long_names) {
   static const std::string empty{""};
   return long_names.empty() ? empty : long_names.front();
 }
 
-class OptionDetails
-{
-  public:
-  OptionDetails
-  (
-    std::string short_,
-    OptionNames long_,
-    String desc,
-    std::shared_ptr<const Value> val
-  )
-  : m_short(std::move(short_))
-  , m_long(std::move(long_))
-  , m_desc(std::move(desc))
-  , m_value(std::move(val))
-  , m_count(0)
-  {
+class OptionDetails {
+public:
+  OptionDetails(std::string short_, OptionNames long_, String desc,
+                std::shared_ptr<const Value> val)
+      : m_short(std::move(short_)), m_long(std::move(long_)),
+        m_desc(std::move(desc)), m_value(std::move(val)), m_count(0) {
     m_hash = std::hash<std::string>{}(first_long_name() + m_short);
   }
 
-  OptionDetails(const OptionDetails& rhs)
-  : m_desc(rhs.m_desc)
-  , m_value(rhs.m_value->clone())
-  , m_count(rhs.m_count)
-  {
-  }
+  OptionDetails(const OptionDetails &rhs)
+      : m_desc(rhs.m_desc), m_value(rhs.m_value->clone()),
+        m_count(rhs.m_count) {}
 
-  OptionDetails(OptionDetails&& rhs) = default;
+  OptionDetails(OptionDetails &&rhs) = default;
 
   CXXOPTS_NODISCARD
-  const String&
-  description() const
-  {
-    return m_desc;
-  }
+  const String &description() const { return m_desc; }
 
   CXXOPTS_NODISCARD
-  const Value&
-  value() const {
-      return *m_value;
-  }
+  const Value &value() const { return *m_value; }
 
   CXXOPTS_NODISCARD
-  std::shared_ptr<Value>
-  make_storage() const
-  {
-    return m_value->clone();
-  }
+  std::shared_ptr<Value> make_storage() const { return m_value->clone(); }
 
   CXXOPTS_NODISCARD
-  const std::string&
-  short_name() const
-  {
-    return m_short;
-  }
+  const std::string &short_name() const { return m_short; }
 
   CXXOPTS_NODISCARD
-  const std::string&
-  first_long_name() const
-  {
-    return first_or_empty(m_long);
-  }
+  const std::string &first_long_name() const { return first_or_empty(m_long); }
 
   CXXOPTS_NODISCARD
-  const std::string&
-  essential_name() const
-  {
+  const std::string &essential_name() const {
     return m_long.empty() ? m_short : m_long.front();
   }
 
   CXXOPTS_NODISCARD
-  const OptionNames &
-  long_names() const
-  {
-    return m_long;
-  }
+  const OptionNames &long_names() const { return m_long; }
 
-  std::size_t
-  hash() const
-  {
-    return m_hash;
-  }
+  std::size_t hash() const { return m_hash; }
 
-  private:
+private:
   std::string m_short{};
   OptionNames m_long{};
   String m_desc{};
@@ -1453,8 +1090,7 @@ class OptionDetails
   std::size_t m_hash{};
 };
 
-struct HelpOptionDetails
-{
+struct HelpOptionDetails {
   std::string s;
   OptionNames l;
   String desc;
@@ -1467,98 +1103,70 @@ struct HelpOptionDetails
   bool is_boolean;
 };
 
-struct HelpGroupDetails
-{
+struct HelpGroupDetails {
   std::string name{};
   std::string description{};
   std::vector<HelpOptionDetails> options{};
 };
 
-class OptionValue
-{
-  public:
-  void
-  add
-  (
-    const std::shared_ptr<const OptionDetails>& details,
-    const std::string& text
-  )
-  {
+class OptionValue {
+public:
+  void add(const std::shared_ptr<const OptionDetails> &details,
+           const std::string &text) {
     ensure_value(details);
     ++m_count;
     m_value->add(text);
     m_long_names = &details->long_names();
   }
 
-  void
-  parse
-  (
-    const std::shared_ptr<const OptionDetails>& details,
-    const std::string& text
-  )
-  {
+  void parse(const std::shared_ptr<const OptionDetails> &details,
+             const std::string &text) {
     ensure_value(details);
     ++m_count;
     m_value->parse(text);
     m_long_names = &details->long_names();
   }
 
-  void
-  parse_default(const std::shared_ptr<const OptionDetails>& details)
-  {
+  void parse_default(const std::shared_ptr<const OptionDetails> &details) {
     ensure_value(details);
     m_default = true;
     m_long_names = &details->long_names();
     m_value->parse();
   }
 
-  void
-  parse_no_value(const std::shared_ptr<const OptionDetails>& details)
-  {
+  void parse_no_value(const std::shared_ptr<const OptionDetails> &details) {
     m_long_names = &details->long_names();
   }
 
 #if defined(CXXOPTS_NULL_DEREF_IGNORE)
-CXXOPTS_DIAGNOSTIC_PUSH
-CXXOPTS_IGNORE_WARNING("-Wnull-dereference")
+  CXXOPTS_DIAGNOSTIC_PUSH
+  CXXOPTS_IGNORE_WARNING("-Wnull-dereference")
 #endif
 
   CXXOPTS_NODISCARD
-  std::size_t
-  count() const noexcept
-  {
-    return m_count;
-  }
+  std::size_t count() const noexcept { return m_count; }
 
 #if defined(CXXOPTS_NULL_DEREF_IGNORE)
-CXXOPTS_DIAGNOSTIC_POP
+  CXXOPTS_DIAGNOSTIC_POP
 #endif
 
   // TODO: maybe default options should count towards the number of arguments
   CXXOPTS_NODISCARD
-  bool
-  has_default() const noexcept
-  {
-    return m_default;
-  }
+  bool has_default() const noexcept { return m_default; }
 
   template <typename T>
-  const T&
-  as() const
-  {
+  const T &as() const {
     if (m_value == nullptr) {
-        throw_or_mimic<exceptions::option_has_no_value>(
-            m_long_names == nullptr ? "" : first_or_empty(*m_long_names));
+      throw_or_mimic<exceptions::option_has_no_value>(
+          m_long_names == nullptr ? "" : first_or_empty(*m_long_names));
     }
 
-    return CXXOPTS_RTTI_CAST<const values::standard_value<T>&>(*m_value).get();
+    return CXXOPTS_RTTI_CAST<const values::standard_value<T> &>(*m_value).get();
   }
 
 #ifdef CXXOPTS_HAS_OPTIONAL
   template <typename T>
-  std::optional<T>
-  as_optional() const
-  {
+  std::optional<T> as_optional() const {
     if (m_value == nullptr) {
       return std::nullopt;
     }
@@ -1566,58 +1174,40 @@ CXXOPTS_DIAGNOSTIC_POP
   }
 #endif
 
-  private:
-  void
-  ensure_value(const std::shared_ptr<const OptionDetails>& details)
-  {
-    if (m_value == nullptr)
-    {
+private:
+  void ensure_value(const std::shared_ptr<const OptionDetails> &details) {
+    if (m_value == nullptr) {
       m_value = details->make_storage();
     }
   }
 
-
-  const OptionNames * m_long_names = nullptr;
-  // Holding this pointer is safe, since OptionValue's only exist in key-value pairs,
-  // where the key has the string we point to.
+  const OptionNames *m_long_names = nullptr;
+  // Holding this pointer is safe, since OptionValue's only exist in key-value
+  // pairs, where the key has the string we point to.
   std::shared_ptr<Value> m_value{};
   std::size_t m_count = 0;
   bool m_default = false;
 };
 
-class KeyValue
-{
-  public:
+class KeyValue {
+public:
   KeyValue(std::string key_, std::string value_) noexcept
-  : m_key(std::move(key_))
-  , m_value(std::move(value_))
-  {
-  }
+      : m_key(std::move(key_)), m_value(std::move(value_)) {}
 
   CXXOPTS_NODISCARD
-  const std::string&
-  key() const
-  {
-    return m_key;
-  }
+  const std::string &key() const { return m_key; }
 
   CXXOPTS_NODISCARD
-  const std::string&
-  value() const
-  {
-    return m_value;
-  }
+  const std::string &value() const { return m_value; }
 
   template <typename T>
-  T
-  as() const
-  {
+  T as() const {
     T result;
     values::parse_value(m_value, result);
     return result;
   }
 
-  private:
+private:
   std::string m_key;
   std::string m_value;
 };
@@ -1625,52 +1215,42 @@ class KeyValue
 using ParsedHashMap = std::unordered_map<std::size_t, OptionValue>;
 using NameHashMap = std::unordered_map<std::string, std::size_t>;
 
-class ParseResult
-{
+class ParseResult {
+public:
+  class Iterator {
   public:
-  class Iterator
-  {
-    public:
     using iterator_category = std::forward_iterator_tag;
     using value_type = KeyValue;
     using difference_type = void;
-    using pointer = const KeyValue*;
-    using reference = const KeyValue&;
+    using pointer = const KeyValue *;
+    using reference = const KeyValue &;
 
     Iterator() = default;
-    Iterator(const Iterator&) = default;
+    Iterator(const Iterator &) = default;
 
-// GCC complains about m_iter not being initialised in the member
-// initializer list
-CXXOPTS_DIAGNOSTIC_PUSH
-CXXOPTS_IGNORE_WARNING("-Weffc++")
-    Iterator(const ParseResult *pr, bool end=false)
-    : m_pr(pr)
-    {
-      if (end)
-      {
+    // GCC complains about m_iter not being initialised in the member
+    // initializer list
+    CXXOPTS_DIAGNOSTIC_PUSH
+    CXXOPTS_IGNORE_WARNING("-Weffc++")
+    Iterator(const ParseResult *pr, bool end = false) : m_pr(pr) {
+      if (end) {
         m_sequential = false;
         m_iter = m_pr->m_defaults.end();
-      }
-      else
-      {
+      } else {
         m_sequential = true;
         m_iter = m_pr->m_sequential.begin();
 
-        if (m_iter == m_pr->m_sequential.end())
-        {
+        if (m_iter == m_pr->m_sequential.end()) {
           m_sequential = false;
           m_iter = m_pr->m_defaults.begin();
         }
       }
     }
-CXXOPTS_DIAGNOSTIC_POP
+    CXXOPTS_DIAGNOSTIC_POP
 
-    Iterator& operator++()
-    {
+    Iterator &operator++() {
       ++m_iter;
-      if(m_sequential && m_iter == m_pr->m_sequential.end())
-      {
+      if (m_sequential && m_iter == m_pr->m_sequential.end()) {
         m_sequential = false;
         m_iter = m_pr->m_defaults.begin();
         return *this;
@@ -1678,106 +1258,76 @@ CXXOPTS_DIAGNOSTIC_POP
       return *this;
     }
 
-    Iterator operator++(int)
-    {
+    Iterator operator++(int) {
       Iterator retval = *this;
       ++(*this);
       return retval;
     }
 
-    bool operator==(const Iterator& other) const
-    {
+    bool operator==(const Iterator &other) const {
       return (m_sequential == other.m_sequential) && (m_iter == other.m_iter);
     }
 
-    bool operator!=(const Iterator& other) const
-    {
-      return !(*this == other);
-    }
+    bool operator!=(const Iterator &other) const { return !(*this == other); }
 
-    const KeyValue& operator*()
-    {
-      return *m_iter;
-    }
+    const KeyValue &operator*() { return *m_iter; }
 
-    const KeyValue* operator->()
-    {
-      return m_iter.operator->();
-    }
+    const KeyValue *operator->() { return m_iter.operator->(); }
 
-    private:
-    const ParseResult* m_pr;
+  private:
+    const ParseResult *m_pr;
     std::vector<KeyValue>::const_iterator m_iter;
     bool m_sequential = true;
   };
 
   ParseResult() = default;
-  ParseResult(const ParseResult&) = default;
+  ParseResult(const ParseResult &) = default;
 
-  ParseResult(NameHashMap&& keys, ParsedHashMap&& values, std::vector<KeyValue> sequential,
-          std::vector<KeyValue> default_opts, std::vector<std::string>&& unmatched_args)
-  : m_keys(std::move(keys))
-  , m_values(std::move(values))
-  , m_sequential(std::move(sequential))
-  , m_defaults(std::move(default_opts))
-  , m_unmatched(std::move(unmatched_args))
-  {
-  }
+  ParseResult(NameHashMap &&keys, ParsedHashMap &&values,
+              std::vector<KeyValue> sequential,
+              std::vector<KeyValue> default_opts,
+              std::vector<std::string> &&unmatched_args)
+      : m_keys(std::move(keys)), m_values(std::move(values)),
+        m_sequential(std::move(sequential)),
+        m_defaults(std::move(default_opts)),
+        m_unmatched(std::move(unmatched_args)) {}
 
-  ParseResult& operator=(ParseResult&&) = default;
-  ParseResult& operator=(const ParseResult&) = default;
+  ParseResult &operator=(ParseResult &&) = default;
+  ParseResult &operator=(const ParseResult &) = default;
 
-  Iterator
-  begin() const
-  {
-    return Iterator(this);
-  }
+  Iterator begin() const { return Iterator(this); }
 
-  Iterator
-  end() const
-  {
-    return Iterator(this, true);
-  }
+  Iterator end() const { return Iterator(this, true); }
 
-  std::size_t
-  count(const std::string& o) const
-  {
+  std::size_t count(const std::string &o) const {
     auto iter = m_keys.find(o);
-    if (iter == m_keys.end())
-    {
+    if (iter == m_keys.end()) {
       return 0;
     }
 
     auto viter = m_values.find(iter->second);
 
-    if (viter == m_values.end())
-    {
+    if (viter == m_values.end()) {
       return 0;
     }
 
     return viter->second.count();
   }
 
-  bool
-  contains(const std::string& o) const
-  {
+  bool contains(const std::string &o) const {
     return static_cast<bool>(count(o));
   }
 
-  const OptionValue&
-  operator[](const std::string& option) const
-  {
+  const OptionValue &operator[](const std::string &option) const {
     auto iter = m_keys.find(option);
 
-    if (iter == m_keys.end())
-    {
+    if (iter == m_keys.end()) {
       throw_or_mimic<exceptions::requested_option_not_present>(option);
     }
 
     auto viter = m_values.find(iter->second);
 
-    if (viter == m_values.end())
-    {
+    if (viter == m_values.end()) {
       throw_or_mimic<exceptions::requested_option_not_present>(option);
     }
 
@@ -1786,15 +1336,11 @@ CXXOPTS_DIAGNOSTIC_POP
 
 #ifdef CXXOPTS_HAS_OPTIONAL
   template <typename T>
-  std::optional<T>
-  as_optional(const std::string& option) const
-  {
+  std::optional<T> as_optional(const std::string &option) const {
     auto iter = m_keys.find(option);
-    if (iter != m_keys.end())
-    {
+    if (iter != m_keys.end()) {
       auto viter = m_values.find(iter->second);
-      if (viter != m_values.end())
-      {
+      if (viter != m_values.end()) {
         return viter->second.as_optional<T>();
       }
     }
@@ -1802,40 +1348,24 @@ CXXOPTS_DIAGNOSTIC_POP
   }
 #endif
 
-  const std::vector<KeyValue>&
-  arguments() const
-  {
-    return m_sequential;
-  }
+  const std::vector<KeyValue> &arguments() const { return m_sequential; }
 
-  const std::vector<std::string>&
-  unmatched() const
-  {
-    return m_unmatched;
-  }
+  const std::vector<std::string> &unmatched() const { return m_unmatched; }
 
-  const std::vector<KeyValue>&
-  defaults() const
-  {
-    return m_defaults;
-  }
+  const std::vector<KeyValue> &defaults() const { return m_defaults; }
 
-  const std::string
-  arguments_string() const
-  {
+  const std::string arguments_string() const {
     std::string result;
-    for(const auto& kv: m_sequential)
-    {
+    for (const auto &kv : m_sequential) {
       result += kv.key() + " = " + kv.value() + "\n";
     }
-    for(const auto& kv: m_defaults)
-    {
+    for (const auto &kv : m_defaults) {
       result += kv.key() + " = " + kv.value() + " " + "(default)" + "\n";
     }
     return result;
   }
 
-  private:
+private:
   NameHashMap m_keys{};
   ParsedHashMap m_values{};
   std::vector<KeyValue> m_sequential{};
@@ -1843,21 +1373,12 @@ CXXOPTS_DIAGNOSTIC_POP
   std::vector<std::string> m_unmatched{};
 };
 
-struct Option
-{
-  Option
-  (
-    std::string opts,
-    std::string desc,
-    std::shared_ptr<const Value>  value = ::cxxopts::value<bool>(),
-    std::string arg_help = ""
-  )
-  : opts_(std::move(opts))
-  , desc_(std::move(desc))
-  , value_(std::move(value))
-  , arg_help_(std::move(arg_help))
-  {
-  }
+struct Option {
+  Option(std::string opts, std::string desc,
+         std::shared_ptr<const Value> value = ::cxxopts::value<bool>(),
+         std::string arg_help = "")
+      : opts_(std::move(opts)), desc_(std::move(desc)),
+        value_(std::move(value)), arg_help_(std::move(arg_help)) {}
 
   std::string opts_;
   std::string desc_;
@@ -1865,59 +1386,41 @@ struct Option
   std::string arg_help_;
 };
 
-using OptionMap = std::unordered_map<std::string, std::shared_ptr<OptionDetails>>;
+using OptionMap =
+    std::unordered_map<std::string, std::shared_ptr<OptionDetails>>;
 using PositionalList = std::vector<std::string>;
 using PositionalListIterator = PositionalList::const_iterator;
 
-class OptionParser
-{
-  public:
-  OptionParser(const OptionMap& options, const PositionalList& positional, bool allow_unrecognised)
-  : m_options(options)
-  , m_positional(positional)
-  , m_allow_unrecognised(allow_unrecognised)
-  {
-  }
+class OptionParser {
+public:
+  OptionParser(const OptionMap &options, const PositionalList &positional,
+               bool allow_unrecognised)
+      : m_options(options), m_positional(positional),
+        m_allow_unrecognised(allow_unrecognised) {}
 
-  ParseResult
-  parse(int argc, const char* const* argv);
+  ParseResult parse(int argc, const char *const *argv);
 
-  bool
-  consume_positional(const std::string& a, PositionalListIterator& next);
+  bool consume_positional(const std::string &a, PositionalListIterator &next);
 
-  void
-  checked_parse_arg
-  (
-    int argc,
-    const char* const* argv,
-    int& current,
-    const std::shared_ptr<OptionDetails>& value,
-    const std::string& name
-  );
+  void checked_parse_arg(int argc, const char *const *argv, int &current,
+                         const std::shared_ptr<OptionDetails> &value,
+                         const std::string &name);
 
-  void
-  add_to_option(const std::shared_ptr<OptionDetails>& value, const std::string& arg);
+  void add_to_option(const std::shared_ptr<OptionDetails> &value,
+                     const std::string &arg);
 
-  void
-  parse_option
-  (
-    const std::shared_ptr<OptionDetails>& value,
-    const std::string& name,
-    const std::string& arg = ""
-  );
+  void parse_option(const std::shared_ptr<OptionDetails> &value,
+                    const std::string &name, const std::string &arg = "");
 
-  void
-  parse_default(const std::shared_ptr<OptionDetails>& details);
+  void parse_default(const std::shared_ptr<OptionDetails> &details);
 
-  void
-  parse_no_value(const std::shared_ptr<OptionDetails>& details);
+  void parse_no_value(const std::shared_ptr<OptionDetails> &details);
 
-  private:
-
+private:
   void finalise_aliases();
 
-  const OptionMap& m_options;
-  const PositionalList& m_positional;
+  const OptionMap &m_options;
+  const PositionalList &m_positional;
 
   std::vector<KeyValue> m_sequential{};
   std::vector<KeyValue> m_defaults{};
@@ -1927,163 +1430,100 @@ class OptionParser
   NameHashMap m_keys{};
 };
 
-class Options
-{
-  public:
-
+class Options {
+public:
   explicit Options(std::string program_name, std::string help_string = "")
-  : m_program(std::move(program_name))
-  , m_help_string(toLocalString(std::move(help_string)))
-  , m_custom_help("[OPTION...]")
-  , m_positional_help("positional parameters")
-  , m_show_positional(false)
-  , m_allow_unrecognised(false)
-  , m_width(76)
-  , m_tab_expansion(false)
-  , m_options(std::make_shared<OptionMap>())
-  {
-  }
+      : m_program(std::move(program_name)),
+        m_help_string(toLocalString(std::move(help_string))),
+        m_custom_help("[OPTION...]"),
+        m_positional_help("positional parameters"), m_show_positional(false),
+        m_allow_unrecognised(false), m_width(76), m_tab_expansion(false),
+        m_options(std::make_shared<OptionMap>()) {}
 
-  Options&
-  positional_help(std::string help_text)
-  {
+  Options &positional_help(std::string help_text) {
     m_positional_help = std::move(help_text);
     return *this;
   }
 
-  Options&
-  custom_help(std::string help_text)
-  {
+  Options &custom_help(std::string help_text) {
     m_custom_help = std::move(help_text);
     return *this;
   }
 
-  Options&
-  show_positional_help()
-  {
+  Options &show_positional_help() {
     m_show_positional = true;
     return *this;
   }
 
-  Options&
-  allow_unrecognised_options()
-  {
+  Options &allow_unrecognised_options() {
     m_allow_unrecognised = true;
     return *this;
   }
 
-  Options&
-  set_width(std::size_t width)
-  {
+  Options &set_width(std::size_t width) {
     m_width = width;
     return *this;
   }
 
-  Options&
-  set_tab_expansion(bool expansion=true)
-  {
+  Options &set_tab_expansion(bool expansion = true) {
     m_tab_expansion = expansion;
     return *this;
   }
 
-  ParseResult
-  parse(int argc, const char* const* argv);
+  ParseResult parse(int argc, const char *const *argv);
 
-  OptionAdder
-  add_options(std::string group = "");
+  OptionAdder add_options(std::string group = "");
 
-  void
-  add_options
-  (
-    const std::string& group,
-    std::initializer_list<Option> options
-  );
+  void add_options(const std::string &group,
+                   std::initializer_list<Option> options);
 
-  void
-  add_option
-  (
-    const std::string& group,
-    const Option& option
-  );
+  void add_option(const std::string &group, const Option &option);
 
-  void
-  add_option
-  (
-    const std::string& group,
-    const std::string& s,
-    const OptionNames& l,
-    std::string desc,
-    const std::shared_ptr<const Value>& value,
-    std::string arg_help
-  );
+  void add_option(const std::string &group, const std::string &s,
+                  const OptionNames &l, std::string desc,
+                  const std::shared_ptr<const Value> &value,
+                  std::string arg_help);
 
-  void
-  add_option
-  (
-    const std::string& group,
-    const std::string& short_name,
-    const std::string& single_long_name,
-    std::string desc,
-    const std::shared_ptr<const Value>& value,
-    std::string arg_help
-  )
-  {
+  void add_option(const std::string &group, const std::string &short_name,
+                  const std::string &single_long_name, std::string desc,
+                  const std::shared_ptr<const Value> &value,
+                  std::string arg_help) {
     OptionNames long_names;
     long_names.emplace_back(single_long_name);
     add_option(group, short_name, long_names, desc, value, arg_help);
   }
 
-  //parse positional arguments into the given option
-  void
-  parse_positional(std::string option);
+  // parse positional arguments into the given option
+  void parse_positional(std::string option);
 
-  void
-  parse_positional(std::vector<std::string> options);
+  void parse_positional(std::vector<std::string> options);
 
-  void
-  parse_positional(std::initializer_list<std::string> options);
+  void parse_positional(std::initializer_list<std::string> options);
 
   template <typename Iterator>
-  void
-  parse_positional(Iterator begin, Iterator end) {
+  void parse_positional(Iterator begin, Iterator end) {
     parse_positional(std::vector<std::string>{begin, end});
   }
 
-  std::string
-  help(const std::vector<std::string>& groups = {}, bool print_usage=true) const;
+  std::string help(const std::vector<std::string> &groups = {},
+                   bool print_usage = true) const;
 
-  std::vector<std::string>
-  groups() const;
+  std::vector<std::string> groups() const;
 
-  const HelpGroupDetails&
-  group_help(const std::string& group) const;
+  const HelpGroupDetails &group_help(const std::string &group) const;
 
-  const std::string& program() const
-  {
-    return m_program;
-  }
+  const std::string &program() const { return m_program; }
 
-  private:
+private:
+  void add_one_option(const std::string &option,
+                      const std::shared_ptr<OptionDetails> &details);
 
-  void
-  add_one_option
-  (
-    const std::string& option,
-    const std::shared_ptr<OptionDetails>& details
-  );
+  String help_one_group(const std::string &group) const;
 
-  String
-  help_one_group(const std::string& group) const;
+  void generate_group_help(String &result,
+                           const std::vector<std::string> &groups) const;
 
-  void
-  generate_group_help
-  (
-    String& result,
-    const std::vector<std::string>& groups
-  ) const;
-
-  void
-  generate_all_groups_help(String& result) const;
+  void generate_all_groups_help(String &result) const;
 
   std::string m_program{};
   String m_help_string{};
@@ -2098,32 +1538,23 @@ class Options
   std::vector<std::string> m_positional{};
   std::unordered_set<std::string> m_positional_set{};
 
-  //mapping from groups to help options
+  // mapping from groups to help options
   std::vector<std::string> m_group{};
   std::map<std::string, HelpGroupDetails> m_help{};
 };
 
-class OptionAdder
-{
-  public:
+class OptionAdder {
+public:
+  OptionAdder(Options &options, std::string group)
+      : m_options(options), m_group(std::move(group)) {}
 
-  OptionAdder(Options& options, std::string group)
-  : m_options(options), m_group(std::move(group))
-  {
-  }
+  OptionAdder &operator()(
+      const std::string &opts, const std::string &desc,
+      const std::shared_ptr<const Value> &value = ::cxxopts::value<bool>(),
+      std::string arg_help = "");
 
-  OptionAdder&
-  operator()
-  (
-    const std::string& opts,
-    const std::string& desc,
-    const std::shared_ptr<const Value>& value
-      = ::cxxopts::value<bool>(),
-    std::string arg_help = ""
-  );
-
-  private:
-  Options& m_options;
+private:
+  Options &m_options;
   std::string m_group;
 };
 
@@ -2131,45 +1562,31 @@ namespace {
 constexpr std::size_t OPTION_LONGEST = 30;
 constexpr std::size_t OPTION_DESC_GAP = 2;
 
-String
-format_option
-(
-  const HelpOptionDetails& o
-)
-{
-  const auto& s = o.s;
-  const auto& l = first_or_empty(o.l);
+String format_option(const HelpOptionDetails &o) {
+  const auto &s = o.s;
+  const auto &l = first_or_empty(o.l);
 
   String result = "  ";
 
-  if (!s.empty())
-  {
+  if (!s.empty()) {
     result += "-" + toLocalString(s);
-    if (!l.empty())
-    {
+    if (!l.empty()) {
       result += ",";
     }
-  }
-  else
-  {
+  } else {
     result += "   ";
   }
 
-  if (!l.empty())
-  {
+  if (!l.empty()) {
     result += " --" + toLocalString(l);
   }
 
   auto arg = !o.arg_help.empty() ? toLocalString(o.arg_help) : "arg";
 
-  if (!o.is_boolean)
-  {
-    if (o.has_implicit)
-    {
+  if (!o.is_boolean) {
+    if (o.has_implicit) {
       result += " [=" + arg + "(=" + toLocalString(o.implicit_value) + ")]";
-    }
-    else
-    {
+    } else {
       result += " " + arg;
     }
   }
@@ -2177,50 +1594,32 @@ format_option
   return result;
 }
 
-String
-format_description
-(
-  const HelpOptionDetails& o,
-  std::size_t start,
-  std::size_t allowed,
-  bool tab_expansion
-)
-{
+String format_description(const HelpOptionDetails &o, std::size_t start,
+                          std::size_t allowed, bool tab_expansion) {
   auto desc = o.desc;
 
-  if (o.has_default && (!o.is_boolean || o.default_value != "false"))
-  {
-    if(!o.default_value.empty())
-    {
+  if (o.has_default && (!o.is_boolean || o.default_value != "false")) {
+    if (!o.default_value.empty()) {
       desc += toLocalString(" (default: " + o.default_value + ")");
-    }
-    else
-    {
+    } else {
       desc += toLocalString(" (default: \"\")");
     }
   }
 
   String result;
 
-  if (tab_expansion)
-  {
+  if (tab_expansion) {
     String desc2;
-    auto size = std::size_t{ 0 };
-    for (auto c = std::begin(desc); c != std::end(desc); ++c)
-    {
-      if (*c == '\n')
-      {
+    auto size = std::size_t{0};
+    for (auto c = std::begin(desc); c != std::end(desc); ++c) {
+      if (*c == '\n') {
         desc2 += *c;
         size = 0;
-      }
-      else if (*c == '\t')
-      {
+      } else if (*c == '\t') {
         auto skip = 8 - size % 8;
         stringAppend(desc2, skip, ' ');
         size += skip;
-      }
-      else
-      {
+      } else {
         desc2 += *c;
         ++size;
       }
@@ -2240,50 +1639,41 @@ format_description
   bool appendNewLine;
   bool onlyWhiteSpace = true;
 
-  while (current != std::end(desc))
-  {
+  while (current != std::end(desc)) {
     appendNewLine = false;
-    if (*previous == ' ' || *previous == '\t')
-    {
+    if (*previous == ' ' || *previous == '\t') {
       lastSpace = current;
     }
-    if (*current != ' ' && *current != '\t')
-    {
+    if (*current != ' ' && *current != '\t') {
       onlyWhiteSpace = false;
     }
 
-    while (*current == '\n')
-    {
+    while (*current == '\n') {
       previous = current;
       ++current;
       appendNewLine = true;
     }
 
-    if (!appendNewLine && size >= allowed)
-    {
-      if (lastSpace != startLine)
-      {
+    if (!appendNewLine && size >= allowed) {
+      if (lastSpace != startLine) {
         current = lastSpace;
         previous = current;
       }
       appendNewLine = true;
     }
 
-    if (appendNewLine)
-    {
+    if (appendNewLine) {
       stringAppend(result, startLine, current);
       startLine = current;
       lastSpace = current;
 
-      if (*previous != '\n')
-      {
+      if (*previous != '\n') {
         stringAppend(result, "\n");
       }
 
       stringAppend(result, start, ' ');
 
-      if (*previous != '\n')
-      {
+      if (*previous != '\n') {
         stringAppend(result, lastSpace, current);
       }
 
@@ -2296,9 +1686,8 @@ format_description
     ++size;
   }
 
-  //append whatever is left but ignore whitespace
-  if (!onlyWhiteSpace)
-  {
+  // append whatever is left but ignore whitespace
+  if (!onlyWhiteSpace) {
     stringAppend(result, startLine, previous);
   }
 
@@ -2307,48 +1696,31 @@ format_description
 
 } // namespace
 
-inline
-void
-Options::add_options
-(
-  const std::string &group,
-  std::initializer_list<Option> options
-)
-{
- OptionAdder option_adder(*this, group);
- for (const auto &option: options)
- {
-   option_adder(option.opts_, option.desc_, option.value_, option.arg_help_);
- }
+inline void Options::add_options(const std::string &group,
+                                 std::initializer_list<Option> options) {
+  OptionAdder option_adder(*this, group);
+  for (const auto &option : options) {
+    option_adder(option.opts_, option.desc_, option.value_, option.arg_help_);
+  }
 }
 
-inline
-OptionAdder
-Options::add_options(std::string group)
-{
+inline OptionAdder Options::add_options(std::string group) {
   return OptionAdder(*this, std::move(group));
 }
 
-inline
-OptionAdder&
-OptionAdder::operator()
-(
-  const std::string& opts,
-  const std::string& desc,
-  const std::shared_ptr<const Value>& value,
-  std::string arg_help
-)
-{
+inline OptionAdder &
+OptionAdder::operator()(const std::string &opts, const std::string &desc,
+                        const std::shared_ptr<const Value> &value,
+                        std::string arg_help) {
   OptionNames option_names = values::parser_tool::split_option_names(opts);
-    // Note: All names will be non-empty; but we must separate the short
-    // (length-1) and longer names
-  std::string short_name {""};
-  auto first_short_name_iter =
-    std::partition(option_names.begin(), option_names.end(),
-      [&](const std::string& name) { return name.length() > 1; }
-    );
+  // Note: All names will be non-empty; but we must separate the short
+  // (length-1) and longer names
+  std::string short_name{""};
+  auto first_short_name_iter = std::partition(
+      option_names.begin(), option_names.end(),
+      [&](const std::string &name) { return name.length() > 1; });
   auto num_length_1_names = (option_names.end() - first_short_name_iter);
-  switch(num_length_1_names) {
+  switch (num_length_1_names) {
   case 1:
     short_name = *first_short_name_iter;
     option_names.erase(first_short_name_iter);
@@ -2359,114 +1731,76 @@ OptionAdder::operator()
     throw_or_mimic<exceptions::invalid_option_format>(opts);
   };
 
-  m_options.add_option
-  (
-    m_group,
-    short_name,
-    option_names,
-    desc,
-    value,
-    std::move(arg_help)
-  );
+  m_options.add_option(m_group, short_name, option_names, desc, value,
+                       std::move(arg_help));
 
   return *this;
 }
 
-inline
-void
-OptionParser::parse_default(const std::shared_ptr<OptionDetails>& details)
-{
+inline void
+OptionParser::parse_default(const std::shared_ptr<OptionDetails> &details) {
   // TODO: remove the duplicate code here
-  auto& store = m_parsed[details->hash()];
+  auto &store = m_parsed[details->hash()];
   store.parse_default(details);
-  m_defaults.emplace_back(details->essential_name(), details->value().get_default_value());
+  m_defaults.emplace_back(details->essential_name(),
+                          details->value().get_default_value());
 }
 
-inline
-void
-OptionParser::parse_no_value(const std::shared_ptr<OptionDetails>& details)
-{
-  auto& store = m_parsed[details->hash()];
+inline void
+OptionParser::parse_no_value(const std::shared_ptr<OptionDetails> &details) {
+  auto &store = m_parsed[details->hash()];
   store.parse_no_value(details);
 }
 
-inline
-void
-OptionParser::parse_option
-(
-  const std::shared_ptr<OptionDetails>& value,
-  const std::string& /*name*/,
-  const std::string& arg
-)
-{
+inline void
+OptionParser::parse_option(const std::shared_ptr<OptionDetails> &value,
+                           const std::string & /*name*/,
+                           const std::string &arg) {
   auto hash = value->hash();
-  auto& result = m_parsed[hash];
+  auto &result = m_parsed[hash];
   result.parse(value, arg);
 
   m_sequential.emplace_back(value->essential_name(), arg);
 }
 
-inline
-void
-OptionParser::checked_parse_arg
-(
-  int argc,
-  const char* const* argv,
-  int& current,
-  const std::shared_ptr<OptionDetails>& value,
-  const std::string& name
-)
-{
-  if (current + 1 >= argc)
-  {
-    if (value->value().has_implicit())
-    {
+inline void
+OptionParser::checked_parse_arg(int argc, const char *const *argv, int &current,
+                                const std::shared_ptr<OptionDetails> &value,
+                                const std::string &name) {
+  if (current + 1 >= argc) {
+    if (value->value().has_implicit()) {
       parse_option(value, name, value->value().get_implicit_value());
-    }
-    else
-    {
+    } else {
       throw_or_mimic<exceptions::missing_argument>(name);
     }
-  }
-  else
-  {
-    if (value->value().has_implicit())
-    {
+  } else {
+    if (value->value().has_implicit()) {
       parse_option(value, name, value->value().get_implicit_value());
-    }
-    else
-    {
+    } else {
       parse_option(value, name, argv[current + 1]);
       ++current;
     }
   }
 }
 
-inline
-void
-OptionParser::add_to_option(const std::shared_ptr<OptionDetails>& value, const std::string& arg)
-{
+inline void
+OptionParser::add_to_option(const std::shared_ptr<OptionDetails> &value,
+                            const std::string &arg) {
   auto hash = value->hash();
-  auto& result = m_parsed[hash];
+  auto &result = m_parsed[hash];
   result.add(value, arg);
 
   m_sequential.emplace_back(value->essential_name(), arg);
 }
 
-inline
-bool
-OptionParser::consume_positional(const std::string& a, PositionalListIterator& next)
-{
-  while (next != m_positional.end())
-  {
+inline bool OptionParser::consume_positional(const std::string &a,
+                                             PositionalListIterator &next) {
+  while (next != m_positional.end()) {
     auto iter = m_options.find(*next);
-    if (iter != m_options.end())
-    {
-      if (!iter->second->value().is_container())
-      {
-        auto& result = m_parsed[iter->second->hash()];
-        if (result.count() == 0)
-        {
+    if (iter != m_options.end()) {
+      if (!iter->second->value().is_container()) {
+        auto &result = m_parsed[iter->second->hash()];
+        if (result.count() == 0) {
           add_to_option(iter->second, a);
           ++next;
           return true;
@@ -2483,51 +1817,36 @@ OptionParser::consume_positional(const std::string& a, PositionalListIterator& n
   return false;
 }
 
-inline
-void
-Options::parse_positional(std::string option)
-{
+inline void Options::parse_positional(std::string option) {
   parse_positional(std::vector<std::string>{std::move(option)});
 }
 
-inline
-void
-Options::parse_positional(std::vector<std::string> options)
-{
+inline void Options::parse_positional(std::vector<std::string> options) {
   m_positional = std::move(options);
 
   m_positional_set.insert(m_positional.begin(), m_positional.end());
 }
 
-inline
-void
-Options::parse_positional(std::initializer_list<std::string> options)
-{
+inline void
+Options::parse_positional(std::initializer_list<std::string> options) {
   parse_positional(std::vector<std::string>(options));
 }
 
-inline
-ParseResult
-Options::parse(int argc, const char* const* argv)
-{
+inline ParseResult Options::parse(int argc, const char *const *argv) {
   OptionParser parser(*m_options, m_positional, m_allow_unrecognised);
 
   return parser.parse(argc, argv);
 }
 
-inline ParseResult
-OptionParser::parse(int argc, const char* const* argv)
-{
+inline ParseResult OptionParser::parse(int argc, const char *const *argv) {
   int current = 1;
   bool consume_remaining = false;
   auto next_positional = m_positional.begin();
 
   std::vector<std::string> unmatched;
 
-  while (current != argc)
-  {
-    if (strcmp(argv[current], "--") == 0)
-    {
+  while (current != argc) {
+    if (strcmp(argv[current], "--") == 0) {
       consume_remaining = true;
       ++current;
       break;
@@ -2536,9 +1855,8 @@ OptionParser::parse(int argc, const char* const* argv)
     values::parser_tool::ArguDesc argu_desc =
         values::parser_tool::ParseArgument(argv[current], matched);
 
-    if (!matched)
-    {
-      //not a flag
+    if (!matched) {
+      // not a flag
 
       // but if it starts with a `-`, then it's an error
       if (argv[current][0] == '-' && argv[current][1] != '\0') {
@@ -2547,132 +1865,104 @@ OptionParser::parse(int argc, const char* const* argv)
         }
       }
 
-      //if true is returned here then it was consumed, otherwise it is
-      //ignored
-      if (consume_positional(argv[current], next_positional))
-      {
-      }
-      else
-      {
+      // if true is returned here then it was consumed, otherwise it is
+      // ignored
+      if (consume_positional(argv[current], next_positional)) {
+      } else {
         unmatched.emplace_back(argv[current]);
       }
-      //if we return from here then it was parsed successfully, so continue
-    }
-    else
-    {
-      //short or long option?
-      if (argu_desc.grouping)
-      {
-        const std::string& s = argu_desc.arg_name;
+      // if we return from here then it was parsed successfully, so continue
+    } else {
+      // short or long option?
+      if (argu_desc.grouping) {
+        const std::string &s = argu_desc.arg_name;
 
-        for (std::size_t i = 0; i != s.size(); ++i)
-        {
+        for (std::size_t i = 0; i != s.size(); ++i) {
           std::string name(1, s[i]);
           auto iter = m_options.find(name);
 
-          if (iter == m_options.end())
-          {
-            if (m_allow_unrecognised)
-            {
+          if (iter == m_options.end()) {
+            if (m_allow_unrecognised) {
               unmatched.push_back(std::string("-") + s[i]);
               continue;
             }
-            //error
+            // error
             throw_or_mimic<exceptions::no_such_option>(name);
           }
 
           auto value = iter->second;
 
-          if (i + 1 == s.size())
-          {
-            //it must be the last argument
+          if (i + 1 == s.size()) {
+            // it must be the last argument
             checked_parse_arg(argc, argv, current, value, name);
-          }
-          else if (value->value().has_implicit())
-          {
+          } else if (value->value().has_implicit()) {
             parse_option(value, name, value->value().get_implicit_value());
-          }
-          else if (i + 1 < s.size())
-          {
+          } else if (i + 1 < s.size()) {
             std::string arg_value = s.substr(i + 1);
             parse_option(value, name, arg_value);
             break;
-          }
-          else
-          {
-            //error
+          } else {
+            // error
             throw_or_mimic<exceptions::option_requires_argument>(name);
           }
         }
-      }
-      else if (argu_desc.arg_name.length() != 0)
-      {
-        const std::string& name = argu_desc.arg_name;
+      } else if (argu_desc.arg_name.length() != 0) {
+        const std::string &name = argu_desc.arg_name;
 
         auto iter = m_options.find(name);
 
-        if (iter == m_options.end())
-        {
-          if (m_allow_unrecognised)
-          {
+        if (iter == m_options.end()) {
+          if (m_allow_unrecognised) {
             // keep unrecognised options in argument list, skip to next argument
             unmatched.emplace_back(argv[current]);
             ++current;
             continue;
           }
-          //error
+          // error
           throw_or_mimic<exceptions::no_such_option>(name);
         }
 
         auto opt = iter->second;
 
-        //equals provided for long option?
-        if (argu_desc.set_value)
-        {
-          //parse the option given
+        // equals provided for long option?
+        if (argu_desc.set_value) {
+          // parse the option given
 
           parse_option(opt, name, argu_desc.value);
-        }
-        else
-        {
-          //parse the next argument
+        } else {
+          // parse the next argument
           checked_parse_arg(argc, argv, current, opt, name);
         }
       }
-
     }
 
     ++current;
   }
 
-  for (auto& opt : m_options)
-  {
-    auto& detail = opt.second;
-    const auto& value = detail->value();
+  for (auto &opt : m_options) {
+    auto &detail = opt.second;
+    const auto &value = detail->value();
 
-    auto& store = m_parsed[detail->hash()];
+    auto &store = m_parsed[detail->hash()];
 
     if (value.has_default()) {
       if (!store.count() && !store.has_default()) {
         parse_default(detail);
       }
-    }
-    else {
+    } else {
       parse_no_value(detail);
     }
   }
 
-  if (consume_remaining)
-  {
-    while (current < argc)
-    {
+  if (consume_remaining) {
+    while (current < argc) {
       if (!consume_positional(argv[current], next_positional)) {
         break;
       }
       ++current;
     }
 
-    //adjust argv for any that couldn't be swallowed
+    // adjust argv for any that couldn't be swallowed
     while (current != argc) {
       unmatched.emplace_back(argv[current]);
       ++current;
@@ -2681,20 +1971,18 @@ OptionParser::parse(int argc, const char* const* argv)
 
   finalise_aliases();
 
-  ParseResult parsed(std::move(m_keys), std::move(m_parsed), std::move(m_sequential), std::move(m_defaults), std::move(unmatched));
+  ParseResult parsed(std::move(m_keys), std::move(m_parsed),
+                     std::move(m_sequential), std::move(m_defaults),
+                     std::move(unmatched));
   return parsed;
 }
 
-inline
-void
-OptionParser::finalise_aliases()
-{
-  for (auto& option: m_options)
-  {
-    auto& detail = *option.second;
+inline void OptionParser::finalise_aliases() {
+  for (auto &option : m_options) {
+    auto &detail = *option.second;
     auto hash = detail.hash();
     m_keys[detail.short_name()] = hash;
-    for(const auto& long_name : detail.long_names()) {
+    for (const auto &long_name : detail.long_names()) {
       m_keys[long_name] = hash;
     }
 
@@ -2702,83 +1990,55 @@ OptionParser::finalise_aliases()
   }
 }
 
-inline
-void
-Options::add_option
-(
-  const std::string& group,
-  const Option& option
-)
-{
-    add_options(group, {option});
+inline void Options::add_option(const std::string &group,
+                                const Option &option) {
+  add_options(group, {option});
 }
 
-inline
-void
-Options::add_option
-(
-  const std::string& group,
-  const std::string& s,
-  const OptionNames& l,
-  std::string desc,
-  const std::shared_ptr<const Value>& value,
-  std::string arg_help
-)
-{
+inline void Options::add_option(const std::string &group, const std::string &s,
+                                const OptionNames &l, std::string desc,
+                                const std::shared_ptr<const Value> &value,
+                                std::string arg_help) {
   auto stringDesc = toLocalString(std::move(desc));
   auto option = std::make_shared<OptionDetails>(s, l, stringDesc, value);
 
-  if (!s.empty())
-  {
+  if (!s.empty()) {
     add_one_option(s, option);
   }
 
-  for(const auto& long_name : l) {
+  for (const auto &long_name : l) {
     add_one_option(long_name, option);
   }
 
-  //add the help details
+  // add the help details
 
-  if (m_help.find(group) == m_help.end())
-  {
+  if (m_help.find(group) == m_help.end()) {
     m_group.push_back(group);
   }
 
-  auto& options = m_help[group];
+  auto &options = m_help[group];
 
-  options.options.emplace_back(HelpOptionDetails{s, l, stringDesc,
-      value->has_default(), value->get_default_value(),
-      value->has_implicit(), value->get_implicit_value(),
-      std::move(arg_help),
-      value->is_container(),
-      value->is_boolean()});
+  options.options.emplace_back(HelpOptionDetails{
+      s, l, stringDesc, value->has_default(), value->get_default_value(),
+      value->has_implicit(), value->get_implicit_value(), std::move(arg_help),
+      value->is_container(), value->is_boolean()});
 }
 
-inline
-void
-Options::add_one_option
-(
-  const std::string& option,
-  const std::shared_ptr<OptionDetails>& details
-)
-{
+inline void
+Options::add_one_option(const std::string &option,
+                        const std::shared_ptr<OptionDetails> &details) {
   auto in = m_options->emplace(option, details);
 
-  if (!in.second)
-  {
+  if (!in.second) {
     throw_or_mimic<exceptions::option_already_exists>(option);
   }
 }
 
-inline
-String
-Options::help_one_group(const std::string& g) const
-{
+inline String Options::help_one_group(const std::string &g) const {
   using OptionHelp = std::vector<std::pair<String, String>>;
 
   auto group = m_help.find(g);
-  if (group == m_help.end())
-  {
+  if (group == m_help.end()) {
     return "";
   }
 
@@ -2788,17 +2048,14 @@ Options::help_one_group(const std::string& g) const
 
   String result;
 
-  if (!g.empty())
-  {
+  if (!g.empty()) {
     result += toLocalString(" " + g + " options:\n");
   }
 
-  for (const auto& o : group->second.options)
-  {
+  for (const auto &o : group->second.options) {
     if (o.l.size() &&
         m_positional_set.find(o.l.front()) != m_positional_set.end() &&
-        !m_show_positional)
-    {
+        !m_show_positional) {
       continue;
     }
 
@@ -2808,36 +2065,30 @@ Options::help_one_group(const std::string& g) const
   }
   longest = (std::min)(longest, OPTION_LONGEST);
 
-  //widest allowed description -- min 10 chars for helptext/line
+  // widest allowed description -- min 10 chars for helptext/line
   std::size_t allowed = 10;
-  if (m_width > allowed + longest + OPTION_DESC_GAP)
-  {
+  if (m_width > allowed + longest + OPTION_DESC_GAP) {
     allowed = m_width - longest - OPTION_DESC_GAP;
   }
 
   auto fiter = format.begin();
-  for (const auto& o : group->second.options)
-  {
+  for (const auto &o : group->second.options) {
     if (o.l.size() &&
         m_positional_set.find(o.l.front()) != m_positional_set.end() &&
-        !m_show_positional)
-    {
+        !m_show_positional) {
       continue;
     }
 
-    auto d = format_description(o, longest + OPTION_DESC_GAP, allowed, m_tab_expansion);
+    auto d = format_description(o, longest + OPTION_DESC_GAP, allowed,
+                                m_tab_expansion);
 
     result += fiter->first;
-    if (stringLength(fiter->first) > longest)
-    {
+    if (stringLength(fiter->first) > longest) {
       result += '\n';
       result += toLocalString(std::string(longest + OPTION_DESC_GAP, ' '));
-    }
-    else
-    {
-      result += toLocalString(std::string(longest + OPTION_DESC_GAP -
-        stringLength(fiter->first),
-        ' '));
+    } else {
+      result += toLocalString(std::string(
+          longest + OPTION_DESC_GAP - stringLength(fiter->first), ' '));
     }
     result += d;
     result += '\n';
@@ -2848,48 +2099,32 @@ Options::help_one_group(const std::string& g) const
   return result;
 }
 
-inline
-void
-Options::generate_group_help
-(
-  String& result,
-  const std::vector<std::string>& print_groups
-) const
-{
-  for (std::size_t i = 0; i != print_groups.size(); ++i)
-  {
-    const String& group_help_text = help_one_group(print_groups[i]);
-    if (empty(group_help_text))
-    {
+inline void Options::generate_group_help(
+    String &result, const std::vector<std::string> &print_groups) const {
+  for (std::size_t i = 0; i != print_groups.size(); ++i) {
+    const String &group_help_text = help_one_group(print_groups[i]);
+    if (empty(group_help_text)) {
       continue;
     }
     result += group_help_text;
-    if (i < print_groups.size() - 1)
-    {
+    if (i < print_groups.size() - 1) {
       result += '\n';
     }
   }
 }
 
-inline
-void
-Options::generate_all_groups_help(String& result) const
-{
+inline void Options::generate_all_groups_help(String &result) const {
   generate_group_help(result, m_group);
 }
 
-inline
-std::string
-Options::help(const std::vector<std::string>& help_groups, bool print_usage) const
-{
+inline std::string Options::help(const std::vector<std::string> &help_groups,
+                                 bool print_usage) const {
   String result = m_help_string;
-  if(print_usage)
-  {
-    result+= "\nUsage:\n  " + toLocalString(m_program);
+  if (print_usage) {
+    result += "\nUsage:\n  " + toLocalString(m_program);
   }
 
-  if (!m_custom_help.empty())
-  {
+  if (!m_custom_help.empty()) {
     result += " " + toLocalString(m_custom_help);
   }
 
@@ -2899,32 +2134,22 @@ Options::help(const std::vector<std::string>& help_groups, bool print_usage) con
 
   result += "\n\n";
 
-  if (help_groups.empty())
-  {
+  if (help_groups.empty()) {
     generate_all_groups_help(result);
-  }
-  else
-  {
+  } else {
     generate_group_help(result, help_groups);
   }
 
   return toUTF8String(result);
 }
 
-inline
-std::vector<std::string>
-Options::groups() const
-{
-  return m_group;
-}
+inline std::vector<std::string> Options::groups() const { return m_group; }
 
-inline
-const HelpGroupDetails&
-Options::group_help(const std::string& group) const
-{
+inline const HelpGroupDetails &
+Options::group_help(const std::string &group) const {
   return m_help.at(group);
 }
 
 } // namespace cxxopts
 
-#endif //CXXOPTS_HPP_INCLUDED
+#endif // CXXOPTS_HPP_INCLUDED

--- a/runtime_lib/test_lib/test_utils.cpp
+++ b/runtime_lib/test_lib/test_utils.cpp
@@ -20,31 +20,40 @@ namespace test_utils {
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
 
-void check_arg_file_exists(const cxxopts::ParseResult& result, std::string name) {
-    if (!result.count(name)) {
-        throw std::runtime_error("Missing required argument: " + name);
-    }
-    std::string path = result[name].as<std::string>();
-    if (!std::filesystem::exists(path)) {
-        throw std::runtime_error("File does not exist: " + path);
-    }
+void check_arg_file_exists(const cxxopts::ParseResult &result,
+                           std::string name) {
+  if (!result.count(name)) {
+    throw std::runtime_error("Missing required argument: " + name);
+  }
+  std::string path = result[name].as<std::string>();
+  if (!std::filesystem::exists(path)) {
+    throw std::runtime_error("File does not exist: " + path);
+  }
 }
 
-void add_default_options(cxxopts::Options& options) {
- options.add_options()
-    ("help,h", "produce help message")
-    ("xclbin,x", "the input xclbin path", cxxopts::value<std::string>())
-    ("kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)", cxxopts::value<std::string>())
-    ("verbosity,v", "the verbosity of the output", cxxopts::value<int>()->default_value("0"))
-    ("instr,i", "path of file containing userspace instructions sent to the NPU", cxxopts::value<std::string>())
-    ("verify", "whether to verify the AIE computed output", cxxopts::value<bool>()->default_value("true"))
-    ("iters", "number of iterations", cxxopts::value<int>()->default_value("1"))
-    ("warmup", "number of warmup iterations", cxxopts::value<int>()->default_value("0"))
-    ("trace_sz,t", "trace size", cxxopts::value<int>()->default_value("0"))
-    ("trace_file", "where to store trace output", cxxopts::value<std::string>()->default_value("trace.txt"));}
+void add_default_options(cxxopts::Options &options) {
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions sent to the NPU",
+      cxxopts::value<std::string>())(
+      "verify", "whether to verify the AIE computed output",
+      cxxopts::value<bool>()->default_value("true"))(
+      "iters", "number of iterations",
+      cxxopts::value<int>()->default_value("1"))(
+      "warmup", "number of warmup iterations",
+      cxxopts::value<int>()->default_value("0"))(
+      "trace_sz,t", "trace size", cxxopts::value<int>()->default_value("0"))(
+      "trace_file", "where to store trace output",
+      cxxopts::value<std::string>()->default_value("trace.txt"));
+}
 
-void parse_options(int argc, const char *argv[], cxxopts::Options& options,
-                   cxxopts::ParseResult& vm) {
+void parse_options(int argc, const char *argv[], cxxopts::Options &options,
+                   cxxopts::ParseResult &vm) {
   try {
     vm = options.parse(argc, argv);
 
@@ -52,7 +61,7 @@ void parse_options(int argc, const char *argv[], cxxopts::Options& options,
       std::cout << options.help() << "\n";
       std::exit(1);
     }
-  } catch (const cxxopts::exceptions::parsing& e) {
+  } catch (const cxxopts::exceptions::parsing &e) {
     std::cerr << e.what() << "\n\n";
     std::cerr << "Usage:\n" << options.help() << "\n";
     std::exit(1);
@@ -83,8 +92,8 @@ std::vector<uint32_t> load_instr_sequence(std::string instr_path) {
     instr_v.push_back(a);
   }
   return instr_v;
-    }
-    
+}
+
 std::vector<uint32_t> load_instr_binary(std::string instr_path) {
   // Open file in binary mode
   std::ifstream instr_file(instr_path, std::ios::binary);
@@ -100,7 +109,7 @@ std::vector<uint32_t> load_instr_binary(std::string instr_path) {
   // Check that the file size is a multiple of 4 bytes (size of uint32_t)
   if (size % 4 != 0) {
     throw std::runtime_error("File size is not a multiple of 4 bytes\n");
-}
+  }
 
   // Allocate vector and read the binary data
   std::vector<uint32_t> instr_v(size / 4);
@@ -134,24 +143,23 @@ void init_xrt_load_kernel(xrt::device &device, xrt::kernel &kernel,
       *std::find_if(xkernels.begin(), xkernels.end(),
                     [kernelNameInXclbin, verbosity](xrt::xclbin::kernel &k) {
                       auto name = k.get_name();
-    if (verbosity >= 1) {
+                      if (verbosity >= 1) {
                         std::cout << "Name: " << name << std::endl;
-    }
+                      }
                       return name.rfind(kernelNameInXclbin, 0) == 0;
                     });
   auto kernelName = xkernel.get_name();
-    
   // Register xclbin
   if (verbosity >= 1)
     std::cout << "Registering xclbin: " << xclbinFileName << "\n";
 
-    device.register_xclbin(xclbin);
-    
+  device.register_xclbin(xclbin);
+
   // Get a hardware context
   if (verbosity >= 1)
     std::cout << "Getting hardware context.\n";
-    xrt::hw_context context(device, xclbin.get_uuid());
-    
+  xrt::hw_context context(device, xclbin.get_uuid());
+
   // Get a kernel handle
   if (verbosity >= 1)
     std::cout << "Getting handle to kernel:" << kernelName << "\n";
@@ -188,8 +196,7 @@ bool nearly_equal(float a, float b, float epsilon, float abs_th)
 // --------------------------------------------------------------------------
 // Tracing
 // --------------------------------------------------------------------------
-void write_out_trace(char *traceOutPtr, size_t trace_size,
-                                 std::string path) {
+void write_out_trace(char *traceOutPtr, size_t trace_size, std::string path) {
   std::ofstream fout(path);
   uint32_t *traceOut = (uint32_t *)traceOutPtr;
   for (int i = 0; i < trace_size / sizeof(traceOut[0]); i++) {
@@ -197,4 +204,4 @@ void write_out_trace(char *traceOutPtr, size_t trace_size,
     fout << std::endl;
   }
 }
-}
+} // namespace test_utils

--- a/runtime_lib/test_lib/test_utils.h
+++ b/runtime_lib/test_lib/test_utils.h
@@ -13,7 +13,7 @@
 #ifndef _TEST_UTILS_H_
 #define _TEST_UTILS_H_
 
-#include <boost/program_options.hpp>
+#include <cxxopts.hpp>
 #include <cfloat>
 #include <cmath>
 #include <cstdint>
@@ -30,16 +30,14 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-namespace po = boost::program_options;
-
 namespace test_utils {
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name);
+void check_arg_file_exists(const cxxopts::ParseResult& result, std::string name);
 
-void add_default_options(po::options_description &desc);
+void add_default_options(cxxopts::Options& options);
 
-void parse_options(int argc, const char *argv[], po::options_description &desc,
-                   po::variables_map &vm);
+void parse_options(int argc, const char *argv[], cxxopts::Options& options,
+                   cxxopts::ParseResult& result);
 
 std::vector<uint32_t> load_instr_sequence(std::string instr_path);
 std::vector<uint32_t> load_instr_binary(std::string instr_path);

--- a/runtime_lib/test_lib/test_utils.h
+++ b/runtime_lib/test_lib/test_utils.h
@@ -13,7 +13,7 @@
 #ifndef _TEST_UTILS_H_
 #define _TEST_UTILS_H_
 
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 #include <cfloat>
 #include <cmath>
 #include <cstdint>
@@ -32,12 +32,13 @@
 
 namespace test_utils {
 
-void check_arg_file_exists(const cxxopts::ParseResult& result, std::string name);
+void check_arg_file_exists(const cxxopts::ParseResult &result,
+                           std::string name);
 
-void add_default_options(cxxopts::Options& options);
+void add_default_options(cxxopts::Options &options);
 
-void parse_options(int argc, const char *argv[], cxxopts::Options& options,
-                   cxxopts::ParseResult& result);
+void parse_options(int argc, const char *argv[], cxxopts::Options &options,
+                   cxxopts::ParseResult &result);
 
 std::vector<uint32_t> load_instr_sequence(std::string instr_path);
 std::vector<uint32_t> load_instr_binary(std::string instr_path);

--- a/runtime_lib/test_lib/xrt_test_wrapper.h
+++ b/runtime_lib/test_lib/xrt_test_wrapper.h
@@ -1,9 +1,9 @@
-#include <fstream>
-#include <iostream>
-#include <sstream>
 #include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
+#include <fstream>
+#include <iostream>
+#include <sstream>
 
 struct args {
   int verbosity;

--- a/runtime_lib/test_lib/xrt_test_wrapper.h
+++ b/runtime_lib/test_lib/xrt_test_wrapper.h
@@ -1,12 +1,9 @@
-
 #include <fstream>
 #include <iostream>
 #include <sstream>
-
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
-
-namespace po = boost::program_options;
 
 struct args {
   int verbosity;
@@ -24,13 +21,13 @@ struct args parse_args(int argc, const char *argv[]) {
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("XRT Test Wrapper");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
 
   struct args myargs;
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  test_utils::parse_options(argc, argv, options, vm);
   myargs.verbosity = vm["verbosity"].as<int>();
   myargs.do_verify = vm["verify"].as<bool>();
   myargs.n_iterations = vm["iters"].as<int>();

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -58,8 +58,7 @@ config.substitutions.append(
 config.substitutions.append(
     (
         "%test_utils_flags",
-        "-lboost_program_options -lboost_filesystem "
-        + f"-I{test_lib_path}/include -L{test_lib_path}/lib -ltest_utils",
+        f"-I{test_lib_path}/include -L{test_lib_path}/lib -ltest_utils",
     )
 )
 

--- a/test/npu-xrt/add_blockwrite/test.cpp
+++ b/test/npu-xrt/add_blockwrite/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_blockwrite/test.cpp
+++ b/test/npu-xrt/add_blockwrite/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_blockwrite/test.cpp
+++ b/test/npu-xrt/add_blockwrite/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,45 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_blockwrite");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_blockwrite/test.cpp
+++ b/test/npu-xrt/add_blockwrite/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/add_maskwrite/test.cpp
+++ b/test/npu-xrt/add_maskwrite/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_maskwrite/test.cpp
+++ b/test/npu-xrt/add_maskwrite/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_maskwrite/test.cpp
+++ b/test/npu-xrt/add_maskwrite/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,45 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_maskwrite");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_maskwrite/test.cpp
+++ b/test/npu-xrt/add_maskwrite/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/add_one_ctrl_packet/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,44 +15,21 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_one_ctrl_packet");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_one_ctrl_packet/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet/test.cpp
@@ -31,9 +31,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/add_one_ctrl_packet/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int OUT_SIZE = 64;
 

--- a/test/npu-xrt/add_one_ctrl_packet/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int OUT_SIZE = 64;
 

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,46 +15,23 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int CTRL_IN_SIZE = 64;
 constexpr int CTRL_OUT_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_one_ctrl_packet_4_cores");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
@@ -33,9 +33,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int CTRL_IN_SIZE = 64;
 constexpr int CTRL_OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int CTRL_IN_SIZE = 64;
 constexpr int CTRL_OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
@@ -33,9 +33,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int CTRL_IN_SIZE = 64;
 constexpr int CTRL_OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int CTRL_IN_SIZE = 64;
 constexpr int CTRL_OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,46 +15,23 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int CTRL_IN_SIZE = 64;
 constexpr int CTRL_OUT_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_one_ctrl_packet_col_overlay");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_one_objFifo/test.cpp
+++ b/test/npu-xrt/add_one_objFifo/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_objFifo/test.cpp
+++ b/test/npu-xrt/add_one_objFifo/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_objFifo/test.cpp
+++ b/test/npu-xrt/add_one_objFifo/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,45 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_one_objFifo");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_one_objFifo/test.cpp
+++ b/test/npu-xrt/add_one_objFifo/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/add_one_two/test.cpp
+++ b/test/npu-xrt/add_one_two/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_two/test.cpp
+++ b/test/npu-xrt/add_one_two/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,43 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")("verbosity,v",
-                               po::value<int>()->default_value(0),
-                               "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_one_two");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_one_two/test.cpp
+++ b/test/npu-xrt/add_one_two/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_two/test.cpp
+++ b/test/npu-xrt/add_one_two/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -13,5 +13,5 @@
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.bin aie1_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-txn --txn-name=transaction.mlir --aie-generate-npu-insts --no-compile-host --npu-insts-name=add_two_insts.bin aie2_arch.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure transaction.mlir -o add_two_cfg.bin
-// RUN: %run_on_npu1% ./test.exe -x add_one.xclbin -i add_one_insts.bin -c add_two_cfg.bin -j add_two_insts.bin
-// RUN: %run_on_npu2% ./test.exe -x add_one.xclbin -i add_one_insts.bin -c add_two_cfg.bin -j add_two_insts.bin
+// RUN: %run_on_npu1% ./test.exe -x add_one.xclbin --instr0 add_one_insts.bin -c add_two_cfg.bin --instr1 add_two_insts.bin
+// RUN: %run_on_npu2% ./test.exe -x add_one.xclbin --instr0 add_one_insts.bin -c add_two_cfg.bin --instr1 add_two_insts.bin

--- a/test/npu-xrt/add_one_two_txn/test.cpp
+++ b/test/npu-xrt/add_one_two_txn/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_two_txn/test.cpp
+++ b/test/npu-xrt/add_one_two_txn/test.cpp
@@ -15,12 +15,12 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "experimental/xrt_kernel.h"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
@@ -29,9 +29,9 @@ int main(int argc, const char *argv[]) {
   // Program arguments parsing
   cxxopts::Options options("add_one_two_txn");
   test_utils::add_default_options(options);
-  options.add_options()("instr0,i", "path to instructions for kernel0",
+  options.add_options()("instr0", "path to instructions for kernel0",
                         cxxopts::value<std::string>())(
-      "instr1,j", "path to instructions for kernel1",
+      "instr1", "path to instructions for kernel1",
       cxxopts::value<std::string>())("cfg,c", "txn binary path",
                                      cxxopts::value<std::string>());
 

--- a/test/npu-xrt/add_one_two_txn/test.cpp
+++ b/test/npu-xrt/add_one_two_txn/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -17,46 +16,27 @@
 #include <vector>
 
 #include "experimental/xrt_kernel.h"
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")("verbosity,v",
-                               po::value<int>()->default_value(0),
-                               "the verbosity of the output")(
-      "instr0,i", po::value<std::string>()->required(),
-      "path to instructions for kernel0")("instr1,j",
-                                          po::value<std::string>()->required(),
-                                          "path to instructions for kernel1")(
-      "cfg,c", po::value<std::string>()->required(), "txn binary path");
-  po::variables_map vm;
+  cxxopts::Options options("add_one_two_txn");
+  test_utils::add_default_options(options);
+  options.add_options()("instr0,i", "path to instructions for kernel0",
+                        cxxopts::value<std::string>())(
+      "instr1,j", "path to instructions for kernel1",
+      cxxopts::value<std::string>())("cfg,c", "txn binary path",
+                                     cxxopts::value<std::string>());
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   std::vector<uint32_t> instr_0_v =
       test_utils::load_instr_binary(vm["instr0"].as<std::string>());

--- a/test/npu-xrt/add_one_using_dma/test.cpp
+++ b/test/npu-xrt/add_one_using_dma/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_using_dma/test.cpp
+++ b/test/npu-xrt/add_one_using_dma/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/add_one_using_dma/test.cpp
+++ b/test/npu-xrt/add_one_using_dma/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,45 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("add_one_using_dma");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/add_one_using_dma/test.cpp
+++ b/test/npu-xrt/add_one_using_dma/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/adjacent_memtile_access/three_memtiles/test.cpp
+++ b/test/npu-xrt/adjacent_memtile_access/three_memtiles/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,24 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("three_memtiles");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/test/npu-xrt/adjacent_memtile_access/three_memtiles/test.cpp
+++ b/test/npu-xrt/adjacent_memtile_access/three_memtiles/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // ------------------------------------------------------

--- a/test/npu-xrt/adjacent_memtile_access/three_memtiles/test.cpp
+++ b/test/npu-xrt/adjacent_memtile_access/three_memtiles/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // ------------------------------------------------------

--- a/test/npu-xrt/adjacent_memtile_access/two_memtiles/test.cpp
+++ b/test/npu-xrt/adjacent_memtile_access/two_memtiles/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // ------------------------------------------------------

--- a/test/npu-xrt/adjacent_memtile_access/two_memtiles/test.cpp
+++ b/test/npu-xrt/adjacent_memtile_access/two_memtiles/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // ------------------------------------------------------

--- a/test/npu-xrt/adjacent_memtile_access/two_memtiles/test.cpp
+++ b/test/npu-xrt/adjacent_memtile_access/two_memtiles/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,24 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("two_memtiles");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/test/npu-xrt/cascade_flows/test.cpp
+++ b/test/npu-xrt/cascade_flows/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/cascade_flows/test.cpp
+++ b/test/npu-xrt/cascade_flows/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,45 +15,22 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("cascade_flows");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/cascade_flows/test.cpp
+++ b/test/npu-xrt/cascade_flows/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 64;
 constexpr int OUT_SIZE = 64;

--- a/test/npu-xrt/cascade_flows/test.cpp
+++ b/test/npu-xrt/cascade_flows/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/column_specific/test.cpp
+++ b/test/npu-xrt/column_specific/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,43 +16,21 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t");
-  po::variables_map vm;
+  cxxopts::Options options("column_specific");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/column_specific/test.cpp
+++ b/test/npu-xrt/column_specific/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/column_specific/test.cpp
+++ b/test/npu-xrt/column_specific/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/column_specific/test.cpp
+++ b/test/npu-xrt/column_specific/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/ctrl_packet_reconfig/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>

--- a/test/npu-xrt/device_width/test.cpp
+++ b/test/npu-xrt/device_width/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/device_width/test.cpp
+++ b/test/npu-xrt/device_width/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/device_width/test.cpp
+++ b/test/npu-xrt/device_width/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,43 +16,21 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t");
-  po::variables_map vm;
+  cxxopts::Options options("device_width");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/device_width/test.cpp
+++ b/test/npu-xrt/device_width/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/dma_complex_dims/test.cpp
+++ b/test/npu-xrt/dma_complex_dims/test.cpp
@@ -40,9 +40,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/dma_complex_dims/test.cpp
+++ b/test/npu-xrt/dma_complex_dims/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/dma_complex_dims/test.cpp
+++ b/test/npu-xrt/dma_complex_dims/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/dmabd_task_queue/test.cpp
+++ b/test/npu-xrt/dmabd_task_queue/test.cpp
@@ -23,7 +23,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int A_VOLUME = 5;
 constexpr int B_VOLUME = 96;

--- a/test/npu-xrt/dmabd_task_queue/test.cpp
+++ b/test/npu-xrt/dmabd_task_queue/test.cpp
@@ -9,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -20,11 +19,11 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int A_VOLUME = 5;
 constexpr int B_VOLUME = 96;
@@ -40,47 +39,13 @@ constexpr int D_SIZE = (D_VOLUME * sizeof(IN_DATATYPE));
 
 constexpr bool VERIFY = true;
 
-namespace po = boost::program_options;
-
-void parse_options(int argc, const char *argv[], po::options_description &desc,
-                   po::variables_map &vm) {
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      std::exit(1);
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    std::exit(1);
-  }
-
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-}
-
-void add_default_options(po::options_description &desc) {
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-}
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  add_default_options(desc);
-  parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("dmabd_task_queue");
+  test_utils::add_default_options(options);
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
 
   srand(time(NULL));

--- a/test/npu-xrt/dmabd_task_queue/test.cpp
+++ b/test/npu-xrt/dmabd_task_queue/test.cpp
@@ -19,11 +19,11 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int A_VOLUME = 5;
 constexpr int B_VOLUME = 96;

--- a/test/npu-xrt/matrix_multiplication_using_cascade/matrix_multiplication.h
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/matrix_multiplication.h
@@ -14,8 +14,8 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
-#include <cmath>
 #include "cxxopts.hpp"
+#include <cmath>
 
 namespace matmul_common {
 
@@ -38,12 +38,14 @@ void check_arg_file_exists(cxxopts::ParseResult &vm_in, std::string name) {
 
 void add_default_options(cxxopts::Options &options) {
   options.add_options()("help,h", "produce help message")(
-      "xclbin,x", "the input xclbin path")(
-      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", "the verbosity of the output",
-      cxxopts::value<int>()->default_value("0"))(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
       "instr,i",
-      "path of file containing userspace instructions sent to the NPU")(
+      "path of file containing userspace instructions sent to the NPU",
+      cxxopts::value<std::string>())(
       "verify", "whether to verify the AIE computed output",
       cxxopts::value<bool>()->default_value("true"))(
       "iters", "number of iterations",

--- a/test/npu-xrt/matrix_multiplication_using_cascade/matrix_multiplication.h
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/matrix_multiplication.h
@@ -14,18 +14,16 @@
 #ifndef MATRIX_MULTIPLICATION_H
 #define MATRIX_MULTIPLICATION_H
 
-#include <boost/program_options.hpp>
 #include <cmath>
+#include <cxxopts.hpp>
 
 namespace matmul_common {
-
-namespace po = boost::program_options;
 
 // --------------------------------------------------------------------------
 // Command Line Argument Handling
 // --------------------------------------------------------------------------
 
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
+void check_arg_file_exists(cxxopts::ParseResult &vm_in, std::string name) {
   if (!vm_in.count(name)) {
     throw std::runtime_error("Error: no " + name + " file was provided\n");
   } else {
@@ -38,38 +36,37 @@ void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
   }
 }
 
-void add_default_options(po::options_description &desc) {
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
+void add_default_options(cxxopts::Options &options) {
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path")(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
+      "verbosity,v", "the verbosity of the output",
+      cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
       "path of file containing userspace instructions sent to the NPU")(
-      "verify", po::value<bool>()->default_value(true),
-      "whether to verify the AIE computed output")(
-      "iters", po::value<int>()->default_value(1))(
-      "warmup", po::value<int>()->default_value(0))(
-      "trace_sz,t", po::value<int>()->default_value(0))(
-      "trace_file", po::value<std::string>()->default_value("trace.txt"),
-      "where to store trace output");
+      "verify", "whether to verify the AIE computed output",
+      cxxopts::value<bool>()->default_value("true"))(
+      "iters", "number of iterations",
+      cxxopts::value<int>()->default_value("1"))(
+      "warmup", "number of warmup iterations",
+      cxxopts::value<int>()->default_value("0"))(
+      "trace_sz,t", "trace size", cxxopts::value<int>()->default_value("0"))(
+      "trace_file", "where to store trace output",
+      cxxopts::value<std::string>()->default_value("trace.txt"));
 }
 
-void parse_options(int argc, const char *argv[], po::options_description &desc,
-                   po::variables_map &vm) {
+void parse_options(int argc, const char *argv[], cxxopts::Options &options,
+                   cxxopts::ParseResult &vm) {
   try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+    vm = options.parse(argc, argv);
 
     if (vm.count("help")) {
-      std::cout << desc << "\n";
+      std::cout << options.help() << "\n";
       std::exit(1);
     }
   } catch (const std::exception &ex) {
     std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
+    std::cerr << "Usage:\n" << options.help() << "\n";
     std::exit(1);
   }
 

--- a/test/npu-xrt/matrix_multiplication_using_cascade/matrix_multiplication.h
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/matrix_multiplication.h
@@ -15,7 +15,7 @@
 #define MATRIX_MULTIPLICATION_H
 
 #include <cmath>
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 namespace matmul_common {
 

--- a/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
@@ -1,4 +1,3 @@
-
 //===- test.cpp -------------------------------------------000---*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
@@ -10,7 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 #include <bits/stdc++.h>
-#include <boost/program_options.hpp>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -21,13 +19,12 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "matrix_multiplication.h"
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-#include "matrix_multiplication.h"
+#include <cxxopts.hpp>
 
 constexpr int M = 16;
 constexpr int K = 16;
@@ -47,15 +44,12 @@ constexpr int C_SIZE = (C_VOLUME * sizeof(C_DATATYPE));
 
 constexpr bool VERIFY = true;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
-
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  matmul_common::add_default_options(desc);
-  matmul_common::parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("matrix_multiplication_using_cascade");
+  cxxopts::ParseResult vm;
+  matmul_common::add_default_options(options);
+  matmul_common::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int trace_size = vm["trace_sz"].as<int>();
 

--- a/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
@@ -19,12 +19,12 @@
 #include <sstream>
 #include <stdfloat>
 
+#include "cxxopts.hpp"
 #include "matrix_multiplication.h"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 constexpr int M = 16;
 constexpr int K = 16;
@@ -48,13 +48,19 @@ int main(int argc, const char *argv[]) {
   // Program arguments parsing
   cxxopts::Options options("matrix_multiplication_using_cascade");
   cxxopts::ParseResult vm;
+  std::cout << "reached line 51" << std::endl;
   matmul_common::add_default_options(options);
+  std::cout << "reached line 53" << std::endl;
   matmul_common::parse_options(argc, argv, options, vm);
+  std::cout << "reached line 55" << std::endl;
   int verbosity = vm["verbosity"].as<int>();
   int trace_size = vm["trace_sz"].as<int>();
 
+  std::cout << "reached line 56" << std::endl;
+
   srand(time(NULL));
 
+  std::cout << "reached line 59" << std::endl;
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)

--- a/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
@@ -48,19 +48,13 @@ int main(int argc, const char *argv[]) {
   // Program arguments parsing
   cxxopts::Options options("matrix_multiplication_using_cascade");
   cxxopts::ParseResult vm;
-  std::cout << "reached line 51" << std::endl;
   matmul_common::add_default_options(options);
-  std::cout << "reached line 53" << std::endl;
   matmul_common::parse_options(argc, argv, options, vm);
-  std::cout << "reached line 55" << std::endl;
   int verbosity = vm["verbosity"].as<int>();
   int trace_size = vm["trace_sz"].as<int>();
 
-  std::cout << "reached line 56" << std::endl;
-
   srand(time(NULL));
 
-  std::cout << "reached line 59" << std::endl;
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
   if (verbosity >= 1)

--- a/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/test.cpp
@@ -24,7 +24,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int M = 16;
 constexpr int K = 16;

--- a/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
+++ b/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,43 +16,21 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t");
-  po::variables_map vm;
+  cxxopts::Options options("blockwrite_using_locks");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
+++ b/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
+++ b/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
+++ b/test/npu-xrt/memtile_dmas/blockwrite_using_locks/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/memtile_dmas/writebd/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/memtile_dmas/writebd/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/memtile_dmas/writebd/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,43 +16,21 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t");
-  po::variables_map vm;
+  cxxopts::Options options("writebd");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/memtile_dmas/writebd/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,43 +16,21 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t");
-  po::variables_map vm;
+  cxxopts::Options options("writebd_tokens");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");

--- a/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
+++ b/test/npu-xrt/memtile_dmas/writebd_tokens/test.cpp
@@ -32,9 +32,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/neighbor_tile_memory_access/test.cpp
+++ b/test/npu-xrt/neighbor_tile_memory_access/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,24 +15,20 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
-
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
-
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::Options options("neighbor_tile_memory_access");
+  cxxopts::ParseResult vm;
+  test_utils::add_default_options(options);
+  test_utils::parse_options(argc, argv, options, vm);
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/test/npu-xrt/neighbor_tile_memory_access/test.cpp
+++ b/test/npu-xrt/neighbor_tile_memory_access/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // ------------------------------------------------------

--- a/test/npu-xrt/neighbor_tile_memory_access/test.cpp
+++ b/test/npu-xrt/neighbor_tile_memory_access/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // ------------------------------------------------------

--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
@@ -34,9 +34,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,77 +16,29 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-namespace po = boost::program_options;
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_binary(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t")(
-      "repeat,r", po::value<int>()->default_value(4),
-      "the compute tile repeat count");
-  po::variables_map vm;
+  cxxopts::Options options("compute_repeat");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"))(
+      "repeat,r", "the compute tile repeat count",
+      cxxopts::value<int>()->default_value("4"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
@@ -34,9 +34,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/distribute_repeat/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,77 +16,29 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-namespace po = boost::program_options;
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_binary(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t")(
-      "repeat,r", po::value<int>()->default_value(7),
-      "the compute tile repeat count");
-  po::variables_map vm;
+  cxxopts::Options options("distribute_repeat");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"))(
+      "repeat,r", "the compute tile repeat count",
+      cxxopts::value<int>()->default_value("7"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/CMakeLists.txt
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/CMakeLists.txt
@@ -5,7 +5,6 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
-# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -13,7 +12,7 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 find_program(WSL NAMES powershell.exe)
@@ -21,11 +20,9 @@ find_program(WSL NAMES powershell.exe)
 if (NOT WSL)
     set(CMAKE_C_COMPILER gcc-13)
     set(CMAKE_CXX_COMPILER g++-13)
-    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
-    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -41,9 +38,6 @@ endif ()
 
 project(${ProjectName})
 
-# Find packages
-find_package(Boost REQUIRED)
-
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../../runtime_lib/test_lib/test_utils.cpp
     test.cpp
@@ -51,25 +45,16 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC 
+target_include_directories (${currentTarget} PUBLIC
     ${XRT_INC_DIR}
-    ${Boost_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
-    ${Boost_LIBRARY_DIRS}
 )
 
-if (NOT WSL)
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-        boost_program_options
-        boost_filesystem
-    )
-else()
-    target_link_libraries(${currentTarget} PUBLIC
-        xrt_coreutil
-    )
-endif()
+
+target_link_libraries(${currentTarget} PUBLIC
+    xrt_coreutil
+)

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
@@ -34,9 +34,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,77 +16,29 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-namespace po = boost::program_options;
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_binary(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t")(
-      "repeat,r", po::value<int>()->default_value(4),
-      "the memtile repeat count");
-  po::variables_map vm;
+  cxxopts::Options options("init_values_repeat");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"))(
+      "repeat,r", "the memtile repeat count",
+      cxxopts::value<int>()->default_value("4"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
@@ -34,9 +34,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 

--- a/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
@@ -20,7 +20,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
@@ -16,11 +16,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing

--- a/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
+++ b/test/npu-xrt/objectfifo_repeat/simple_repeat/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -17,77 +16,29 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-namespace po = boost::program_options;
-
-void check_arg_file_exists(po::variables_map &vm_in, std::string name) {
-  if (!vm_in.count(name)) {
-    throw std::runtime_error("Error: no " + name + " file was provided\n");
-  } else {
-    std::ifstream test(vm_in[name].as<std::string>());
-    if (!test) {
-      throw std::runtime_error("The " + name + " file " +
-                               vm_in[name].as<std::string>() +
-                               " does not exist.\n");
-    }
-  }
-}
-
-std::vector<uint32_t> load_instr_binary(std::string instr_path) {
-  std::ifstream instr_file(instr_path);
-  std::string line;
-  std::vector<uint32_t> instr_v;
-  while (std::getline(instr_file, line)) {
-    std::istringstream iss(line);
-    uint32_t a;
-    if (!(iss >> std::hex >> a)) {
-      throw std::runtime_error("Unable to parse instruction file\n");
-    }
-    instr_v.push_back(a);
-  }
-  return instr_v;
-}
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6")(
-      "length,l", po::value<int>()->default_value(4096),
-      "the length of the transfer in int32_t")(
-      "repeat,r", po::value<int>()->default_value(4),
-      "the memtile repeat count");
-  po::variables_map vm;
+  cxxopts::Options options("simple_repeat");
+  test_utils::add_default_options(options);
+  options.add_options()("length,l", "the length of the transfer in int32_t",
+                        cxxopts::value<int>()->default_value("4096"))(
+      "repeat,r", "the memtile repeat count",
+      cxxopts::value<int>()->default_value("4"));
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
-    if (vm.count("help")) {
-      std::cout << desc << std::endl;
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << std::endl;
-    return 1;
-  }
-
-  check_arg_file_exists(vm, "xclbin");
-  check_arg_file_exists(vm, "instr");
+  test_utils::check_arg_file_exists(vm, "xclbin");
+  test_utils::check_arg_file_exists(vm, "instr");
 
   std::vector<uint32_t> instr_v =
-      load_instr_binary(vm["instr"].as<std::string>());
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
   int verbosity = vm["verbosity"].as<int>();
   if (verbosity >= 1)

--- a/test/npu-xrt/runtime_cumsum/test.cpp
+++ b/test/npu-xrt/runtime_cumsum/test.cpp
@@ -24,117 +24,124 @@
 using INOUT_DATATYPE = int32_t;
 
 int main(int argc, const char *argv[]) {
-    std::vector<uint32_t> instr_v;
+  std::vector<uint32_t> instr_v;
 
-    instr_v = test_utils::load_instr_binary("insts.bin");
+  instr_v = test_utils::load_instr_binary("insts.bin");
 
-    int INOUT_SIZE = 128;
+  int INOUT_SIZE = 128;
 
-    // Start the XRT test code
-    // Get a device handle
-    unsigned int device_index = 0;
-    auto device = xrt::device(device_index);
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
 
-    // Load the xclbin
-    auto xclbin = xrt::xclbin("aie.xclbin");
+  // Load the xclbin
+  auto xclbin = xrt::xclbin("aie.xclbin");
 
-    std::string Node = "MLIR_AIE";
+  std::string Node = "MLIR_AIE";
 
-    // Get the kernel from the xclbin
-    auto xkernels = xclbin.get_kernels();
-    auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
-                                 [Node](xrt::xclbin::kernel &k) {
-                                   auto name = k.get_name();
-                                   return name.rfind(Node, 0) == 0;
-                                 });
-    auto kernelName = xkernel.get_name();
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
 
-    device.register_xclbin(xclbin);
+  device.register_xclbin(xclbin);
 
-    // get a hardware context
-    xrt::hw_context context(device, xclbin.get_uuid());
+  // get a hardware context
+  xrt::hw_context context(device, xclbin.get_uuid());
 
-    // get a kernel handle
-    auto kernel = xrt::kernel(context, kernelName);
+  // get a kernel handle
+  auto kernel = xrt::kernel(context, kernelName);
 
-    auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
-                            XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
-    auto bo_inA = xrt::bo(device, INOUT_SIZE * sizeof(INOUT_DATATYPE),
-                          XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_inA = xrt::bo(device, INOUT_SIZE * sizeof(INOUT_DATATYPE),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
 
-    INOUT_DATATYPE *bufInA = bo_inA.map<INOUT_DATATYPE *>();
-    std::vector<INOUT_DATATYPE> srcVecA(INOUT_SIZE);
-    for(int j = 0; j < 1; j++){
-        for (int i = 0; i < 16; i++){
-            srcVecA[j * 16 + i] = 1;
-        }
+  INOUT_DATATYPE *bufInA = bo_inA.map<INOUT_DATATYPE *>();
+  std::vector<INOUT_DATATYPE> srcVecA(INOUT_SIZE);
+  for (int j = 0; j < 1; j++) {
+    for (int i = 0; i < 16; i++) {
+      srcVecA[j * 16 + i] = 1;
     }
-    printf("Input:\n");
-    for (int i = 0; i < INOUT_SIZE; i++){
-        printf("%d\t", srcVecA[i]);
-        if ((i + 1) % 16 == 0){
-            printf("\n");
-        }
+  }
+  printf("Input:\n");
+  for (int i = 0; i < INOUT_SIZE; i++) {
+    printf("%d\t", srcVecA[i]);
+    if ((i + 1) % 16 == 0) {
+      printf("\n");
     }
-    printf("\n");
+  }
+  printf("\n");
 
-    memcpy(bufInA, srcVecA.data(), (srcVecA.size() * sizeof(INOUT_DATATYPE)));
+  memcpy(bufInA, srcVecA.data(), (srcVecA.size() * sizeof(INOUT_DATATYPE)));
 
-    void *bufInstr = bo_instr.map<void *>();
-    memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
 
-    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-    bo_inA.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_inA.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
-    unsigned int opcode = 3;
-    auto run = kernel(opcode, bo_instr, instr_v.size(), bo_inA);
-    ert_cmd_state r = run.wait();
-    if (r != ERT_CMD_STATE_COMPLETED) {
-      std::cout << "Kernel did not complete. Returned status: " << r << "\n";
-      return 1;
-    }
-
-    bo_inA.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-
-    INOUT_DATATYPE *bufOut = bo_inA.map<INOUT_DATATYPE *>();
-
-    std::vector<INOUT_DATATYPE> ref(INOUT_SIZE);
-    for (int i = 0; i < 16; i++){
-        ref[i] = srcVecA[i];
-        ref[1 * 16 + i] = srcVecA[i];
-        ref[2 * 16 + i] = ref[1 * 16 + i] + ref[i];
-        ref[3 * 16 + i] = ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
-        ref[4 * 16 + i] = ref[3 * 16 + i] + ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
-        ref[5 * 16 + i] = ref[4 * 16 + i] + ref[3 * 16 + i] + ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
-        ref[6 * 16 + i] = ref[5 * 16 + i] + ref[4 * 16 + i] + ref[3 * 16 + i] + ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
-        ref[7 * 16 + i] = ref[6 * 16 + i] + ref[5 * 16 + i] + ref[4 * 16 + i] + ref[3 * 16 + i] + ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
-    }
-
-    int errors = 0;
-
-    printf("Output:\n");
-    for (uint32_t i = 0; i < INOUT_SIZE; i++) {
-        printf("%d\t", bufOut[i]);
-        if ((i + 1) % 16 == 0){
-            printf("\n");
-        }
-    }
-    printf("\n");
-
-    for (uint32_t i = 0; i < INOUT_SIZE; i++){
-        if (*(bufOut + i) != ref[i]) {
-            if(errors < 10){
-                std::cout << "Error in output " << i << "; Input: " << srcVecA[i] << "; Output: " << *(bufOut + i) << " != reference:" << ref[i] << std::endl;
-            }
-            errors++;
-        }
-    }
-
-    if (!errors) {
-        std::cout << "\nPASS!\n\n";
-        return 0;
-    }
-
-    std::cout << "\nfailed.\n\n";
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), bo_inA);
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
     return 1;
+  }
+
+  bo_inA.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  INOUT_DATATYPE *bufOut = bo_inA.map<INOUT_DATATYPE *>();
+
+  std::vector<INOUT_DATATYPE> ref(INOUT_SIZE);
+  for (int i = 0; i < 16; i++) {
+    ref[i] = srcVecA[i];
+    ref[1 * 16 + i] = srcVecA[i];
+    ref[2 * 16 + i] = ref[1 * 16 + i] + ref[i];
+    ref[3 * 16 + i] = ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
+    ref[4 * 16 + i] =
+        ref[3 * 16 + i] + ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
+    ref[5 * 16 + i] = ref[4 * 16 + i] + ref[3 * 16 + i] + ref[2 * 16 + i] +
+                      ref[1 * 16 + i] + ref[i];
+    ref[6 * 16 + i] = ref[5 * 16 + i] + ref[4 * 16 + i] + ref[3 * 16 + i] +
+                      ref[2 * 16 + i] + ref[1 * 16 + i] + ref[i];
+    ref[7 * 16 + i] = ref[6 * 16 + i] + ref[5 * 16 + i] + ref[4 * 16 + i] +
+                      ref[3 * 16 + i] + ref[2 * 16 + i] + ref[1 * 16 + i] +
+                      ref[i];
+  }
+
+  int errors = 0;
+
+  printf("Output:\n");
+  for (uint32_t i = 0; i < INOUT_SIZE; i++) {
+    printf("%d\t", bufOut[i]);
+    if ((i + 1) % 16 == 0) {
+      printf("\n");
+    }
+  }
+  printf("\n");
+
+  for (uint32_t i = 0; i < INOUT_SIZE; i++) {
+    if (*(bufOut + i) != ref[i]) {
+      if (errors < 10) {
+        std::cout << "Error in output " << i << "; Input: " << srcVecA[i]
+                  << "; Output: " << *(bufOut + i) << " != reference:" << ref[i]
+                  << std::endl;
+      }
+      errors++;
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  }
+
+  std::cout << "\nfailed.\n\n";
+  return 1;
 }

--- a/test/npu-xrt/static_L1_init/test.cpp
+++ b/test/npu-xrt/static_L1_init/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/static_L1_init/test.cpp
+++ b/test/npu-xrt/static_L1_init/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,24 +15,23 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
 
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("static_L1_init");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/test/npu-xrt/static_L1_init/test.cpp
+++ b/test/npu-xrt/static_L1_init/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/two_col/test.cpp
+++ b/test/npu-xrt/two_col/test.cpp
@@ -125,24 +125,24 @@ int main(int argc, const char *argv[]) {
     if (srcVec[i] <= 50) { // Obviously change this back to 100
       if (*(bufOut + i) != 0) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
                     << " should be zero "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "Wow:   " << (uint8_t)*(bufOut + i) << " at " << i
+        std::cout << "Wow:   " << (uint8_t) * (bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }
     } else {
       if (*(bufOut + i) != UINT8_MAX) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
                     << " should be UINT8_MAX "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "WowT:  " << (uint8_t)*(bufOut + i) << " at " << i
+        std::cout << "WowT:  " << (uint8_t) * (bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }

--- a/test/npu-xrt/two_col/test.cpp
+++ b/test/npu-xrt/two_col/test.cpp
@@ -6,11 +6,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 #define IMAGE_WIDTH_IN 128
 #define IMAGE_HEIGHT_IN 64
@@ -128,24 +128,24 @@ int main(int argc, const char *argv[]) {
     if (srcVec[i] <= 50) { // Obviously change this back to 100
       if (*(bufOut + i) != 0) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
                     << " should be zero "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "Wow:   " << (uint8_t)*(bufOut + i) << " at " << i
+        std::cout << "Wow:   " << (uint8_t) * (bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }
     } else {
       if (*(bufOut + i) != UINT8_MAX) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
                     << " should be UINT8_MAX "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "WowT:  " << (uint8_t)*(bufOut + i) << " at " << i
+        std::cout << "WowT:  " << (uint8_t) * (bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }

--- a/test/npu-xrt/two_col/test.cpp
+++ b/test/npu-xrt/two_col/test.cpp
@@ -10,7 +10,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 #define IMAGE_WIDTH_IN 128
 #define IMAGE_HEIGHT_IN 64

--- a/test/npu-xrt/two_col/test.cpp
+++ b/test/npu-xrt/two_col/test.cpp
@@ -1,4 +1,3 @@
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -7,11 +6,11 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
+#include <cxxopts.hpp>
 
 #define IMAGE_WIDTH_IN 128
 #define IMAGE_HEIGHT_IN 64
@@ -25,36 +24,14 @@
 constexpr int IN_SIZE = (IMAGE_AREA_IN * sizeof(uint8_t));
 constexpr int OUT_SIZE = (IMAGE_AREA_OUT * sizeof(uint8_t));
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
+  cxxopts::Options options("two_col");
+  test_utils::add_default_options(options);
 
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   test_utils::check_arg_file_exists(vm, "xclbin");
   test_utils::check_arg_file_exists(vm, "instr");
@@ -151,24 +128,24 @@ int main(int argc, const char *argv[]) {
     if (srcVec[i] <= 50) { // Obviously change this back to 100
       if (*(bufOut + i) != 0) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
                     << " should be zero "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "Wow:   " << (uint8_t) * (bufOut + i) << " at " << i
+        std::cout << "Wow:   " << (uint8_t)*(bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }
     } else {
       if (*(bufOut + i) != UINT8_MAX) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
                     << " should be UINT8_MAX "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "WowT:  " << (uint8_t) * (bufOut + i) << " at " << i
+        std::cout << "WowT:  " << (uint8_t)*(bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }

--- a/test/npu-xrt/two_col/test.cpp
+++ b/test/npu-xrt/two_col/test.cpp
@@ -33,9 +33,6 @@ int main(int argc, const char *argv[]) {
   cxxopts::ParseResult vm;
   test_utils::parse_options(argc, argv, options, vm);
 
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
-
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());
 
@@ -128,24 +125,24 @@ int main(int argc, const char *argv[]) {
     if (srcVec[i] <= 50) { // Obviously change this back to 100
       if (*(bufOut + i) != 0) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
                     << " should be zero "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "Wow:   " << (uint8_t) * (bufOut + i) << " at " << i
+        std::cout << "Wow:   " << (uint8_t)*(bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }
     } else {
       if (*(bufOut + i) != UINT8_MAX) {
         if (errors < max_errors)
-          std::cout << "Error: " << (uint8_t) * (bufOut + i) << " at " << i
+          std::cout << "Error: " << (uint8_t)*(bufOut + i) << " at " << i
                     << " should be UINT8_MAX "
                     << " : input " << (uint8_t)srcVec[i] << std::endl;
         errors++;
       } else {
-        std::cout << "WowT:  " << (uint8_t) * (bufOut + i) << " at " << i
+        std::cout << "WowT:  " << (uint8_t)*(bufOut + i) << " at " << i
                   << " is correct "
                   << " : input " << (uint8_t)srcVec[i] << std::endl;
       }

--- a/test/npu-xrt/vec_vec_add_memtile_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_memtile_init/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/vec_vec_add_memtile_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_memtile_init/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,24 +15,23 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
 
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("vec_vec_add_memtile_init");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/test/npu-xrt/vec_vec_add_memtile_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_memtile_init/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/vec_vec_add_objfifo_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_objfifo_init/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/vec_vec_add_objfifo_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_objfifo_init/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,24 +15,23 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
 
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("vec_vec_add_objfifo_init");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/test/npu-xrt/vec_vec_add_objfifo_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_objfifo_init/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/vec_vec_add_tile_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_tile_init/test.cpp
@@ -15,11 +15,11 @@
 #include <string>
 #include <vector>
 
+#include "cxxopts.hpp"
 #include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/vec_vec_add_tile_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_tile_init/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -16,24 +15,23 @@
 #include <string>
 #include <vector>
 
+#include "test_utils.h"
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-
-#include "test_utils.h"
-
-namespace po = boost::program_options;
+#include <cxxopts.hpp>
 
 int main(int argc, const char *argv[]) {
 
   // ------------------------------------------------------
   // Parse program arguments
   // ------------------------------------------------------
-  po::options_description desc("Allowed options");
-  po::variables_map vm;
-  test_utils::add_default_options(desc);
+  cxxopts::Options options("vec_vec_add_tile_init");
+  test_utils::add_default_options(options);
 
-  test_utils::parse_options(argc, argv, desc, vm);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
   int verbosity = vm["verbosity"].as<int>();
   int do_verify = vm["verify"].as<bool>();
   int n_iterations = vm["iters"].as<int>();

--- a/test/npu-xrt/vec_vec_add_tile_init/test.cpp
+++ b/test/npu-xrt/vec_vec_add_tile_init/test.cpp
@@ -19,7 +19,7 @@
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 int main(int argc, const char *argv[]) {
 

--- a/test/npu-xrt/vector_scalar_using_dma/test.cpp
+++ b/test/npu-xrt/vector_scalar_using_dma/test.cpp
@@ -20,8 +20,8 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-#include "test_utils.h"
 #include "cxxopts.hpp"
+#include "test_utils.h"
 
 constexpr int IN_SIZE = 4096;
 constexpr int OUT_SIZE = 4096;

--- a/test/npu-xrt/vector_scalar_using_dma/test.cpp
+++ b/test/npu-xrt/vector_scalar_using_dma/test.cpp
@@ -8,7 +8,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <boost/program_options.hpp>
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
@@ -22,43 +21,18 @@
 #include "xrt/xrt_kernel.h"
 
 #include "test_utils.h"
+#include <cxxopts.hpp>
 
 constexpr int IN_SIZE = 4096;
 constexpr int OUT_SIZE = 4096;
 
-namespace po = boost::program_options;
-
 int main(int argc, const char *argv[]) {
 
   // Program arguments parsing
-  po::options_description desc("Allowed options");
-  desc.add_options()("help,h", "produce help message")(
-      "xclbin,x", po::value<std::string>()->required(),
-      "the input xclbin path")(
-      "kernel,k", po::value<std::string>()->required(),
-      "the kernel name in the XCLBIN (for instance PP_PRE_FD)")(
-      "verbosity,v", po::value<int>()->default_value(0),
-      "the verbosity of the output")(
-      "instr,i", po::value<std::string>()->required(),
-      "path of file containing userspace instructions to be sent to the LX6");
-  po::variables_map vm;
-
-  try {
-    po::store(po::parse_command_line(argc, argv, desc), vm);
-    po::notify(vm);
-
-    if (vm.count("help")) {
-      std::cout << desc << "\n";
-      return 1;
-    }
-  } catch (const std::exception &ex) {
-    std::cerr << ex.what() << "\n\n";
-    std::cerr << "Usage:\n" << desc << "\n";
-    return 1;
-  }
-
-  test_utils::check_arg_file_exists(vm, "xclbin");
-  test_utils::check_arg_file_exists(vm, "instr");
+  cxxopts::Options options("vector_scalar_using_dma");
+  test_utils::add_default_options(options);
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
 
   std::vector<uint32_t> instr_v =
       test_utils::load_instr_binary(vm["instr"].as<std::string>());

--- a/test/npu-xrt/vector_scalar_using_dma/test.cpp
+++ b/test/npu-xrt/vector_scalar_using_dma/test.cpp
@@ -21,7 +21,7 @@
 #include "xrt/xrt_kernel.h"
 
 #include "test_utils.h"
-#include <cxxopts.hpp>
+#include "cxxopts.hpp"
 
 constexpr int IN_SIZE = 4096;
 constexpr int OUT_SIZE = 4096;

--- a/test/unit_tests/chess_compiler_tests/01_precompiled_core_function/test.cpp
+++ b/test/unit_tests/chess_compiler_tests/01_precompiled_core_function/test.cpp
@@ -8,69 +8,67 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "test_library.h"
 #include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <thread>
-#include <stdlib.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
 #include <xaiengine.h>
-#include "test_library.h"
 
 #include "aie_inc.cpp"
 
-int
-main(int argc, char *argv[])
-{
-    printf("test start.\n");
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
 
-    aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
-    mlir_aie_init_device(_xaie);
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
 
-    mlir_aie_clear_tile_memory(_xaie, 1, 3);
+  mlir_aie_clear_tile_memory(_xaie, 1, 3);
 
-    mlir_aie_configure_cores(_xaie);
-    mlir_aie_configure_switchboxes(_xaie);
-    mlir_aie_configure_dmas(_xaie);
-    mlir_aie_initialize_locks(_xaie);
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_configure_dmas(_xaie);
+  mlir_aie_initialize_locks(_xaie);
 
-    int errors = 0;
+  int errors = 0;
 
-    printf("Acquire input buffer lock first.\n");
-    mlir_aie_acquire_input_lock(_xaie, 0, 0); // Should this part of setup???
-    mlir_aie_write_buffer_a(_xaie, 3, 7);
+  printf("Acquire input buffer lock first.\n");
+  mlir_aie_acquire_input_lock(_xaie, 0, 0); // Should this part of setup???
+  mlir_aie_write_buffer_a(_xaie, 3, 7);
 
-    printf("Start cores\n");
-    mlir_aie_start_cores(_xaie);
+  printf("Start cores\n");
+  mlir_aie_start_cores(_xaie);
 
-    mlir_aie_check("Before release lock:", mlir_aie_read_buffer_b(_xaie, 5), 0,
-                   errors);
+  mlir_aie_check("Before release lock:", mlir_aie_read_buffer_b(_xaie, 5), 0,
+                 errors);
 
-    printf("Release input buffer lock.\n");
-    mlir_aie_release_input_lock(_xaie, 1, 0);
+  printf("Release input buffer lock.\n");
+  mlir_aie_release_input_lock(_xaie, 1, 0);
 
-    printf("Waiting to acquire output lock for read ...\n");
-    if (mlir_aie_acquire_output_lock(_xaie, 1, 1000)) {
-      errors++;
-      printf("ERROR: Failed to acquire output lock!\n");
-    }
+  printf("Waiting to acquire output lock for read ...\n");
+  if (mlir_aie_acquire_output_lock(_xaie, 1, 1000)) {
+    errors++;
+    printf("ERROR: Failed to acquire output lock!\n");
+  }
 
-    mlir_aie_check("After release lock:", mlir_aie_read_buffer_b(_xaie, 5), 35,
-                   errors);
+  mlir_aie_check("After release lock:", mlir_aie_read_buffer_b(_xaie, 5), 35,
+                 errors);
 
-    int res = 0;
-    if (!errors) {
-      printf("PASS!\n");
-      res = 0;
-    } else {
-      printf("Fail!\n");
-      res = -1;
-    }
-    mlir_aie_deinit_libxaie(_xaie);
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
 
-    printf("test done.\n");
-    return res;
+  printf("test done.\n");
+  return res;
 }

--- a/test/unit_tests/chess_compiler_tests/02_precompiled_kernel/test.cpp
+++ b/test/unit_tests/chess_compiler_tests/02_precompiled_kernel/test.cpp
@@ -8,69 +8,67 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "test_library.h"
 #include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <thread>
-#include <stdlib.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
 #include <xaiengine.h>
-#include "test_library.h"
 
 #include "aie_inc.cpp"
 
-int
-main(int argc, char *argv[])
-{
-    printf("test start.\n");
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
 
-    aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
-    mlir_aie_init_device(_xaie);
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
 
-    mlir_aie_clear_tile_memory(_xaie, 1, 3);
+  mlir_aie_clear_tile_memory(_xaie, 1, 3);
 
-    mlir_aie_configure_cores(_xaie);
-    mlir_aie_configure_switchboxes(_xaie);
-    mlir_aie_configure_dmas(_xaie);
-    mlir_aie_initialize_locks(_xaie);
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_configure_dmas(_xaie);
+  mlir_aie_initialize_locks(_xaie);
 
-    int errors = 0;
+  int errors = 0;
 
-    printf("Acquire input buffer lock first.\n");
-    mlir_aie_acquire_input_lock(_xaie, 0, 0); // Should this part of setup???
-    mlir_aie_write_buffer_a(_xaie, 3, 7);
+  printf("Acquire input buffer lock first.\n");
+  mlir_aie_acquire_input_lock(_xaie, 0, 0); // Should this part of setup???
+  mlir_aie_write_buffer_a(_xaie, 3, 7);
 
-    printf("Start cores\n");
-    mlir_aie_start_cores(_xaie);
+  printf("Start cores\n");
+  mlir_aie_start_cores(_xaie);
 
-    mlir_aie_check("Before release lock:", mlir_aie_read_buffer_b(_xaie, 5), 0,
-                   errors);
+  mlir_aie_check("Before release lock:", mlir_aie_read_buffer_b(_xaie, 5), 0,
+                 errors);
 
-    printf("Release input buffer lock.\n");
-    mlir_aie_release_input_lock(_xaie, 1, 0);
+  printf("Release input buffer lock.\n");
+  mlir_aie_release_input_lock(_xaie, 1, 0);
 
-    printf("Waiting to acquire output lock for read ...\n");
-    if (mlir_aie_acquire_output_lock(_xaie, 1, 1000)) {
-      errors++;
-      printf("ERROR: Failed to acquire output lock!\n");
-    }
+  printf("Waiting to acquire output lock for read ...\n");
+  if (mlir_aie_acquire_output_lock(_xaie, 1, 1000)) {
+    errors++;
+    printf("ERROR: Failed to acquire output lock!\n");
+  }
 
-    mlir_aie_check("After release lock:", mlir_aie_read_buffer_b(_xaie, 5), 35,
-                   errors);
+  mlir_aie_check("After release lock:", mlir_aie_read_buffer_b(_xaie, 5), 35,
+                 errors);
 
-    int res = 0;
-    if (!errors) {
-      printf("PASS!\n");
-      res = 0;
-    } else {
-      printf("Fail!\n");
-      res = -1;
-    }
-    mlir_aie_deinit_libxaie(_xaie);
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
 
-    printf("test done.\n");
-    return res;
+  printf("test done.\n");
+  return res;
 }

--- a/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/test.cpp
+++ b/test/unit_tests/chess_compiler_tests/03_cascade_core_functions/test.cpp
@@ -8,71 +8,69 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "test_library.h"
 #include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <thread>
-#include <stdlib.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
 #include <xaiengine.h>
-#include "test_library.h"
 
 #include "aie_inc.cpp"
 
-int
-main(int argc, char *argv[])
-{
-    printf("test start.\n");
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
 
-    aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
-    mlir_aie_init_device(_xaie);
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
 
-    mlir_aie_configure_cores(_xaie);
-    mlir_aie_configure_switchboxes(_xaie);
-    mlir_aie_configure_dmas(_xaie);
-    mlir_aie_initialize_locks(_xaie);
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_configure_dmas(_xaie);
+  mlir_aie_initialize_locks(_xaie);
 
-    int errors = 0;
+  int errors = 0;
 
-    mlir_aie_write_buffer_a(_xaie, 3, 7);
+  mlir_aie_write_buffer_a(_xaie, 3, 7);
 
-    printf("Start cores\n");
-    mlir_aie_start_cores(_xaie);
+  printf("Start cores\n");
+  mlir_aie_start_cores(_xaie);
 
-    // In simulation, we can't perform this check. because
-    // memory is not initialized to zero.
+  // In simulation, we can't perform this check. because
+  // memory is not initialized to zero.
 #ifndef __AIESIM__
-    mlir_aie_check("Before release lock:", mlir_aie_read_buffer_c(_xaie, 5), 0,
-                   errors);
+  mlir_aie_check("Before release lock:", mlir_aie_read_buffer_c(_xaie, 5), 0,
+                 errors);
 #endif
 
-    printf("Release input buffer lock.\n");
-    mlir_aie_release_input_lock(_xaie, 1, 0);
+  printf("Release input buffer lock.\n");
+  mlir_aie_release_input_lock(_xaie, 1, 0);
 
-    printf("Waiting to acquire output lock for read ...\n");
-    if (mlir_aie_acquire_output_lock(_xaie, 1, 1000)) {
-      errors++;
-      printf("ERROR: Failed to acquire output lock!\n");
-    }
+  printf("Waiting to acquire output lock for read ...\n");
+  if (mlir_aie_acquire_output_lock(_xaie, 1, 1000)) {
+    errors++;
+    printf("ERROR: Failed to acquire output lock!\n");
+  }
 
-    // mlir_aie_dump_tile_memory(_xaie, 1, 3);
-    // mlir_aie_dump_tile_memory(_xaie, 2, 3);
-    mlir_aie_check("After acquire lock:", mlir_aie_read_buffer_c(_xaie, 5), 175,
-                   errors);
+  // mlir_aie_dump_tile_memory(_xaie, 1, 3);
+  // mlir_aie_dump_tile_memory(_xaie, 2, 3);
+  mlir_aie_check("After acquire lock:", mlir_aie_read_buffer_c(_xaie, 5), 175,
+                 errors);
 
-    int res = 0;
-    if (!errors) {
-      printf("PASS!\n");
-      res = 0;
-    } else {
-      printf("Fail!\n");
-      res = -1;
-    }
-    mlir_aie_deinit_libxaie(_xaie);
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
 
-    printf("test done.\n");
-    return res;
+  printf("test done.\n");
+  return res;
 }

--- a/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/test.cpp
+++ b/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/test.cpp
@@ -12,11 +12,11 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <thread>
-#include <stdlib.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
 #include <xaiengine.h>
 
 #include "memory_allocator.h"
@@ -24,220 +24,219 @@
 
 #include "aie_inc.cpp"
 
-int
-main(int argc, char *argv[])
-{
-    printf("test start.\n");
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
 
-    aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
-    mlir_aie_init_device(_xaie);
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
 
-    /*
-    XAieDma_Shim ShimDMAInst_7_0;
-    XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
-    XAieDma_ShimChResetAll(&ShimDMAInst_7_0);
-    XAieDma_ShimBdClearAll(&ShimDMAInst_7_0);
+  /*
+  XAieDma_Shim ShimDMAInst_7_0;
+  XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
+  XAieDma_ShimChResetAll(&ShimDMAInst_7_0);
+  XAieDma_ShimBdClearAll(&ShimDMAInst_7_0);
 
-    XAieDma_Tile TileDmaInst_7_3;
-    XAieDma_TileInitialize(&(TileInst[7][3]), &TileDmaInst_7_3);
-    XAieDma_TileBdClearAll(&TileDmaInst_7_3);
-    XAieDma_TileChResetAll(&TileDmaInst_7_3);
-    */
+  XAieDma_Tile TileDmaInst_7_3;
+  XAieDma_TileInitialize(&(TileInst[7][3]), &TileDmaInst_7_3);
+  XAieDma_TileBdClearAll(&TileDmaInst_7_3);
+  XAieDma_TileChResetAll(&TileDmaInst_7_3);
+  */
 
-    mlir_aie_configure_cores(_xaie);
-    mlir_aie_configure_switchboxes(_xaie);
-    mlir_aie_release_input_lock(_xaie, 0x0, 0);
-    mlir_aie_release_output_lock(_xaie, 0x0, 0);
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_release_input_lock(_xaie, 0x0, 0);
+  mlir_aie_release_output_lock(_xaie, 0x0, 0);
 
-    for (int bd=0;bd<16;bd++) {
-        // Take no prisoners.  No regerts
-        // Overwrites the DMA_BDX_Control registers
-        for(int ofst=0;ofst<0x14;ofst+=0x4){
-          u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
-                                              0x0001D000 + (bd * 0x14) + ofst);
-          if (rb != 0) {
-            printf("Before : bd%d_%x control is %08X\n", bd, ofst, rb);
-          }
-          // mlir_aie_write32(TileInst[7][0].TileAddr +
-          // 0x0001D000+(bd*0x14)+ofst, 0x0);
-        }
+  for (int bd = 0; bd < 16; bd++) {
+    // Take no prisoners.  No regerts
+    // Overwrites the DMA_BDX_Control registers
+    for (int ofst = 0; ofst < 0x14; ofst += 0x4) {
+      u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
+                                          0x0001D000 + (bd * 0x14) + ofst);
+      if (rb != 0) {
+        printf("Before : bd%d_%x control is %08X\n", bd, ofst, rb);
+      }
+      // mlir_aie_write32(TileInst[7][0].TileAddr +
+      // 0x0001D000+(bd*0x14)+ofst, 0x0);
     }
+  }
 
-    for (int dma=0;dma<4;dma++) {
-        for(int ofst=0;ofst<0x8;ofst+=0x4){
-          u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
-                                              0x0001D140 + (dma * 0x8) + ofst);
-          if (rb != 0) {
-            printf("Before : dma%d_%x control is %08X\n", dma, ofst, rb);
-          }
-          // mlir_aie_write32(TileInst[7][0].TileAddr +
-          // 0x0001D140+(dma*0x8)+ofst, 0x0);
-        }
+  for (int dma = 0; dma < 4; dma++) {
+    for (int ofst = 0; ofst < 0x8; ofst += 0x4) {
+      u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
+                                          0x0001D140 + (dma * 0x8) + ofst);
+      if (rb != 0) {
+        printf("Before : dma%d_%x control is %08X\n", dma, ofst, rb);
+      }
+      // mlir_aie_write32(TileInst[7][0].TileAddr +
+      // 0x0001D140+(dma*0x8)+ofst, 0x0);
     }
+  }
 
-    mlir_aie_initialize_locks(_xaie);
+  mlir_aie_initialize_locks(_xaie);
 
-    printf("before DMA config\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
+  printf("before DMA config\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
 
-    mlir_aie_configure_dmas(_xaie);
+  mlir_aie_configure_dmas(_xaie);
 
-    printf("after DMA config\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
+  printf("after DMA config\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
 
-    int errors = 0;
+  int errors = 0;
 
-    /*
-        uint32_t *ddr_ptr_in, *ddr_ptr_out;
-        #define DDR_ADDR_IN  (0x4000+0x020100000000LL)
-        #define DDR_ADDR_OUT (0x6000+0x020100000000LL)
-        #define DMA_COUNT 512
+  /*
+      uint32_t *ddr_ptr_in, *ddr_ptr_out;
+      #define DDR_ADDR_IN  (0x4000+0x020100000000LL)
+      #define DDR_ADDR_OUT (0x6000+0x020100000000LL)
+      #define DMA_COUNT 512
 
-        int fd = open("/dev/mem", O_RDWR | O_SYNC);
-        if (fd != -1) {
-            ddr_ptr_in  = (uint32_t *)mmap(NULL, 0x800, PROT_READ|PROT_WRITE,
-       MAP_SHARED, fd, DDR_ADDR_IN); ddr_ptr_out = (uint32_t *)mmap(NULL, 0x800,
-       PROT_READ|PROT_WRITE, MAP_SHARED, fd, DDR_ADDR_OUT); for (int i=0;
-       i<DMA_COUNT; i++) { ddr_ptr_in[i] = i+1; ddr_ptr_out[i] = 0;
-            }
-        }
-    */
+      int fd = open("/dev/mem", O_RDWR | O_SYNC);
+      if (fd != -1) {
+          ddr_ptr_in  = (uint32_t *)mmap(NULL, 0x800, PROT_READ|PROT_WRITE,
+     MAP_SHARED, fd, DDR_ADDR_IN); ddr_ptr_out = (uint32_t *)mmap(NULL, 0x800,
+     PROT_READ|PROT_WRITE, MAP_SHARED, fd, DDR_ADDR_OUT); for (int i=0;
+     i<DMA_COUNT; i++) { ddr_ptr_in[i] = i+1; ddr_ptr_out[i] = 0;
+          }
+      }
+  */
 #define DMA_COUNT 512
-    ext_mem_model_t buf0, buf1;
-    int *ddr_ptr_in = mlir_aie_mem_alloc(_xaie, buf0, DMA_COUNT);
-    int *ddr_ptr_out = mlir_aie_mem_alloc(_xaie, buf1, DMA_COUNT);
-    for (int i = 0; i < DMA_COUNT; i++) {
-      *(ddr_ptr_in + i) = i + 1;
-      *(ddr_ptr_out + i) = 0;
+  ext_mem_model_t buf0, buf1;
+  int *ddr_ptr_in = mlir_aie_mem_alloc(_xaie, buf0, DMA_COUNT);
+  int *ddr_ptr_out = mlir_aie_mem_alloc(_xaie, buf1, DMA_COUNT);
+  for (int i = 0; i < DMA_COUNT; i++) {
+    *(ddr_ptr_in + i) = i + 1;
+    *(ddr_ptr_out + i) = 0;
+  }
+  mlir_aie_sync_mem_dev(buf0);
+  mlir_aie_sync_mem_dev(buf1);
+
+  mlir_aie_external_set_addr_input_buffer(_xaie, (u64)ddr_ptr_in);
+  mlir_aie_external_set_addr_output_buffer(_xaie, (u64)ddr_ptr_out);
+  mlir_aie_configure_shimdma_70(_xaie);
+
+  mlir_aie_clear_tile_memory(_xaie, 7, 3);
+
+  // Set iteration to 2 TODO: fix this
+  // XAieTile_DmWriteWord(&(TileInst[7][3]), 5120 , 2);
+
+  for (int i = 0; i < DMA_COUNT / 2; i++) {
+    mlir_aie_write_buffer_a_ping(_xaie, i, 0x4);
+    mlir_aie_write_buffer_a_pong(_xaie, i, 0x4);
+    mlir_aie_write_buffer_b_ping(_xaie, i, 0x4);
+    mlir_aie_write_buffer_b_pong(_xaie, i, 0x4);
+  }
+
+  mlir_aie_check("Before", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_a_pong(_xaie, 3), 4, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_b_ping(_xaie, 5), 4, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_b_pong(_xaie, 5), 4, errors);
+
+  //    mlir_aie_dump_tile_memory(TileInst[7][3]);
+
+  /*
+      // TODO Check for completion of shimdma
+      int shimdma_stat_mm2s0, shimdma_stat_s2mm0;
+      XAieDma_Shim ShimDMAInst_7_0;
+      XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
+      shimdma_stat_mm2s0 = XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0,
+     XAIEDMA_SHIM_CHNUM_MM2S0); shimdma_stat_s2mm0 =
+     XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_S2MM0);
+      printf("shimdma_stat_mm2s0/s2mm0 = %d/ %d\n",shimdma_stat_mm2s0,
+     shimdma_stat_s2mm0);
+  */
+
+  printf("before core start\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
+
+  printf("Start cores\n");
+  mlir_aie_start_cores(_xaie);
+
+  printf("Release lock for accessing DDR.\n");
+  mlir_aie_release_input_lock(_xaie, /*r/w*/ 1, 0);
+  mlir_aie_release_output_lock(_xaie, /*r/w*/ 1, 0);
+
+  if (mlir_aie_acquire_input_lock(_xaie, /*r/w*/ 0, 10000)) {
+    printf("input_lock timeout!\n");
+    errors++;
+  }
+  if (mlir_aie_acquire_output_lock(_xaie, /*r/w*/ 0, 10000)) {
+    printf("output_lock timeout\n");
+    errors++;
+  }
+
+  printf("after lock release\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
+  mlir_aie_print_dma_status(_xaie, 7, 3);
+  mlir_aie_print_shimdma_status(_xaie, 7, 0);
+
+  mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 0), 1, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 1), 2, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 2), 3, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
+
+  mlir_aie_check("After", mlir_aie_read_buffer_a_pong(_xaie, 3), 256 + 4,
+                 errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_b_ping(_xaie, 5), 20, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_b_pong(_xaie, 5), (256 + 4) * 5,
+                 errors);
+
+  /*
+      // Dump contents of ddr_ptr_out
+      for (int i=0; i<DMA_COUNT; i++) {
+          uint32_t d = ddr_ptr_out[i];
+          if(d != 0)
+              printf("ddr_ptr_out[%d] = %d\n", i, d);
+      }
+  */
+  mlir_aie_sync_mem_cpu(buf1);
+  mlir_aie_check("DDR out", ddr_ptr_out[5], 20, errors);
+  mlir_aie_check("DDR out", ddr_ptr_out[256 + 5], (256 + 4) * 5, errors);
+
+  /*
+  XAieDma_Shim ShimDmaInst1;
+  XAieDma_ShimSoftInitialize(&(TileInst[7][0]), &ShimDmaInst1);
+  XAieDma_ShimBdClearAll((&ShimDmaInst1));
+  XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_MM2S0, XAIE_DISABLE,
+  XAIE_DISABLE, XAIE_DISABLE); XAieDma_ShimChControl((&ShimDmaInst1),
+  XAIEDMA_SHIM_CHNUM_S2MM0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
+  */
+  for (int bd = 0; bd < 16; bd++) {
+    // Take no prisoners.  No regerts
+    // Overwrites the DMA_BDX_Control registers
+    for (int ofst = 0; ofst < 0x14; ofst += 0x4) {
+      // u32 rb = mlir_aie_read32(TileInst[7][0].TileAddr +
+      // 0x0001D000+(bd*0x14)+ofst); printf("Before : bd%d_%x control is
+      // %08X\n", bd, ofst, rb);
+      mlir_aie_write32(_xaie,
+                       mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D000 +
+                           (bd * 0x14) + ofst,
+                       0x0);
     }
-    mlir_aie_sync_mem_dev(buf0);
-    mlir_aie_sync_mem_dev(buf1);
+  }
 
-    mlir_aie_external_set_addr_input_buffer(_xaie, (u64)ddr_ptr_in);
-    mlir_aie_external_set_addr_output_buffer(_xaie, (u64)ddr_ptr_out);
-    mlir_aie_configure_shimdma_70(_xaie);
-
-    mlir_aie_clear_tile_memory(_xaie, 7, 3);
-
-    // Set iteration to 2 TODO: fix this
-    // XAieTile_DmWriteWord(&(TileInst[7][3]), 5120 , 2);
-
-    for (int i=0; i<DMA_COUNT/2; i++) {
-      mlir_aie_write_buffer_a_ping(_xaie, i, 0x4);
-      mlir_aie_write_buffer_a_pong(_xaie, i, 0x4);
-      mlir_aie_write_buffer_b_ping(_xaie, i, 0x4);
-      mlir_aie_write_buffer_b_pong(_xaie, i, 0x4);
+  for (int dma = 0; dma < 4; dma++) {
+    for (int ofst = 0; ofst < 0x8; ofst += 0x4) {
+      // u32 rb = mlir_aie_read32(TileInst[7][0].TileAddr +
+      // 0x0001D140+(dma*0x8)+ofst); printf("Before : dma%d_%x control is
+      // %08X\n", dma, ofst, rb);
+      mlir_aie_write32(_xaie,
+                       mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D140 +
+                           (dma * 0x8) + ofst,
+                       0x0);
     }
+  }
 
-    mlir_aie_check("Before", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
-    mlir_aie_check("Before", mlir_aie_read_buffer_a_pong(_xaie, 3), 4, errors);
-    mlir_aie_check("Before", mlir_aie_read_buffer_b_ping(_xaie, 5), 4, errors);
-    mlir_aie_check("Before", mlir_aie_read_buffer_b_pong(_xaie, 5), 4, errors);
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
 
-    //    mlir_aie_dump_tile_memory(TileInst[7][3]);
-
-    /*
-        // TODO Check for completion of shimdma
-        int shimdma_stat_mm2s0, shimdma_stat_s2mm0;
-        XAieDma_Shim ShimDMAInst_7_0;
-        XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
-        shimdma_stat_mm2s0 = XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0,
-       XAIEDMA_SHIM_CHNUM_MM2S0); shimdma_stat_s2mm0 =
-       XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_S2MM0);
-        printf("shimdma_stat_mm2s0/s2mm0 = %d/ %d\n",shimdma_stat_mm2s0,
-       shimdma_stat_s2mm0);
-    */
-
-    printf("before core start\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-
-    printf("Start cores\n");
-    mlir_aie_start_cores(_xaie);
-
-    printf("Release lock for accessing DDR.\n");
-    mlir_aie_release_input_lock(_xaie, /*r/w*/ 1, 0);
-    mlir_aie_release_output_lock(_xaie, /*r/w*/ 1, 0);
-
-    if (mlir_aie_acquire_input_lock(_xaie, /*r/w*/ 0, 10000)) {
-      printf("input_lock timeout!\n");
-      errors++;
-    }
-    if (mlir_aie_acquire_output_lock(_xaie, /*r/w*/ 0, 10000)) {
-      printf("output_lock timeout\n");
-      errors++;
-    }
-
-    printf("after lock release\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-    mlir_aie_print_dma_status(_xaie, 7, 3);
-    mlir_aie_print_shimdma_status(_xaie, 7, 0);
-
-    mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 0), 1, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 1), 2, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 2), 3, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
-
-    mlir_aie_check("After", mlir_aie_read_buffer_a_pong(_xaie, 3), 256 + 4,
-                   errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_b_ping(_xaie, 5), 20, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_b_pong(_xaie, 5),
-                   (256 + 4) * 5, errors);
-
-    /*
-        // Dump contents of ddr_ptr_out
-        for (int i=0; i<DMA_COUNT; i++) {
-            uint32_t d = ddr_ptr_out[i];
-            if(d != 0)
-                printf("ddr_ptr_out[%d] = %d\n", i, d);
-        }
-    */
-    mlir_aie_sync_mem_cpu(buf1);
-    mlir_aie_check("DDR out", ddr_ptr_out[5], 20, errors);
-    mlir_aie_check("DDR out", ddr_ptr_out[256 + 5], (256 + 4) * 5, errors);
-
-    /*
-    XAieDma_Shim ShimDmaInst1;
-    XAieDma_ShimSoftInitialize(&(TileInst[7][0]), &ShimDmaInst1);
-    XAieDma_ShimBdClearAll((&ShimDmaInst1));
-    XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_MM2S0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
-    XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_S2MM0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
-    */
-    for (int bd=0;bd<16;bd++) {
-        // Take no prisoners.  No regerts
-        // Overwrites the DMA_BDX_Control registers
-        for(int ofst=0;ofst<0x14;ofst+=0x4){
-          // u32 rb = mlir_aie_read32(TileInst[7][0].TileAddr +
-          // 0x0001D000+(bd*0x14)+ofst); printf("Before : bd%d_%x control is
-          // %08X\n", bd, ofst, rb);
-          mlir_aie_write32(_xaie,
-                           mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D000 +
-                               (bd * 0x14) + ofst,
-                           0x0);
-        }
-    }
-
-    for (int dma=0;dma<4;dma++) {
-        for(int ofst=0;ofst<0x8;ofst+=0x4){
-          // u32 rb = mlir_aie_read32(TileInst[7][0].TileAddr +
-          // 0x0001D140+(dma*0x8)+ofst); printf("Before : dma%d_%x control is
-          // %08X\n", dma, ofst, rb);
-          mlir_aie_write32(_xaie,
-                           mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D140 +
-                               (dma * 0x8) + ofst,
-                           0x0);
-        }
-    }
-
-    int res = 0;
-    if (!errors) {
-      printf("PASS!\n");
-      res = 0;
-    } else {
-      printf("Fail!\n");
-      res = -1;
-    }
-    mlir_aie_deinit_libxaie(_xaie);
-
-    printf("test done.\n");
-    return res;
+  printf("test done.\n");
+  return res;
 }

--- a/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/test.cpp
+++ b/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/test.cpp
@@ -12,11 +12,11 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <thread>
-#include <stdlib.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
 #include <xaiengine.h>
 
 #include "memory_allocator.h"
@@ -24,220 +24,219 @@
 
 #include "aie_inc.cpp"
 
-int
-main(int argc, char *argv[])
-{
-    printf("test start.\n");
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
 
-    aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
-    mlir_aie_init_device(_xaie);
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
 
-    /*
-    XAieDma_Shim ShimDMAInst_7_0;
-    XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
-    XAieDma_ShimChResetAll(&ShimDMAInst_7_0);
-    XAieDma_ShimBdClearAll(&ShimDMAInst_7_0);
+  /*
+  XAieDma_Shim ShimDMAInst_7_0;
+  XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
+  XAieDma_ShimChResetAll(&ShimDMAInst_7_0);
+  XAieDma_ShimBdClearAll(&ShimDMAInst_7_0);
 
-    XAieDma_Tile TileDmaInst_7_3;
-    XAieDma_TileInitialize(&(TileInst[7][3]), &TileDmaInst_7_3);
-    XAieDma_TileBdClearAll(&TileDmaInst_7_3);
-    XAieDma_TileChResetAll(&TileDmaInst_7_3);
-    */
+  XAieDma_Tile TileDmaInst_7_3;
+  XAieDma_TileInitialize(&(TileInst[7][3]), &TileDmaInst_7_3);
+  XAieDma_TileBdClearAll(&TileDmaInst_7_3);
+  XAieDma_TileChResetAll(&TileDmaInst_7_3);
+  */
 
-    mlir_aie_configure_cores(_xaie);
-    mlir_aie_configure_switchboxes(_xaie);
-    mlir_aie_release_input_lock(_xaie, 0x0, 0);
-    mlir_aie_release_output_lock(_xaie, 0x0, 0);
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_release_input_lock(_xaie, 0x0, 0);
+  mlir_aie_release_output_lock(_xaie, 0x0, 0);
 
-    for (int bd=0;bd<16;bd++) {
-        // Take no prisoners.  No regerts
-        // Overwrites the DMA_BDX_Control registers
-        for(int ofst=0;ofst<0x14;ofst+=0x4){
-          u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
-                                              0x0001D000 + (bd * 0x14) + ofst);
-          if (rb != 0) {
-            printf("Before : bd%d_%x control is %08X\n", bd, ofst, rb);
-          }
-          // mlir_aie_write32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
-          // 0x0001D000+(bd*0x14)+ofst, 0x0);
-        }
+  for (int bd = 0; bd < 16; bd++) {
+    // Take no prisoners.  No regerts
+    // Overwrites the DMA_BDX_Control registers
+    for (int ofst = 0; ofst < 0x14; ofst += 0x4) {
+      u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
+                                          0x0001D000 + (bd * 0x14) + ofst);
+      if (rb != 0) {
+        printf("Before : bd%d_%x control is %08X\n", bd, ofst, rb);
+      }
+      // mlir_aie_write32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
+      // 0x0001D000+(bd*0x14)+ofst, 0x0);
     }
+  }
 
-    for (int dma=0;dma<4;dma++) {
-        for(int ofst=0;ofst<0x8;ofst+=0x4){
-          u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
-                                              0x0001D140 + (dma * 0x8) + ofst);
-          if (rb != 0) {
-            printf("Before : dma%d_%x control is %08X\n", dma, ofst, rb);
-          }
-          // mlir_aie_write32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
-          // 0x0001D140+(dma*0x8)+ofst, 0x0);
-        }
+  for (int dma = 0; dma < 4; dma++) {
+    for (int ofst = 0; ofst < 0x8; ofst += 0x4) {
+      u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
+                                          0x0001D140 + (dma * 0x8) + ofst);
+      if (rb != 0) {
+        printf("Before : dma%d_%x control is %08X\n", dma, ofst, rb);
+      }
+      // mlir_aie_write32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0) +
+      // 0x0001D140+(dma*0x8)+ofst, 0x0);
     }
+  }
 
-    mlir_aie_initialize_locks(_xaie);
+  mlir_aie_initialize_locks(_xaie);
 
-    printf("before DMA config\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
+  printf("before DMA config\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
 
-    mlir_aie_configure_dmas(_xaie);
+  mlir_aie_configure_dmas(_xaie);
 
-    printf("after DMA config\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
+  printf("after DMA config\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
 
-    int errors = 0;
-    /*
-        uint32_t *ddr_ptr_in, *ddr_ptr_out;
-        #define DDR_ADDR_IN  (0x4000+0x020100000000LL)
-        #define DDR_ADDR_OUT (0x6000+0x020100000000LL)
-        #define DMA_COUNT 512
+  int errors = 0;
+  /*
+      uint32_t *ddr_ptr_in, *ddr_ptr_out;
+      #define DDR_ADDR_IN  (0x4000+0x020100000000LL)
+      #define DDR_ADDR_OUT (0x6000+0x020100000000LL)
+      #define DMA_COUNT 512
 
-        int fd = open("/dev/mem", O_RDWR | O_SYNC);
-        if (fd != -1) {
-            ddr_ptr_in  = (uint32_t *)mmap(NULL, 0x800, PROT_READ|PROT_WRITE,
-       MAP_SHARED, fd, DDR_ADDR_IN); ddr_ptr_out = (uint32_t *)mmap(NULL, 0x800,
-       PROT_READ|PROT_WRITE, MAP_SHARED, fd, DDR_ADDR_OUT); for (int i=0;
-       i<DMA_COUNT; i++) { ddr_ptr_in[i] = i+1; ddr_ptr_out[i] = 0;
-            }
-        }
-    */
+      int fd = open("/dev/mem", O_RDWR | O_SYNC);
+      if (fd != -1) {
+          ddr_ptr_in  = (uint32_t *)mmap(NULL, 0x800, PROT_READ|PROT_WRITE,
+     MAP_SHARED, fd, DDR_ADDR_IN); ddr_ptr_out = (uint32_t *)mmap(NULL, 0x800,
+     PROT_READ|PROT_WRITE, MAP_SHARED, fd, DDR_ADDR_OUT); for (int i=0;
+     i<DMA_COUNT; i++) { ddr_ptr_in[i] = i+1; ddr_ptr_out[i] = 0;
+          }
+      }
+  */
 
 #define DMA_COUNT 512
-    ext_mem_model_t buf0, buf1;
-    int *ddr_ptr_in = mlir_aie_mem_alloc(_xaie, buf0, DMA_COUNT);
-    int *ddr_ptr_out = mlir_aie_mem_alloc(_xaie, buf1, DMA_COUNT);
-    for (int i = 0; i < DMA_COUNT; i++) {
-      *(ddr_ptr_in + i) = i + 1;
-      *(ddr_ptr_out + i) = 0;
+  ext_mem_model_t buf0, buf1;
+  int *ddr_ptr_in = mlir_aie_mem_alloc(_xaie, buf0, DMA_COUNT);
+  int *ddr_ptr_out = mlir_aie_mem_alloc(_xaie, buf1, DMA_COUNT);
+  for (int i = 0; i < DMA_COUNT; i++) {
+    *(ddr_ptr_in + i) = i + 1;
+    *(ddr_ptr_out + i) = 0;
+  }
+  mlir_aie_sync_mem_dev(buf0);
+  mlir_aie_sync_mem_dev(buf1);
+
+  mlir_aie_external_set_addr_input_buffer(_xaie, (u64)ddr_ptr_in);
+  mlir_aie_external_set_addr_output_buffer(_xaie, (u64)ddr_ptr_out);
+  mlir_aie_configure_shimdma_70(_xaie);
+
+  mlir_aie_clear_tile_memory(_xaie, 7, 3);
+
+  // Set iteration to 2 TODO: fix this
+  // XAieTile_DmWriteWord(&(TileInst[7][3]), 5120 , 2);
+
+  for (int i = 0; i < DMA_COUNT / 2; i++) {
+    mlir_aie_write_buffer_a_ping(_xaie, i, 0x4);
+    mlir_aie_write_buffer_a_pong(_xaie, i, 0x4);
+    mlir_aie_write_buffer_b_ping(_xaie, i, 0x4);
+    mlir_aie_write_buffer_b_pong(_xaie, i, 0x4);
+  }
+
+  mlir_aie_check("Before", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_a_pong(_xaie, 3), 4, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_b_ping(_xaie, 5), 4, errors);
+  mlir_aie_check("Before", mlir_aie_read_buffer_b_pong(_xaie, 5), 4, errors);
+
+  //    mlir_aie_dump_tile_memory(TileInst[7][3]);
+
+  /*
+      // TODO Check for completion of shimdma
+      int shimdma_stat_mm2s0, shimdma_stat_s2mm0;
+      XAieDma_Shim ShimDMAInst_7_0;
+      XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
+      shimdma_stat_mm2s0 = XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0,
+     XAIEDMA_SHIM_CHNUM_MM2S0); shimdma_stat_s2mm0 =
+     XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_S2MM0);
+      printf("shimdma_stat_mm2s0/s2mm0 = %d/ %d\n",shimdma_stat_mm2s0,
+     shimdma_stat_s2mm0);
+  */
+
+  printf("before core start\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
+
+  printf("Start cores\n");
+  mlir_aie_start_cores(_xaie);
+
+  printf("after core start\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
+
+  printf("Release lock for accessing DDR.\n");
+  mlir_aie_release_input_lock(_xaie, /*r/w*/ 1, 0);
+  mlir_aie_release_output_lock(_xaie, /*r/w*/ 1, 0);
+
+  if (mlir_aie_acquire_input_lock(_xaie, /*r/w*/ 0, 10000)) {
+    printf("input_lock timeout!\n");
+    errors++;
+  }
+  if (mlir_aie_acquire_output_lock(_xaie, /*r/w*/ 0, 10000)) {
+    printf("output_lock timeout\n");
+    errors++;
+  }
+
+  printf("after lock release\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
+  mlir_aie_print_dma_status(_xaie, 7, 3);
+  mlir_aie_print_shimdma_status(_xaie, 7, 0);
+
+  mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 2), 3, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_a_pong(_xaie, 3), 256 + 4,
+                 errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_b_ping(_xaie, 5), 20, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_b_pong(_xaie, 5), (256 + 4) * 5,
+                 errors);
+
+  /*
+      // Dump contents of ddr_ptr_out
+      for (int i=0; i<DMA_COUNT; i++) {
+          uint32_t d = ddr_ptr_out[i];
+          if(d != 0)
+              printf("ddr_ptr_out[%d] = %d\n", i, d);
+      }
+  */
+  mlir_aie_sync_mem_cpu(buf1);
+  mlir_aie_check("DDR out", ddr_ptr_out[5], 20, errors);
+  mlir_aie_check("DDR out", ddr_ptr_out[256 + 5], (256 + 4) * 5, errors);
+
+  /*
+  XAieDma_Shim ShimDmaInst1;
+  XAieDma_ShimSoftInitialize(&(TileInst[7][0]), &ShimDmaInst1);
+  XAieDma_ShimBdClearAll((&ShimDmaInst1));
+  XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_MM2S0, XAIE_DISABLE,
+  XAIE_DISABLE, XAIE_DISABLE); XAieDma_ShimChControl((&ShimDmaInst1),
+  XAIEDMA_SHIM_CHNUM_S2MM0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
+  */
+  for (int bd = 0; bd < 16; bd++) {
+    // Take no prisoners.  No regerts
+    // Overwrites the DMA_BDX_Control registers
+    for (int ofst = 0; ofst < 0x14; ofst += 0x4) {
+      // u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0)
+      // + 0x0001D000+(bd*0x14)+ofst); printf("Before : bd%d_%x control is
+      // %08X\n", bd, ofst, rb);
+      mlir_aie_write32(_xaie,
+                       mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D000 +
+                           (bd * 0x14) + ofst,
+                       0x0);
     }
-    mlir_aie_sync_mem_dev(buf0);
-    mlir_aie_sync_mem_dev(buf1);
+  }
 
-    mlir_aie_external_set_addr_input_buffer(_xaie, (u64)ddr_ptr_in);
-    mlir_aie_external_set_addr_output_buffer(_xaie, (u64)ddr_ptr_out);
-    mlir_aie_configure_shimdma_70(_xaie);
-
-    mlir_aie_clear_tile_memory(_xaie, 7, 3);
-
-    // Set iteration to 2 TODO: fix this
-    // XAieTile_DmWriteWord(&(TileInst[7][3]), 5120 , 2);
-
-    for (int i=0; i<DMA_COUNT/2; i++) {
-      mlir_aie_write_buffer_a_ping(_xaie, i, 0x4);
-      mlir_aie_write_buffer_a_pong(_xaie, i, 0x4);
-      mlir_aie_write_buffer_b_ping(_xaie, i, 0x4);
-      mlir_aie_write_buffer_b_pong(_xaie, i, 0x4);
+  for (int dma = 0; dma < 4; dma++) {
+    for (int ofst = 0; ofst < 0x8; ofst += 0x4) {
+      // u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0)
+      // + 0x0001D140+(dma*0x8)+ofst); printf("Before : dma%d_%x control is
+      // %08X\n", dma, ofst, rb);
+      mlir_aie_write32(_xaie,
+                       mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D140 +
+                           (dma * 0x8) + ofst,
+                       0x0);
     }
+  }
 
-    mlir_aie_check("Before", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
-    mlir_aie_check("Before", mlir_aie_read_buffer_a_pong(_xaie, 3), 4, errors);
-    mlir_aie_check("Before", mlir_aie_read_buffer_b_ping(_xaie, 5), 4, errors);
-    mlir_aie_check("Before", mlir_aie_read_buffer_b_pong(_xaie, 5), 4, errors);
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
 
-    //    mlir_aie_dump_tile_memory(TileInst[7][3]);
-
-    /*
-        // TODO Check for completion of shimdma
-        int shimdma_stat_mm2s0, shimdma_stat_s2mm0;
-        XAieDma_Shim ShimDMAInst_7_0;
-        XAieDma_ShimInitialize(&(TileInst[7][0]), &ShimDMAInst_7_0);
-        shimdma_stat_mm2s0 = XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0,
-       XAIEDMA_SHIM_CHNUM_MM2S0); shimdma_stat_s2mm0 =
-       XAieDma_ShimPendingBdCount(&ShimDMAInst_7_0, XAIEDMA_SHIM_CHNUM_S2MM0);
-        printf("shimdma_stat_mm2s0/s2mm0 = %d/ %d\n",shimdma_stat_mm2s0,
-       shimdma_stat_s2mm0);
-    */
-
-    printf("before core start\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-
-    printf("Start cores\n");
-    mlir_aie_start_cores(_xaie);
-
-    printf("after core start\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-
-    printf("Release lock for accessing DDR.\n");
-    mlir_aie_release_input_lock(_xaie, /*r/w*/ 1, 0);
-    mlir_aie_release_output_lock(_xaie, /*r/w*/ 1, 0);
-
-    if (mlir_aie_acquire_input_lock(_xaie, /*r/w*/ 0, 10000)) {
-      printf("input_lock timeout!\n");
-      errors++;
-    }
-    if (mlir_aie_acquire_output_lock(_xaie, /*r/w*/ 0, 10000)) {
-      printf("output_lock timeout\n");
-      errors++;
-    }
-
-    printf("after lock release\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-    mlir_aie_print_dma_status(_xaie, 7, 3);
-    mlir_aie_print_shimdma_status(_xaie, 7, 0);
-
-    mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 2), 3, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 3), 4, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_a_pong(_xaie, 3), 256 + 4,
-                   errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_b_ping(_xaie, 5), 20, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_b_pong(_xaie, 5),
-                   (256 + 4) * 5, errors);
-
-    /*
-        // Dump contents of ddr_ptr_out
-        for (int i=0; i<DMA_COUNT; i++) {
-            uint32_t d = ddr_ptr_out[i];
-            if(d != 0)
-                printf("ddr_ptr_out[%d] = %d\n", i, d);
-        }
-    */
-    mlir_aie_sync_mem_cpu(buf1);
-    mlir_aie_check("DDR out", ddr_ptr_out[5], 20, errors);
-    mlir_aie_check("DDR out", ddr_ptr_out[256 + 5], (256 + 4) * 5, errors);
-
-    /*
-    XAieDma_Shim ShimDmaInst1;
-    XAieDma_ShimSoftInitialize(&(TileInst[7][0]), &ShimDmaInst1);
-    XAieDma_ShimBdClearAll((&ShimDmaInst1));
-    XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_MM2S0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
-    XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_S2MM0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
-    */
-    for (int bd=0;bd<16;bd++) {
-        // Take no prisoners.  No regerts
-        // Overwrites the DMA_BDX_Control registers
-        for(int ofst=0;ofst<0x14;ofst+=0x4){
-          // u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0)
-          // + 0x0001D000+(bd*0x14)+ofst); printf("Before : bd%d_%x control is
-          // %08X\n", bd, ofst, rb);
-          mlir_aie_write32(_xaie,
-                           mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D000 +
-                               (bd * 0x14) + ofst,
-                           0x0);
-        }
-    }
-
-    for (int dma=0;dma<4;dma++) {
-        for(int ofst=0;ofst<0x8;ofst+=0x4){
-          // u32 rb = mlir_aie_read32(_xaie, mlir_aie_get_tile_addr(_xaie, 7, 0)
-          // + 0x0001D140+(dma*0x8)+ofst); printf("Before : dma%d_%x control is
-          // %08X\n", dma, ofst, rb);
-          mlir_aie_write32(_xaie,
-                           mlir_aie_get_tile_addr(_xaie, 7, 0) + 0x0001D140 +
-                               (dma * 0x8) + ofst,
-                           0x0);
-        }
-    }
-
-    int res = 0;
-    if (!errors) {
-      printf("PASS!\n");
-      res = 0;
-    } else {
-      printf("Fail!\n");
-      res = -1;
-    }
-    mlir_aie_deinit_libxaie(_xaie);
-
-    printf("test done.\n");
-    return res;
+  printf("test done.\n");
+  return res;
 }

--- a/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/test.cpp
+++ b/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/test.cpp
@@ -12,11 +12,11 @@
 #include <cmath>
 #include <cstdio>
 #include <cstring>
-#include <thread>
-#include <stdlib.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdlib.h>
 #include <sys/mman.h>
+#include <thread>
+#include <unistd.h>
 #include <xaiengine.h>
 
 #include "memory_allocator.h"
@@ -24,114 +24,112 @@
 
 #include "aie_inc.cpp"
 
+int main(int argc, char *argv[]) {
+  printf("test start.\n");
 
-int
-main(int argc, char *argv[])
-{
-    printf("test start.\n");
+  aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
+  mlir_aie_init_device(_xaie);
 
-    aie_libxaie_ctx_t *_xaie = mlir_aie_init_libxaie();
-    mlir_aie_init_device(_xaie);
+  mlir_aie_configure_cores(_xaie);
+  mlir_aie_configure_switchboxes(_xaie);
+  mlir_aie_initialize_locks(_xaie);
 
-    mlir_aie_configure_cores(_xaie);
-    mlir_aie_configure_switchboxes(_xaie);
-    mlir_aie_initialize_locks(_xaie);
+  printf("before DMA config\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
 
-    printf("before DMA config\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
+  mlir_aie_configure_dmas(_xaie);
 
-    mlir_aie_configure_dmas(_xaie);
+  printf("after DMA config\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
 
-    printf("after DMA config\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-
-    int errors = 0;
+  int errors = 0;
 #define DMA_COUNT 512
-    ext_mem_model_t buf0, buf1;
-    int *ddr_ptr_in = mlir_aie_mem_alloc(_xaie, buf0, DMA_COUNT);
-    int *ddr_ptr_out = mlir_aie_mem_alloc(_xaie, buf1, DMA_COUNT);
-    for (int i = 0; i < DMA_COUNT; i++) {
-      *(ddr_ptr_in + i) = i;
-      *(ddr_ptr_out + i) = 0;
-    }
-    mlir_aie_sync_mem_dev(buf0);
-    mlir_aie_sync_mem_dev(buf1);
+  ext_mem_model_t buf0, buf1;
+  int *ddr_ptr_in = mlir_aie_mem_alloc(_xaie, buf0, DMA_COUNT);
+  int *ddr_ptr_out = mlir_aie_mem_alloc(_xaie, buf1, DMA_COUNT);
+  for (int i = 0; i < DMA_COUNT; i++) {
+    *(ddr_ptr_in + i) = i;
+    *(ddr_ptr_out + i) = 0;
+  }
+  mlir_aie_sync_mem_dev(buf0);
+  mlir_aie_sync_mem_dev(buf1);
 
-    mlir_aie_print_shimdma_status(_xaie, 7, 0);
+  mlir_aie_print_shimdma_status(_xaie, 7, 0);
 
-    mlir_aie_external_set_addr_input_buffer(_xaie, (u64)ddr_ptr_in);
-    mlir_aie_external_set_addr_output_buffer(_xaie, (u64)ddr_ptr_out);
-    mlir_aie_configure_shimdma_70(_xaie);
+  mlir_aie_external_set_addr_input_buffer(_xaie, (u64)ddr_ptr_in);
+  mlir_aie_external_set_addr_output_buffer(_xaie, (u64)ddr_ptr_out);
+  mlir_aie_configure_shimdma_70(_xaie);
 
-    mlir_aie_clear_tile_memory(_xaie, 7, 3);
+  mlir_aie_clear_tile_memory(_xaie, 7, 3);
 
-    mlir_aie_print_shimdma_status(_xaie, 7, 0);
+  mlir_aie_print_shimdma_status(_xaie, 7, 0);
 
-    printf("before core start\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
+  printf("before core start\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
 
-    printf("Start cores\n");
-    mlir_aie_start_cores(_xaie);
+  printf("Start cores\n");
+  mlir_aie_start_cores(_xaie);
 
-    printf("after core start\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-    mlir_aie_print_dma_status(_xaie, 7, 3);
-    mlir_aie_print_shimdma_status(_xaie, 7, 0);
+  printf("after core start\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
+  mlir_aie_print_dma_status(_xaie, 7, 3);
+  mlir_aie_print_shimdma_status(_xaie, 7, 0);
 
-    printf("Release lock for accessing DDR.\n");
-    mlir_aie_release_input_lock(_xaie, /*r/w*/ 1, 0);
-    mlir_aie_release_output_lock(_xaie, /*r/w*/ 1, 0);
+  printf("Release lock for accessing DDR.\n");
+  mlir_aie_release_input_lock(_xaie, /*r/w*/ 1, 0);
+  mlir_aie_release_output_lock(_xaie, /*r/w*/ 1, 0);
 
-    if (mlir_aie_acquire_input_lock(_xaie, /*r/w*/ 0, 10000)) {
-      printf("input_lock timeout!\n");
-      errors++;
-    }
-    if (mlir_aie_acquire_output_lock(_xaie, /*r/w*/ 0, 10000)) {
-      printf("output_lock timeout\n");
-      errors++;
-    }
+  if (mlir_aie_acquire_input_lock(_xaie, /*r/w*/ 0, 10000)) {
+    printf("input_lock timeout!\n");
+    errors++;
+  }
+  if (mlir_aie_acquire_output_lock(_xaie, /*r/w*/ 0, 10000)) {
+    printf("output_lock timeout\n");
+    errors++;
+  }
 
-    printf("after lock release\n");
-    mlir_aie_print_tile_status(_xaie, 7, 3);
-    mlir_aie_print_dma_status(_xaie, 7, 3);
-    mlir_aie_print_shimdma_status(_xaie, 7, 0);
+  printf("after lock release\n");
+  mlir_aie_print_tile_status(_xaie, 7, 3);
+  mlir_aie_print_dma_status(_xaie, 7, 3);
+  mlir_aie_print_shimdma_status(_xaie, 7, 0);
 
-    mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 0), 384, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_a_pong(_xaie, 0), 448, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_b_ping(_xaie, 0), 385, errors);
-    mlir_aie_check("After", mlir_aie_read_buffer_b_pong(_xaie, 0), 449, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_a_ping(_xaie, 0), 384, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_a_pong(_xaie, 0), 448, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_b_ping(_xaie, 0), 385, errors);
+  mlir_aie_check("After", mlir_aie_read_buffer_b_pong(_xaie, 0), 449, errors);
 
-    // mlir_aie_dump_tile_memory(_xaie, 7, 3);
+  // mlir_aie_dump_tile_memory(_xaie, 7, 3);
 
-    mlir_aie_sync_mem_cpu(buf1);
+  mlir_aie_sync_mem_cpu(buf1);
 
-    // Dump contents of ddr_ptr_out
-    for (int i=0; i<16; i++) {
-        uint32_t d = ddr_ptr_out[i];
-        printf("ddr_ptr_out[%d] = %d\n", i, d);
-    }
+  // Dump contents of ddr_ptr_out
+  for (int i = 0; i < 16; i++) {
+    uint32_t d = ddr_ptr_out[i];
+    printf("ddr_ptr_out[%d] = %d\n", i, d);
+  }
 
-    for (int i=0; i<512; i++)
-      mlir_aie_check("DDR out", ddr_ptr_out[i], i + 1, errors);
+  for (int i = 0; i < 512; i++)
+    mlir_aie_check("DDR out", ddr_ptr_out[i], i + 1, errors);
 
-    /*
-    XAieDma_Shim ShimDmaInst1;
-    XAieDma_ShimSoftInitialize(&(TileInst[7][0]), &ShimDmaInst1);
-    XAieDma_ShimBdClearAll((&ShimDmaInst1));
-    XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_MM2S0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
-    XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_S2MM0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
-    */
+  /*
+  XAieDma_Shim ShimDmaInst1;
+  XAieDma_ShimSoftInitialize(&(TileInst[7][0]), &ShimDmaInst1);
+  XAieDma_ShimBdClearAll((&ShimDmaInst1));
+  XAieDma_ShimChControl((&ShimDmaInst1), XAIEDMA_SHIM_CHNUM_MM2S0, XAIE_DISABLE,
+  XAIE_DISABLE, XAIE_DISABLE); XAieDma_ShimChControl((&ShimDmaInst1),
+  XAIEDMA_SHIM_CHNUM_S2MM0, XAIE_DISABLE, XAIE_DISABLE, XAIE_DISABLE);
+  */
 
-    int res = 0;
-    if (!errors) {
-      printf("PASS!\n");
-      res = 0;
-    } else {
-      printf("Fail!\n");
-      res = -1;
-    }
-    mlir_aie_deinit_libxaie(_xaie);
+  int res = 0;
+  if (!errors) {
+    printf("PASS!\n");
+    res = 0;
+  } else {
+    printf("Fail!\n");
+    res = -1;
+  }
+  mlir_aie_deinit_libxaie(_xaie);
 
-    printf("test done.\n");
-    return res;
+  printf("test done.\n");
+  return res;
 }


### PR DESCRIPTION
This PR removes the Boost dependency and uses [cxxopts](https://github.com/jarro2783/cxxopts) instead for command line arguments. `cxxopts` is a single-file library and has similar API to Boost’s `program_options`.

I copied the entire header here ([link with sha](https://github.com/jarro2783/cxxopts/blob/dbf4c6a66816f6c3872b46cc6af119ad227e04e1/include/cxxopts.hpp)), but we can fetch it at build time if people prefer that.

Closes #2231 