### PR TITLE
Fix mlir_tutorials

### DIFF
--- a/mlir_tutorials/tutorial-1/Makefile
+++ b/mlir_tutorials/tutorial-1/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
 
@@ -10,7 +11,7 @@ all: core_1_4.elf
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-core_1_4.elf : aie.mlir
+core_1_4.elf : ${srcdir}/aie.mlir
 	aiecc.py -j4 $<
 
 clean:
@@ -20,6 +21,6 @@ clean:
 # Additional make targets for tutorial exercises
 # Note: AIECC_HOST_FLAGS is defined in the included tutorials/makefile-common.
 #------------------------------------------------------------------------------
-tutorial-1.exe: test.cpp aie.mlir
+tutorial-1.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 

--- a/mlir_tutorials/tutorial-1/aie.mlir
+++ b/mlir_tutorials/tutorial-1/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-1.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S tutorial-1.exe
+// RUN: make -f %S/Makefile tutorial-1.exe
 // RUN: %run_on_board ./tutorial-1.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design

--- a/mlir_tutorials/tutorial-2/tutorial-2a/Makefile
+++ b/mlir_tutorials/tutorial-2/tutorial-2a/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,10 +11,10 @@ all: tutorial-2a.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-2a.exe : test.cpp aie.mlir
+tutorial-2a.exe : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 ${AIECC_FLAGS} $(word 2,$^) ${AIECC_HOST_FLAGS} ./$< -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:

--- a/mlir_tutorials/tutorial-2/tutorial-2a/aie.mlir
+++ b/mlir_tutorials/tutorial-2/tutorial-2a/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-2a.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-2a.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 
 // Declare this MLIR module. A block encapsulates all

--- a/mlir_tutorials/tutorial-2/tutorial-2b/Makefile
+++ b/mlir_tutorials/tutorial-2/tutorial-2b/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,10 +11,10 @@ all: tutorial-2b.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-2b.exe : test.cpp aie.mlir
+tutorial-2b.exe : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:

--- a/mlir_tutorials/tutorial-2/tutorial-2b/aie.mlir
+++ b/mlir_tutorials/tutorial-2/tutorial-2b/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-2b.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-2b.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 
 // Declare this MLIR module. A block encapsulates all

--- a/mlir_tutorials/tutorial-2/tutorial-2c/Makefile
+++ b/mlir_tutorials/tutorial-2/tutorial-2c/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,10 +11,10 @@ all: tutorial-2c.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-2c.exe : test.cpp aie.mlir
+tutorial-2c.exe : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-Work/ps/c_rts/systemC/generated-objects/ps_i96.so: test.cpp aie.mlir
+Work/ps/c_rts/systemC/generated-objects/ps_i96.so: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	make -C Work/ps/c_rts/systemC link
 
 sim: Work/ps/c_rts/systemC/generated-objects/ps_i96.so

--- a/mlir_tutorials/tutorial-2/tutorial-2c/aie.mlir
+++ b/mlir_tutorials/tutorial-2/tutorial-2c/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-2c.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-2c.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design

--- a/mlir_tutorials/tutorial-3/Makefile
+++ b/mlir_tutorials/tutorial-3/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
 
@@ -10,10 +11,10 @@ all: tutorial-3.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-3.exe: test.cpp aie.mlir
+tutorial-3.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:

--- a/mlir_tutorials/tutorial-3/aie.mlir
+++ b/mlir_tutorials/tutorial-3/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-3.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-3.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement

--- a/mlir_tutorials/tutorial-3/objectFifo_ver/Makefile
+++ b/mlir_tutorials/tutorial-3/objectFifo_ver/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,7 +11,7 @@ all: tutorial-3.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-3.exe: test.cpp aie.mlir 
+tutorial-3.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir 
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:

--- a/mlir_tutorials/tutorial-4/Makefile
+++ b/mlir_tutorials/tutorial-4/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
 
@@ -10,10 +11,10 @@ all: tutorial-4.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-4.exe: test.cpp aie.mlir
+tutorial-4.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:

--- a/mlir_tutorials/tutorial-4/aie.mlir
+++ b/mlir_tutorials/tutorial-4/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-4.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-4.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement

