### PR TITLE
Update AIEPathFinder.cpp

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -194,7 +194,7 @@ void Pathfinder::initialize(int maxCol, int maxRow,
     TileID coords = {col, row};
     SwitchboxConnect sb = {coords};
 
-    for (int i = 0, e = getMaxEnumValForWireBundle()+1; i < e; ++i) {
+    for (int i = 0, e = getMaxEnumValForWireBundle() + 1; i < e; ++i) {
       WireBundle bundle = symbolizeWireBundle(i).value();
       // get all ports into current switchbox
       int channels =

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -194,12 +194,8 @@ void Pathfinder::initialize(int maxCol, int maxRow,
     TileID coords = {col, row};
     SwitchboxConnect sb = {coords};
 
-    const std::vector<WireBundle> bundles = {
-        WireBundle::Core,  WireBundle::DMA,        WireBundle::FIFO,
-        WireBundle::South, WireBundle::West,       WireBundle::North,
-        WireBundle::East,  WireBundle::PLIO,       WireBundle::NOC,
-        WireBundle::Trace, WireBundle::TileControl};
-    for (WireBundle bundle : bundles) {
+    for (int i = 0, e = getMaxEnumValForWireBundle()+1; i < e; ++i) {
+      WireBundle bundle = symbolizeWireBundle(i).value();
       // get all ports into current switchbox
       int channels =
           targetModel.getNumSourceSwitchboxConnections(col, row, bundle);


### PR DESCRIPTION
Don't hardcode WireBundle enumeration, loop over all the values instead. The old code might cause problems if future hardware adds WireBundle types.