### PR TITLE
Update npu-xrt tests to compile with c++17

### DIFF
--- a/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin
 //

--- a/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/test.cpp
+++ b/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/test.cpp
@@ -36,7 +36,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/add_21_i8_using_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_21_i8_using_dma_op_with_padding/run.lit
@@ -7,6 +7,6 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin

--- a/test/npu-xrt/add_21_i8_using_dma_op_with_padding/test.cpp
+++ b/test/npu-xrt/add_21_i8_using_dma_op_with_padding/test.cpp
@@ -36,7 +36,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/add_256_using_dma_op_no_double_buffering/run.lit
+++ b/test/npu-xrt/add_256_using_dma_op_no_double_buffering/run.lit
@@ -7,6 +7,6 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin

--- a/test/npu-xrt/add_256_using_dma_op_no_double_buffering/test.cpp
+++ b/test/npu-xrt/add_256_using_dma_op_no_double_buffering/test.cpp
@@ -33,7 +33,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/add_314_using_dma_op/run.lit
+++ b/test/npu-xrt/add_314_using_dma_op/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/add_314_using_dma_op/test.cpp
+++ b/test/npu-xrt/add_314_using_dma_op/test.cpp
@@ -33,7 +33,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/add_378_i32_using_dma_op_with_padding/run.lit
+++ b/test/npu-xrt/add_378_i32_using_dma_op_with_padding/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/add_378_i32_using_dma_op_with_padding/test.cpp
+++ b/test/npu-xrt/add_378_i32_using_dma_op_with_padding/test.cpp
@@ -33,7 +33,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/add_blockwrite/run.lit
+++ b/test/npu-xrt/add_blockwrite/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/add_maskwrite/run.lit
+++ b/test/npu-xrt/add_maskwrite/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/add_one_ctrl_packet/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet/run.lit
@@ -7,6 +7,6 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_4_cores/run.lit
@@ -7,6 +7,6 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_4col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall -lrt -lstdc++ %xrt_flags %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall -lrt -lstdc++ %xrt_flags %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
+++ b/test/npu-xrt/add_one_ctrl_packet_col_overlay/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai_npu1
 //
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --generate-ctrl-pkt-overlay --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_objFifo/run.lit
+++ b/test/npu-xrt/add_one_objFifo/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu1% %python %S/test.py -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/add_one_two/run.lit
+++ b/test/npu-xrt/add_one_two/run.lit
@@ -15,7 +15,6 @@
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie2_arch.mlir
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=insts.bin aie1_arch.mlir
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDTWO --xclbin-kernel-id=0x902 --xclbin-instance-name=ADDTWOINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-input=add_one.xclbin --xclbin-name=add_two.xclbin --npu-insts-name=insts.bin aie2_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x add_two.xclbin -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x add_two.xclbin -i insts.bin
-

--- a/test/npu-xrt/add_one_two_txn/run.lit
+++ b/test/npu-xrt/add_one_two_txn/run.lit
@@ -9,7 +9,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie2_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie1_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie2_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %python aiecc.py --xclbin-kernel-name=ADDONE --xclbin-kernel-id=0x901 --xclbin-instance-name=ADDONEINST --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=add_one.xclbin --npu-insts-name=add_one_insts.bin aie1_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-txn --txn-name=transaction.mlir --aie-generate-npu-insts --no-compile-host --npu-insts-name=add_two_insts.bin aie2_arch.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure transaction.mlir -o add_two_cfg.bin

--- a/test/npu-xrt/add_one_using_dma/run.lit
+++ b/test/npu-xrt/add_one_using_dma/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/adjacent_memtile_access/three_memtiles/aie2.py
+++ b/test/npu-xrt/adjacent_memtile_access/three_memtiles/aie2.py
@@ -10,7 +10,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie2.mlir
-# RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+# RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 import numpy as np
 import sys

--- a/test/npu-xrt/adjacent_memtile_access/two_memtiles/aie2.py
+++ b/test/npu-xrt/adjacent_memtile_access/two_memtiles/aie2.py
@@ -10,7 +10,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie2.mlir
-# RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+# RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 import numpy as np
 import sys

