### PR TITLE
Remove `pip install -r requirements.txt` from `quick_setup.sh`

### DIFF
--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -64,8 +64,6 @@ export MLIR_AIE_INSTALL_DIR="$(pip show mlir_aie | grep ^Location: | awk '{print
 python3 -m pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
 export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 
-python3 -m pip install -r python/requirements.txt
-
 # This installs the pre-commit hooks defined in .pre-commit-config.yaml
 pre-commit install
 


### PR DESCRIPTION
… as the new wheel should install with dependency check.