### PR TITLE
draft: Single CT read control_packet

### DIFF
--- a/programming_examples/basic/passthrough_control_packet/CT_0_2.py
+++ b/programming_examples/basic/passthrough_control_packet/CT_0_2.py
@@ -1,0 +1,155 @@
+from re import L
+from struct import pack
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+import math
+
+import numpy as np
+import sys
+
+from ml_dtypes import bfloat16
+from aie.extras.context import mlir_mod_ctx
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.helpers.dialects.ext.scf import _for as range_
+
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+from aie.dialects import memref
+
+from aie.dialects._aie_ops_gen import buffer as buffer_raw
+from aie.helpers.util import try_convert_np_type_to_mlir_type
+import numpy as np
+import sys
+import aie.utils.trace as trace_utils
+from aie.utils.trace import PortEvent
+from aie.utils.trace_events_enum import CoreEvent, MemEvent, ShimTileEvent, MemTileEvent
+from enum import IntEnum
+from aie.extras.dialects.ext.arith import constant, index_cast
+
+from aie.ir import *
+from aie.ir import MemRefType, IndexType
+from aie.dialects import arith, memref
+from aie.dialects.memref import AllocaScopeOp
+
+from aie.helpers.util import np_ndarray_type_to_memref_type
+from aie.dialects.memref import alloc, store, alloca
+from aie.extras import types as T
+
+from aie.dialects.aiex import control_packet
+
+import os
+import json
+import json
+
+from aie._mlir_libs._mlir.ir import Attribute
+from aie.dialects._aiex_ops_gen import _Dialect
+
+from helper_func import generate_packet_attribute, custom_ceil
+
+def setup_CT_0_2(in_data_ty, out_data_ty, control_package_ty,
+                 buffer_size:int, total_size:int):
+
+    ComputeTile_0_2 = tile(0,2, allocation_scheme="basic-sequential")
+    ComputeTile_0_2.attributes["controlled_id"] = generate_packet_attribute(0, 26)    
+    #NOTE: mem_bank flag seem not working anymore after Tile() is configure to basic-sequential address mode
+    offset = 1024 # reserve for stack
+    assert offset %64 == 0
+    in_buffer = [
+        buffer_raw(tile=ComputeTile_0_2, buffer=try_convert_np_type_to_mlir_type(in_data_ty), sym_name=f"in_buffer_{0}", address=offset),
+
+    ]
+    in_buffer_prod_lock = lock(ComputeTile_0_2, lock_id=8, init=2, sym_name="in_buffer_p_lock")
+    in_buffer_con_lock = lock(ComputeTile_0_2, lock_id=9, init=0, sym_name="in_buffer_c_lock")
+    offset+= buffer_size*2*4
+    
+    offset = custom_ceil(offset, 64)
+    assert offset %64 == 0
+
+
+    # out_buffer_address = (64*1024) - (buffer_size_of_out_ping_pong*2*4) # 4 byte per float
+    out_buffer = [
+        buffer_raw(tile=ComputeTile_0_2, buffer=try_convert_np_type_to_mlir_type(out_data_ty), sym_name=f"out_buffer_{0}", address=offset ), # 
+    ]        
+    out_buffer_prod_lock = lock(ComputeTile_0_2, lock_id=10, init=2)
+    out_buffer_con_lock = lock(ComputeTile_0_2, lock_id=11, init=0)
+
+    assert offset+buffer_size*2*4 <= (64*1024)  # total of less than 64kB
+    offset += buffer_size*2*4
+    
+    CT2_control_out_prod_lock = lock(ComputeTile_0_2, lock_id=0, init=1, sym_name="CT2_control_out_prod_lock")
+    CT2_control_out_con_lock = lock(ComputeTile_0_2, lock_id=1, init=0, sym_name="CT2_control_out_con_lock")
+    CT2_control_out_buffer = [
+        buffer_raw(tile=ComputeTile_0_2, buffer=try_convert_np_type_to_mlir_type(control_package_ty), sym_name="CT2_control_out_buffer", address=offset)
+    ]
+    
+    offset += 16*4
+    CT2_control_in_buffer = [
+        buffer_raw(tile=ComputeTile_0_2, buffer=try_convert_np_type_to_mlir_type(control_package_ty), sym_name="CT2_control_in_buffer", address=offset)
+    ]
+    CT2_control_in_prod_lock = lock(ComputeTile_0_2, lock_id=2, init=1, sym_name="CT2_control_in_prod_lock")
+    CT2_control_in_con_lock = lock(ComputeTile_0_2, lock_id=3, init=0, sym_name="CT2_control_in_con_lock")
+    
+
+    
+    @mem(ComputeTile_0_2)
+    def m(block):
+    
+        s0 = dma_start( DMAChannelDir.S2MM, 0, dest=block[1], chain=block[3]) # input DMA0
+        
+        with block[1]:
+            use_lock(in_buffer_prod_lock, LockAction.AcquireGreaterEqual, value=1)
+            dma_bd(in_buffer[0], offset=0, len=buffer_size)
+            use_lock(in_buffer_con_lock, LockAction.Release, value=1)
+            next_bd(block[2])
+        with block[2]:
+            use_lock(in_buffer_prod_lock, LockAction.AcquireGreaterEqual, value=1)
+            dma_bd(in_buffer[0], offset=buffer_size, len=buffer_size)
+            use_lock(in_buffer_con_lock, LockAction.Release, value=1)
+            next_bd(block[1])
+            
+        with block[3]:
+            s1 = dma_start(DMAChannelDir.MM2S, 0, dest=block[4], chain=block[6])
+        with block[4]:
+            use_lock(out_buffer_con_lock, LockAction.AcquireGreaterEqual, value=1)
+            dma_bd(out_buffer[0], offset=0, len=buffer_size, packet=(0,9)) # error to be fixed through control_packet
+            # purposefully leave the error, fix by control packet in kernel
+            use_lock(out_buffer_prod_lock, LockAction.Release, value=1)
+            next_bd(block[5])
+        with block[5]:
+            use_lock(out_buffer_con_lock, LockAction.AcquireGreaterEqual, value=1)
+            dma_bd(out_buffer[0], offset=buffer_size, len=buffer_size, packet=(0,9))
+            use_lock(out_buffer_prod_lock, LockAction.Release, value=1)
+            next_bd(block[4])
+        with block[6]:
+            s2 = dma_start(DMAChannelDir.MM2S, 1, dest=block[7], chain=block[8])
+        with block[7]:
+            use_lock(CT2_control_out_con_lock, LockAction.AcquireGreaterEqual, value=1)
+            dma_bd(CT2_control_out_buffer[0], offset=0, len=1, packet=(0,13)) # for now as read packet?
+            use_lock(CT2_control_out_prod_lock, LockAction.Release, value=1)
+            next_bd(block[7])
+        with block[8]:
+            s3 = dma_start(DMAChannelDir.S2MM, 1, dest=block[9], chain=block[10] )
+        with block[9]:
+            use_lock(CT2_control_in_prod_lock, LockAction.AcquireGreaterEqual, value=1)
+            dma_bd(CT2_control_in_buffer[0], offset=0, len=1)
+            use_lock(CT2_control_in_con_lock, LockAction.Release, value=1)
+            next_bd(block[9])
+        with block[10]:
+            EndOp()
+                            
+
+        
+    return ComputeTile_0_2, in_buffer, out_buffer, CT2_control_out_buffer, CT2_control_in_buffer
+    

