### PR TITLE
Remove flock, Update lit substitutions for programming examples and guide

### DIFF
--- a/programming_examples/basic/dma_transpose/run_makefile.lit
+++ b/programming_examples/basic/dma_transpose/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/dma_transpose/run_makefile_iron.lit
+++ b/programming_examples/basic/dma_transpose/run_makefile_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p iron_test
 // RUN: cd iron_test
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/dma_transpose/run_makefile_placed.lit
+++ b/programming_examples/basic/dma_transpose/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/dma_transpose/run_strix_makefile.lit
+++ b/programming_examples/basic/dma_transpose/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/dma_transpose/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/dma_transpose/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/cascade/run_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/cascade/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/cascade/run_makefile_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/cascade/run_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/cascade/run_strix_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/cascade/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/cascade/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/cascade/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_stx
 // RUN: cd test_placed_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test
 // RUN: cd test
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_chess.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess 
+// REQUIRES: ryzen_ai_npu1, chess
 //
 // RUN: mkdir -p test_chess
 // RUN: cd test_chess
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess
-// RUN: %run_on_npu make -f %S/Makefile.chess run
+// RUN: %run_on_npu1% make -f %S/Makefile.chess run

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_iron
 // RUN: cd test_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile_chess.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess 
+// REQUIRES: ryzen_ai_npu2, chess
 //
 // RUN: mkdir -p test_chess_stx
 // RUN: cd test_chess_stx
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile.chess run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile.chess run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_iron_stx
 // RUN: cd test_iron_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_iron=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_stx
 // RUN: cd test_placed_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_1
 // RUN: cd test_1
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu make -f %S/Makefile trace
+// RUN: %run_on_npu1% make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_1.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_1.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_2
 // RUN: cd test_2
 // RUN: make -f %S/Makefile clean
 // RUN: env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile 
-// RUN: %run_on_npu env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile run
+// RUN: %run_on_npu1% env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile trace
+// RUN: %run_on_npu1% env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_chess.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess 
+// REQUIRES: ryzen_ai_npu1, chess
 //
 // RUN: mkdir -p test_chess
 // RUN: cd test_chess
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess
-// RUN: %run_on_npu make -f %S/Makefile.chess run
+// RUN: %run_on_npu1% make -f %S/Makefile.chess run
 // RUN: make -f %S/Makefile.chess clean
-// RUN: %run_on_npu make -f %S/Makefile.chess trace
+// RUN: %run_on_npu1% make -f %S/Makefile.chess trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_col_maj.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_col_maj.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_b_col_maj_s
 // RUN: cd test_b_col_maj_s
 // RUN: make -f %S/Makefile clean
 // RUN: env b_col_maj=1 make -f %S/Makefile 
-// RUN: %run_on_npu env b_col_maj=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env b_col_maj=1 make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu env b_col_maj=1 make -f %S/Makefile trace
+// RUN: %run_on_npu1% env b_col_maj=1 make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_col_maj_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_col_maj_iron.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_b_col_maj_iron_s
 // RUN: cd test_b_col_maj_iron_s
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 b_col_maj=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 b_col_maj=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 b_col_maj=1 make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu env use_iron=1 b_col_maj=1 make -f %S/Makefile trace
+// RUN: %run_on_npu1% env use_iron=1 b_col_maj=1 make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_col_maj_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_col_maj_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_b_col_maj_placed_s
 // RUN: cd test_b_col_maj_placed_s
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 b_col_maj=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 b_col_maj=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 b_col_maj=1 make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu env use_placed=1 b_col_maj=1 make -f %S/Makefile trace
+// RUN: %run_on_npu1% env use_placed=1 b_col_maj=1 make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_i8.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_i8.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_i8
 // RUN: cd test_i8
 // RUN: make -f %S/Makefile clean
 // RUN: env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile 
-// RUN: %run_on_npu env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile run
+// RUN: %run_on_npu1% env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile trace
+// RUN: %run_on_npu1% env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_iron.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_iron
 // RUN: cd test_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu env use_iron=1 make -f %S/Makefile trace
+// RUN: %run_on_npu1% env use_iron=1 make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_makefile_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_makefile_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu env use_placed=1 make -f %S/Makefile trace
+// RUN: %run_on_npu1% env use_placed=1 make -f %S/Makefile trace

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_2_stx
 // RUN: cd test_2_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% env M=768 K=512 N=512 m=64 k=64 n=64 dtype_in=i16 dtype_out=i16 make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_chess.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess 
+// REQUIRES: ryzen_ai_npu2, chess
 //
 // RUN: mkdir -p test_chess_stx
 // RUN: cd test_chess_stx
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile.chess run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile.chess run devicename=npu2
 // RUN: make -f %S/Makefile.chess clean
-// RUN: %run_on_2npu make -f %S/Makefile.chess trace devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile.chess trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_col_maj.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_col_maj.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_b_col_maj_stx_s
 // RUN: cd test_b_col_maj_stx_s
 // RUN: make -f %S/Makefile clean
 // RUN: env b_col_maj=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env b_col_maj=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env b_col_maj=1 make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu env b_col_maj=1 make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% env b_col_maj=1 make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_col_maj_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_col_maj_iron.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_b_col_maj_stx_iron_s
 // RUN: cd test_b_col_maj_stx_iron_s
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 b_col_maj=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_iron=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu env use_iron=1 b_col_maj=1 make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 b_col_maj=1 make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_col_maj_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_col_maj_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_b_col_maj_stx_placed_s
 // RUN: cd test_b_col_maj_stx_placed_s
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 b_col_maj=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu env use_placed=1 b_col_maj=1 make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 b_col_maj=1 make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_i8.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_i8.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_i8_stx
 // RUN: cd test_i8_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% env dtype_in=i8 dtype_out=i8 m=64 k=128 n=64 M=512 K=512 N=512 make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_iron.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_iron_stx
 // RUN: cd test_iron_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu env use_iron=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu env use_iron=1 make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/run_strix_makefile_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_stx
 // RUN: cd test_placed_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu env use_placed=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu env use_placed=1 make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_1_col
 // RUN: cd test_1_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=1 make -f %S/Makefile 
-// RUN: %run_on_npu env n_aie_cols=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env n_aie_cols=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_1_col_iron
 // RUN: cd test_1_col_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 n_aie_cols=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 n_aie_cols=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 n_aie_cols=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_1_col_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_1_col_placed
 // RUN: cd test_1_col_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 n_aie_cols=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 n_aie_cols=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 n_aie_cols=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_2_col
 // RUN: cd test_2_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=2 make -f %S/Makefile 
