### PR TITLE
Increase stack size for conv skip to enable resnet and bottleneck designs on Strix

### DIFF
--- a/programming_examples/ml/bottleneck/bottleneck.py
+++ b/programming_examples/ml/bottleneck/bottleneck.py
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
 import numpy as np
 import sys
 
@@ -347,6 +347,7 @@ def bottleneck4AIEs():
             rtp_barrier,
         ],
         placement=Tile(0, 4),
+        stack_size=0xA00,
     )
     workers.append(worker)
 

--- a/programming_examples/ml/bottleneck/bottleneck_placed.py
+++ b/programming_examples/ml/bottleneck/bottleneck_placed.py
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
 import numpy as np
 import sys
 
@@ -435,7 +435,7 @@ def bottleneck4AIEs():
                     wts_buf_01.release(ObjectFifoPort.Consume, 1)
 
             # # 1x1 conv2d and add skip
-            @core(ComputeTile4, "conv2dk1_skip.o")
+            @core(ComputeTile4, "conv2dk1_skip.o", stack_size=0xA00)
             def core_body():
                 for _ in range_(sys.maxsize):
 

--- a/programming_examples/ml/bottleneck/run_strix_makefile.lit
+++ b/programming_examples/ml/bottleneck/run_strix_makefile.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env device=npu2 make -f %S/Makefile
-// %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run

--- a/programming_examples/ml/bottleneck/run_strix_makefile.lit
+++ b/programming_examples/ml/bottleneck/run_strix_makefile.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env device=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run_py

--- a/programming_examples/ml/bottleneck/run_strix_makefile.lit
+++ b/programming_examples/ml/bottleneck/run_strix_makefile.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
-// RUN: env device=npu2 make -f %S/Makefile
+// RUN: env devicename=npu2 make -f %S/Makefile
 // RUN: %run_on_2npu make -f %S/Makefile run_py

--- a/programming_examples/ml/bottleneck/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/bottleneck/run_strix_makefile_placed.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run_py

--- a/programming_examples/ml/bottleneck/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/bottleneck/run_strix_makefile_placed.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run

--- a/programming_examples/ml/resnet/layers_conv2_x/resnet.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/resnet.py
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
 import numpy as np
 import sys
 
@@ -513,6 +513,7 @@ for i in range(n_cols):
             i,
         ],
         placement=placement,
+        stack_size=0xA00,
     )
     workers.append(w)
     w = Worker(

--- a/programming_examples/ml/resnet/layers_conv2_x/resnet_placed.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/resnet_placed.py
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc.
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
 import numpy as np
 import sys
 
@@ -807,7 +807,7 @@ def resnet_conv_x():
             # # 1x1 conv2d and add skip
             for i in range(n_cols):
 
-                @core(cores[i][2], conv3_kernels[i])
+                @core(cores[i][2], conv3_kernels[i], stack_size=0xA00)
                 def core_body():
                     for _ in range_(sys.maxsize):
 

--- a/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env devicename=npu2 make -f %S/Makefile
-// %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run

--- a/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run_py

--- a/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile_placed.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run_py

--- a/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile_placed.lit
@@ -7,4 +7,4 @@
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_2npu make -f %S/Makefile run


### PR DESCRIPTION
Increase the stack size of the `conv2dk1_skip` kernel to enable resnet and bottleneck designs on Strix

Part of #2092