### PR TITLE
Don't make wheel uploads latest

### DIFF
--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -435,4 +435,4 @@ jobs:
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true
-          makeLatest: true
+          makeLatest: false

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -442,4 +442,4 @@ jobs:
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true
-          makeLatest: true
+          makeLatest: false


### PR DESCRIPTION
Reserve the "latest release" tag for mlir-aie releases rather than wheel uploads 