### PR TITLE
Update ld script gen for https://github.com/Xilinx/llvm-aie/pull/504

### DIFF
--- a/lib/Targets/AIETargetLdScript.cpp
+++ b/lib/Targets/AIETargetLdScript.cpp
@@ -131,6 +131,9 @@ SECTIONS
   .strtab : {
      *(.strtab)
   }
+  .stack_sizes : {
+     *(.stack_sizes)
+  }
 
 )THESCRIPT";
       auto doBuffer = [&](std::optional<TileID> tile, int offset,


### PR DESCRIPTION
`crtl.o` for aie2p is compiled with `-fstack-size-section` [in latest llvm-aie](https://github.com/Xilinx/llvm-aie/pull/504/files#diff-32f3985711212f7aced52bed4ea4e3138025a46c5e250cb57bbf96fe508a928aR21) nightly wheel. This has resulted in failures in CI on aie2p in this repository: 
```
ld.lld: error: /home/github/actions-runner/_work/mlir-aie/mlir-aie/ironenv/lib/python3.12/site-packages/llvm-aie/bin/../lib/aie2p-none-unknown-elf/crt1.o:(.stack_sizes) is being placed in '.stack_sizes'
clang: error: ld.lld command failed with exit code 1 (use -v to see invocation)
```
As a wild guess I added `.stack_sizes` to the linker script generated by aiecc and it fixed the problem locally.