### PR TITLE
Two small programming guide updates

### DIFF
--- a/programming_guide/section-0/README.md
+++ b/programming_guide/section-0/README.md
@@ -26,7 +26,7 @@ This programming guide focuses on application programming for the NPU found in R
 
 #### **Please be sure to follow the quick setup path.**
 
-### [Getting Started on AMD Ryzen™ AI with Linux](../README.md) **\*Recommended**
+### [Getting Started on AMD Ryzen™ AI with Linux](../../README.md) **(Recommended)**
 
 ### [Building IRON and MLIR-AIE from source on Linux](../../docs/Building.md)
 


### PR DESCRIPTION
I'm going through the programming guide to get up to speed on what's new in the repository and familiarize myself with the new higher-level abstractions that @hunhoffe started (which look really cool). 

As I'm going through it, I thought to an outsider it might not be immediately clear that the code they write doesn't directly run on the NPU. Obviously there's no such thing as a Python interpreter on the NPU, but I still think it doesn't hurt to make it abundantly clear from the start that we are really metaprogramming here.

If you think this is too verbose or an unnecessary/confusing clarification at the start of the tutorial, I'm open to discussion.

I also noticed that the link to the Linux setup should probably point to the main repo's README.md, as the programming_guide/README.md does not contain any installation instructions, so I fixed that link.