### PR TITLE
VectorToAIEVec: get device arch from IR, instead of pass option

### DIFF
--- a/include/aie/Dialect/AIEVec/Pipelines/Passes.h
+++ b/include/aie/Dialect/AIEVec/Pipelines/Passes.h
@@ -39,11 +39,6 @@ namespace aievec {
 /// Options for the "canonicalize-vector-for-aievec" pipeline.
 struct CanonicalizeVectorForAIEVecOptions
     : public mlir::PassPipelineOptions<CanonicalizeVectorForAIEVecOptions> {
-  PassOptions::Option<std::string> aieTarget{
-      *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
-                     "determine the vector size and available operations."),
-      llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{
       *this, "target-backend",
       llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
@@ -55,11 +50,6 @@ struct CanonicalizeVectorForAIEVecOptions
 /// Options for the "lower-vector-to-aievec" pipeline.
 struct LowerVectorToAIEVecOptions
     : public mlir::PassPipelineOptions<LowerVectorToAIEVecOptions> {
-  PassOptions::Option<std::string> aieTarget{
-      *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
-                     "determine the vector size and available operations."),
-      llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{
       *this, "target-backend",
       llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
@@ -71,11 +61,6 @@ struct LowerVectorToAIEVecOptions
 /// Options for the "optimize-aievec" pipeline.
 struct OptimizeAIEVecOptions
     : public mlir::PassPipelineOptions<OptimizeAIEVecOptions> {
-  PassOptions::Option<std::string> aieTarget{
-      *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
-                     "determine the vector size and available operations."),
-      llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{
       *this, "target-backend",
       llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
@@ -107,11 +92,6 @@ struct ConvertVectorToAIEVecOptions
       llvm::cl::desc("Duplication factor for each value in convolution filter "
                      "(useful in 8x8 scheme)"),
       llvm::cl::init(2)};
-  PassOptions::Option<std::string> aieTarget{
-      *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
-                     "determine the vector size and available operations."),
-      llvm::cl::init("aie")};
   PassOptions::Option<std::string> targetBackend{
       *this, "target-backend",
       llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
@@ -122,11 +102,8 @@ struct ConvertVectorToAIEVecOptions
   mlir::LogicalResult parseFromString(mlir::StringRef options) {
     auto res = PassPipelineOptions::parseFromString(options);
     if (!failed(res)) {
-      lowerOptions.aieTarget = aieTarget;
       lowerOptions.targetBackend = targetBackend;
-      canonicalizeOptions.aieTarget = aieTarget;
       canonicalizeOptions.targetBackend = targetBackend;
-      optimizeOptions.aieTarget = aieTarget;
       optimizeOptions.targetBackend = targetBackend;
       optimizeOptions.shiftParam = shiftParam;
     }

--- a/include/aie/Dialect/AIEVec/Utils/Utils.h
+++ b/include/aie/Dialect/AIEVec/Utils/Utils.h
@@ -11,6 +11,7 @@
 #ifndef AIE_DIALECT_AIEVEC_UTILS_UTILS_H
 #define AIE_DIALECT_AIEVEC_UTILS_UTILS_H
 
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include <cstdint>
 #include <optional>
@@ -38,6 +39,8 @@ std::optional<int64_t> getTransferReadAlignmentOffset(TransferReadLikeOp readOp,
                                                       int64_t alignment);
 
 mlir::VectorType getFlattenedVectorType(mlir::VectorType vecTy);
+
+std::optional<xilinx::AIE::AIEArch> getAIEVersionFromModule(mlir::ModuleOp moduleOp);
 
 } // namespace xilinx::aievec
 

--- a/include/aie/Dialect/AIEVec/Utils/Utils.h
+++ b/include/aie/Dialect/AIEVec/Utils/Utils.h
@@ -40,7 +40,8 @@ std::optional<int64_t> getTransferReadAlignmentOffset(TransferReadLikeOp readOp,
 
 mlir::VectorType getFlattenedVectorType(mlir::VectorType vecTy);
 
-std::optional<xilinx::AIE::AIEArch> getAIEVersionFromModule(mlir::ModuleOp moduleOp);
+std::optional<xilinx::AIE::AIEArch>
+getAIEVersionFromModule(mlir::ModuleOp moduleOp);
 
 } // namespace xilinx::aievec
 

--- a/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/Dialect/Vector/Transforms/LoweringPatterns.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -48,16 +49,6 @@ static TargetBackend decodeTargetBackend(const std::string &backend) {
       return TargetBackend::UNKNOWN;
   }
   return TargetBackend::CPP;
-}
-
-static AIEArch decodeAIETarget(const std::string &target) {
-  if (!target.empty()) {
-    if (target == "aieml" || target == "aie2")
-      return AIEArch::AIE2;
-    if (target != "aie")
-      return AIEArch::UNKNOWN;
-  }
-  return AIEArch::AIE;
 }
 
 //============================================================================//
@@ -632,6 +623,130 @@ struct ExtractTransposeFromContractionOp
   }
 };
 
+/// Utility function to check if all provided indices are constant zero values.
+/// @return success() if all indices are constant zeros, failure() otherwise
+static LogicalResult isAllZeroOffsetAccess(mlir::OperandRange indices) {
+  if (!llvm::all_of(indices, [](Value val) {
+        IntegerAttr attr;
+        if (!matchPattern(val, m_Constant(&attr)))
+          return false;
+        return attr.getInt() == 0;
+      })) {
+    return failure();
+  }
+  return success();
+}
+
+/// Utility function to convert OpFoldResult offsets from a SubView operation
+/// into a vector of Values.
+static SmallVector<Value> opFoldResultsToValues(PatternRewriter &rewriter,
+                                                Location loc,
+                                                memref::SubViewOp subViewOp) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(subViewOp);
+  SmallVector<Value> newIndices;
+  for (OpFoldResult offset : subViewOp.getMixedOffsets()) {
+    Value indexVal;
+    if (auto attr = dyn_cast<Attribute>(offset)) {
+      indexVal = rewriter.create<arith::ConstantIndexOp>(
+          loc, cast<IntegerAttr>(attr).getInt());
+    } else {
+      indexVal = cast<Value>(offset);
+    }
+    newIndices.push_back(indexVal);
+  }
+  return newIndices;
+}
+
+/// Pattern to canonicalize trivial vector.transfer_read operations on subviews.
+///
+/// This pattern eliminates unnecessary memref.subview operations when the
+/// transfer_read accesses the subview with all-zero indices. It transforms:
+///
+/// INPUT:
+///   %subview = memref.subview %memref [offset0, offset1, ...]
+///   %result = vector.transfer_read %subview[0, 0, ...]
+///
+/// OUTPUT:
+///   %result = vector.transfer_read %memref[offset0, offset1, ...]
+///
+/// The pattern only matches when:
+/// - The base of transfer_read is defined by a memref.subview operation
+/// - All indices in the transfer_read are constant zeros
+struct CanonicalizeTrivialReadAccessSubviewOpPattern
+    : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp readOp,
+                                PatternRewriter &rewriter) const override {
+    // Check if the base memref comes from a subview operation
+    auto subViewOp = dyn_cast_if_present<memref::SubViewOp>(
+        readOp.getBase().getDefiningOp());
+    if (!subViewOp)
+      return failure();
+    
+    // Verify that all access indices are zero
+    if (failed(isAllZeroOffsetAccess(readOp.getIndices())))
+      return failure();
+    
+    // Convert subview offsets to explicit index values
+    SmallVector<Value> newIndices =
+        opFoldResultsToValues(rewriter, readOp.getLoc(), subViewOp);
+    
+    // Replace with direct access to the original memref using subview offsets
+    rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
+        readOp, readOp.getType(), subViewOp.getSource(), newIndices,
+        readOp.getPadding(), readOp.getInBoundsValues());
+    return success();
+  }
+};
+
+/// Pattern to canonicalize trivial vector.transfer_write operations on subviews.
+///
+/// This pattern eliminates unnecessary memref.subview operations when the
+/// transfer_write accesses the subview with all-zero indices. It transforms:
+///
+/// INPUT:
+///   %subview = memref.subview %memref [offset0, offset1, ...]
+///   vector.transfer_write %value, %subview[0, 0, ...]
+///
+/// OUTPUT:
+///   vector.transfer_write %value, %memref[offset0, offset1, ...]
+///
+/// The pattern only matches when:
+/// - The base of transfer_write is defined by a memref.subview operation
+/// - All indices in the transfer_write are constant zeros
+struct CanonicalizeTrivialWriteAccessSubviewOpPattern
+    : public OpRewritePattern<vector::TransferWriteOp> {
+  using OpRewritePattern<vector::TransferWriteOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferWriteOp writeOp,
+                                PatternRewriter &rewriter) const override {
+    // Check if the base memref comes from a subview operation
+    auto subViewOp = dyn_cast_if_present<memref::SubViewOp>(
+        writeOp.getBase().getDefiningOp());
+    if (!subViewOp)
+      return failure();
+    
+    // Verify that all access indices are zero
+    if (failed(isAllZeroOffsetAccess(writeOp.getIndices())))
+      return failure();
+    
+    // Convert subview offsets to explicit index values
+    SmallVector<Value> newIndices =
+        opFoldResultsToValues(rewriter, writeOp.getLoc(), subViewOp);
+    
+    // Create new transfer_write with direct access to original memref
+    rewriter.create<vector::TransferWriteOp>(
+        writeOp.getLoc(), writeOp.getVector(), subViewOp.getSource(),
+        newIndices, writeOp.getInBoundsValues());
+    
+    // Remove the original transfer_write operation
+    rewriter.eraseOp(writeOp);
+    return success();
+  }
+};
+
 //============================================================================//
 //============ AIE2 canonicalization conversion patterns ===============//
 //============================================================================//
@@ -790,7 +905,6 @@ struct CanonicalizeVectorForAIEVecPass
   CanonicalizeVectorForAIEVecPass(
       const CanonicalizeVectorForAIEVecOptions &options)
       : CanonicalizeVectorForAIEVecPass() {
-    aieTarget = options.aieTarget;
     targetBackend = options.targetBackend;
   }
 
@@ -810,12 +924,6 @@ struct CanonicalizeVectorForAIEVecPass
                 vector::VectorDialect, affine::AffineDialect, ub::UBDialect>();
   }
 