-// RUN: %run_on_npu env n_aie_cols=2 make -f %S/Makefile run
+// RUN: %run_on_npu1% env n_aie_cols=2 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_2_col_iron
 // RUN: cd test_2_col_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 n_aie_cols=2 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 n_aie_cols=2 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 n_aie_cols=2 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_2_col_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_2_col_placed
 // RUN: cd test_2_col_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 n_aie_cols=2 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 n_aie_cols=2 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 n_aie_cols=2 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_4_col
 // RUN: cd test_4_col
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=4 make -f %S/Makefile 
-// RUN: %run_on_npu env n_aie_cols=4 make -f %S/Makefile run
+// RUN: %run_on_npu1% env n_aie_cols=4 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_4_col_i8
 // RUN: cd test_4_col_i8
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile 
-// RUN: %run_on_npu env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run
+// RUN: %run_on_npu1% env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_4_col_i8_iron
 // RUN: cd test_4_col_i8_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_i8_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_4_col_i8_placed
 // RUN: cd test_4_col_i8_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_4_col_iron
 // RUN: cd test_4_col_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env user_tile=1 n_aie_cols=4 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 n_aie_cols=4 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 n_aie_cols=4 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_4_col_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_4_col_placed
 // RUN: cd test_4_col_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env user_tile=1 n_aie_cols=4 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 n_aie_cols=4 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 n_aie_cols=4 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_chess.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess 
+// REQUIRES: ryzen_ai_npu1, chess
 //
 // RUN: mkdir -p test_chess
 // RUN: cd test_chess
 // RUN: make -f %S/Makefile.chess clean
 // RUN: make -f %S/Makefile.chess
-// RUN: %run_on_npu make -f %S/Makefile.chess run
+// RUN: %run_on_npu1% make -f %S/Makefile.chess run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_b_col_maj
 // RUN: cd test_b_col_maj
 // RUN: make -f %S/Makefile clean
 // RUN: env b_col_maj=1 make -f %S/Makefile 
-// RUN: %run_on_npu env b_col_maj=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env b_col_maj=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_b_col_maj_iron
 // RUN: cd test_b_col_maj_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 b_col_maj=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_iron=1 b_col_maj=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_iron=1 b_col_maj=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_makefile_col_maj_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_b_col_maj_placed
 // RUN: cd test_b_col_maj_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 b_col_maj=1 make -f %S/Makefile 
-// RUN: %run_on_npu env use_placed=1 b_col_maj=1 make -f %S/Makefile run
+// RUN: %run_on_npu1% env use_placed=1 b_col_maj=1 make -f %S/Makefile run

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_1_col placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_1_col placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_1_col_placed_stx
 // RUN: cd test_1_col_placed_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 n_aie_cols=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 n_aie_cols=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 n_aie_cols=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_1_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_1_col.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_1_col_stx
 // RUN: cd test_1_col_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env n_aie_cols=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env n_aie_cols=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_1_col_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_1_col_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_1_col_iron_stx
 // RUN: cd test_1_col_iron_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 n_aie_cols=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_iron=1 n_aie_cols=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 n_aie_cols=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_2_col placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_2_col placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_2_col_placed_stx
 // RUN: cd test_2_col_placed_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 n_aie_cols=2 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 n_aie_cols=2 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 n_aie_cols=2 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_2_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_2_col.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_2_col_stx
 // RUN: cd test_2_col_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=2 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env n_aie_cols=2 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env n_aie_cols=2 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_2_col_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_2_col_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_2_col_iron_stx
 // RUN: cd test_2_col_iron_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 n_aie_cols=2 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_iron=1 n_aie_cols=2 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 n_aie_cols=2 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_4_col i8.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_4_col i8.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_4_col_stx
 // RUN: cd test_4_col_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_4_col i8_iron placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_4_col i8_iron placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_4_col_stx_placed
 // RUN: cd test_4_col_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_4_col i8_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_4_col i8_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_4_col_stx_iron
 // RUN: cd test_4_col_stx_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_iron=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 n_aie_cols=4 dtype_in=i8 dtype_out=i8 M=512 K=512 N=512 m=64 k=128 n=64 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_8_col.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_8_col.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_8_col_stx
 // RUN: cd test_8_col_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env n_aie_cols=8 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env n_aie_cols=8 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env n_aie_cols=8 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_8_col_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_8_col_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_8_col_stx_iron
 // RUN: cd test_8_col_stx_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 n_aie_cols=8 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_iron=1 n_aie_cols=8 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 n_aie_cols=8 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_8_col_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_8_col_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_8_col_stx_placed
 // RUN: cd test_8_col_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 n_aie_cols=8 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 n_aie_cols=8 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 n_aie_cols=8 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_chess.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_chess.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess 
+// REQUIRES: ryzen_ai_npu2, chess
 //
 // RUN: mkdir -p test_chess_stx
 // RUN: cd test_chess_stx
 // RUN: make -f %S/Makefile.chess clean
 // RUN: env make -f %S/Makefile.chess devicename=npu2
-// RUN: %run_on_2npu env make -f %S/Makefile.chess run devicename=npu2
+// RUN: %run_on_npu2% env make -f %S/Makefile.chess run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_col_maj.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_col_maj.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_b_col_maj_stx
 // RUN: cd test_b_col_maj_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env b_col_maj=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env b_col_maj=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env b_col_maj=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_col_maj_iron.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_col_maj_iron.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_b_col_maj_stx_iron
 // RUN: cd test_b_col_maj_stx_iron
 // RUN: make -f %S/Makefile clean
 // RUN: env use_iron=1 b_col_maj=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_iron=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_iron=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_col_maj_placed.lit
+++ b/programming_examples/basic/matrix_multiplication/whole_array/run_strix_makefile_col_maj_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_b_col_maj_stx_placed
 // RUN: cd test_b_col_maj_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 b_col_maj=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu env use_placed=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% env use_placed=1 b_col_maj=1 make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_scalar_add/run_makefile.lit
+++ b/programming_examples/basic/matrix_scalar_add/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/matrix_scalar_add/run_makefile_placed.lit
+++ b/programming_examples/basic/matrix_scalar_add/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/matrix_scalar_add/run_strix_makefile.lit
+++ b/programming_examples/basic/matrix_scalar_add/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/matrix_scalar_add/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/matrix_scalar_add/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/memcpy/run_makefile.lit
+++ b/programming_examples/basic/memcpy/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/memcpy/run_strix_makefile.lit
+++ b/programming_examples/basic/memcpy/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/packet_switch/run_makefile_placed.lit
+++ b/programming_examples/basic/packet_switch/run_makefile_placed.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/packet_switch/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/packet_switch/run_strix_makefile_placed.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile DEVICE=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run DEVICE=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run DEVICE=npu2

