### PR TITLE
Remove uncaptured dependence in Conversion passes

### DIFF
--- a/include/aie/Conversion/AIEToConfiguration/AIEToConfiguration.h
+++ b/include/aie/Conversion/AIEToConfiguration/AIEToConfiguration.h
@@ -11,14 +11,13 @@
 #ifndef AIE_CONVERSION_AIETOCONFIGURATION_AIETOCONFIGURATION_H
 #define AIE_CONVERSION_AIETOCONFIGURATION_AIETOCONFIGURATION_H
 
-#include "aie/Dialect/AIE/IR/AIEDialect.h"
-#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
-
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
-
 #include <memory>
 
 namespace xilinx::AIE {
+
+class DeviceOp;
 
 std::unique_ptr<mlir::OperationPass<xilinx::AIE::DeviceOp>>
 createConvertAIEToTransactionPass();

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -11,6 +11,8 @@
 #include "../PassDetail.h"
 
 #include "aie/Conversion/AIEToConfiguration/AIEToConfiguration.h"
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "aie/Targets/AIERT.h"
 
 #include "llvm/Support/Debug.h"

--- a/lib/Conversion/PassDetail.h
+++ b/lib/Conversion/PassDetail.h
@@ -21,6 +21,18 @@
 
 namespace xilinx {
 
+namespace AIE {
+
+class AIEDialect;
+
+} // namespace AIE
+
+namespace AIEX {
+
+class AIEXDialect;
+
+} // namespace AIEX
+
 namespace aievec {
 
 class AIEVecDialect;


### PR DESCRIPTION
Resolve a race condition during build due to uncaptured cmake dependence.

`AIEToConfiguration.h` included aie and aiex dialect headers, which means that the aie and aiex dialect `*.inc` files (ops, attrs, enums, etc) must be built (by TableGen) before anything depending on `AIEToConfiguration.h` can be built, which includes everything in `lib/Conversion/`. However this dependence is not captured in cmake for either of the subdirectories in `lib/Conversion/`, nor is it desirable to do so. Instead this PR removes the `#includes` and provides some forward declarations in the headers.

Without this fix I occasionally see build errors like this:
```bash
ccache /usr/bin/c++ -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/scratch/github/actions-runner/_work/mlir-aie/mlir-aie/mlir/include -I/scratch/github/actions-runner/_work/mlir-aie/mlir-aie/include -I/scratch/github/actions-runner/_work/mlir-aie/mlir-aie/build/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -Wimplicit-fallthrough -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -Werror=sign-compare -Werror=unused -Werror=return-type -Werror=mismatched-tags -std=gnu++17   -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fno-exceptions -funwind-tables -UNDEBUG -MD -MT lib/Conversion/AIEVecToLLVM/CMakeFiles/obj.MLIRAIEVecToLLVM.dir/AIEVecToLLVM.cpp.o -MF lib/Conversion/AIEVecToLLVM/CMakeFiles/obj.MLIRAIEVecToLLVM.dir/AIEVecToLLVM.cpp.o.d -o lib/Conversion/AIEVecToLLVM/CMakeFiles/obj.MLIRAIEVecToLLVM.dir/AIEVecToLLVM.cpp.o -c /scratch/github/actions-runner/_work/mlir-aie/mlir-aie/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
In file included from /scratch/github/actions-runner/_work/mlir-aie/mlir-aie/include/aie/Dialect/AIE/IR/AIEDialect.h:14,
                 from /scratch/github/actions-runner/_work/mlir-aie/mlir-aie/include/aie/Conversion/AIEToConfiguration/AIEToConfiguration.h:14,
                 from /scratch/github/actions-runner/_work/mlir-aie/mlir-aie/include/aie/Conversion/Passes.h:14,
                 from /scratch/github/actions-runner/_work/mlir-aie/mlir-aie/lib/Conversion/AIEVecToLLVM/../PassDetail.h:14,
                 from /scratch/github/actions-runner/_work/mlir-aie/mlir-aie/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp:12:
/scratch/github/actions-runner/_work/mlir-aie/mlir-aie/include/aie/Dialect/AIE/IR/AIEEnums.h:17:10: fatal error: aie/Dialect/AIE/IR/AIEEnums.h.inc: No such file or directory
   17 | #include "aie/Dialect/AIE/IR/AIEEnums.h.inc"
```