-  Option<std::string> aieTarget{
-      *this, "aie-target",
-      llvm::cl::desc("Select AIE version: \"aie\" or \"aie2\". This will "
-                     "determine the vector size and available operations."),
-      llvm::cl::init("aie")};
-
   Option<std::string> targetBackend{
       *this, "target-backend",
       llvm::cl::desc("Select translation backend: \"cpp\" or \"llvmir\". This "
@@ -824,17 +932,16 @@ struct CanonicalizeVectorForAIEVecPass
       llvm::cl::init("cpp")};
 
   void runOnOperation() override {
-    auto *op = getOperation();
+    ModuleOp op = dyn_cast_if_present<ModuleOp>(getOperation());
+
+    auto aieVersionOpt = getAIEVersionFromModule(op);
+    if (!aieVersionOpt)
+      return;
+    auto aieVersion = *aieVersionOpt;
+
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
     ConversionTarget target(*context);
-
-    AIEArch aieVersion = decodeAIETarget(aieTarget);
-    if (aieVersion == AIEArch::UNKNOWN) {
-      op->emitError() << "unknown AIE target '" << aieTarget << "'";
-      signalPassFailure();
-      return;
-    }
 
     TargetBackend backend = decodeTargetBackend(targetBackend);
     if (backend == TargetBackend::UNKNOWN) {
@@ -842,7 +949,7 @@ struct CanonicalizeVectorForAIEVecPass
       signalPassFailure();
       return;
     }
-    if (backend == TargetBackend::LLVMIR && aieVersion == AIEArch::AIE) {
+    if (backend == TargetBackend::LLVMIR && aieVersion == AIE::AIEArch::AIE1) {
       op->emitError() << "targetting LLVM IR is not supported for AIEv1";
       signalPassFailure();
       return;
@@ -850,12 +957,20 @@ struct CanonicalizeVectorForAIEVecPass
 
     populateCommonAIECanonicalizeConversionPatterns(patterns, backend);
     configureCommonAIECanonicalizeLegalizations(target, backend);
-    if (aieVersion == AIEArch::AIE) {
+    if (aieVersion == AIE::AIEArch::AIE1) {
       populateAIEv1CanonicalizeConversionPatterns(patterns, backend);
       configureAIEv1CanonicalizeLegalizations(target, backend);
-    } else {
+    } else if (aieVersion == AIE::AIEArch::AIE2) {
       populateAIE2CanonicalizeConversionPatterns(patterns, backend);
       configureAIE2CanonicalizeLegalizations(target, backend);
+    } else
+      return;
+
+    {
+      RewritePatternSet patterns(context);
+      patterns.add<CanonicalizeTrivialReadAccessSubviewOpPattern,
+                   CanonicalizeTrivialWriteAccessSubviewOpPattern>(context);
+      (void)applyPatternsGreedily(op, std::move(patterns));
     }
 
     if (failed(applyPartialConversion(op, target, std::move(patterns)))) {

--- a/lib/Dialect/AIEVec/Utils/Utils.cpp
+++ b/lib/Dialect/AIEVec/Utils/Utils.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "aie/Dialect/AIEVec/Utils/Utils.h"
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -103,6 +104,17 @@ VectorType getFlattenedVectorType(VectorType vecTy) {
   return VectorType::get(
       {std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<>())},
       vecTy.getElementType());
+}
+
+std::optional<xilinx::AIE::AIEArch> getAIEVersionFromModule(ModuleOp moduleOp) {
+  llvm::SmallVector<xilinx::AIE::DeviceOp> deviceOps;
+  moduleOp.walk([&](xilinx::AIE::DeviceOp d) { deviceOps.push_back(d); });
+
+  if (deviceOps.empty())
+    return std::nullopt;
+
+  const auto &targetModel = deviceOps.front().getTargetModel();
+  return targetModel.getTargetArch();
 }
 
 } // namespace xilinx::aievec

--- a/test/Conversion/VectorToAIEVec/fold-aievec-shift-and-broadcast.mlir
+++ b/test/Conversion/VectorToAIEVec/fold-aievec-shift-and-broadcast.mlir
@@ -1,15 +1,17 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-func.func @fold_aievec_shift_and_broadcast(%a: memref<48xi8>) -> (vector<32xi8>, vector<32xi8>) {
-    %c0 = arith.constant 0 : index
-    %c16 = arith.constant 16 : i32
-    %c22 = arith.constant 22 : i32
-    %0 = aievec.upd %a[%c0] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<32xi8>
-    %1 = aievec.shift %0, %0, %c16 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-    %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
-    %3 = aievec.shift %0, %0, %c22 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-    %4 = aievec.broadcast %3 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
-    return %2, %4 : vector<32xi8>, vector<32xi8>
+aie.device(npu1) {
+  func.func @fold_aievec_shift_and_broadcast(%a: memref<48xi8>) -> (vector<32xi8>, vector<32xi8>) {
+      %c0 = arith.constant 0 : index
+      %c16 = arith.constant 16 : i32
+      %c22 = arith.constant 22 : i32
+      %0 = aievec.upd %a[%c0] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<32xi8>
+      %1 = aievec.shift %0, %0, %c16 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+      %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
+      %3 = aievec.shift %0, %0, %c22 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+      %4 = aievec.broadcast %3 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
+      return %2, %4 : vector<32xi8>, vector<32xi8>
+  }
 }
 // CHECK-LABEL: func @fold_aievec_shift_and_broadcast   
 // CHECK      :    %[[C0:.*]] = arith.constant 0 : index
@@ -18,4 +20,3 @@ func.func @fold_aievec_shift_and_broadcast(%a: memref<48xi8>) -> (vector<32xi8>,
 // CHECK      :    %[[T1:.*]] = aievec.broadcast %[[T0:.*]] {idx = 16 : i8} : vector<32xi8>, vector<32xi8>
 // CHECK      :    %[[T2:.*]] = aievec.broadcast %[[T0:.*]] {idx = 24 : i8} : vector<32xi8>, vector<32xi8>
 // CHECK      :    return %[[T1:.*]], %[[T2:.*]] : vector<32xi8>, vector<32xi8>
-

--- a/test/Conversion/VectorToAIEVec/gemm64_int16_unroll16_vectorized.mlir
+++ b/test/Conversion/VectorToAIEVec/gemm64_int16_unroll16_vectorized.mlir
@@ -19,224 +19,226 @@
 // CHECK-SAME: %[[MA:[A-Za-z0-9]+]]: memref<?x64xi16>,
 // CHECK-SAME: %[[MB:[A-Za-z0-9]+]]: memref<?x64xi16>,
 // CHECK-SAME: %[[MC:[A-Za-z0-9]+]]: memref<?x64xi16>
-func.func @matmul(%arg0: memref<?x64xi16>, %arg1: memref<?x64xi16>, %arg2: memref<?x64xi16>) {
-  // CHECK-DAG: %[[C0I32:.*]] = arith.constant 0 : i32
-  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
-  // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-  // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
-  // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
-  // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
-  // CHECK-DAG: %[[C5:.*]] = arith.constant 5 : index
-  // CHECK-DAG: %[[C6:.*]] = arith.constant 6 : index
-  // CHECK-DAG: %[[C7:.*]] = arith.constant 7 : index
-  // CHECK-DAG: %[[C8:.*]] = arith.constant 8 : index
-  // CHECK-DAG: %[[C9:.*]] = arith.constant 9 : index
-  // CHECK-DAG: %[[C10:.*]] = arith.constant 10 : index
-  // CHECK-DAG: %[[C11:.*]] = arith.constant 11 : index
-  // CHECK-DAG: %[[C12:.*]] = arith.constant 12 : index
-  // CHECK-DAG: %[[C13:.*]] = arith.constant 13 : index
-  // CHECK-DAG: %[[C14:.*]] = arith.constant 14 : index
-  // CHECK-DAG: %[[C15:.*]] = arith.constant 15 : index
-  // CHECK-DAG: %[[C16:.*]] = arith.constant 16 : index
-  // CHECK-DAG: %[[C64:.*]] = arith.constant 64 : index
-  %c0_i16 = arith.constant 0 : i16
-  // CHECK: scf.for %[[I:.*]] = %[[C0]] to %[[C64]] step %[[C1]] {
-  affine.for %arg3 = 0 to 64 {
-    // CHECK: scf.for %[[J:.*]] = %[[C0]] to %[[C64]] step %[[C16]] {
-    affine.for %arg4 = 0 to 64 step 16 {
-      // CHECK: %[[ACC0:.*]] = aievec.upd %[[MC]][%[[I]], %[[J]]]
-      // CHECK-SAME:                    {index = 0 : i8, offset = 0 : i32}
-      // CHECK-SAME:                    : memref<?x64xi16>, vector<16xi16>
-      %0 = vector.transfer_read %arg2[%arg3, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-      // CHECK: %[[ACCn:.*]] = scf.for %[[K:.*]] = %[[C0]] to %[[C64]] step %[[C16]]
-      // CHECK-SAME:                   iter_args(%[[ACCk:.*]] = %[[ACC0]]) -> (vector<16xi16>) {
-      %1 = affine.for %arg5 = 0 to 64 step 16 iter_args(%arg6 = %0) -> (vector<16xi16>) {
-        // CHECK: %[[VA:.*]] = aievec.upd %[[MA]][%[[I]], %[[K]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VB0:.*]] = aievec.upd %[[MB]][%[[K]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VC:.*]] = aievec.ups %[[ACCk]] {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
-        %2 = vector.transfer_read %arg0[%arg3, %arg5], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %3 = vector.transfer_read %arg1[%arg5, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %4 = arith.muli %2, %3 : vector<16xi16>
-        %5 = arith.addi %arg6, %4 : vector<16xi16>
-        // CHECK: %[[K1:.*]] = arith.addi %[[K]], %[[C1]] : index
-        // CHECK: %[[VB1:.*]] = aievec.upd %[[MB]][%[[K1]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VB01:.*]] = aievec.concat %[[VB0]], %[[VB1]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk0:.*]] = aievec_aie1.mac %[[VB01]], %[[VA]], %[[VC]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"}
-        // CHECK-SAME:                       : vector<32xi16>, vector<16xi16>, vector<16xi48>
-        %6 = affine.apply #map1(%arg5)
-        %7 = vector.transfer_read %arg0[%arg3, %6], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %8 = vector.transfer_read %arg1[%6, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %9 = arith.muli %7, %8 : vector<16xi16>
-        %10 = arith.addi %5, %9 : vector<16xi16>
-        // CHECK: %[[K2:.*]] = arith.addi %[[K]], %[[C2]] : index
-        // CHECK: %[[VB2:.*]] = aievec.upd %[[MB]][%[[K2]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        %11 = affine.apply #map2(%arg5)
-        %12 = vector.transfer_read %arg0[%arg3, %11], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %13 = vector.transfer_read %arg1[%11, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %14 = arith.muli %12, %13 : vector<16xi16>
-        %15 = arith.addi %10, %14 : vector<16xi16>
-        // CHECK: %[[K3:.*]] = arith.addi %[[K]], %[[C3]] : index
-        // CHECK: %[[VB3:.*]] = aievec.upd %[[MB]][%[[K3]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VB23:.*]] = aievec.concat %[[VB2]], %[[VB3]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk2:.*]] = aievec_aie1.mac %[[VB23]], %[[VA]], %[[ACCk0]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"}
-        %16 = affine.apply #map3(%arg5)
-        %17 = vector.transfer_read %arg0[%arg3, %16], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %18 = vector.transfer_read %arg1[%16, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %19 = arith.muli %17, %18 : vector<16xi16>
-        %20 = arith.addi %15, %19 : vector<16xi16>
-        // CHECK: %[[K4:.*]] = arith.addi %[[K]], %[[C4]] : index
-        // CHECK: %[[VB4:.*]] = aievec.upd %[[MB]][%[[K4]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        %21 = affine.apply #map4(%arg5)
-        %22 = vector.transfer_read %arg0[%arg3, %21], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %23 = vector.transfer_read %arg1[%21, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %24 = arith.muli %22, %23 : vector<16xi16>
-        %25 = arith.addi %20, %24 : vector<16xi16>
-        // CHECK: %[[K5:.*]] = arith.addi %[[K]], %[[C5]] : index
-        // CHECK: %[[VB5:.*]] = aievec.upd %[[MB]][%[[K5]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VB45:.*]] = aievec.concat %[[VB4]], %[[VB5]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk4:.*]] = aievec_aie1.mac %[[VB45]], %[[VA]], %[[ACCk2]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"}
-        %26 = affine.apply #map5(%arg5)
-        %27 = vector.transfer_read %arg0[%arg3, %26], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %28 = vector.transfer_read %arg1[%26, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %29 = arith.muli %27, %28 : vector<16xi16>
-        %30 = arith.addi %25, %29 : vector<16xi16>
-        // CHECK: %[[K6:.*]] = arith.addi %[[K]], %[[C6]] : index
-        // CHECK: %[[VB6:.*]] = aievec.upd %[[MB]][%[[K6]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        %31 = affine.apply #map6(%arg5)
-        %32 = vector.transfer_read %arg0[%arg3, %31], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %33 = vector.transfer_read %arg1[%31, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %34 = arith.muli %32, %33 : vector<16xi16>
-        %35 = arith.addi %30, %34 : vector<16xi16>
-        // CHECK: %[[K7:.*]] = arith.addi %[[K]], %[[C7]] : index
-        // CHECK: %[[VB7:.*]] = aievec.upd %[[MB]][%[[K7]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VB67:.*]] = aievec.concat %[[VB6]], %[[VB7]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk6:.*]] = aievec_aie1.mac %[[VB67]], %[[VA]], %[[ACCk4]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"}
-        %36 = affine.apply #map7(%arg5)
-        %37 = vector.transfer_read %arg0[%arg3, %36], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %38 = vector.transfer_read %arg1[%36, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %39 = arith.muli %37, %38 : vector<16xi16>
-        %40 = arith.addi %35, %39 : vector<16xi16>
-        // CHECK: %[[K8:.*]] = arith.addi %[[K]], %[[C8]] : index
-        // CHECK: %[[VB8:.*]] = aievec.upd %[[MB]][%[[K8]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        %41 = affine.apply #map8(%arg5)
-        %42 = vector.transfer_read %arg0[%arg3, %41], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %43 = vector.transfer_read %arg1[%41, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %44 = arith.muli %42, %43 : vector<16xi16>
-        %45 = arith.addi %40, %44 : vector<16xi16>
-        // CHECK: %[[K9:.*]] = arith.addi %[[K]], %[[C9]] : index
-        // CHECK: %[[VB9:.*]] = aievec.upd %[[MB]][%[[K9]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VB89:.*]] = aievec.concat %[[VB8]], %[[VB9]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk8:.*]] = aievec_aie1.mac %[[VB89]], %[[VA]], %[[ACCk6]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"}
-        %46 = affine.apply #map9(%arg5)
-        %47 = vector.transfer_read %arg0[%arg3, %46], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %48 = vector.transfer_read %arg1[%46, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %49 = arith.muli %47, %48 : vector<16xi16>
-        %50 = arith.addi %45, %49 : vector<16xi16>
-        // CHECK: %[[K10:.*]] = arith.addi %[[K]], %[[C10]] : index
-        // CHECK: %[[VB10:.*]] = aievec.upd %[[MB]][%[[K10]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        %51 = affine.apply #map10(%arg5)
-        %52 = vector.transfer_read %arg0[%arg3, %51], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %53 = vector.transfer_read %arg1[%51, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %54 = arith.muli %52, %53 : vector<16xi16>
-        %55 = arith.addi %50, %54 : vector<16xi16>
-        // CHECK: %[[K11:.*]] = arith.addi %[[K]], %[[C11]] : index
-        // CHECK: %[[VB11:.*]] = aievec.upd %[[MB]][%[[K11]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VBab:.*]] = aievec.concat %[[VB10]], %[[VB11]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk10:.*]] = aievec_aie1.mac %[[VBab]], %[[VA]], %[[ACCk8]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"}
-        %56 = affine.apply #map11(%arg5)
-        %57 = vector.transfer_read %arg0[%arg3, %56], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %58 = vector.transfer_read %arg1[%56, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %59 = arith.muli %57, %58 : vector<16xi16>
-        %60 = arith.addi %55, %59 : vector<16xi16>
-        // CHECK: %[[K12:.*]] = arith.addi %[[K]], %[[C12]] : index
-        // CHECK: %[[VB12:.*]] = aievec.upd %[[MB]][%[[K12]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        %61 = affine.apply #map12(%arg5)
-        %62 = vector.transfer_read %arg0[%arg3, %61], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %63 = vector.transfer_read %arg1[%61, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %64 = arith.muli %62, %63 : vector<16xi16>
-        %65 = arith.addi %60, %64 : vector<16xi16>
-        // CHECK: %[[K13:.*]] = arith.addi %[[K]], %[[C13]] : index
-        // CHECK: %[[VB13:.*]] = aievec.upd %[[MB]][%[[K13]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VBcd:.*]] = aievec.concat %[[VB12]], %[[VB13]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk12:.*]] = aievec_aie1.mac %[[VBcd]], %[[VA]], %[[ACCk10]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "12", zstep = "1"}
-        %66 = affine.apply #map13(%arg5)
-        %67 = vector.transfer_read %arg0[%arg3, %66], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %68 = vector.transfer_read %arg1[%66, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %69 = arith.muli %67, %68 : vector<16xi16>
-        %70 = arith.addi %65, %69 : vector<16xi16>
-        // CHECK: %[[K14:.*]] = arith.addi %[[K]], %[[C14]] : index
-        // CHECK: %[[VB14:.*]] = aievec.upd %[[MB]][%[[K14]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        %71 = affine.apply #map14(%arg5)
-        %72 = vector.transfer_read %arg0[%arg3, %71], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %73 = vector.transfer_read %arg1[%71, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %74 = arith.muli %72, %73 : vector<16xi16>
-        %75 = arith.addi %70, %74 : vector<16xi16>
-        // CHECK: %[[K15:.*]] = arith.addi %[[K]], %[[C15]] : index
-        // CHECK: %[[VB15:.*]] = aievec.upd %[[MB]][%[[K15]], %[[J]]]
-        // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
-        // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
-        // CHECK: %[[VBef:.*]] = aievec.concat %[[VB14]], %[[VB15]] : vector<16xi16>, vector<32xi16>
-        // CHECK: %[[ACCk14:.*]] = aievec_aie1.mac %[[VBef]], %[[VA]], %[[ACCk12]]
-        // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-        // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "14", zstep = "1"}
-        // CHECK: %[[ACC:.*]] = aievec.srs %[[ACCk14]], %[[C0I32]] : vector<16xi48>, i32, vector<16xi16>
-        %76 = affine.apply #map15(%arg5)
-        %77 = vector.transfer_read %arg0[%arg3, %76], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
-        %78 = vector.transfer_read %arg1[%76, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
-        %79 = arith.muli %77, %78 : vector<16xi16>
-        %80 = arith.addi %75, %79 : vector<16xi16>
-        // CHECK: scf.yield %[[ACC]] : vector<16xi16>
-        affine.yield %80 : vector<16xi16>
+aie.device(xcvc1902) {
+  func.func @matmul(%arg0: memref<?x64xi16>, %arg1: memref<?x64xi16>, %arg2: memref<?x64xi16>) {
+    // CHECK-DAG: %[[C0I32:.*]] = arith.constant 0 : i32
+    // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+    // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+    // CHECK-DAG: %[[C2:.*]] = arith.constant 2 : index
+    // CHECK-DAG: %[[C3:.*]] = arith.constant 3 : index
+    // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : index
+    // CHECK-DAG: %[[C5:.*]] = arith.constant 5 : index
+    // CHECK-DAG: %[[C6:.*]] = arith.constant 6 : index
+    // CHECK-DAG: %[[C7:.*]] = arith.constant 7 : index
+    // CHECK-DAG: %[[C8:.*]] = arith.constant 8 : index
+    // CHECK-DAG: %[[C9:.*]] = arith.constant 9 : index
+    // CHECK-DAG: %[[C10:.*]] = arith.constant 10 : index
+    // CHECK-DAG: %[[C11:.*]] = arith.constant 11 : index
+    // CHECK-DAG: %[[C12:.*]] = arith.constant 12 : index
+    // CHECK-DAG: %[[C13:.*]] = arith.constant 13 : index
+    // CHECK-DAG: %[[C14:.*]] = arith.constant 14 : index
+    // CHECK-DAG: %[[C15:.*]] = arith.constant 15 : index
+    // CHECK-DAG: %[[C16:.*]] = arith.constant 16 : index
+    // CHECK-DAG: %[[C64:.*]] = arith.constant 64 : index
+    %c0_i16 = arith.constant 0 : i16
+    // CHECK: scf.for %[[I:.*]] = %[[C0]] to %[[C64]] step %[[C1]] {
+    affine.for %arg3 = 0 to 64 {
+      // CHECK: scf.for %[[J:.*]] = %[[C0]] to %[[C64]] step %[[C16]] {
+      affine.for %arg4 = 0 to 64 step 16 {
+        // CHECK: %[[ACC0:.*]] = aievec.upd %[[MC]][%[[I]], %[[J]]]
+        // CHECK-SAME:                    {index = 0 : i8, offset = 0 : i32}
+        // CHECK-SAME:                    : memref<?x64xi16>, vector<16xi16>
+        %0 = vector.transfer_read %arg2[%arg3, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+        // CHECK: %[[ACCn:.*]] = scf.for %[[K:.*]] = %[[C0]] to %[[C64]] step %[[C16]]
+        // CHECK-SAME:                   iter_args(%[[ACCk:.*]] = %[[ACC0]]) -> (vector<16xi16>) {
+        %1 = affine.for %arg5 = 0 to 64 step 16 iter_args(%arg6 = %0) -> (vector<16xi16>) {
+          // CHECK: %[[VA:.*]] = aievec.upd %[[MA]][%[[I]], %[[K]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VB0:.*]] = aievec.upd %[[MB]][%[[K]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VC:.*]] = aievec.ups %[[ACCk]] {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
+          %2 = vector.transfer_read %arg0[%arg3, %arg5], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %3 = vector.transfer_read %arg1[%arg5, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %4 = arith.muli %2, %3 : vector<16xi16>
+          %5 = arith.addi %arg6, %4 : vector<16xi16>
+          // CHECK: %[[K1:.*]] = arith.addi %[[K]], %[[C1]] : index
+          // CHECK: %[[VB1:.*]] = aievec.upd %[[MB]][%[[K1]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VB01:.*]] = aievec.concat %[[VB0]], %[[VB1]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk0:.*]] = aievec_aie1.mac %[[VB01]], %[[VA]], %[[VC]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "0", zstep = "1"}
+          // CHECK-SAME:                       : vector<32xi16>, vector<16xi16>, vector<16xi48>
+          %6 = affine.apply #map1(%arg5)
+          %7 = vector.transfer_read %arg0[%arg3, %6], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %8 = vector.transfer_read %arg1[%6, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %9 = arith.muli %7, %8 : vector<16xi16>
+          %10 = arith.addi %5, %9 : vector<16xi16>
+          // CHECK: %[[K2:.*]] = arith.addi %[[K]], %[[C2]] : index
+          // CHECK: %[[VB2:.*]] = aievec.upd %[[MB]][%[[K2]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          %11 = affine.apply #map2(%arg5)
+          %12 = vector.transfer_read %arg0[%arg3, %11], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %13 = vector.transfer_read %arg1[%11, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %14 = arith.muli %12, %13 : vector<16xi16>
+          %15 = arith.addi %10, %14 : vector<16xi16>
+          // CHECK: %[[K3:.*]] = arith.addi %[[K]], %[[C3]] : index
+          // CHECK: %[[VB3:.*]] = aievec.upd %[[MB]][%[[K3]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VB23:.*]] = aievec.concat %[[VB2]], %[[VB3]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk2:.*]] = aievec_aie1.mac %[[VB23]], %[[VA]], %[[ACCk0]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "2", zstep = "1"}
+          %16 = affine.apply #map3(%arg5)
+          %17 = vector.transfer_read %arg0[%arg3, %16], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %18 = vector.transfer_read %arg1[%16, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %19 = arith.muli %17, %18 : vector<16xi16>
+          %20 = arith.addi %15, %19 : vector<16xi16>
+          // CHECK: %[[K4:.*]] = arith.addi %[[K]], %[[C4]] : index
+          // CHECK: %[[VB4:.*]] = aievec.upd %[[MB]][%[[K4]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          %21 = affine.apply #map4(%arg5)
+          %22 = vector.transfer_read %arg0[%arg3, %21], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %23 = vector.transfer_read %arg1[%21, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %24 = arith.muli %22, %23 : vector<16xi16>
+          %25 = arith.addi %20, %24 : vector<16xi16>
+          // CHECK: %[[K5:.*]] = arith.addi %[[K]], %[[C5]] : index
+          // CHECK: %[[VB5:.*]] = aievec.upd %[[MB]][%[[K5]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VB45:.*]] = aievec.concat %[[VB4]], %[[VB5]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk4:.*]] = aievec_aie1.mac %[[VB45]], %[[VA]], %[[ACCk2]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "4", zstep = "1"}
+          %26 = affine.apply #map5(%arg5)
+          %27 = vector.transfer_read %arg0[%arg3, %26], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %28 = vector.transfer_read %arg1[%26, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %29 = arith.muli %27, %28 : vector<16xi16>
+          %30 = arith.addi %25, %29 : vector<16xi16>
+          // CHECK: %[[K6:.*]] = arith.addi %[[K]], %[[C6]] : index
+          // CHECK: %[[VB6:.*]] = aievec.upd %[[MB]][%[[K6]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          %31 = affine.apply #map6(%arg5)
+          %32 = vector.transfer_read %arg0[%arg3, %31], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %33 = vector.transfer_read %arg1[%31, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %34 = arith.muli %32, %33 : vector<16xi16>
+          %35 = arith.addi %30, %34 : vector<16xi16>
+          // CHECK: %[[K7:.*]] = arith.addi %[[K]], %[[C7]] : index
+          // CHECK: %[[VB7:.*]] = aievec.upd %[[MB]][%[[K7]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VB67:.*]] = aievec.concat %[[VB6]], %[[VB7]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk6:.*]] = aievec_aie1.mac %[[VB67]], %[[VA]], %[[ACCk4]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "6", zstep = "1"}
+          %36 = affine.apply #map7(%arg5)
+          %37 = vector.transfer_read %arg0[%arg3, %36], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %38 = vector.transfer_read %arg1[%36, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %39 = arith.muli %37, %38 : vector<16xi16>
+          %40 = arith.addi %35, %39 : vector<16xi16>
+          // CHECK: %[[K8:.*]] = arith.addi %[[K]], %[[C8]] : index
+          // CHECK: %[[VB8:.*]] = aievec.upd %[[MB]][%[[K8]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          %41 = affine.apply #map8(%arg5)
+          %42 = vector.transfer_read %arg0[%arg3, %41], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %43 = vector.transfer_read %arg1[%41, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %44 = arith.muli %42, %43 : vector<16xi16>
+          %45 = arith.addi %40, %44 : vector<16xi16>
+          // CHECK: %[[K9:.*]] = arith.addi %[[K]], %[[C9]] : index
+          // CHECK: %[[VB9:.*]] = aievec.upd %[[MB]][%[[K9]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VB89:.*]] = aievec.concat %[[VB8]], %[[VB9]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk8:.*]] = aievec_aie1.mac %[[VB89]], %[[VA]], %[[ACCk6]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "8", zstep = "1"}
+          %46 = affine.apply #map9(%arg5)
+          %47 = vector.transfer_read %arg0[%arg3, %46], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %48 = vector.transfer_read %arg1[%46, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %49 = arith.muli %47, %48 : vector<16xi16>
+          %50 = arith.addi %45, %49 : vector<16xi16>
+          // CHECK: %[[K10:.*]] = arith.addi %[[K]], %[[C10]] : index
+          // CHECK: %[[VB10:.*]] = aievec.upd %[[MB]][%[[K10]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          %51 = affine.apply #map10(%arg5)
+          %52 = vector.transfer_read %arg0[%arg3, %51], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %53 = vector.transfer_read %arg1[%51, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %54 = arith.muli %52, %53 : vector<16xi16>
+          %55 = arith.addi %50, %54 : vector<16xi16>
+          // CHECK: %[[K11:.*]] = arith.addi %[[K]], %[[C11]] : index
+          // CHECK: %[[VB11:.*]] = aievec.upd %[[MB]][%[[K11]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VBab:.*]] = aievec.concat %[[VB10]], %[[VB11]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk10:.*]] = aievec_aie1.mac %[[VBab]], %[[VA]], %[[ACCk8]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "10", zstep = "1"}
+          %56 = affine.apply #map11(%arg5)
+          %57 = vector.transfer_read %arg0[%arg3, %56], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %58 = vector.transfer_read %arg1[%56, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %59 = arith.muli %57, %58 : vector<16xi16>
+          %60 = arith.addi %55, %59 : vector<16xi16>
+          // CHECK: %[[K12:.*]] = arith.addi %[[K]], %[[C12]] : index
+          // CHECK: %[[VB12:.*]] = aievec.upd %[[MB]][%[[K12]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          %61 = affine.apply #map12(%arg5)
+          %62 = vector.transfer_read %arg0[%arg3, %61], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %63 = vector.transfer_read %arg1[%61, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %64 = arith.muli %62, %63 : vector<16xi16>
+          %65 = arith.addi %60, %64 : vector<16xi16>
+          // CHECK: %[[K13:.*]] = arith.addi %[[K]], %[[C13]] : index
+          // CHECK: %[[VB13:.*]] = aievec.upd %[[MB]][%[[K13]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VBcd:.*]] = aievec.concat %[[VB12]], %[[VB13]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk12:.*]] = aievec_aie1.mac %[[VBcd]], %[[VA]], %[[ACCk10]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "12", zstep = "1"}
+          %66 = affine.apply #map13(%arg5)
+          %67 = vector.transfer_read %arg0[%arg3, %66], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %68 = vector.transfer_read %arg1[%66, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %69 = arith.muli %67, %68 : vector<16xi16>
+          %70 = arith.addi %65, %69 : vector<16xi16>
+          // CHECK: %[[K14:.*]] = arith.addi %[[K]], %[[C14]] : index
+          // CHECK: %[[VB14:.*]] = aievec.upd %[[MB]][%[[K14]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          %71 = affine.apply #map14(%arg5)
+          %72 = vector.transfer_read %arg0[%arg3, %71], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %73 = vector.transfer_read %arg1[%71, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %74 = arith.muli %72, %73 : vector<16xi16>
+          %75 = arith.addi %70, %74 : vector<16xi16>
+          // CHECK: %[[K15:.*]] = arith.addi %[[K]], %[[C15]] : index
+          // CHECK: %[[VB15:.*]] = aievec.upd %[[MB]][%[[K15]], %[[J]]]
+          // CHECK-SAME:                  {index = 0 : i8, offset = 0 : i32}
+          // CHECK-SAME:                  : memref<?x64xi16>, vector<16xi16>
+          // CHECK: %[[VBef:.*]] = aievec.concat %[[VB14]], %[[VB15]] : vector<16xi16>, vector<32xi16>
+          // CHECK: %[[ACCk14:.*]] = aievec_aie1.mac %[[VBef]], %[[VA]], %[[ACCk12]]
+          // CHECK-SAME:                       {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+          // CHECK-SAME:                        xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "14", zstep = "1"}
+          // CHECK: %[[ACC:.*]] = aievec.srs %[[ACCk14]], %[[C0I32]] : vector<16xi48>, i32, vector<16xi16>
+          %76 = affine.apply #map15(%arg5)
+          %77 = vector.transfer_read %arg0[%arg3, %76], %c0_i16 {in_bounds = [true], permutation_map = #map} : memref<?x64xi16>, vector<16xi16>
+          %78 = vector.transfer_read %arg1[%76, %arg4], %c0_i16 : memref<?x64xi16>, vector<16xi16>
+          %79 = arith.muli %77, %78 : vector<16xi16>
+          %80 = arith.addi %75, %79 : vector<16xi16>
+          // CHECK: scf.yield %[[ACC]] : vector<16xi16>
+          affine.yield %80 : vector<16xi16>
+        }
+        // CHECK: vector.transfer_write %[[ACCn]], %[[MC]][%[[I]], %[[J]]] {in_bounds = [true]} : vector<16xi16>, memref<?x64xi16>
+        vector.transfer_write %1, %arg2[%arg3, %arg4] : vector<16xi16>, memref<?x64xi16>
       }
-      // CHECK: vector.transfer_write %[[ACCn]], %[[MC]][%[[I]], %[[J]]] {in_bounds = [true]} : vector<16xi16>, memref<?x64xi16>
-      vector.transfer_write %1, %arg2[%arg3, %arg4] : vector<16xi16>, memref<?x64xi16>
     }
+    return
   }
-  return
 }

--- a/test/Conversion/VectorToAIEVec/leading-unit-dim-contract.mlir
+++ b/test/Conversion/VectorToAIEVec/leading-unit-dim-contract.mlir
@@ -1,43 +1,45 @@
-// RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aie2 target-backend=llvmir" | FileCheck %s
+// RUN: aie-opt %s -convert-vector-to-aievec="target-backend=llvmir" | FileCheck %s
 
 #map  = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d2, d5, d4, d6, d8)>
 #map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d2, d1, d3, d5, d8, d7)>
 #map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d3, d4, d6, d7)>
-func.func @matmul(%A : memref<1x1x4x8x4x8xbf16, 2 : i32>,
-                  %B : memref<1x1x8x4x8x4xbf16, 2 : i32>,
-                  %C : memref<1x1x8x8x4x4xf32, 2 : i32>) {
-  %c0 = arith.constant 0 : index
-  %c0_bf16 = arith.constant 0.0 : bf16
-  %c0_f32 = arith.constant 0.0 : f32
-  affine.for %i = 0 to 8 step 1 {
-    affine.for %j = 0 to 8 step 1 {
-      affine.for %k = 0 to 4 step 1 {
-        %0 = vector.transfer_read %A[%c0, %c0, %k, %i, %c0, %c0], %c0_bf16
-                {in_bounds = [true, true, true, true, true, true]}
-                : memref<1x1x4x8x4x8xbf16, 2 : i32>, vector<1x1x1x1x4x8xbf16>
-        %1 = vector.transfer_read %B[%c0, %c0, %j, %k, %c0, %c0], %c0_bf16
-                {in_bounds = [true, true, true, true, true, true]}
-                : memref<1x1x8x4x8x4xbf16, 2 : i32>, vector<1x1x1x1x8x4xbf16>
-        %2 = vector.transfer_read %C[%c0, %c0, %j, %i, %c0, %c0], %c0_f32
-                {in_bounds = [true, true, true, true, true, true]}
-                : memref<1x1x8x8x4x4xf32, 2 : i32>, vector<1x1x1x1x4x4xf32>
-        %3 = arith.extf %0 : vector<1x1x1x1x4x8xbf16> to vector<1x1x1x1x4x8xf32>
-        %4 = arith.extf %1 : vector<1x1x1x1x8x4xbf16> to vector<1x1x1x1x8x4xf32>
-        %5 = vector.contract {
-                          indexing_maps = [#map, #map1, #map2],
-                          iterator_types = ["parallel", "parallel", "reduction",
-                                            "parallel", "parallel", "reduction",
-                                            "parallel", "parallel", "reduction"],
-                                            kind = #vector.kind<add>} %3, %4, %2
-                              : vector<1x1x1x1x4x8xf32>, vector<1x1x1x1x8x4xf32>
-                                into vector<1x1x1x1x4x4xf32>
-        vector.transfer_write %5, %C[%c0, %c0, %j, %i, %c0, %c0]
-                {in_bounds = [true, true, true, true, true, true]}
-                : vector<1x1x1x1x4x4xf32>, memref<1x1x8x8x4x4xf32, 2 : i32>
+aie.device(npu1) {
+  func.func @matmul(%A : memref<1x1x4x8x4x8xbf16, 2 : i32>,
+                    %B : memref<1x1x8x4x8x4xbf16, 2 : i32>,
+                    %C : memref<1x1x8x8x4x4xf32, 2 : i32>) {
+    %c0 = arith.constant 0 : index
+    %c0_bf16 = arith.constant 0.0 : bf16
+    %c0_f32 = arith.constant 0.0 : f32
+    affine.for %i = 0 to 8 step 1 {
+      affine.for %j = 0 to 8 step 1 {
+        affine.for %k = 0 to 4 step 1 {
+          %0 = vector.transfer_read %A[%c0, %c0, %k, %i, %c0, %c0], %c0_bf16
+                  {in_bounds = [true, true, true, true, true, true]}
+                  : memref<1x1x4x8x4x8xbf16, 2 : i32>, vector<1x1x1x1x4x8xbf16>
+          %1 = vector.transfer_read %B[%c0, %c0, %j, %k, %c0, %c0], %c0_bf16
+                  {in_bounds = [true, true, true, true, true, true]}
+                  : memref<1x1x8x4x8x4xbf16, 2 : i32>, vector<1x1x1x1x8x4xbf16>
+          %2 = vector.transfer_read %C[%c0, %c0, %j, %i, %c0, %c0], %c0_f32
+                  {in_bounds = [true, true, true, true, true, true]}
+                  : memref<1x1x8x8x4x4xf32, 2 : i32>, vector<1x1x1x1x4x4xf32>
+          %3 = arith.extf %0 : vector<1x1x1x1x4x8xbf16> to vector<1x1x1x1x4x8xf32>
+          %4 = arith.extf %1 : vector<1x1x1x1x8x4xbf16> to vector<1x1x1x1x8x4xf32>
+          %5 = vector.contract {
+                            indexing_maps = [#map, #map1, #map2],
+                            iterator_types = ["parallel", "parallel", "reduction",
+                                              "parallel", "parallel", "reduction",
+                                              "parallel", "parallel", "reduction"],
+                                              kind = #vector.kind<add>} %3, %4, %2
+                                : vector<1x1x1x1x4x8xf32>, vector<1x1x1x1x8x4xf32>
+                                  into vector<1x1x1x1x4x4xf32>
+          vector.transfer_write %5, %C[%c0, %c0, %j, %i, %c0, %c0]
+                  {in_bounds = [true, true, true, true, true, true]}
+                  : vector<1x1x1x1x4x4xf32>, memref<1x1x8x8x4x4xf32, 2 : i32>
+        }
       }
     }
+    return
   }
-  return
 }
 
 // CHECK: #[[CMAP:.*]] = affine_map<(d0, d1) -> (d0 * 128 + d1 * 16)>

--- a/test/Conversion/VectorToAIEVec/test-arith-aie2.mlir
+++ b/test/Conversion/VectorToAIEVec/test-arith-aie2.mlir
@@ -1,217 +1,251 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
 // CHECK-LABEL: func @vecaddi_i32(
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecaddi_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[RES:.*]] = aievec.add_elem %[[LHS]], %[[RHS]] : vector<16xi32>
-  %0 = arith.addi %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi32>
-  return %0 : vector<16xi32>
+aie.device(npu1) {
+  func.func @vecaddi_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[RES:.*]] = aievec.add_elem %[[LHS]], %[[RHS]] : vector<16xi32>
+    %0 = arith.addi %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi32>
+    return %0 : vector<16xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecaddi_32xi32(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi32>)
-func.func @vecaddi_32xi32(%arg0: vector<32xi32>, %arg1: vector<32xi32>) -> vector<32xi32> {
-  // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
-  // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
-  // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LCAST]], %[[RCAST]] : vector<32xi32>
-  // CHECK:  %[[RES:.*]] = aievec.cast %[[ADD]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %0 = arith.addi %arg0, %arg1 : vector<32xi32>
-  // CHECK: return %[[RES]] : vector<32xi32>
-  return %0 : vector<32xi32>
+aie.device(npu1) {
+  func.func @vecaddi_32xi32(%arg0: vector<32xi32>, %arg1: vector<32xi32>) -> vector<32xi32> {
+    // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
+    // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
+    // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LCAST]], %[[RCAST]] : vector<32xi32>
+    // CHECK:  %[[RES:.*]] = aievec.cast %[[ADD]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+    %0 = arith.addi %arg0, %arg1 : vector<32xi32>
+    // CHECK: return %[[RES]] : vector<32xi32>
+    return %0 : vector<32xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecaddi_i16_i32(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecaddi_i16_i32(%arg0 : vector<32xi16>, %arg1 : vector<32xi16>) -> vector<32xi32> {
-  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
-  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
-  // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[ADD]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %1 = arith.extsi %arg0 : vector<32xi16> to vector<32xi32>
-  %2 = arith.extsi %arg1 : vector<32xi16> to vector<32xi32>
-  %3 = arith.addi %1, %2 : vector<32xi32>
-  // CHECK: return %[[CAST]] : vector<32xi32>
-  return %3 : vector<32xi32>
+aie.device(npu1) {
+  func.func @vecaddi_i16_i32(%arg0 : vector<32xi16>, %arg1 : vector<32xi16>) -> vector<32xi32> {
+    // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
+    // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
+    // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
+    // CHECK:  %[[CAST:.*]] = aievec.cast %[[ADD]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+    %1 = arith.extsi %arg0 : vector<32xi16> to vector<32xi32>
+    %2 = arith.extsi %arg1 : vector<32xi16> to vector<32xi32>
+    %3 = arith.addi %1, %2 : vector<32xi32>
+    // CHECK: return %[[CAST]] : vector<32xi32>
+    return %3 : vector<32xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecaddi_i16_i32_2(
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecaddi_i16_i32_2(%arg0 : vector<16xi16>, %arg1 : vector<16xi32>) -> vector<16xi32> {
-  // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<16xi16>, vector<16xi64>
-  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
-  // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<16xi64>
-  // CHECK:  %[[SRS:.*]] = aievec.srs %[[ADD]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
-  %1 = arith.extsi %arg0 : vector<16xi16> to vector<16xi32>
-  %2 = arith.addi %1, %arg1 : vector<16xi32>
-  // CHECK: return %[[SRS]] : vector<16xi32>
-  return %2 : vector<16xi32>
+aie.device(npu1) {
+  func.func @vecaddi_i16_i32_2(%arg0 : vector<16xi16>, %arg1 : vector<16xi32>) -> vector<16xi32> {
+    // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+    // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<16xi16>, vector<16xi64>
+    // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
+    // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<16xi64>
+    // CHECK:  %[[SRS:.*]] = aievec.srs %[[ADD]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
+    %1 = arith.extsi %arg0 : vector<16xi16> to vector<16xi32>
+    %2 = arith.addi %1, %arg1 : vector<16xi32>
+    // CHECK: return %[[SRS]] : vector<16xi32>
+    return %2 : vector<16xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecaddi_i8_i32(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi8>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi8>)
-func.func @vecaddi_i8_i32(%arg0 : vector<32xi8>, %arg1 : vector<32xi8>) -> vector<32xi32> {
-  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
-  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
-  // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[ADD]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %1 = arith.extsi %arg0 : vector<32xi8> to vector<32xi32>
-  %2 = arith.extsi %arg1 : vector<32xi8> to vector<32xi32>
-  %3 = arith.addi %1, %2 : vector<32xi32>
-  // CHECK: return %[[CAST]] : vector<32xi32>
-  return %3 : vector<32xi32>
+aie.device(npu1) {
+  func.func @vecaddi_i8_i32(%arg0 : vector<32xi8>, %arg1 : vector<32xi8>) -> vector<32xi32> {
+    // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
+    // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
+    // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
+    // CHECK:  %[[CAST:.*]] = aievec.cast %[[ADD]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+    %1 = arith.extsi %arg0 : vector<32xi8> to vector<32xi32>
+    %2 = arith.extsi %arg1 : vector<32xi8> to vector<32xi32>
+    %3 = arith.addi %1, %2 : vector<32xi32>
+    // CHECK: return %[[CAST]] : vector<32xi32>
+    return %3 : vector<32xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecaddi_i16(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecaddi_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
-  // CHECK: %[[RES:.*]] = aievec.add_elem %[[LHS]], %[[RHS]] : vector<32xi16>
-  %0 = arith.addi %arg0, %arg1 : vector<32xi16>
-  // CHECK: return %[[RES]] : vector<32xi16>
-  return %0 : vector<32xi16>
+aie.device(npu1) {
+  func.func @vecaddi_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
+    // CHECK: %[[RES:.*]] = aievec.add_elem %[[LHS]], %[[RHS]] : vector<32xi16>
+    %0 = arith.addi %arg0, %arg1 : vector<32xi16>
+    // CHECK: return %[[RES]] : vector<32xi16>
+    return %0 : vector<32xi16>
+  }
 }
 
 // CHECK-LABEL: func @vecaddi_i8(
 // CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
 // CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
-func.func @vecaddi_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
-  // CHECK: %[[RES:.*]] = aievec.add_elem %[[LHS]], %[[RHS]] : vector<64xi8>
-  %0 = arith.addi %arg0, %arg1 : vector<64xi8>
-  // CHECK: return %[[RES]] : vector<64xi8>
-  return %0 : vector<64xi8>
+aie.device(npu1) {
+  func.func @vecaddi_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
+    // CHECK: %[[RES:.*]] = aievec.add_elem %[[LHS]], %[[RHS]] : vector<64xi8>
+    %0 = arith.addi %arg0, %arg1 : vector<64xi8>
+    // CHECK: return %[[RES]] : vector<64xi8>
+    return %0 : vector<64xi8>
+  }
 }
 
 // CHECK-LABEL: func @vecsubi_i32(
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecsubi_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[RES:.*]] = aievec.sub_elem %[[LHS]], %[[RHS]] : vector<16xi32>
-  %0 = arith.subi %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi32>
-  return %0 : vector<16xi32>
+aie.device(npu1) {
+  func.func @vecsubi_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[RES:.*]] = aievec.sub_elem %[[LHS]], %[[RHS]] : vector<16xi32>
+    %0 = arith.subi %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi32>
+    return %0 : vector<16xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecsubi_i16(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecsubi_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
-  // CHECK: %[[RES:.*]] = aievec.sub_elem %[[LHS]], %[[RHS]] : vector<32xi16>
-  %0 = arith.subi %arg0, %arg1 : vector<32xi16>
-  // CHECK: return %[[RES]] : vector<32xi16>
-  return %0 : vector<32xi16>
+aie.device(npu1) {
+  func.func @vecsubi_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
+    // CHECK: %[[RES:.*]] = aievec.sub_elem %[[LHS]], %[[RHS]] : vector<32xi16>
+    %0 = arith.subi %arg0, %arg1 : vector<32xi16>
+    // CHECK: return %[[RES]] : vector<32xi16>
+    return %0 : vector<32xi16>
+  }
 }
 
 // CHECK-LABEL: func @vecsubi_i8(
 // CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
 // CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
-func.func @vecsubi_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
-  // CHECK: %[[RES:.*]] = aievec.sub_elem %[[LHS]], %[[RHS]] : vector<64xi8>
-  %0 = arith.subi %arg0, %arg1 : vector<64xi8>
-  // CHECK: return %[[RES]] : vector<64xi8>
-  return %0 : vector<64xi8>
+aie.device(npu1) {
+  func.func @vecsubi_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
+    // CHECK: %[[RES:.*]] = aievec.sub_elem %[[LHS]], %[[RHS]] : vector<64xi8>
+    %0 = arith.subi %arg0, %arg1 : vector<64xi8>
+    // CHECK: return %[[RES]] : vector<64xi8>
+    return %0 : vector<64xi8>
+  }
 }
 
 // CHECK-LABEL: func @vecsubi_32xi32(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi32>)
-func.func @vecsubi_32xi32(%arg0: vector<32xi32>, %arg1: vector<32xi32>) -> vector<32xi32> {
-  // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
-  // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
-  // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LCAST]], %[[RCAST]] : vector<32xi32>
-  // CHECK:  %[[RES:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %0 = arith.subi %arg0, %arg1 : vector<32xi32>
-  // CHECK: return %[[RES]] : vector<32xi32>
-  return %0 : vector<32xi32>
+aie.device(npu1) {
+  func.func @vecsubi_32xi32(%arg0: vector<32xi32>, %arg1: vector<32xi32>) -> vector<32xi32> {
+    // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
+    // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<32xi32>, vector<32xi32>
+    // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LCAST]], %[[RCAST]] : vector<32xi32>
+    // CHECK:  %[[RES:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+    %0 = arith.subi %arg0, %arg1 : vector<32xi32>
+    // CHECK: return %[[RES]] : vector<32xi32>
+    return %0 : vector<32xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecsubi_i16_i32(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecsubi_i16_i32(%arg0 : vector<32xi16>, %arg1 : vector<32xi16>) -> vector<32xi32> {
-  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
-  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
-  // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %1 = arith.extsi %arg0 : vector<32xi16> to vector<32xi32>
-  %2 = arith.extsi %arg1 : vector<32xi16> to vector<32xi32>
-  %3 = arith.subi %1, %2 : vector<32xi32>
-  // CHECK: return %[[CAST]] : vector<32xi32>
-  return %3 : vector<32xi32>
+aie.device(npu1) {
+  func.func @vecsubi_i16_i32(%arg0 : vector<32xi16>, %arg1 : vector<32xi16>) -> vector<32xi32> {
+    // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
+    // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi16>, vector<32xi32>
+    // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
+    // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+    %1 = arith.extsi %arg0 : vector<32xi16> to vector<32xi32>
+    %2 = arith.extsi %arg1 : vector<32xi16> to vector<32xi32>
+    %3 = arith.subi %1, %2 : vector<32xi32>
+    // CHECK: return %[[CAST]] : vector<32xi32>
+    return %3 : vector<32xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecsubi_i8_i32(
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi8>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi8>)
-func.func @vecsubi_i8_i32(%arg0 : vector<32xi8>, %arg1 : vector<32xi8>) -> vector<32xi32> {
-  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
-  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
-  // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %1 = arith.extsi %arg0 : vector<32xi8> to vector<32xi32>
-  %2 = arith.extsi %arg1 : vector<32xi8> to vector<32xi32>
-  %3 = arith.subi %1, %2 : vector<32xi32>
-  // CHECK: return %[[CAST]] : vector<32xi32>
-  return %3 : vector<32xi32>
+aie.device(npu1) {
+  func.func @vecsubi_i8_i32(%arg0 : vector<32xi8>, %arg1 : vector<32xi8>) -> vector<32xi32> {
+    // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
+    // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
+    // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LUPS]], %[[RUPS]] : vector<32xi32>
+    // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+    %1 = arith.extsi %arg0 : vector<32xi8> to vector<32xi32>
+    %2 = arith.extsi %arg1 : vector<32xi8> to vector<32xi32>
+    %3 = arith.subi %1, %2 : vector<32xi32>
+    // CHECK: return %[[CAST]] : vector<32xi32>
+    return %3 : vector<32xi32>
+  }
 }
 
 // CHECK-LABEL: func @vecaddf_f32(
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecaddf_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK:  %[[SUB:.*]] = aievec.add_elem %[[LCAST]], %[[RCAST:.*]] : vector<16xf32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  %0 = arith.addf %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[CAST]] : vector<16xf32>
-  return %0 : vector<16xf32>
+aie.device(npu1) {
+  func.func @vecaddf_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+    // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+    // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+    // CHECK:  %[[SUB:.*]] = aievec.add_elem %[[LCAST]], %[[RCAST:.*]] : vector<16xf32>
+    // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+    %0 = arith.addf %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[CAST]] : vector<16xf32>
+    return %0 : vector<16xf32>
+  }
 }
 
 // CHECK-LABEL: func @vecaddf_bf16(
 // CHECK-SAME: %[[LHS:.*]]: vector<16xbf16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xbf16>)
-func.func @vecaddf_bf16(%arg0: vector<16xbf16>, %arg1: vector<16xbf16>) -> vector<16xbf16> {
-  // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
-  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
-  // CHECK:  %[[SUB:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<16xf32>
-  // CHECK:  %[[SRS:.*]] = aievec.srs %[[SUB]], %[[C0]] : vector<16xf32>, i32, vector<16xbf16>
-  %0 = arith.addf %arg0, %arg1 : vector<16xbf16>
-  // CHECK: return %[[SRS]] : vector<16xbf16>
-  return %0 : vector<16xbf16>
+aie.device(npu1) {
+  func.func @vecaddf_bf16(%arg0: vector<16xbf16>, %arg1: vector<16xbf16>) -> vector<16xbf16> {
+    // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+    // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+    // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+    // CHECK:  %[[SUB:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<16xf32>
+    // CHECK:  %[[SRS:.*]] = aievec.srs %[[SUB]], %[[C0]] : vector<16xf32>, i32, vector<16xbf16>
+    %0 = arith.addf %arg0, %arg1 : vector<16xbf16>
+    // CHECK: return %[[SRS]] : vector<16xbf16>
+    return %0 : vector<16xbf16>
+  }
 }
 
 // CHECK-LABEL: func @vecsubf_f32(
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecsubf_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LCAST]], %[[RCAST:.*]] : vector<16xf32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  %0 = arith.subf %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[CAST]] : vector<16xf32>
-  return %0 : vector<16xf32>
+aie.device(npu1) {
+  func.func @vecsubf_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+    // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+    // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+    // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LCAST]], %[[RCAST:.*]] : vector<16xf32>
+    // CHECK:  %[[CAST:.*]] = aievec.cast %[[SUB]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+    %0 = arith.subf %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[CAST]] : vector<16xf32>
+    return %0 : vector<16xf32>
+  }
 }
 
 // CHECK-LABEL: func @vecsubf_bf16(
 // CHECK-SAME: %[[LHS:.*]]: vector<16xbf16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xbf16>)
-func.func @vecsubf_bf16(%arg0: vector<16xbf16>, %arg1: vector<16xbf16>) -> vector<16xbf16> {
-  // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
-  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
-  // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LUPS]], %[[RUPS]] : vector<16xf32>
-  // CHECK:  %[[SRS:.*]] = aievec.srs %[[SUB]], %[[C0]] : vector<16xf32>, i32, vector<16xbf16>
-  %0 = arith.subf %arg0, %arg1 : vector<16xbf16>
-  // CHECK: return %[[SRS]] : vector<16xbf16>
-  return %0 : vector<16xbf16>
+aie.device(npu1) {
+  func.func @vecsubf_bf16(%arg0: vector<16xbf16>, %arg1: vector<16xbf16>) -> vector<16xbf16> {
+    // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+    // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+    // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+    // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LUPS]], %[[RUPS]] : vector<16xf32>
+    // CHECK:  %[[SRS:.*]] = aievec.srs %[[SUB]], %[[C0]] : vector<16xf32>, i32, vector<16xbf16>
+    %0 = arith.subf %arg0, %arg1 : vector<16xbf16>
+    // CHECK: return %[[SRS]] : vector<16xbf16>
+    return %0 : vector<16xbf16>
+  }
 }
 

--- a/test/Conversion/VectorToAIEVec/test-arith.mlir
+++ b/test/Conversion/VectorToAIEVec/test-arith.mlir
@@ -1,75 +1,77 @@
 // RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL: func @vecaddi(
-// CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecaddi(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[RES:.*]] = aievec_aie1.add %[[LHS]], %[[RHS]] : vector<16xi32>, vector<16xi32>, vector<16xi32>
-  %0 = arith.addi %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi32>
-  return %0 : vector<16xi32>
-}
+aie.device(xcvc1902) {
+    // CHECK-LABEL: func @vecaddi(
+    // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
+    // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
+    func.func @vecaddi(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+      // CHECK: %[[RES:.*]] = aievec_aie1.add %[[LHS]], %[[RHS]] : vector<16xi32>, vector<16xi32>, vector<16xi32>
+      %0 = arith.addi %arg0, %arg1 : vector<16xi32>
+      // CHECK: return %[[RES]] : vector<16xi32>
+      return %0 : vector<16xi32>
+    }
 
-// CHECK-LABEL: func @vecaddf(
-// CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecaddf(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[RES:.*]] = aievec_aie1.add %[[LHS]], %[[RHS]] : vector<16xf32>, vector<16xf32>, vector<16xf32>
-  %0 = arith.addf %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xf32>
-  return %0 : vector<16xf32>
-}
+    // CHECK-LABEL: func @vecaddf(
+    // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
+    // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
+    func.func @vecaddf(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+      // CHECK: %[[RES:.*]] = aievec_aie1.add %[[LHS]], %[[RHS]] : vector<16xf32>, vector<16xf32>, vector<16xf32>
+      %0 = arith.addf %arg0, %arg1 : vector<16xf32>
+      // CHECK: return %[[RES]] : vector<16xf32>
+      return %0 : vector<16xf32>
+    }
 
-// CHECK-LABEL: func @vecsubi(
-// CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecsubi(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[RES:.*]] = aievec_aie1.sub %[[LHS]], %[[RHS]] : vector<16xi32>, vector<16xi32>, vector<16xi32>
-  %0 = arith.subi %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi32>
-  return %0 : vector<16xi32>
-}
+    // CHECK-LABEL: func @vecsubi(
+    // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
+    // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
+    func.func @vecsubi(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+      // CHECK: %[[RES:.*]] = aievec_aie1.sub %[[LHS]], %[[RHS]] : vector<16xi32>, vector<16xi32>, vector<16xi32>
+      %0 = arith.subi %arg0, %arg1 : vector<16xi32>
+      // CHECK: return %[[RES]] : vector<16xi32>
+      return %0 : vector<16xi32>
+    }
 
-// CHECK-LABEL: func @vecsubf(
-// CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecsubf(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[RES:.*]] = aievec_aie1.sub %[[LHS]], %[[RHS]] : vector<16xf32>, vector<16xf32>, vector<16xf32>
-  %0 = arith.subf %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xf32>
-  return %0 : vector<16xf32>
-}
+    // CHECK-LABEL: func @vecsubf(
+    // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
+    // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
+    func.func @vecsubf(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+      // CHECK: %[[RES:.*]] = aievec_aie1.sub %[[LHS]], %[[RHS]] : vector<16xf32>, vector<16xf32>, vector<16xf32>
+      %0 = arith.subf %arg0, %arg1 : vector<16xf32>
+      // CHECK: return %[[RES]] : vector<16xf32>
+      return %0 : vector<16xf32>
+    }
 
-// CHECK-LABEL: func @vecmuli16(
-// CHECK-SAME: %[[LHS:.*]]: vector<16xi16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xi16>)
-func.func @vecmuli16(%arg0: vector<16xi16>, %arg1: vector<16xi16>) -> vector<16xi16> {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[MUL:.*]] = aievec_aie1.mul %[[LHS]], %[[RHS]] : vector<16xi16>, vector<16xi16>, vector<16xi48>
-  // CHECK: %[[RES:.*]] = aievec.srs %[[MUL]], %[[C0]] : vector<16xi48>, i32, vector<16xi16>
-  %0 = arith.muli %arg0, %arg1 : vector<16xi16>
-  // CHECK: return %[[RES]] : vector<16xi16>
-  return %0 : vector<16xi16>
-}
+    // CHECK-LABEL: func @vecmuli16(
+    // CHECK-SAME: %[[LHS:.*]]: vector<16xi16>,
+    // CHECK-SAME: %[[RHS:.*]]: vector<16xi16>)
+    func.func @vecmuli16(%arg0: vector<16xi16>, %arg1: vector<16xi16>) -> vector<16xi16> {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[MUL:.*]] = aievec_aie1.mul %[[LHS]], %[[RHS]] : vector<16xi16>, vector<16xi16>, vector<16xi48>
+      // CHECK: %[[RES:.*]] = aievec.srs %[[MUL]], %[[C0]] : vector<16xi48>, i32, vector<16xi16>
+      %0 = arith.muli %arg0, %arg1 : vector<16xi16>
+      // CHECK: return %[[RES]] : vector<16xi16>
+      return %0 : vector<16xi16>
+    }
 
-// CHECK-LABEL: func @vecmuli32(
-// CHECK-SAME: %[[LHS:.*]]: vector<8xi32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<8xi32>)
-func.func @vecmuli32(%arg0: vector<8xi32>, %arg1: vector<8xi32>) -> vector<8xi32> {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[MUL:.*]] = aievec_aie1.mul %[[LHS]], %[[RHS]] : vector<8xi32>, vector<8xi32>, vector<8xi80>
-  // CHECK: %[[RES:.*]] = aievec.srs %[[MUL]], %[[C0]] : vector<8xi80>, i32, vector<8xi32>
-  %0 = arith.muli %arg0, %arg1 : vector<8xi32>
-  // CHECK: return %[[RES]] : vector<8xi32>
-  return %0 : vector<8xi32>
-}
+    // CHECK-LABEL: func @vecmuli32(
+    // CHECK-SAME: %[[LHS:.*]]: vector<8xi32>,
+    // CHECK-SAME: %[[RHS:.*]]: vector<8xi32>)
+    func.func @vecmuli32(%arg0: vector<8xi32>, %arg1: vector<8xi32>) -> vector<8xi32> {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[MUL:.*]] = aievec_aie1.mul %[[LHS]], %[[RHS]] : vector<8xi32>, vector<8xi32>, vector<8xi80>
+      // CHECK: %[[RES:.*]] = aievec.srs %[[MUL]], %[[C0]] : vector<8xi80>, i32, vector<8xi32>
+      %0 = arith.muli %arg0, %arg1 : vector<8xi32>
+      // CHECK: return %[[RES]] : vector<8xi32>
+      return %0 : vector<8xi32>
+    }
 
-// CHECK-LABEL: func @vecmulf(
-// CHECK-SAME: %[[LHS:.*]]: vector<8xf32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<8xf32>)
-func.func @vecmulf(%arg0: vector<8xf32>, %arg1: vector<8xf32>) -> vector<8xf32> {
-  // CHECK: %[[RES:.*]] = aievec_aie1.mul %[[LHS]], %[[RHS]] : vector<8xf32>, vector<8xf32>, vector<8xf32>
-  %0 = arith.mulf %arg0, %arg1 : vector<8xf32>
-  // CHECK: return %[[RES]] : vector<8xf32>
-  return %0 : vector<8xf32>
+    // CHECK-LABEL: func @vecmulf(
+    // CHECK-SAME: %[[LHS:.*]]: vector<8xf32>,
+    // CHECK-SAME: %[[RHS:.*]]: vector<8xf32>)
+    func.func @vecmulf(%arg0: vector<8xf32>, %arg1: vector<8xf32>) -> vector<8xf32> {
+      // CHECK: %[[RES:.*]] = aievec_aie1.mul %[[LHS]], %[[RHS]] : vector<8xf32>, vector<8xf32>, vector<8xf32>
+      %0 = arith.mulf %arg0, %arg1 : vector<8xf32>
+      // CHECK: return %[[RES]] : vector<8xf32>
+      return %0 : vector<8xf32>
+    }
 }

--- a/test/Conversion/VectorToAIEVec/test-cmp.mlir
+++ b/test/Conversion/VectorToAIEVec/test-cmp.mlir
@@ -1,166 +1,196 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
 // CHECK-LABEL:func @veccmp_i32
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @veccmp_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpi sgt, %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1> 
+aie.device(npu1) {
+  func.func @veccmp_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpi sgt, %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1> 
+  }
 }
 
 // CHECK-LABEL:func @veccmp_eq
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @veccmp_eq(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "eq"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpi eq, %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_eq(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "eq"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpi eq, %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_ne
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @veccmp_ne(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ne"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpi ne, %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_ne(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ne"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpi ne, %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_lt
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @veccmp_lt(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "slt"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpi slt, %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_lt(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "slt"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpi slt, %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_le
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @veccmp_le(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sle"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpi sle, %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_le(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sle"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpi sle, %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_ge
 // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @veccmp_ge(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sge"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpi sge, %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_ge(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sge"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpi sge, %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_i16
 // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @veccmp_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<32xi16>, vector<32xi16>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<32xi1>
-  %0 = arith.cmpi sgt, %arg0, %arg1 : vector<32xi16>
-  // CHECK: return %[[RES]] : vector<32xi1>
-  return %0 : vector<32xi1>
+aie.device(npu1) {
+  func.func @veccmp_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<32xi16>, vector<32xi16>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<32xi1>
+    %0 = arith.cmpi sgt, %arg0, %arg1 : vector<32xi16>
+    // CHECK: return %[[RES]] : vector<32xi1>
+    return %0 : vector<32xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_i8
 // CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
 // CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
-func.func @veccmp_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<64xi8>, vector<64xi8>, ui64
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui64 to vector<64xi1>
-  %0 = arith.cmpi sgt, %arg0, %arg1 : vector<64xi8>
-  // CHECK: return %[[RES]] : vector<64xi1>
-  return %0 : vector<64xi1>
+aie.device(npu1) {
+  func.func @veccmp_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<64xi8>, vector<64xi8>, ui64
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui64 to vector<64xi1>
+    %0 = arith.cmpi sgt, %arg0, %arg1 : vector<64xi8>
+    // CHECK: return %[[RES]] : vector<64xi1>
+    return %0 : vector<64xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_bf16
 // CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
 // CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
-func.func @veccmp_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<32xbf16>, vector<32xbf16>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<32xi1>
-  %0 = arith.cmpf ogt, %arg0, %arg1 : vector<32xbf16>
-  // CHECK: return %[[RES]] : vector<32xi1>
-  return %0 : vector<32xi1>
+aie.device(npu1) {
+  func.func @veccmp_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<32xbf16>, vector<32xbf16>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<32xi1>
+    %0 = arith.cmpf ogt, %arg0, %arg1 : vector<32xbf16>
+    // CHECK: return %[[RES]] : vector<32xi1>
+    return %0 : vector<32xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_f32
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @veccmp_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpf ogt, %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpf ogt, %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_feq
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @veccmp_feq(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "eq"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpf oeq, %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_feq(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "eq"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpf oeq, %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_fne
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @veccmp_fne(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ne"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpf one, %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_fne(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ne"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpf one, %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_flt
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @veccmp_flt(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "slt"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpf olt, %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_flt(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "slt"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpf olt, %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_fle
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @veccmp_fle(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sle"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpf ole, %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_fle(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sle"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpf ole, %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }
 
 // CHECK-LABEL:func @veccmp_fge
 // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
 // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @veccmp_fge(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sge"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
-  %0 = arith.cmpf oge, %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xi1>
-  return %0 : vector<16xi1>
+aie.device(npu1) {
+  func.func @veccmp_fge(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xi1> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sge"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[RES:.*]] = builtin.unrealized_conversion_cast %[[CMP]] : ui32 to vector<16xi1>
+    %0 = arith.cmpf oge, %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xi1>
+    return %0 : vector<16xi1>
+  }
 }

--- a/test/Conversion/VectorToAIEVec/test-contract.mlir
+++ b/test/Conversion/VectorToAIEVec/test-contract.mlir
@@ -1,177 +1,178 @@
-// RUN: aie-opt %s -convert-vector-to-aievec=aie-target=aie2 | FileCheck %s
-// RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aie2 target-backend=llvmir" | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: aie-opt %s -convert-vector-to-aievec | FileCheck %s
+// RUN: aie-opt %s -convert-vector-to-aievec="target-backend=llvmir" | FileCheck %s --check-prefix=CHECK-LLVM
 
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map3 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-// CHECK-LABEL: func.func @contractbf16bf16f32(
-// CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
-// CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
-// CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
-// CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xf32>, vector<4x4xf32>
-// CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
-// CHECK-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
-// CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xf32>, vector<4x4xf32>
-// CHECK:        return %[[R]] : vector<4x4xf32>
+aie.device(npu1) {
+    // CHECK-LABEL: func.func @contractbf16bf16f32(
+    // CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
+    // CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
+    // CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
+    // CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xf32>, vector<4x4xf32>
+    // CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
+    // CHECK-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
+    // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xf32>, vector<4x4xf32>
+    // CHECK:        return %[[R]] : vector<4x4xf32>
 
-// CHECK-LLVM-LABEL: func.func @contractbf16bf16f32(
-// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
-// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
-// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
-// CHECK-LLVM-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
-// CHECK-LLVM:        return %[[MM]] : vector<4x4xf32>
-func.func @contractbf16bf16f32(%A : vector<4x8xbf16>,
-                               %B : vector<8x4xbf16>,
-                               %C : vector<4x4xf32>) -> vector<4x4xf32> {
-  %0 = vector.contract {indexing_maps = [#map1, #map2, #map3],
-                        iterator_types = ["parallel", "parallel", "reduction"],
-                        kind = #vector.kind<add>} %A, %B, %C :
-                        vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
-  return %0 : vector<4x4xf32>
+    // CHECK-LLVM-LABEL: func.func @contractbf16bf16f32(
+    // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
+    // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
+    // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
+    // CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+    // CHECK-LLVM-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
+    // CHECK-LLVM:        return %[[MM]] : vector<4x4xf32>
+    func.func @contractbf16bf16f32(%A : vector<4x8xbf16>,
+                                   %B : vector<8x4xbf16>,
+                                   %C : vector<4x4xf32>) -> vector<4x4xf32> {
+      %0 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                            iterator_types = ["parallel", "parallel", "reduction"],
+                            kind = #vector.kind<add>} %A, %B, %C :
+                            vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
+      return %0 : vector<4x4xf32>
+    }
+
+    // CHECK-LABEL: func.func @contracti16i8i32(
+    // CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
+    // CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+    // CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+    // CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x8xi32>, vector<4x8xi32>
+    // CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
+    // CHECK-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+    // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x8xi32>, vector<4x8xi32>
+    // CHECK:        return %[[R]] : vector<4x8xi32>
+
+    // CHECK-LLVM-LABEL: func.func @contracti16i8i32(
+    // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
+    // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+    // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+    // CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+    // CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+    // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
+    func.func @contracti16i8i32(%A : vector<4x4xi16>,
+                                %B : vector<4x8xi8>,
+                                %C : vector<4x8xi32>) -> vector<4x8xi32> {
+      %0 = arith.extsi %B : vector<4x8xi8> to vector<4x8xi16>
+      %1 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                            iterator_types = ["parallel", "parallel", "reduction"],
+                            kind = #vector.kind<add>} %A, %0, %C :
+                            vector<4x4xi16>, vector<4x8xi16> into vector<4x8xi32>
+      return %1 : vector<4x8xi32>
+    }
+
+    // CHECK-LABEL: func.func @contracti32i16i64(
+    // CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
+    // CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
+    // CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
+    // CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xi64>, vector<4x4xi64>
+    // CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
+    // CHECK-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+    // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xi64>, vector<4x4xi64>
+    // CHECK:        return %[[R]] : vector<4x4xi64>
+
+    // CHECK-LLVM-LABEL: func.func @contracti32i16i64(
+    // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
+    // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
+    // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
+    // CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+    // CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+    // CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
+    func.func @contracti32i16i64(%A : vector<4x2xi32>,
+                                 %B : vector<2x4xi16>,
+                                 %C : vector<4x4xi64>) -> vector<4x4xi64> {
+      %0 = arith.extsi %B : vector<2x4xi16> to vector<2x4xi32>
+      %1 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                            iterator_types = ["parallel", "parallel", "reduction"],
+                            kind = #vector.kind<add>} %A, %0, %C :
+                            vector<4x2xi32>, vector<2x4xi32> into vector<4x4xi64>
+      return %1 : vector<4x4xi64>
+    }
+
+    // CHECK-LABEL: func.func @contractf32f32f32(
+    // CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
+    // CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
+    // CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
+    // CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xf32>, vector<4x4xf32>
+    // CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
+    // CHECK-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
+    // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xf32>, vector<4x4xf32>
+    // CHECK:        return %[[R]] : vector<4x4xf32>
+
+    // CHECK-LLVM-LABEL: func.func @contractf32f32f32(
+    // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
+    // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
+    // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
+    // CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+    // CHECK-LLVM-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
+    // CHECK-LLVM:        return %[[MM]] : vector<4x4xf32>
+    func.func @contractf32f32f32(%A : vector<4x8xbf16>,
+                                 %B : vector<8x4xbf16>,
+                                 %C : vector<4x4xf32>) -> vector<4x4xf32> {
+      %0 = arith.extf %A : vector<4x8xbf16> to vector<4x8xf32>
+      %1 = arith.extf %B : vector<8x4xbf16> to vector<8x4xf32>
+      %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                            iterator_types = ["parallel", "parallel", "reduction"],
+                            kind = #vector.kind<add>} %0, %1, %C :
+                            vector<4x8xf32>, vector<8x4xf32> into vector<4x4xf32>
+      return %2 : vector<4x4xf32>
+    }
+
+    // CHECK-LABEL: func.func @contracti32i32i32(
+    // CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
+    // CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+    // CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+    // CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x8xi32>, vector<4x8xi32>
+    // CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
+    // CHECK-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+    // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x8xi32>, vector<4x8xi32>
+    // CHECK:        return %[[R]] : vector<4x8xi32>
+
+    // CHECK-LLVM-LABEL: func.func @contracti32i32i32(
+    // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
+    // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
+    // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
+    // CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+    // CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
+    // CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
+    func.func @contracti32i32i32(%A : vector<4x4xi16>,
+                                 %B : vector<4x8xi8>,
+                                 %C : vector<4x8xi32>) -> vector<4x8xi32> {
+      %0 = arith.extsi %A : vector<4x4xi16> to vector<4x4xi32>
+      %1 = arith.extsi %B : vector<4x8xi8> to vector<4x8xi32>
+      %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                            iterator_types = ["parallel", "parallel", "reduction"],
+                            kind = #vector.kind<add>} %0, %1, %C :
+                            vector<4x4xi32>, vector<4x8xi32> into vector<4x8xi32>
+      return %2 : vector<4x8xi32>
+    }
+
+    // CHECK-LABEL: func.func @contracti64i64i64(
+    // CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
+    // CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
+    // CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
+    // CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xi64>, vector<4x4xi64>
+    // CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
+    // CHECK-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+    // CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xi64>, vector<4x4xi64>
+    // CHECK:        return %[[R]] : vector<4x4xi64>
+
+    // CHECK-LLVM-LABEL: func.func @contracti64i64i64(
+    // CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
+    // CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
+    // CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
+    // CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
+    // CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
+    // CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
+    func.func @contracti64i64i64(%A : vector<4x2xi32>,
+                                 %B : vector<2x4xi16>,
+                                 %C : vector<4x4xi64>) -> vector<4x4xi64> {
+      %0 = arith.extui %A : vector<4x2xi32> to vector<4x2xi64>
+      %1 = arith.extui %B : vector<2x4xi16> to vector<2x4xi64>
+      %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
+                            iterator_types = ["parallel", "parallel", "reduction"],
+                            kind = #vector.kind<add>} %0, %1, %C :
+                            vector<4x2xi64>, vector<2x4xi64> into vector<4x4xi64>
+      return %2 : vector<4x4xi64>
+    }
 }
-
-// CHECK-LABEL: func.func @contracti16i8i32(
-// CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
-// CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
-// CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x8xi32>, vector<4x8xi32>
-// CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
-// CHECK-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
-// CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x8xi32>, vector<4x8xi32>
-// CHECK:        return %[[R]] : vector<4x8xi32>
-
-// CHECK-LLVM-LABEL: func.func @contracti16i8i32(
-// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
-// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
-// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
-// CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
-// CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
-func.func @contracti16i8i32(%A : vector<4x4xi16>,
-                            %B : vector<4x8xi8>,
-                            %C : vector<4x8xi32>) -> vector<4x8xi32> {
-  %0 = arith.extsi %B : vector<4x8xi8> to vector<4x8xi16>
-  %1 = vector.contract {indexing_maps = [#map1, #map2, #map3],
-                        iterator_types = ["parallel", "parallel", "reduction"],
-                        kind = #vector.kind<add>} %A, %0, %C :
-                        vector<4x4xi16>, vector<4x8xi16> into vector<4x8xi32>
-  return %1 : vector<4x8xi32>
-}
-
-// CHECK-LABEL: func.func @contracti32i16i64(
-// CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
-// CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
-// CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xi64>, vector<4x4xi64>
-// CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
-// CHECK-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
-// CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xi64>, vector<4x4xi64>
-// CHECK:        return %[[R]] : vector<4x4xi64>
-
-// CHECK-LLVM-LABEL: func.func @contracti32i16i64(
-// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
-// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
-// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
-// CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
-// CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
-func.func @contracti32i16i64(%A : vector<4x2xi32>,
-                             %B : vector<2x4xi16>,
-                             %C : vector<4x4xi64>) -> vector<4x4xi64> {
-  %0 = arith.extsi %B : vector<2x4xi16> to vector<2x4xi32>
-  %1 = vector.contract {indexing_maps = [#map1, #map2, #map3],
-                        iterator_types = ["parallel", "parallel", "reduction"],
-                        kind = #vector.kind<add>} %A, %0, %C :
-                        vector<4x2xi32>, vector<2x4xi32> into vector<4x4xi64>
-  return %1 : vector<4x4xi64>
-}
-
-// CHECK-LABEL: func.func @contractf32f32f32(
-// CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
-// CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
-// CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
-// CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xf32>, vector<4x4xf32>
-// CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
-// CHECK-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
-// CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xf32>, vector<4x4xf32>
-// CHECK:        return %[[R]] : vector<4x4xf32>
-
-// CHECK-LLVM-LABEL: func.func @contractf32f32f32(
-// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x8xbf16>,
-// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<8x4xbf16>,
-// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xf32>) -> vector<4x4xf32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
-// CHECK-LLVM-SAME:   vector<4x8xbf16>, vector<8x4xbf16> into vector<4x4xf32>
-// CHECK-LLVM:        return %[[MM]] : vector<4x4xf32>
-func.func @contractf32f32f32(%A : vector<4x8xbf16>,
-                             %B : vector<8x4xbf16>,
-                             %C : vector<4x4xf32>) -> vector<4x4xf32> {
-  %0 = arith.extf %A : vector<4x8xbf16> to vector<4x8xf32>
-  %1 = arith.extf %B : vector<8x4xbf16> to vector<8x4xf32>
-  %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
-                        iterator_types = ["parallel", "parallel", "reduction"],
-                        kind = #vector.kind<add>} %0, %1, %C :
-                        vector<4x8xf32>, vector<8x4xf32> into vector<4x4xf32>
-  return %2 : vector<4x4xf32>
-}
-
-// CHECK-LABEL: func.func @contracti32i32i32(
-// CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
-// CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
-// CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x8xi32>, vector<4x8xi32>
-// CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
-// CHECK-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
-// CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x8xi32>, vector<4x8xi32>
-// CHECK:        return %[[R]] : vector<4x8xi32>
-
-// CHECK-LLVM-LABEL: func.func @contracti32i32i32(
-// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x4xi16>,
-// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<4x8xi8>,
-// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x8xi32>) -> vector<4x8xi32> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
-// CHECK-LLVM-SAME:   vector<4x4xi16>, vector<4x8xi8> into vector<4x8xi32>
-// CHECK-LLVM:        return %[[MM]] : vector<4x8xi32>
-func.func @contracti32i32i32(%A : vector<4x4xi16>,
-                             %B : vector<4x8xi8>,
-                             %C : vector<4x8xi32>) -> vector<4x8xi32> {
-  %0 = arith.extsi %A : vector<4x4xi16> to vector<4x4xi32>
-  %1 = arith.extsi %B : vector<4x8xi8> to vector<4x8xi32>
-  %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
-                        iterator_types = ["parallel", "parallel", "reduction"],
-                        kind = #vector.kind<add>} %0, %1, %C :
-                        vector<4x4xi32>, vector<4x8xi32> into vector<4x8xi32>
-  return %2 : vector<4x8xi32>
-}
-
-// CHECK-LABEL: func.func @contracti64i64i64(
-// CHECK-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
-// CHECK-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
-// CHECK-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK:        %[[ACC:.*]] = aievec.cast %[[C]] {isResAcc = true} : vector<4x4xi64>, vector<4x4xi64>
-// CHECK:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[ACC]] :
-// CHECK-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
-// CHECK:        %[[R:.*]] = aievec.cast %[[MM]] {isResAcc = false} : vector<4x4xi64>, vector<4x4xi64>
-// CHECK:        return %[[R]] : vector<4x4xi64>
-
-// CHECK-LLVM-LABEL: func.func @contracti64i64i64(
-// CHECK-LLVM-SAME: %[[A:[a-zA-Z0-9]+]]: vector<4x2xi32>,
-// CHECK-LLVM-SAME: %[[B:[a-zA-Z0-9]+]]: vector<2x4xi16>,
-// CHECK-LLVM-SAME: %[[C:[a-zA-Z0-9]+]]: vector<4x4xi64>) -> vector<4x4xi64> {
-// CHECK-LLVM:        %[[MM:.*]] = aievec.matmul %[[A]], %[[B]], %[[C]] :
-// CHECK-LLVM-SAME:   vector<4x2xi32>, vector<2x4xi16> into vector<4x4xi64>
-// CHECK-LLVM:        return %[[MM]] : vector<4x4xi64>
-func.func @contracti64i64i64(%A : vector<4x2xi32>,
-                             %B : vector<2x4xi16>,
-                             %C : vector<4x4xi64>) -> vector<4x4xi64> {
-  %0 = arith.extui %A : vector<4x2xi32> to vector<4x2xi64>
-  %1 = arith.extui %B : vector<2x4xi16> to vector<2x4xi64>
-  %2 = vector.contract {indexing_maps = [#map1, #map2, #map3],
-                        iterator_types = ["parallel", "parallel", "reduction"],
-                        kind = #vector.kind<add>} %0, %1, %C :
-                        vector<4x2xi64>, vector<2x4xi64> into vector<4x4xi64>
-  return %2 : vector<4x4xi64>
-}
-

--- a/test/Conversion/VectorToAIEVec/test-conv-op-i16.mlir
+++ b/test/Conversion/VectorToAIEVec/test-conv-op-i16.mlir
@@ -1,29 +1,31 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 shift=10" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec="shift=10" | FileCheck %s
 
-func.func @conv2d(%arg0: memref<18x288xi16>, %arg1: memref<9xi16>, %arg2: memref<16x256xi16>) {
-  %c0 = arith.constant 0 : index
-  %c2_i32 = arith.constant 2 : i32
-  %c4_i32 = arith.constant 4 : i32
-  affine.for %arg3 = 0 to 16 {
-    affine.for %arg4 = 0 to 256 step 16 {
-      %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<18x288xi16>, vector<32xi16>
-      %sbh = aievec.ext %0 {index = 0 : i8} : vector<32xi16>, vector<16xi16>
-      %sth = aievec.ext %0 {index = 1 : i8} : vector<32xi16>, vector<16xi16>
-      %1 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : i32} : memref<9xi16>, vector<16xi16>
-      %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<16xi16>, vector<16xi16>
-      %3 = arith.muli %sbh, %2 : vector<16xi16>
-      %4 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
-      %5 = aievec.broadcast %1 {idx = 1 : i8} : vector<16xi16>, vector<16xi16>
-      %6 = arith.muli %4, %5 : vector<16xi16>
-      %7 = arith.addi %3, %6 : vector<16xi16>
-      %8 = aievec.shift %sbh, %sth, %c4_i32 {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
-      %9 = aievec.broadcast %1 {idx = 2 : i8} : vector<16xi16>, vector<16xi16>
-      %10 = arith.muli %8, %9 : vector<16xi16>
-      %11 = arith.addi %7, %10 : vector<16xi16>
-      vector.transfer_write %11, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<16x256xi16>
+aie.device(npu1) {
+    func.func @conv2d(%arg0: memref<18x288xi16>, %arg1: memref<9xi16>, %arg2: memref<16x256xi16>) {
+      %c0 = arith.constant 0 : index
+      %c2_i32 = arith.constant 2 : i32
+      %c4_i32 = arith.constant 4 : i32
+      affine.for %arg3 = 0 to 16 {
+        affine.for %arg4 = 0 to 256 step 16 {
+          %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<18x288xi16>, vector<32xi16>
+          %sbh = aievec.ext %0 {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+          %sth = aievec.ext %0 {index = 1 : i8} : vector<32xi16>, vector<16xi16>
+          %1 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : i32} : memref<9xi16>, vector<16xi16>
+          %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<16xi16>, vector<16xi16>
+          %3 = arith.muli %sbh, %2 : vector<16xi16>
+          %4 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+          %5 = aievec.broadcast %1 {idx = 1 : i8} : vector<16xi16>, vector<16xi16>
+          %6 = arith.muli %4, %5 : vector<16xi16>
+          %7 = arith.addi %3, %6 : vector<16xi16>
+          %8 = aievec.shift %sbh, %sth, %c4_i32 {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+          %9 = aievec.broadcast %1 {idx = 2 : i8} : vector<16xi16>, vector<16xi16>
+          %10 = arith.muli %8, %9 : vector<16xi16>
+          %11 = arith.addi %7, %10 : vector<16xi16>
+          vector.transfer_write %11, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<16xi16>, memref<16x256xi16>
+        }
+      }
+      return
     }
-  }
-  return
 }
 
 // CHECK-LABEL: func @conv2d

--- a/test/Conversion/VectorToAIEVec/test-conv-op-i8-init.mlir
+++ b/test/Conversion/VectorToAIEVec/test-conv-op-i8-init.mlir
@@ -1,31 +1,33 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
-  %c0 = arith.constant 0 : index
-  %c1_i32 = arith.constant 1 : i32
-  %c2_i32 = arith.constant 2 : i32
-  affine.for %arg3 = 0 to 16 {
-    affine.for %arg4 = 0 to 256 step 32 {
-      %0 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<16x256xi8>, vector<32xi8>
-      %1 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<18x288xi8>, vector<64xi8>
-      %sbh = aievec.ext %1 {index = 0 : i8} : vector<64xi8>, vector<32xi8>
-      %sth = aievec.ext %1 {index = 1 : i8} : vector<64xi8>, vector<32xi8>
-      %2 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<32xi8>
-      %3 = aievec.broadcast %2 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
-      %4 = arith.muli %sbh, %3 : vector<32xi8>
-      %5 = arith.addi %0, %4 : vector<32xi8>
-      %7 = aievec.shift %sbh, %sth, %c1_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-      %8 = aievec.broadcast %2 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
-      %9 = arith.muli %7, %8 : vector<32xi8>
-      %10 = arith.addi %5, %9 : vector<32xi8>
-      %12 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-      %13 = aievec.broadcast %2 {idx = 4 : i8} : vector<32xi8>, vector<32xi8>
-      %14 = arith.muli %12, %13 : vector<32xi8>
-      %15 = arith.addi %10, %14 : vector<32xi8>
-      vector.transfer_write %15, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
+aie.device(npu1) {
+  func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    affine.for %arg3 = 0 to 16 {
+      affine.for %arg4 = 0 to 256 step 32 {
+        %0 = aievec.upd %arg2[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<16x256xi8>, vector<32xi8>
+        %1 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<18x288xi8>, vector<64xi8>
+        %sbh = aievec.ext %1 {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+        %sth = aievec.ext %1 {index = 1 : i8} : vector<64xi8>, vector<32xi8>
+        %2 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<32xi8>
+        %3 = aievec.broadcast %2 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
+        %4 = arith.muli %sbh, %3 : vector<32xi8>
+        %5 = arith.addi %0, %4 : vector<32xi8>
+        %7 = aievec.shift %sbh, %sth, %c1_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+        %8 = aievec.broadcast %2 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
+        %9 = arith.muli %7, %8 : vector<32xi8>
+        %10 = arith.addi %5, %9 : vector<32xi8>
+        %12 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+        %13 = aievec.broadcast %2 {idx = 4 : i8} : vector<32xi8>, vector<32xi8>
+        %14 = arith.muli %12, %13 : vector<32xi8>
+        %15 = arith.addi %10, %14 : vector<32xi8>
+        vector.transfer_write %15, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
+      }
     }
+    return
   }
-  return
 }
 
 // CHECK-LABEL: func @conv2d

--- a/test/Conversion/VectorToAIEVec/test-conv-op-i8.mlir
+++ b/test/Conversion/VectorToAIEVec/test-conv-op-i8.mlir
@@ -1,29 +1,31 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
-  %c0 = arith.constant 0 : index
-  %c1_i32 = arith.constant 1 : i32
-  %c2_i32 = arith.constant 2 : i32
-  affine.for %arg3 = 0 to 16 {
-    affine.for %arg4 = 0 to 256 step 32 {
-      %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<18x288xi8>, vector<64xi8>
-      %sbh = aievec.ext %0 {index = 0 : i8} : vector<64xi8>, vector<32xi8>
-      %sth = aievec.ext %0 {index = 1 : i8} : vector<64xi8>, vector<32xi8>
-      %1 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<32xi8>
-      %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
-      %3 = arith.muli %sbh, %2 : vector<32xi8>
-      %4 = aievec.shift %sbh, %sth, %c1_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-      %5 = aievec.broadcast %1 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
-      %6 = arith.muli %4, %5 : vector<32xi8>
-      %7 = arith.addi %3, %6 : vector<32xi8>
-      %8 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-      %9 = aievec.broadcast %1 {idx = 4 : i8} : vector<32xi8>, vector<32xi8>
-      %10 = arith.muli %8, %9 : vector<32xi8>
-      %11 = arith.addi %7, %10 : vector<32xi8>
-      vector.transfer_write %11, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
+aie.device(npu1) {
+  func.func @conv2d(%arg0: memref<18x288xi8>, %arg1: memref<48xi8>, %arg2: memref<16x256xi8>) {
+    %c0 = arith.constant 0 : index
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    affine.for %arg3 = 0 to 16 {
+      affine.for %arg4 = 0 to 256 step 32 {
+        %0 = aievec.upd %arg0[%arg3, %arg4] {index = 0 : i8, offset = 0 : i32} : memref<18x288xi8>, vector<64xi8>
+        %sbh = aievec.ext %0 {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+        %sth = aievec.ext %0 {index = 1 : i8} : vector<64xi8>, vector<32xi8>
+        %1 = aievec.upd %arg1[%c0] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<32xi8>
+        %2 = aievec.broadcast %1 {idx = 0 : i8} : vector<32xi8>, vector<32xi8>
+        %3 = arith.muli %sbh, %2 : vector<32xi8>
+        %4 = aievec.shift %sbh, %sth, %c1_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+        %5 = aievec.broadcast %1 {idx = 2 : i8} : vector<32xi8>, vector<32xi8>
+        %6 = arith.muli %4, %5 : vector<32xi8>
+        %7 = arith.addi %3, %6 : vector<32xi8>
+        %8 = aievec.shift %sbh, %sth, %c2_i32 {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+        %9 = aievec.broadcast %1 {idx = 4 : i8} : vector<32xi8>, vector<32xi8>
+        %10 = arith.muli %8, %9 : vector<32xi8>
+        %11 = arith.addi %7, %10 : vector<32xi8>
+        vector.transfer_write %11, %arg2[%arg3, %arg4] {in_bounds = [true]} : vector<32xi8>, memref<16x256xi8>
+      }
     }
+    return
   }
-  return
 }
 
 // CHECK-LABEL: func @conv2d

--- a/test/Conversion/VectorToAIEVec/test-mac.mlir
+++ b/test/Conversion/VectorToAIEVec/test-mac.mlir
@@ -1,104 +1,106 @@
 // RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL: func.func @muladd2mac_i32(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
-func.func @muladd2mac_i32(%a : vector<8xi32>,
-                          %b : vector<8xi32>,
-                          %c : vector<8xi32>) -> vector<8xi32> {
-    // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
-    // CHECK: %[[AA:.*]] = aievec.concat %[[A]], %[[A]] : vector<8xi32>, vector<16xi32>
-    // CHECK: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
-    // CHECK: %[[MAC:.*]] = aievec_aie1.mac %[[AA]], %[[B]], %[[ACC]] : vector<16xi32>, vector<8xi32>, vector<8xi80>
-    // CHECK: %[[RES:.*]] = aievec.srs %[[MAC]], %[[C0]] : vector<8xi80>, i32, vector<8xi32>
-    %0 = arith.muli %a, %b : vector<8xi32>
-    %1 = arith.addi %0, %c : vector<8xi32>
-    // CHECK: return %[[RES]] : vector<8xi32>
-    return %1 : vector<8xi32>
-}
+aie.device(xcvc1902) {
+    // CHECK-LABEL: func.func @muladd2mac_i32(
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
+    func.func @muladd2mac_i32(%a : vector<8xi32>,
+                            %b : vector<8xi32>,
+                            %c : vector<8xi32>) -> vector<8xi32> {
+        // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+        // CHECK: %[[AA:.*]] = aievec.concat %[[A]], %[[A]] : vector<8xi32>, vector<16xi32>
+        // CHECK: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+        // CHECK: %[[MAC:.*]] = aievec_aie1.mac %[[AA]], %[[B]], %[[ACC]] : vector<16xi32>, vector<8xi32>, vector<8xi80>
+        // CHECK: %[[RES:.*]] = aievec.srs %[[MAC]], %[[C0]] : vector<8xi80>, i32, vector<8xi32>
+        %0 = arith.muli %a, %b : vector<8xi32>
+        %1 = arith.addi %0, %c : vector<8xi32>
+        // CHECK: return %[[RES]] : vector<8xi32>
+        return %1 : vector<8xi32>
+    }
 
-// CHECK-LABEL: func.func @muladd2mac_inv(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
-func.func @muladd2mac_inv(%a : vector<8xi32>,
-                          %b : vector<8xi32>,
-                          %c : vector<8xi32>) -> vector<8xi32> {
-    // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
-    // CHECK: %[[AA:.*]] = aievec.concat %[[A]], %[[A]] : vector<8xi32>, vector<16xi32>
-    // CHECK: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
-    // CHECK: %[[MAC:.*]] = aievec_aie1.mac %[[AA]], %[[B]], %[[ACC]] : vector<16xi32>, vector<8xi32>, vector<8xi80>
-    // CHECK: %[[RES:.*]] = aievec.srs %[[MAC]], %[[C0]] : vector<8xi80>, i32, vector<8xi32>
-    %0 = arith.muli %a, %b : vector<8xi32>
-    %1 = arith.addi %c, %0 : vector<8xi32>
-    // CHECK: return %[[RES]] : vector<8xi32>
-    return %1 : vector<8xi32>
-}
+    // CHECK-LABEL: func.func @muladd2mac_inv(
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
+    func.func @muladd2mac_inv(%a : vector<8xi32>,
+                            %b : vector<8xi32>,
+                            %c : vector<8xi32>) -> vector<8xi32> {
+        // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+        // CHECK: %[[AA:.*]] = aievec.concat %[[A]], %[[A]] : vector<8xi32>, vector<16xi32>
+        // CHECK: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+        // CHECK: %[[MAC:.*]] = aievec_aie1.mac %[[AA]], %[[B]], %[[ACC]] : vector<16xi32>, vector<8xi32>, vector<8xi80>
+        // CHECK: %[[RES:.*]] = aievec.srs %[[MAC]], %[[C0]] : vector<8xi80>, i32, vector<8xi32>
+        %0 = arith.muli %a, %b : vector<8xi32>
+        %1 = arith.addi %c, %0 : vector<8xi32>
+        // CHECK: return %[[RES]] : vector<8xi32>
+        return %1 : vector<8xi32>
+    }
 
-// CHECK-LABEL: func.func @splatAndMac2SplatMac(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
-func.func @splatAndMac2SplatMac(%a : vector<8xi32>,
-                                %b : vector<8xi32>,
-                                %c : vector<8xi32>) -> vector<8xi80> {
-    %0 = vector.extract %a[2] : i32 from vector<8xi32>
-    %1 = vector.broadcast %0 : i32 to vector<8xi32>
-    %2 = aievec.concat %1, %1 : vector<8xi32>, vector<16xi32>
-    %3 = aievec.ups %c {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
-    %4 = aievec_aie1.mac %2, %b, %3 : vector<16xi32>, vector<8xi32>, vector<8xi80>
-    return %4 : vector<8xi80>
-    // CHECK-DAG: %[[CVZ:.*]] = arith.constant dense<0> : vector<8xi32>
-    // CHECK-DAG: %[[BB:.*]] = aievec.concat %[[B]], %[[CVZ]] : vector<8xi32>, vector<16xi32>
-    // CHECK-DAG: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
-    // CHECK-DAG: %[[MAC:.*]] = aievec_aie1.mac %[[BB]], %[[A]], %[[ACC]]
-    // CHECK-SAME:              {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000",
-    // CHECK-SAME:               zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
-    // CHECK: return %[[MAC]] : vector<8xi80>
-}
-
-// CHECK-LABEL: func.func @splatAndMac2SplatMac_inv(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
-func.func @splatAndMac2SplatMac_inv(%a : vector<8xi32>,
+    // CHECK-LABEL: func.func @splatAndMac2SplatMac(
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
+    func.func @splatAndMac2SplatMac(%a : vector<8xi32>,
                                     %b : vector<8xi32>,
                                     %c : vector<8xi32>) -> vector<8xi80> {
-    %0 = vector.extract %b[4] : i32 from vector<8xi32>
-    %1 = vector.broadcast %0 : i32 to vector<8xi32>
-    %2 = aievec.concat %a, %a : vector<8xi32>, vector<16xi32>
-    %3 = aievec.ups %c {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
-    %4 = aievec_aie1.mac %2, %1, %3 : vector<16xi32>, vector<8xi32>, vector<8xi80>
-    return %4 : vector<8xi80>
-    // CHECK-DAG: %[[CVZ:.*]] = arith.constant dense<0> : vector<8xi32>
-    // CHECK-DAG: %[[AA:.*]] = aievec.concat %[[A]], %[[CVZ]] : vector<8xi32>, vector<16xi32>
-    // CHECK-DAG: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
-    // CHECK-DAG: %[[MAC:.*]] = aievec_aie1.mac %[[AA]], %[[B]], %[[ACC]]
-    // CHECK-SAME:              {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000",
-    // CHECK-SAME:               zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
-    // CHECK: return %[[MAC]] : vector<8xi80>
-}
+        %0 = vector.extract %a[2] : i32 from vector<8xi32>
+        %1 = vector.broadcast %0 : i32 to vector<8xi32>
+        %2 = aievec.concat %1, %1 : vector<8xi32>, vector<16xi32>
+        %3 = aievec.ups %c {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+        %4 = aievec_aie1.mac %2, %b, %3 : vector<16xi32>, vector<8xi32>, vector<8xi80>
+        return %4 : vector<8xi80>
+        // CHECK-DAG: %[[CVZ:.*]] = arith.constant dense<0> : vector<8xi32>
+        // CHECK-DAG: %[[BB:.*]] = aievec.concat %[[B]], %[[CVZ]] : vector<8xi32>, vector<16xi32>
+        // CHECK-DAG: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+        // CHECK-DAG: %[[MAC:.*]] = aievec_aie1.mac %[[BB]], %[[A]], %[[ACC]]
+        // CHECK-SAME:              {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000",
+        // CHECK-SAME:               zstart = "2"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+        // CHECK: return %[[MAC]] : vector<8xi80>
+    }
 
-// CHECK-LABEL: func.func @splatAndMac2SplatMacI16(
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi16>,
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi16>,
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi16>
-func.func @splatAndMac2SplatMacI16(%a : vector<16xi16>,
-                                   %b : vector<16xi16>,
-                                   %c : vector<16xi16>) -> vector<16xi48> {
-    %0 = vector.extract %a[3] : i16 from vector<16xi16>
-    %1 = vector.broadcast %0 : i16 to vector<16xi16>
-    %2 = aievec.concat %1, %1 : vector<16xi16>, vector<32xi16>
-    %3 = aievec.ups %c {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
-    %4 = aievec_aie1.mac %2, %b, %3 : vector<32xi16>, vector<16xi16>, vector<16xi48>
-    return %4 : vector<16xi48>
-    // CHECK-DAG: %[[CVZ:.*]] = arith.constant dense<0> : vector<16xi16>
-    // CHECK-DAG: %[[BB:.*]] = aievec.concat %[[B]], %[[CVZ]] : vector<16xi16>, vector<32xi16>
-    // CHECK-DAG: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
-    // CHECK-DAG: %[[MAC:.*]] = aievec_aie1.mac %[[BB]], %[[A]], %[[ACC]]
-    // CHECK-SAME:              {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
-    // CHECK-SAME:               xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "3", zstep = "1"}
-    // CHECK-SAME:              : vector<32xi16>, vector<16xi16>, vector<16xi48>
-    // CHECK: return %[[MAC]] : vector<16xi48>
+    // CHECK-LABEL: func.func @splatAndMac2SplatMac_inv(
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<8xi32>,
+    // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<8xi32>
+    func.func @splatAndMac2SplatMac_inv(%a : vector<8xi32>,
+                                        %b : vector<8xi32>,
+                                        %c : vector<8xi32>) -> vector<8xi80> {
+        %0 = vector.extract %b[4] : i32 from vector<8xi32>
+        %1 = vector.broadcast %0 : i32 to vector<8xi32>
+        %2 = aievec.concat %a, %a : vector<8xi32>, vector<16xi32>
+        %3 = aievec.ups %c {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+        %4 = aievec_aie1.mac %2, %1, %3 : vector<16xi32>, vector<8xi32>, vector<8xi80>
+        return %4 : vector<8xi80>
+        // CHECK-DAG: %[[CVZ:.*]] = arith.constant dense<0> : vector<8xi32>
+        // CHECK-DAG: %[[AA:.*]] = aievec.concat %[[A]], %[[CVZ]] : vector<8xi32>, vector<16xi32>
+        // CHECK-DAG: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<8xi32>, vector<8xi80>
+        // CHECK-DAG: %[[MAC:.*]] = aievec_aie1.mac %[[AA]], %[[B]], %[[ACC]]
+        // CHECK-SAME:              {xoffsets = "0x76543210", xstart = "0", zoffsets = "0x00000000",
+        // CHECK-SAME:               zstart = "4"} : vector<16xi32>, vector<8xi32>, vector<8xi80>
+        // CHECK: return %[[MAC]] : vector<8xi80>
+    }
+
+    // CHECK-LABEL: func.func @splatAndMac2SplatMacI16(
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi16>,
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi16>,
+    // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi16>
+    func.func @splatAndMac2SplatMacI16(%a : vector<16xi16>,
+                                    %b : vector<16xi16>,
+                                    %c : vector<16xi16>) -> vector<16xi48> {
+        %0 = vector.extract %a[3] : i16 from vector<16xi16>
+        %1 = vector.broadcast %0 : i16 to vector<16xi16>
+        %2 = aievec.concat %1, %1 : vector<16xi16>, vector<32xi16>
+        %3 = aievec.ups %c {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
+        %4 = aievec_aie1.mac %2, %b, %3 : vector<32xi16>, vector<16xi16>, vector<16xi48>
+        return %4 : vector<16xi48>
+        // CHECK-DAG: %[[CVZ:.*]] = arith.constant dense<0> : vector<16xi16>
+        // CHECK-DAG: %[[BB:.*]] = aievec.concat %[[B]], %[[CVZ]] : vector<16xi16>, vector<32xi16>
+        // CHECK-DAG: %[[ACC:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi16>, vector<16xi48>
+        // CHECK-DAG: %[[MAC:.*]] = aievec_aie1.mac %[[BB]], %[[A]], %[[ACC]]
+        // CHECK-SAME:              {xoffsets = "0x73727170", xoffsets_hi = "0x77767574", xsquare = "0x3120",
+        // CHECK-SAME:               xstart = "0", zoffsets = "0", zoffsets_hi = "0", zstart = "3", zstep = "1"}
+        // CHECK-SAME:              : vector<32xi16>, vector<16xi16>, vector<16xi48>
+        // CHECK: return %[[MAC]] : vector<16xi48>
+    }
 }

--- a/test/Conversion/VectorToAIEVec/test-max.mlir
+++ b/test/Conversion/VectorToAIEVec/test-max.mlir
@@ -1,52 +1,53 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL:func @vecmax_i32
-// CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecmax_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<16xi32>
-  %0 = arith.maxsi %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi32>
-  return %0 : vector<16xi32>
+aie.device(npu1) {
+  // CHECK-LABEL:func @vecmax_i32
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
+  func.func @vecmax_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<16xi32>
+    %0 = arith.maxsi %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi32>
+    return %0 : vector<16xi32>
+  }
+
+  // CHECK-LABEL:func @vecmax_i16
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
+  func.func @vecmax_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
+    // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<32xi16>
+    %0 = arith.maxsi %arg0, %arg1 : vector<32xi16>
+    // CHECK: return %[[RES]] : vector<32xi16>
+    return %0 : vector<32xi16>
+  }
+
+  // CHECK-LABEL:func @vecmax_i8
+  // CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
+  func.func @vecmax_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
+    // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<64xi8>
+    %0 = arith.maxsi %arg0, %arg1 : vector<64xi8>
+    // CHECK: return %[[RES]] : vector<64xi8>
+    return %0 : vector<64xi8>
+  }
+
+  // CHECK-LABEL:func @vecmax_bf16
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
+  func.func @vecmax_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
+    // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<32xbf16>
+    %0 = arith.maximumf %arg0, %arg1 : vector<32xbf16>
+    // CHECK: return %[[RES]] : vector<32xbf16>
+    return %0 : vector<32xbf16>
+  }
+
+  // CHECK-LABEL:func @vecmax_f32
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
+  func.func @vecmax_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+    // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<16xf32>
+    %0 = arith.maximumf %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xf32>
+    return %0 : vector<16xf32>
+  }
 }
-
-// CHECK-LABEL:func @vecmax_i16
-// CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecmax_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
-  // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<32xi16>
-  %0 = arith.maxsi %arg0, %arg1 : vector<32xi16>
-  // CHECK: return %[[RES]] : vector<32xi16>
-  return %0 : vector<32xi16>
-}
-
-// CHECK-LABEL:func @vecmax_i8
-// CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
-// CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
-func.func @vecmax_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
-  // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<64xi8>
-  %0 = arith.maxsi %arg0, %arg1 : vector<64xi8>
-  // CHECK: return %[[RES]] : vector<64xi8>
-  return %0 : vector<64xi8>
-}
-
-// CHECK-LABEL:func @vecmax_bf16
-// CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
-func.func @vecmax_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
-  // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<32xbf16>
-  %0 = arith.maximumf %arg0, %arg1 : vector<32xbf16>
-  // CHECK: return %[[RES]] : vector<32xbf16>
-  return %0 : vector<32xbf16>
-}
-
-// CHECK-LABEL:func @vecmax_f32
-// CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecmax_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[RES:.*]] = aievec.max %[[LHS]], %[[RHS]] : vector<16xf32>
-  %0 = arith.maximumf %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xf32>
-  return %0 : vector<16xf32>
-}
-

--- a/test/Conversion/VectorToAIEVec/test-min.mlir
+++ b/test/Conversion/VectorToAIEVec/test-min.mlir
@@ -1,52 +1,54 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL:func @vecmin_i32
-// CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecmin_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<16xi32>
-  %0 = arith.minsi %arg0, %arg1 : vector<16xi32>
-  // CHECK: return %[[RES]] : vector<16xi32>
-  return %0 : vector<16xi32>
-}
+aie.device(npu1) {
+  // CHECK-LABEL:func @vecmin_i32
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
+  func.func @vecmin_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<16xi32>
+    %0 = arith.minsi %arg0, %arg1 : vector<16xi32>
+    // CHECK: return %[[RES]] : vector<16xi32>
+    return %0 : vector<16xi32>
+  }
 
-// CHECK-LABEL:func @vecmin_i16
-// CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecmin_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
-  // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<32xi16>
-  %0 = arith.minsi %arg0, %arg1 : vector<32xi16>
-  // CHECK: return %[[RES]] : vector<32xi16>
-  return %0 : vector<32xi16>
-}
+  // CHECK-LABEL:func @vecmin_i16
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
+  func.func @vecmin_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
+    // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<32xi16>
+    %0 = arith.minsi %arg0, %arg1 : vector<32xi16>
+    // CHECK: return %[[RES]] : vector<32xi16>
+    return %0 : vector<32xi16>
+  }
 
-// CHECK-LABEL:func @vecmin_i8
-// CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
-// CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
-func.func @vecmin_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
-  // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<64xi8>
-  %0 = arith.minsi %arg0, %arg1 : vector<64xi8>
-  // CHECK: return %[[RES]] : vector<64xi8>
-  return %0 : vector<64xi8>
-}
+  // CHECK-LABEL:func @vecmin_i8
+  // CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
+  func.func @vecmin_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
+    // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<64xi8>
+    %0 = arith.minsi %arg0, %arg1 : vector<64xi8>
+    // CHECK: return %[[RES]] : vector<64xi8>
+    return %0 : vector<64xi8>
+  }
 
-// CHECK-LABEL:func @vecmin_bf16
-// CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
-func.func @vecmin_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
-  // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<32xbf16>
-  %0 = arith.minimumf %arg0, %arg1 : vector<32xbf16>
-  // CHECK: return %[[RES]] : vector<32xbf16>
-  return %0 : vector<32xbf16>
-}
+  // CHECK-LABEL:func @vecmin_bf16
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
+  func.func @vecmin_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
+    // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<32xbf16>
+    %0 = arith.minimumf %arg0, %arg1 : vector<32xbf16>
+    // CHECK: return %[[RES]] : vector<32xbf16>
+    return %0 : vector<32xbf16>
+  }
 
-// CHECK-LABEL:func @vecmin_f32
-// CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecmin_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<16xf32>
-  %0 = arith.minimumf %arg0, %arg1 : vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xf32>
-  return %0 : vector<16xf32>
+  // CHECK-LABEL:func @vecmin_f32
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
+  func.func @vecmin_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+    // CHECK: %[[RES:.*]] = aievec.min %[[LHS]], %[[RHS]] : vector<16xf32>
+    %0 = arith.minimumf %arg0, %arg1 : vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xf32>
+    return %0 : vector<16xf32>
+  }
 }
 

--- a/test/Conversion/VectorToAIEVec/test-reduce.mlir
+++ b/test/Conversion/VectorToAIEVec/test-reduce.mlir
@@ -1,349 +1,351 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL:func @reduce_add_i32
-// CHECK-SAME: %[[SRC:.*]]: vector<16xi32>
-func.func @reduce_add_i32(%arg0: vector<16xi32>) -> i32 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[SRC]], %[[SHIFT32]] : vector<16xi32>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[ADD1]], %[[ADD1]], %[[C16]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[SHIFT16]] : vector<16xi32>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[ADD2]], %[[ADD2]], %[[C8]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[SHIFT8]] : vector<16xi32>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[ADD3]], %[[ADD3]], %[[C4]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[SHIFT4]] : vector<16xi32>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[ADD4]], %[[C0]] : vector<16xi32>, i32, i32
-  %0 = vector.reduction <add>, %arg0 : vector<16xi32> into i32
-  // CHECK: return %[[EXTELEM]] : i32
-  return %0 : i32
-}
+aie.device(npu1) {
+    // CHECK-LABEL:func @reduce_add_i32
+    // CHECK-SAME: %[[SRC:.*]]: vector<16xi32>
+    func.func @reduce_add_i32(%arg0: vector<16xi32>) -> i32 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[SRC]], %[[SHIFT32]] : vector<16xi32>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[ADD1]], %[[ADD1]], %[[C16]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[SHIFT16]] : vector<16xi32>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[ADD2]], %[[ADD2]], %[[C8]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[SHIFT8]] : vector<16xi32>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[ADD3]], %[[ADD3]], %[[C4]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[SHIFT4]] : vector<16xi32>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[ADD4]], %[[C0]] : vector<16xi32>, i32, i32
+      %0 = vector.reduction <add>, %arg0 : vector<16xi32> into i32
+      // CHECK: return %[[EXTELEM]] : i32
+      return %0 : i32
+    }
 
-// CHECK-LABEL:func @reduce_min_i32
-// CHECK-SAME: %[[SRC:.*]]: vector<16xi32>
-func.func @reduce_min_i32(%arg0: vector<16xi32>) -> i32 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<16xi32>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<16xi32>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<16xi32>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<16xi32>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN4]], %[[C0]] : vector<16xi32>, i32, i32
-  %0 = vector.reduction <minsi>, %arg0 : vector<16xi32> into i32
-  // CHECK: return %[[EXTELEM]] : i32
-  return %0 : i32
-}
+    // CHECK-LABEL:func @reduce_min_i32
+    // CHECK-SAME: %[[SRC:.*]]: vector<16xi32>
+    func.func @reduce_min_i32(%arg0: vector<16xi32>) -> i32 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<16xi32>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<16xi32>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<16xi32>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<16xi32>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN4]], %[[C0]] : vector<16xi32>, i32, i32
+      %0 = vector.reduction <minsi>, %arg0 : vector<16xi32> into i32
+      // CHECK: return %[[EXTELEM]] : i32
+      return %0 : i32
+    }
 
-// CHECK-LABEL:func @reduce_max_i32
-// CHECK-SAME: %[[SRC:.*]]: vector<16xi32>
-func.func @reduce_max_i32(%arg0: vector<16xi32>) -> i32 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<16xi32>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<16xi32>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<16xi32>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
-  // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<16xi32>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX4]], %[[C0]] : vector<16xi32>, i32, i32
-  %0 = vector.reduction <maxsi>, %arg0 : vector<16xi32> into i32
-  // CHECK: return %[[EXTELEM]] : i32
-  return %0 : i32
-}
+    // CHECK-LABEL:func @reduce_max_i32
+    // CHECK-SAME: %[[SRC:.*]]: vector<16xi32>
+    func.func @reduce_max_i32(%arg0: vector<16xi32>) -> i32 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<16xi32>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<16xi32>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<16xi32>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<16xi32>, vector<16xi32>, i32, vector<16xi32>
+      // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<16xi32>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX4]], %[[C0]] : vector<16xi32>, i32, i32
+      %0 = vector.reduction <maxsi>, %arg0 : vector<16xi32> into i32
+      // CHECK: return %[[EXTELEM]] : i32
+      return %0 : i32
+    }
 
-// CHECK-LABEL:func @reduce_add_i16
-// CHECK-SAME: %[[SRC:.*]]: vector<32xi16>
-func.func @reduce_add_i16(%arg0: vector<32xi16>) -> i16 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C2:.*]] = arith.constant 2 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[SRC]], %[[SHIFT32]] : vector<32xi16>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[ADD1]], %[[ADD1]], %[[C16]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[SHIFT16]] : vector<32xi16>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[ADD2]], %[[ADD2]], %[[C8]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[SHIFT8]] : vector<32xi16>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[ADD3]], %[[ADD3]], %[[C4]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[SHIFT4]] : vector<32xi16>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[ADD4]], %[[ADD4]], %[[C2]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[ADD5:.*]] = aievec.add_elem %[[ADD4]], %[[SHIFT5]] : vector<32xi16>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[ADD5]], %[[C0]] : vector<32xi16>, i32, i16
-  %0 = vector.reduction <add>, %arg0 : vector<32xi16> into i16
-  // CHECK: return %[[EXTELEM]] : i16
-  return %0 : i16
-}
+    // CHECK-LABEL:func @reduce_add_i16
+    // CHECK-SAME: %[[SRC:.*]]: vector<32xi16>
+    func.func @reduce_add_i16(%arg0: vector<32xi16>) -> i16 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C2:.*]] = arith.constant 2 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[SRC]], %[[SHIFT32]] : vector<32xi16>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[ADD1]], %[[ADD1]], %[[C16]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[SHIFT16]] : vector<32xi16>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[ADD2]], %[[ADD2]], %[[C8]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[SHIFT8]] : vector<32xi16>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[ADD3]], %[[ADD3]], %[[C4]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[SHIFT4]] : vector<32xi16>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[ADD4]], %[[ADD4]], %[[C2]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[ADD5:.*]] = aievec.add_elem %[[ADD4]], %[[SHIFT5]] : vector<32xi16>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[ADD5]], %[[C0]] : vector<32xi16>, i32, i16
+      %0 = vector.reduction <add>, %arg0 : vector<32xi16> into i16
+      // CHECK: return %[[EXTELEM]] : i16
+      return %0 : i16
+    }
 
-// CHECK-LABEL:func @reduce_min_i16
-// CHECK-SAME: %[[SRC:.*]]: vector<32xi16>
-func.func @reduce_min_i16(%arg0: vector<32xi16>) -> i16 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C2:.*]] = arith.constant 2 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<32xi16>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<32xi16>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<32xi16>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<32xi16>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MIN4]], %[[MIN4]], %[[C2]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MIN5:.*]] = aievec.min %[[MIN4]], %[[SHIFT5]] : vector<32xi16>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN5]], %[[C0]] : vector<32xi16>, i32, i16
-  %0 = vector.reduction <minsi>, %arg0 : vector<32xi16> into i16
-  // CHECK: return %[[EXTELEM]] : i16
-  return %0 : i16
-}
+    // CHECK-LABEL:func @reduce_min_i16
+    // CHECK-SAME: %[[SRC:.*]]: vector<32xi16>
+    func.func @reduce_min_i16(%arg0: vector<32xi16>) -> i16 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C2:.*]] = arith.constant 2 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<32xi16>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<32xi16>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<32xi16>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<32xi16>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MIN4]], %[[MIN4]], %[[C2]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MIN5:.*]] = aievec.min %[[MIN4]], %[[SHIFT5]] : vector<32xi16>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN5]], %[[C0]] : vector<32xi16>, i32, i16
+      %0 = vector.reduction <minsi>, %arg0 : vector<32xi16> into i16
+      // CHECK: return %[[EXTELEM]] : i16
+      return %0 : i16
+    }
 
-// CHECK-LABEL:func @reduce_max_i16
-// CHECK-SAME: %[[SRC:.*]]: vector<32xi16>
-func.func @reduce_max_i16(%arg0: vector<32xi16>) -> i16 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C2:.*]] = arith.constant 2 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<32xi16>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<32xi16>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<32xi16>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<32xi16>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MAX4]], %[[MAX4]], %[[C2]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
-  // CHECK: %[[MAX5:.*]] = aievec.max %[[MAX4]], %[[SHIFT5]] : vector<32xi16>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xi16>, i32, i16
-  %0 = vector.reduction <maxsi>, %arg0 : vector<32xi16> into i16
-  // CHECK: return %[[EXTELEM]] : i16
-  return %0 : i16
-}
+    // CHECK-LABEL:func @reduce_max_i16
+    // CHECK-SAME: %[[SRC:.*]]: vector<32xi16>
+    func.func @reduce_max_i16(%arg0: vector<32xi16>) -> i16 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C2:.*]] = arith.constant 2 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<32xi16>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<32xi16>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<32xi16>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<32xi16>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MAX4]], %[[MAX4]], %[[C2]] {isAcc = false} : vector<32xi16>, vector<32xi16>, i32, vector<32xi16>
+      // CHECK: %[[MAX5:.*]] = aievec.max %[[MAX4]], %[[SHIFT5]] : vector<32xi16>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xi16>, i32, i16
+      %0 = vector.reduction <maxsi>, %arg0 : vector<32xi16> into i16
+      // CHECK: return %[[EXTELEM]] : i16
+      return %0 : i16
+    }
 
-// CHECK-LABEL:func @reduce_add_i8
-// CHECK-SAME: %[[SRC:.*]]: vector<64xi8>
-func.func @reduce_add_i8(%arg0: vector<64xi8>) -> i8 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C1:.*]] = arith.constant 1 : i32
-  // CHECK: %[[C2:.*]] = arith.constant 2 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[SRC]], %[[SHIFT32]] : vector<64xi8>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[ADD1]], %[[ADD1]], %[[C16]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[SHIFT16]] : vector<64xi8>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[ADD2]], %[[ADD2]], %[[C8]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[SHIFT8]] : vector<64xi8>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[ADD3]], %[[ADD3]], %[[C4]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[SHIFT4]] : vector<64xi8>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[ADD4]], %[[ADD4]], %[[C2]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[ADD5:.*]] = aievec.add_elem %[[ADD4]], %[[SHIFT5]] : vector<64xi8>
-  // CHECK: %[[SHIFT6:.*]] = aievec.shift %[[ADD5]], %[[ADD5]], %[[C1]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[ADD6:.*]] = aievec.add_elem %[[ADD5]], %[[SHIFT6]] : vector<64xi8>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[ADD6]], %[[C0]] : vector<64xi8>, i32, i8
-  %0 = vector.reduction <add>, %arg0 : vector<64xi8> into i8
-  // CHECK: return %[[EXTELEM]] : i8
-  return %0 : i8
-}
+    // CHECK-LABEL:func @reduce_add_i8
+    // CHECK-SAME: %[[SRC:.*]]: vector<64xi8>
+    func.func @reduce_add_i8(%arg0: vector<64xi8>) -> i8 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C1:.*]] = arith.constant 1 : i32
+      // CHECK: %[[C2:.*]] = arith.constant 2 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[SRC]], %[[SHIFT32]] : vector<64xi8>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[ADD1]], %[[ADD1]], %[[C16]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[SHIFT16]] : vector<64xi8>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[ADD2]], %[[ADD2]], %[[C8]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[SHIFT8]] : vector<64xi8>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[ADD3]], %[[ADD3]], %[[C4]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[SHIFT4]] : vector<64xi8>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[ADD4]], %[[ADD4]], %[[C2]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[ADD5:.*]] = aievec.add_elem %[[ADD4]], %[[SHIFT5]] : vector<64xi8>
+      // CHECK: %[[SHIFT6:.*]] = aievec.shift %[[ADD5]], %[[ADD5]], %[[C1]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[ADD6:.*]] = aievec.add_elem %[[ADD5]], %[[SHIFT6]] : vector<64xi8>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[ADD6]], %[[C0]] : vector<64xi8>, i32, i8
+      %0 = vector.reduction <add>, %arg0 : vector<64xi8> into i8
+      // CHECK: return %[[EXTELEM]] : i8
+      return %0 : i8
+    }
 
-// CHECK-LABEL:func @reduce_min_i8
-// CHECK-SAME: %[[SRC:.*]]: vector<64xi8>
-func.func @reduce_min_i8(%arg0: vector<64xi8>) -> i8 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C1:.*]] = arith.constant 1 : i32
-  // CHECK: %[[C2:.*]] = arith.constant 2 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<64xi8>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<64xi8>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<64xi8>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<64xi8>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MIN4]], %[[MIN4]], %[[C2]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MIN5:.*]] = aievec.min %[[MIN4]], %[[SHIFT5]] : vector<64xi8>
-  // CHECK: %[[SHIFT6:.*]] = aievec.shift %[[MIN5]], %[[MIN5]], %[[C1]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MIN6:.*]] = aievec.min %[[MIN5]], %[[SHIFT6]] : vector<64xi8>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN6]], %[[C0]] : vector<64xi8>, i32, i8
-  %0 = vector.reduction <minsi>, %arg0 : vector<64xi8> into i8
-  // CHECK: return %[[EXTELEM]] : i8
-  return %0 : i8
-}
+    // CHECK-LABEL:func @reduce_min_i8
+    // CHECK-SAME: %[[SRC:.*]]: vector<64xi8>
+    func.func @reduce_min_i8(%arg0: vector<64xi8>) -> i8 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C1:.*]] = arith.constant 1 : i32
+      // CHECK: %[[C2:.*]] = arith.constant 2 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<64xi8>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<64xi8>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<64xi8>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<64xi8>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MIN4]], %[[MIN4]], %[[C2]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MIN5:.*]] = aievec.min %[[MIN4]], %[[SHIFT5]] : vector<64xi8>
+      // CHECK: %[[SHIFT6:.*]] = aievec.shift %[[MIN5]], %[[MIN5]], %[[C1]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MIN6:.*]] = aievec.min %[[MIN5]], %[[SHIFT6]] : vector<64xi8>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN6]], %[[C0]] : vector<64xi8>, i32, i8
+      %0 = vector.reduction <minsi>, %arg0 : vector<64xi8> into i8
+      // CHECK: return %[[EXTELEM]] : i8
+      return %0 : i8
+    }
 
-// CHECK-LABEL:func @reduce_max_i8
-// CHECK-SAME: %[[SRC:.*]]: vector<64xi8>
-func.func @reduce_max_i8(%arg0: vector<64xi8>) -> i8 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C1:.*]] = arith.constant 1 : i32
-  // CHECK: %[[C2:.*]] = arith.constant 2 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<64xi8>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<64xi8>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<64xi8>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<64xi8>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MAX4]], %[[MAX4]], %[[C2]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MAX5:.*]] = aievec.max %[[MAX4]], %[[SHIFT5]] : vector<64xi8>
-  // CHECK: %[[SHIFT6:.*]] = aievec.shift %[[MAX5]], %[[MAX5]], %[[C1]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
-  // CHECK: %[[MAX6:.*]] = aievec.max %[[MAX5]], %[[SHIFT6]] : vector<64xi8>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX6]], %[[C0]] : vector<64xi8>, i32, i8
-  %0 = vector.reduction <maxsi>, %arg0 : vector<64xi8> into i8
-  // CHECK: return %[[EXTELEM]] : i8
-  return %0 : i8
-}
+    // CHECK-LABEL:func @reduce_max_i8
+    // CHECK-SAME: %[[SRC:.*]]: vector<64xi8>
+    func.func @reduce_max_i8(%arg0: vector<64xi8>) -> i8 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C1:.*]] = arith.constant 1 : i32
+      // CHECK: %[[C2:.*]] = arith.constant 2 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<64xi8>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<64xi8>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<64xi8>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<64xi8>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MAX4]], %[[MAX4]], %[[C2]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MAX5:.*]] = aievec.max %[[MAX4]], %[[SHIFT5]] : vector<64xi8>
+      // CHECK: %[[SHIFT6:.*]] = aievec.shift %[[MAX5]], %[[MAX5]], %[[C1]] {isAcc = false} : vector<64xi8>, vector<64xi8>, i32, vector<64xi8>
+      // CHECK: %[[MAX6:.*]] = aievec.max %[[MAX5]], %[[SHIFT6]] : vector<64xi8>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX6]], %[[C0]] : vector<64xi8>, i32, i8
+      %0 = vector.reduction <maxsi>, %arg0 : vector<64xi8> into i8
+      // CHECK: return %[[EXTELEM]] : i8
+      return %0 : i8
+    }
 
