### PR TITLE
Fix `bf16` GEMM on Strix using Peano

### DIFF
--- a/aie_kernels/aie2p/mm.cc
+++ b/aie_kernels/aie2p/mm.cc
@@ -214,9 +214,9 @@ matmul_vectorized_8x8x8_bf16_bf16(const bfloat16 *__restrict pA,
 
   // After extensive experimentation, the 8x8x8 aie::mmul size was found to be
   // optimal for AIE2P, in combination with the 2x2 mmul expanded kernel
-  constexpr int r = 8;
+  constexpr int r = 4;
   constexpr int s = 8;
-  constexpr int t = 8;
+  constexpr int t = 4;
 
   // Since the kernel has been expanded 2 times for both A ('m' dimension) and B
   // ('n' dimension), the following assertions veirify this even division for
@@ -239,9 +239,9 @@ matmul_vectorized_8x8x8_bf16_f32(const bfloat16 *__restrict pA,
 
   // After extensive experimentation, the 4x8x4 aie::mmul size was found to be
   // optimal for AIE2P, in combination with the 2x2 mmul expanded kernel
-  constexpr int r = 8;
+  constexpr int r = 4;
   constexpr int s = 8;
-  constexpr int t = 8;
+  constexpr int t = 4;
 
   // Since the kernel has been expanded 2 times for both A ('m' dimension) and B
   // ('n' dimension), the following assertions veirify this even division for

--- a/programming_examples/basic/matrix_multiplication/single_core/single_core.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/single_core.py
@@ -91,9 +91,9 @@ def my_matmul(
             t = 4
     else:
         if dtype_in_str == "bf16":
-            r = 8
+            r = 4
             s = 8
-            t = 8
+            t = 4
         elif dtype_in_str == "i8":
             r = 8
             s = 8

--- a/programming_examples/basic/matrix_multiplication/single_core/single_core_iron.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/single_core_iron.py
@@ -114,9 +114,9 @@ def my_matmul(
             t = 4
     else:
         if dtype_in_str == "bf16":
-            r = 8
+            r = 4
             s = 8
-            t = 8
+            t = 4
         elif dtype_in_str == "i8":
             r = 8
             s = 8

--- a/programming_examples/basic/matrix_multiplication/single_core/single_core_placed.py
+++ b/programming_examples/basic/matrix_multiplication/single_core/single_core_placed.py
@@ -117,9 +117,9 @@ def my_matmul(
             t = 4
     else:
         if dtype_in_str == "bf16":
-            r = 8
+            r = 4
             s = 8
-            t = 8
+            t = 4
         elif dtype_in_str == "i8":
             r = 8
             s = 8

--- a/programming_examples/basic/matrix_multiplication/whole_array/whole_array.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/whole_array.py
@@ -126,9 +126,9 @@ def my_matmul(
             t = 4
     else:
         if dtype_in_str == "bf16":
-            r = 8
+            r = 4
             s = 8
-            t = 8
+            t = 4
         elif dtype_in_str == "i8":
             r = 8
             s = 8

--- a/programming_examples/basic/matrix_multiplication/whole_array/whole_array_iron.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/whole_array_iron.py
@@ -122,9 +122,9 @@ def my_matmul(
             t = 4
     else:
         if dtype_in_str == "bf16":
-            r = 8
+            r = 4
             s = 8
-            t = 8
+            t = 4
         elif dtype_in_str == "i8":
             r = 8
             s = 8

--- a/programming_examples/basic/matrix_multiplication/whole_array/whole_array_placed.py
+++ b/programming_examples/basic/matrix_multiplication/whole_array/whole_array_placed.py
@@ -125,9 +125,9 @@ def my_matmul(
             t = 4
     else:
         if dtype_in_str == "bf16":
-            r = 8
+            r = 4
             s = 8
-            t = 8
+            t = 4
         elif dtype_in_str == "i8":
             r = 8
             s = 8


### PR DESCRIPTION
Fixes #2383. The AIE API supposedly supports an `8x8x8` GEMM for `bf16`, but the way this is achieved is through emulation via bfp16. See footnote (e) in the table [here](https://xilinx.github.io/aie_api/group__group__mmul.html).

Something in this emulation code seems to break in peano (chess is fine). As a fix for now, let's choose a different intrinsic size -- `4x8x4` -- that does not rely on this emulation. This restores the GEMM to functional. Drawback: may come with a performance penalty.

@L-roro mostly investigated and came up with this fix.

Related: PR #2385 adds the required `-DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16` flag to peano as well (currently only chess is called with this flag). With that PR merged, when the issue in peano is fixed, we can consider switching the AIE API call back to the `8x8x8` variant.