### PR TITLE
Verbose support for compile wrappers

### DIFF
--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -428,10 +428,10 @@ class FlowRunner:
             )
             stdout, stderr = await proc.communicate()
             ret = proc.returncode
-            if self.opts.verbose:
-                print(f"{stdout.decode()}\n")
-            if ret != 0:
-                print(f"{stderr.decode()}\n")
+            if self.opts.verbose and stdout:
+                print(f"{stdout.decode()}")
+            if ret != 0 and stderr:
+                print(f"{stderr.decode()}", file=sys.stderr)
         else:
             ret = 0
         end = time.time()
@@ -1319,7 +1319,7 @@ def run(mlir_module, args=None):
         sys.exit("AIE Simulation (--aiesim) currently requires --xbridge")
 
     if opts.verbose:
-        sys.stderr.write(f"\ncompiling {opts.filename}\n")
+        print(f"Compiling {opts.filename}")
 
     if opts.tmpdir:
         tmpdirname = opts.tmpdir

--- a/python/iron/compile/compile.py
+++ b/python/iron/compile/compile.py
@@ -65,7 +65,7 @@ def compile_cxx_core_function(
 
 
 def compile_mlir_module_to_pdi(
-    mlir_module: str, insts_path: str, pdi_path: str, options=None
+    mlir_module: str, insts_path: str, pdi_path: str, options=None, verbose=False
 ):
     """
     Compile an MLIR module to instruction and PDI files using the aiecc module.
@@ -77,6 +77,7 @@ def compile_mlir_module_to_pdi(
         insts_path (str): Path to the instruction binary file.
         pdi_path (str): Path to the PDI file.
         options (list[str]): List of additional options.
+        verbose (bool): Enable verbose output.
     """
 
     args = [
@@ -89,6 +90,8 @@ def compile_mlir_module_to_pdi(
         f"--pdi-name={pdi_path}",
         f"--npu-insts-name={insts_path}",
     ]
+    if verbose:
+        args = args + ["--verbose"]
     if options:
         args = args + options
     try:

--- a/python/iron/compile/compile.py
+++ b/python/iron/compile/compile.py
@@ -7,7 +7,6 @@
 # (c) Copyright 2025 Advanced Micro Devices, Inc.
 
 import subprocess
-import sys
 import aie.compiler.aiecc.main as aiecc
 import aie.utils.config as config
 
@@ -18,6 +17,7 @@ def compile_cxx_core_function(
     output_path: str,
     compile_args=None,
     cwd=None,
+    verbose=False,
 ):
     """
     Compile a C++ core function.
@@ -30,6 +30,7 @@ def compile_cxx_core_function(
         output_path (str): Output object file path.
         compile_args (list[str]): Compile arguments to peano.
         cwd (str): Overrides the current working directory.
+        verbose (bool): Enable verbose output.
     """
     cmd = [
         config.peano_cxx_path(),
@@ -49,16 +50,18 @@ def compile_cxx_core_function(
     ]
     if compile_args:
         cmd = cmd + compile_args
-    try:
-        subprocess.run(
-            cmd,
-            cwd=cwd,
-            check=True,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-        )
-    except subprocess.CalledProcessError as e:
-        raise RuntimeError("[Peano] compilation failed") from e
+    if verbose:
+        print("Executing:", " ".join(cmd))
+    ret = subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+    )
+    if verbose:
+        print(f"{ret.stdout.decode()}")
+    if ret.returncode != 0:
+        raise RuntimeError(f"[Peano] compilation failed:\n{ret.stderr.decode()}")
 
 
 def compile_mlir_module_to_pdi(

--- a/python/iron/compile/compile.py
+++ b/python/iron/compile/compile.py
@@ -58,10 +58,13 @@ def compile_cxx_core_function(
         check=False,
         capture_output=True,
     )
-    if verbose:
+    if verbose and ret.stdout:
         print(f"{ret.stdout.decode()}")
     if ret.returncode != 0:
-        raise RuntimeError(f"[Peano] compilation failed:\n{ret.stderr.decode()}")
+        if ret.stderr:
+            raise RuntimeError(f"[Peano] compilation failed:\n{ret.stderr.decode()}")
+        else:
+            raise RuntimeError("[Peano] compilation failed")
 
 
 def compile_mlir_module_to_pdi(


### PR DESCRIPTION
This PR adds support for verbose compilation.

It also avoids printing in aiecc if there is no captured output and redirects to the appropriate stream.