### PR TITLE
Capturing bootgen output and print it iff verbose

### DIFF
--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -423,9 +423,18 @@ class FlowRunner:
         if self.opts.verbose:
             print(commandstr)
         if self.opts.execute or force:
-            proc = await asyncio.create_subprocess_exec(*command)
-            await proc.wait()
-            ret = proc.returncode
+            proc = await asyncio.create_subprocess_exec(
+                *command, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
+            )
+            if self.opts.verbose:
+                stdout, stderr = await proc.communicate()
+                ret = proc.returncode
+                print(f"{stdout.decode()}\n")
+                if ret != 0:
+                    print(f"{stderr.decode()}\n")
+            else:
+                await proc.wait()
+                ret = proc.returncode
         else:
             ret = 0
         end = time.time()


### PR DESCRIPTION
This removes the 
```
****** Bootgen v2024.1
  **** Build date : May 18 2025-11:52:24
    ** Copyright 1986-2022 Xilinx, Inc. All Rights Reserved.
    ** Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.


[INFO]   : Bootimage generated successfully
```
unless verbose is set to `True`.

The last three lines remaining are:
```
Generating: /tmp/tmpemsw03v4/aie_cdo_elfs.bin
Generating: /tmp/tmpemsw03v4/aie_cdo_init.bin
Generating: /tmp/tmpemsw03v4/aie_cdo_enable.bin

```
from https://github.com/Xilinx/mlir-aie/blob/aee6888a62ec3709f17dd1b7f42d80309d613c91/lib/Targets/AIETargetCDODirect.cpp#L64