### PR TITLE
Update test.cpp

### DIFF
--- a/programming_examples/basic/row_wise_bias_add/test.cpp
+++ b/programming_examples/basic/row_wise_bias_add/test.cpp
@@ -73,7 +73,7 @@ int main(int argc, const char *argv[]) {
   xrt::device device = xrt::device(device_index);
 
   // Load the xclbin
-  xrt::xclbin xclbin = xrt::xclbin(XCLBIN);
+  xrt::xclbin xclbin = xrt::xclbin(std::string(XCLBIN));
 
   // Get the kernel from the xclbin
   std::vector<xrt::xclbin::kernel> xkernels = xclbin.get_kernels();


### PR DESCRIPTION
Fix test failing to build. Similar reason to https://github.com/Xilinx/mlir-aie/pull/2283

Otherwise [this happens](https://github.com/Xilinx/mlir-aie/actions/runs/15144050125/job/42575236791#step:4:6428):
```
/home/github/actions-runner/_work/mlir-aie/mlir-aie/programming_examples/basic/row_wise_bias_add/test.cpp: In function 'int main(int, const char**)':
/home/github/actions-runner/_work/mlir-aie/mlir-aie/programming_examples/basic/row_wise_bias_add/test.cpp:76:42: error: call of overloaded 'xclbin(const char [19])' is ambiguous
   76 |   xrt::xclbin xclbin = xrt::xclbin(XCLBIN);
```