--- a/programming_examples/basic/passthrough_dmas/run_makefile.lit
+++ b/programming_examples/basic/passthrough_dmas/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/passthrough_dmas/run_makefile_placed.lit
+++ b/programming_examples/basic/passthrough_dmas/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/passthrough_dmas/run_strix_makefile.lit
+++ b/programming_examples/basic/passthrough_dmas/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/passthrough_dmas/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/passthrough_dmas/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/passthrough_kernel/run_makefile.lit
+++ b/programming_examples/basic/passthrough_kernel/run_makefile.lit
@@ -1,14 +1,14 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test
 // RUN: cd test
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false %run_on_npu make -f %S/Makefile trace 
-// RUN: env CHESS=false %run_on_npu make -f %S/Makefile trace_py 
+// RUN: env CHESS=false %run_on_npu1% make -f %S/Makefile trace
+// RUN: env CHESS=false %run_on_npu1% make -f %S/Makefile trace_py

--- a/programming_examples/basic/passthrough_kernel/run_makefile_placed.lit
+++ b/programming_examples/basic/passthrough_kernel/run_makefile_placed.lit
@@ -1,14 +1,14 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace 
-// RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace_py 
+// RUN: env CHESS=false use_placed=1 %run_on_npu1% make -f %S/Makefile trace
+// RUN: env CHESS=false use_placed=1 %run_on_npu1% make -f %S/Makefile trace_py
   

--- a/programming_examples/basic/passthrough_kernel/run_strix_makefile.lit
+++ b/programming_examples/basic/passthrough_kernel/run_strix_makefile.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: env CHESS=false %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/passthrough_kernel/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/passthrough_kernel/run_strix_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env use_placed=1 %run_on_2npu make -f %S/Makefile trace devicename=npu2
-// RUN: env use_placed=1 %run_on_2npu make -f %S/Makefile trace_py devicename=npu2
+// RUN: env use_placed=1 %run_on_npu2% make -f %S/Makefile trace devicename=npu2
+// RUN: env use_placed=1 %run_on_npu2% make -f %S/Makefile trace_py devicename=npu2

--- a/programming_examples/basic/passthrough_pykernel/run_makefile.lit
+++ b/programming_examples/basic/passthrough_pykernel/run_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // CHECK: Running...

--- a/programming_examples/basic/passthrough_pykernel/run_makefile_placed.lit
+++ b/programming_examples/basic/passthrough_pykernel/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
   

--- a/programming_examples/basic/passthrough_pykernel/run_notebook.lit
+++ b/programming_examples/basic/passthrough_pykernel/run_notebook.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean_notebook
-// RUN: %run_on_npu make -f %S/Makefile run_notebook
+// RUN: %run_on_npu1% make -f %S/Makefile run_notebook
 // CHECK: Running...
 // CHECK: PASSED!

--- a/programming_examples/basic/passthrough_pykernel/run_strix_makefile.lit
+++ b/programming_examples/basic/passthrough_pykernel/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/passthrough_pykernel/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/passthrough_pykernel/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/row_wise_bias_add/run_makefile.lit
+++ b/programming_examples/basic/row_wise_bias_add/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/row_wise_bias_add/run_makefile_placed.lit
+++ b/programming_examples/basic/row_wise_bias_add/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/row_wise_bias_add/run_strix_makefile.lit
+++ b/programming_examples/basic/row_wise_bias_add/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/row_wise_bias_add/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/row_wise_bias_add/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/shuffle_transpose/run_makefile.lit
+++ b/programming_examples/basic/shuffle_transpose/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/shuffle_transpose/run_strix_makefile.lit
+++ b/programming_examples/basic/shuffle_transpose/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/tiling_exploration/per_tile/run_makefile.lit
+++ b/programming_examples/basic/tiling_exploration/per_tile/run_makefile.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // CHECK: Running...

--- a/programming_examples/basic/tiling_exploration/tile_group/run_makefile.lit
+++ b/programming_examples/basic/tiling_exploration/tile_group/run_makefile.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // CHECK: Running...

--- a/programming_examples/basic/vector_exp/run_makefile.lit
+++ b/programming_examples/basic/vector_exp/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_exp/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_exp/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/vector_exp/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_exp/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_exp/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_exp/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_reduce_add/run_makefile.lit
+++ b/programming_examples/basic/vector_reduce_add/run_makefile.lit
@@ -5,4 +5,4 @@
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_reduce_add/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_reduce_add/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/vector_reduce_add/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_reduce_add/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_reduce_add/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_reduce_add/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_reduce_max/run_makefile.lit
+++ b/programming_examples/basic/vector_reduce_max/run_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile trace 
+// RUN: %run_on_npu1% make -f %S/Makefile trace 

--- a/programming_examples/basic/vector_reduce_max/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_reduce_max/run_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace 
+// RUN: env CHESS=false use_placed=1 %run_on_npu1% make -f %S/Makefile trace 
   

--- a/programming_examples/basic/vector_reduce_max/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_reduce_max/run_strix_makefile.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/vector_reduce_max/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_reduce_max/run_strix_makefile_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env use_placed=1 %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: env use_placed=1 %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/vector_reduce_min/run_makefile.lit
+++ b/programming_examples/basic/vector_reduce_min/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_reduce_min/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_reduce_min/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/vector_reduce_min/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_reduce_min/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_reduce_min/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_reduce_min/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_scalar_add/run_makefile.lit
+++ b/programming_examples/basic/vector_scalar_add/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_scalar_add/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_scalar_add/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/vector_scalar_add/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_scalar_add/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_scalar_add/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_scalar_add/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_scalar_add_runlist/run_makefile.lit
+++ b/programming_examples/basic/vector_scalar_add_runlist/run_makefile.lit
@@ -5,4 +5,4 @@
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_scalar_add_runlist/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_scalar_add_runlist/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/vector_scalar_add_runlist/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_scalar_add_runlist/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_scalar_add_runlist/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_scalar_add_runlist/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_scalar_mul/run_makefile.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_makefile.lit
@@ -1,14 +1,14 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_peano
 // RUN: cd test_peano
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=false make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run 
-// RUN: %run_on_npu make -f %S/Makefile run_py 
+// RUN: %run_on_npu1% make -f %S/Makefile run 
+// RUN: %run_on_npu1% make -f %S/Makefile run_py 
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false %run_on_npu make -f %S/Makefile trace 
-// RUN: env CHESS=false %run_on_npu make -f %S/Makefile trace_py 
+// RUN: env CHESS=false %run_on_npu1% make -f %S/Makefile trace 
+// RUN: env CHESS=false %run_on_npu1% make -f %S/Makefile trace_py 