-// CHECK-LABEL:func @reduce_add_f32
-// CHECK-SAME: %[[SRC:.*]]: vector<16xf32>
-func.func @reduce_add_f32(%arg0: vector<16xf32>) -> f32 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[CASTL1:.*]] = aievec.cast %[[SRC]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[CASTR1:.*]] = aievec.cast %[[SHIFT32]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[CASTL1]], %[[CASTR1]] : vector<16xf32>
-  // CHECK: %[[CAST1:.*]] = aievec.cast %[[ADD1]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[CAST1]], %[[CAST1]], %[[C16]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[CASTR2:.*]] = aievec.cast %[[SHIFT16]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[CASTR2]] : vector<16xf32>
-  // CHECK: %[[CAST2:.*]] = aievec.cast %[[ADD2]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[CAST2]], %[[CAST2]], %[[C8]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[CASTR3:.*]] = aievec.cast %[[SHIFT8]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[CASTR3]] : vector<16xf32>
-  // CHECK: %[[CAST3:.*]] = aievec.cast %[[ADD3]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[CAST3]], %[[CAST3]], %[[C4]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[CASTR4:.*]] = aievec.cast %[[SHIFT4]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[CASTR4]] : vector<16xf32>
-  // CHECK: %[[CAST4:.*]] = aievec.cast %[[ADD4]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[CAST4]], %[[C0]] : vector<16xf32>, i32, f32
-  %0 = vector.reduction <add>, %arg0 : vector<16xf32> into f32
-  // CHECK: return %[[EXTELEM]] : f32
-  return %0 : f32
-}
+    // CHECK-LABEL:func @reduce_add_f32
+    // CHECK-SAME: %[[SRC:.*]]: vector<16xf32>
+    func.func @reduce_add_f32(%arg0: vector<16xf32>) -> f32 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[CASTL1:.*]] = aievec.cast %[[SRC]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[CASTR1:.*]] = aievec.cast %[[SHIFT32]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[CASTL1]], %[[CASTR1]] : vector<16xf32>
+      // CHECK: %[[CAST1:.*]] = aievec.cast %[[ADD1]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[CAST1]], %[[CAST1]], %[[C16]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[CASTR2:.*]] = aievec.cast %[[SHIFT16]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[CASTR2]] : vector<16xf32>
+      // CHECK: %[[CAST2:.*]] = aievec.cast %[[ADD2]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[CAST2]], %[[CAST2]], %[[C8]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[CASTR3:.*]] = aievec.cast %[[SHIFT8]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[CASTR3]] : vector<16xf32>
+      // CHECK: %[[CAST3:.*]] = aievec.cast %[[ADD3]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[CAST3]], %[[CAST3]], %[[C4]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[CASTR4:.*]] = aievec.cast %[[SHIFT4]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[CASTR4]] : vector<16xf32>
+      // CHECK: %[[CAST4:.*]] = aievec.cast %[[ADD4]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[CAST4]], %[[C0]] : vector<16xf32>, i32, f32
+      %0 = vector.reduction <add>, %arg0 : vector<16xf32> into f32
+      // CHECK: return %[[EXTELEM]] : f32
+      return %0 : f32
+    }
 