--- a/programming_examples/basic/passthrough_control_packet/Makefile
+++ b/programming_examples/basic/passthrough_control_packet/Makefile
@@ -1,0 +1,70 @@
+##===- Makefile -----------------------------------------------------------===##
+# 
+# This file licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (C) 2025, Advanced Micro Devices, Inc.
+# 
+##===----------------------------------------------------------------------===##
+
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+include ${srcdir}/../../makefile-common
+
+XILINX_XRT=/opt/xilinx/xrt/
+XILINX_XRT_INCLUDE?=${XILINX_XRT}/include
+XILINX_XRT_LIB?=${XILINX_XRT}/lib
+
+XRT_FLAGS=-I${XILINX_XRT_INCLUDE} -L${XILINX_XRT_LIB}
+XRT_LIBS=-lxrt_coreutil
+CXX=g++-13 -ggdb
+
+UTILS_INCLUDE := -I$(srcdir)/../../../runtime_lib/test_lib/
+UTILS_LIB=$(srcdir)/../../../runtime_lib/test_lib/test_utils.cpp
+
+mlir_target?=build/aie.mlir
+xclbin_target?=build/final.xclbin
+insts_target?=build/insts.bin
+host_target?=build/test
+
+devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
+
+
+aie_py_src=passthrough_aie.py
+
+
+.PHONY: all
+all: ${xclbin_target} ${host_target}
+
+build/kernel.o: ${srcdir}/kernel/kernel.cc
+	mkdir -p ${@D}
+ifeq (${devicename}, npu2)
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -DDIM_m=$m -DDIM_n=$n -c $< -o ${@F}
+else
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -DDIM_m=$m -DDIM_n=$n -c $< -o ${@F}
+endif
+
+${mlir_target}: ${srcdir}/${aie_py_src}
+	mkdir -p ${@D}
+	python3 $< ${devicename} $M $N $m $n > $@
+
+${xclbin_target}: ${mlir_target} build/kernel.o
+	mkdir -p ${@D}
+	cd ${@D} && aiecc.py -v --aie-generate-xclbin --no-compile-host --xclbin-name=${@F} \
+				--no-xchesscc --no-xbridge \
+				--aie-generate-npu-insts --npu-insts-name=${insts_target:build/%=%} ${<:%=../%}
+
+${host_target}: ${srcdir}/test.cpp ${xclbin_target}
+	mkdir -p ${@D}
+	${CXX} ${XRT_FLAGS} ${UTILS_INCLUDE} ${UTILS_LIB} -o $@ $< ${XRT_LIBS}
+
+.PHONY: run
+run: ${host_target}
+	./${host_target} -x build/final.xclbin -i build/insts.bin -k MLIR_AIE 
+
+
+.PHONY: clean
+clean:
+	rm -rf trace.txt
+	rm -rf build