--- a/programming_examples/basic/vector_scalar_mul/run_makefile_chess.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_makefile_chess.lit
@@ -1,14 +1,14 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess
+// REQUIRES: ryzen_ai_npu1, chess
 //
 // RUN: mkdir -p test_chess
 // RUN: cd test_chess
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=true use_placed=1 %run_on_npu make -f %S/Makefile trace
-// RUN: env CHESS=true use_placed=1 %run_on_npu make -f %S/Makefile trace_py
+// RUN: env CHESS=true use_placed=1 %run_on_npu1% make -f %S/Makefile trace
+// RUN: env CHESS=true use_placed=1 %run_on_npu1% make -f %S/Makefile trace_py

--- a/programming_examples/basic/vector_scalar_mul/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run 
+// RUN: %run_on_npu1% make -f %S/Makefile run 
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace 
-// RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace_py 
+// RUN: env CHESS=false use_placed=1 %run_on_npu1% make -f %S/Makefile trace 
+// RUN: env CHESS=false use_placed=1 %run_on_npu1% make -f %S/Makefile trace_py 

--- a/programming_examples/basic/vector_scalar_mul/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_strix_makefile.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu make -f %S/Makefile trace devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile trace_py devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile trace_py devicename=npu2

--- a/programming_examples/basic/vector_scalar_mul/run_strix_makefile_chess.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_strix_makefile_chess.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess
+// REQUIRES: ryzen_ai_npu2, chess
 //
 // RUN: mkdir -p test_stx_chess
 // RUN: cd test_stx_chess
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true make -f %S/Makefile devicename=npu2 
-// RUN: env CHESS=true %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: env CHESS=true %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=true %run_on_2npu make -f %S/Makefile trace devicename=npu2
-// RUN: env CHESS=true %run_on_2npu make -f %S/Makefile trace_py devicename=npu2
+// RUN: env CHESS=true %run_on_npu2% make -f %S/Makefile trace devicename=npu2
+// RUN: env CHESS=true %run_on_npu2% make -f %S/Makefile trace_py devicename=npu2

--- a/programming_examples/basic/vector_scalar_mul/run_strix_makefile_chess_placed.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_strix_makefile_chess_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess
+// REQUIRES: ryzen_ai_npu2, chess
 //
 // RUN: mkdir -p test_stx_placed_chess
 // RUN: cd test_stx_placed_chess
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=true use_placed=1 %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: env CHESS=true use_placed=1 %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/basic/vector_scalar_mul/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_scalar_mul/run_strix_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env use_placed=1 %run_on_2npu make -f %S/Makefile trace devicename=npu2
-// RUN: env use_placed=1 %run_on_2npu make -f %S/Makefile trace_py devicename=npu2
+// RUN: env use_placed=1 %run_on_npu2% make -f %S/Makefile trace devicename=npu2
+// RUN: env use_placed=1 %run_on_npu2% make -f %S/Makefile trace_py devicename=npu2

--- a/programming_examples/basic/vector_vector_add/run.lit
+++ b/programming_examples/basic/vector_vector_add/run.lit
@@ -1,6 +1,6 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
-// RUN: %run_on_npu python3 %S/vector_vector_add.py --device=npu
+// RUN: %run_on_npu1% python3 %S/vector_vector_add.py --device=npu

--- a/programming_examples/basic/vector_vector_add/run_placed.lit
+++ b/programming_examples/basic/vector_vector_add/run_placed.lit
@@ -3,4 +3,4 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
-// RUN: %run_on_npu python3 %S/vector_vector_add_placed.py --device=npu
+// RUN: %run_on_npu1% python3 %S/vector_vector_add_placed.py --device=npu

--- a/programming_examples/basic/vector_vector_add/run_strix.lit
+++ b/programming_examples/basic/vector_vector_add/run_strix.lit
@@ -1,6 +1,6 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: %run_on_2npu python3 %S/vector_vector_add.py --device=npu2
+// RUN: %run_on_npu2% python3 %S/vector_vector_add.py --device=npu2

--- a/programming_examples/basic/vector_vector_add/run_strix_placed.lit
+++ b/programming_examples/basic/vector_vector_add/run_strix_placed.lit
@@ -1,6 +1,6 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
-// RUN: %run_on_2npu python3 %S/vector_vector_add_placed.py --device=npu2
+// RUN: %run_on_npu2% python3 %S/vector_vector_add_placed.py --device=npu2

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/run_makefile.lit
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/run_makefile.lit
@@ -5,4 +5,4 @@
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_vector_modulo/run_makefile.lit
+++ b/programming_examples/basic/vector_vector_modulo/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_vector_modulo/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_vector_modulo/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/vector_vector_modulo/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_vector_modulo/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_vector_modulo/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_vector_modulo/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_vector_mul/run_makefile.lit
+++ b/programming_examples/basic/vector_vector_mul/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/basic/vector_vector_mul/run_makefile_placed.lit
+++ b/programming_examples/basic/vector_vector_mul/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/basic/vector_vector_mul/run_strix_makefile.lit
+++ b/programming_examples/basic/vector_vector_mul/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/basic/vector_vector_mul/run_strix_makefile_placed.lit
+++ b/programming_examples/basic/vector_vector_mul/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/experimental/run_makefile.lit
+++ b/programming_examples/experimental/run_makefile.lit
@@ -1,7 +1,7 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu make -f %S/Makefile
+// RUN: %run_on_npu1% make -f %S/Makefile

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -19,7 +19,7 @@ from lit.llvm import llvm_config
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = "AIE_TUTORIALS"
+config.name = "AIE_PROGRAMMING_EXAMPLES"
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
@@ -111,8 +111,8 @@ else:
     config.substitutions.append(("%link_against_hsa%", ""))
     config.substitutions.append(("%HSA_DIR%", ""))
 
-run_on_npu = "echo"
-run_on_2npu = "echo"
+run_on_npu1 = "echo"
+run_on_npu2 = "echo"
 xrt_flags = ""
 
 if config.xrt_lib_dir:
@@ -144,16 +144,15 @@ if config.xrt_lib_dir:
                 model = str(m.group(4))
             print(f"\tmodel: '{model}'")
             config.available_features.add("ryzen_ai")
+            run_on_npu = f"{config.aie_src_root}/utils/run_on_npu.sh"
             if model in ["npu1", "Phoenix"]:
-                run_on_npu = (
-                    f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
-                )
-                print("Running tests on NPU1 with command line: ", run_on_npu)
+                run_on_npu1 = run_on_npu
+                config.available_features.add("ryzen_ai_npu1")
+                print("Running tests on NPU1 with command line: ", run_on_npu1)
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
-                run_on_2npu = (
-                    f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
-                )
-                print("Running tests on NPU4 with command line: ", run_on_2npu)
+                run_on_npu2 = run_on_npu
+                config.available_features.add("ryzen_ai_npu2")
+                print("Running tests on NPU4 with command line: ", run_on_npu2)
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")
             break
