### PR TITLE
Make matplotlib dependency optional

### DIFF
--- a/python/helpers/taplib/tap.py
+++ b/python/helpers/taplib/tap.py
@@ -10,7 +10,6 @@ from .utils import (
     validate_offset,
     validate_tensor_dims,
 )
-from .visualization2d import visualize_from_accesses
 
 
 class TensorAccessPattern:
@@ -245,6 +244,8 @@ class TensorAccessPattern:
         Raises:
             NotImplementedError: This function is not implemented for all dimensions.
         """
+        from .visualization2d import visualize_from_accesses
+
         if len(self._tensor_dims) != 2:
             raise NotImplementedError(
                 "Visualization is only currently supported for 1- or 2-dimensional tensors"

--- a/python/helpers/taplib/tas.py
+++ b/python/helpers/taplib/tas.py
@@ -243,9 +243,7 @@ class TensorAccessSequence(abc.MutableSequence, abc.Iterable):
             combined_access_order_tensor -= 1
         return (combined_access_order_tensor, combined_access_count_tensor)
 
-    def animate(
-        self, title: str | None = None, animate_access_count: bool = False
-    ):
+    def animate(self, title: str | None = None, animate_access_count: bool = False):
         """
         Creates and returns a handle to a TensorAccessSequence animation. Each frame
         in the animation represents one TensorAccessPattern in the sequence.

--- a/python/helpers/taplib/tas.py
+++ b/python/helpers/taplib/tas.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from collections import abc
 from copy import deepcopy
-import matplotlib.animation as animation
 import numpy as np
 from typing import Callable, Sequence
 
@@ -11,7 +10,6 @@ from .utils import (
     validate_offset,
     validate_tensor_dims,
 )
-from .visualization2d import animate_from_accesses, visualize_from_accesses
 
 
 class TensorAccessSequence(abc.MutableSequence, abc.Iterable):
@@ -247,7 +245,7 @@ class TensorAccessSequence(abc.MutableSequence, abc.Iterable):
 
     def animate(
         self, title: str | None = None, animate_access_count: bool = False
-    ) -> animation.FuncAnimation:
+    ):
         """
         Creates and returns a handle to a TensorAccessSequence animation. Each frame
         in the animation represents one TensorAccessPattern in the sequence.
@@ -262,6 +260,8 @@ class TensorAccessSequence(abc.MutableSequence, abc.Iterable):
         Returns:
             animation.FuncAnimation: A handle to the animation, produced by the matplotlib.animation module.
         """
+        from .visualization2d import animate_from_accesses
+
         if len(self._tensor_dims) != 2:
             raise NotImplementedError(
                 "Visualization is only currently supported for 1- or 2-dimensional tensors"
@@ -317,6 +317,8 @@ class TensorAccessSequence(abc.MutableSequence, abc.Iterable):
         Raises:
             NotImplementedError: Not all dimensions of tensor may be visualized.
         """
+        from .visualization2d import visualize_from_accesses
+
         if len(self._tensor_dims) != 2:
             raise NotImplementedError(
                 "Visualization is only currently supported for 1- or 2-dimensional tensors"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,6 +9,5 @@ rich
 setuptools
 wheel
 ml_dtypes
-matplotlib
 pre-commit
 nanobind>=2.5

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,6 @@ PyYAML>=6.0.2
 aiofiles
 cmake>=3.29, <4.0
 dataclasses>=0.6, <=0.8
-filelock==3.13.1
 numpy>=1.19.5, <2.0 # 2.1 would be nice for typing improvements, but it doesn't seem to work well with pyxrt
 pybind11>=2.9.0, <=2.10.3
 rich


### PR DESCRIPTION
This PR makes the matplotlib dependency optional (only when visualize2d is loaded). 

`filelock` also appears not to be used.