### PR TITLE
Add event options to trace

### DIFF
--- a/aie_kernels/aie2/scale.cc
+++ b/aie_kernels/aie2/scale.cc
@@ -56,7 +56,7 @@ template <>
 void scale_vectorized<int32_t>(int32_t *__restrict a, int32_t *__restrict c,
                                int32_t factor, const int32_t N) {
   event0();
-  constexpr int vec_factor = 32;
+  constexpr int vec_factor = 16;
   int32_t *__restrict pA1 = a;
   int32_t *__restrict pC1 = c;
   const int F = N / vec_factor;
@@ -75,26 +75,30 @@ void scale_vectorized<int32_t>(int32_t *__restrict a, int32_t *__restrict c,
 
 extern "C" {
 
-// 16-bit datatype
-void vector_scalar_mul_int32_scalar(int32_t *a_in, int32_t *c_out,
-                                    int32_t *factor, int32_t N) {
-  scale_scalar<int32_t>(a_in, c_out, *factor, N);
-}
+#if BIT_WIDTH == 16
 
-void vector_scalar_mul_int32_vector(int32_t *a_in, int32_t *c_out,
-                                    int32_t *factor, int32_t N) {
-  scale_vectorized<int32_t>(a_in, c_out, *factor, N);
-}
-
-// 32-bit datatype
-void vector_scalar_mul_int16_scalar(int16_t *a_in, int16_t *c_out,
+void vector_scalar_mul_scalar(int16_t *a_in, int16_t *c_out,
                                     int32_t *factor, int32_t N) {
   scale_scalar<int16_t>(a_in, c_out, *factor, N);
 }
 
-void vector_scalar_mul_int16_vector(int16_t *a_in, int16_t *c_out,
+void vector_scalar_mul_vector(int16_t *a_in, int16_t *c_out,
                                     int32_t *factor, int32_t N) {
   scale_vectorized<int16_t>(a_in, c_out, *factor, N);
 }
+
+#else // Defaults to 32-bit
+
+void vector_scalar_mul_scalar(int32_t *a_in, int32_t *c_out,
+                                    int32_t *factor, int32_t N) {
+  scale_scalar<int32_t>(a_in, c_out, *factor, N);
+}
+
+void vector_scalar_mul_vector(int32_t *a_in, int32_t *c_out,
+                                    int32_t *factor, int32_t N) {
+  scale_vectorized<int32_t>(a_in, c_out, *factor, N);
+}
+
+#endif
 
 } // extern "C"

--- a/aie_kernels/aie2/scale.cc
+++ b/aie_kernels/aie2/scale.cc
@@ -77,25 +77,25 @@ extern "C" {
 
 #if BIT_WIDTH == 16
 
-void vector_scalar_mul_scalar(int16_t *a_in, int16_t *c_out,
-                                    int32_t *factor, int32_t N) {
+void vector_scalar_mul_scalar(int16_t *a_in, int16_t *c_out, int32_t *factor,
+                              int32_t N) {
   scale_scalar<int16_t>(a_in, c_out, *factor, N);
 }
 
-void vector_scalar_mul_vector(int16_t *a_in, int16_t *c_out,
-                                    int32_t *factor, int32_t N) {
+void vector_scalar_mul_vector(int16_t *a_in, int16_t *c_out, int32_t *factor,
+                              int32_t N) {
   scale_vectorized<int16_t>(a_in, c_out, *factor, N);
 }
 
 #else // Defaults to 32-bit
 
-void vector_scalar_mul_scalar(int32_t *a_in, int32_t *c_out,
-                                    int32_t *factor, int32_t N) {
+void vector_scalar_mul_scalar(int32_t *a_in, int32_t *c_out, int32_t *factor,
+                              int32_t N) {
   scale_scalar<int32_t>(a_in, c_out, *factor, N);
 }
 
-void vector_scalar_mul_vector(int32_t *a_in, int32_t *c_out,
-                                    int32_t *factor, int32_t N) {
+void vector_scalar_mul_vector(int32_t *a_in, int32_t *c_out, int32_t *factor,
+                              int32_t N) {
   scale_vectorized<int32_t>(a_in, c_out, *factor, N);
 }
 

--- a/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 set(IN1_SIZE 8192 CACHE STRING "in1 buffer size")
 set(IN2_SIZE 4 CACHE STRING "in2 buffer size")
 set(OUT_SIZE 8192 CACHE STRING "out buffer size")
+set(INT_BIT_WIDTH 16 CACHE STRING "integer bit width size")
 set(TARGET_NAME test CACHE STRING "Target to be built")
 
 SET (ProjectName ${TARGET_NAME})
@@ -51,6 +52,7 @@ target_compile_definitions(${currentTarget} PUBLIC
     IN1_SIZE=${IN1_SIZE}
     IN2_SIZE=${IN2_SIZE}
     OUT_SIZE=${OUT_SIZE}
+    INT_BIT_WIDTH=${INT_BIT_WIDTH}
     DISABLE_ABI_CHECK=1
     )
 

--- a/programming_examples/basic/vector_scalar_mul/Makefile
+++ b/programming_examples/basic/vector_scalar_mul/Makefile
@@ -16,9 +16,16 @@ VPATH := ${srcdir}/../../../aie_kernels/aie2
 
 devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 targetname = vector_scalar_mul
+int_bit_width = 16
+
+ifeq (${int_bit_width}, 16)
 in1_size = 8192 # in bytes
-in2_size = 4 # in bytes, should always be 4 (1x int32)
 out_size = 8192 # in bytes, should always be equal to in1_size
+else # assume int_bit_width == 32
+in1_size = 16384 # in bytes
+out_size = 16384 # in bytes, should always be equal to in1_size
+endif
+in2_size = 4 # in bytes, should always be 4 (1x int32)
 trace_size = 8192
 CHESS ?= false
 
@@ -37,15 +44,15 @@ build/%.o: %.cc
 	mkdir -p ${@D}
 ifeq ($(devicename),npu)
 ifeq ($(CHESS), true)
-	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -c $< -o ${@F}; 
+	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2_FLAGS} -DBIT_WIDTH=${int_bit_width} -c $< -o ${@F}; 
 else 
-	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -c $< -o ${@F}; 
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -DBIT_WIDTH=${int_bit_width} -c $< -o ${@F}; 
 endif
 else ifeq ($(devicename),npu2)
 ifeq ($(CHESS), true)
-	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2P_FLAGS} -DBIT_WIDTH=8 -c $< -o ${@F}; 
+	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2P_FLAGS} -DBIT_WIDTH=${int_bit_width} -c $< -o ${@F}; 
 else 
-	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -c $< -o ${@F}; 
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -DBIT_WIDTH=${int_bit_width}-c $< -o ${@F}; 
 endif
 else
 	echo "Device type not supported"
@@ -53,11 +60,11 @@ endif
 
 build/aie_${data_size}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
-	python3 $< -d ${devicename} -i1s ${in1_size} -i2s ${in2_size} -os ${out_size} > $@
+	python3 $< -d ${devicename} -i1s ${in1_size} -i2s ${in2_size} -os ${out_size} -bw ${int_bit_width} > $@
 
 build/aie_trace_${data_size}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
-	python3 $< -d ${devicename} -i1s ${in1_size} -i2s ${in2_size} -os ${out_size} -t ${trace_size} > $@
+	python3 $< -d ${devicename} -i1s ${in1_size} -i2s ${in2_size} -os ${out_size} -bw ${int_bit_width}  -t ${trace_size} > $@
 
 #build/insts_${data_size}.bin: build/final_${data_size}.xclbin
 build/final_${data_size}.xclbin: build/aie_${data_size}.mlir build/scale.o
@@ -85,7 +92,7 @@ endif
 ${targetname}_${data_size}.exe: ${srcdir}/test.cpp
 	rm -rf _build
 	mkdir -p _build
-	cd _build && ${powershell} cmake `${getwslpath} ${srcdir}` -DTARGET_NAME=${targetname}_${data_size} -DIN1_SIZE=${in1_size} -DIN2_SIZE=${in2_size} -DOUT_SIZE=${out_size}
+	cd _build && ${powershell} cmake `${getwslpath} ${srcdir}` -DTARGET_NAME=${targetname}_${data_size} -DIN1_SIZE=${in1_size} -DIN2_SIZE=${in2_size} -DOUT_SIZE=${out_size} -DINT_BIT_WIDTH=${int_bit_width} 
 	cd _build && ${powershell} cmake --build . --config Release
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}_${data_size}.exe $@

--- a/programming_examples/basic/vector_scalar_mul/Makefile
+++ b/programming_examples/basic/vector_scalar_mul/Makefile
@@ -52,7 +52,7 @@ else ifeq ($(devicename),npu2)
 ifeq ($(CHESS), true)
 	cd ${@D} && xchesscc_wrapper ${CHESSCCWRAP2P_FLAGS} -DBIT_WIDTH=${int_bit_width} -c $< -o ${@F}; 
 else 
-	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -DBIT_WIDTH=${int_bit_width}-c $< -o ${@F}; 
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -DBIT_WIDTH=${int_bit_width} -c $< -o ${@F}; 
 endif
 else
 	echo "Device type not supported"

--- a/programming_examples/basic/vector_scalar_mul/test.cpp
+++ b/programming_examples/basic/vector_scalar_mul/test.cpp
@@ -22,9 +22,14 @@
 // ------------------------------------------------------
 // Configure this to match your buffer data type
 // ------------------------------------------------------
-using DATATYPE_IN1 = std::uint16_t;
+#if INT_BIT_WIDTH == 16
+using DATATYPE_IN1 = std::int16_t;
+using DATATYPE_OUT = std::int16_t;
+#else
+using DATATYPE_IN1 = std::int32_t;
+using DATATYPE_OUT = std::int32_t;
+#endif
 using DATATYPE_IN2 = std::int32_t;
-using DATATYPE_OUT = std::uint16_t;
 #endif
 
 // Initialize Input buffer 1

--- a/programming_examples/basic/vector_scalar_mul/vector_scalar_mul_placed.py
+++ b/programming_examples/basic/vector_scalar_mul/vector_scalar_mul_placed.py
@@ -156,7 +156,7 @@ int_bit_width = int(opts.int_bit_width)
 trace_size = int(opts.trace_size)
 
 with mlir_mod_ctx() as ctx:
-    my_vector_scalar_mul(dev, in1_size, in2_size, out_size, trace_size)
+    my_vector_scalar_mul(dev, in1_size, in2_size, out_size, int_bit_width, trace_size)
     res = ctx.module.operation.verify()
     if res == True:
         print(ctx.module)

--- a/programming_examples/basic/vector_scalar_mul/vector_scalar_mul_placed.py
+++ b/programming_examples/basic/vector_scalar_mul/vector_scalar_mul_placed.py
@@ -17,10 +17,16 @@ from aie.helpers.dialects.ext.scf import _for as range_
 import aie.utils.trace as trace_utils
 
 
-def my_vector_scalar_mul(dev, in1_size, in2_size, out_size, trace_size):
-    in1_dtype = np.int16
+def my_vector_scalar_mul(dev, in1_size, in2_size, out_size, int_bit_width, trace_size):
+
+    if int_bit_width == 16:
+        in1_dtype = np.int16
+        out_dtype = np.int16
+    else:  # default is 32-bit
+        in1_dtype = np.int32
+        out_dtype = np.int32
+
     in2_dtype = np.int32
-    out_dtype = np.int16
 
     tensor_size = in1_size // in1_dtype(0).nbytes
     num_sub_vectors = 4
@@ -40,7 +46,7 @@ def my_vector_scalar_mul(dev, in1_size, in2_size, out_size, trace_size):
         # AIE Core Function declarations
         func_type = "vector" if vectorized else "scalar"
         scale = external_func(
-            f"vector_scalar_mul_int16_{func_type}",
+            f"vector_scalar_mul_{func_type}",
             inputs=[tile_ty, tile_ty, scalar_ty, np.int32],
         )
 
@@ -116,6 +122,13 @@ p.add_argument(
 )
 p.add_argument("-os", "--out_size", required=True, dest="out_size", help="Output size")
 p.add_argument(
+    "-bw",
+    "--int_bit_width",
+    required=True,
+    dest="int_bit_width",
+    help="Integer Bit Width",
+)
+p.add_argument(
     "-t",
     "--trace_size",
     required=False,
@@ -139,6 +152,7 @@ if in1_size % 128 != 0 or in1_size < 1024:
     raise ValueError
 in2_size = int(opts.in2_size)
 out_size = int(opts.out_size)
+int_bit_width = int(opts.int_bit_width)
 trace_size = int(opts.trace_size)
 
 with mlir_mod_ctx() as ctx:

--- a/python/iron/runtime/runtime.py
+++ b/python/iron/runtime/runtime.py
@@ -313,7 +313,7 @@ class Runtime(Resolvable):
                         self._trace_offset if self._trace_offset is not None else 0
                     ),
                     ddr_id=self._ddr_id if self._ddr_id is not None else 4,
-                    coretile_events=self._coretile_events ,
+                    coretile_events=self._coretile_events,
                     memtile_events=self._memtile_events,
                     shimtile_events=self._shimtile_events,
                     coremem_events=self._coremem_events,

--- a/python/iron/runtime/runtime.py
+++ b/python/iron/runtime/runtime.py
@@ -237,7 +237,6 @@ class Runtime(Resolvable):
         coretile_events: [] = None,
         memtile_events: [] = None,
         shimtile_events: [] = None,
-        coremem_events: [] = None,
     ):
         """Enable trace."""
         self._trace_size = trace_size
@@ -247,7 +246,6 @@ class Runtime(Resolvable):
         self._coretile_events = coretile_events
         self._memtile_events = memtile_events
         self._shimtile_events = shimtile_events
-        self._coremem_events = coremem_events
 
     def set_barrier(self, barrier: WorkerRuntimeBarrier, value: int):
         """Set the value of a worker barrier.
@@ -316,7 +314,6 @@ class Runtime(Resolvable):
                     coretile_events=self._coretile_events,
                     memtile_events=self._memtile_events,
                     shimtile_events=self._shimtile_events,
-                    coremem_events=self._coremem_events,
                 )
 
             for rt_data, rt_data_val in zip(self._rt_data, args):

--- a/python/iron/runtime/runtime.py
+++ b/python/iron/runtime/runtime.py
@@ -234,12 +234,20 @@ class Runtime(Resolvable):
         trace_offset: int = None,
         workers: [] = None,
         ddr_id: int = None,
+        coretile_events: [] = None,
+        memtile_events: [] = None,
+        shimtile_events: [] = None,
+        coremem_events: [] = None,
     ):
         """Enable trace."""
         self._trace_size = trace_size
         self._trace_offset = trace_offset
         self._trace_workers = workers
         self._ddr_id = ddr_id
+        self._coretile_events = coretile_events
+        self._memtile_events = memtile_events
+        self._shimtile_events = shimtile_events
+        self._coremem_events = coremem_events
 
     def set_barrier(self, barrier: WorkerRuntimeBarrier, value: int):
         """Set the value of a worker barrier.
@@ -305,6 +313,10 @@ class Runtime(Resolvable):
                         self._trace_offset if self._trace_offset is not None else 0
                     ),
                     ddr_id=self._ddr_id if self._ddr_id is not None else 4,
+                    coretile_events=self._coretile_events ,
+                    memtile_events=self._memtile_events,
+                    shimtile_events=self._shimtile_events,
+                    coremem_events=self._coremem_events,
                 )
 
             for rt_data, rt_data_val in zip(self._rt_data, args):

--- a/python/utils/trace.py
+++ b/python/utils/trace.py
@@ -1041,7 +1041,6 @@ def configure_packet_tracing_aie2(
     shim_burst_length=64,
 ):
 
-
     if coretile_events == None:
         coretile_events = [
             CoreEvent.INSTR_EVENT_0,
@@ -1088,7 +1087,7 @@ def configure_packet_tracing_aie2(
             MemEvent.EDGE_DETECTION_EVENT_0,
             MemEvent.EDGE_DETECTION_EVENT_1,
         ]
-            
+
     start_core_broadcast_event = CoreEvent(107 + start_broadcast_num)
     stop_core_broadcast_event = CoreEvent(107 + stop_broadcast_num)
     start_memtile_broadcast_event = MemTileEvent(142 + start_broadcast_num)

--- a/python/utils/trace.py
+++ b/python/utils/trace.py
@@ -276,6 +276,119 @@ def pack4bytes(b3, b2, b1, b0):
     return w
 
 
+
+# This function configures the a tile's memory trace unit given a set of configurations as described below:
+#
+# function arguments:
+# * `tile` - ocre tile to configure
+# * `start` - start event. We generally use a global broadcast signal to synchronize the start event
+#             for multiple cores.
+# * `stop` - stop event. We generally use a global broadcast signal to synchronize the stop event for
+#            multiple cores.
+# * `events` - array of 8 events to trace
+# * `enable_packet` - enables putting event data into packets
+# * `packet_id` - packet id or flow id used to route the packets through the stream switch
+# * `packet_type` - packet type is an arbitrary field but we use it to describe the tile type the
+#                   packets are coming from
+def configure_coremem_tracing_aie2(
+    tile,
+    start=MemEvent.TRUE,
+    stop=MemEvent.NONE,
+    events=[
+        MemEvent.DMA_S2MM_0_START_TASK,
+        MemEvent.DMA_S2MM_0_FINISHED_BD,
+        MemEvent.CONFLICT_DM_BANK_0,
+        MemEvent.CONFLICT_DM_BANK_1,
+        MemEvent.CONFLICT_DM_BANK_2,
+        MemEvent.CONFLICT_DM_BANK_3,
+        MemEvent.EDGE_DETECTION_EVENT_0,
+        MemEvent.EDGE_DETECTION_EVENT_1,
+    ],
+    enable_packet=0,
+    packet_id=0,
+    packet_type=PacketType.MEM,
+):
+    if isinstance(start, int):
+        start = MemEvent(start)
+    if isinstance(stop, int):
+        stop = MemEvent(stop)
+    if len(events) > 8:
+        raise RuntimeError(
+            f"At most 8 events can be traced at once, have {len(events)}."
+        )
+    events = (events + [MemEvent.NONE] * 8)[:8]
+    
+    # Reorder events so they match the event order for display
+    ordered_events = [events[p] for p in [3, 2, 1, 0, 7, 6, 5, 4]]
+    
+    # Assure all selected events are valid
+    ordered_events = [
+        e if isinstance(e, GenericEvent) else GenericEvent(e) for e in ordered_events
+    ]
+
+    # Require ports to be specifically given for port events.
+    for event in ordered_events:
+        if event.code in PortEventCodes and not isinstance(event, PortEvent):
+            raise RuntimeError(
+                f"Tracing: {event.code.name} is a PortEvent and requires a port to be specified alongside it. \n"
+                "To select master port N, specify the event as follows: "
+                f"PortEvent(CoreEvent.{event.code.name}, N, master=True), "
+                "and analogously with master=False for slave ports. "
+                "For example: "
+                f"configure_simple_tracing_aie2( ..., events=[PortEvent(CoreEvent.{event.code.name}, 1, master=True)])"
+            )
+            
+    # 140D0: Trace Control 0
+    #          0xAABB---C
+    #            AA        <- Event to stop trace capture
+    #              BB      <- Event to start trace capture
+    #                   C  <- Trace mode, 00=event=time, 01=event-PC, 10=execution
+    # Configure so that "Event 1" (always true) causes tracing to start
+    npu_write32(
+        column=int(tile.col),
+        row=int(tile.row),
+        address=0x140D0,
+        value=pack4bytes(stop.value, start.value, 0, 0),
+    )
+    # 0x140D4: Trace Control 1
+    npu_write32(
+        column=int(tile.col),
+        row=int(tile.row),
+        address=0x140D4,
+        value=((packet_type & 0x7) << 12) | (packet_id & 0x1F) if enable_packet else 0,
+    )    
+    # 0x140E0: Trace Event Group 1  (Which events to trace)
+    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
+    npu_write32(
+        column=int(tile.col),
+        row=int(tile.row),
+        address=0x140E0,
+        value=pack4bytes(*(e.code.value for e in ordered_events[0:4])),
+    )
+    # 0x140E4: Trace Event Group 2  (Which events to trace)
+    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
+    npu_write32(
+        column=int(tile.col),
+        row=int(tile.row),
+        address=0x140E4,
+        value=pack4bytes(*(e.code.value for e in ordered_events[4:8])),
+    )
+    
+    # Event specific register writes
+    all_reg_writes = {}
+    for e in ordered_events:
+        reg_writes = e.get_register_writes()
+        for addr, value in reg_writes.items():
+            if addr in all_reg_writes:
+                all_reg_writes[addr] |= value
+            else:
+                all_reg_writes[addr] = value
+    for addr, value in all_reg_writes.items():
+        npu_write32(
+            column=int(tile.col), row=int(tile.row), address=addr, value=value
+        )  # For backwards compatibility, allow integers for start/stop events
+        
+    
 # This function configures the a tile's trace unit given a set of configurations as described below:
 #
 # function arguments:
@@ -594,6 +707,18 @@ def configure_shimtile_tracing_aie2(
         npu_write32(column=int(tile.col), row=int(tile.row), address=addr, value=value)
 
 
+# Configure timer in core tile's memory to reset based on `event`
+def configure_timer_ctrl_coremem_aie2(tile, event):
+    addr = 0x14000
+    eventValue = (event.value & 0x7F) << 8
+    npu_write32(
+        column=int(tile.col),
+        row=int(tile.row),
+        address=addr,
+        value=eventValue,
+    )
+
+
 # Configure timer in core tile to reset based on `event`
 def configure_timer_ctrl_coretile_aie2(tile, event):
     addr = 0x34000
@@ -748,6 +873,66 @@ def configure_shimtile_dma_tracing_aie2(
         address=0x1D204 if channel == 0 else 0x1D20C,
         value=((enable_token & 0x1) << 31) | bd_id,
     )
+
+
+# Wrapper to configure the core tile and shim tile for packet tracing. This does
+# the following:
+# 1. Configure core tile based on start/ stop, events, and flow id. The flow id
+#    needs to be unique per flow.
+# 2. Configure timer based on broadcast event (default is 15). This ensures all
+#    tiles keying off this event has a synchronized timer so their trace are
+#    synchronized. This event is also used as the start event for tracing.
+# 3. Configure shim tile to receive this flow and move the data to offset/ size.
+#
+def configure_coremem_packet_tracing_aie2(
+    tile,
+    shim,
+    flow_id=0,
+    bd_id=15,
+    size=8192,
+    offset=0,
+    enable_token=0,
+    # brdcst_event=0x7A,  # event 122 - broadcast 15 # TODO
+    channel=1,
+    ddr_id=4,
+    start=MemEvent.BROADCAST_15,
+    stop=MemEvent.BROADCAST_14,
+    events=[
+        MemEvent.DMA_S2MM_0_START_TASK,
+        MemEvent.DMA_S2MM_0_FINISHED_BD,
+        MemEvent.CONFLICT_DM_BANK_0,
+        MemEvent.CONFLICT_DM_BANK_1,
+        MemEvent.CONFLICT_DM_BANK_2,
+        MemEvent.CONFLICT_DM_BANK_3,
+        MemEvent.EDGE_DETECTION_EVENT_0,
+        MemEvent.EDGE_DETECTION_EVENT_1,
+    ],
+    shim_burst_length=64,
+):
+    configure_coremem_tracing_aie2(
+        tile=tile,
+        start=start,
+        stop=stop,
+        events=events,
+        enable_packet=1,
+        packet_id=flow_id,
+        packet_type=PacketType.MEM,
+    )
+    configure_timer_ctrl_coremem_aie2(tile, start)
+    configure_shimtile_dma_tracing_aie2(
+        shim=shim,
+        channel=channel,
+        bd_id=bd_id,
+        ddr_id=ddr_id,
+        size=size,
+        offset=offset,
+        enable_token=enable_token,
+        enable_packet=1,
+        packet_id=flow_id,
+        packet_type=PacketType.MEM,
+        shim_burst_length=shim_burst_length,
+    )
+
 
 
 # Wrapper to configure the core tile and shim tile for packet tracing. This does
@@ -933,17 +1118,35 @@ def configure_shimtile_packet_tracing_aie2(
 # * `tiles to trace` - array of tiles to trace
 # * `shim tile` - Single shim tile to configure for writing trace packets to DDR
 def configure_packet_tracing_flow(tiles_to_trace, shim):
+    
+    exist_traces = []
     for i in range(len(tiles_to_trace)):
-        packetflow(
-            i + 1,
-            tiles_to_trace[i],
-            WireBundle.Trace,
-            0,
-            shim,
-            WireBundle.DMA,
-            1,
-            keep_pkt_header=True,
-        )
+        
+        if tiles_to_trace[i] not in exist_traces:
+            packetflow(
+                i + 1,
+                tiles_to_trace[i],
+                WireBundle.Trace,
+                0,
+                shim,
+                WireBundle.DMA,
+                1,
+                keep_pkt_header=True,
+            )
+            
+            exist_traces.append(tiles_to_trace[i])
+        else:
+            # Ct's memory trace?
+            packetflow(
+                i + 1,
+                tiles_to_trace[i],
+                WireBundle.Trace,
+                1,
+                shim,
+                WireBundle.DMA,
+                1,
+                keep_pkt_header=True,
+            )
 
 
 # Configure the shim tile to support packet tracing via:
@@ -962,7 +1165,7 @@ def configure_shim_trace_start_aie2(
     brdcst_num=15,
     user_event=ShimTileEvent.USER_EVENT_1,  # 0x7F, 127: user even t#1
 ):
-    configure_timer_ctrl_coretile_aie2(shim, user_event)
+    configure_timer_ctrl_coretile_aie2(shim, user_event) #TODO: should have call configure_timer_ctrl_shimtile_aie2() instead?
     configure_broadcast_core_aie2(shim, brdcst_num, user_event)
     configure_event_gen_core_aie2(shim, user_event)
 
@@ -1038,8 +1241,67 @@ def configure_packet_tracing_aie2(
         ShimTileEvent.DMA_S2MM_0_STREAM_STARVATION,
         ShimTileEvent.DMA_S2MM_1_STREAM_STARVATION,
     ],
+    coremem_events=[
+        MemEvent.DMA_S2MM_0_START_TASK,
+        MemEvent.DMA_MM2S_0_START_TASK,
+        MemEvent.CONFLICT_DM_BANK_0,
+        MemEvent.CONFLICT_DM_BANK_1,
+        MemEvent.CONFLICT_DM_BANK_2,
+        MemEvent.CONFLICT_DM_BANK_3,
+        MemEvent.EDGE_DETECTION_EVENT_0,
+        MemEvent.EDGE_DETECTION_EVENT_1,
+    ],
     shim_burst_length=64,
 ):
+
+    if coretile_events == None:
+        coretile_events=[
+            CoreEvent.INSTR_EVENT_0,
+            CoreEvent.INSTR_EVENT_1,
+            CoreEvent.INSTR_VECTOR,
+            PortEvent(CoreEvent.PORT_RUNNING_0, 1, True),  # master(1)
+            PortEvent(CoreEvent.PORT_RUNNING_1, 1, False),  # slave(1)
+            CoreEvent.INSTR_LOCK_ACQUIRE_REQ,
+            CoreEvent.INSTR_LOCK_RELEASE_REQ,
+            CoreEvent.LOCK_STALL,
+        ]
+    if memtile_events == None:
+        memtile_events=[
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_0, 0, True),  # master(0)
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_1, 14, False),  # slave(14/ north1)
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_2, 0, False),  # slave(0)
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_3, 1, False),  # slave(1)
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_4, 2, False),  # slave(2)
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_5, 3, False),  # slave(3)
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_6, 4, False),  # slave(4)
+            MemTilePortEvent(MemTileEvent.PORT_RUNNING_7, 5, False),  # slave(5)
+        ]
+    if shimtile_events == None:
+        shimtile_events=[
+            ShimTileEvent.DMA_S2MM_0_START_TASK,
+            ShimTileEvent.DMA_S2MM_1_START_TASK,
+            ShimTileEvent.DMA_MM2S_0_START_TASK,
+            ShimTileEvent.DMA_S2MM_0_FINISHED_TASK,
+            ShimTileEvent.DMA_S2MM_1_FINISHED_TASK,
+            ShimTileEvent.DMA_MM2S_0_FINISHED_TASK,
+            ShimTileEvent.DMA_S2MM_0_STREAM_STARVATION,
+            ShimTileEvent.DMA_S2MM_1_STREAM_STARVATION,
+        ]
+    if coremem_events == None:
+        coremem_events=[
+            MemEvent.DMA_S2MM_0_START_TASK,
+            MemEvent.DMA_MM2S_0_START_TASK,
+            MemEvent.CONFLICT_DM_BANK_0,
+            MemEvent.CONFLICT_DM_BANK_1,
+            MemEvent.CONFLICT_DM_BANK_2,
+            MemEvent.CONFLICT_DM_BANK_3,
+            MemEvent.EDGE_DETECTION_EVENT_0,
+            MemEvent.EDGE_DETECTION_EVENT_1,
+        ]
+
+
+    start_core_mem_broadcast_event= MemEvent(107+start_broadcast_num)
+    stop_core_mem_broadcast_event = MemEvent(107+ stop_broadcast_num)
     start_core_broadcast_event = CoreEvent(107 + start_broadcast_num)
     stop_core_broadcast_event = CoreEvent(107 + stop_broadcast_num)
     start_memtile_broadcast_event = MemTileEvent(142 + start_broadcast_num)