@@ -163,8 +162,8 @@ if config.xrt_lib_dir:
 else:
     print("xrt not found")
 
-config.substitutions.append(("%run_on_npu", run_on_npu))
-config.substitutions.append(("%run_on_2npu", run_on_2npu))
+config.substitutions.append(("%run_on_npu1%", run_on_npu1))
+config.substitutions.append(("%run_on_npu2%", run_on_npu2))
 config.substitutions.append(("%xrt_flags", xrt_flags))
 
 opencv_flags = ""

--- a/programming_examples/ml/bottleneck/run_makefile.lit
+++ b/programming_examples/ml/bottleneck/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py

--- a/programming_examples/ml/bottleneck/run_makefile_placed.lit
+++ b/programming_examples/ml/bottleneck/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
   

--- a/programming_examples/ml/bottleneck/run_strix_makefile.lit
+++ b/programming_examples/ml/bottleneck/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run_py
+// RUN: %run_on_npu2% make -f %S/Makefile run_py

--- a/programming_examples/ml/bottleneck/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/bottleneck/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run_py
+// RUN: %run_on_npu2% make -f %S/Makefile run_py

--- a/programming_examples/ml/conv2d/run_makefile.lit
+++ b/programming_examples/ml/conv2d/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py

--- a/programming_examples/ml/conv2d/run_makefile_placed.lit
+++ b/programming_examples/ml/conv2d/run_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu make -f %S/Makefile trace_py
+// RUN: %run_on_npu1% make -f %S/Makefile trace_py
   

--- a/programming_examples/ml/conv2d/run_strix_makefile.lit
+++ b/programming_examples/ml/conv2d/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess, torch
+// REQUIRES: ryzen_ai_npu2, chess, torch
 //
 // RUN: mkdir -p test_strix_chess
 // RUN: cd test_strix_chess
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true make -f %S/Makefile devicename=npu2
-// RUN: env CHESS=true %run_on_2npu make -f %S/Makefile run_py devicename=npu2
+// RUN: env CHESS=true %run_on_npu2% make -f %S/Makefile run_py devicename=npu2

--- a/programming_examples/ml/conv2d/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/conv2d/run_strix_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess, torch
+// REQUIRES: ryzen_ai_npu2, chess, torch
 //
 // RUN: mkdir -p test_placed_strix
 // RUN: cd test_placed_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: env CHESS=true use_placed=1 %run_on_2npu make -f %S/Makefile run_py devicename=npu2
+// RUN: env CHESS=true use_placed=1 %run_on_npu2% make -f %S/Makefile run_py devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=true use_placed=1 %run_on_2npu make -f %S/Makefile trace_py devicename=npu2
+// RUN: env CHESS=true use_placed=1 %run_on_npu2% make -f %S/Makefile trace_py devicename=npu2
   

--- a/programming_examples/ml/conv2d_fused_relu/run_makefile.lit
+++ b/programming_examples/ml/conv2d_fused_relu/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py

--- a/programming_examples/ml/conv2d_fused_relu/run_makefile_placed.lit
+++ b/programming_examples/ml/conv2d_fused_relu/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
   

--- a/programming_examples/ml/conv2d_fused_relu/run_strix_makefile.lit
+++ b/programming_examples/ml/conv2d_fused_relu/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess, torch
+// REQUIRES: ryzen_ai_npu2, chess, torch
 //
 // RUN: mkdir -p test_strix_chess
 // RUN: cd test_strix_chess
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true make -f %S/Makefile devicename=npu2
-// RUN: env CHESS=true %run_on_2npu make -f %S/Makefile run_py devicename=npu2
+// RUN: env CHESS=true %run_on_npu2% make -f %S/Makefile run_py devicename=npu2

--- a/programming_examples/ml/conv2d_fused_relu/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/conv2d_fused_relu/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess, torch
+// REQUIRES: ryzen_ai_npu2, chess, torch
 //
 // RUN: mkdir -p test_placed_strix
 // RUN: cd test_placed_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: env CHESS=true use_placed=1 %run_on_2npu make -f %S/Makefile run_py devicename=npu2
+// RUN: env CHESS=true use_placed=1 %run_on_npu2% make -f %S/Makefile run_py devicename=npu2

--- a/programming_examples/ml/eltwise_add/run_makefile.lit
+++ b/programming_examples/ml/eltwise_add/run_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu make -f %S/Makefile trace
+// RUN: %run_on_npu1% make -f %S/Makefile trace

--- a/programming_examples/ml/eltwise_add/run_makefile_placed.lit
+++ b/programming_examples/ml/eltwise_add/run_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: env use_placed=1 %run_on_npu make -f %S/Makefile trace
+// RUN: env use_placed=1 %run_on_npu1% make -f %S/Makefile trace
   

--- a/programming_examples/ml/eltwise_add/run_strix_makefile.lit
+++ b/programming_examples/ml/eltwise_add/run_strix_makefile.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/ml/eltwise_add/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/eltwise_add/run_strix_makefile_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env use_placed=1 %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: env use_placed=1 %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/ml/eltwise_mul/run_makefile.lit
+++ b/programming_examples/ml/eltwise_mul/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/ml/eltwise_mul/run_makefile_placed.lit
+++ b/programming_examples/ml/eltwise_mul/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/ml/eltwise_mul/run_strix_makefile.lit
+++ b/programming_examples/ml/eltwise_mul/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/ml/eltwise_mul/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/eltwise_mul/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/ml/relu/run_makefile.lit
+++ b/programming_examples/ml/relu/run_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_npu make -f %S/Makefile trace
+// RUN: %run_on_npu1% make -f %S/Makefile trace

--- a/programming_examples/ml/relu/run_makefile_placed.lit
+++ b/programming_examples/ml/relu/run_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
 // RUN: make -f %S/Makefile clean
-// RUN: env use_placed=1 %run_on_npu make -f %S/Makefile trace
+// RUN: env use_placed=1 %run_on_npu1% make -f %S/Makefile trace
   

--- a/programming_examples/ml/relu/run_strix_makefile.lit
+++ b/programming_examples/ml/relu/run_strix_makefile.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/ml/relu/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/relu/run_strix_makefile_placed.lit
@@ -1,12 +1,12 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
 // RUN: make -f %S/Makefile clean
-// RUN: env use_placed=1 %run_on_2npu make -f %S/Makefile trace devicename=npu2
+// RUN: env use_placed=1 %run_on_npu2% make -f %S/Makefile trace devicename=npu2

