### PR TITLE
Reduce number of buffer overflows in AIEFlowsToJSON.cpp

### DIFF
--- a/lib/Targets/AIEFlowsToJSON.cpp
+++ b/lib/Targets/AIEFlowsToJSON.cpp
@@ -96,7 +96,7 @@ void translateSwitchboxes(DeviceOp targetOp, raw_ostream &output) {
                     std::to_string(destinationCounts[{col, row}]) + ",\n";
 
     // write routing demand info
-    uint32_t connectCounts[10];
+    std::vector<uint32_t> connectCounts(getMaxEnumValForWireBundle() + 1, 0);
     for (auto &connectCount : connectCounts)
       connectCount = 0;
 


### PR DESCRIPTION
Remove buffer overflow in `aie-translate --aie-flows-to-json`.  The code assumes a max enum value of 9 for WireBundles, which is wrong, and can cause mysterious segfaults.