### PR TITLE
fixed vector_reduce_add example

### DIFF
--- a/programming_examples/basic/vector_reduce_add/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_add/CMakeLists.txt
@@ -5,6 +5,7 @@
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
 # parameters
+# -DBOOST_ROOT: Path to Boost install
 # -DXRT_INC_DIR: Full path to src/runtime_src/core/include in XRT cloned repo
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
@@ -12,12 +13,19 @@
 # cmake needs this line
 cmake_minimum_required(VERSION 3.1)
 
+set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
 find_program(WSL NAMES powershell.exe)
 
 if (NOT WSL)
+    set(CMAKE_C_COMPILER gcc-13)
+    set(CMAKE_CXX_COMPILER g++-13)
+    set(BOOST_ROOT /usr/include/boost CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
+    set(BOOST_ROOT C:/Technical/thirdParty/boost_1_83_0 CACHE STRING "Path to Boost install")
     set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
 endif()
@@ -29,11 +37,12 @@ SET (currentTarget ${TARGET_NAME})
 
 if ( WSL )
 	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
 endif ()
 
 project(${ProjectName})
 
+# Find packages
+find_package(Boost REQUIRED)
 
 add_executable(${currentTarget}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib/test_utils.cpp
@@ -42,17 +51,25 @@ add_executable(${currentTarget}
 
 target_compile_definitions(${currentTarget} PUBLIC DISABLE_ABI_CHECK=1)
 
-target_include_directories (${currentTarget} PUBLIC
-    ../../utils
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib
+target_include_directories (${currentTarget} PUBLIC 
     ${XRT_INC_DIR}
+    ${Boost_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime_lib/test_lib
 )
 
 target_link_directories(${currentTarget} PUBLIC
     ${XRT_LIB_DIR}
+    ${Boost_LIBRARY_DIRS}
 )
 
-target_link_libraries(${currentTarget} PUBLIC
-    xrt_coreutil
-)
+if (NOT WSL)
+    target_link_libraries(${currentTarget} PUBLIC
+        xrt_coreutil
+        boost_program_options
+        boost_filesystem
+    )
+else()
+    target_link_libraries(${currentTarget} PUBLIC
+        xrt_coreutil
+    )
+endif()

--- a/programming_examples/basic/vector_reduce_add/Makefile
+++ b/programming_examples/basic/vector_reduce_add/Makefile
@@ -12,11 +12,12 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-targetname = vector_reduce_add
-devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
-col = 0
+all: build/final.xclbin
 
-colshift ?= $(if $(filter npu,$(devicename)),1,0)
+device ?= $(if $(filter 1,$(NPU2)),npu2,npu)
+targetname = vector_reduce_add
+trace_size = 8192
+
 aie_py_src=${targetname}.py
 use_placed?=0
 
@@ -24,32 +25,43 @@ ifeq (${use_placed}, 1)
 aie_py_src=${targetname}_placed.py
 endif
 
-all: build/final.xclbin build/insts.bin
-
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
-build/%.cc.o: %.cc
+build/%.o: %.cc
 	mkdir -p ${@D}
-ifeq ($(devicename),npu2)
-	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS}  -c $< -o ${@F}
+ifeq ($(device),npu)
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}
+else ifeq ($(device),npu2)
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -c $< -o ${@F}
 else
-	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS}  -c $< -o ${@F}
+	echo "Device type not supported"
 endif
 
 build/aie.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
-	python3 $< ${devicename} ${col} > $@
+	python3 $< ${device} 0 > $@
 
-build/final.xclbin: build/aie.mlir build/reduce_add.cc.o
+build/aie_trace.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
-	cd ${@D} && aiecc.py --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
-    	--no-xchesscc --no-xbridge --peano ${PEANO_INSTALL_DIR} \
-				--aie-generate-npu-insts --npu-insts-name=insts.bin $(<:%=../%)
+	python3 $< ${device} ${trace_size} > $@
+
+build/final.xclbin: build/aie.mlir build/reduce_add.o
+	mkdir -p ${@D}
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
+		--no-xchesscc --no-xbridge \
+		--xclbin-name=${@F} --npu-insts-name=insts.bin ${<F}
+
+build/final_trace.xclbin: build/aie_trace.mlir build/reduce_add.o
+	mkdir -p ${@D}
+	cd ${@D} && aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host \
+		--no-xchesscc --no-xbridge \
+		--xclbin-name=${@F} --npu-insts-name=insts.bin ${<F}
+
 
 ${targetname}.exe: ${srcdir}/test.cpp
 	rm -rf _build
 	mkdir -p _build
-	cd _build && ${powershell} cmake `${getwslpath} ${srcdir}` -DTARGET_NAME=${targetname}
+	cd _build && ${powershell} cmake ${srcdir}/ -DTARGET_NAME=${targetname}
 	cd _build && ${powershell} cmake --build . --config Release
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
@@ -60,11 +72,10 @@ endif
 run: ${targetname}.exe build/final.xclbin
 	${powershell} ./$< -x build/final.xclbin -i build/insts.bin -k MLIR_AIE
 
-trace:
-	../../utils/parse_trace.py --input trace.txt --mlir build/aie.mlir --colshift $(colshift) --output parse_eventIR_vs.json
+trace: ${targetname}.exe build/final_trace.xclbin
+	${powershell} ./$< -x build/final_trace.xclbin -i build/insts.bin -k MLIR_AIE -t ${trace_size}
+	${srcdir}/../../utils/parse_trace.py --filename trace.txt --mlir build/aie_trace.mlir --colshift 1 > trace_eltwise_mul.json
+	${srcdir}/../../utils/get_trace_summary.py --filename trace_eltwise_mul.json
 
-clean_trace:
-	rm -rf tmpTrace trace.txt
-
-clean: clean_trace
-	rm -rf build _build inst aie.mlir.prj core_* test.elf ${targetname}.exe
+clean:
+	rm -rf build _build ${targetname}.exe

--- a/programming_examples/basic/vector_reduce_add/vector_reduce_add.py
+++ b/programming_examples/basic/vector_reduce_add/vector_reduce_add.py
@@ -1,62 +1,115 @@
-# vector_reduce_add/vector_reduce_add.py -*- Python -*-
 #
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024 AMD Inc.
+from ml_dtypes import bfloat16
 import numpy as np
 import sys
 
 from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
 from aie.iron.placers import SequentialPlacer
-from aie.iron.device import NPU1Col1, NPU2Col1
+from aie.iron.device import NPU1Col1, NPU2
+from aie.iron.controlflow import range_
+from aie.helpers.util import np_ndarray_type_get_shape
 
 
-if len(sys.argv) > 2:
-    if sys.argv[1] == "npu":
-        dev = NPU1Col1()
-    elif sys.argv[1] == "npu2":
-        dev = NPU2Col1()
-    else:
-        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[1]))
+def my_relu(dev, trace_size):
+    N = 65536 #tiles with reduce_add produce a segmentation error
 