-// CHECK-LABEL:func @reduce_min_f32
-// CHECK-SAME: %[[SRC:.*]]: vector<16xf32>
-func.func @reduce_min_f32(%arg0: vector<16xf32>) -> f32 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<16xf32>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<16xf32>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<16xf32>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<16xf32>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN4]], %[[C0]] : vector<16xf32>, i32, f32 
-  %0 = vector.reduction <minimumf>, %arg0 : vector<16xf32> into f32
-  // CHECK: return %[[EXTELEM]] : f32
-  return %0 : f32
-}
+    // CHECK-LABEL:func @reduce_min_f32
+    // CHECK-SAME: %[[SRC:.*]]: vector<16xf32>
+    func.func @reduce_min_f32(%arg0: vector<16xf32>) -> f32 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<16xf32>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<16xf32>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<16xf32>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<16xf32>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MIN4]], %[[C0]] : vector<16xf32>, i32, f32 
+      %0 = vector.reduction <minimumf>, %arg0 : vector<16xf32> into f32
+      // CHECK: return %[[EXTELEM]] : f32
+      return %0 : f32
+    }
 
-// CHECK-LABEL:func @reduce_max_f32
-// CHECK-SAME: %[[SRC:.*]]: vector<16xf32>
-func.func @reduce_max_f32(%arg0: vector<16xf32>) -> f32 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<16xf32>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<16xf32>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<16xf32>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
-  // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<16xf32>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX4]], %[[C0]] : vector<16xf32>, i32, f32
-  %0 = vector.reduction <maximumf>, %arg0 : vector<16xf32> into f32
-  // CHECK: return %[[EXTELEM]] : f32
-  return %0 : f32
-}
+    // CHECK-LABEL:func @reduce_max_f32
+    // CHECK-SAME: %[[SRC:.*]]: vector<16xf32>
+    func.func @reduce_max_f32(%arg0: vector<16xf32>) -> f32 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<16xf32>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<16xf32>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<16xf32>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+      // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<16xf32>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX4]], %[[C0]] : vector<16xf32>, i32, f32
+      %0 = vector.reduction <maximumf>, %arg0 : vector<16xf32> into f32
+      // CHECK: return %[[EXTELEM]] : f32
+      return %0 : f32
+    }
 
