### PR TITLE
Move BD address calculation to AIETargetModel

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -249,6 +249,23 @@ public:
   virtual bool isBdChannelAccessible(int col, int row, uint32_t bd_id,
                                      int channel) const = 0;
 
+  /// Return the array address of the dma buffer descriptor for the given
+  /// col, row, buffer descriptor id, channel and direction. Not all
+  /// architecture variants will use channel and direction so these have default
+  /// values.
+  virtual uint64_t getDmaBdAddress(
+      int col, int row, uint32_t bd_id, int channel = -1,
+      AIE::DMAChannelDir direction = AIE::DMAChannelDir::MM2S) const = 0;
+
+  /// Return the offset of the base address field within the shim dma buffer
+  /// descriptor.
+  virtual uint32_t getDmaBdAddressOffset(int col, int row) const = 0;
+
+  /// Return the array address of the dma task queue register for the given
+  /// col, row, channel and direction
+  virtual uint32_t getDmaControlAddress(int col, int row, int channel,
+                                        AIE::DMAChannelDir direction) const = 0;
+
   virtual uint32_t getNumMemTileRows() const = 0;
   /// Return the size (in bytes) of a MemTile.
   virtual uint32_t getMemTileSize() const = 0;
@@ -350,6 +367,15 @@ public:
                              int channel) const override {
     return true;
   }
+
+  uint64_t getDmaBdAddress(int col, int row, uint32_t bd_id, int channel,
+                           AIE::DMAChannelDir direction) const override;
+
+  uint32_t getDmaBdAddressOffset(int col, int row) const override;
+
+  uint32_t getDmaControlAddress(int col, int row, int channel,
+                                AIE::DMAChannelDir direction) const override;
+
   uint32_t getNumMemTileRows() const override { return 0; }
   uint32_t getMemTileSize() const override { return 0; }
   uint32_t getNumBanks(int col, int row) const override { return 4; }
@@ -441,6 +467,14 @@ public:
       }
     }
   }
+
+  uint64_t getDmaBdAddress(int col, int row, uint32_t bd_id, int channel,
+                           AIE::DMAChannelDir direction) const override;
+
+  uint32_t getDmaBdAddressOffset(int col, int row) const override;
+
+  uint32_t getDmaControlAddress(int col, int row, int channel,
+                                AIE::DMAChannelDir direction) const override;
 
   uint32_t getMemTileSize() const override { return 0x00080000; }
 