--- a/programming_examples/basic/passthrough_control_packet/helper_func.py
+++ b/programming_examples/basic/passthrough_control_packet/helper_func.py
@@ -1,0 +1,62 @@
+from struct import pack
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+import math
+
+import numpy as np
+import sys
+
+from ml_dtypes import bfloat16
+from aie.extras.context import mlir_mod_ctx
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.helpers.dialects.ext.scf import _for as range_
+
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+from aie.dialects import memref
+
+from aie.dialects._aie_ops_gen import buffer as buffer_raw
+from aie.helpers.util import try_convert_np_type_to_mlir_type
+import numpy as np
+import sys
+import aie.utils.trace as trace_utils
+from aie.utils.trace import PortEvent
+from aie.utils.trace_events_enum import CoreEvent, MemEvent, ShimTileEvent, MemTileEvent
+from enum import IntEnum
+from aie.extras.dialects.ext.arith import constant, index_cast
+
+from aie.ir import *
+from aie.ir import MemRefType, IndexType
+from aie.dialects import arith, memref
+from aie.dialects.memref import AllocaScopeOp
+
+from aie.helpers.util import np_ndarray_type_to_memref_type
+from aie.dialects.memref import alloc, store, alloca
+from aie.extras import types as T
+
+from aie.dialects.aiex import control_packet
+
+import os
+import json
+import json
+
+from aie._mlir_libs._mlir.ir import Attribute
+from aie.dialects._aiex_ops_gen import _Dialect
+def custom_ceil(x, multiplier):
+  return math.ceil(x / multiplier) * multiplier
+
+def generate_packet_attribute(packet_type:int, packet_id:int):
+    return Attribute.parse(f"#aie.packet_info<pkt_type = {packet_type}, pkt_id = {packet_id}>")
+

