### PR TITLE
Correct dlt for bfp

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1771,6 +1771,10 @@ LogicalResult DMABDOp::verify() {
     if (getBufferElementTypeWidthInBytes() < 4 && dims->back().getStride() != 1)
       return emitOpError(
           "For <32b width datatypes, inner-most dim stride must be 1");
+
+    if (getBufferElementTypeWidthInBytes() > 4 && dims->back().getStride() != 1)
+      return emitOpError(
+          "For >32b width datatypes, inner-most dim stride must be 1");
   }
   if (auto paddims = getPadDimensions(); paddims.has_value()) {
     auto dims = getDimensions();

--- a/test/dialect/AIE/bad_dma_op.mlir
+++ b/test/dialect/AIE/bad_dma_op.mlir
@@ -50,3 +50,21 @@ module {
     }
   }
 }
+
+// -----
+
+// CHECK: For >32b width datatypes, inner-most dim stride must be 1 
+module {
+  aie.device(npu1) {
+    %tile14 = aie.tile(1, 4)
+    %buf14 = aie.buffer(%tile14) { sym_name = "buf14" } : memref<128x!aiex.bfp<"v8bfp16ebs8">>
+    %mem14 = aie.mem(%tile14) {
+      %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
+      ^bd0:
+        aie.dma_bd(%buf14 : memref<128x!aiex.bfp<"v8bfp16ebs8">>, 0, 128, [<size = 8, stride = 16>]) {}
+        aie.next_bd ^end
+      ^end: 
+        aie.end
+    }
+  }
+}


### PR DESCRIPTION
This is an oversight on my end when I implemented blocked datatypes that I only realized when testing data layout transformations more extensively. This corrects this oversights. A test showing that data layout transformations now work correctly is coming in a separate pr with gemm examples using bfp16 as input.