--- a/include/aie/Dialect/AIEX/IR/AIEXDialect.h
+++ b/include/aie/Dialect/AIEX/IR/AIEXDialect.h
@@ -26,8 +26,6 @@
 namespace xilinx {
 namespace AIEX {
 
-uint64_t getBufferDescriptorAddressRegisterAddress(
-    const AIE::AIETargetModel &tm, unsigned bd_id, unsigned col, unsigned row);
 void getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
                              mlir::BaseMemRefType referencedBufType,
                              llvm::SmallVector<int64_t, 4> inputSizes,

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -29,7 +29,7 @@ using namespace xilinx::AIE;
 #include "aie/Dialect/AIE/IR/AIEDialect.cpp.inc"
 
 #define GET_TYPEDEF_CLASSES
-#include "aie/Dialect/AIE/IR/AIETypes.cpp.inc" 
+#include "aie/Dialect/AIE/IR/AIETypes.cpp.inc"
 
 namespace {
 

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -455,8 +455,7 @@ AIE2TargetModel::getDmaControlAddress(int col, int row, int channel,
     offset = 0x0001D200 + (channel * 0x8);
     if (direction == AIE::DMAChannelDir::MM2S)
       offset += 0x10;
-  }
-  if (isMemTile(col, row)) {
+  } else if (isMemTile(col, row)) {
     offset = 0x000A0600 + (channel * 0x8);
     if (direction == AIE::DMAChannelDir::MM2S)
       offset += 0x30;

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -107,6 +107,49 @@ bool AIE1TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
   return IsMemSouth || IsMemNorth || IsMemWest || IsMemEast;
 }
 
+uint64_t AIE1TargetModel::getDmaBdAddress(int col, int row, uint32_t bd_id,
+                                          int channel,
+                                          AIE::DMAChannelDir direction) const {
+  uint32_t offset = 0;
+  if (isShimNOCTile(col, row)) {
+    offset = 0x0001D000 + (bd_id * 0x14);
+  } else if (isCoreTile(col, row)) {
+    offset = 0x0001D000 + (bd_id * 0x20);
+  } else {
+    llvm_unreachable(
+        "AIE1TargetModel::getDmaBdAddress called for non-DMA tile");
+  }
+  return ((col & 0xff) << getColumnShift()) | ((row & 0xff) << getRowShift()) |
+         offset;
+}
+
+uint32_t AIE1TargetModel::getDmaBdAddressOffset(int col, int row) const {
+  if (isShimNOCTile(col, row) || isCoreTile(col, row)) {
+    return 0;
+  }
+  llvm_unreachable(
+      "AIE1TargetModel::getDmaBdAddressOffset called for non-DMA tile");
+}
+
+uint32_t
+AIE1TargetModel::getDmaControlAddress(int col, int row, int channel,
+                                      AIE::DMAChannelDir direction) const {
+  uint32_t offset = 0;
+  if (isShimNOCTile(col, row))
+    offset = 0x0001D140 + (channel * 0x8);
+  else if (isCoreTile(col, row))
+    offset = 0x0001DE00 + (channel * 0x8);
+  else
+    llvm_unreachable(
+        "AIE1TargetModel::getDmaControlAddress called for non-DMA tile");
+
+  if (direction == AIE::DMAChannelDir::MM2S)
+    offset += 010;
+
+  return ((col & 0xff) << getColumnShift()) | ((row & 0xff) << getRowShift()) |
+         offset;
+}
+
 uint32_t
 AIE1TargetModel::getNumDestSwitchboxConnections(int col, int row,
                                                 WireBundle bundle) const {
@@ -378,6 +421,56 @@ bool AIE2TargetModel::isLegalMemAffinity(int coreCol, int coreRow, int memCol,
            isWest(coreCol, coreRow, memCol, memRow);
   return (IsMemSouth && !isMemTile(memCol, memRow)) || IsMemNorth ||
          IsMemWest || IsMemEast;
+}
+
+uint64_t AIE2TargetModel::getDmaBdAddress(int col, int row, uint32_t bd_id,
+                                          int channel,
+                                          AIE::DMAChannelDir direction) const {
+  uint64_t offset = 0;
+  if (isShimNOCTile(col, row)) {
+    offset = 0x0001D000 + bd_id * 0x20;
+  } else if (isMemTile(col, row)) {
+    offset = 0x000A0000 + bd_id * 0x20;
+  } else if (isCoreTile(col, row)) {
+    offset = 0x0001D000 + bd_id * 0x20;
+  } else {
+    llvm_unreachable(
+        "AIE2TargetModel::getDmaBdAddress called for non-DMA tile");
+  }
+  return ((col & 0xff) << getColumnShift()) | ((row & 0xff) << getRowShift()) |
+         offset;
+}
+
+uint32_t AIE2TargetModel::getDmaBdAddressOffset(int col, int row) const {
+  if (isCoreTile(col, row))
+    return 0x0;
+  return 0x4;
+}
+
+uint32_t
+AIE2TargetModel::getDmaControlAddress(int col, int row, int channel,
+                                      AIE::DMAChannelDir direction) const {
+  uint32_t offset = 0;
+  if (isShimNOCTile(col, row)) {
+    offset = 0x0001D200 + (channel * 0x8);
+    if (direction == AIE::DMAChannelDir::MM2S)
+      offset += 0x10;
+  }
+  if (isMemTile(col, row)) {
+    offset = 0x000A0600 + (channel * 0x8);
+    if (direction == AIE::DMAChannelDir::MM2S)
+      offset += 0x30;
+  } else if (isCoreTile(col, row)) {
+    offset = 0x0001DE00 + (channel * 0x8);
+    if (direction == AIE::DMAChannelDir::MM2S)
+      offset += 0x10;
+  } else {
+    llvm_unreachable(
+        "AIE2TargetModel::getDmaControlAddress called for non-DMA tile");
+  }
+
+  return ((col & 0xff) << getColumnShift()) | ((row & 0xff) << getRowShift()) |
+         offset;
 }
 
 uint32_t

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -10,8 +10,8 @@
 
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 
-#include "mlir/IR/DialectImplementation.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/DialectImplementation.h"
 #include "mlir/Interfaces/FoldInterfaces.h"
 #include "mlir/Transforms/InliningUtils.h"
 
@@ -45,13 +45,6 @@ void AIEXDialect::initialize() {
 
 #define GET_OP_CLASSES
 #include "aie/Dialect/AIEX/IR/AIEX.cpp.inc"
-
-uint64_t AIEX::getBufferDescriptorAddressRegisterAddress(
-    const AIE::AIETargetModel &tm, unsigned bd_id, unsigned col, unsigned row) {
-  assert(bd_id < tm.getNumBDs(col, row));
-  return ((col & 0xff) << tm.getColumnShift()) |
-         ((row & 0xff) << tm.getRowShift()) | (0x1D004 + bd_id * 0x20);
-}
 
 /* Return the correct values to write to the hardware registers to configure
   strides and wraps given the input user-facing strides and wraps.

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -401,8 +401,8 @@ struct AIEDMATasksToNPUPass : AIEDMATasksToNPUBase<AIEDMATasksToNPUPass> {
         /*iteration_stride=*/iteration_stride,
         /* TODO: Next BD */
         /*next_bd=*/next_bd_id,
-        /*use_next_bd=*/use_next_bd,
         /*row=*/tile.getRow(),
+        /*use_next_bd=*/use_next_bd,
         /*valid_bd=*/1,
         /* TODO: Locks */
         /*lock_rel_val=*/0, /*lock_rel_id=*/0, /*lock_acq_enable=*/0,

--- a/test/Conversion/DmaToNpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToNpu/aiert_insts.mlir
@@ -8,9 +8,9 @@
 
 // RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
 // CHECK: aiex.npu.blockwrite(%{{.*}}) {address = 118816 : ui32} : memref<8xi32>
-// CHECK: aiex.npu.write32 {address = 119300 : ui32, column = 0 : i32, row = 0 : i32, value = 2147483649 : ui32}
+// CHECK: aiex.npu.write32 {address = 119300 : ui32, value = 2147483649 : ui32}
 // CHECK: aiex.npu.blockwrite(%{{.*}}) {address = 118784 : ui32} : memref<8xi32>
-// CHECK: aiex.npu.write32 {address = 119316 : ui32, column = 0 : i32, row = 0 : i32, value = 0 : ui32}
+// CHECK: aiex.npu.write32 {address = 119316 : ui32, value = 0 : ui32}
 
 module {
   aie.device(npu1_4col) {

--- a/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-dma-to-npu %s 2>&1 | FileCheck %s
+// RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
 
 // CHECK-LABEL:  aie.device(xcve2302) {
 // CHECK:     memref.global "public" @toMem : memref<65536xbf16>
@@ -19,7 +19,7 @@
 // CHECK:       %0 = memref.get_global @blockwrite_data_0 : memref<8xi32>
 // CHECK:       aiex.npu.blockwrite(%0) {address = 67227648 : ui32} : memref<8xi32>
 // CHECK:       aiex.npu.address_patch {addr = 67227652 : ui32, arg_idx = 0 : i32, arg_plus = 0 : i32}
-// CHECK:       aiex.npu.write32 {address = 119300 : ui32, column = 2 : i32, row = 0 : i32, value = 2147680256 : ui32}
+// CHECK:       aiex.npu.write32 {address = 67228164 : ui32, value = 2147680256 : ui32}
 // CHECK:       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
 // CHECK:     }
 // CHECK:     aie.shim_dma_allocation @toMem(S2MM, 0, 2)

--- a/test/Conversion/DmaToNpu/push_to_queue.mlir
+++ b/test/Conversion/DmaToNpu/push_to_queue.mlir
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
-// CHECK: aiex.npu.write32 {address = 119308 : ui32, column = 0 : i32, row = 0 : i32, value = 2147483651 : ui32}
-// CHECK: aiex.npu.write32 {address = 119316 : ui32, column = 2 : i32, row = 0 : i32, value = 196610 : ui32}
+// CHECK: aiex.npu.write32 {address = 119308 : ui32, value = 2147483651 : ui32}
+// CHECK: aiex.npu.write32 {address = 67228180 : ui32, value = 196610 : ui32}
 
 module {
   aie.device(npu1_4col) {

--- a/test/Targets/NPU/npu_dma_memcpy.mlir
+++ b/test/Targets/NPU/npu_dma_memcpy.mlir
@@ -15,7 +15,7 @@
 // CHECK:   %[[VALUE:.*]] = memref.get_global {{.*}} : memref<8xi32>
 // CHECK:   aiex.npu.blockwrite(%[[VALUE]]) {address = 118784 : ui32} : memref<8xi32>
 // CHECK:   aiex.npu.address_patch {addr = 118788 : ui32, arg_idx = 0 : i32, arg_plus = 16384 : i32}
-// CHECK:   aiex.npu.write32 {address = 119316 : ui32, column = 0 : i32, row = 0 : i32, value = 0 : ui32}
+// CHECK:   aiex.npu.write32 {address = 119316 : ui32, value = 0 : ui32}
 // CHECK: }
 
 module {

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-4.mlir
@@ -20,7 +20,7 @@ module {
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d0_zero_after = 0 : i32, d0_zero_before = 0 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d1_zero_after = 0 : i32, d1_zero_before = 0 : i32, d2_size = 4 : i32, d2_stride = 0 : i32, d2_zero_after = 0 : i32, d2_zero_before = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 1 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.write32 {address = 1167364 : ui32, value = 48879 : ui32}
+      // CHECK: aiex.npu.write32 {address = 1703940 : ui32, value = 48879 : ui32}
       %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
           aie.dma_bd(%buf : memref<32xi8>, 4, 16,
                      [<size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>]) {bd_id = 0 : i32}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-5.mlir
@@ -24,11 +24,11 @@ module {
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
-          // CHECK: aiex.npu.write32 {address = 1167364 : ui32, value = [[ADDR1]] : ui32}
+          // CHECK: aiex.npu.write32 {address = 1703940 : ui32, value = [[ADDR1]] : ui32}
           aie.dma_bd(%buf0 : memref<32xi8>, 4, 16) {bd_id = 0 : i32}
           aie.next_bd ^bd2
         ^bd2:
-          // CHECK: aiex.npu.write32 {address = 1167396 : ui32, value = [[ADDR2]] : ui32}
+          // CHECK: aiex.npu.write32 {address = 1703972 : ui32, value = [[ADDR2]] : ui32}
           aie.dma_bd(%buf1 : memref<32xi8>, 4, 16) {bd_id = 1 : i32}
           aie.end
       }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-7.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-7.mlir
@@ -16,7 +16,7 @@ module {
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d0_zero_after = 1 : i32, d0_zero_before = 2 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d1_zero_after = 0 : i32, d1_zero_before = 0 : i32, d2_size = 4 : i32, d2_stride = 0 : i32, d2_zero_after = 0 : i32, d2_zero_before = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 1 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.write32 {address = 1167364 : ui32, value = 48879 : ui32}
+      // CHECK: aiex.npu.write32 {address = 1703940 : ui32, value = 48879 : ui32}
       %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
           aie.dma_bd(%buf : memref<32xi8>, 4, 16,
                      [<size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>], [<const_pad_before=2, const_pad_after=1>]) {bd_id = 0 : i32}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-8.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-8.mlir
@@ -16,7 +16,7 @@ module {
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d0_zero_after = 1 : i32, d0_zero_before = 1 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d1_zero_after = 2 : i32, d1_zero_before = 2 : i32, d2_size = 4 : i32, d2_stride = 0 : i32, d2_zero_after = 1 : i32, d2_zero_before = 2 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 1 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.write32 {address = 1167364 : ui32, value = 48879 : ui32}
+      // CHECK: aiex.npu.write32 {address = 1703940 : ui32, value = 48879 : ui32}
       %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
           aie.dma_bd(%buf : memref<32xi8>, 4, 16,
                      [<size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>], [<const_pad_before=2, const_pad_after=1>, <const_pad_before=2, const_pad_after=2>, <const_pad_before=1, const_pad_after=1>]) {bd_id = 0 : i32}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-9.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-9.mlir
@@ -16,7 +16,7 @@ module {
 
     aiex.runtime_sequence(%arg0: memref<32xi8>) {
       // CHECK: aiex.npu.writebd {bd_id = 0 : i32, buffer_length = 4 : i32, buffer_offset = 4 : i32, column = 0 : i32, d0_size = 1 : i32, d0_stride = 0 : i32, d0_zero_after = 1 : i32, d0_zero_before = 1 : i32, d1_size = 2 : i32, d1_stride = 1 : i32, d1_zero_after = 2 : i32, d1_zero_before = 2 : i32, d2_size = 4 : i32, d2_stride = 0 : i32, d2_zero_after = 0 : i32, d2_zero_before = 0 : i32, enable_packet = 0 : i32, iteration_current = 0 : i32, iteration_size = 0 : i32, iteration_stride = 0 : i32, lock_acq_enable = 0 : i32, lock_acq_id = 0 : i32, lock_acq_val = 0 : i32, lock_rel_id = 0 : i32, lock_rel_val = 0 : i32, next_bd = 0 : i32, out_of_order_id = 0 : i32, packet_id = 0 : i32, packet_type = 0 : i32, row = 1 : i32, use_next_bd = 0 : i32, valid_bd = 1 : i32}
-      // CHECK: aiex.npu.write32 {address = 1167364 : ui32, value = 48879 : ui32}
+      // CHECK: aiex.npu.write32 {address = 1703940 : ui32, value = 48879 : ui32}
       %t1 = aiex.dma_configure_task(%tile_0_1, MM2S, 0) {
           aie.dma_bd(%buf : memref<32xi8>, 4, 16,
                      [<size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>], [<const_pad_before=2, const_pad_after=2>, <const_pad_before=1, const_pad_after=1>]) {bd_id = 0 : i32}


### PR DESCRIPTION
This PR moves some ad-hoc AIE2 specific address calculations from AIEXDialect (`getBufferDescriptorAddressRegisterAddress`) and AIEDmaToNpu.cpp into `AIETargetModel`. It also extends said calculations to be correct for MemTile and CoreTile instead of ShimTile only.