-// CHECK-LABEL:func @reduce_min_bf16
-// CHECK-SAME: %[[SRC:.*]]: vector<32xbf16>
-func.func @reduce_min_bf16(%arg0: vector<32xbf16>) -> bf16 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<32xbf16>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<32xbf16>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<32xbf16>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<32xbf16>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MIN4]], %[[MIN4]], %[[C2]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MIN5:.*]] = aievec.min %[[MIN4]], %[[SHIFT5]] : vector<32xbf16>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xbf16>, i32, bf16
-  %0 = vector.reduction <minimumf>, %arg0 : vector<32xbf16> into bf16
-  // CHECK: return %[[EXTELEM]] : bf16
-  return %0 : bf16
-}
+    // CHECK-LABEL:func @reduce_min_bf16
+    // CHECK-SAME: %[[SRC:.*]]: vector<32xbf16>
+    func.func @reduce_min_bf16(%arg0: vector<32xbf16>) -> bf16 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<32xbf16>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<32xbf16>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<32xbf16>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<32xbf16>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MIN4]], %[[MIN4]], %[[C2]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MIN5:.*]] = aievec.min %[[MIN4]], %[[SHIFT5]] : vector<32xbf16>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xbf16>, i32, bf16
+      %0 = vector.reduction <minimumf>, %arg0 : vector<32xbf16> into bf16
+      // CHECK: return %[[EXTELEM]] : bf16
+      return %0 : bf16
+    }
 
-// CHECK-LABEL:func @reduce_max_bf16
-// CHECK-SAME: %[[SRC:.*]]: vector<32xbf16>
-func.func @reduce_max_bf16(%arg0: vector<32xbf16>) -> bf16 {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[C4:.*]] = arith.constant 4 : i32
-  // CHECK: %[[C8:.*]] = arith.constant 8 : i32
-  // CHECK: %[[C16:.*]] = arith.constant 16 : i32
-  // CHECK: %[[C32:.*]] = arith.constant 32 : i32
-  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<32xbf16>
-  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<32xbf16>
-  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<32xbf16>
-  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<32xbf16>
-  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MAX4]], %[[MAX4]], %[[C2]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
-  // CHECK: %[[MAX5:.*]] = aievec.max %[[MAX4]], %[[SHIFT5]] : vector<32xbf16>
-  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xbf16>, i32, bf16
-  %0 = vector.reduction <maximumf>, %arg0 : vector<32xbf16> into bf16
-  // CHECK: return %[[EXTELEM]] : bf16
-  return %0 : bf16
+    // CHECK-LABEL:func @reduce_max_bf16
+    // CHECK-SAME: %[[SRC:.*]]: vector<32xbf16>
+    func.func @reduce_max_bf16(%arg0: vector<32xbf16>) -> bf16 {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[C4:.*]] = arith.constant 4 : i32
+      // CHECK: %[[C8:.*]] = arith.constant 8 : i32
+      // CHECK: %[[C16:.*]] = arith.constant 16 : i32
+      // CHECK: %[[C32:.*]] = arith.constant 32 : i32
+      // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<32xbf16>
+      // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<32xbf16>
+      // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<32xbf16>
+      // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<32xbf16>
+      // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MAX4]], %[[MAX4]], %[[C2]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+      // CHECK: %[[MAX5:.*]] = aievec.max %[[MAX4]], %[[SHIFT5]] : vector<32xbf16>
+      // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xbf16>, i32, bf16
+      %0 = vector.reduction <maximumf>, %arg0 : vector<32xbf16> into bf16
+      // CHECK: return %[[EXTELEM]] : bf16
+      return %0 : bf16
+    }
 }

--- a/test/Conversion/VectorToAIEVec/test-sel.mlir
+++ b/test/Conversion/VectorToAIEVec/test-sel.mlir
@@ -1,121 +1,123 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL:func @vecsel_i32
-// CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecsel_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xi32>, vector<16xi32>, ui32, vector<16xi32>
-  %0 = arith.cmpi sgt, %arg0, %arg1 : vector<16xi32>
-  %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xi32>
-  // CHECK: return %[[SEL]] : vector<16xi32>
-  return %1 : vector<16xi32> 
-}
+aie.device(npu1) {
+  // CHECK-LABEL:func @vecsel_i32
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
+  func.func @vecsel_i32(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xi32>, vector<16xi32>, ui32, vector<16xi32>
+    %0 = arith.cmpi sgt, %arg0, %arg1 : vector<16xi32>
+    %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xi32>
+    // CHECK: return %[[SEL]] : vector<16xi32>
+    return %1 : vector<16xi32> 
+  }
 
-// CHECK-LABEL:func @vecsel_i32_unsigned_cmp
-// CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
-func.func @vecsel_i32_unsigned_cmp(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ugt"} : vector<16xi32>, vector<16xi32>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xi32>, vector<16xi32>, ui32, vector<16xi32>
-  %0 = arith.cmpi ugt, %arg0, %arg1 : vector<16xi32>
-  %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xi32>
-  // CHECK: return %[[SEL]] : vector<16xi32>
-  return %1 : vector<16xi32>
-}
+  // CHECK-LABEL:func @vecsel_i32_unsigned_cmp
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xi32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xi32>)
+  func.func @vecsel_i32_unsigned_cmp(%arg0: vector<16xi32>, %arg1: vector<16xi32>) -> vector<16xi32> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ugt"} : vector<16xi32>, vector<16xi32>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xi32>, vector<16xi32>, ui32, vector<16xi32>
+    %0 = arith.cmpi ugt, %arg0, %arg1 : vector<16xi32>
+    %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xi32>
+    // CHECK: return %[[SEL]] : vector<16xi32>
+    return %1 : vector<16xi32>
+  }
 
-// CHECK-LABEL:func @vecsel_i16
-// CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecsel_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "slt"} : vector<32xi16>, vector<32xi16>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xi16>, vector<32xi16>, ui32, vector<32xi16>
-  %0 = arith.cmpi slt, %arg0, %arg1 : vector<32xi16>
-  %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xi16>
-  // CHECK: return %[[SEL]] : vector<32xi16>
-  return %1 : vector<32xi16>
-}
+  // CHECK-LABEL:func @vecsel_i16
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
+  func.func @vecsel_i16(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "slt"} : vector<32xi16>, vector<32xi16>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xi16>, vector<32xi16>, ui32, vector<32xi16>
+    %0 = arith.cmpi slt, %arg0, %arg1 : vector<32xi16>
+    %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xi16>
+    // CHECK: return %[[SEL]] : vector<32xi16>
+    return %1 : vector<32xi16>
+  }
 
-// CHECK-LABEL:func @vecsel_i16_unsigned_cmp
-// CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
-func.func @vecsel_i16_unsigned_cmp(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ult"} : vector<32xi16>, vector<32xi16>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xi16>, vector<32xi16>, ui32, vector<32xi16>
-  %0 = arith.cmpi ult, %arg0, %arg1 : vector<32xi16>
-  %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xi16>
-  // CHECK: return %[[SEL]] : vector<32xi16>
-  return %1 : vector<32xi16>
-}
+  // CHECK-LABEL:func @vecsel_i16_unsigned_cmp
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xi16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xi16>)
+  func.func @vecsel_i16_unsigned_cmp(%arg0: vector<32xi16>, %arg1: vector<32xi16>) -> vector<32xi16> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ult"} : vector<32xi16>, vector<32xi16>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xi16>, vector<32xi16>, ui32, vector<32xi16>
+    %0 = arith.cmpi ult, %arg0, %arg1 : vector<32xi16>
+    %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xi16>
+    // CHECK: return %[[SEL]] : vector<32xi16>
+    return %1 : vector<32xi16>
+  }
 
-// CHECK-LABEL:func @vecsel_i8
-// CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
-// CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
-func.func @vecsel_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sge"} : vector<64xi8>, vector<64xi8>, ui64
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<64xi8>, vector<64xi8>, ui64, vector<64xi8>
-  %0 = arith.cmpi sge, %arg0, %arg1 : vector<64xi8>
-  %1 = arith.select %0, %arg0, %arg1 : vector<64xi1>, vector<64xi8>
-  // CHECK: return %[[SEL]] : vector<64xi8>
-  return %1 : vector<64xi8>
-}
+  // CHECK-LABEL:func @vecsel_i8
+  // CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
+  func.func @vecsel_i8(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sge"} : vector<64xi8>, vector<64xi8>, ui64
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<64xi8>, vector<64xi8>, ui64, vector<64xi8>
+    %0 = arith.cmpi sge, %arg0, %arg1 : vector<64xi8>
+    %1 = arith.select %0, %arg0, %arg1 : vector<64xi1>, vector<64xi8>
+    // CHECK: return %[[SEL]] : vector<64xi8>
+    return %1 : vector<64xi8>
+  }
 
-// CHECK-LABEL:func @vecsel_i8_unsigned_cmp
-// CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
-// CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
-func.func @vecsel_i8_unsigned_cmp(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "uge"} : vector<64xi8>, vector<64xi8>, ui64
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<64xi8>, vector<64xi8>, ui64, vector<64xi8>
-  %0 = arith.cmpi uge, %arg0, %arg1 : vector<64xi8>
-  %1 = arith.select %0, %arg0, %arg1 : vector<64xi1>, vector<64xi8>
-  // CHECK: return %[[SEL]] : vector<64xi8>
-  return %1 : vector<64xi8>
-}
+  // CHECK-LABEL:func @vecsel_i8_unsigned_cmp
+  // CHECK-SAME: %[[LHS:.*]]: vector<64xi8>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<64xi8>)
+  func.func @vecsel_i8_unsigned_cmp(%arg0: vector<64xi8>, %arg1: vector<64xi8>) -> vector<64xi8> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "uge"} : vector<64xi8>, vector<64xi8>, ui64
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<64xi8>, vector<64xi8>, ui64, vector<64xi8>
+    %0 = arith.cmpi uge, %arg0, %arg1 : vector<64xi8>
+    %1 = arith.select %0, %arg0, %arg1 : vector<64xi1>, vector<64xi8>
+    // CHECK: return %[[SEL]] : vector<64xi8>
+    return %1 : vector<64xi8>
+  }
 
-// CHECK-LABEL:func @vecsel_bf16
-// CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
-func.func @vecsel_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sle"} : vector<32xbf16>, vector<32xbf16>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xbf16>, vector<32xbf16>, ui32, vector<32xbf16>
-  %0 = arith.cmpf ole, %arg0, %arg1 : vector<32xbf16>
-  %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xbf16>
-  // CHECK: return %[[SEL]] : vector<32xbf16>
-  return %1 : vector<32xbf16>
-}
+  // CHECK-LABEL:func @vecsel_bf16
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
+  func.func @vecsel_bf16(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sle"} : vector<32xbf16>, vector<32xbf16>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xbf16>, vector<32xbf16>, ui32, vector<32xbf16>
+    %0 = arith.cmpf ole, %arg0, %arg1 : vector<32xbf16>
+    %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xbf16>
+    // CHECK: return %[[SEL]] : vector<32xbf16>
+    return %1 : vector<32xbf16>
+  }
 
-// CHECK-LABEL:func @vecsel_bf16_unsigned_cmp
-// CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
-// CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
-func.func @vecsel_bf16_unsigned_cmp(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ule"} : vector<32xbf16>, vector<32xbf16>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xbf16>, vector<32xbf16>, ui32, vector<32xbf16>
-  %0 = arith.cmpf ule, %arg0, %arg1 : vector<32xbf16>
-  %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xbf16>
-  // CHECK: return %[[SEL]] : vector<32xbf16>
-  return %1 : vector<32xbf16>
-}
+  // CHECK-LABEL:func @vecsel_bf16_unsigned_cmp
+  // CHECK-SAME: %[[LHS:.*]]: vector<32xbf16>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<32xbf16>)
+  func.func @vecsel_bf16_unsigned_cmp(%arg0: vector<32xbf16>, %arg1: vector<32xbf16>) -> vector<32xbf16> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ule"} : vector<32xbf16>, vector<32xbf16>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<32xbf16>, vector<32xbf16>, ui32, vector<32xbf16>
+    %0 = arith.cmpf ule, %arg0, %arg1 : vector<32xbf16>
+    %1 = arith.select %0, %arg0, %arg1 : vector<32xi1>, vector<32xbf16>
+    // CHECK: return %[[SEL]] : vector<32xbf16>
+    return %1 : vector<32xbf16>
+  }
 
-// CHECK-LABEL:func @vecsel_f32
-// CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecsel_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xf32>, vector<16xf32>, ui32, vector<16xf32>
-  %0 = arith.cmpf ogt, %arg0, %arg1 : vector<16xf32>
-  %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xf32>
-  // CHECK: return %[[SEL]] : vector<16xf32>
-  return %1 : vector<16xf32>
-}
+  // CHECK-LABEL:func @vecsel_f32
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
+  func.func @vecsel_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "sgt"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xf32>, vector<16xf32>, ui32, vector<16xf32>
+    %0 = arith.cmpf ogt, %arg0, %arg1 : vector<16xf32>
+    %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xf32>
+    // CHECK: return %[[SEL]] : vector<16xf32>
+    return %1 : vector<16xf32>
+  }
 
-// CHECK-LABEL:func @vecsel_f32_unsigned_cmp
-// CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
-// CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
-func.func @vecsel_f32_unsigned_cmp(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ugt"} : vector<16xf32>, vector<16xf32>, ui32
-  // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xf32>, vector<16xf32>, ui32, vector<16xf32>
-  %0 = arith.cmpf ugt, %arg0, %arg1 : vector<16xf32>
-  %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xf32>
-  // CHECK: return %[[SEL]] : vector<16xf32>
-  return %1 : vector<16xf32>
+  // CHECK-LABEL:func @vecsel_f32_unsigned_cmp
+  // CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
+  // CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
+  func.func @vecsel_f32_unsigned_cmp(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+    // CHECK: %[[CMP:.*]] = aievec.cmp %[[LHS]], %[[RHS]] {pred = "ugt"} : vector<16xf32>, vector<16xf32>, ui32
+    // CHECK: %[[SEL:.*]] = aievec.sel %[[LHS]], %[[RHS]], %[[CMP]] : vector<16xf32>, vector<16xf32>, ui32, vector<16xf32>
+    %0 = arith.cmpf ugt, %arg0, %arg1 : vector<16xf32>
+    %1 = arith.select %0, %arg0, %arg1 : vector<16xi1>, vector<16xf32>
+    // CHECK: return %[[SEL]] : vector<16xf32>
+    return %1 : vector<16xf32>
+  }
 }

