### PR TITLE
Ignore peano `-Wmissing-template-arg-list-after-template-kw` in programming examples

### DIFF
--- a/programming_examples/makefile-common
+++ b/programming_examples/makefile-common
@@ -5,7 +5,7 @@ AIE2_INCLUDE_DIR ?= ${AIETOOLS_DIR}/data/aie_ml/lib
 
 AIEOPT_DIR ?= $(shell realpath $(dir $(shell which aie-opt))/..)
 
-WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body
+WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body -Wno-missing-template-arg-list-after-template-kw
 
 CHESSCC1_FLAGS = -f -p me -P ${AIE_INCLUDE_DIR} -I ${AIETOOLS_DIR}/include
 CHESSCC2_FLAGS = -f -p me -P ${AIE2_INCLUDE_DIR} -I ${AIETOOLS_DIR}/include


### PR DESCRIPTION
Using nightly peano causes our programming examples to no longer compile (and the CI to fail) with:

```
error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
```

We have a bunch of code that uses `template` without a argument list after in the AIE API C++ code.

I'm not sure if this points to an actual issue in the AIE API C++ code. Please advise if there is a more fundamental fix needed.