### PR TITLE
[WIP] Enable build mlir-aie and run tests without Vitis

### DIFF
--- a/programming_examples/basic/lit.local.cfg
+++ b/programming_examples/basic/lit.local.cfg
@@ -7,5 +7,5 @@
 
 config.suffixes = ['.lit']
 
-if 'AIE2' not in config.vitis_components:
+if 'AIE2' not in config.vitis_components and 'AIE2P' not in config.vitis_components:
     config.unsupported = True

--- a/programming_examples/basic/vector_scalar_mul/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_makefile_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=true use_placed=1 make -f %S/Makefile 
+// RUN: env CHESS=false use_placed=1 make -f %S/Makefile 
 // RUN: %run_on_npu make -f %S/Makefile run 
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace 

--- a/programming_examples/experimental/lit.local.cfg
+++ b/programming_examples/experimental/lit.local.cfg
@@ -7,5 +7,5 @@
 
 config.suffixes = ['.lit']
 
-if 'AIE2' not in config.vitis_components:
+if 'AIE2' not in config.vitis_components and 'AIE2P' not in config.vitis_components:
     config.unsupported = True

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -148,11 +148,13 @@ if config.xrt_lib_dir:
                 run_on_npu = (
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
+                config.vitis_components.append("AIE2")
                 print("Running tests on NPU1 with command line: ", run_on_npu)
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
                 run_on_2npu = (
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
+                config.vitis_components.append("AIE2P")
                 print("Running tests on NPU4 with command line: ", run_on_2npu)
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")

--- a/programming_examples/ml/lit.local.cfg
+++ b/programming_examples/ml/lit.local.cfg
@@ -7,5 +7,5 @@
 
 config.suffixes = ['.lit']
 
-if 'AIE2' not in config.vitis_components:
+if 'AIE2' not in config.vitis_components and 'AIE2P' not in config.vitis_components:
     config.unsupported = True

--- a/programming_examples/vision/lit.local.cfg
+++ b/programming_examples/vision/lit.local.cfg
@@ -7,5 +7,5 @@
 
 config.suffixes = ['.lit']
 
-if 'AIE2' not in config.vitis_components:
+if 'AIE2' not in config.vitis_components and 'AIE2P' not in config.vitis_components:
     config.unsupported = True

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -150,11 +150,14 @@ if config.xrt_lib_dir:
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
                 print("Running tests on NPU1 with command line: ", run_on_npu)
+                # Add AIE2 to config.vitis_components
+                config.vitis_components.append("AIE2")
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
                 run_on_2npu = (
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
                 print("Running tests on NPU4 with command line: ", run_on_2npu)
+                config.vitis_components.append("AIE2P")
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")
             break

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -149,15 +149,14 @@ if config.xrt_lib_dir:
                 run_on_npu = (
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
-                print("Running tests on NPU1 with command line: ", run_on_npu)
-                # Add AIE2 to config.vitis_components
                 config.vitis_components.append("AIE2")
+                print("Running tests on NPU1 with command line: ", run_on_npu)
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
                 run_on_2npu = (
                     f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
                 )
-                print("Running tests on NPU4 with command line: ", run_on_2npu)
                 config.vitis_components.append("AIE2P")
+                print("Running tests on NPU4 with command line: ", run_on_2npu)
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")
             break

--- a/programming_guide/lit.local.cfg
+++ b/programming_guide/lit.local.cfg
@@ -7,5 +7,5 @@
 
 config.suffixes = ['.lit']
 
-if 'AIE2' not in config.vitis_components:
+if 'AIE2' not in config.vitis_components and 'AIE2P' not in config.vitis_components:
     config.unsupported = True

--- a/programming_guide/section-1/run_makefile_placed.lit
+++ b/programming_guide/section-1/run_makefile_placed.lit
@@ -3,5 +3,7 @@
  //
  // REQUIRES: ryzen_ai, peano 
  //
+ // RUN: mkdir -p test_placed 
+ // RUN: cd test_placed
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile placed

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -171,12 +171,14 @@ if config.xrt_lib_dir:
             if model in ["npu1", "Phoenix"]:
                 run_on_npu1 = run_on_npu
                 config.available_features.add("ryzen_ai_npu1")
-                config.vitis_components.append("AIE2")
+                # TODO: many npu-xrt tests are not compatible without Vitis
+                # config.vitis_components.append("AIE2")
                 print("Running tests on NPU with command line: ", run_on_npu1)
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
                 run_on_npu2 = run_on_npu
                 config.available_features.add("ryzen_ai_npu2")
-                config.vitis_components.append("AIE2P")
+                # TODO: many npu-xrt tests are not compatible without Vitis
+                # config.vitis_components.append("AIE2P")
                 print("Running tests on NPU with command line: ", run_on_npu2)
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -171,10 +171,12 @@ if config.xrt_lib_dir:
             if model in ["npu1", "Phoenix"]:
                 run_on_npu1 = run_on_npu
                 config.available_features.add("ryzen_ai_npu1")
+                config.vitis_components.append("AIE2")
                 print("Running tests on NPU with command line: ", run_on_npu1)
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
                 run_on_npu2 = run_on_npu
                 config.available_features.add("ryzen_ai_npu2")
+                config.vitis_components.append("AIE2P")
                 print("Running tests on NPU with command line: ", run_on_npu2)
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")


### PR DESCRIPTION
Discover "supported" components at runtime from `xrt-smi` to enable the programming_guide, programming_examples, and tests/npu-xrt.