+    # Tile sizes and types
+    n = 256
+    N_div_n = N // n
 
-def my_reduce_add():
-    N = 1024
+    n_cores = 1
+    tiles = N_div_n // n_cores
 
-    in_ty = np.ndarray[(N,), np.dtype[np.int32]]
-    out_ty = np.ndarray[(1,), np.dtype[np.int32]]
+    tensor_ty = np.ndarray[(N,), np.dtype[np.int32]]
+    tile_ty = np.ndarray[(n,), np.dtype[np.int32]]
+    out_ty = np.ndarray[(n,), np.dtype[np.int32]]
 
-    # AIE-array data movement with object fifos
-    of_in = ObjectFifo(in_ty, name="in")
-    of_out = ObjectFifo(out_ty, name="out")
+    # Type used in the tile memory
+    A_ty = np.ndarray[(n,), np.dtype[np.int32]]
+    C_ty = np.ndarray[(n,), np.dtype[np.int32]] #DMAs only transfer multiples of 32 bits
+
+    # Type used in the memory tile which aggregates across the 4 cores
+    A_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[np.int32]]
+    C_memTile_ty = np.ndarray[(n * n_cores,), np.dtype[np.int32]]
 
     # AIE Core Function declarations
-    reduce_add_vector = Kernel(
-        "reduce_add_vector", "reduce_add.cc.o", [in_ty, out_ty, np.int32]
+    relu = Kernel("reduce_add_vector", "reduce_add.o", [tile_ty, out_ty, np.int32])
+
+    # AIE-array data movement with object fifos
+    # Input A
+    inA = ObjectFifo(A_memTile_ty, name="inA")
+    of_offsets = [
+        (np.prod(np_ndarray_type_get_shape(A_memTile_ty)) // n_cores) * i
+        for i in range(n_cores)
+    ]
+    inA_fifos = inA.cons().split(
+        of_offsets,
+        obj_types=[A_ty] * n_cores,
+        names=[f"memA{i}" for i in range(n_cores)],
     )
 
-    # A task for a core to perform
-    def core_body(of_in, of_out, reduce_add_vector):
-        elem_out = of_out.acquire(1)
-        elem_in = of_in.acquire(1)
-        reduce_add_vector(elem_in, elem_out, N)
-        of_in.release(1)
-        of_out.release(1)
+    # Output C
+    outC = ObjectFifo(C_memTile_ty, name="outC")
+    of_offsets = [
+        (np.prod(np_ndarray_type_get_shape(C_memTile_ty)) // n_cores) * i
+        for i in range(n_cores)
+    ]
+    outC_fifos = outC.prod().join(
+        of_offsets,
+        obj_types=[C_ty] * n_cores,
+        names=[f"memC{i}" for i in range(n_cores)],
+    )
 
-    # Create a worker to run a task on a core
-    worker = Worker(core_body, fn_args=[of_in.cons(), of_out.prod(), reduce_add_vector])
+    # Task for cores to perform
+    def core_fn(of_a, of_c, relu_fn):
+        for _ in range_(tiles):
+            elem_out = of_c.acquire(1)
+            elem_in_a = of_a.acquire(1)
+            relu_fn(elem_in_a, elem_out, n)
+            of_a.release(1)
+            of_c.release(1)
+
+    # Create workers to perform the task
+    workers = []
+    for i in range(n_cores):
+        workers.append(
+            Worker(
+                core_fn,
+                fn_args=[
+                    inA_fifos[i].cons(),
+                    outC_fifos[i].prod(),
+                    relu,
+                ],
+            )
+        )
 
     # Runtime operations to move data to/from the AIE-array
     rt = Runtime()
-    with rt.sequence(in_ty, out_ty) as (a_in, c_out):
-        rt.start(worker)
-        rt.fill(of_in.prod(), a_in)
-        rt.drain(of_out.cons(), c_out, wait=True)
+    with rt.sequence(tensor_ty, tensor_ty, tensor_ty) as (A, B, C):
+        rt.start(*workers)
+        rt.fill(inA.prod(), A)
+        rt.drain(outC.cons(), C, wait=True)
 
-    # Place program components (assign them resources on the device) and generate an MLIR module
+    # Place components (assign them resources on the device) and generate an MLIR module
     return Program(dev, rt).resolve_program(SequentialPlacer())
 
 
-print(my_reduce_add())
+try:
+    device_name = str(sys.argv[1])
+    if device_name == "npu":
+        dev = NPU1Col1()
+    elif device_name == "npu2":
+        dev = NPU2()
+    else:
+        raise ValueError("[ERROR] Device name {} is unknown".format(sys.argv[2]))
+    trace_size = 0 if (len(sys.argv) != 3) else int(sys.argv[2])
+except ValueError:
+    print("Argument is not an integer")
+
+module = my_relu(dev, trace_size)
+print(module)


### PR DESCRIPTION
original programming example didn't work with test.cpp from other examples. the issue apparently stemmed from distinct kernel syntax requirements associated with the older way of managing host-NPU buffers.

now works with the newer host-NPU buffer method already present in most other examples.
furthermore: supports tiled computation. kernel code uses templates.
