### PR TITLE
Fixup tests to include math.h

### DIFF
--- a/test/unit_tests/aievec_tests/aie/float_dynamic_sized_memref/float.cc
+++ b/test/unit_tests/aievec_tests/aie/float_dynamic_sized_memref/float.cc
@@ -1,5 +1,6 @@
 #include "float.h"
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/unit_tests/aievec_tests/aie/float_static_sized_memref/float.cc
+++ b/test/unit_tests/aievec_tests/aie/float_static_sized_memref/float.cc
@@ -1,5 +1,6 @@
 #include "float.h"
 
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fixup two tests failing to compile `fabs()` with newer versions of xchesscc because of missing `math.h` include.