### PR TITLE
Run the CI Nightly at Midnight

### DIFF
--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -8,6 +8,9 @@ on:
     types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
   merge_group:
+  schedule:
+    # Runs at midnight (00:00) every day
+    - cron: '0 0 * * *'
 
 defaults:
   run:

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -8,6 +8,9 @@ on:
     types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
   merge_group:
+  schedule:
+    # Runs at midnight (00:00) every day
+    - cron: '0 0 * * *'
 
 env:
   # Run apt package manager in the CI in non-interactive mode.

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -7,6 +7,9 @@ on:
       - test-ryzen-ai
   pull_request:
   merge_group:
+  schedule:
+    # Runs at midnight (00:00) every day
+    - cron: '0 0 * * *'
 
   # Allows you to run this workflow manually from the Actions tab by
   # selecting CI and then "Run workflow" menu on the right branch

--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -12,6 +12,9 @@ on:
         type: string
         required: false
         default: ''
+  schedule:
+    # Runs at midnight (00:00) every day
+    - cron: '0 0 * * *'
 
 defaults:
   run:

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -10,6 +10,9 @@ on:
         required: false
         default: ''
   merge_group:
+  schedule:
+    # Runs at midnight (00:00) every day
+    - cron: '0 0 * * *'
 
   schedule:
     # At 04:00. (see https://crontab.guru)

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -5,6 +5,9 @@ on:
     types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
   merge_group:
+  schedule:
+    # Runs at midnight (00:00) every day
+    - cron: '0 0 * * *'
 
 env:
   # Run apt package manager in the CI in non-interactive mode.


### PR DESCRIPTION
Several of our dependencies are nightly builds (for instance Peano). To naturally track if one of our dependency is breaking IRON, we can run the CI every night at midnight.