--- a/test/npu-xrt/cascade_flows/run.lit
+++ b/test/npu-xrt/cascade_flows/run.lit
@@ -7,5 +7,5 @@
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel2.cc -o ./kernel2.o
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel3.cc -o ./kernel3.o
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/ctrl_packet_reconfig/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig/run.lit
@@ -14,5 +14,5 @@
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig/test.cpp
@@ -46,7 +46,7 @@ int main(int argc, const char *argv[]) {
 
   // Load the xclbin
   // Skeleton xclbin containing only the control packet network
-  auto xclbin = xrt::xclbin("aie1.xclbin");
+  auto xclbin = xrt::xclbin(std::string("aie1.xclbin"));
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
@@ -14,5 +14,5 @@
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // UN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/test.cpp
@@ -40,7 +40,7 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie1.xclbin");
+  auto xclbin = xrt::xclbin(std::string("aie1.xclbin"));
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
@@ -14,5 +14,5 @@
 // RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // UN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/test.cpp
@@ -40,7 +40,7 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie1.xclbin");
+  auto xclbin = xrt::xclbin(std::string("aie1.xclbin"));
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/dma_task_large_linear/aie2.py
+++ b/test/npu-xrt/dma_task_large_linear/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
-# RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+# RUN: clang %S/test.cpp -o test -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test
 import numpy as np
 from aie.extras.context import mlir_mod_ctx

--- a/test/npu-xrt/dma_task_large_linear/test.cpp
+++ b/test/npu-xrt/dma_task_large_linear/test.cpp
@@ -16,7 +16,7 @@
 #include "test_utils.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/dmabd_task_queue/run.lit
+++ b/test/npu-xrt/dmabd_task_queue/run.lit
@@ -7,6 +7,6 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_4col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_4col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/dynamic_object_fifo/nested_loops/test.cpp
+++ b/test/npu-xrt/dynamic_object_fifo/nested_loops/test.cpp
@@ -14,7 +14,7 @@
 #include "xrt/xrt_kernel.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/dynamic_object_fifo/ping_pong/test.cpp
+++ b/test/npu-xrt/dynamic_object_fifo/ping_pong/test.cpp
@@ -14,7 +14,7 @@
 #include "xrt/xrt_kernel.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/dynamic_object_fifo/reduction/test.cpp
+++ b/test/npu-xrt/dynamic_object_fifo/reduction/test.cpp
@@ -14,7 +14,7 @@
 #include "xrt/xrt_kernel.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/dynamic_object_fifo/sliding_window/test.cpp
+++ b/test/npu-xrt/dynamic_object_fifo/sliding_window/test.cpp
@@ -14,7 +14,7 @@
 #include "xrt/xrt_kernel.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/run.lit
+++ b/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/run.lit
@@ -5,5 +5,5 @@
 //
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --dynamic-objFifos --xclbin-name=final.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x final.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/test.cpp
+++ b/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/test.cpp
@@ -14,7 +14,7 @@
 #include "xrt/xrt_kernel.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/dynamic_object_fifo/two_core_sliding_window/test.cpp
+++ b/test/npu-xrt/dynamic_object_fifo/two_core_sliding_window/test.cpp
@@ -14,7 +14,7 @@
 #include "xrt/xrt_kernel.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/lit.local.cfg
+++ b/test/npu-xrt/lit.local.cfg
@@ -6,7 +6,6 @@
 
 config.suffixes = [".lit", ".py"]
 
-print (config.vitis_components)
 if 'AIE2' not in config.vitis_components and 'AIE2P' not in config.vitis_components:
     config.unsupported = True
 

--- a/test/npu-xrt/matrix_transpose/test.cpp
+++ b/test/npu-xrt/matrix_transpose/test.cpp
@@ -16,7 +16,7 @@
 #include "test_utils.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/memtile_dmas/blockwrite_using_locks/run.lit
+++ b/test/npu-xrt/memtile_dmas/blockwrite_using_locks/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai_npu1, chess
 //
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/memtile_dmas/writebd/run.lit
+++ b/test/npu-xrt/memtile_dmas/writebd/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai_npu1, chess
 //
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/memtile_dmas/writebd_tokens/run.lit
+++ b/test/npu-xrt/memtile_dmas/writebd_tokens/run.lit
@@ -4,5 +4,5 @@
 // REQUIRES: ryzen_ai_npu1, chess
 //
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/nd_memcpy_linear_repeat/test.cpp
+++ b/test/npu-xrt/nd_memcpy_linear_repeat/test.cpp
@@ -16,7 +16,7 @@
 #include "test_utils.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/nd_memcpy_transforms/aie2.py
+++ b/test/npu-xrt/nd_memcpy_transforms/aie2.py
@@ -10,7 +10,7 @@
 # RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cc -o ./kernel.o
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
-# RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+# RUN: clang %S/test.cpp -o test -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test
 import numpy as np
 from aie.extras.context import mlir_mod_ctx

--- a/test/npu-xrt/nd_memcpy_transforms/test.cpp
+++ b/test/npu-xrt/nd_memcpy_transforms/test.cpp
@@ -16,7 +16,7 @@
 #include "test_utils.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/packet_flow/run.lit
+++ b/test/npu-xrt/packet_flow/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/packet_flow/test.cpp
+++ b/test/npu-xrt/packet_flow/test.cpp
@@ -36,7 +36,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/packet_flow_fanin/run.lit
+++ b/test/npu-xrt/packet_flow_fanin/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/packet_flow_fanin/test.cpp
+++ b/test/npu-xrt/packet_flow_fanin/test.cpp
@@ -36,7 +36,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/packet_flow_fanout/run.lit
+++ b/test/npu-xrt/packet_flow_fanout/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe aie.xclbin
 // RUN: %run_on_npu2% ./test.exe aie.xclbin
 

--- a/test/npu-xrt/packet_flow_fanout/test.cpp
+++ b/test/npu-xrt/packet_flow_fanout/test.cpp
@@ -36,7 +36,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/runtime_cumsum/run.lit
+++ b/test/npu-xrt/runtime_cumsum/run.lit
@@ -5,5 +5,5 @@
 //
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -DBIT_WIDTH=8 -c %S/sum.cc -o ./sum.o
 // RUN: %python aiecc.py --xchesscc --xbridge --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/runtime_cumsum/test.cpp
+++ b/test/npu-xrt/runtime_cumsum/test.cpp
@@ -36,7 +36,8 @@ int main(int argc, const char *argv[]) {
   auto device = xrt::device(device_index);
 
   // Load the xclbin
-  auto xclbin = xrt::xclbin("aie.xclbin");
+  std::string xclbin_name = "aie.xclbin";
+  xrt::xclbin xclbin(xclbin_name);
 
   std::string Node = "MLIR_AIE";
 

--- a/test/npu-xrt/static_L1_init/run.lit
+++ b/test/npu-xrt/static_L1_init/run.lit
@@ -7,6 +7,6 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/sync_task_complete_token/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
-# RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+# RUN: clang %S/test.cpp -o test -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # UN: %run_on_npu1% ./test
 
 from aie.extras.context import mlir_mod_ctx

--- a/test/npu-xrt/sync_task_complete_token/test.cpp
+++ b/test/npu-xrt/sync_task_complete_token/test.cpp
@@ -16,7 +16,7 @@
 #include "test_utils.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
@@ -9,7 +9,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
-# RUN: clang %S/test.cpp -o test -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+# RUN: clang %S/test.cpp -o test -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test
 
 from aie.extras.context import mlir_mod_ctx

--- a/test/npu-xrt/sync_task_complete_token_bd_chaining/test.cpp
+++ b/test/npu-xrt/sync_task_complete_token_bd_chaining/test.cpp
@@ -16,7 +16,7 @@
 #include "test_utils.h"
 
 #ifndef XCLBIN
-#define XCLBIN "final.xclbin"
+#define XCLBIN std::string("final.xclbin")
 #endif
 
 #ifndef INSTS_TXT

--- a/test/npu-xrt/two_col/run.lit
+++ b/test/npu-xrt/two_col/run.lit
@@ -5,5 +5,5 @@
 //
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -DBIT_WIDTH=8 -c %S/threshold.cc -o ./threshold.o
 // RUN: %python aiecc.py --xchesscc --xbridge --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/vec_vec_add_memtile_init/run.lit
+++ b/test/npu-xrt/vec_vec_add_memtile_init/run.lit
@@ -7,7 +7,7 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 

--- a/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
+++ b/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
@@ -10,7 +10,7 @@
 #
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --no-xchesscc --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-# RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+# RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 import numpy as np
 import sys

--- a/test/npu-xrt/vec_vec_add_tile_init/run.lit
+++ b/test/npu-xrt/vec_vec_add_tile_init/run.lit
@@ -7,6 +7,6 @@
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
 // RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --alloc-scheme=basic-sequential --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/vector_scalar_using_dma/run.lit
+++ b/test/npu-xrt/vector_scalar_using_dma/run.lit
@@ -5,5 +5,5 @@
 //
 // RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/scale.cc -o ./scale.o
 // RUN: %python aiecc.py --xbridge --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
-// RUN: clang %S/test.cpp -o test.exe -std=c++11 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin


### PR DESCRIPTION
Newer versions of clang will fail without std >= c++ 17 because xrt headers use std::string_view, which is a c++ 17 feature.

