### PR TITLE
WSL Compatibility: ironenv config examines Windows xrt-smi

### DIFF
--- a/python/iron/config.py
+++ b/python/iron/config.py
@@ -10,6 +10,19 @@ import subprocess
 
 from .device import NPU1, NPU2
 
+# Detect WSL
+def is_wsl() -> bool:
+    try:
+        with open("/proc/sys/kernel/osrelease", "r", encoding="utf-8") as kernel:
+            return "microsoft" in kernel.read().lower()
+    except OSError:
+        return False
+    
+# Prefer Windows xrt-smi when in WSL. Linux native otherwise.
+def xrt_smi_path() -> str:
+    if is_wsl():
+        return "/mnt/c/Windows/System32/AMD/xrt-smi.exe"
+    return "/opt/xilinx/xrt/bin/xrt-smi"
 
 def detect_npu_device():
     """Detects the current device in the system.
@@ -21,8 +34,9 @@ def detect_npu_device():
     """
     try:
         # Run `xrt-smi examine` and capture output
+        xrt_smi = xrt_smi_path()
         result = subprocess.run(
-            ["/opt/xilinx/xrt/bin/xrt-smi", "examine"],
+            [xrt_smi, "examine"],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -31,7 +45,7 @@ def detect_npu_device():
         output = result.stdout
 
         # Match strings for NPU2 or NPU1
-        # Set's generic "whole array" devices, this is overkill...
+        # Sets generic "whole array" devices. Overkill.
         if any(
             keyword.lower() in output.lower()
             for keyword in [
@@ -56,6 +70,10 @@ def detect_npu_device():
             raise RuntimeError("No supported NPU device found.")
 
     except FileNotFoundError:
+        if is_wsl():
+            raise RuntimeError(
+                "WSL detected but Windows xrt-smi.exe not found. Install AMD Ryzen AI Software."
+            )
         raise RuntimeError("xrt-smi not found. Make sure XRT is installed.")
     except subprocess.CalledProcessError:
         raise RuntimeError("Failed to run xrt-smi examine.")


### PR DESCRIPTION
Old behavior: script always fails on WSL, making builds impossible if XRT is also installed.
New behavior: script detects if it is running in WSL and looks at the Windows xrt-smi.exe instead of the Linux version. All logic is strictly identical to the original file.

Frankly, I question the need for this script in the first place. It is redundant to other checks, it ignores the environment, and it flagrantly disrespect arguments explicitly passed to the makes. If I weren't a newcomer, I would propose eliminating it entirely. At minimum, it could probably use another pass to force it to respect arguments and the environment.