### PR TITLE
Use a new release for nightly wheels

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -162,8 +162,8 @@ jobs:
         with:
           artifacts: wheelhouse/repaired_wheel/mlir_aie*whl
           token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: 'latest-wheels'
-          name: 'latest-wheels'
+          tag: 'latest-wheels-2'
+          name: 'latest-wheels-2'
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true


### PR DESCRIPTION
Temporary fix that adds a new release `latest-wheels-2` for nightly wheels