--- a/test/Conversion/VectorToAIEVec/test-trunc-ext.mlir
+++ b/test/Conversion/VectorToAIEVec/test-trunc-ext.mlir
@@ -1,79 +1,81 @@
 // RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL: func.func @test_exti(
-// CHECK-SAME: %[[V1:[a-zA-Z0-9]+]]: vector<32xi8>
-// CHECK-SAME: %[[V2:[a-zA-Z0-9]+]]: vector<32xi8>
-// CHECK-SAME: %[[V3:[a-zA-Z0-9]+]]: vector<32xi16>
-func.func @test_exti(%vi8_4_i16 : vector<32xi8>, %vi8_4_i32 : vector<32xi8>,
-                     %vi16_4_i32 : vector<32xi16>) ->
-                        (vector<32xi16>, vector<32xi32>, vector<32xi32>) {
-    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-    %0 = arith.extsi %vi8_4_i16 : vector<32xi8> to vector<32xi16>
-    // CHECK: %[[V1A:.*]] = aievec.ups %[[V1]] {shift = 0 : i8} :
-    // CHECK-SAME:                           vector<32xi8>, vector<32xi32>
-    // CHECK: %[[V1E:.*]] = aievec.srs %[[V1A]], %[[C0]] :
-    // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi16>
-    %1 = arith.extsi %vi8_4_i32 : vector<32xi8> to vector<32xi32>
-    // CHECK: %[[V2A:.*]] = aievec.ups %[[V2]] {shift = 0 : i8} :
-    // CHECK-SAME:                           vector<32xi8>, vector<32xi32>
-    // CHECK: %[[V2E:.*]] = aievec.cast %[[V2A]] {isResAcc = false} :
-    // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
-    %2 = arith.extsi %vi16_4_i32 : vector<32xi16> to vector<32xi32>
-    // CHECK: %[[V3A:.*]] = aievec.ups %[[V3]] {shift = 0 : i8} :
-    // CHECK-SAME:                           vector<32xi16>, vector<32xi32>
-    // CHECK: %[[V3E:.*]] = aievec.cast %[[V3A]] {isResAcc = false} :
-    // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
-    return %0, %1, %2 : vector<32xi16>, vector<32xi32>, vector<32xi32>
-    // CHECK: return %[[V1E]], %[[V2E]], %[[V3E]]
-}
+aie.device(xcvc1902) {
+    // CHECK-LABEL: func.func @test_exti(
+    // CHECK-SAME: %[[V1:[a-zA-Z0-9]+]]: vector<32xi8>
+    // CHECK-SAME: %[[V2:[a-zA-Z0-9]+]]: vector<32xi8>
+    // CHECK-SAME: %[[V3:[a-zA-Z0-9]+]]: vector<32xi16>
+    func.func @test_exti(%vi8_4_i16 : vector<32xi8>, %vi8_4_i32 : vector<32xi8>,
+                        %vi16_4_i32 : vector<32xi16>) ->
+                            (vector<32xi16>, vector<32xi32>, vector<32xi32>) {
+        // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+        %0 = arith.extsi %vi8_4_i16 : vector<32xi8> to vector<32xi16>
+        // CHECK: %[[V1A:.*]] = aievec.ups %[[V1]] {shift = 0 : i8} :
+        // CHECK-SAME:                           vector<32xi8>, vector<32xi32>
+        // CHECK: %[[V1E:.*]] = aievec.srs %[[V1A]], %[[C0]] :
+        // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi16>
+        %1 = arith.extsi %vi8_4_i32 : vector<32xi8> to vector<32xi32>
+        // CHECK: %[[V2A:.*]] = aievec.ups %[[V2]] {shift = 0 : i8} :
+        // CHECK-SAME:                           vector<32xi8>, vector<32xi32>
+        // CHECK: %[[V2E:.*]] = aievec.cast %[[V2A]] {isResAcc = false} :
+        // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
+        %2 = arith.extsi %vi16_4_i32 : vector<32xi16> to vector<32xi32>
+        // CHECK: %[[V3A:.*]] = aievec.ups %[[V3]] {shift = 0 : i8} :
+        // CHECK-SAME:                           vector<32xi16>, vector<32xi32>
+        // CHECK: %[[V3E:.*]] = aievec.cast %[[V3A]] {isResAcc = false} :
+        // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
+        return %0, %1, %2 : vector<32xi16>, vector<32xi32>, vector<32xi32>
+        // CHECK: return %[[V1E]], %[[V2E]], %[[V3E]]
+    }
 
-// CHECK-LABEL: func.func @test_extf(
-// CHECK-SAME: %[[V:[a-zA-Z0-9]+]]: vector<16xbf16>
-func.func @test_extf(%vbf16_4_f32 : vector<16xbf16>) -> vector<16xf32> {
-    %0 = arith.extf %vbf16_4_f32 : vector<16xbf16> to vector<16xf32>
-    // CHECK: %[[VA:.*]] = aievec.ups %[[V]] {shift = 0 : i8} :
-    // CHECK-SAME:                           vector<16xbf16>, vector<16xf32>
-    // CHECK: %[[VE:.*]] = aievec.cast %[[VA]] {isResAcc = false} :
-    // CHECK-SAME:                           vector<16xf32>, vector<16xf32>
-    return %0 : vector<16xf32>
-    // CHECK: return %[[VE]]
-}
+    // CHECK-LABEL: func.func @test_extf(
+    // CHECK-SAME: %[[V:[a-zA-Z0-9]+]]: vector<16xbf16>
+    func.func @test_extf(%vbf16_4_f32 : vector<16xbf16>) -> vector<16xf32> {
+        %0 = arith.extf %vbf16_4_f32 : vector<16xbf16> to vector<16xf32>
+        // CHECK: %[[VA:.*]] = aievec.ups %[[V]] {shift = 0 : i8} :
+        // CHECK-SAME:                           vector<16xbf16>, vector<16xf32>
+        // CHECK: %[[VE:.*]] = aievec.cast %[[VA]] {isResAcc = false} :
+        // CHECK-SAME:                           vector<16xf32>, vector<16xf32>
+        return %0 : vector<16xf32>
+        // CHECK: return %[[VE]]
+    }
 
-// CHECK-LABEL: func.func @test_trunci(
-// CHECK-SAME: %[[V1:[a-zA-Z0-9]+]]: vector<32xi32>
-// CHECK-SAME: %[[V2:[a-zA-Z0-9]+]]: vector<32xi32>
-// CHECK-SAME: %[[V3:[a-zA-Z0-9]+]]: vector<32xi16>
-func.func @test_trunci(%vi32_4_i8 : vector<32xi32>, %vi32_4_i16 : vector<32xi32>,
-                       %vi16_4_i8 : vector<32xi16>) ->
-                        (vector<32xi8>, vector<32xi16>, vector<32xi8>) {
-    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-    %0 = arith.trunci %vi32_4_i8 : vector<32xi32> to vector<32xi8>
-    // CHECK: %[[V1A:.*]] = aievec.cast %[[V1]] {isResAcc = true} :
-    // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
-    // CHECK: %[[V1T:.*]] = aievec.srs %[[V1A]], %[[C0]] :
-    // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi8>
-    %1 = arith.trunci %vi32_4_i16 : vector<32xi32> to vector<32xi16>
-    // CHECK: %[[V2A:.*]] = aievec.cast %[[V2]] {isResAcc = true} :
-    // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
-    // CHECK: %[[V2T:.*]] = aievec.srs %[[V2A]], %[[C0]] :
-    // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi16>
-    %2 = arith.trunci %vi16_4_i8 : vector<32xi16> to vector<32xi8>
-    // CHECK: %[[V3A:.*]] = aievec.ups %[[V3]] {shift = 0 : i8} :
-    // CHECK-SAME:                           vector<32xi16>, vector<32xi32>
-    // CHECK: %[[V3T:.*]] = aievec.srs %[[V3A]], %[[C0]] :
-    // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi8>
-    return %0, %1, %2 : vector<32xi8>, vector<32xi16>, vector<32xi8>
-    // CHECK: return %[[V1T]], %[[V2T]], %[[V3T]]
-}
+    // CHECK-LABEL: func.func @test_trunci(
+    // CHECK-SAME: %[[V1:[a-zA-Z0-9]+]]: vector<32xi32>
+    // CHECK-SAME: %[[V2:[a-zA-Z0-9]+]]: vector<32xi32>
+    // CHECK-SAME: %[[V3:[a-zA-Z0-9]+]]: vector<32xi16>
+    func.func @test_trunci(%vi32_4_i8 : vector<32xi32>, %vi32_4_i16 : vector<32xi32>,
+                        %vi16_4_i8 : vector<32xi16>) ->
+                            (vector<32xi8>, vector<32xi16>, vector<32xi8>) {
+        // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+        %0 = arith.trunci %vi32_4_i8 : vector<32xi32> to vector<32xi8>
+        // CHECK: %[[V1A:.*]] = aievec.cast %[[V1]] {isResAcc = true} :
+        // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
+        // CHECK: %[[V1T:.*]] = aievec.srs %[[V1A]], %[[C0]] :
+        // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi8>
+        %1 = arith.trunci %vi32_4_i16 : vector<32xi32> to vector<32xi16>
+        // CHECK: %[[V2A:.*]] = aievec.cast %[[V2]] {isResAcc = true} :
+        // CHECK-SAME:                           vector<32xi32>, vector<32xi32>
+        // CHECK: %[[V2T:.*]] = aievec.srs %[[V2A]], %[[C0]] :
+        // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi16>
+        %2 = arith.trunci %vi16_4_i8 : vector<32xi16> to vector<32xi8>
+        // CHECK: %[[V3A:.*]] = aievec.ups %[[V3]] {shift = 0 : i8} :
+        // CHECK-SAME:                           vector<32xi16>, vector<32xi32>
+        // CHECK: %[[V3T:.*]] = aievec.srs %[[V3A]], %[[C0]] :
+        // CHECK-SAME:                           vector<32xi32>, i32, vector<32xi8>
+        return %0, %1, %2 : vector<32xi8>, vector<32xi16>, vector<32xi8>
+        // CHECK: return %[[V1T]], %[[V2T]], %[[V3T]]
+    }
 
-// CHECK-LABEL: func.func @test_truncf(
-// CHECK-SAME: %[[V:[a-zA-Z0-9]+]]: vector<16xf32>
-func.func @test_truncf(%vf32_4_bf16 : vector<16xf32>) -> vector<16xbf16> {
-    %0 = arith.truncf %vf32_4_bf16 : vector<16xf32> to vector<16xbf16>
-    // CHECK: %[[VA:.*]] = aievec.cast %[[V]] {isResAcc = true} :
-    // CHECK-SAME:                           vector<16xf32>, vector<16xf32>
-    // CHECK: %[[VT:.*]] = aievec.srs %[[VA]], %[[C0]] :
-    // CHECK-SAME:                           vector<16xf32>, i32, vector<16xbf16>
-    return %0 : vector<16xbf16>
-    // CHECK: return %[[VE]]
+    // CHECK-LABEL: func.func @test_truncf(
+    // CHECK-SAME: %[[V:[a-zA-Z0-9]+]]: vector<16xf32>
+    func.func @test_truncf(%vf32_4_bf16 : vector<16xf32>) -> vector<16xbf16> {
+        %0 = arith.truncf %vf32_4_bf16 : vector<16xf32> to vector<16xbf16>
+        // CHECK: %[[VA:.*]] = aievec.cast %[[V]] {isResAcc = true} :
+        // CHECK-SAME:                           vector<16xf32>, vector<16xf32>
+        // CHECK: %[[VT:.*]] = aievec.srs %[[VA]], %[[C0]] :
+        // CHECK-SAME:                           vector<16xf32>, i32, vector<16xbf16>
+        return %0 : vector<16xbf16>
+        // CHECK: return %[[VE]]
+    }
 }

--- a/test/Conversion/VectorToAIEVec/test-upd.mlir
+++ b/test/Conversion/VectorToAIEVec/test-upd.mlir
@@ -1,102 +1,48 @@
 // RUN: aie-opt %s --convert-vector-to-aievec -split-input-file | FileCheck %s
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" -split-input-file | FileCheck %s --check-prefix=CHECK-V2
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=llvmir" -split-input-file | FileCheck %s --check-prefix=CHECK-V2-LLVM
 
-// CHECK-V2-LABEL: func @veccopy_i8
-// CHECK-V2-LLVM-LABEL: func @veccopy_i8
-func.func @veccopy_i8(%arg0: memref<256xi8>, %arg1: memref<256xi8>) {
-  %c0_i8 = arith.constant 0 : i8
-  affine.for %arg2 = 0 to 256 step 16 {
-    // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi8>, vector<16xi8>
-    // CHECK-V2-LLVM: %[[LD:.*]] = vector.transfer_read {{.*}}, {{.*}} : memref<256xi8>, vector<16xi8>
-    %0 = vector.transfer_read %arg0[%arg2], %c0_i8 : memref<256xi8>, vector<16xi8>
-    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}} : vector<16xi8>, memref<256xi8>
-    // CHECK-V2-LLVM: vector.transfer_write %[[LD]], {{.*}} : vector<16xi8>, memref<256xi8>
-    vector.transfer_write %0, %arg1[%arg2] : vector<16xi8>, memref<256xi8>
+aie.device(xcvc1902) {
+  // CHECK-LABEL: func @veccopy_i16
+  func.func @veccopy_i16(%arg0: memref<256xi16>, %arg1: memref<256xi16>) {
+    %c0_i16 = arith.constant 0 : i16
+    affine.for %arg2 = 0 to 256 step 16 {
+      // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi16>, vector<16xi16>
+      %0 = vector.transfer_read %arg0[%arg2], %c0_i16 : memref<256xi16>, vector<16xi16>
+      // CHECK: vector.transfer_write %[[LD]], {{.*}} : vector<16xi16>, memref<256xi16>
+      vector.transfer_write %0, %arg1[%arg2] : vector<16xi16>, memref<256xi16>
+    }
+    return
   }
-  return
 }
 
 // -----
 
-// CHECK-LABEL: func @veccopy_i16
-// CHECK-V2-LABEL: func @veccopy_i16
-// CHECK-V2-LLVM-LABEL: func @veccopy_i16
-func.func @veccopy_i16(%arg0: memref<256xi16>, %arg1: memref<256xi16>) {
-  %c0_i16 = arith.constant 0 : i16
-  affine.for %arg2 = 0 to 256 step 16 {
-    // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi16>, vector<16xi16>
-    // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi16>, vector<16xi16>
-    // CHECK-V2-LLVM: %[[LD:.*]] = vector.transfer_read {{.*}}, {{.*}} : memref<256xi16>, vector<16xi16>
-    %0 = vector.transfer_read %arg0[%arg2], %c0_i16 : memref<256xi16>, vector<16xi16>
-    // CHECK: vector.transfer_write %[[LD]], {{.*}} : vector<16xi16>, memref<256xi16>
-    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}} : vector<16xi16>, memref<256xi16>
-    // CHECK-V2-LLVM: vector.transfer_write %[[LD]], {{.*}} : vector<16xi16>, memref<256xi16>
-    vector.transfer_write %0, %arg1[%arg2] : vector<16xi16>, memref<256xi16>
+aie.device(xcvc1902) {
+  // CHECK-LABEL: func @veccopy_i32
+  func.func @veccopy_i32(%arg0: memref<256xi32>, %arg1: memref<256xi32>) {
+    %c0_i32 = arith.constant 0 : i32
+    affine.for %arg2 = 0 to 256 step 8 {
+      // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi32>, vector<8xi32>
+      %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<8xi32>
+      // CHECK: vector.transfer_write %[[LD]], {{.*}} : vector<8xi32>, memref<256xi32>
+      vector.transfer_write %0, %arg1[%arg2] : vector<8xi32>, memref<256xi32>
+    }
+    return
   }
-  return
 }
 
 // -----
 
-// CHECK-LABEL: func @veccopy_i32
-// CHECK-V2-LABEL: func @veccopy_i32
-// CHECK-V2-LLVM-LABEL: func @veccopy_i32
-func.func @veccopy_i32(%arg0: memref<256xi32>, %arg1: memref<256xi32>) {
-  %c0_i32 = arith.constant 0 : i32
-  affine.for %arg2 = 0 to 256 step 8 {
-    // CHECK: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi32>, vector<8xi32>
-    // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi32>, vector<8xi32>
-    // CHECK-V2-LLVM: %[[LD:.*]] = vector.transfer_read {{.*}}, {{.*}} : memref<256xi32>, vector<8xi32>
-    %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<8xi32>
-    // CHECK: vector.transfer_write %[[LD]], {{.*}} : vector<8xi32>, memref<256xi32>
-    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}} : vector<8xi32>, memref<256xi32>
-    // CHECK-V2-LLVM: vector.transfer_write %[[LD]], {{.*}} : vector<8xi32>, memref<256xi32>
-    vector.transfer_write %0, %arg1[%arg2] : vector<8xi32>, memref<256xi32>
+aie.device(xcvc1902) {
+  // CHECK-LABEL: func @veccopy_long_i32
+  func.func @veccopy_long_i32(%arg0: memref<256xi32>, %arg1: memref<256xi32>) {
+    %c0_i32 = arith.constant 0 : i32
+    affine.for %arg2 = 0 to 256 step 16 {
+      // CHECK: %[[LD0:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi32>, vector<16xi32>
+      // CHECK-NEXT: %[[LD1:.*]] = aievec.upd {{.*}}, %[[LD0]] {index = 1 : i8, offset = 256 : i32} : memref<256xi32>, vector<16xi32>
+      %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<16xi32>
+      // CHECK: vector.transfer_write %[[LD1]], {{.*}} : vector<16xi32>, memref<256xi32>
+      vector.transfer_write %0, %arg1[%arg2] : vector<16xi32>, memref<256xi32>
+    }
+    return
   }
-  return
 }
-
-// -----
-
-// CHECK-LABEL: func @veccopy_long_i32
-// CHECK-V2-LABEL: func @veccopy_long_i32
-// CHECK-V2-LLVM-LABEL: func @veccopy_long_i32
-func.func @veccopy_long_i32(%arg0: memref<256xi32>, %arg1: memref<256xi32>) {
-  %c0_i32 = arith.constant 0 : i32
-  affine.for %arg2 = 0 to 256 step 16 {
-    // CHECK: %[[LD0:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi32>, vector<16xi32>
-    // CHECK-NEXT: %[[LD1:.*]] = aievec.upd {{.*}}, %[[LD0]] {index = 1 : i8, offset = 256 : i32} : memref<256xi32>, vector<16xi32>
-    // CHECK-V2: %[[LD:.*]] = aievec.upd {{.*}} {index = 0 : i8, offset = 0 : i32} : memref<256xi32>, vector<16xi32>
-    // CHECK-V2-LLVM: %[[LD:.*]] = vector.transfer_read {{.*}}, {{.*}} : memref<256xi32>, vector<16xi32>
-    %0 = vector.transfer_read %arg0[%arg2], %c0_i32 : memref<256xi32>, vector<16xi32>
-    // CHECK: vector.transfer_write %[[LD1]], {{.*}} : vector<16xi32>, memref<256xi32>
-    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}} : vector<16xi32>, memref<256xi32>
-    // CHECK-V2-LLVM: vector.transfer_write %[[LD]], {{.*}} : vector<16xi32>, memref<256xi32>
-    vector.transfer_write %0, %arg1[%arg2] : vector<16xi32>, memref<256xi32>
-  }
-  return
-}
-
-// -----
-
-// CHECK-V2-LABEL: func @veccopy_2d_i32
-// CHECK-V2-LLVM-LABEL: func @veccopy_2d_i32
-func.func @veccopy_2d_i32(%arg0: memref<16x4x4xi32>, %arg1: memref<16x4x4xi32>) {
-  %c0 = arith.constant 0 : index
-  %c0_i32 = arith.constant 0 : i32
-  // CHECK-V2: %[[COLLAPSE_SHAPE_0:.*]] = memref.collapse_shape %arg0 {{\[\[}}0], [1, 2]] : memref<16x4x4xi32> into memref<16x16xi32>
-  // CHECK-V2: %[[COLLAPSE_SHAPE_1:.*]] = memref.collapse_shape %arg1 {{\[\[}}0], [1, 2]] : memref<16x4x4xi32> into memref<16x16xi32>
-  // CHECK-V2-LLVM: %[[COLLAPSE_SHAPE_0:.*]] = memref.collapse_shape %arg0 {{\[\[}}0], [1, 2]] : memref<16x4x4xi32> into memref<16x16xi32>
-  // CHECK-V2-LLVM: %[[COLLAPSE_SHAPE_1:.*]] = memref.collapse_shape %arg1 {{\[\[}}0], [1, 2]] : memref<16x4x4xi32> into memref<16x16xi32>
-  affine.for %arg2 = 0 to 16 step 1 {
-    // CHECK-V2: %[[LD:.*]] = aievec.upd %[[COLLAPSE_SHAPE_0]]{{\[}}%arg2, %c0] {index = 0 : i8, offset = 0 : i32} : memref<16x16xi32>, vector<16xi32>
-    // CHECK-V2-LLVM: %[[LD:.*]] = vector.transfer_read %[[COLLAPSE_SHAPE_0]]{{\[}}%arg2, %c0], {{.*}} {in_bounds = [true]} : memref<16x16xi32>, vector<16xi32>
-    %0 = vector.transfer_read %arg0[%arg2, %c0, %c0], %c0_i32 {in_bounds = [true, true]} : memref<16x4x4xi32>, vector<4x4xi32>
-    // CHECK-V2: vector.transfer_write %[[LD]], {{.*}} {in_bounds = [true]} : vector<16xi32>, memref<16x16xi32>
-    // CHECK-V2-LLVM: vector.transfer_write %[[LD]], {{.*}} {in_bounds = [true]} : vector<16xi32>, memref<16x16xi32>
-    vector.transfer_write %0, %arg1[%arg2, %c0, %c0] {in_bounds = [true, true]} : vector<4x4xi32>, memref<16x4x4xi32>
-  }
-  return
-}
-

--- a/test/Conversion/VectorToAIEVec/test-vector-fma.mlir
+++ b/test/Conversion/VectorToAIEVec/test-vector-fma.mlir
@@ -1,37 +1,41 @@
-// RUN: aie-opt %s -convert-vector-to-aievec="aie-target=aie2" -split-input-file | FileCheck %s
+// RUN: aie-opt %s -convert-vector-to-aievec -split-input-file | FileCheck %s
 