--- a/programming_examples/ml/resnet/layers_conv2_x/run_makefile.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py

--- a/programming_examples/ml/resnet/layers_conv2_x/run_makefile_placed.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, torch
+// REQUIRES: ryzen_ai_npu1, peano, torch
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
   

--- a/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, torch
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run_py
+// RUN: %run_on_npu2% make -f %S/Makefile run_py

--- a/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/resnet/layers_conv2_x/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, torch
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run_py
+// RUN: %run_on_npu2% make -f %S/Makefile run_py

--- a/programming_examples/ml/scale_shift/run_makefile.lit
+++ b/programming_examples/ml/scale_shift/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/ml/scale_shift/run_strix_makefile.lit
+++ b/programming_examples/ml/scale_shift/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/ml/softmax/run_makefile.lit
+++ b/programming_examples/ml/softmax/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/ml/softmax/run_makefile_placed.lit
+++ b/programming_examples/ml/softmax/run_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/ml/softmax/run_makefile_whole_array_placed.lit
+++ b/programming_examples/ml/softmax/run_makefile_whole_array_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_whole_array
 // RUN: cd test_whole_array
 // RUN: make -f %S/Makefile clean
 // RUN: env use_whole_array=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/ml/softmax/run_strix_makefile.lit
+++ b/programming_examples/ml/softmax/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/ml/softmax/run_strix_makefile_placed.lit
+++ b/programming_examples/ml/softmax/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/ml/softmax/run_strix_makefile_whole_array_placed.lit
+++ b/programming_examples/ml/softmax/run_strix_makefile_whole_array_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_stx_whole_array
 // RUN: cd test_stx_whole_array
 // RUN: make -f %S/Makefile clean
 // RUN: env use_whole_array=1 devicename=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_examples/vision/color_detect/run_makefile.lit
+++ b/programming_examples/vision/color_detect/run_makefile.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano, opencv
+ // REQUIRES: ryzen_ai_npu1, peano, opencv
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/vision/color_detect/run_makefile_placed.lit
+++ b/programming_examples/vision/color_detect/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, opencv
+// REQUIRES: ryzen_ai_npu1, peano, opencv
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/vision/color_detect/run_strix_makefile.lit
+++ b/programming_examples/vision/color_detect/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess
+// REQUIRES: ryzen_ai_npu2, chess, opencv
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env device=npu2 make -f %S/Makefile
-// %run_on_2npu make -f %S/Makefile run
+// %run_on_npu2% make -f %S/Makefile run

--- a/programming_examples/vision/color_detect/run_strix_makefile_placed.lit
+++ b/programming_examples/vision/color_detect/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, chess
+// REQUIRES: ryzen_ai_npu2, chess, opencv
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 device=npu2 make -f %S/Makefile
-// %run_on_2npu make -f %S/Makefile run
+// %run_on_npu2% make -f %S/Makefile run

--- a/programming_examples/vision/color_threshold/run_makefile.lit
+++ b/programming_examples/vision/color_threshold/run_makefile.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano, opencv
+ // REQUIRES: ryzen_ai_npu1, peano, opencv
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/vision/color_threshold/run_makefile_placed.lit
+++ b/programming_examples/vision/color_threshold/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, opencv
+// REQUIRES: ryzen_ai_npu1, peano, opencv
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/vision/color_threshold/run_strix_makefile.lit
+++ b/programming_examples/vision/color_threshold/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, opencv
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env device=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_npu2% make -f %S/Makefile run

--- a/programming_examples/vision/color_threshold/run_strix_makefile_placed.lit
+++ b/programming_examples/vision/color_threshold/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, opencv
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 device=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_npu2% make -f %S/Makefile run

--- a/programming_examples/vision/edge_detect/run_makefile.lit
+++ b/programming_examples/vision/edge_detect/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano, opencv
+ // REQUIRES: ryzen_ai_npu1, peano, opencv
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_examples/vision/edge_detect/run_makefile_placed.lit
+++ b/programming_examples/vision/edge_detect/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, opencv
+// REQUIRES: ryzen_ai_npu1, peano, opencv
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/vision/edge_detect/run_strix_makefile.lit
+++ b/programming_examples/vision/edge_detect/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, opencv
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env device=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_npu2% make -f %S/Makefile run

--- a/programming_examples/vision/edge_detect/run_strix_makefile_placed.lit
+++ b/programming_examples/vision/edge_detect/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, opencv
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 device=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_npu2% make -f %S/Makefile run

--- a/programming_examples/vision/vision_passthrough/run_makefile.lit
+++ b/programming_examples/vision/vision_passthrough/run_makefile.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano, opencv
+ // REQUIRES: ryzen_ai_npu1, peano, opencv
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/vision/vision_passthrough/run_makefile_placed.lit
+++ b/programming_examples/vision/vision_passthrough/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano, opencv
+// REQUIRES: ryzen_ai_npu1, peano, opencv
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_examples/vision/vision_passthrough/run_strix_makefile.lit
+++ b/programming_examples/vision/vision_passthrough/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, opencv
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx
 // RUN: make -f %S/Makefile clean
 // RUN: env device=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_npu2% make -f %S/Makefile run

--- a/programming_examples/vision/vision_passthrough/run_strix_makefile_placed.lit
+++ b/programming_examples/vision/vision_passthrough/run_strix_makefile_placed.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano
+// REQUIRES: ryzen_ai_npu2, peano, opencv
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 device=npu2 make -f %S/Makefile
-// RUN: %run_on_2npu make -f %S/Makefile run
+// RUN: %run_on_npu2% make -f %S/Makefile run

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -111,9 +111,8 @@ else:
     config.substitutions.append(("%link_against_hsa%", ""))
     config.substitutions.append(("%HSA_DIR%", ""))
 
-
-run_on_npu = "echo"
-run_on_2npu = "echo"
+run_on_npu1 = "echo"
+run_on_npu2 = "echo"
 xrt_flags = ""
 
 if config.xrt_lib_dir:
@@ -145,16 +144,15 @@ if config.xrt_lib_dir:
                 model = str(m.group(4))
             print(f"\tmodel: '{model}'")
             config.available_features.add("ryzen_ai")
+            run_on_npu = f"{config.aie_src_root}/utils/run_on_npu.sh"
             if model in ["npu1", "Phoenix"]:
-                run_on_npu = (
-                    f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
-                )
-                print("Running tests on NPU1 with command line: ", run_on_npu)
+                run_on_npu1 = run_on_npu
+                config.available_features.add("ryzen_ai_npu1")
+                print("Running tests on NPU1 with command line: ", run_on_npu1)
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
-                run_on_2npu = (
-                    f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
-                )
-                print("Running tests on NPU4 with command line: ", run_on_2npu)
+                run_on_npu2 = run_on_npu
+                config.available_features.add("ryzen_ai_npu2")
+                print("Running tests on NPU4 with command line: ", run_on_npu2)
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")
             break
@@ -164,8 +162,8 @@ if config.xrt_lib_dir:
 else:
     print("xrt not found")
 
-config.substitutions.append(("%run_on_npu", run_on_npu))
-config.substitutions.append(("%run_on_2npu", run_on_2npu))
+config.substitutions.append(("%run_on_npu1%", run_on_npu1))
+config.substitutions.append(("%run_on_npu2%", run_on_npu2))
 config.substitutions.append(("%xrt_flags", xrt_flags))
 
 opencv_flags = ""

--- a/programming_guide/mini_tutorial/exercise_1/run.lit
+++ b/programming_guide/mini_tutorial/exercise_1/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: %run_on_npu python3 %S/exercise_1.py
-// RUN: %run_on_2npu python3 %S/exercise_1.py
+// RUN: %run_on_npu1% python3 %S/exercise_1.py
+// RUN: %run_on_npu2% python3 %S/exercise_1.py

--- a/programming_guide/mini_tutorial/exercise_2/run.lit
+++ b/programming_guide/mini_tutorial/exercise_2/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
-// RUN: %run_on_npu python3 %S/exercise_2.py
-// RUN: %run_on_2npu python3 %S/exercise_2.py
+// RUN: %run_on_npu1% python3 %S/exercise_2.py
+// RUN: %run_on_npu2% python3 %S/exercise_2.py

--- a/programming_guide/mini_tutorial/exercise_3/run.lit
+++ b/programming_guide/mini_tutorial/exercise_3/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano
 //
-// RUN: %run_on_npu python3 %S/exercise_3.py
-// RUN: %run_on_2npu python3 %S/exercise_3.py
+// RUN: %run_on_npu1% python3 %S/exercise_3.py
+// RUN: %run_on_npu2% python3 %S/exercise_3.py

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4a/run.lit
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4a/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: %run_on_npu python3 %S/exercise_4a.py 
-// RUN: %run_on_2npu python3 %S/exercise_4a.py 
+// RUN: %run_on_npu1% python3 %S/exercise_4a.py 
+// RUN: %run_on_npu2% python3 %S/exercise_4a.py 

--- a/programming_guide/mini_tutorial/exercise_4/exercise_4b/run.lit
+++ b/programming_guide/mini_tutorial/exercise_4/exercise_4b/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: %run_on_npu python3 %S/exercise_4b.py
-// RUN: %run_on_2npu python3 %S/exercise_4b.py
+// RUN: %run_on_npu1% python3 %S/exercise_4b.py
+// RUN: %run_on_npu2% python3 %S/exercise_4b.py

--- a/programming_guide/mini_tutorial/run.lit
+++ b/programming_guide/mini_tutorial/run.lit
@@ -3,5 +3,5 @@
 //
 // REQUIRES: ryzen_ai, peano 
 //
-// RUN: %run_on_npu python3 %S/aie2p.py
-// RUN: %run_on_2npu python3 %S/aie2p.py
+// RUN: %run_on_npu1% python3 %S/aie2p.py
+// RUN: %run_on_npu2% python3 %S/aie2p.py

--- a/programming_guide/section-2/section-2e/run_makefile_strix.lit
+++ b/programming_guide/section-2/section-2e/run_makefile_strix.lit
@@ -1,7 +1,7 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile devicename=npu2

--- a/programming_guide/section-2/section-2e/run_makefile_strix_placed.lit
+++ b/programming_guide/section-2/section-2e/run_makefile_strix_placed.lit
@@ -1,7 +1,7 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano 
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile placed devicename=npu2

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/run_makefile.lit
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/run_makefile.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano 
+ // REQUIRES: ryzen_ai_npu1, peano 
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run
  

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/run_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano 
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/run_strix_makefile.lit
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano 
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: mkdir -p test_strix
  // RUN: cd test_strix
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile devicename=npu2
- // RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+ // RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/run_strix_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/run_strix_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_strix
 // RUN: cd test_placed_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2
   

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/run_makefile.lit
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu1, peano
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/run_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano 
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/run_strix_makefile.lit
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: mkdir -p test_strix
  // RUN: cd test_strix
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile devicename=npu2  
- // RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
+ // RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/run_strix_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/run_strix_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_strix
 // RUN: cd test_placed_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2  
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 
   

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_makefile.lit
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu1, peano
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano 
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_strix_makefile.lit
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: mkdir -p test_strix
  // RUN: cd test_strix
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile devicename=npu2 
- // RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
+ // RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_strix_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/run_strix_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_strix
 // RUN: cd test_placed_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 
   

--- a/programming_guide/section-2/section-2f/05_join_L2/run_makefile.lit
+++ b/programming_guide/section-2/section-2f/05_join_L2/run_makefile.lit
@@ -1,8 +1,8 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu1, peano
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run

--- a/programming_guide/section-2/section-2f/05_join_L2/run_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/05_join_L2/run_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run
   

--- a/programming_guide/section-2/section-2f/05_join_L2/run_strix_makefile.lit
+++ b/programming_guide/section-2/section-2f/05_join_L2/run_strix_makefile.lit
@@ -1,10 +1,10 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: mkdir -p test_strix
  // RUN: cd test_strix
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile devicename=npu2  
- // RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
+ // RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 

--- a/programming_guide/section-2/section-2f/05_join_L2/run_strix_makefile_placed.lit
+++ b/programming_guide/section-2/section-2f/05_join_L2/run_strix_makefile_placed.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_strix
 // RUN: cd test_placed_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env use_placed=1 make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 
   

--- a/programming_guide/section-3/run_makefile.lit
+++ b/programming_guide/section-3/run_makefile.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano 
+ // REQUIRES: ryzen_ai_npu1, peano 
  //
  // RUN: mkdir -p test_peano 
  // RUN: cd test_peano
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
- // RUN: %run_on_npu make -f %S/Makefile run_py
+ // RUN: %run_on_npu1% make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run_py

--- a/programming_guide/section-3/run_strix_makefile.lit
+++ b/programming_guide/section-3/run_strix_makefile.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano 
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: mkdir -p test_strix 
  // RUN: cd test_strix
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile devicename=npu2 
- // RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
- // RUN: %run_on_2npu make -f %S/Makefile run_py devicename=npu2 
+ // RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 
+ // RUN: %run_on_npu2% make -f %S/Makefile run_py devicename=npu2 

