### PR TITLE
Remove `Pure` trait for `LockOp`

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1182,7 +1182,7 @@ def AIE_NextBDOp: AIE_Op<"next_bd", [Terminator]> {
 }
 
 def AIE_LockOp: AIE_Op<"lock", [
-    TileElement, Pure,
+    TileElement,
     DeclareOpInterfaceMethods<InferTypeOpInterface>
   ]>, Results<(outs Index)> {
   let summary = "Declare a physical lock";


### PR DESCRIPTION
Locks in AIE are hardware resources and `LockOp` sets its initial value, so they have hardware side effects. They shouldn't get canonicalized away even if they have no users.