### PR TITLE
Avoid generating `ub.poison` when collapsing vector shape

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
@@ -451,7 +451,9 @@ struct FlattenMultDimTransferReadPattern
         rewriter, readOp.getLoc(), vecShape.size(), adaptor.getBase());
     auto newVector = rewriter.create<vector::TransferReadOp>(
         readOp.getLoc(), newVectorTy, newSource, newIndices,
-        /*padding*/ std::nullopt);
+        /*padding*/
+        arith::getZeroConstant(rewriter, readOp.getLoc(),
+                               newVectorTy.getElementType()));
 
     auto inBoundsArrayAttrOpt = adaptor.getInBounds();
     if (inBoundsArrayAttrOpt) {

--- a/test/Conversion/VectorToAIEVec/leading-unit-dim-contract.mlir
+++ b/test/Conversion/VectorToAIEVec/leading-unit-dim-contract.mlir
@@ -47,8 +47,8 @@ func.func @matmul(%A : memref<1x1x4x8x4x8xbf16, 2 : i32>,
 // CHECK-SAME:        %[[A:.*]]: memref<1x1x4x8x4x8xbf16, 2 : i32>,
 // CHECK-SAME:        %[[B:.*]]: memref<1x1x8x4x8x4xbf16, 2 : i32>,
 // CHECK-SAME:        %[[C:.*]]: memref<1x1x8x8x4x4xf32, 2 : i32>) {
-// CHECK:         %[[C0F32:.*]] = ub.poison : f32
-// CHECK:         %[[C0BF16:.*]] = ub.poison : bf16
+// CHECK:         %[[C0BF16:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:         %[[C0F32:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:         %[[CSA:.*]] = memref.collapse_shape %[[A]] {{\[\[}}0, 1, 2, 3, 4, 5]]
 // CHECK:         %[[CSB:.*]] = memref.collapse_shape %[[B]] {{\[\[}}0, 1, 2, 3, 4, 5]]
 // CHECK:         %[[CSC:.*]] = memref.collapse_shape %[[C]] {{\[\[}}0, 1, 2, 3, 4, 5]]

--- a/test/dialect/AIEVec/precanonicalization-aieml.mlir
+++ b/test/dialect/AIEVec/precanonicalization-aieml.mlir
@@ -4,7 +4,7 @@
 // CHECK-SAME: %[[IMEM:[a-zA-Z0-9]+]]: memref<64x64x4x8xbf16>,
 // CHECK-SAME: %[[OMEM:[a-zA-Z0-9]+]]: memref<64x64x4x8xbf16>) {
 // CHECK:   %[[C0:.*]] = arith.constant 0 : index
-// CHECK:   %[[C0bf16:.*]] = ub.poison : bf16
+// CHECK:   %[[C0bf16:.*]] = arith.constant 0.000000e+00 : bf16
 // CHECK:   affine.for %[[I:.*]] = 0 to 64 {
 // CHECK:       affine.for %[[J:.*]] = 0 to 64 {
 // CHECK:           %[[FIMEM:.*]] = memref.collapse_shape %[[IMEM]]
@@ -47,7 +47,7 @@ func.func @multidim_vector_transfer(%in : memref<64x64x4x8xbf16>,
 // CHECK-LABEL: func.func @multidim_vector_transfer(
 // CHECK-SAME: %[[IMEM:[a-zA-Z0-9]+]]: memref<64x64x32x8xbf16>,
 // CHECK-SAME: %[[OMEM:[a-zA-Z0-9]+]]: memref<64x64x32x8xbf16>) {
-// CHECK:   %[[C0bf16:.*]] = ub.poison : bf16
+// CHECK:   %[[C0bf16:.*]] = arith.constant 0.000000e+00 : bf16
 // CHECK:   affine.for %[[I:.*]] = 0 to 64 {
 // CHECK:     affine.for %[[J:.*]] = 0 to 64 {
 // CHECK:       affine.for %[[K:.*]] = 0 to 32 step 4 {


### PR DESCRIPTION
- One case where `vector.transfer_read` builder creates `ub.poison`: https://github.com/llvm/llvm-project/blob/5a076e3b4d5ec26d8944bff129c1cae67a44b3ef/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td#L1446