-// CHECK-LABEL: test_fma_bf16
-// CHECK-SAME: %[[V0:[a-zA-Z0-9]+]]: vector<16xbf16>,
-// CHECK-SAME: %[[V1:.*]]: vector<16xbf16>,
-// CHECK-SAME: %[[V2:.*]]: vector<16xbf16>)
-func.func @test_fma_bf16(%v0: vector<16xbf16>,
-                         %v1: vector<16xbf16>,
-                         %v2: vector<16xbf16>) -> vector<16xbf16> {
-  // CHECK: %[[ACC:.*]] = aievec.ups %[[V2]] {shift = 0 : i8}
-  // CHECK-SAME:              : vector<16xbf16>, vector<16xf32>
-  // CHECK: %[[FMA:.*]] = aievec.mac_elem %[[V0]], %[[V1]], %[[ACC]]
-  // CHECK-SAME:              : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
-  // CHECK: %[[RES:.*]] = aievec.srs %[[FMA]], %{{[a-zA-Z0-9]+}}
-  // CHECK-SAME:              : vector<16xf32>, i32, vector<16xbf16>
-  // CHECK: return %[[RES]] : vector<16xbf16>
-  %0 = vector.fma %v0, %v1, %v2 : vector<16xbf16>
-  return %0 : vector<16xbf16>
+aie.device(npu1) {
+  // CHECK-LABEL: test_fma_bf16
+  // CHECK-SAME: %[[V0:[a-zA-Z0-9]+]]: vector<16xbf16>,
+  // CHECK-SAME: %[[V1:.*]]: vector<16xbf16>,
+  // CHECK-SAME: %[[V2:.*]]: vector<16xbf16>)
+  func.func @test_fma_bf16(%v0: vector<16xbf16>,
+                          %v1: vector<16xbf16>,
+                          %v2: vector<16xbf16>) -> vector<16xbf16> {
+    // CHECK: %[[ACC:.*]] = aievec.ups %[[V2]] {shift = 0 : i8}
+    // CHECK-SAME:              : vector<16xbf16>, vector<16xf32>
+    // CHECK: %[[FMA:.*]] = aievec.mac_elem %[[V0]], %[[V1]], %[[ACC]]
+    // CHECK-SAME:              : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
+    // CHECK: %[[RES:.*]] = aievec.srs %[[FMA]], %{{[a-zA-Z0-9]+}}
+    // CHECK-SAME:              : vector<16xf32>, i32, vector<16xbf16>
+    // CHECK: return %[[RES]] : vector<16xbf16>
+    %0 = vector.fma %v0, %v1, %v2 : vector<16xbf16>
+    return %0 : vector<16xbf16>
+  }
 }
 
 // -----
 
-// CHECK-LABEL: test_fma_f32
-// CHECK-SAME: %[[V0:[a-zA-Z0-9]+]]: vector<16xbf16>,
-// CHECK-SAME: %[[V1:.*]]: vector<16xbf16>,
-// CHECK-SAME: %[[V2:.*]]: vector<16xf32>)
-func.func @test_fma_f32(%v0: vector<16xbf16>,
-                        %v1: vector<16xbf16>,
-                        %v2: vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[RES:.*]] = aievec.mac_elem %[[V0]], %[[V1]], %[[V2]]
-  // CHECK-SAME:              : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
-  // CHECK: return %[[RES]] : vector<16xf32>
-  %v0f32 = arith.extf %v0 : vector<16xbf16> to vector<16xf32>
-  %v1f32 = arith.extf %v1 : vector<16xbf16> to vector<16xf32>
-  %0 = vector.fma %v0f32, %v1f32, %v2 : vector<16xf32>
-  return %0 : vector<16xf32>
+aie.device(npu1) {
+  // CHECK-LABEL: test_fma_f32
+  // CHECK-SAME: %[[V0:[a-zA-Z0-9]+]]: vector<16xbf16>,
+  // CHECK-SAME: %[[V1:.*]]: vector<16xbf16>,
+  // CHECK-SAME: %[[V2:.*]]: vector<16xf32>)
+  func.func @test_fma_f32(%v0: vector<16xbf16>,
+                          %v1: vector<16xbf16>,
+                          %v2: vector<16xf32>) -> vector<16xf32> {
+    // CHECK: %[[RES:.*]] = aievec.mac_elem %[[V0]], %[[V1]], %[[V2]]
+    // CHECK-SAME:              : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
+    // CHECK: return %[[RES]] : vector<16xf32>
+    %v0f32 = arith.extf %v0 : vector<16xbf16> to vector<16xf32>
+    %v1f32 = arith.extf %v1 : vector<16xbf16> to vector<16xf32>
+    %0 = vector.fma %v0f32, %v1f32, %v2 : vector<16xf32>
+    return %0 : vector<16xf32>
+  }
 }

--- a/test/Conversion/VectorToAIEVec/test_broadcast.mlir
+++ b/test/Conversion/VectorToAIEVec/test_broadcast.mlir
@@ -1,57 +1,65 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
 // CHECK-LABEL: func @vector_extract_broadcast_to_aievec_512(
 // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
-func.func @vector_extract_broadcast_to_aievec_512(%a : vector<16xi32>) -> (vector<16xi32>, vector<16xi32>) {
-  // CHECK: aievec.broadcast %[[A]] {idx = 0 : i8} : vector<16xi32>, vector<16xi32>
-  %0 = vector.extract %a[0] : i32 from vector<16xi32>
-  %1 = vector.broadcast %0 : i32 to vector<16xi32>
-  // CHECK: aievec.broadcast %[[A]] {idx = 2 : i8} : vector<16xi32>, vector<16xi32>
-  %2 = vector.extract %a[2] : i32 from vector<16xi32>
-  %3 = vector.broadcast %2 : i32 to vector<16xi32>
-  return %1, %3 : vector<16xi32>, vector<16xi32>
+aie.device(npu1) {
+  func.func @vector_extract_broadcast_to_aievec_512(%a : vector<16xi32>) -> (vector<16xi32>, vector<16xi32>) {
+    // CHECK: aievec.broadcast %[[A]] {idx = 0 : i8} : vector<16xi32>, vector<16xi32>
+    %0 = vector.extract %a[0] : i32 from vector<16xi32>
+    %1 = vector.broadcast %0 : i32 to vector<16xi32>
+    // CHECK: aievec.broadcast %[[A]] {idx = 2 : i8} : vector<16xi32>, vector<16xi32>
+    %2 = vector.extract %a[2] : i32 from vector<16xi32>
+    %3 = vector.broadcast %2 : i32 to vector<16xi32>
+    return %1, %3 : vector<16xi32>, vector<16xi32>
+  }
 }
 
 // CHECK-LABEL: func @vector_extract_broadcast_to_aievec_256(
 // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
-func.func @vector_extract_broadcast_to_aievec_256(%a : vector<16xbf16>) -> (vector<16xbf16>, vector<16xbf16>) {
-  // CHECK: %[[CC1:.*]] = aievec.concat %[[A]], %[[A]] : vector<16xbf16>, vector<32xbf16>
-  // CHECK: %[[BCAST1:.*]] = aievec.broadcast %[[CC1]] {idx = 0 : i8} : vector<32xbf16>, vector<32xbf16>
-  // CHECK: %[[EXT1:.*]] = aievec.ext %[[BCAST1]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
-  %0 = vector.extract %a[0] : bf16 from vector<16xbf16>
-  %1 = vector.broadcast %0 : bf16 to vector<16xbf16>
-  // CHECK: %[[BCAST2:.*]] = aievec.broadcast %[[CC1]] {idx = 2 : i8} : vector<32xbf16>, vector<32xbf16>
-  // CHECK: %[[EXT2:.*]] = aievec.ext %[[BCAST2]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
-  %2 = vector.extract %a[2] : bf16 from vector<16xbf16>
-  %3 = vector.broadcast %2 : bf16 to vector<16xbf16>
-  return %1, %3 : vector<16xbf16>, vector<16xbf16>
+aie.device(npu1) {
+  func.func @vector_extract_broadcast_to_aievec_256(%a : vector<16xbf16>) -> (vector<16xbf16>, vector<16xbf16>) {
+    // CHECK: %[[CC1:.*]] = aievec.concat %[[A]], %[[A]] : vector<16xbf16>, vector<32xbf16>
+    // CHECK: %[[BCAST1:.*]] = aievec.broadcast %[[CC1]] {idx = 0 : i8} : vector<32xbf16>, vector<32xbf16>
+    // CHECK: %[[EXT1:.*]] = aievec.ext %[[BCAST1]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
+    %0 = vector.extract %a[0] : bf16 from vector<16xbf16>
+    %1 = vector.broadcast %0 : bf16 to vector<16xbf16>
+    // CHECK: %[[BCAST2:.*]] = aievec.broadcast %[[CC1]] {idx = 2 : i8} : vector<32xbf16>, vector<32xbf16>
+    // CHECK: %[[EXT2:.*]] = aievec.ext %[[BCAST2]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
+    %2 = vector.extract %a[2] : bf16 from vector<16xbf16>
+    %3 = vector.broadcast %2 : bf16 to vector<16xbf16>
+    return %1, %3 : vector<16xbf16>, vector<16xbf16>
+  }
 }
 
 // CHECK-LABEL: func @vector_extract_broadcast_to_aievec_1024(
 // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi32>
-func.func @vector_extract_broadcast_to_aievec_1024(%a : vector<32xi32>) -> (vector<32xi32>, vector<32xi32>) {
-  // CHECK: %[[EXT1:.*]] = aievec.ext %[[A]] {index = 0 : i8} : vector<32xi32>, vector<16xi32>
-  // CHECK: %[[BCAST1:.*]] = aievec.broadcast %[[EXT1]] {idx = 0 : i8} : vector<16xi32>, vector<16xi32>
-  // CHECK: %[[CC1:.*]] = aievec.concat %[[BCAST1]], %[[BCAST1]] : vector<16xi32>, vector<32xi32>
-  %0 = vector.extract %a[0] : i32 from vector<32xi32>
-  %1 = vector.broadcast %0 : i32 to vector<32xi32>
-  // CHECK: %[[BCAST2:.*]] = aievec.broadcast %[[EXT1]] {idx = 2 : i8} : vector<16xi32>, vector<16xi32>
-  // CHECK: %[[CC2:.*]] = aievec.concat %[[BCAST2]], %[[BCAST2]] : vector<16xi32>, vector<32xi32>
-  %2 = vector.extract %a[2] : i32 from vector<32xi32>
-  %3 = vector.broadcast %2 : i32 to vector<32xi32>
-  return %1, %3 : vector<32xi32>, vector<32xi32>
+aie.device(npu1) {
+  func.func @vector_extract_broadcast_to_aievec_1024(%a : vector<32xi32>) -> (vector<32xi32>, vector<32xi32>) {
+    // CHECK: %[[EXT1:.*]] = aievec.ext %[[A]] {index = 0 : i8} : vector<32xi32>, vector<16xi32>
+    // CHECK: %[[BCAST1:.*]] = aievec.broadcast %[[EXT1]] {idx = 0 : i8} : vector<16xi32>, vector<16xi32>
+    // CHECK: %[[CC1:.*]] = aievec.concat %[[BCAST1]], %[[BCAST1]] : vector<16xi32>, vector<32xi32>
+    %0 = vector.extract %a[0] : i32 from vector<32xi32>
+    %1 = vector.broadcast %0 : i32 to vector<32xi32>
+    // CHECK: %[[BCAST2:.*]] = aievec.broadcast %[[EXT1]] {idx = 2 : i8} : vector<16xi32>, vector<16xi32>
+    // CHECK: %[[CC2:.*]] = aievec.concat %[[BCAST2]], %[[BCAST2]] : vector<16xi32>, vector<32xi32>
+    %2 = vector.extract %a[2] : i32 from vector<32xi32>
+    %3 = vector.broadcast %2 : i32 to vector<32xi32>
+    return %1, %3 : vector<32xi32>, vector<32xi32>
+  }
 }
 
 // CHECK-LABEL: func @vector_broadcast_from_scalar(
-func.func @vector_broadcast_from_scalar(%a : i32, %b :bf16) -> (vector<16xi32>, vector<32xi32>, vector<16xbf16>, vector<32xbf16>) {
-  // CHECK: %[[BCAST1:.*]] = aievec.broadcast_scalar %arg0 : i32, vector<16xi32>
-  %0 = vector.broadcast %a : i32 to vector<16xi32>
-  // CHECK: %[[CC:.*]] = aievec.concat %[[BCAST1]], %[[BCAST1]] : vector<16xi32>, vector<32xi32>
-  %1 = vector.broadcast %a : i32 to vector<32xi32>
-  // CHECK: %[[BCAST2:.*]] = aievec.broadcast_scalar %arg1 : bf16, vector<32xbf16>
-  %3 = vector.broadcast %b : bf16 to vector<32xbf16>
-  // CHECK: %[[EXT1:.*]] = aievec.ext %[[BCAST2]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
-  %2 = vector.broadcast %b : bf16 to vector<16xbf16>
-  return %0, %1, %2, %3 : vector<16xi32>, vector<32xi32>, vector<16xbf16>, vector<32xbf16>
+aie.device(npu1) {
+  func.func @vector_broadcast_from_scalar(%a : i32, %b :bf16) -> (vector<16xi32>, vector<32xi32>, vector<16xbf16>, vector<32xbf16>) {
+    // CHECK: %[[BCAST1:.*]] = aievec.broadcast_scalar %arg0 : i32, vector<16xi32>
+    %0 = vector.broadcast %a : i32 to vector<16xi32>
+    // CHECK: %[[CC:.*]] = aievec.concat %[[BCAST1]], %[[BCAST1]] : vector<16xi32>, vector<32xi32>
+    %1 = vector.broadcast %a : i32 to vector<32xi32>
+    // CHECK: %[[BCAST2:.*]] = aievec.broadcast_scalar %arg1 : bf16, vector<32xbf16>
+    %3 = vector.broadcast %b : bf16 to vector<32xbf16>
+    // CHECK: %[[EXT1:.*]] = aievec.ext %[[BCAST2]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
+    %2 = vector.broadcast %b : bf16 to vector<16xbf16>
+    return %0, %1, %2, %3 : vector<16xi32>, vector<32xi32>, vector<16xbf16>, vector<32xbf16>
+  }
 }
 

--- a/test/Conversion/VectorToAIEVec/test_lut_based_ops.mlir
+++ b/test/Conversion/VectorToAIEVec/test_lut_based_ops.mlir
@@ -1,15 +1,17 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=llvmir" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec="target-backend=llvmir" | FileCheck %s
 
 
 // CHECK-LABEL: func private @getExpBf16(vector<16xbf16>) -> vector<8xi64>
-// CHECK-LABEL: func @test_exp_lut
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
-func.func @test_exp_lut(%a: vector<16xbf16>) -> vector<16xbf16> {
-    // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-    // CHECK: %[[CALL:.*]] = call @getExpBf16(%[[A]]) : (vector<16xbf16>) -> vector<8xi64>
-    // CHECK: %[[CAST:.*]] = vector.bitcast %[[CALL]] : vector<8xi64> to vector<16xf32>
-    // CHECK: %[[SRS:.*]] = aievec.srs %[[CAST]], %[[C0]] : vector<16xf32>, i32, vector<16xbf16>
-    %0 = math.exp %a : vector<16xbf16>
-    // CHECK: return %[[SRS]] : vector<16xbf16>
-    return %0 : vector<16xbf16>
+aie.device(npu1) {
+    // CHECK-LABEL: func @test_exp_lut
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
+    func.func @test_exp_lut(%a: vector<16xbf16>) -> vector<16xbf16> {
+        // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+        // CHECK: %[[CALL:.*]] = call @getExpBf16(%[[A]]) : (vector<16xbf16>) -> vector<8xi64>
+        // CHECK: %[[CAST:.*]] = vector.bitcast %[[CALL]] : vector<8xi64> to vector<16xf32>
+        // CHECK: %[[SRS:.*]] = aievec.srs %[[CAST]], %[[C0]] : vector<16xf32>, i32, vector<16xbf16>
+        %0 = math.exp %a : vector<16xbf16>
+        // CHECK: return %[[SRS]] : vector<16xbf16>
+        return %0 : vector<16xbf16>
+    }
 }

--- a/test/Conversion/VectorToAIEVec/test_mac_elem.mlir
+++ b/test/Conversion/VectorToAIEVec/test_mac_elem.mlir
@@ -1,35 +1,37 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL: func @test_mac_elem
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi32>
-func.func @test_mac_elem(%a : vector<16xi32>,
-                         %b : vector<16xi32>,
-                         %c : vector<16xi32>) -> vector<16xi32> {
-    // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
-    // CHECK: %[[UPS:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
-    // CHECK: %[[ME:.*]] = aievec.mac_elem %[[A]], %[[B]], %[[UPS:.*]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
-    // CHECK: %[[RES:.*]] = aievec.srs %[[ME:.*]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
-    %0 = arith.muli %a, %b : vector<16xi32>
-    %1 = arith.addi %0, %c : vector<16xi32>
-    // CHECK: return %[[RES:.*]] : vector<16xi32>
-    return %1 : vector<16xi32>
-}
-
-// CHECK-LABEL: func @test_mac_elem_inv
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
-// CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi32>
-func.func @test_mac_elem_inv(%a : vector<16xi32>,
+aie.device(npu1) {
+    // CHECK-LABEL: func @test_mac_elem
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+    // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi32>
+    func.func @test_mac_elem(%a : vector<16xi32>,
                              %b : vector<16xi32>,
                              %c : vector<16xi32>) -> vector<16xi32> {
-    // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
-    // CHECK: %[[UPS:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
-    // CHECK: %[[ME:.*]] = aievec.mac_elem %[[A]], %[[B]], %[[UPS:.*]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
-    // CHECK: %[[RES:.*]] = aievec.srs %[[ME:.*]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
-    %0 = arith.muli %a, %b : vector<16xi32>
-    %1 = arith.addi %c, %0 : vector<16xi32>
-    // CHECK: return %[[RES:.*]] : vector<16xi32>
-    return %1 : vector<16xi32>
+        // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+        // CHECK: %[[UPS:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
+        // CHECK: %[[ME:.*]] = aievec.mac_elem %[[A]], %[[B]], %[[UPS:.*]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
+        // CHECK: %[[RES:.*]] = aievec.srs %[[ME:.*]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
+        %0 = arith.muli %a, %b : vector<16xi32>
+        %1 = arith.addi %0, %c : vector<16xi32>
+        // CHECK: return %[[RES:.*]] : vector<16xi32>
+        return %1 : vector<16xi32>
+    }
+
+    // CHECK-LABEL: func @test_mac_elem_inv
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+    // CHECK-SAME: %[[C:[A-Za-z0-9]+]]: vector<16xi32>
+    func.func @test_mac_elem_inv(%a : vector<16xi32>,
+                                 %b : vector<16xi32>,
+                                 %c : vector<16xi32>) -> vector<16xi32> {
+        // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+        // CHECK: %[[UPS:.*]] = aievec.ups %[[C]] {shift = 0 : i8} : vector<16xi32>, vector<16xi64>
+        // CHECK: %[[ME:.*]] = aievec.mac_elem %[[A]], %[[B]], %[[UPS:.*]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
+        // CHECK: %[[RES:.*]] = aievec.srs %[[ME:.*]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
+        %0 = arith.muli %a, %b : vector<16xi32>
+        %1 = arith.addi %c, %0 : vector<16xi32>
+        // CHECK: return %[[RES:.*]] : vector<16xi32>
+        return %1 : vector<16xi32>
+    }
 }

--- a/test/Conversion/VectorToAIEVec/test_mul_elem.mlir
+++ b/test/Conversion/VectorToAIEVec/test_mul_elem.mlir
@@ -1,142 +1,144 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" | FileCheck %s
+// RUN: aie-opt %s --convert-vector-to-aievec | FileCheck %s
 
-// CHECK-LABEL: func @test_mul_elem_i32
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
-func.func @test_mul_elem_i32(%a : vector<16xi32>,
-                         %b : vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
-  // CHECK: %[[RES:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
-  %1 = arith.muli %a, %b : vector<16xi32>
-  return %1 : vector<16xi32>
-}
+aie.device(npu1) {
+    // CHECK-LABEL: func @test_mul_elem_i32
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi32>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+    func.func @test_mul_elem_i32(%a : vector<16xi32>,
+                             %b : vector<16xi32>) -> vector<16xi32> {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xi32>, vector<16xi32>, vector<16xi64>
+      // CHECK: %[[RES:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
+      %1 = arith.muli %a, %b : vector<16xi32>
+      return %1 : vector<16xi32>
+    }
 
-// CHECK-LABEL: func @test_mul_elem_i16
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi16>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi16>
-func.func @test_mul_elem_i16(%a : vector<32xi16>,
-                         %b : vector<32xi16>) -> vector<32xi16> {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi16>, vector<32xi16>, vector<32xi32>
-  // CHECK: %[[RES:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<32xi32>, i32, vector<32xi16>
-  %1 = arith.muli %a, %b : vector<32xi16>
-  return %1 : vector<32xi16>
-}
+    // CHECK-LABEL: func @test_mul_elem_i16
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi16>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi16>
+    func.func @test_mul_elem_i16(%a : vector<32xi16>,
+                             %b : vector<32xi16>) -> vector<32xi16> {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi16>, vector<32xi16>, vector<32xi32>
+      // CHECK: %[[RES:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<32xi32>, i32, vector<32xi16>
+      %1 = arith.muli %a, %b : vector<32xi16>
+      return %1 : vector<32xi16>
+    }
 
-// CHECK-LABEL: func @test_mul_elem_i16_i32
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi16>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi16>
-func.func @test_mul_elem_i16_i32(%a : vector<32xi16>,
-                         %b : vector<32xi16>) -> vector<32xi32> {
-  %1 = arith.extsi %a : vector<32xi16> to vector<32xi32>
-  %2 = arith.extsi %b : vector<32xi16> to vector<32xi32>
-  // CHECK: %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi16>, vector<32xi16>, vector<32xi32>
-  // CHECK: %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %3 = arith.muli %1, %2 : vector<32xi32>
-  return %3 : vector<32xi32> 
-}
+    // CHECK-LABEL: func @test_mul_elem_i16_i32
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi16>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi16>
+    func.func @test_mul_elem_i16_i32(%a : vector<32xi16>,
+                             %b : vector<32xi16>) -> vector<32xi32> {
+      %1 = arith.extsi %a : vector<32xi16> to vector<32xi32>
+      %2 = arith.extsi %b : vector<32xi16> to vector<32xi32>
+      // CHECK: %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi16>, vector<32xi16>, vector<32xi32>
+      // CHECK: %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+      %3 = arith.muli %1, %2 : vector<32xi32>
+      return %3 : vector<32xi32> 
+    }
 
-// CHECK-LABEL: func @test_mul_elem_i8_i32 
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi8>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi8>
-func.func @test_mul_elem_i8_i32(%a : vector<32xi8>,
-                         %b : vector<32xi8>) -> vector<32xi32> {
-  %1 = arith.extsi %a : vector<32xi8> to vector<32xi32>
-  %2 = arith.extsi %b : vector<32xi8> to vector<32xi32>
-  // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi8>, vector<32xi8>, vector<32xi32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %3 = arith.muli %1, %2 : vector<32xi32>
-  return %3 : vector<32xi32>
-}
+    // CHECK-LABEL: func @test_mul_elem_i8_i32 
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi8>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi8>
+    func.func @test_mul_elem_i8_i32(%a : vector<32xi8>,
+                             %b : vector<32xi8>) -> vector<32xi32> {
+      %1 = arith.extsi %a : vector<32xi8> to vector<32xi32>
+      %2 = arith.extsi %b : vector<32xi8> to vector<32xi32>
+      // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi8>, vector<32xi8>, vector<32xi32>
+      // CHECK:  %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+      %3 = arith.muli %1, %2 : vector<32xi32>
+      return %3 : vector<32xi32>
+    }
 
-// CHECK-LABEL: func @test_mul_elem_i8_i8 
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi8>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi8>
-func.func @test_mul_elem_i8_i8(%a : vector<32xi8>,
-                         %b : vector<32xi8>) -> vector<32xi8> {
-  // CHECK:  %[[C0I32:.*]] = arith.constant 0 : i32
-  // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi8>, vector<32xi8>, vector<32xi32>
-  // CHECK:  %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0I32]] : vector<32xi32>, i32, vector<32xi8>
-  %1 = arith.muli %a, %b : vector<32xi8>
-  return %1 : vector<32xi8>
-}
+    // CHECK-LABEL: func @test_mul_elem_i8_i8 
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi8>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi8>
+    func.func @test_mul_elem_i8_i8(%a : vector<32xi8>,
+                             %b : vector<32xi8>) -> vector<32xi8> {
+      // CHECK:  %[[C0I32:.*]] = arith.constant 0 : i32
+      // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<32xi8>, vector<32xi8>, vector<32xi32>
+      // CHECK:  %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0I32]] : vector<32xi32>, i32, vector<32xi8>
+      %1 = arith.muli %a, %b : vector<32xi8>
+      return %1 : vector<32xi8>
+    }
 
-// CHECK-LABEL: func @test_mul_elem_bf16
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xbf16>
-func.func @test_mul_elem_bf16(%a : vector<16xbf16>,
-                         %b : vector<16xbf16>) -> vector<16xbf16> {
-  // CHECK:  %[[C0I32:.*]] = arith.constant 0 : i32
-  // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
-  // CHECK:  %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0I32]] : vector<16xf32>, i32, vector<16xbf16>
-  %1 = arith.mulf %a, %b : vector<16xbf16>
-  return %1 : vector<16xbf16>
-}
+    // CHECK-LABEL: func @test_mul_elem_bf16
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xbf16>
+    func.func @test_mul_elem_bf16(%a : vector<16xbf16>,
+                             %b : vector<16xbf16>) -> vector<16xbf16> {
+      // CHECK:  %[[C0I32:.*]] = arith.constant 0 : i32
+      // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
+      // CHECK:  %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0I32]] : vector<16xf32>, i32, vector<16xbf16>
+      %1 = arith.mulf %a, %b : vector<16xbf16>
+      return %1 : vector<16xbf16>
+    }
 
-// CHECK-LABEL: func @test_mul_elem_bf16_float
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xbf16>
-func.func @test_mul_elem_bf16_float(%a : vector<16xbf16>,
-                         %b : vector<16xbf16>) -> vector<16xf32> {
-  // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
-  // CHECK:  %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  %1 = arith.extf %a : vector<16xbf16> to vector<16xf32>
-  %2 = arith.extf %b : vector<16xbf16> to vector<16xf32>
-  %3 = arith.mulf %1, %2 : vector<16xf32>
-  return %3 : vector<16xf32>
-}
+    // CHECK-LABEL: func @test_mul_elem_bf16_float
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xbf16>
+    func.func @test_mul_elem_bf16_float(%a : vector<16xbf16>,
+                             %b : vector<16xbf16>) -> vector<16xf32> {
+      // CHECK:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
+      // CHECK:  %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+      %1 = arith.extf %a : vector<16xbf16> to vector<16xf32>
+      %2 = arith.extf %b : vector<16xbf16> to vector<16xf32>
+      %3 = arith.mulf %1, %2 : vector<16xf32>
+      return %3 : vector<16xf32>
+    }
 
-// CHECK-LABEL: func @test_mul_elem_float
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xf32>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xf32>
-func.func @test_mul_elem_float(%a : vector<16xf32>,
-                         %b : vector<16xf32>) -> vector<16xf32> {
-  // CHECK-NEXT:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xf32>, vector<16xf32>, vector<16xf32>
-  // CHECK-NEXT:  %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
-  %3 = arith.mulf %a, %b : vector<16xf32>
-  return %3 : vector<16xf32>
-}
+    // CHECK-LABEL: func @test_mul_elem_float
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xf32>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xf32>
+    func.func @test_mul_elem_float(%a : vector<16xf32>,
+                             %b : vector<16xf32>) -> vector<16xf32> {
+      // CHECK-NEXT:  %[[ME:.*]] = aievec.mul_elem %[[A]], %[[B]] : vector<16xf32>, vector<16xf32>, vector<16xf32>
+      // CHECK-NEXT:  %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+      %3 = arith.mulf %a, %b : vector<16xf32>
+      return %3 : vector<16xf32>
+    }
 
-// CHECK-LABEL: func @test_i8_i16_mul_elem
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi8>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi16>
-func.func @test_i8_i16_mul_elem(%a : vector<32xi8>, %b : vector<32xi16>) -> vector<32xi32> {
-  // CHECK: %[[UNPACK:.*]] = aievec.unpack %arg0 : vector<32xi8>, vector<32xi16>
-  // CHECK: %[[ME:.*]] = aievec.mul_elem %arg1, %[[UNPACK:.*]] : vector<32xi16>, vector<32xi16>, vector<32xi32>
-  // CHECK: %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  %1 = arith.extsi %b : vector<32xi16> to vector<32xi32>
-  %2 = arith.extsi %a : vector<32xi8> to vector<32xi32>
-  %3 = arith.muli %1, %2 : vector<32xi32>
-  return %3 : vector<32xi32>
-}
+    // CHECK-LABEL: func @test_i8_i16_mul_elem
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xi8>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<32xi16>
+    func.func @test_i8_i16_mul_elem(%a : vector<32xi8>, %b : vector<32xi16>) -> vector<32xi32> {
+      // CHECK: %[[UNPACK:.*]] = aievec.unpack %arg0 : vector<32xi8>, vector<32xi16>
+      // CHECK: %[[ME:.*]] = aievec.mul_elem %arg1, %[[UNPACK:.*]] : vector<32xi16>, vector<32xi16>, vector<32xi32>
+      // CHECK: %[[CAST:.*]] = aievec.cast %[[ME]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+      %1 = arith.extsi %b : vector<32xi16> to vector<32xi32>
+      %2 = arith.extsi %a : vector<32xi8> to vector<32xi32>
+      %3 = arith.muli %1, %2 : vector<32xi32>
+      return %3 : vector<32xi32>
+    }
 
-// CHECK-LABEL: func @test_i8_i32_mul_elem
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi8>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
-func.func @test_i8_i32_mul_elem(%a : vector<16xi8>, %b : vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[CC:.*]] = aievec.concat %arg0, %arg0 : vector<16xi8>, vector<32xi8>
-  // CHECK: %[[UPS:.*]] = aievec.ups %[[CC]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
-  // CHECK: %[[CAST:.*]] = aievec.cast %[[UPS]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
-  // CHECK: %[[EXT:.*]] = aievec.ext %[[CAST]] {index = 0 : i8} : vector<32xi32>, vector<16xi32>
-  // CHECK: %[[ME:.*]] = aievec.mul_elem %[[EXT]], %arg1 : vector<16xi32>, vector<16xi32>, vector<16xi64>
-  // CHECK: %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
-  %1 = arith.extsi %a : vector<16xi8> to vector<16xi32>
-  %2 = arith.muli %1, %b : vector<16xi32>
-  return %2 : vector<16xi32>
-}
+    // CHECK-LABEL: func @test_i8_i32_mul_elem
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi8>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+    func.func @test_i8_i32_mul_elem(%a : vector<16xi8>, %b : vector<16xi32>) -> vector<16xi32> {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[CC:.*]] = aievec.concat %arg0, %arg0 : vector<16xi8>, vector<32xi8>
+      // CHECK: %[[UPS:.*]] = aievec.ups %[[CC]] {shift = 0 : i8} : vector<32xi8>, vector<32xi32>
+      // CHECK: %[[CAST:.*]] = aievec.cast %[[UPS]] {isResAcc = false} : vector<32xi32>, vector<32xi32>
+      // CHECK: %[[EXT:.*]] = aievec.ext %[[CAST]] {index = 0 : i8} : vector<32xi32>, vector<16xi32>
+      // CHECK: %[[ME:.*]] = aievec.mul_elem %[[EXT]], %arg1 : vector<16xi32>, vector<16xi32>, vector<16xi64>
+      // CHECK: %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
+      %1 = arith.extsi %a : vector<16xi8> to vector<16xi32>
+      %2 = arith.muli %1, %b : vector<16xi32>
+      return %2 : vector<16xi32>
+    }
 
-// CHECK-LABEL: func @test_i16_i32_mul_elem
-// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi16>
-// CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
-func.func @test_i16_i32_mul_elem(%a : vector<16xi16>, %b : vector<16xi32>) -> vector<16xi32> {
-  // CHECK: %[[C0:.*]] = arith.constant 0 : i32
-  // CHECK: %[[UPS:.*]] = aievec.ups %arg0 {shift = 0 : i8} : vector<16xi16>, vector<16xi32>
-  // CHECK: %[[CAST:.*]] = aievec.cast %[[UPS]] {isResAcc = false} : vector<16xi32>, vector<16xi32>
-  // CHECK: %[[ME:.*]] = aievec.mul_elem %[[CAST]], %arg1 : vector<16xi32>, vector<16xi32>, vector<16xi64>
-  // CHECK: %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
-  %1 = arith.extsi %a : vector<16xi16> to vector<16xi32>
-  %2 = arith.muli %1, %b : vector<16xi32>
-  return %2 : vector<16xi32>
+    // CHECK-LABEL: func @test_i16_i32_mul_elem
+    // CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xi16>
+    // CHECK-SAME: %[[B:[A-Za-z0-9]+]]: vector<16xi32>
+    func.func @test_i16_i32_mul_elem(%a : vector<16xi16>, %b : vector<16xi32>) -> vector<16xi32> {
+      // CHECK: %[[C0:.*]] = arith.constant 0 : i32
+      // CHECK: %[[UPS:.*]] = aievec.ups %arg0 {shift = 0 : i8} : vector<16xi16>, vector<16xi32>
+      // CHECK: %[[CAST:.*]] = aievec.cast %[[UPS]] {isResAcc = false} : vector<16xi32>, vector<16xi32>
+      // CHECK: %[[ME:.*]] = aievec.mul_elem %[[CAST]], %arg1 : vector<16xi32>, vector<16xi32>, vector<16xi64>
+      // CHECK: %[[SRS:.*]] = aievec.srs %[[ME]], %[[C0]] : vector<16xi64>, i32, vector<16xi32>
+      %1 = arith.extsi %a : vector<16xi16> to vector<16xi32>
+      %2 = arith.muli %1, %b : vector<16xi32>
+      return %2 : vector<16xi32>
+    }
 }

--- a/test/Conversion/VectorToAIEVec/unaligned-load-aieml.mlir
+++ b/test/Conversion/VectorToAIEVec/unaligned-load-aieml.mlir
@@ -1,24 +1,72 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" -split-input-file | FileCheck %s --check-prefix=CHECK
-func.func @unaligned_read(%a: memref<48xi8>) -> (vector<32xi8>, vector<32xi8>) {
-   %c0_i8 = arith.constant 0 : i8
-   %c16 = arith.constant 16 : index
-   %c34 = arith.constant 34 : index
-   %0 = vector.transfer_read %a[%c16], %c0_i8 : memref<48xi8>, vector<32xi8>
-   %1 = vector.transfer_read %a[%c34], %c0_i8 : memref<48xi8>, vector<32xi8>
-   return %0, %1 : vector<32xi8>, vector<32xi8>
+// RUN: aie-opt %s --convert-vector-to-aievec -split-input-file | FileCheck %s --check-prefix=CHECK
+
+aie.device(npu1) {
+   // CHECK-LABEL: func @unaligned_read
+   //   CHECK-DAG:    %[[C2i32:.*]] = arith.constant 2 : i32
+   //   CHECK-DAG:    %[[C32:.*]] = arith.constant 32 : index
+   //   CHECK-DAG:    %[[C16i32:.*]] = arith.constant 16 : i32
+   //   CHECK-DAG:    %[[C0:.*]] = arith.constant 0 : index
+   //       CHECK:    %[[T0:.*]] = aievec.upd {{.*}}[%[[C0:.*]]] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<64xi8>
+   //       CHECK:    %[[T0E0:.*]] = aievec.ext %[[T0]] {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+   //       CHECK:    %[[T0E1:.*]] = aievec.ext %[[T0]] {index = 1 : i8} : vector<64xi8>, vector<32xi8>
+   //       CHECK:    %[[R0:.*]] = aievec.shift %[[T0E0]], %[[T0E1]], %[[C16i32]] {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+   //       CHECK:    %[[T1:.*]] = aievec.upd {{.*}}[%[[C32:.*]]] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<64xi8>
+   //       CHECK:    %[[T1E0:.*]] = aievec.ext %[[T1]] {index = 0 : i8} : vector<64xi8>, vector<32xi8>
+   //       CHECK:    %[[T1E1:.*]] = aievec.ext %[[T1]] {index = 1 : i8} : vector<64xi8>, vector<32xi8>
+   //       CHECK:    %[[R1:.*]] = aievec.shift %[[T1E0]], %[[T1E1]], %[[C2i32]] {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
+   //       CHECK:    return %[[R0:.*]], %[[R1:.*]] : vector<32xi8>, vector<32xi8>
+   func.func @unaligned_read(%a: memref<48xi8>) -> (vector<32xi8>, vector<32xi8>) {
+      %c0_i8 = arith.constant 0 : i8
+      %c16 = arith.constant 16 : index
+      %c34 = arith.constant 34 : index
+      %0 = vector.transfer_read %a[%c16], %c0_i8 : memref<48xi8>, vector<32xi8>
+      %1 = vector.transfer_read %a[%c34], %c0_i8 : memref<48xi8>, vector<32xi8>
+      return %0, %1 : vector<32xi8>, vector<32xi8>
+   }
 }
 
-// CHECK-LABEL: func @unaligned_read
-//   CHECK-DAG:    %[[C2i32:.*]] = arith.constant 2 : i32
-//   CHECK-DAG:    %[[C32:.*]] = arith.constant 32 : index
-//   CHECK-DAG:    %[[C16i32:.*]] = arith.constant 16 : i32
-//   CHECK-DAG:    %[[C0:.*]] = arith.constant 0 : index
-//       CHECK:    %[[T0:.*]] = aievec.upd {{.*}}[%[[C0:.*]]] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<64xi8>
-//       CHECK:    %[[T0E0:.*]] = aievec.ext %[[T0]] {index = 0 : i8} : vector<64xi8>, vector<32xi8>
-//       CHECK:    %[[T0E1:.*]] = aievec.ext %[[T0]] {index = 1 : i8} : vector<64xi8>, vector<32xi8>
-//       CHECK:    %[[R0:.*]] = aievec.shift %[[T0E0]], %[[T0E1]], %[[C16i32]] {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-//       CHECK:    %[[T1:.*]] = aievec.upd {{.*}}[%[[C32:.*]]] {index = 0 : i8, offset = 0 : i32} : memref<48xi8>, vector<64xi8>
-//       CHECK:    %[[T1E0:.*]] = aievec.ext %[[T1]] {index = 0 : i8} : vector<64xi8>, vector<32xi8>
-//       CHECK:    %[[T1E1:.*]] = aievec.ext %[[T1]] {index = 1 : i8} : vector<64xi8>, vector<32xi8>
-//       CHECK:    %[[R1:.*]] = aievec.shift %[[T1E0]], %[[T1E1]], %[[C2i32]] {isAcc = false} : vector<32xi8>, vector<32xi8>, i32, vector<32xi8>
-//       CHECK:    return %[[R0:.*]], %[[R1:.*]] : vector<32xi8>, vector<32xi8>
+// -----
+
+aie.device(npu1) {
+   // CHECK-LABEL: func @unaligned_read
+   // CHECK: %[[C24i32:.*]] = arith.constant 24 : i32
+   // CHECK: %[[C12i32:.*]] = arith.constant 12 : i32
+   // CHECK: %[[C0:.*]] = arith.constant 0 : index
+   // CHECK: %[[LV:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi32>, vector<16xi32>
+   // CHECK: %[[LV0:.*]] = aievec.ext %[[LV]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
+   // CHECK: %[[LV1:.*]] = aievec.ext %[[LV]] {index = 1 : i8} : vector<16xi32>, vector<8xi32>
+   // CHECK: %[[R0:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C12i32]] {isAcc = false} : vector<8xi32>, vector<8xi32>, i32, vector<8xi32>
+   // CHECK: %[[R1:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C24i32]] {isAcc = false} : vector<8xi32>, vector<8xi32>, i32, vector<8xi32>
+   // CHECK: return %[[R0]], %[[R1]] : vector<8xi32>, vector<8xi32>
+   func.func @unaligned_read(%m: memref<64xi32>) -> (vector<8xi32>, vector<8xi32>) {
+      %c0_i32 = arith.constant 0 : i32
+      %c3 = arith.constant 3 : index
+      %c6 = arith.constant 6 : index
+      %0 = vector.transfer_read %m[%c3], %c0_i32 : memref<64xi32>, vector<8xi32>
+      %1 = vector.transfer_read %m[%c6], %c0_i32 : memref<64xi32>, vector<8xi32>
+      return %0, %1 : vector<8xi32>, vector<8xi32>
+   }
+}
+
+// -----
+
+aie.device(npu1) {
+   // CHECK-LABEL: func @unaligned_read
+   // CHECK: %[[C12i32:.*]] = arith.constant 12 : i32
+   // CHECK: %[[C6i32:.*]] = arith.constant 6 : i32
+   // CHECK: %[[C0:.*]] = arith.constant 0 : index
+   // CHECK: %[[LV:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi16>, vector<32xi16>
+   // CHECK: %[[LV0:.*]] = aievec.ext %[[LV]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+   // CHECK: %[[LV1:.*]] = aievec.ext %[[LV]] {index = 1 : i8} : vector<32xi16>, vector<16xi16>
+   // CHECK: %[[R0:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C6i32]] {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+   // CHECK: %[[R1:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C12i32]] {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
+   // CHECK: return %[[R0]], %[[R1]] : vector<16xi16>, vector<16xi16>
+   func.func @unaligned_read(%m: memref<64xi16>) -> (vector<16xi16>, vector<16xi16>) {
+      %c0_i16 = arith.constant 0 : i16
+      %c3 = arith.constant 3 : index
+      %c6 = arith.constant 6 : index
+      %0 = vector.transfer_read %m[%c3], %c0_i16 : memref<64xi16>, vector<16xi16>
+      %1 = vector.transfer_read %m[%c6], %c0_i16 : memref<64xi16>, vector<16xi16>
+      return %0, %1 : vector<16xi16>, vector<16xi16>
+   }
+}

--- a/test/Conversion/VectorToAIEVec/unaligned-load.mlir
+++ b/test/Conversion/VectorToAIEVec/unaligned-load.mlir
@@ -1,70 +1,51 @@
 // RUN: aie-opt %s --convert-vector-to-aievec -split-input-file | FileCheck %s
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" -split-input-file | FileCheck %s --check-prefix=CHECK-V2
 
-// CHECK-LABEL: func @unaligned_read
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[V0B:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi32>, vector<16xi32>
-// CHECK: %[[V0T:.*]] = aievec.upd %{{.*}}[%[[C0]]], %[[V0B]] {index = 1 : i8, offset = 256 : i32} : memref<64xi32>, vector<16xi32>
-// CHECK: %[[V0ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0", xoffsets = "0x76543210", xsquare = "0x3210", xstart = "3",
-// CHECK-SAME:                                                  yoffsets = "0", ysquare = "0", ystart = "0"}
-// CHECK-SAME:                                   : vector<16xi32>, vector<16xi32>
-// CHECK: %[[V0:.*]] = aievec_aie1.ext %[[V0ROT]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
-// CHECK: %[[V1ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0", xoffsets = "0x76543210", xsquare = "0x3210", xstart = "6",
-// CHECK-SAME:                                                  yoffsets = "0", ysquare = "0", ystart = "0"}
-// CHECK-SAME:                                   : vector<16xi32>, vector<16xi32>
-// CHECK: %[[V1:.*]] = aievec_aie1.ext %[[V1ROT]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
-// CHECK: return %[[V0]], %[[V1]] : vector<8xi32>, vector<8xi32>
-
-// CHECK-V2-LABEL: func @unaligned_read
-// CHECK-V2: %[[C24i32:.*]] = arith.constant 24 : i32
-// CHECK-V2: %[[C12i32:.*]] = arith.constant 12 : i32
-// CHECK-V2: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-V2: %[[LV:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi32>, vector<16xi32>
-// CHECK-V2: %[[LV0:.*]] = aievec.ext %[[LV]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
-// CHECK-V2: %[[LV1:.*]] = aievec.ext %[[LV]] {index = 1 : i8} : vector<16xi32>, vector<8xi32>
-// CHECK-V2: %[[R0:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C12i32]] {isAcc = false} : vector<8xi32>, vector<8xi32>, i32, vector<8xi32>
-// CHECK-V2: %[[R1:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C24i32]] {isAcc = false} : vector<8xi32>, vector<8xi32>, i32, vector<8xi32>
-// CHECK-V2: return %[[R0]], %[[R1]] : vector<8xi32>, vector<8xi32>
-func.func @unaligned_read(%m: memref<64xi32>) -> (vector<8xi32>, vector<8xi32>) {
-   %c0_i32 = arith.constant 0 : i32
-   %c3 = arith.constant 3 : index
-   %c6 = arith.constant 6 : index
-   %0 = vector.transfer_read %m[%c3], %c0_i32 : memref<64xi32>, vector<8xi32>
-   %1 = vector.transfer_read %m[%c6], %c0_i32 : memref<64xi32>, vector<8xi32>
-   return %0, %1 : vector<8xi32>, vector<8xi32>
+aie.device(xcvc1902) {
+   // CHECK-LABEL: func @unaligned_read
+   // CHECK: %[[C0:.*]] = arith.constant 0 : index
+   // CHECK: %[[V0B:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi32>, vector<16xi32>
+   // CHECK: %[[V0T:.*]] = aievec.upd %{{.*}}[%[[C0]]], %[[V0B]] {index = 1 : i8, offset = 256 : i32} : memref<64xi32>, vector<16xi32>
+   // CHECK: %[[V0ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0", xoffsets = "0x76543210", xsquare = "0x3210", xstart = "3",
+   // CHECK-SAME:                                                  yoffsets = "0", ysquare = "0", ystart = "0"}
+   // CHECK-SAME:                                   : vector<16xi32>, vector<16xi32>
+   // CHECK: %[[V0:.*]] = aievec_aie1.ext %[[V0ROT]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
+   // CHECK: %[[V1ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0", xoffsets = "0x76543210", xsquare = "0x3210", xstart = "6",
+   // CHECK-SAME:                                                  yoffsets = "0", ysquare = "0", ystart = "0"}
+   // CHECK-SAME:                                   : vector<16xi32>, vector<16xi32>
+   // CHECK: %[[V1:.*]] = aievec_aie1.ext %[[V1ROT]] {index = 0 : i8} : vector<16xi32>, vector<8xi32>
+   // CHECK: return %[[V0]], %[[V1]] : vector<8xi32>, vector<8xi32>
+   func.func @unaligned_read(%m: memref<64xi32>) -> (vector<8xi32>, vector<8xi32>) {
+      %c0_i32 = arith.constant 0 : i32
+      %c3 = arith.constant 3 : index
+      %c6 = arith.constant 6 : index
+      %0 = vector.transfer_read %m[%c3], %c0_i32 : memref<64xi32>, vector<8xi32>
+      %1 = vector.transfer_read %m[%c6], %c0_i32 : memref<64xi32>, vector<8xi32>
+      return %0, %1 : vector<8xi32>, vector<8xi32>
+   }
 }
 
 // -----
 
-// CHECK-LABEL: func @unaligned_read
-// CHECK: %[[C0:.*]] = arith.constant 0 : index
-// CHECK: %[[V0B:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi16>, vector<32xi16>
-// CHECK: %[[V0T:.*]] = aievec.upd %{{.*}}[%[[C0]]], %[[V0B]] {index = 1 : i8, offset = 256 : i32} : memref<64xi16>, vector<32xi16>
-// CHECK: %[[V0ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0x11111111", xoffsets = "0x06040200", xoffsets_hi = "0x0e0c0a08", xsquare = "0x2103", xstart = "4",
-// CHECK-SAME:                                                           yoffsets = "0x0503010f", yoffsets_hi = "0x0d0b0907", ysquare = "0x2103", ystart = "2"}
-// CHECK-SAME:                                   : vector<32xi16>, vector<32xi16>
-// CHECK: %[[V0:.*]] = aievec_aie1.ext %[[V0ROT]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
-// CHECK: %[[V1ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0", xoffsets = "0x06040200", xoffsets_hi = "0x0e0c0a08", xsquare = "0x3210", xstart = "6",
-// CHECK-SAME:                                                  yoffsets = "0", yoffsets_hi = "0", ysquare = "0", ystart = "0"}
-// CHECK-SAME:                                   : vector<32xi16>, vector<32xi16>
-// CHECK: %[[V1:.*]] = aievec_aie1.ext %[[V1ROT]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
-// CHECK: return %[[V0]], %[[V1]] : vector<16xi16>, vector<16xi16>
-
-// CHECK-V2-LABEL: func @unaligned_read
-// CHECK-V2: %[[C12i32:.*]] = arith.constant 12 : i32
-// CHECK-V2: %[[C6i32:.*]] = arith.constant 6 : i32
-// CHECK-V2: %[[C0:.*]] = arith.constant 0 : index
-// CHECK-V2: %[[LV:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi16>, vector<32xi16>
-// CHECK-V2: %[[LV0:.*]] = aievec.ext %[[LV]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
-// CHECK-V2: %[[LV1:.*]] = aievec.ext %[[LV]] {index = 1 : i8} : vector<32xi16>, vector<16xi16>
-// CHECK-V2: %[[R0:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C6i32]] {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
-// CHECK-V2: %[[R1:.*]] = aievec.shift %[[LV0]], %[[LV1]], %[[C12i32]] {isAcc = false} : vector<16xi16>, vector<16xi16>, i32, vector<16xi16>
-// CHECK-V2: return %[[R0]], %[[R1]] : vector<16xi16>, vector<16xi16>
-func.func @unaligned_read(%m: memref<64xi16>) -> (vector<16xi16>, vector<16xi16>) {
-   %c0_i16 = arith.constant 0 : i16
-   %c3 = arith.constant 3 : index
-   %c6 = arith.constant 6 : index
-   %0 = vector.transfer_read %m[%c3], %c0_i16 : memref<64xi16>, vector<16xi16>
-   %1 = vector.transfer_read %m[%c6], %c0_i16 : memref<64xi16>, vector<16xi16>
-   return %0, %1 : vector<16xi16>, vector<16xi16>
+aie.device(xcvc1902) {
+   // CHECK-LABEL: func @unaligned_read
+   // CHECK: %[[C0:.*]] = arith.constant 0 : index
+   // CHECK: %[[V0B:.*]] = aievec.upd %{{.*}}[%[[C0]]] {index = 0 : i8, offset = 0 : i32} : memref<64xi16>, vector<32xi16>
+   // CHECK: %[[V0T:.*]] = aievec.upd %{{.*}}[%[[C0]]], %[[V0B]] {index = 1 : i8, offset = 256 : i32} : memref<64xi16>, vector<32xi16>
+   // CHECK: %[[V0ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0x11111111", xoffsets = "0x06040200", xoffsets_hi = "0x0e0c0a08", xsquare = "0x2103", xstart = "4",
+   // CHECK-SAME:                                                           yoffsets = "0x0503010f", yoffsets_hi = "0x0d0b0907", ysquare = "0x2103", ystart = "2"}
+   // CHECK-SAME:                                   : vector<32xi16>, vector<32xi16>
+   // CHECK: %[[V0:.*]] = aievec_aie1.ext %[[V0ROT]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+   // CHECK: %[[V1ROT:.*]] = aievec_aie1.select %[[V0T]] {select = "0", xoffsets = "0x06040200", xoffsets_hi = "0x0e0c0a08", xsquare = "0x3210", xstart = "6",
+   // CHECK-SAME:                                                  yoffsets = "0", yoffsets_hi = "0", ysquare = "0", ystart = "0"}
+   // CHECK-SAME:                                   : vector<32xi16>, vector<32xi16>
+   // CHECK: %[[V1:.*]] = aievec_aie1.ext %[[V1ROT]] {index = 0 : i8} : vector<32xi16>, vector<16xi16>
+   // CHECK: return %[[V0]], %[[V1]] : vector<16xi16>, vector<16xi16>
+   func.func @unaligned_read(%m: memref<64xi16>) -> (vector<16xi16>, vector<16xi16>) {
+      %c0_i16 = arith.constant 0 : i16
+      %c3 = arith.constant 3 : index
+      %c6 = arith.constant 6 : index
+      %0 = vector.transfer_read %m[%c3], %c0_i16 : memref<64xi16>, vector<16xi16>
+      %1 = vector.transfer_read %m[%c6], %c0_i16 : memref<64xi16>, vector<16xi16>
+      return %0, %1 : vector<16xi16>, vector<16xi16>
+   }
 }

--- a/test/Conversion/VectorToAIEVec/vector-transpose.mlir
+++ b/test/Conversion/VectorToAIEVec/vector-transpose.mlir
@@ -1,108 +1,116 @@
-// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2" -split-input-file | FileCheck %s --check-prefix=CHECK
+// RUN: aie-opt %s --convert-vector-to-aievec -split-input-file | FileCheck %s --check-prefix=CHECK
 
-// CHECK-LABEL: transpose_i8_types
-// CHECK-SAME: %[[V0:.*]]: vector<4x16xi8>,
-// CHECK-SAME: %[[V1:.*]]: vector<16x4xi8>,
-// CHECK-SAME: %[[V2:.*]]: vector<8x8xi8>
-func.func @transpose_i8_types(%v0 : vector<4x16xi8>,
-                              %v1 : vector<16x4xi8>,
-                              %v2 : vector<8x8xi8>)
-    -> (vector<4x16xi8>, vector<16x4xi8>, vector<8x8xi8>) {
-  // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<4x16xi8> to vector<64xi8>
-  // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t8_4x16] : vector<64xi8>
-  // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<64xi8> to vector<16x4xi8>
-  %v0t = vector.transpose %v0, [1, 0] : vector<4x16xi8> to vector<16x4xi8>
-  // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<16x4xi8> to vector<64xi8>
-  // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t8_16x4] : vector<64xi8>
-  // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<64xi8> to vector<4x16xi8>
-  %v1t = vector.transpose %v1, [1, 0] : vector<16x4xi8> to vector<4x16xi8>
-  // CHECK: %[[FV2:.*]] = vector.shape_cast %[[V2]] : vector<8x8xi8> to vector<64xi8>
-  // CHECK: %[[FR2:.*]] = aievec.shuffle %[[FV2]] [t8_8x8] : vector<64xi8>
-  // CHECK: %[[R2:.*]] = vector.shape_cast %[[FR2]] : vector<64xi8> to vector<8x8xi8>
-  %v2t = vector.transpose %v2, [1, 0] : vector<8x8xi8> to vector<8x8xi8>
-  return %v1t, %v0t, %v2t : vector<4x16xi8>, vector<16x4xi8>, vector<8x8xi8>
+aie.device(npu1) {
+  // CHECK-LABEL: transpose_i8_types
+  // CHECK-SAME: %[[V0:.*]]: vector<4x16xi8>,
+  // CHECK-SAME: %[[V1:.*]]: vector<16x4xi8>,
+  // CHECK-SAME: %[[V2:.*]]: vector<8x8xi8>
+  func.func @transpose_i8_types(%v0 : vector<4x16xi8>,
+                                %v1 : vector<16x4xi8>,
+                                %v2 : vector<8x8xi8>)
+      -> (vector<4x16xi8>, vector<16x4xi8>, vector<8x8xi8>) {
+    // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<4x16xi8> to vector<64xi8>
+    // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t8_4x16] : vector<64xi8>
+    // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<64xi8> to vector<16x4xi8>
+    %v0t = vector.transpose %v0, [1, 0] : vector<4x16xi8> to vector<16x4xi8>
+    // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<16x4xi8> to vector<64xi8>
+    // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t8_16x4] : vector<64xi8>
+    // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<64xi8> to vector<4x16xi8>
+    %v1t = vector.transpose %v1, [1, 0] : vector<16x4xi8> to vector<4x16xi8>
+    // CHECK: %[[FV2:.*]] = vector.shape_cast %[[V2]] : vector<8x8xi8> to vector<64xi8>
+    // CHECK: %[[FR2:.*]] = aievec.shuffle %[[FV2]] [t8_8x8] : vector<64xi8>
+    // CHECK: %[[R2:.*]] = vector.shape_cast %[[FR2]] : vector<64xi8> to vector<8x8xi8>
+    %v2t = vector.transpose %v2, [1, 0] : vector<8x8xi8> to vector<8x8xi8>
+    return %v1t, %v0t, %v2t : vector<4x16xi8>, vector<16x4xi8>, vector<8x8xi8>
+  }
 }
 
 // -----
 
-// CHECK-LABEL: transpose_16b_types
-// CHECK-SAME: %[[V0:.*]]: vector<4x8xbf16>,
-// CHECK-SAME: %[[V1:.*]]: vector<8x4xbf16>,
-// CHECK-SAME: %[[V2:.*]]: vector<2x16xi16>,
-// CHECK-SAME: %[[V3:.*]]: vector<16x2xi16>
-func.func @transpose_16b_types(%v0 : vector<4x8xbf16>,
-                               %v1 : vector<8x4xbf16>,
-                               %v2 : vector<2x16xi16>,
-                               %v3 : vector<16x2xi16>)
-    -> (vector<4x8xbf16>, vector<8x4xbf16>, vector<2x16xi16>, vector<16x2xi16>) {
-  // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<4x8xbf16> to vector<32xbf16>
-  // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t16_4x8] : vector<32xbf16>
-  // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<32xbf16> to vector<8x4xbf16>
-  %v0t = vector.transpose %v0, [1, 0] : vector<4x8xbf16> to vector<8x4xbf16>
-  // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<8x4xbf16> to vector<32xbf16>
-  // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t16_8x4] : vector<32xbf16>
-  // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<32xbf16> to vector<4x8xbf16>
-  %v1t = vector.transpose %v1, [1, 0] : vector<8x4xbf16> to vector<4x8xbf16>
-  // CHECK: %[[FV2:.*]] = vector.shape_cast %[[V2]] : vector<2x16xi16> to vector<32xi16>
-  // CHECK: %[[FR2:.*]] = aievec.shuffle %[[FV2]] [t16_2x16] : vector<32xi16>
-  // CHECK: %[[R2:.*]] = vector.shape_cast %[[FR2]] : vector<32xi16> to vector<16x2xi16>
-  %v2t = vector.transpose %v2, [1, 0] : vector<2x16xi16> to vector<16x2xi16>
-  // CHECK: %[[FV3:.*]] = vector.shape_cast %[[V3]] : vector<16x2xi16> to vector<32xi16>
-  // CHECK: %[[FR3:.*]] = aievec.shuffle %[[FV3]] [t16_16x2] : vector<32xi16>
-  // CHECK: %[[R3:.*]] = vector.shape_cast %[[FR3]] : vector<32xi16> to vector<2x16xi16>
-  %v3t = vector.transpose %v3, [1, 0] : vector<16x2xi16> to vector<2x16xi16>
-  return %v1t, %v0t, %v3t, %v2t : vector<4x8xbf16>, vector<8x4xbf16>,
-                                  vector<2x16xi16>, vector<16x2xi16>
+aie.device(npu1) {
+  // CHECK-LABEL: transpose_16b_types
+  // CHECK-SAME: %[[V0:.*]]: vector<4x8xbf16>,
+  // CHECK-SAME: %[[V1:.*]]: vector<8x4xbf16>,
+  // CHECK-SAME: %[[V2:.*]]: vector<2x16xi16>,
+  // CHECK-SAME: %[[V3:.*]]: vector<16x2xi16>
+  func.func @transpose_16b_types(%v0 : vector<4x8xbf16>,
+                                %v1 : vector<8x4xbf16>,
+                                %v2 : vector<2x16xi16>,
+                                %v3 : vector<16x2xi16>)
+      -> (vector<4x8xbf16>, vector<8x4xbf16>, vector<2x16xi16>, vector<16x2xi16>) {
+    // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<4x8xbf16> to vector<32xbf16>
+    // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t16_4x8] : vector<32xbf16>
+    // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<32xbf16> to vector<8x4xbf16>
+    %v0t = vector.transpose %v0, [1, 0] : vector<4x8xbf16> to vector<8x4xbf16>
+    // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<8x4xbf16> to vector<32xbf16>
+    // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t16_8x4] : vector<32xbf16>
+    // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<32xbf16> to vector<4x8xbf16>
+    %v1t = vector.transpose %v1, [1, 0] : vector<8x4xbf16> to vector<4x8xbf16>
+    // CHECK: %[[FV2:.*]] = vector.shape_cast %[[V2]] : vector<2x16xi16> to vector<32xi16>
+    // CHECK: %[[FR2:.*]] = aievec.shuffle %[[FV2]] [t16_2x16] : vector<32xi16>
+    // CHECK: %[[R2:.*]] = vector.shape_cast %[[FR2]] : vector<32xi16> to vector<16x2xi16>
+    %v2t = vector.transpose %v2, [1, 0] : vector<2x16xi16> to vector<16x2xi16>
+    // CHECK: %[[FV3:.*]] = vector.shape_cast %[[V3]] : vector<16x2xi16> to vector<32xi16>
+    // CHECK: %[[FR3:.*]] = aievec.shuffle %[[FV3]] [t16_16x2] : vector<32xi16>
+    // CHECK: %[[R3:.*]] = vector.shape_cast %[[FR3]] : vector<32xi16> to vector<2x16xi16>
+    %v3t = vector.transpose %v3, [1, 0] : vector<16x2xi16> to vector<2x16xi16>
+    return %v1t, %v0t, %v3t, %v2t : vector<4x8xbf16>, vector<8x4xbf16>,
+                                    vector<2x16xi16>, vector<16x2xi16>
+  }
 }
 
 // -----
 
-// CHECK-LABEL: transpose_32b_types
-// CHECK-SAME: %[[V0:.*]]: vector<4x4xi32>,
-// CHECK-SAME: %[[V1:.*]]: vector<4x4xf32>
-func.func @transpose_32b_types(%v0 : vector<4x4xi32>,
-                               %v1 : vector<4x4xf32>)
-    -> (vector<4x4xi32>, vector<4x4xf32>) {
-  // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<4x4xi32> to vector<16xi32>
-  // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t32_4x4] : vector<16xi32>
-  // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<16xi32> to vector<4x4xi32>
-  %v0t = vector.transpose %v0, [1, 0] : vector<4x4xi32> to vector<4x4xi32>
-  // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<4x4xf32> to vector<16xf32>
-  // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t32_4x4] : vector<16xf32>
-  // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<16xf32> to vector<4x4xf32>
-  %v1t = vector.transpose %v1, [1, 0] : vector<4x4xf32> to vector<4x4xf32>
-  return %v0t, %v1t : vector<4x4xi32>, vector<4x4xf32>
+aie.device(npu1) {
+  // CHECK-LABEL: transpose_32b_types
+  // CHECK-SAME: %[[V0:.*]]: vector<4x4xi32>,
+  // CHECK-SAME: %[[V1:.*]]: vector<4x4xf32>
+  func.func @transpose_32b_types(%v0 : vector<4x4xi32>,
+                                %v1 : vector<4x4xf32>)
+      -> (vector<4x4xi32>, vector<4x4xf32>) {
+    // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<4x4xi32> to vector<16xi32>
+    // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t32_4x4] : vector<16xi32>
+    // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<16xi32> to vector<4x4xi32>
+    %v0t = vector.transpose %v0, [1, 0] : vector<4x4xi32> to vector<4x4xi32>
+    // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<4x4xf32> to vector<16xf32>
+    // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t32_4x4] : vector<16xf32>
+    // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<16xf32> to vector<4x4xf32>
+    %v1t = vector.transpose %v1, [1, 0] : vector<4x4xf32> to vector<4x4xf32>
+    return %v0t, %v1t : vector<4x4xi32>, vector<4x4xf32>
+  }
 }
 
 // -----
 
-// CHECK-LABEL: transpose_leading_unit_dims
-// CHECK-SAME: %[[V0:.*]]: vector<1x1x4x8xbf16>,
-// CHECK-SAME: %[[V1:.*]]: vector<1x1x8x4xbf16>,
-// CHECK-SAME: %[[V2:.*]]: vector<1x1x1x2x16xi16>,
-// CHECK-SAME: %[[V3:.*]]: vector<1x1x1x16x2xi16>
-func.func @transpose_leading_unit_dims(%v0 : vector<1x1x4x8xbf16>,
-                                       %v1 : vector<1x1x8x4xbf16>,
-                                       %v2 : vector<1x1x1x2x16xi16>,
-                                       %v3 : vector<1x1x1x16x2xi16>)
-    -> (vector<1x1x4x8xbf16>, vector<1x1x8x4xbf16>,
-        vector<1x1x1x2x16xi16>, vector<1x1x1x16x2xi16>) {
-  // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<1x1x4x8xbf16> to vector<32xbf16>
-  // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t16_4x8] : vector<32xbf16>
-  // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<32xbf16> to vector<1x1x8x4xbf16>
-  %v0t = vector.transpose %v0, [0, 1, 3, 2] : vector<1x1x4x8xbf16> to vector<1x1x8x4xbf16>
-  // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<1x1x8x4xbf16> to vector<32xbf16>
-  // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t16_8x4] : vector<32xbf16>
-  // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<32xbf16> to vector<1x1x4x8xbf16>
-  %v1t = vector.transpose %v1, [0, 1, 3, 2] : vector<1x1x8x4xbf16> to vector<1x1x4x8xbf16>
-  // CHECK: %[[FV2:.*]] = vector.shape_cast %[[V2]] : vector<1x1x1x2x16xi16> to vector<32xi16>
-  // CHECK: %[[FR2:.*]] = aievec.shuffle %[[FV2]] [t16_2x16] : vector<32xi16>
-  // CHECK: %[[R2:.*]] = vector.shape_cast %[[FR2]] : vector<32xi16> to vector<1x1x1x16x2xi16>
-  %v2t = vector.transpose %v2, [0, 1, 2, 4, 3] : vector<1x1x1x2x16xi16> to vector<1x1x1x16x2xi16>
-  // CHECK: %[[FV3:.*]] = vector.shape_cast %[[V3]] : vector<1x1x1x16x2xi16> to vector<32xi16>
-  // CHECK: %[[FR3:.*]] = aievec.shuffle %[[FV3]] [t16_16x2] : vector<32xi16>
-  // CHECK: %[[R3:.*]] = vector.shape_cast %[[FR3]] : vector<32xi16> to vector<1x1x1x2x16xi16>
-  %v3t = vector.transpose %v3, [0, 1, 2, 4, 3] : vector<1x1x1x16x2xi16> to vector<1x1x1x2x16xi16>
-  return %v1t, %v0t, %v3t, %v2t : vector<1x1x4x8xbf16>, vector<1x1x8x4xbf16>,
-                                  vector<1x1x1x2x16xi16>, vector<1x1x1x16x2xi16>
+aie.device(npu1) {
+  // CHECK-LABEL: transpose_leading_unit_dims
+  // CHECK-SAME: %[[V0:.*]]: vector<1x1x4x8xbf16>,
+  // CHECK-SAME: %[[V1:.*]]: vector<1x1x8x4xbf16>,
+  // CHECK-SAME: %[[V2:.*]]: vector<1x1x1x2x16xi16>,
+  // CHECK-SAME: %[[V3:.*]]: vector<1x1x1x16x2xi16>
+  func.func @transpose_leading_unit_dims(%v0 : vector<1x1x4x8xbf16>,
+                                        %v1 : vector<1x1x8x4xbf16>,
+                                        %v2 : vector<1x1x1x2x16xi16>,
+                                        %v3 : vector<1x1x1x16x2xi16>)
+      -> (vector<1x1x4x8xbf16>, vector<1x1x8x4xbf16>,
+          vector<1x1x1x2x16xi16>, vector<1x1x1x16x2xi16>) {
+    // CHECK: %[[FV0:.*]] = vector.shape_cast %[[V0]] : vector<1x1x4x8xbf16> to vector<32xbf16>
+    // CHECK: %[[FR0:.*]] = aievec.shuffle %[[FV0]] [t16_4x8] : vector<32xbf16>
+    // CHECK: %[[R0:.*]] = vector.shape_cast %[[FR0]] : vector<32xbf16> to vector<1x1x8x4xbf16>
+    %v0t = vector.transpose %v0, [0, 1, 3, 2] : vector<1x1x4x8xbf16> to vector<1x1x8x4xbf16>
+    // CHECK: %[[FV1:.*]] = vector.shape_cast %[[V1]] : vector<1x1x8x4xbf16> to vector<32xbf16>
+    // CHECK: %[[FR1:.*]] = aievec.shuffle %[[FV1]] [t16_8x4] : vector<32xbf16>
+    // CHECK: %[[R1:.*]] = vector.shape_cast %[[FR1]] : vector<32xbf16> to vector<1x1x4x8xbf16>
+    %v1t = vector.transpose %v1, [0, 1, 3, 2] : vector<1x1x8x4xbf16> to vector<1x1x4x8xbf16>
+    // CHECK: %[[FV2:.*]] = vector.shape_cast %[[V2]] : vector<1x1x1x2x16xi16> to vector<32xi16>
+    // CHECK: %[[FR2:.*]] = aievec.shuffle %[[FV2]] [t16_2x16] : vector<32xi16>
+    // CHECK: %[[R2:.*]] = vector.shape_cast %[[FR2]] : vector<32xi16> to vector<1x1x1x16x2xi16>
+    %v2t = vector.transpose %v2, [0, 1, 2, 4, 3] : vector<1x1x1x2x16xi16> to vector<1x1x1x16x2xi16>
+    // CHECK: %[[FV3:.*]] = vector.shape_cast %[[V3]] : vector<1x1x1x16x2xi16> to vector<32xi16>
+    // CHECK: %[[FR3:.*]] = aievec.shuffle %[[FV3]] [t16_16x2] : vector<32xi16>
+    // CHECK: %[[R3:.*]] = vector.shape_cast %[[FR3]] : vector<32xi16> to vector<1x1x1x2x16xi16>
+    %v3t = vector.transpose %v3, [0, 1, 2, 4, 3] : vector<1x1x1x16x2xi16> to vector<1x1x1x2x16xi16>
+    return %v1t, %v0t, %v3t, %v2t : vector<1x1x4x8xbf16>, vector<1x1x8x4xbf16>,
+                                    vector<1x1x1x2x16xi16>, vector<1x1x1x16x2xi16>
+  }
 }


### PR DESCRIPTION
- The conversion pass from `vector` to `aievec` needs to be placed fairly early in the `aiecc` pipeline, when it doesn't yet parse the device model; it's more convenient if the conversion pass reads the `aie.device` op instead.
- Registers conversion passes with `vector` dialect and `aievec` dialect into `aiecc` pipeline.