@@ -1047,6 +1309,7 @@ def configure_packet_tracing_aie2(
     start_shimtile_broadcast_event = ShimTileEvent(110 + start_broadcast_num)
     stop_shimtile_broadcast_event = ShimTileEvent(110 + stop_broadcast_num)
 
+    exist_core_tile_traces = []
     for i in range(len(tiles_to_trace)):
         if isShimTile(tiles_to_trace[i]):
             if tiles_to_trace[i] == shim:
@@ -1095,20 +1358,37 @@ def configure_packet_tracing_aie2(
                 shim_burst_length=shim_burst_length,
             )
         elif isCoreTile(tiles_to_trace[i]):
-            configure_coretile_packet_tracing_aie2(
-                tile=tiles_to_trace[i],
-                shim=shim,
-                flow_id=i + 1,
-                bd_id=15 - i,
-                ddr_id=ddr_id,
-                size=trace_size,
-                offset=trace_offset,
-                enable_token=enable_token,
-                start=start_core_broadcast_event,
-                stop=stop_core_broadcast_event,
-                events=coretile_events,
-                shim_burst_length=shim_burst_length,
-            )
+            if tiles_to_trace[i] not in exist_core_tile_traces:
+                configure_coretile_packet_tracing_aie2(
+                    tile=tiles_to_trace[i],
+                    shim=shim,
+                    flow_id=i + 1,
+                    bd_id=15 - i,
+                    ddr_id=ddr_id,
+                    size=trace_size,
+                    offset=trace_offset,
+                    enable_token=enable_token,
+                    start=start_core_broadcast_event,
+                    stop=stop_core_broadcast_event,
+                    events=coretile_events,
+                    shim_burst_length=shim_burst_length,
+                )
+                exist_core_tile_traces.append(tiles_to_trace[i])
+            else:
+                configure_coremem_packet_tracing_aie2(
+                    tile=tiles_to_trace[i],
+                    shim=shim,
+                    flow_id=i + 1,
+                    bd_id=15 - i,
+                    ddr_id=ddr_id,
+                    size=trace_size,
+                    offset=trace_offset,
+                    enable_token=enable_token,
+                    start=start_core_mem_broadcast_event,
+                    stop=stop_core_mem_broadcast_event,
+                    events=coremem_events,
+                    shim_burst_length=shim_burst_length
+                )
         else:
             raise ValueError(
                 "Invalid tile("

--- a/python/utils/trace.py
+++ b/python/utils/trace.py
@@ -276,118 +276,6 @@ def pack4bytes(b3, b2, b1, b0):
     return w
 
 
-# This function configures the a tile's memory trace unit given a set of configurations as described below:
-#
-# function arguments:
-# * `tile` - ocre tile to configure
-# * `start` - start event. We generally use a global broadcast signal to synchronize the start event
-#             for multiple cores.
-# * `stop` - stop event. We generally use a global broadcast signal to synchronize the stop event for
-#            multiple cores.
-# * `events` - array of 8 events to trace
-# * `enable_packet` - enables putting event data into packets
-# * `packet_id` - packet id or flow id used to route the packets through the stream switch
-# * `packet_type` - packet type is an arbitrary field but we use it to describe the tile type the
-#                   packets are coming from
-def configure_coremem_tracing_aie2(
-    tile,
-    start=MemEvent.TRUE,
-    stop=MemEvent.NONE,
-    events=[
-        MemEvent.DMA_S2MM_0_START_TASK,
-        MemEvent.DMA_S2MM_0_FINISHED_BD,
-        MemEvent.CONFLICT_DM_BANK_0,
-        MemEvent.CONFLICT_DM_BANK_1,
-        MemEvent.CONFLICT_DM_BANK_2,
-        MemEvent.CONFLICT_DM_BANK_3,
-        MemEvent.EDGE_DETECTION_EVENT_0,
-        MemEvent.EDGE_DETECTION_EVENT_1,
-    ],
-    enable_packet=0,
-    packet_id=0,
-    packet_type=PacketType.MEM,
-):
-    if isinstance(start, int):
-        start = MemEvent(start)
-    if isinstance(stop, int):
-        stop = MemEvent(stop)
-    if len(events) > 8:
-        raise RuntimeError(
-            f"At most 8 events can be traced at once, have {len(events)}."
-        )
-    events = (events + [MemEvent.NONE] * 8)[:8]
-
-    # Reorder events so they match the event order for display
-    ordered_events = [events[p] for p in [3, 2, 1, 0, 7, 6, 5, 4]]
-
-    # Assure all selected events are valid
-    ordered_events = [
-        e if isinstance(e, GenericEvent) else GenericEvent(e) for e in ordered_events
-    ]
-
-    # Require ports to be specifically given for port events.
-    for event in ordered_events:
-        if event.code in PortEventCodes and not isinstance(event, PortEvent):
-            raise RuntimeError(
-                f"Tracing: {event.code.name} is a PortEvent and requires a port to be specified alongside it. \n"
-                "To select master port N, specify the event as follows: "
-                f"PortEvent(CoreEvent.{event.code.name}, N, master=True), "
-                "and analogously with master=False for slave ports. "
-                "For example: "
-                f"configure_simple_tracing_aie2( ..., events=[PortEvent(CoreEvent.{event.code.name}, 1, master=True)])"
-            )
-
-    # 140D0: Trace Control 0
-    #          0xAABB---C
-    #            AA        <- Event to stop trace capture
-    #              BB      <- Event to start trace capture
-    #                   C  <- Trace mode, 00=event=time, 01=event-PC, 10=execution
-    # Configure so that "Event 1" (always true) causes tracing to start
-    npu_write32(
-        column=int(tile.col),
-        row=int(tile.row),
-        address=0x140D0,
-        value=pack4bytes(stop.value, start.value, 0, 0),
-    )
-    # 0x140D4: Trace Control 1
-    npu_write32(
-        column=int(tile.col),
-        row=int(tile.row),
-        address=0x140D4,
-        value=((packet_type & 0x7) << 12) | (packet_id & 0x1F) if enable_packet else 0,
-    )
-    # 0x140E0: Trace Event Group 1  (Which events to trace)
-    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
-    npu_write32(
-        column=int(tile.col),
-        row=int(tile.row),
-        address=0x140E0,
-        value=pack4bytes(*(e.code.value for e in ordered_events[0:4])),
-    )
-    # 0x140E4: Trace Event Group 2  (Which events to trace)
-    #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
-    npu_write32(
-        column=int(tile.col),
-        row=int(tile.row),
-        address=0x140E4,
-        value=pack4bytes(*(e.code.value for e in ordered_events[4:8])),
-    )
-
-    # Event specific register writes
-    all_reg_writes = {}
-    for e in ordered_events:
-        reg_writes = e.get_register_writes()
-        for addr, value in reg_writes.items():
-            if addr in all_reg_writes:
-                all_reg_writes[addr] |= value
-            else:
-                all_reg_writes[addr] = value
-    for addr, value in all_reg_writes.items():
-        npu_write32(
-            column=int(tile.col), row=int(tile.row), address=addr, value=value
-        )  # For backwards compatibility, allow integers for start/stop events
-
-
 # This function configures the a tile's trace unit given a set of configurations as described below:
 #
 # function arguments:
@@ -706,18 +594,6 @@ def configure_shimtile_tracing_aie2(
         npu_write32(column=int(tile.col), row=int(tile.row), address=addr, value=value)
 
 
-# Configure timer in core tile's memory to reset based on `event`
-def configure_timer_ctrl_coremem_aie2(tile, event):
-    addr = 0x14000
-    eventValue = (event.value & 0x7F) << 8
-    npu_write32(
-        column=int(tile.col),
-        row=int(tile.row),
-        address=addr,
-        value=eventValue,
-    )
-
-
 # Configure timer in core tile to reset based on `event`
 def configure_timer_ctrl_coretile_aie2(tile, event):
     addr = 0x34000
@@ -871,65 +747,6 @@ def configure_shimtile_dma_tracing_aie2(
         row=int(shim.row),
         address=0x1D204 if channel == 0 else 0x1D20C,
         value=((enable_token & 0x1) << 31) | bd_id,
-    )
-
-
-# Wrapper to configure the core tile and shim tile for packet tracing. This does
-# the following:
-# 1. Configure core tile based on start/ stop, events, and flow id. The flow id
-#    needs to be unique per flow.
-# 2. Configure timer based on broadcast event (default is 15). This ensures all
-#    tiles keying off this event has a synchronized timer so their trace are
-#    synchronized. This event is also used as the start event for tracing.
-# 3. Configure shim tile to receive this flow and move the data to offset/ size.
-#
-def configure_coremem_packet_tracing_aie2(
-    tile,
-    shim,
-    flow_id=0,
-    bd_id=15,
-    size=8192,
-    offset=0,
-    enable_token=0,
-    # brdcst_event=0x7A,  # event 122 - broadcast 15 # TODO
-    channel=1,
-    ddr_id=4,
-    start=MemEvent.BROADCAST_15,
-    stop=MemEvent.BROADCAST_14,
-    events=[
-        MemEvent.DMA_S2MM_0_START_TASK,
-        MemEvent.DMA_S2MM_0_FINISHED_BD,
-        MemEvent.CONFLICT_DM_BANK_0,
-        MemEvent.CONFLICT_DM_BANK_1,
-        MemEvent.CONFLICT_DM_BANK_2,
-        MemEvent.CONFLICT_DM_BANK_3,
-        MemEvent.EDGE_DETECTION_EVENT_0,
-        MemEvent.EDGE_DETECTION_EVENT_1,
-    ],
-    shim_burst_length=64,
-):
-    configure_coremem_tracing_aie2(
-        tile=tile,
-        start=start,
-        stop=stop,
-        events=events,
-        enable_packet=1,
-        packet_id=flow_id,
-        packet_type=PacketType.MEM,
-    )
-    configure_timer_ctrl_coremem_aie2(tile, start)
-    configure_shimtile_dma_tracing_aie2(
-        shim=shim,
-        channel=channel,
-        bd_id=bd_id,
-        ddr_id=ddr_id,
-        size=size,
-        offset=offset,
-        enable_token=enable_token,
-        enable_packet=1,
-        packet_id=flow_id,
-        packet_type=PacketType.MEM,
-        shim_burst_length=shim_burst_length,
     )
 
 
@@ -1116,35 +933,17 @@ def configure_shimtile_packet_tracing_aie2(
 # * `tiles to trace` - array of tiles to trace
 # * `shim tile` - Single shim tile to configure for writing trace packets to DDR
 def configure_packet_tracing_flow(tiles_to_trace, shim):
-
-    exist_traces = []
     for i in range(len(tiles_to_trace)):
-
-        if tiles_to_trace[i] not in exist_traces:
-            packetflow(
-                i + 1,
-                tiles_to_trace[i],
-                WireBundle.Trace,
-                0,
-                shim,
-                WireBundle.DMA,
-                1,
-                keep_pkt_header=True,
-            )
-
-            exist_traces.append(tiles_to_trace[i])
-        else:
-            # Ct's memory trace?
-            packetflow(
-                i + 1,
-                tiles_to_trace[i],
-                WireBundle.Trace,
-                1,
-                shim,
-                WireBundle.DMA,
-                1,
-                keep_pkt_header=True,
-            )
+        packetflow(
+            i + 1,
+            tiles_to_trace[i],
+            WireBundle.Trace,
+            0,
+            shim,
+            WireBundle.DMA,
+            1,
+            keep_pkt_header=True,
+        )
 
 
 # Configure the shim tile to support packet tracing via:
@@ -1163,9 +962,7 @@ def configure_shim_trace_start_aie2(
     brdcst_num=15,
     user_event=ShimTileEvent.USER_EVENT_1,  # 0x7F, 127: user even t#1
 ):
-    configure_timer_ctrl_coretile_aie2(
-        shim, user_event
-    )  # TODO: should have call configure_timer_ctrl_shimtile_aie2() instead?
+    configure_timer_ctrl_coretile_aie2(shim, user_event)
     configure_broadcast_core_aie2(shim, brdcst_num, user_event)
     configure_event_gen_core_aie2(shim, user_event)
 
@@ -1241,18 +1038,9 @@ def configure_packet_tracing_aie2(
         ShimTileEvent.DMA_S2MM_0_STREAM_STARVATION,
         ShimTileEvent.DMA_S2MM_1_STREAM_STARVATION,
     ],
-    coremem_events=[
-        MemEvent.DMA_S2MM_0_START_TASK,
-        MemEvent.DMA_MM2S_0_START_TASK,
-        MemEvent.CONFLICT_DM_BANK_0,
-        MemEvent.CONFLICT_DM_BANK_1,
-        MemEvent.CONFLICT_DM_BANK_2,
-        MemEvent.CONFLICT_DM_BANK_3,
-        MemEvent.EDGE_DETECTION_EVENT_0,
-        MemEvent.EDGE_DETECTION_EVENT_1,
-    ],
     shim_burst_length=64,
 ):
+
 
     if coretile_events == None:
         coretile_events = [
@@ -1300,9 +1088,7 @@ def configure_packet_tracing_aie2(
             MemEvent.EDGE_DETECTION_EVENT_0,
             MemEvent.EDGE_DETECTION_EVENT_1,
         ]
-
-    start_core_mem_broadcast_event = MemEvent(107 + start_broadcast_num)
-    stop_core_mem_broadcast_event = MemEvent(107 + stop_broadcast_num)
+            
     start_core_broadcast_event = CoreEvent(107 + start_broadcast_num)
     stop_core_broadcast_event = CoreEvent(107 + stop_broadcast_num)
     start_memtile_broadcast_event = MemTileEvent(142 + start_broadcast_num)
@@ -1310,7 +1096,6 @@ def configure_packet_tracing_aie2(
     start_shimtile_broadcast_event = ShimTileEvent(110 + start_broadcast_num)
     stop_shimtile_broadcast_event = ShimTileEvent(110 + stop_broadcast_num)
 
-    exist_core_tile_traces = []
     for i in range(len(tiles_to_trace)):
         if isShimTile(tiles_to_trace[i]):
             if tiles_to_trace[i] == shim:
@@ -1359,37 +1144,20 @@ def configure_packet_tracing_aie2(
                 shim_burst_length=shim_burst_length,
             )
         elif isCoreTile(tiles_to_trace[i]):
-            if tiles_to_trace[i] not in exist_core_tile_traces:
-                configure_coretile_packet_tracing_aie2(
-                    tile=tiles_to_trace[i],
-                    shim=shim,
-                    flow_id=i + 1,
-                    bd_id=15 - i,
-                    ddr_id=ddr_id,
-                    size=trace_size,
-                    offset=trace_offset,
-                    enable_token=enable_token,
-                    start=start_core_broadcast_event,
-                    stop=stop_core_broadcast_event,
-                    events=coretile_events,
-                    shim_burst_length=shim_burst_length,
-                )
-                exist_core_tile_traces.append(tiles_to_trace[i])
-            else:
-                configure_coremem_packet_tracing_aie2(
-                    tile=tiles_to_trace[i],
-                    shim=shim,
-                    flow_id=i + 1,
-                    bd_id=15 - i,
-                    ddr_id=ddr_id,
-                    size=trace_size,
-                    offset=trace_offset,
-                    enable_token=enable_token,
-                    start=start_core_mem_broadcast_event,
-                    stop=stop_core_mem_broadcast_event,
-                    events=coremem_events,
-                    shim_burst_length=shim_burst_length,
-                )
+            configure_coretile_packet_tracing_aie2(
+                tile=tiles_to_trace[i],
+                shim=shim,
+                flow_id=i + 1,
+                bd_id=15 - i,
+                ddr_id=ddr_id,
+                size=trace_size,
+                offset=trace_offset,
+                enable_token=enable_token,
+                start=start_core_broadcast_event,
+                stop=stop_core_broadcast_event,
+                events=coretile_events,
+                shim_burst_length=shim_burst_length,
+            )
         else:
             raise ValueError(
                 "Invalid tile("

--- a/python/utils/trace.py
+++ b/python/utils/trace.py
@@ -1076,17 +1076,6 @@ def configure_packet_tracing_aie2(
             ShimTileEvent.DMA_S2MM_0_STREAM_STARVATION,
             ShimTileEvent.DMA_S2MM_1_STREAM_STARVATION,
         ]
-    if coremem_events == None:
-        coremem_events = [
-            MemEvent.DMA_S2MM_0_START_TASK,
-            MemEvent.DMA_MM2S_0_START_TASK,
-            MemEvent.CONFLICT_DM_BANK_0,
-            MemEvent.CONFLICT_DM_BANK_1,
-            MemEvent.CONFLICT_DM_BANK_2,
-            MemEvent.CONFLICT_DM_BANK_3,
-            MemEvent.EDGE_DETECTION_EVENT_0,
-            MemEvent.EDGE_DETECTION_EVENT_1,
-        ]
 
     start_core_broadcast_event = CoreEvent(107 + start_broadcast_num)
     stop_core_broadcast_event = CoreEvent(107 + stop_broadcast_num)

--- a/python/utils/trace.py
+++ b/python/utils/trace.py
@@ -276,7 +276,6 @@ def pack4bytes(b3, b2, b1, b0):
     return w
 
 
-
 # This function configures the a tile's memory trace unit given a set of configurations as described below:
 #
 # function arguments:
@@ -317,10 +316,10 @@ def configure_coremem_tracing_aie2(
             f"At most 8 events can be traced at once, have {len(events)}."
         )
     events = (events + [MemEvent.NONE] * 8)[:8]
-    
+
     # Reorder events so they match the event order for display
     ordered_events = [events[p] for p in [3, 2, 1, 0, 7, 6, 5, 4]]
-    
+
     # Assure all selected events are valid
     ordered_events = [
         e if isinstance(e, GenericEvent) else GenericEvent(e) for e in ordered_events
@@ -337,7 +336,7 @@ def configure_coremem_tracing_aie2(
                 "For example: "
                 f"configure_simple_tracing_aie2( ..., events=[PortEvent(CoreEvent.{event.code.name}, 1, master=True)])"
             )
-            
+
     # 140D0: Trace Control 0
     #          0xAABB---C
     #            AA        <- Event to stop trace capture
@@ -356,7 +355,7 @@ def configure_coremem_tracing_aie2(
         row=int(tile.row),
         address=0x140D4,
         value=((packet_type & 0x7) << 12) | (packet_id & 0x1F) if enable_packet else 0,
-    )    
+    )
     # 0x140E0: Trace Event Group 1  (Which events to trace)
     #          0xAABBCCDD    AA, BB, CC, DD <- four event slots
     npu_write32(
@@ -373,7 +372,7 @@ def configure_coremem_tracing_aie2(
         address=0x140E4,
         value=pack4bytes(*(e.code.value for e in ordered_events[4:8])),
     )
-    
+
     # Event specific register writes
     all_reg_writes = {}
     for e in ordered_events:
@@ -387,8 +386,8 @@ def configure_coremem_tracing_aie2(
         npu_write32(
             column=int(tile.col), row=int(tile.row), address=addr, value=value
         )  # For backwards compatibility, allow integers for start/stop events
-        
-    
+
+
 # This function configures the a tile's trace unit given a set of configurations as described below:
 #
 # function arguments:
@@ -934,7 +933,6 @@ def configure_coremem_packet_tracing_aie2(
     )
 
 
-
 # Wrapper to configure the core tile and shim tile for packet tracing. This does
 # the following:
 # 1. Configure core tile based on start/ stop, events, and flow id. The flow id
@@ -1118,10 +1116,10 @@ def configure_shimtile_packet_tracing_aie2(
 # * `tiles to trace` - array of tiles to trace
 # * `shim tile` - Single shim tile to configure for writing trace packets to DDR
 def configure_packet_tracing_flow(tiles_to_trace, shim):
-    
+
     exist_traces = []
     for i in range(len(tiles_to_trace)):
-        
+
         if tiles_to_trace[i] not in exist_traces:
             packetflow(
                 i + 1,
@@ -1133,7 +1131,7 @@ def configure_packet_tracing_flow(tiles_to_trace, shim):
                 1,
                 keep_pkt_header=True,
             )
-            
+
             exist_traces.append(tiles_to_trace[i])
         else:
             # Ct's memory trace?
@@ -1165,7 +1163,9 @@ def configure_shim_trace_start_aie2(
     brdcst_num=15,
     user_event=ShimTileEvent.USER_EVENT_1,  # 0x7F, 127: user even t#1
 ):
-    configure_timer_ctrl_coretile_aie2(shim, user_event) #TODO: should have call configure_timer_ctrl_shimtile_aie2() instead?
+    configure_timer_ctrl_coretile_aie2(
+        shim, user_event
+    )  # TODO: should have call configure_timer_ctrl_shimtile_aie2() instead?
     configure_broadcast_core_aie2(shim, brdcst_num, user_event)
     configure_event_gen_core_aie2(shim, user_event)
 
@@ -1255,7 +1255,7 @@ def configure_packet_tracing_aie2(
 ):
 
     if coretile_events == None:
-        coretile_events=[
+        coretile_events = [
             CoreEvent.INSTR_EVENT_0,
             CoreEvent.INSTR_EVENT_1,
             CoreEvent.INSTR_VECTOR,
@@ -1266,9 +1266,11 @@ def configure_packet_tracing_aie2(
             CoreEvent.LOCK_STALL,
         ]
     if memtile_events == None:
-        memtile_events=[
+        memtile_events = [
             MemTilePortEvent(MemTileEvent.PORT_RUNNING_0, 0, True),  # master(0)
-            MemTilePortEvent(MemTileEvent.PORT_RUNNING_1, 14, False),  # slave(14/ north1)
+            MemTilePortEvent(
+                MemTileEvent.PORT_RUNNING_1, 14, False
+            ),  # slave(14/ north1)
             MemTilePortEvent(MemTileEvent.PORT_RUNNING_2, 0, False),  # slave(0)
             MemTilePortEvent(MemTileEvent.PORT_RUNNING_3, 1, False),  # slave(1)
             MemTilePortEvent(MemTileEvent.PORT_RUNNING_4, 2, False),  # slave(2)
@@ -1277,7 +1279,7 @@ def configure_packet_tracing_aie2(
             MemTilePortEvent(MemTileEvent.PORT_RUNNING_7, 5, False),  # slave(5)
         ]
     if shimtile_events == None:
-        shimtile_events=[
+        shimtile_events = [
             ShimTileEvent.DMA_S2MM_0_START_TASK,
             ShimTileEvent.DMA_S2MM_1_START_TASK,
             ShimTileEvent.DMA_MM2S_0_START_TASK,
@@ -1288,7 +1290,7 @@ def configure_packet_tracing_aie2(
             ShimTileEvent.DMA_S2MM_1_STREAM_STARVATION,
         ]
     if coremem_events == None:
-        coremem_events=[
+        coremem_events = [
             MemEvent.DMA_S2MM_0_START_TASK,
             MemEvent.DMA_MM2S_0_START_TASK,
             MemEvent.CONFLICT_DM_BANK_0,
@@ -1299,9 +1301,8 @@ def configure_packet_tracing_aie2(
             MemEvent.EDGE_DETECTION_EVENT_1,
         ]
 
-
-    start_core_mem_broadcast_event= MemEvent(107+start_broadcast_num)
-    stop_core_mem_broadcast_event = MemEvent(107+ stop_broadcast_num)
+    start_core_mem_broadcast_event = MemEvent(107 + start_broadcast_num)
+    stop_core_mem_broadcast_event = MemEvent(107 + stop_broadcast_num)
     start_core_broadcast_event = CoreEvent(107 + start_broadcast_num)
     stop_core_broadcast_event = CoreEvent(107 + stop_broadcast_num)
     start_memtile_broadcast_event = MemTileEvent(142 + start_broadcast_num)
@@ -1387,7 +1388,7 @@ def configure_packet_tracing_aie2(
                     start=start_core_mem_broadcast_event,
                     stop=stop_core_mem_broadcast_event,
                     events=coremem_events,
-                    shim_burst_length=shim_burst_length
+                    shim_burst_length=shim_burst_length,
                 )
         else:
             raise ValueError(


### PR DESCRIPTION
We added the option to pass in coretile_events, coremem_events, memtile_events, and shimtile_events to the enable_trace function. Updates to section-4c to include changing datatype exercises.