### PR TITLE
Re-enable tests after driver update

### DIFF
--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
@@ -15,4 +15,4 @@
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-// UN: %run_on_npu1% ./test.exe
+// RUN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
@@ -15,4 +15,4 @@
 // RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-// UN: %run_on_npu1% ./test.exe
+// RUN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/sync_task_complete_token/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token/aie2.py
@@ -10,7 +10,7 @@
 # RUN: %python %S/aie2.py > ./aie2.mlir
 # RUN: %python aiecc.py --no-aiesim --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
 # RUN: clang %S/test.cpp -o test -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-# UN: %run_on_npu1% ./test
+# RUN: %run_on_npu1% ./test
 
 from aie.extras.context import mlir_mod_ctx
 

--- a/utils/build_drivers.sh
+++ b/utils/build_drivers.sh
@@ -31,7 +31,7 @@ fi
 
 echo "Cloning the XDNA driver repository..."
 # Clone the XDNA driver repository and initialize submodules
-XDNA_SHA=deceb066418f2d53fe172a595f59413a731ccee8
+XDNA_SHA=0e6d303b2cc2b3fe1cf10aba0acbf57a422588fb
 git clone https://github.com/amd/xdna-driver.git
 export XDNA_SRC_DIR=$(realpath xdna-driver)
 cd xdna-driver


### PR DESCRIPTION
Resolves https://github.com/Xilinx/mlir-aie/issues/2200.  Recent driver and/or firmware updates appear to solve the problem in my local testing. Runners have been updated to xdna-driver [0e6d303b2](https://github.com/amd/xdna-driver/commit/0e6d303b2cc2b3fe1cf10aba0acbf57a422588fb)