### PR TITLE
Fix some failing npu-xrt peano tests

### DIFF
--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
@@ -7,10 +7,9 @@
 # (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
 
 # REQUIRES: ryzen_ai_npu1, peano
-# XFAIL: *
 #
 # RUN: %python %S/aie2.py 4096 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --no-xbridge --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test.exe -x final.xclbin -i insts.bin -k MLIR_AIE -l 4096
 import numpy as np

--- a/test/npu-xrt/objectfifo_repeat/distribute_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/distribute_repeat/aie2.py
@@ -10,7 +10,7 @@
 # XFAIL: *
 #
 # RUN: %python %S/aie2.py 36 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --no-xbridge --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test.exe -x final.xclbin -i insts.bin -k MLIR_AIE -l 36
 import numpy as np

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
@@ -7,10 +7,9 @@
 # (c) Copyright 2024 AMD Inc.
 
 # REQUIRES: ryzen_ai_npu1, peano
-# XFAIL: *
 #
 # RUN: %python %S/aie2.py 4096 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --no-xchesscc --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --no-xchesscc --no-xbridge --aie-generate-npu-insts --aie-generate-xclbin --no-compile-host --xclbin-name=final.xclbin --npu-insts-name=insts.bin ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test.exe -x final.xclbin -i insts.bin -k MLIR_AIE -l 4096
 import numpy as np

--- a/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
+++ b/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
@@ -7,10 +7,9 @@
 # (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
 
 # REQUIRES: ryzen_ai_npu1, peano
-# XFAIL: *
 #
 # RUN: %python %S/aie2.py npu 0 > ./aie2.mlir
-# RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --no-xchesscc --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie2.mlir
+# RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --no-xchesscc --no-xbridge --xclbin-name=aie.xclbin --npu-insts-name=insts.bin ./aie2.mlir
 # RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 # RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
 import numpy as np


### PR DESCRIPTION
Update peano tests to use `--no-xbridge` to prevent linking segfault