--- a/programming_examples/basic/passthrough_control_packet/kernel/kernel.cc
+++ b/programming_examples/basic/passthrough_control_packet/kernel/kernel.cc
@@ -1,0 +1,132 @@
+//===- passThrough.cc -------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2022, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// #define __AIENGINE__ 1
+#define NOCPP
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <aie_api/aie.hpp>
+
+// template <typename T, int N>
+// __attribute__((noinline)) void passThrough_aie(T *restrict in, T *restrict out,
+//                                                const int32_t height,
+//                                                const int32_t width) {
+//   event0();
+
+//   v64uint8 *restrict outPtr = (v64uint8 *)out;
+//   v64uint8 *restrict inPtr = (v64uint8 *)in;
+
+//   for (int j = 0; j < (height * width); j += N) // Nx samples per loop
+//     chess_prepare_for_pipelining chess_loop_range(6, ) { *                                                                                                                                          outPtr++ = *inPtr++; }
+
+//   event1();
+// }
+
+template<typename T>
+__attribute__((noinline)) void passThrough_simple(uint32_t *restrict in, uint32_t*restrict out, const int32_t size){
+  
+  // event0()  ;
+
+  for( int32_t j = 0; j < size; j++){
+    *out = *in;
+    out++;
+    in++;
+  }
+  // event1();
+}
+bool parity(uint32_t n) {
+    uint32_t p = 0;
+    while (n) {
+        p += n & 1;
+        n >>= 1;
+    }
+    return (p % 2) == 0;
+}
+uint32_t control_packet_gen(int32_t stream_id, int32_t operation, int32_t beats, int32_t address){
+  //operation: 0 read, 1 write
+  uint32_t control_packet =
+        stream_id << 24 | operation << 22 | beats << 20 | address;
+  control_packet |= (0x1 & parity(control_packet)) << 31;
+
+  return control_packet;
+}
+
+extern "C" {
+
+void passThroughTest(uint32_t *in, uint32_t *out, 
+                  int32_t buffer_size, int32_t total_passThrough_size,
+                  int32_t in_buffer_prod_lock, int32_t in_buffer_con_lock,
+                  int32_t out_buffer_prod_lock, int32_t out_buffer_con_lock,
+
+
+                  int32_t* CT2_control_out_buffer, int32_t* CT2_control_res_buffer,
+                  int32_t CT2_control_out_prod_lock, int32_t CT2_control_out_con_lock,
+                  int32_t CT2_control_in_prod_lock, int32_t CT2_control_in_con_lock
+                  
+){
+  // assume divisible and multiple of two
+  for(uint32_t i = 0; i < (total_passThrough_size /buffer_size ); i += 2){
+
+    acquire_greater_equal(in_buffer_con_lock, 1);
+    if(i == 0){
+
+        acquire_greater_equal(CT2_control_out_prod_lock, 1);
+        *CT2_control_out_buffer = control_packet_gen(14, 1,0,0x001D044);
+        release(CT2_control_out_con_lock, 1);
+
+        acquire_greater_equal(CT2_control_in_con_lock, 1); // stuck here, result never return back from packet_id 14, bug in packet_flow?
+        *(in) = *CT2_control_res_buffer;
+        release(CT2_control_in_prod_lock, 1);
+    }else{
+       
+    }
+
+    // *in = 0x10001;
+    acquire_greater_equal(out_buffer_prod_lock, 1);
+    passThrough_simple<uint32_t>(in, out, buffer_size);
+    release(in_buffer_prod_lock, 1);
+    release(out_buffer_con_lock, 1);
+
+  
+
+
+    acquire_greater_equal(in_buffer_con_lock, 1);
+    acquire_greater_equal(out_buffer_prod_lock, 1);
+    passThrough_simple<uint32_t>(in+buffer_size, out+buffer_size, buffer_size);
+    release(in_buffer_prod_lock, 1);
+    release(out_buffer_con_lock, 1);
+
+  }
+
+
+}
+
+
+// // #endif
+// void passThroughLine_float_0(float *in, float *out, int32_t lineWidth) {
+//   passThrough_simple<float>( in, out, lineWidth);
+// }
+// void passThroughLine_float_1(float *in, float *out, int32_t lineWidth) {
+//   passThrough_simple<float>( in, out, lineWidth);
+// }
+
+// void passThroughLine_float_2(float *in, float *out, int32_t lineWidth) {
+//   passThrough_simple<float>( in, out, lineWidth);
+// }
+
+// void passThroughLine_float_3(float *in, float *out, int32_t lineWidth) {
+//   passThrough_simple<float>( in, out, lineWidth);
+// }
+
+
+
+} // extern "C"