--- a/mlir_tutorials/tutorial-4/flow/Makefile
+++ b/mlir_tutorials/tutorial-4/flow/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,7 +11,7 @@ all: tutorial-4.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-4.exe: test.cpp aie.mlir
+tutorial-4.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:

--- a/mlir_tutorials/tutorial-4/switchbox/Makefile
+++ b/mlir_tutorials/tutorial-4/switchbox/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,7 +11,7 @@ all: tutorial-4.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-4.exe: test.cpp aie.mlir
+tutorial-4.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 pathfinder:

--- a/mlir_tutorials/tutorial-4/switchbox/aie.mlir
+++ b/mlir_tutorials/tutorial-4/switchbox/aie.mlir
@@ -61,7 +61,7 @@ module @tutorial_4 {
         aie.dma_start("MM2S", 0, ^bd0, ^end)
         ^bd0:
             aie.use_lock(%lock14_6, Acquire, 1)
-            aie.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock14_6, Release, 0)
             aie.next_bd ^end
         ^end:
@@ -104,7 +104,7 @@ module @tutorial_4 {
             // 0   - offset of transfer
             // 256 - length of transfer
             // 0   - A/B mode enable (default is disabled)
-            aie.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock34_7, Release, 1)
             aie.next_bd ^end
         ^end:

--- a/mlir_tutorials/tutorial-5/Makefile
+++ b/mlir_tutorials/tutorial-5/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
  
@@ -11,10 +12,10 @@ all: tutorial-5.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-5.exe: aie.mlir test.cpp 
-	aiecc.py -j4 $(AIECC_FLAGS) ./aie.mlir $(AIECC_HOST_FLAGS) ./test.cpp -o $@
+tutorial-5.exe: ${srcdir}/aie.mlir ${srcdir}/test.cpp 
+	aiecc.py -j4 $(AIECC_FLAGS) ${srcdir}/aie.mlir $(AIECC_HOST_FLAGS) ${srcdir}/test.cpp -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:

--- a/mlir_tutorials/tutorial-5/aie.mlir
+++ b/mlir_tutorials/tutorial-5/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-5.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-5.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement

--- a/mlir_tutorials/tutorial-5/flow/Makefile
+++ b/mlir_tutorials/tutorial-5/flow/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,7 +11,7 @@ all: tutorial-5.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-5.exe: test.cpp aie.mlir
+tutorial-5.exe: ${srcdir}/../test.cpp ${srcdir}/../aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:

--- a/mlir_tutorials/tutorial-5/flow/aie.mlir
+++ b/mlir_tutorials/tutorial-5/flow/aie.mlir
@@ -53,12 +53,12 @@ module @tutorial_5 {
         ^bd1:
             // Lock used to allow host to start transfer
             aie.use_lock(%lock70_in, "Acquire", 1)
-            aie.dma_bd(<%ext_buf70_in : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%ext_buf70_in : memref<256xi32>, 0, 256)
             aie.use_lock(%lock70_in, "Release", 0)
             aie.next_bd ^end
         ^bd2:
             aie.use_lock(%lock70_out, "Acquire", 1)
-            aie.dma_bd(<%ext_buf70_out : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%ext_buf70_out : memref<256xi32>, 0, 256)
             aie.use_lock(%lock70_out, "Release", 0)
             aie.next_bd ^end
         ^end:
@@ -103,12 +103,12 @@ module @tutorial_5 {
             // 0   - offset of transfer
             // 256 - length of transfer
             // 0   - A/B mode enable (default is disabled)
-            aie.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock34_in, "Release", 1)
             aie.next_bd ^end
         ^bd1:
             aie.use_lock(%lock34_out, "Acquire", 1)
-            aie.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock34_out, "Release", 0)
             aie.next_bd ^end
         ^end:

--- a/mlir_tutorials/tutorial-6/Makefile
+++ b/mlir_tutorials/tutorial-6/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
 
@@ -10,10 +11,10 @@ all: tutorial-6.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-6.exe: test.cpp aie.mlir
+tutorial-6.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:

--- a/mlir_tutorials/tutorial-6/aie.mlir
+++ b/mlir_tutorials/tutorial-6/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-6.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-6.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement
@@ -67,7 +67,7 @@ module @tutorial_6 {
                 // 0x4 - packet type, arbitary value
                 // 0xD - packet ID, arbitary value but used for routing
                 aie.dma_bd_packet(0x4, 0xD)
-                aie.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+                aie.dma_bd(%buf14 : memref<256xi32>, 0, 256)
                 aie.use_lock(%lock14_6, Release, 0)
                 aie.next_bd ^end
             ^end:
@@ -100,7 +100,7 @@ module @tutorial_6 {
             ^bd0:
                 aie.use_lock(%lock34_7, Acquire, 0)
                 // Packets headers are dropped so no need to define packet behavior here
-                aie.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+                aie.dma_bd(%buf34 : memref<256xi32>, 0, 256)
                 aie.use_lock(%lock34_7, Release, 1)
                 aie.next_bd ^end
             ^end:

--- a/mlir_tutorials/tutorial-7/Makefile
+++ b/mlir_tutorials/tutorial-7/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
 
@@ -10,10 +11,10 @@ all: tutorial-7.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-7.exe: test.cpp aie.mlir
+tutorial-7.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:

--- a/mlir_tutorials/tutorial-7/aie.mlir
+++ b/mlir_tutorials/tutorial-7/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-7.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-7.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement

--- a/mlir_tutorials/tutorial-7/flow/Makefile
+++ b/mlir_tutorials/tutorial-7/flow/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,7 +11,7 @@ all: tutorial-7.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-7.exe: test.cpp aie.mlir
+tutorial-7.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:

--- a/mlir_tutorials/tutorial-7/flow/aie.mlir
+++ b/mlir_tutorials/tutorial-7/flow/aie.mlir
@@ -76,7 +76,7 @@ module @tutorial_7 {
             // 0x4 - packet type, arbitary value
             // 0xD - packet ID, arbitary value but used for routing
             aie.dma_bd_packet(0x4, 0xD)
-            aie.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock14_6, Release, 0)
             aie.next_bd ^end
         ^end:
@@ -111,7 +111,7 @@ module @tutorial_7 {
         ^bd0:
             aie.use_lock(%lock34_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            aie.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock34_7, Release, 1)
             aie.next_bd ^end
         ^end:
@@ -146,7 +146,7 @@ module @tutorial_7 {
         ^bd0:
             aie.use_lock(%lock35_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            aie.dma_bd(<%buf35 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf35 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock35_7, Release, 1)
             aie.next_bd ^end
         ^end:

--- a/mlir_tutorials/tutorial-7/switchbox/Makefile
+++ b/mlir_tutorials/tutorial-7/switchbox/Makefile
@@ -1,4 +1,5 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: all clean
 
@@ -10,7 +11,7 @@ all: tutorial-7.exe
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-7.exe: test.cpp aie.mlir
+tutorial-7.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
 clean:

--- a/mlir_tutorials/tutorial-7/switchbox/aie.mlir
+++ b/mlir_tutorials/tutorial-7/switchbox/aie.mlir
@@ -76,7 +76,7 @@ module @tutorial_7 {
             // 0x4 - packet type, arbitary value
             // 0xD - packet ID, arbitary value but used for routing
             aie.dma_bd_packet(0x4, 0xD)
-            aie.dma_bd(<%buf14 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf14 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock14_6, Release, 0)
             aie.next_bd ^end
         ^end:
@@ -111,7 +111,7 @@ module @tutorial_7 {
         ^bd0:
             aie.use_lock(%lock34_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            aie.dma_bd(<%buf34 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf34 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock34_7, Release, 1)
             aie.next_bd ^end
         ^end:
@@ -146,7 +146,7 @@ module @tutorial_7 {
         ^bd0:
             aie.use_lock(%lock35_7, Acquire, 0)
             // Packets headers are dropped so no need to define packet behavior here
-            aie.dma_bd(<%buf35 : memref<256xi32>, 0, 256>, A)
+            aie.dma_bd(%buf35 : memref<256xi32>, 0, 256)
             aie.use_lock(%lock35_7, Release, 1)
             aie.next_bd ^end
         ^end:

--- a/mlir_tutorials/tutorial-8/Makefile
+++ b/mlir_tutorials/tutorial-8/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
 
@@ -8,16 +9,16 @@ all: tutorial-8.exe
 	@cp ./elf/*.elf ./elf/*.elf.map .
 
 # Command line AIE kernel compile. See tutorial-2 for more info.
-%.o: %.cc
+%.o: ${srcdir}/%.cc
 	xchesscc ${CHESSCC_FLAGS} -c $<
 
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-8.exe: test.cpp aie.mlir kernel1.o kernel2.o
+tutorial-8.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir kernel1.o kernel2.o
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-sim : test.cpp aie.mlir
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:
@@ -26,5 +27,5 @@ clean:
 #------------------------------------------------------------------------------
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
-tutorial-8_q3.exe: test.cpp ./answers/aie.mlir kernel1.o kernel2.o
+tutorial-8_q3.exe: ${srcdir}/test.cpp ${srcdir}/answers/aie.mlir kernel1.o kernel2.o
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@

--- a/mlir_tutorials/tutorial-8/aie.mlir
+++ b/mlir_tutorials/tutorial-8/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-8.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-8.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A wrapper that can contain all
 // AIE tiles, buffers, and data movement

--- a/mlir_tutorials/tutorial-8/answers/aie.mlir
+++ b/mlir_tutorials/tutorial-8/answers/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-8.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/../Makefile
 // RUN: %run_on_board ./tutorial-8_q3.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/../Makefile clean
 
 
 // Declare this MLIR module. A wrapper that can contain all

--- a/mlir_tutorials/tutorial-9/Makefile
+++ b/mlir_tutorials/tutorial-9/Makefile
@@ -1,4 +1,5 @@
-include ../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../makefile-common
 
 .PHONY: all clean
 
@@ -7,11 +8,13 @@ all: tutorial-9.exe
 	@mv *.elf* ./elf
 	@cp ./elf/*.elf ./elf/*.elf.map .
 
-external_kernel/kernel.o: external_kernel/kernel.cc
-	$(MAKE) -C external_kernel mlir
+external_kernel/kernel.o: ${srcdir}/external_kernel/kernel.cc
+	mkdir -p external_kernel
+	cd external_kernel && $(MAKE) -f ${srcdir}/external_kernel/Makefile mlir
 
-matmul_kernel/kernel.o: matmul_kernel/kernel.cc
-	$(MAKE) -C matmul_kernel mlir
+matmul_kernel/kernel.o: ${srcdir}/matmul_kernel/kernel.cc
+	mkdir -p matmul_kernel
+	cd matmul_kernel && $(MAKE) -f ${srcdir}/matmul_kernel/Makefile mlir
 
 kernel.o: external_kernel/kernel.o
 	cp external_kernel/kernel.o ./kernel.o
@@ -22,22 +25,22 @@ kernel_matmul.o: matmul_kernel/kernel.o
 # Command line mlir-aie compile script "aiecc.py"
 # Sysroot and host target used to cross compile  host executable
 # Local runtime_lib needed for testbench functions
-tutorial-9.exe: test.cpp aie.mlir kernel.o
+tutorial-9.exe: ${srcdir}/test.cpp ${srcdir}/aie.mlir kernel.o
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-sim : test.cpp aie.mlir kernel.o
+sim : ${srcdir}/test.cpp ${srcdir}/aie.mlir kernel.o
 	aiecc.py -j4 --xchesscc --xbridge --aiesim $(word 2,$^) -I$(AIE_RUNTIME_LIB)/x86_64/test_lib/include -L$(AIE_RUNTIME_LIB)/x86_64/test_lib/lib -ltest_lib ./$<
 
 clean:
-	$(MAKE) -C external_kernel clean
-	$(MAKE) -C matmul_kernel clean
+	rm -rf external_kernel
+	rm -rf matmul_kernel
 	rm -rf aie.mlir.prj aiesimulator_output *elf core* *log *vcd *exe pl_sample_counts *.o .AIE_SIM_CMD_LINE_OPTIONS
 
 #------------------------------------------------------------------------------
 # Additional make targets for tutorial exercises
 #------------------------------------------------------------------------------
-tutorial-9_perf.exe: ./answers/test_perf.cpp ./aie.mlir kernel.o
+tutorial-9_perf.exe: ${srcdir}/answers/test_perf.cpp ${srcdir}/aie.mlir kernel.o
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@
 
-tutorial-9_matmul_perf.exe: ./answers/test_matmul_perf.cpp ./answers/aie_matmul.mlir kernel_matmul.o
+tutorial-9_matmul_perf.exe: ${srcdir}/answers/test_matmul_perf.cpp ${srcdir}/answers/aie_matmul.mlir kernel_matmul.o
 	aiecc.py -j4 $(AIECC_FLAGS) $(word 2,$^) $(AIECC_HOST_FLAGS) ./$< -o $@

--- a/mlir_tutorials/tutorial-9/aie.mlir
+++ b/mlir_tutorials/tutorial-9/aie.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 -%VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-9.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/Makefile
 // RUN: %run_on_board ./tutorial-9.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/Makefile clean
 
 // Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design

--- a/mlir_tutorials/tutorial-9/answers/aie_matmul.mlir
+++ b/mlir_tutorials/tutorial-9/answers/aie_matmul.mlir
@@ -11,9 +11,9 @@
 // aiecc.py -j4 %VitisSysrootFlag% --host-target=%aieHostTargetTriplet% %s -I%aie_runtime_lib%/test_lib/include %extraAieCcFlags% -L%aie_runtime_lib%/test_lib/lib -ltest_lib %S/test.cpp -o tutorial-9.exe
 
 // REQUIRES: valid_xchess_license
-// RUN: make -C %S
+// RUN: make -f %S/../Makefile
 // RUN: %run_on_board ./tutorial-9.exe
-// RUN: make -C %S clean
+// RUN: make -f %S/../Makefile clean
 
 // Declare this MLIR module. A block encapsulates all
 // AIE tiles, buffers, and communication in an AI Engine design

--- a/mlir_tutorials/tutorial-9/external_kernel/Makefile
+++ b/mlir_tutorials/tutorial-9/external_kernel/Makefile
@@ -1,10 +1,11 @@
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: build gui sim
 
 mlir: kernel.o
 
-%.o: %.cc
+%.o: ${srcdir}/%.cc
 	xchesscc ${CHESSCC_FLAGS} -c $<
 
 build:

--- a/mlir_tutorials/tutorial-9/matmul_kernel/Makefile
+++ b/mlir_tutorials/tutorial-9/matmul_kernel/Makefile
@@ -1,11 +1,12 @@
 
-include ../../makefile-common
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+include ${srcdir}/../../makefile-common
 
 .PHONY: build gui sim
 
 mlir: kernel.o
 
-%.o: %.cc
+%.o: ${srcdir}/%.cc
 	xchesscc ${CHESSCC_FLAGS} -c $<
 
 build:


### PR DESCRIPTION
* Fix dialect syntax issues `aie.dma_bd` syntax has changed
* Fix lit / Makefiles to not pollute src dir during testsing

before :(
```
********************
Failed Tests (7):
  AIE_TUTORIALS :: tutorial-4/switchbox/aie.mlir
  AIE_TUTORIALS :: tutorial-5/flow/aie.mlir
  AIE_TUTORIALS :: tutorial-6/aie.mlir
  AIE_TUTORIALS :: tutorial-7/flow/aie.mlir
  AIE_TUTORIALS :: tutorial-7/switchbox/aie.mlir
  AIE_TUTORIALS :: tutorial-8/answers/aie.mlir
  AIE_TUTORIALS :: tutorial-9/answers/aie_matmul.mlir


Testing Time: 24.63s

Total Discovered Tests: 26
  Passed           : 16 (61.54%)
  Expectedly Failed:  3 (11.54%)
  Failed           :  7 (26.92%)
```
after :)
```
Total Discovered Tests: 26
  Passed           : 23 (88.46%)
  Expectedly Failed:  3 (11.54%)
```