--- a/programming_guide/section-4/section-4a/run_makefile.lit
+++ b/programming_guide/section-4/section-4a/run_makefile.lit
@@ -1,9 +1,9 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu1, peano
  //
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile 
- // RUN: %run_on_npu make -f %S/Makefile run
- // RUN: %run_on_npu make -f %S/Makefile run_py
+ // RUN: %run_on_npu1% make -f %S/Makefile run
+ // RUN: %run_on_npu1% make -f %S/Makefile run_py

--- a/programming_guide/section-4/section-4a/run_strix_makefile.lit
+++ b/programming_guide/section-4/section-4a/run_strix_makefile.lit
@@ -1,11 +1,11 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
  // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  //
- // REQUIRES: ryzen_ai, peano
+ // REQUIRES: ryzen_ai_npu2, peano
  //
  // RUN: mkdir -p test_strix
  // RUN: cd test_strix
  // RUN: make -f %S/Makefile clean
  // RUN: make -f %S/Makefile devicename=npu2  
- // RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
- // RUN: %run_on_2npu make -f %S/Makefile run_py devicename=npu2 
+ // RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 
+ // RUN: %run_on_npu2% make -f %S/Makefile run_py devicename=npu2 

--- a/programming_guide/section-4/section-4b/run_makefile.lit
+++ b/programming_guide/section-4/section-4b/run_makefile.lit
@@ -1,14 +1,14 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_peano
 // RUN: cd test_peano
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=false make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run
-// RUN: %run_on_npu make -f %S/Makefile run_py
+// RUN: %run_on_npu1% make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile run_py
 // make -f %S/Makefile clean
-// env CHESS=false %run_on_npu make -f %S/Makefile trace
-// env CHESS=false %run_on_npu make -f %S/Makefile trace_py
+// env CHESS=false %run_on_npu1% make -f %S/Makefile trace
+// env CHESS=false %run_on_npu1% make -f %S/Makefile trace_py

--- a/programming_guide/section-4/section-4b/run_makefile_placed.lit
+++ b/programming_guide/section-4/section-4b/run_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2024 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu1, peano
 //
 // RUN: mkdir -p test_placed
 // RUN: cd test_placed
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true use_placed=1 make -f %S/Makefile 
-// RUN: %run_on_npu make -f %S/Makefile run 
+// RUN: %run_on_npu1% make -f %S/Makefile run 
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace 
-// RUN: env CHESS=false use_placed=1 %run_on_npu make -f %S/Makefile trace_py 
+// RUN: env CHESS=false use_placed=1 %run_on_npu1% make -f %S/Makefile trace 
+// RUN: env CHESS=false use_placed=1 %run_on_npu1% make -f %S/Makefile trace_py 

--- a/programming_guide/section-4/section-4b/run_strix_makefile.lit
+++ b/programming_guide/section-4/section-4b/run_strix_makefile.lit
@@ -1,14 +1,14 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_peano_strix
 // RUN: cd test_peano_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=false make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run_py devicename=npu2 
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 
+// RUN: %run_on_npu2% make -f %S/Makefile run_py devicename=npu2 
 // make -f %S/Makefile clean
-// env CHESS=false %run_on_2npu make -f %S/Makefile trace devicename=npu2 
-// env CHESS=false %run_on_2npu make -f %S/Makefile trace_py devicename=npu2 
+// env CHESS=false %run_on_npu2% make -f %S/Makefile trace devicename=npu2 
+// env CHESS=false %run_on_npu2% make -f %S/Makefile trace_py devicename=npu2 

--- a/programming_guide/section-4/section-4b/run_strix_makefile_placed.lit
+++ b/programming_guide/section-4/section-4b/run_strix_makefile_placed.lit
@@ -1,13 +1,13 @@
 // (c) Copyright 2025 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai, peano 
+// REQUIRES: ryzen_ai_npu2, peano
 //
 // RUN: mkdir -p test_placed_strix
 // RUN: cd test_placed_strix
 // RUN: make -f %S/Makefile clean
 // RUN: env CHESS=true use_placed=1 make -f %S/Makefile devicename=npu2 
-// RUN: %run_on_2npu make -f %S/Makefile run devicename=npu2 
+// RUN: %run_on_npu2% make -f %S/Makefile run devicename=npu2 
 // RUN: make -f %S/Makefile clean
-// RUN: env CHESS=false use_placed=1 %run_on_2npu make -f %S/Makefile trace devicename=npu2 
-// RUN: env CHESS=false use_placed=1 %run_on_2npu make -f %S/Makefile trace_py devicename=npu2 
+// RUN: env CHESS=false use_placed=1 %run_on_npu2% make -f %S/Makefile trace devicename=npu2 
+// RUN: env CHESS=false use_placed=1 %run_on_npu2% make -f %S/Makefile trace_py devicename=npu2 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -23,7 +23,7 @@ from lit.llvm.subst import FindTool
 # Configuration file for the 'lit' test runner.
 
 # name: The name of this test suite.
-config.name = "AIE"
+config.name = "AIE_TEST"
 
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.environment["PYTHONPATH"] = "{}".format(
@@ -165,17 +165,15 @@ if config.xrt_lib_dir:
                 model = str(m.group(4))
             print(f"\tmodel: '{model}'")
             config.available_features.add("ryzen_ai")
-            run_on_npu = (
-                f"flock /tmp/npu.lock {config.aie_src_root}/utils/run_on_npu.sh"
-            )
+            run_on_npu = f"{config.aie_src_root}/utils/run_on_npu.sh"
             if model in ["npu1", "Phoenix"]:
                 run_on_npu1 = run_on_npu
                 config.available_features.add("ryzen_ai_npu1")
-                print("Running tests on NPU with command line: ", run_on_npu1)
+                print("Running tests on NPU1 with command line: ", run_on_npu1)
             elif model in ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"]:
                 run_on_npu2 = run_on_npu
                 config.available_features.add("ryzen_ai_npu2")
-                print("Running tests on NPU with command line: ", run_on_npu2)
+                print("Running tests on NPU4 with command line: ", run_on_npu2)
             else:
                 print("WARNING: xrt-smi reported unknown NPU model '{model}'.")
             break

--- a/utils/run_on_npu.sh
+++ b/utils/run_on_npu.sh
@@ -3,9 +3,6 @@
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Don't require root.
-export XRT_HACK_UNSECURE_LOADING_XCLBIN=1 
-
 XRT_DIR=/opt/xilinx/xrt
 source $XRT_DIR/setup.sh
 


### PR DESCRIPTION
Remove outdated flock and environment variable for running npu tests. At the same time update the lit substitutions for programming examples and programming guide to match https://github.com/Xilinx/mlir-aie/pull/2232.