--- a/programming_examples/basic/passthrough_control_packet/passthrough_aie.py
+++ b/programming_examples/basic/passthrough_control_packet/passthrough_aie.py
@@ -1,0 +1,196 @@
+from struct import pack
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+import math
+
+import numpy as np
+import sys
+
+from ml_dtypes import bfloat16
+from aie.extras.context import mlir_mod_ctx
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.helpers.dialects.ext.scf import _for as range_
+
+import numpy as np
+import sys
+
+from aie.dialects.aie import *
+from aie.dialects.aiex import *
+from aie.extras.context import mlir_mod_ctx
+from aie.helpers.dialects.ext.scf import _for as range_
+
+from aie.dialects import memref
+
+from aie.dialects._aie_ops_gen import buffer as buffer_raw
+from aie.helpers.util import try_convert_np_type_to_mlir_type
+import numpy as np
+import sys
+import aie.utils.trace as trace_utils
+from aie.utils.trace import PortEvent
+from aie.utils.trace_events_enum import CoreEvent, MemEvent, ShimTileEvent, MemTileEvent
+from enum import IntEnum
+from aie.extras.dialects.ext.arith import constant, index_cast
+
+from aie.ir import *
+from aie.ir import MemRefType, IndexType
+from aie.dialects import arith, memref
+from aie.dialects.memref import AllocaScopeOp
+
+from aie.helpers.util import np_ndarray_type_to_memref_type
+from aie.dialects.memref import alloc, store, alloca
+from aie.extras import types as T
+
+from aie.dialects.aiex import control_packet
+
+import os
+import json
+import json
+
+from aie._mlir_libs._mlir.ir import Attribute
+from aie.dialects._aiex_ops_gen import _Dialect
+from CT_0_2 import setup_CT_0_2
+from helper_func import generate_packet_attribute, custom_ceil
+def single_mat_vect_mult():
+    dev = AIEDevice.npu2
+    
+    trace_size = 8192
+    buffer_size = 1024
+    
+    total_size = 4096
+
+    dtype_in = np.dtype[np.uint32]
+    dtype_out = np.dtype[np.uint32]
+    
+    
+    @device(AIEDevice.npu2)
+    def device_body():
+
+
+   
+        # Tile declarations
+        ShimTile_0 = tile(0,0)
+        ShimTile_0.attributes["controlled_id"] = generate_packet_attribute(0,27)
+        ShimTile_1 = tile(1, 0)
+
+
+        in_data_ty = np.ndarray[ (buffer_size*2, ), dtype_in]
+        out_data_ty = np.ndarray[ (buffer_size*2, ), dtype_out]
+        control_packet_ty = np.ndarray[ (2,), np.dtype[np.int32]]
+
+       
+        ComputeTile_0_2, in_buffer, out_buffer, CT2_control_out_buffer, CT2_control_in_buffer = setup_CT_0_2(
+            in_data_ty, out_data_ty, control_packet_ty,
+            buffer_size, total_size
+        )
+        
+        passThroughTest_func = external_func("passThroughTest", inputs=[
+            in_data_ty, out_data_ty, 
+            np.int32, np.int32,
+            np.int32, np.int32,
+            np.int32, np.int32,
+
+            control_packet_ty,      
+            control_packet_ty,
+            np.int32, np.int32,        
+            np.int32, np.int32               
+        ])
+
+        @core(ComputeTile_0_2, "kernel.o", stack_size=1024)
+        def core_body():
+            passThroughTest_func(
+                in_buffer[0], out_buffer[0],
+                constant(buffer_size), constant(total_size),
+                constant(8+48), constant(9+48),
+                constant(10+48), constant(11+48),
+
+                CT2_control_out_buffer[0], CT2_control_in_buffer[0],
+                constant(0+48), constant(1+48),
+                constant(2+48), constant(3+48)
+                
+            )
+            
+            
+        if(trace_size > 0):
+            tiles_to_trace = [ComputeTile_0_2] #TODO: also shimtile?
+            trace_utils.configure_packet_tracing_flow(tiles_to_trace, ShimTile_1)
+
+        # leave first 6(0-5) packet id for tracing
+        packetflow( 6, source=ShimTile_0, source_port=WireBundle.DMA, source_channel=0, 
+                   dest = ComputeTile_0_2, dest_port=WireBundle.DMA, dest_channel=0
+                   )
+
+        packetflow(9, source=ComputeTile_0_2, source_port=WireBundle.DMA, source_channel=0,
+                    dest = ShimTile_0, dest_port= WireBundle.DMA, dest_channel=1
+                   ) 
+        # path for control packet 
+        packetflow(13, ComputeTile_0_2, source_port=WireBundle.DMA , source_channel=1,
+                   dest=ComputeTile_0_2, dest_port=WireBundle.TileControl, dest_channel=0
+                   )
+        packetflow(14, ComputeTile_0_2, source_port=WireBundle.TileControl, source_channel=0,
+                   dest=ComputeTile_0_2, dest_port=WireBundle.DMA, dest_channel=1
+                   )
+        
+        memref.global_("in_SHM_CT_0_2_0", T.memref( total_size, T.f32() ), sym_visibility="public")            
+        memref.global_("out_CT_0_2_SHM", T.memref( total_size, T.f32()), sym_visibility="public" ) # result out
+
+     
+        shim_dma_allocation("in_SHM_CT_0_2_0", DMAChannelDir.MM2S, 0, 0)        
+        shim_dma_allocation("out_CT_0_2_SHM", DMAChannelDir.S2MM, 1,0)
+
+
+        @runtime_sequence(np.ndarray[(total_size, ), dtype_in], np.ndarray[(total_size, ), dtype_out], np.ndarray[(1, ), dtype_in], np.ndarray[(1, ), dtype_in]  )
+        def sequence(A,B, zero0, zero1):
+            # work balance module
+            if(trace_size > 0):
+                trace_utils.configure_packet_tracing_aie2(
+                    tiles_to_trace=tiles_to_trace,
+                    ddr_id=4,   # last in/out parameter(not just need to pass in host, did not define in sequence)
+                    shim =ShimTile_1,
+                    trace_size=trace_size, # beacuse have 2 tile to,
+                        coretile_events=[
+                        CoreEvent.INSTR_EVENT_0,
+                        CoreEvent.DM_ADDRESS_OUT_OF_RANGE,
+                        PortEvent(CoreEvent.PORT_RUNNING_0, 1, True),  # master(1)
+                        PortEvent(CoreEvent.PORT_RUNNING_1, 1, False),  # slave(1)
+                        PortEvent(CoreEvent.PORT_RUNNING_2, 7, False),  # slave(1)                        
+                        CoreEvent.CONTROL_PKT_ERROR,
+                        CoreEvent.DM_ACCESS_TO_UNAVAILABLE
+                        # CoreEvent.LOCK_STALL,
+                    ],
+                )
+
+            npu_dma_memcpy_nd(
+                metadata="in_SHM_CT_0_2_0",
+                bd_id=0,
+                mem=A,
+                offsets=[0,0,0,0],
+                sizes=[1,1,1, total_size],
+                strides=[0,0,0,1],
+                packet=(0,6)
+            )
+            npu_dma_memcpy_nd(
+                metadata="out_CT_0_2_SHM",
+                bd_id=1,
+                mem=B,
+                offsets=[0,0,0,0],
+                sizes=[1,1,1, total_size],
+                strides=[0,0,0,1],
+                issue_token=True
+            )
+            
+            
+            npu_dma_wait("out_CT_0_2_SHM")
+
+with mlir_mod_ctx() as ctx:
+    single_mat_vect_mult()
+    res = ctx.module.operation.verify()
+    if res == True:
+        print(ctx.module)
+    else:
+        print(res)

