### PR TITLE
Support aiebu elf format for instruction binaries

### DIFF
--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -323,6 +323,20 @@ def parse_args(args=None):
         default="0x901",
         help="Kernel id in xclbin file",
     )
+    parser.add_argument(
+        "--aie-generate-elf",
+        dest="elf",
+        default=False,
+        action="store_const",
+        const=True,
+        help="Generate elf for AIE control and/or configuration",
+    )
+    parser.add_argument(
+        "--elf-name",
+        dest="elf_name",
+        default="design.elf",
+        help="Output elf filename for ELF target",
+    )
 
     opts = parser.parse_args(args)
     return opts

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1160,10 +1160,10 @@ class FlowRunner:
                             asm_bin = None
 
                     if asm_bin is None:
-                        print(
-                            "Warning: aiebu-asm not found. Skipping NPU elf binary generation.",
-                            file=sys.stderr,
-                        )
+                        if opts.verbose:
+                            print(
+                                "Warning: aiebu-asm not found. Skipping NPU elf binary generation."
+                            )
                         return
 
                     await self.do_call(

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1150,13 +1150,6 @@ class FlowRunner:
                     with open(opts.insts_name, "wb") as f:
                         f.write(struct.pack("I" * len(npu_insts), *npu_insts))
 
-                    asm_bin = os.path.join(
-                        aie.compiler.aiecc.configure.install_path(),
-                        "aiebu",
-                        "aiebu",
-                        "bin",
-                        "aiebu-asm",
-                    )
                     # exteral_buffers_json = {
                     #     "external_buffers": {
                     #         "buffer0" : {
@@ -1178,6 +1171,23 @@ class FlowRunner:
                     # }
                     # with open(self.prepend_tmp("external_buffers.json"), "w") as f:
                     #     json.dump(exteral_buffers_json, f, indent=2)
+
+                    # find aiebu-asm binary
+                    asm_bin = "aiebu-asm"
+                    if shutil.which(asm_bin) is None:
+                        asm_bin = os.path.join(
+                            "/", "opt", "xilinx", "aiebu", "bin", "aiebu-asm"
+                        )
+                        if shutil.which(asm_bin) is None:
+                            asm_bin = None
+
+                    if asm_bin is None:
+                        print(
+                            "Warning: aiebu-asm not found. Skipping NPU elf binary generation.",
+                            file=sys.stderr,
+                        )
+                        return
+
                     await self.do_call(
                         None,
                         [

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -639,38 +639,37 @@ class FlowRunner:
             )
             # translate npu instructions to binary and write to file
             npu_insts = aiedialect.translate_npu_to_binary(npu_insts_module.operation)
-            npu_insts_bin = self.prepend_tmp("npu_insts.bin")
-            with open(npu_insts_bin, "wb") as f:
-                f.write(struct.pack("I" * len(npu_insts), *npu_insts))
 
-            # find aiebu-asm binary
-            asm_bin = "aiebu-asm"
+        npu_insts_bin = self.prepend_tmp("npu_insts.bin")
+        with open(npu_insts_bin, "wb") as f:
+            f.write(struct.pack("I" * len(npu_insts), *npu_insts))
+
+        # find aiebu-asm binary
+        asm_bin = "aiebu-asm"
+        if shutil.which(asm_bin) is None:
+            asm_bin = os.path.join("/", "opt", "xilinx", "aiebu", "bin", "aiebu-asm")
             if shutil.which(asm_bin) is None:
-                asm_bin = os.path.join(
-                    "/", "opt", "xilinx", "aiebu", "bin", "aiebu-asm"
-                )
-                if shutil.which(asm_bin) is None:
-                    asm_bin = None
+                asm_bin = None
 
-            if asm_bin is None:
-                print(
-                    "Error: aiebu-asm not found, generation of ELF file failed.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-
-            await self.do_call(
-                None,
-                [
-                    asm_bin,
-                    "-t",
-                    "aie2txn",
-                    "-c",
-                    npu_insts_bin,
-                    "-o",
-                    opts.elf_name,
-                ],
+        if asm_bin is None:
+            print(
+                "Error: aiebu-asm not found, generation of ELF file failed.",
+                file=sys.stderr,
             )
+            sys.exit(1)
+
+        await self.do_call(
+            None,
+            [
+                asm_bin,
+                "-t",
+                "aie2txn",
+                "-c",
+                npu_insts_bin,
+                "-o",
+                opts.elf_name,
+            ],
+        )
 
     async def process_pdi_gen(self):
 

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1150,6 +1150,47 @@ class FlowRunner:
                     with open(opts.insts_name, "wb") as f:
                         f.write(struct.pack("I" * len(npu_insts), *npu_insts))
 
+                    asm_bin = os.path.join(
+                        aie.compiler.aiecc.configure.install_path(),
+                        "aiebu",
+                        "aiebu",
+                        "bin",
+                        "aiebu-asm",
+                    )
+                    # exteral_buffers_json = {
+                    #     "external_buffers": {
+                    #         "buffer0" : {
+                    #             "kernel_id" : 0,
+                    #             "logical_id": 0,
+                    #             "name": "bo0",
+                    #         },
+                    #         "buffer1" : {
+                    #             "kernel_id" : 1,
+                    #             "logical_id": 1,
+                    #             "name": "bo1",
+                    #         },
+                    #         "buffer2" : {
+                    #             "kernel_id" : 2,
+                    #             "logical_id": 2,
+                    #             "name": "bo2",
+                    #         },
+                    #     }
+                    # }
+                    # with open(self.prepend_tmp("external_buffers.json"), "w") as f:
+                    #     json.dump(exteral_buffers_json, f, indent=2)
+                    await self.do_call(
+                        None,
+                        [
+                            asm_bin,
+                            "-t",
+                            "aie2txn",
+                            "-c",
+                            opts.insts_name,
+                            "-o",
+                            opts.insts_name + ".elf",
+                        ],
+                    )
+
             # fmt: off
             if opts.unified:
                 file_opt_with_addresses = self.prepend_tmp("input_opt_with_addresses.mlir")

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -629,7 +629,7 @@ class FlowRunner:
             module = Module.parse(module_str)
             pass_pipeline = NPU_LOWERING_PIPELINE.materialize(module=True)
             npu_insts_mlir = (
-                self.prepend_tmp("npu_insts.mlir") if self.opts.verbose else None
+                self.prepend_tmp("elf_insts.mlir") if self.opts.verbose else None
             )
             npu_insts_module = run_passes_module(
                 pass_pipeline,
@@ -640,7 +640,7 @@ class FlowRunner:
             # translate npu instructions to binary and write to file
             npu_insts = aiedialect.translate_npu_to_binary(npu_insts_module.operation)
 
-        npu_insts_bin = self.prepend_tmp("npu_insts.bin")
+        npu_insts_bin = self.prepend_tmp("elf_insts.bin")
         with open(npu_insts_bin, "wb") as f:
             f.write(struct.pack("I" * len(npu_insts), *npu_insts))
 

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -1150,28 +1150,6 @@ class FlowRunner:
                     with open(opts.insts_name, "wb") as f:
                         f.write(struct.pack("I" * len(npu_insts), *npu_insts))
 
-                    # exteral_buffers_json = {
-                    #     "external_buffers": {
-                    #         "buffer0" : {
-                    #             "kernel_id" : 0,
-                    #             "logical_id": 0,
-                    #             "name": "bo0",
-                    #         },
-                    #         "buffer1" : {
-                    #             "kernel_id" : 1,
-                    #             "logical_id": 1,
-                    #             "name": "bo1",
-                    #         },
-                    #         "buffer2" : {
-                    #             "kernel_id" : 2,
-                    #             "logical_id": 2,
-                    #             "name": "bo2",
-                    #         },
-                    #     }
-                    # }
-                    # with open(self.prepend_tmp("external_buffers.json"), "w") as f:
-                    #     json.dump(exteral_buffers_json, f, indent=2)
-
                     # find aiebu-asm binary
                     asm_bin = "aiebu-asm"
                     if shutil.which(asm_bin) is None:

--- a/test/npu-xrt/add_one_objFifo_elf/aie.mlir
+++ b/test/npu-xrt/add_one_objFifo_elf/aie.mlir
@@ -1,0 +1,55 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(NPUDEVICE) {
+    %t00 = aie.tile(0, 0)
+    %t01 = aie.tile(0, 1)
+    %t02 = aie.tile(0, 2)
+  
+    aie.objectfifo @objFifo_in0(%t00, {%t01}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @objFifo_in1(%t01, {%t02}, 2 : i32) : !aie.objectfifo<memref<8xi32>>
+    aie.objectfifo.link [@objFifo_in0] -> [@objFifo_in1] ([] [])
+
+    aie.objectfifo @objFifo_out1(%t02, {%t01}, 2 : i32) : !aie.objectfifo<memref<8xi32>>
+    aie.objectfifo @objFifo_out0(%t01, {%t00}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.link [@objFifo_out1] -> [@objFifo_out0] ([] [])
+  
+    aie.core(%t02) {
+      %c8 = arith.constant 8 : index
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c1_32 = arith.constant 41 : i32
+  
+      scf.for %steps = %c0 to %c8 step %c1 {
+        %subview0 = aie.objectfifo.acquire @objFifo_in1(Consume, 1) : !aie.objectfifosubview<memref<8xi32>>
+        %elem0 = aie.objectfifo.subview.access %subview0[0] : !aie.objectfifosubview<memref<8xi32>> -> memref<8xi32>
+        %subview1 = aie.objectfifo.acquire @objFifo_out1(Produce, 1) : !aie.objectfifosubview<memref<8xi32>>
+        %elem1 = aie.objectfifo.subview.access %subview1[0] : !aie.objectfifosubview<memref<8xi32>> -> memref<8xi32>
+        scf.for %arg3 = %c0 to %c8 step %c1 {
+            %0 = memref.load %elem0[%arg3] : memref<8xi32>
+            %1 = arith.addi %0, %c1_32 : i32
+            memref.store %1, %elem1[%arg3] : memref<8xi32>
+        }
+        aie.objectfifo.release @objFifo_in1(Consume, 1)
+        aie.objectfifo.release @objFifo_out1(Produce, 1)
+      }
+      aie.end
+    }
+    aiex.runtime_sequence(%in : memref<64xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c64 = arith.constant 64 : i64
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_wait { symbol = @objFifo_out0 }
+    }
+  }
+}

--- a/test/npu-xrt/add_one_objFifo_elf/run.lit
+++ b/test/npu-xrt/add_one_objFifo_elf/run.lit
@@ -6,7 +6,7 @@
 // RUN: cp %S/aie.mlir aie_arch.mlir
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-elf --elf-name=insts.elf --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
-// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin.elf
-// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin.elf
+// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf
+// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf

--- a/test/npu-xrt/add_one_objFifo_elf/run.lit
+++ b/test/npu-xrt/add_one_objFifo_elf/run.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2023 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+//
+// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin.elf
+// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin.elf

--- a/test/npu-xrt/add_one_objFifo_elf/run.lit
+++ b/test/npu-xrt/add_one_objFifo_elf/run.lit
@@ -6,7 +6,7 @@
 // RUN: cp %S/aie.mlir aie_arch.mlir
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
 // RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-elf --elf-name=insts.elf --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie_arch.mlir
+// RUN: %python aiecc.py --aie-generate-xclbin --xclbin-name=aie.xclbin --aie-generate-elf --elf-name=insts.elf --no-compile-host ./aie_arch.mlir
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf
 // RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.elf

--- a/test/npu-xrt/add_one_objFifo_elf/test.cpp
+++ b/test/npu-xrt/add_one_objFifo_elf/test.cpp
@@ -19,9 +19,9 @@
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"
 
-#include "experimental/xrt_elf.h"
-#include "experimental/xrt_module.h"
-#include "experimental/xrt_ext.h"
+#include "xrt/experimental/xrt_elf.h"
+#include "xrt/experimental/xrt_module.h"
+#include "xrt/experimental/xrt_ext.h"
 
 #include "cxxopts.hpp"
 #include "test_utils.h"
@@ -82,13 +82,9 @@ int main(int argc, const char *argv[]) {
     std::cout << "Getting handle to kernel:" << kernelName << "\n";
   auto kernel = xrt::ext::kernel(context, mod, kernelName);
 
-  // TODO: what are the requirements to use xrt::ext::bo here?
-  auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(int32_t),
-                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
-  auto bo_inB = xrt::bo(device, IN_SIZE * sizeof(int32_t),
-                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
-  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
-                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+  xrt::bo bo_inA = xrt::ext::bo{device, IN_SIZE * sizeof(int32_t)};
+  xrt::bo bo_inB = xrt::ext::bo{device, IN_SIZE * sizeof(int32_t)};
+  xrt::bo bo_out = xrt::ext::bo{device, OUT_SIZE * sizeof(int32_t)};
 
   if (verbosity >= 1)
     std::cout << "Writing data into buffer objects.\n";

--- a/test/npu-xrt/add_one_objFifo_elf/test.cpp
+++ b/test/npu-xrt/add_one_objFifo_elf/test.cpp
@@ -1,0 +1,135 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2023, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include "experimental/xrt_elf.h"
+#include "experimental/xrt_module.h"
+#include "experimental/xrt_ext.h"
+
+#include "cxxopts.hpp"
+#include "test_utils.h"
+
+constexpr int IN_SIZE = 64;
+constexpr int OUT_SIZE = 64;
+
+int main(int argc, const char *argv[]) {
+  // Program arguments parsing
+  cxxopts::Options options("add_one_objFifo_elf");
+  test_utils::add_default_options(options);
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
+  int verbosity = vm["verbosity"].as<int>();
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  if (verbosity >= 1)
+    std::cout << "Loading xclbin: " << vm["xclbin"].as<std::string>() << "\n";
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+
+  if (verbosity >= 1)
+    std::cout << "Kernel opcode: " << vm["kernel"].as<std::string>() << "\n";
+  std::string Node = vm["kernel"].as<std::string>();
+
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 std::cout << "Name: " << name << std::endl;
+                                 return name.rfind(Node, 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  if (verbosity >= 1)
+    std::cout << "Registering xclbin: " << vm["xclbin"].as<std::string>()
+              << "\n";
+
+  device.register_xclbin(xclbin);
+
+  xrt::elf elf(vm["instr"].as<std::string>());
+  xrt::module mod{elf};
+
+  // get a hardware context
+  if (verbosity >= 1)
+    std::cout << "Getting hardware context.\n";
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  if (verbosity >= 1)
+    std::cout << "Getting handle to kernel:" << kernelName << "\n";
+  auto kernel = xrt::ext::kernel(context, mod, kernelName);
+
+  // TODO: what are the requirements to use xrt::ext::bo here?
+  auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_inB = xrt::bo(device, IN_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  if (verbosity >= 1)
+    std::cout << "Writing data into buffer objects.\n";
+
+  uint32_t *bufInA = bo_inA.map<uint32_t *>();
+  std::vector<uint32_t> srcVecA;
+  for (int i = 0; i < IN_SIZE; i++)
+    srcVecA.push_back(i + 1);
+  memcpy(bufInA, srcVecA.data(), (srcVecA.size() * sizeof(uint32_t)));
+
+  bo_inA.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running Kernel.\n";
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, 0, 0, bo_inA, bo_inB, bo_out);
+  run.wait2();
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  uint32_t *bufOut = bo_out.map<uint32_t *>();
+
+  int errors = 0;
+
+  for (uint32_t i = 0; i < 64; i++) {
+    uint32_t ref = i + 42;
+    if (*(bufOut + i) != ref) {
+      std::cout << "Error in output " << *(bufOut + i) << " != " << ref
+                << std::endl;
+      errors++;
+    } else {
+      std::cout << "Correct output " << *(bufOut + i) << " == " << ref
+                << std::endl;
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  } else {
+    std::cout << "\nfailed.\n\n";
+    return 1;
+  }
+}

--- a/utils/build_drivers.sh
+++ b/utils/build_drivers.sh
@@ -72,10 +72,12 @@ case "$UBUNTU_VERSION" in
     "24.04")
         base_suffix="24.04-amd64-base.deb"
         dev_suffix="24.04-amd64-base-dev.deb"
+        runtime_suffix="24.04-amd64-Runtime.deb"
         ;;
     "24.10")
         base_suffix="24.10-amd64-base.deb"
         dev_suffix="24.10-amd64-base-dev.deb"
+        runtime_suffix="24.10-amd64-Runtime.deb"
         ;;
     *)
         echo "Error: Unsupported Ubuntu version ($UBUNTU_VERSION). Supported versions: 24.04, 24.10"
@@ -86,14 +88,17 @@ esac
 # Find matching .deb files
 base_pkg=$(ls *"$base_suffix" 2>/dev/null | head -n 1)
 dev_pkg=$(ls *"$dev_suffix" 2>/dev/null | head -n 1)
-if [[ -z "$base_pkg" || -z "$dev_pkg" ]]; then
-    echo "Error: Could not find .deb packages matching suffixes:"
+runtime_pkg=$(ls *"$runtime_suffix" 2>/dev/null | head -n 1)
+if [[ -z "$base_pkg" || -z "$dev_pkg" || -z "$runtime_pkg" ]]; then
+    echo "Error: Could not find .deb packages matching one or more suffixes:"
     echo " - $base_suffix"
     echo " - $dev_suffix"
+    echo " - $runtime_suffix"
     exit 1
 fi
 sudo apt reinstall "./$base_pkg"
 sudo apt reinstall "./$dev_pkg"
+sudo apt reinstall "./$runtime_pkg"
 
 echo "Building XDNA Driver..."
 # Build XDNA Driver


### PR DESCRIPTION
* aiecc.py:  add `--aie-generate-elf` / `--elf-name` to generate ELF for runtime sequence control code using [aiebu](https://github.com/Xilinx/aiebu)
* add test which uses xrt::elf in test.cpp instead of loading insts.bin into a buffer
* update `build_drivers.sh` to install `xrt-Runtime` deb to get aiebu. aiebu can also be in PATH which will override the default location.
