### PR TITLE
Add test of tile mapped memory read

### DIFF
--- a/test/npu-xrt/tile_mapped_read/aie.mlir
+++ b/test/npu-xrt/tile_mapped_read/aie.mlir
@@ -1,0 +1,68 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu1_1col) {
+    func.func private @read_processor_bus(memref<8xi32>, i32, i32, i32)
+    %t00 = aie.tile(0, 0)
+    %t01 = aie.tile(0, 1)
+    %t02 = aie.tile(0, 2)
+  
+    aie.objectfifo @objFifo_in0(%t00, {%t01}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @objFifo_in1(%t01, {%t02}, 2 : i32) : !aie.objectfifo<memref<8xi32>>
+    aie.objectfifo.link [@objFifo_in0] -> [@objFifo_in1] ([] [])
+
+    aie.objectfifo @objFifo_out1(%t02, {%t01}, 2 : i32) : !aie.objectfifo<memref<8xi32>>
+    aie.objectfifo @objFifo_out0(%t01, {%t00}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.link [@objFifo_out1] -> [@objFifo_out0] ([] [])
+  
+    // Create 8 locks on tile 0,2 with init values 42 to 49
+    // This is the data the core will read over the processor bus
+    aie.lock(%t02, 8) {init = 42 : i32, sym_name = "lock8"}
+    aie.lock(%t02, 9) {init = 43 : i32, sym_name = "lock9"}
+    aie.lock(%t02, 10) {init = 44 : i32, sym_name = "lock10"}
+    aie.lock(%t02, 11) {init = 45 : i32, sym_name = "lock11"}
+    aie.lock(%t02, 12) {init = 46 : i32, sym_name = "lock12"}
+    aie.lock(%t02, 13) {init = 47 : i32, sym_name = "lock13"}
+    aie.lock(%t02, 14) {init = 48 : i32, sym_name = "lock14"}
+    aie.lock(%t02, 15) {init = 49 : i32, sym_name = "lock15"}
+
+    aie.core(%t02) {
+      %c8 = arith.constant 8 : index
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %size = arith.constant 8 : i32
+      %stride = arith.constant 0x10 : i32
+      %addr = arith.constant 0x0001F080 : i32
+      scf.for %steps = %c0 to %c8 step %c1 {
+        %subview0 = aie.objectfifo.acquire @objFifo_in1(Consume, 1) : !aie.objectfifosubview<memref<8xi32>>
+        %elem0 = aie.objectfifo.subview.access %subview0[0] : !aie.objectfifosubview<memref<8xi32>> -> memref<8xi32>
+        %subview1 = aie.objectfifo.acquire @objFifo_out1(Produce, 1) : !aie.objectfifosubview<memref<8xi32>>
+        %elem1 = aie.objectfifo.subview.access %subview1[0] : !aie.objectfifosubview<memref<8xi32>> -> memref<8xi32>
+        func.call @read_processor_bus(%elem1, %addr, %size, %stride) : (memref<8xi32>, i32, i32, i32) -> ()
+        aie.objectfifo.release @objFifo_in1(Consume, 1)
+        aie.objectfifo.release @objFifo_out1(Produce, 1)
+      }
+      aie.end
+    } {link_with = "kernel.o"}
+
+    aiex.runtime_sequence(%in : memref<64xi32>, %out : memref<64xi32>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c64 = arith.constant 64 : i64
+      // Set Core_Processor_Bus register Enable = 1. Without this the core will hang on access to the processor bus
+      aiex.npu.maskwrite32 {address = 0x32038 : ui32, row = 2 : i32, column = 0 : i32, value = 0x1 : ui32, mask = 0x1 : ui32}
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_wait { symbol = @objFifo_out0 }
+    }
+  }
+
+}

--- a/test/npu-xrt/tile_mapped_read/kernel.cpp
+++ b/test/npu-xrt/tile_mapped_read/kernel.cpp
@@ -1,0 +1,26 @@
+//===- read_processor_bus.cpp -----------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+
+extern "C" {
+
+constexpr uint32_t tm_start_addr = 0x80000;
+static volatile uint32_t chess_storage(TM : tm_start_addr) addr_space_start;
+
+void read_processor_bus(uint32_t *data, uint32_t addr, uint32_t size,
+                        uint32_t stride) {
+  for (uint32_t i = 0; i < size; i++) {
+    uint32_t offset = addr + (i * stride);
+    data[i] = *(&addr_space_start + (offset / 4));
+  }
+}
+
+} // extern "C"

--- a/test/npu-xrt/tile_mapped_read/run.lit
+++ b/test/npu-xrt/tile_mapped_read/run.lit
@@ -1,0 +1,9 @@
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu1, chess
+//
+// RUN: xchesscc_wrapper aie2 -I %aietools/include -c %S/kernel.cpp -o kernel.o
+// RUN: %python aiecc.py --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin %S/aie.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/tile_mapped_read/test.cpp
+++ b/test/npu-xrt/tile_mapped_read/test.cpp
@@ -1,0 +1,138 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "cxxopts.hpp"
+#include "test_utils.h"
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+constexpr int IN_SIZE = 64;
+constexpr int OUT_SIZE = 64;
+
+int main(int argc, const char *argv[]) {
+  // Program arguments parsing
+  cxxopts::Options options("add_one_objFifo");
+  test_utils::add_default_options(options);
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+
+  int verbosity = vm["verbosity"].as<int>();
+  if (verbosity >= 1)
+    std::cout << "Sequence instr count: " << instr_v.size() << "\n";
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::kernel(context, kernelName);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  // the input buffer is only used for synchronization
+  uint32_t *bufInA = bo_inA.map<uint32_t *>();
+  std::vector<uint32_t> srcVecA;
+  for (int i = 0; i < IN_SIZE; i++)
+    srcVecA.push_back(0xfabcdef);
+  memcpy(bufInA, srcVecA.data(), (srcVecA.size() * sizeof(uint32_t)));
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_inA.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running Kernel.\n";
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), bo_inA, bo_out);
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
+    return 1;
+  }
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  uint32_t *bufOut = bo_out.map<uint32_t *>();
+
+  int errors = 0;
+
+  for (uint32_t i = 0; i < 64; i++) {
+    uint32_t ref = i % 8 + 42;
+    if (*(bufOut + i) != ref) {
+      std::cout << "Error in output " << *(bufOut + i) << " != " << ref
+                << std::endl;
+      errors++;
+    } else {
+      std::cout << "Correct output " << *(bufOut + i) << " == " << ref
+                << std::endl;
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nfailed.\n\n";
+    return 1;
+  }
+}


### PR DESCRIPTION
Accessing the processor bus from a core requires certain load and store encodings at the ISA level.

This PR exercises the chess compiler way to do this. It adds a test which reads some lock values of a core then sends them to host via shim.

llvm-aie appears to [expose intrinsics](https://github.com/Xilinx/llvm-aie/blob/aie-public/clang/lib/Headers/aiev2intrin.h#L63) to do the same, but this is not part of or tested in this PR.

It should be possible to expose the peano version up to mlir, similar to user events. It is less clear how to do the same for chess_storage.