--- a/programming_examples/basic/passthrough_control_packet/test.cpp
+++ b/programming_examples/basic/passthrough_control_packet/test.cpp
@@ -1,0 +1,156 @@
+
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include "cxxopts.hpp"
+#include "test_utils.h"
+
+using int32 = std::int32_t;
+typedef uint32_t TYPE_IN;
+typedef uint32_t TYPE_OUT;
+
+int main(int argc, const char *argv[]) {
+
+  cxxopts::Options options("Passthrough control packet",
+                           "Demonstrate control packet feature");
+  options.add_options()("help,h", "produce help message")(
+      "xclbin,x", "the input xclbin path", cxxopts::value<std::string>())(
+      "kernel,k", "the kernel name in the XCLBIN (for instance PP_PRE_FD)",
+      cxxopts::value<std::string>())("verbosity,v",
+                                     "the verbosity of the output",
+                                     cxxopts::value<int>()->default_value("0"))(
+      "instr,i",
+      "path of file containing userspace instructions to be sent to the LX6",
+      cxxopts::value<std::string>());
+
+  auto vm = options.parse(argc, argv);
+
+  // Check required options
+  if (!vm.count("xclbin") || !vm.count("kernel") || !vm.count("instr")) {
+    std::cerr << "Error: Required options missing\n\n";
+    std::cerr << "Usage:\n" << options.help() << std::endl;
+    return 1;
+  }
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+  assert(instr_v.size() > 0);
+
+  // Get a device handle
+  unsigned int device_index = 0;
+  xrt::device device = xrt::device(device_index);
+
+  // Load the xclbin
+  xrt::xclbin xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  std::string Node = vm["kernel"].as<std::string>();
+  // Get the kernel from the xclbin
+  std::vector<xrt::xclbin::kernel> xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+
+  std::string kernel_name = xkernel.get_name();
+  assert(strcmp(kernel_name.c_str(), Node.c_str()) == 0);
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  auto kernel = xrt::kernel(context, kernel_name);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+
+  int total_size = 4096;
+  int TRACE_SIZE = 8192;
+
+  auto in_0 = xrt::bo(device, total_size * sizeof(TYPE_IN),
+                      XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+
+  auto out_0 = xrt::bo(device, total_size * sizeof(TYPE_OUT),
+                       XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+
+  auto zero_0 = xrt::bo(device, 1 * sizeof(TYPE_IN), XRT_BO_FLAGS_HOST_ONLY,
+                        kernel.group_id(5));
+  auto zero_1 = xrt::bo(device, 1 * sizeof(TYPE_IN), XRT_BO_FLAGS_HOST_ONLY,
+                        kernel.group_id(6));
+
+  int tmp_trace_size = (TRACE_SIZE * 4 > 0) ? TRACE_SIZE : 1;
+  auto trace_res = xrt::bo(device, tmp_trace_size, XRT_BO_FLAGS_HOST_ONLY,
+                           kernel.group_id(7));
+
+  TYPE_IN *in_0_buf = in_0.map<TYPE_IN *>();
+
+ TYPE_OUT *out_0_buf = out_0.map<TYPE_OUT *>();
+  memset(out_0_buf, 0, total_size* sizeof(TYPE_OUT) );
+
+
+  for (uint32_t i = 0; i < total_size; i++) {
+    *(in_0_buf + i) = i + 1;
+  }
+
+
+
+  // Instruction buffer for DMA configuration
+  void *buf_instr = bo_instr.map<void *>();
+  memcpy(buf_instr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  in_0.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  out_0.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  char *bufTrace = trace_res.map<char *>();
+  if (TRACE_SIZE > 0) {
+    memset(bufTrace, 0, TRACE_SIZE);
+    trace_res.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  }
+
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), in_0, out_0, zero_0,
+                    zero_1, trace_res);
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
+    return 1;
+  }
+  out_0.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+  if (TRACE_SIZE > 0) {
+    trace_res.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    test_utils::write_out_trace(((char *)bufTrace), TRACE_SIZE, "trace.txt");
+  }
+
+  bool pass = true;
+ 
+  for (auto k = 0; k < 10; k++) {
+
+    if (*(out_0_buf + k) != *(in_0_buf + k)) {
+      pass = false;
+      std::cout << "&&&&&&&&&&&&&&" << std::endl;
+      std::cout << " " << std::hex << k << "  index for  " << std::hex
+                << *(out_0_buf + k) << " with expect" <<  *(in_0_buf + k) << std::endl;
+
+    } else {
+    }
+  }
+
+  if (pass == false) {
+    std::cout << "Fail stage 1" << std::endl;
+  } else {
+    printf("passed first stage input\n");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
@erwei-xilinx 

This is the PR that I was hoping to use as an example for the control-packet feature.

## Background:
In this passthrough program, I am trying to send a control packet to read a certain register and send the result of that register value back to host.

Currently, the program does not work correctly due to the potential issue I discussed earlier.

I defined [packet_flow](https://github.com/joeldushouyu/mlir-aie/blob/c9660a52ec705a13f876a475afca6b33d3decbec/programming_examples/basic/passthrough_control_packet/passthrough_aie.py#L133) path for  
1. Control packet from CT(Compute Tile) -> TileControl(packet_id = 13)
2. TileControl -> send result back to CT (packet_id = 14).

## ISSUE 
As of right now, the kernel stuck at this [line](https://github.com/joeldushouyu/mlir-aie/blob/c9660a52ec705a13f876a475afca6b33d3decbec/programming_examples/basic/passthrough_control_packet/kernel/kernel.cc#L86).
After doing some analysis, I found something strange with how the packet_flow is being translated, and I suspect that could be the reason for why the read result of control packet not being send back.

Looking at the switchbox dialect in "build/input_physical.mlir", I found the section below to be strange.

```mlir
    %tile_0_2 = aie.tile(0, 2) {allocation_scheme = "basic-sequential", controlled_id = #aie.packet_info<pkt_type = 0, pkt_id = 26>, controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 27>}
    %switchbox_0_2 = aie.switchbox(%tile_0_2) {
      %0 = aie.amsel<0> (0)
      %1 = aie.amsel<1> (0)
      %2 = aie.amsel<2> (0)
      %3 = aie.amsel<3> (0)
      %4 = aie.amsel<4> (0)
      %5 = aie.masterset(DMA : 0, %0)
      %6 = aie.masterset(DMA : 1, %3)
      %7 = aie.masterset(South : 1, %2)
      %8 = aie.masterset(South : 3, %1)
      %9 = aie.masterset(TileControl : 0, %4)
      aie.packet_rules(Core : 0) {
        aie.rule(31, 14, %3)
      }
      aie.packet_rules(DMA : 1) {
        aie.rule(31, 13, %4)
      }
      aie.packet_rules(DMA : 0) {
        aie.rule(31, 9, %2)
      }
      aie.packet_rules(South : 2) {
        aie.rule(31, 6, %0)
      }
      aie.packet_rules(Trace : 0) {
        aie.rule(31, 1, %1)
      }
    }

```
While it make sense for packet_flow 13 being send from DMA-1 - > %2 -> %9(TileControl 0)
But I expected to see packet_id 14 under TileControl(as shown below) instead of Core. If this were indeed an bug, 
then this explains why the kernel is stuck at this case. 
```mlir
aie.packet_rules(TileControl:0){
  aie.rule(31, 14, %3)
}
```
