### PR TITLE
CI Tests on Strix Halo 

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -131,7 +131,9 @@ if config.xrt_lib_dir:
         result = result.stdout.decode("utf-8").split("\n")
         # Older format is "|[0000:41:00.1]  ||RyzenAI-npu1  |"
         # Newer format is "|[0000:41:00.1]  |NPU Phoenix  |"
+        # p = re.compile(r"[\|]?(\[.+:.+:.+\]).+\|(RyzenAI-(npu\d)|NPU ([^\|]+))\W*\|")
         p = re.compile(r"[\|]?(\[.+:.+:.+\]).+\|(RyzenAI-(npu\d)|NPU (\w+))\W*\|")
+
         for l in result:
             m = p.match(l)
             if not m:
@@ -141,7 +143,7 @@ if config.xrt_lib_dir:
             if m.group(3):
                 model = str(m.group(3))
             if m.group(4):
-                model = str(m.group(4))
+                model = str(m.group(4))#.strip()
             print(f"\tmodel: '{model}'")
             config.available_features.add("ryzen_ai")
             run_on_npu = f"{config.aie_src_root}/utils/run_on_npu.sh"


### PR DESCRIPTION
In the various `lit.cfg.py`, the regex used on the output of the `xrt-smi` (or `xbutil`) to determine which device we are using is broken for Strix Halo. Even if we don't use Strix Halo for the GitHub action CI, it's useful for developers to run the CI tests locally.

Here is the output of `xrt-smi` or `xbutil`:
```
Device(s) Present
|BDF             |Name            |
|----------------|----------------|
|[0000:c6:00.1]  |NPU Strix Halo  |
```

Changing `[\|]?(\[.+:.+:.+\]).+\|(RyzenAI-(npu\d)|NPU (\w+))\W*\|` to `[\|]?(\[.+:.+:.+\]).+\|(RyzenAI-(npu\d)|NPU ([^\|]+))\W*\|` does the trick to also match Strix Halo (with a `.strip()` to remove the trailing white spaces).


Note: First version of this PR is without modification just to test if the CI passes from my fork.