### PR TITLE
chore(cmake): set cmake_minimum_required to 3.30 across tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,7 @@
 #  -DAIE_RUNTIME_TARGETS: list of targets (x86_64,aarch64) to build runtime libs for, default: x86_64; cross compilation for aarch64 against default Vitis Sysroot
 #  -DAIE_RUNTIME_TEST_TARGET: runtime test target (x86_64 or aarch64) used for running unit test and tutorials, default x86_64
 
-cmake_minimum_required(VERSION 3.23)
-
+cmake_minimum_required(VERSION 3.30)
 set(TOOLCHAINFILES_PATH ${CMAKE_SOURCE_DIR}/cmake/modulesXilinx)
 
 set(AIE_RUNTIME_TARGETS

--- a/mlir_tutorials/CMakeLists.txt
+++ b/mlir_tutorials/CMakeLists.txt
@@ -5,8 +5,7 @@
 #
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
 
-cmake_minimum_required(VERSION 3.10)
-
+cmake_minimum_required(VERSION 3.30)
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()

--- a/programming_examples/CMakeLists.txt
+++ b/programming_examples/CMakeLists.txt
@@ -5,8 +5,7 @@
 #
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
 
-cmake_minimum_required(VERSION 3.10)
-
+cmake_minimum_required(VERSION 3.30)
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()

--- a/programming_examples/basic/dma_transpose/CMakeLists.txt
+++ b/programming_examples/basic/dma_transpose/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/matrix_multiplication/CMakeLists.txt
+++ b/programming_examples/basic/matrix_multiplication/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/matrix_scalar_add/CMakeLists.txt
+++ b/programming_examples/basic/matrix_scalar_add/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/memcpy/CMakeLists.txt
+++ b/programming_examples/basic/memcpy/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23) 
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/passthrough_dmas/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_dmas/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/passthrough_dmas_plio/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_dmas_plio/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/passthrough_kernel/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_kernel/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/passthrough_pykernel/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_pykernel/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_exp/CMakeLists.txt
+++ b/programming_examples/basic/vector_exp/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_reduce_add/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_add/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_reduce_max/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_max/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_reduce_min/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_min/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_scalar_add/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_add/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_scalar_add_runlist/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_add_runlist/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_vector_modulo/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_modulo/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/basic/vector_vector_mul/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_mul/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/block_datatypes/bfp_conversion/CMakeLists.txt
+++ b/programming_examples/ml/block_datatypes/bfp_conversion/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/block_datatypes/matrix_multiplication/CMakeLists.txt
+++ b/programming_examples/ml/block_datatypes/matrix_multiplication/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/block_datatypes/vector_passthrough/CMakeLists.txt
+++ b/programming_examples/ml/block_datatypes/vector_passthrough/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/bottleneck/CMakeLists.txt
+++ b/programming_examples/ml/bottleneck/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/conv2d/CMakeLists.txt
+++ b/programming_examples/ml/conv2d/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/conv2d_fused_relu/CMakeLists.txt
+++ b/programming_examples/ml/conv2d_fused_relu/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/eltwise_add/CMakeLists.txt
+++ b/programming_examples/ml/eltwise_add/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/eltwise_mul/CMakeLists.txt
+++ b/programming_examples/ml/eltwise_mul/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/gelu/CMakeLists.txt
+++ b/programming_examples/ml/gelu/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23) 
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/layernorm/CMakeLists.txt
+++ b/programming_examples/ml/layernorm/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/relu/CMakeLists.txt
+++ b/programming_examples/ml/relu/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23) 
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/resnet/layers_conv2_x/CMakeLists.txt
+++ b/programming_examples/ml/resnet/layers_conv2_x/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/rmsnorm/CMakeLists.txt
+++ b/programming_examples/ml/rmsnorm/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/rope/CMakeLists.txt
+++ b/programming_examples/ml/rope/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/scale_shift/CMakeLists.txt
+++ b/programming_examples/ml/scale_shift/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/silu/CMakeLists.txt
+++ b/programming_examples/ml/silu/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23) 
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/softmax/CMakeLists.txt
+++ b/programming_examples/ml/softmax/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/ml/swiglu/CMakeLists.txt
+++ b/programming_examples/ml/swiglu/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23) 
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/vision/color_detect/CMakeLists.txt
+++ b/programming_examples/vision/color_detect/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/vision/color_threshold/CMakeLists.txt
+++ b/programming_examples/vision/color_threshold/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/vision/edge_detect/CMakeLists.txt
+++ b/programming_examples/vision/edge_detect/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_examples/vision/vision_passthrough/CMakeLists.txt
+++ b/programming_examples/vision/vision_passthrough/CMakeLists.txt
@@ -11,8 +11,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 #set(CMAKE_CXX_STANDARD 23)
 #set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_guide/CMakeLists.txt
+++ b/programming_guide/CMakeLists.txt
@@ -5,8 +5,7 @@
 #
 # Copyright (C) 2022, Advanced Micro Devices, Inc.
 
-cmake_minimum_required(VERSION 3.10)
-
+cmake_minimum_required(VERSION 3.30)
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_guide/section-2/section-2f/05_join_L2/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/05_join_L2/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_guide/section-3/CMakeLists.txt
+++ b/programming_guide/section-3/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_guide/section-4/section-4a/CMakeLists.txt
+++ b/programming_guide/section-4/section-4a/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/programming_guide/section-4/section-4b/CMakeLists.txt
+++ b/programming_guide/section-4/section-4b/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/runtime_lib/CMakeLists.txt
+++ b/runtime_lib/CMakeLists.txt
@@ -6,8 +6,7 @@
 # (c) Copyright 2021 Xilinx Inc.
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.20.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/runtime_lib/test_lib/CMakeLists.txt
+++ b/runtime_lib/test_lib/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
-cmake_minimum_required(VERSION 3.21)
-
+cmake_minimum_required(VERSION 3.30)
 project("test lib for ${AIE_RUNTIME_TARGET}")
 
 # test_lib library

--- a/runtime_lib/xaiengine/CMakeLists.txt
+++ b/runtime_lib/xaiengine/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # (c) Copyright 2023 Advanced Micro Devices, Inc.
 
-cmake_minimum_required(VERSION 3.20.1)
-
+cmake_minimum_required(VERSION 3.30)
 project("xaiengine lib for ${AIE_RUNTIME_TARGET}")
 include("aiert.cmake")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,8 +4,7 @@
 #
 # (c) Copyright 2021 Xilinx Inc.
 
-cmake_minimum_required(VERSION 3.10)
-
+cmake_minimum_required(VERSION 3.30)
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif()

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/CMakeLists.txt
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/CMakeLists.txt
@@ -10,8 +10,7 @@
 # -DTARGET_NAME: Target name to be built
 
 # cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/utils/mlir_aie_wheels/python_bindings/CMakeLists.txt
+++ b/utils/mlir_aie_wheels/python_bindings/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.13.4)
-
+cmake_minimum_required(VERSION 3.30)
 if(POLICY CMP0068)
   cmake_policy(SET CMP0068 NEW)
   set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)


### PR DESCRIPTION
Stops Cmake from complaining. Enables example projects to be built.