### PR TITLE
MLIR-AIE root path for compiling examples

### DIFF
--- a/programming_examples/basic/vector_exp/Makefile
+++ b/programming_examples/basic/vector_exp/Makefile
@@ -1,18 +1,18 @@
 ##===- Makefile -----------------------------------------------------------===##
-# 
+#
 # This file licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc.
-# 
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
+#
 ##===----------------------------------------------------------------------===##
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-aie2_runtime_dir = ${AIEOPT_DIR}/aie_runtime_lib/AIE2
+aie2_runtime_dir = ${MLIR_AIE_DIR}/aie_runtime_lib/AIE2
 
 targetname = vector_exp
 devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
@@ -73,12 +73,12 @@ ${targetname}.exe: ${srcdir}/test.cpp
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
 else
-	cp _build/${targetname} $@ 
+	cp _build/${targetname} $@
 endif
 
 run: ${targetname}.exe build/final.xclbin
 	${powershell} ./$< -x build/final.xclbin -i build/insts.bin -k MLIR_AIE
 
-clean: 
-	rm -rf build _build ${targetname}.exe 
+clean:
+	rm -rf build _build ${targetname}.exe
 

--- a/programming_examples/makefile-common
+++ b/programming_examples/makefile-common
@@ -3,7 +3,7 @@ AIETOOLS_DIR ?= $(shell realpath $(dir $(shell which xchesscc))/../)
 AIE_INCLUDE_DIR ?= ${AIETOOLS_DIR}/data/versal_prod/lib
 AIE2_INCLUDE_DIR ?= ${AIETOOLS_DIR}/data/aie_ml/lib
 
-AIEOPT_DIR ?= $(shell realpath $(dir $(shell which aie-opt))/..)
+MLIR_AIE_DIR ?= $(shell python3 -c "from aie.utils.config import root_path; print(root_path())")
 
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body -Wno-missing-template-arg-list-after-template-kw
 
@@ -11,17 +11,17 @@ CHESSCC1_FLAGS = -f -p me -P ${AIE_INCLUDE_DIR} -I ${AIETOOLS_DIR}/include
 CHESSCC2_FLAGS = -f -p me -P ${AIE2_INCLUDE_DIR} -I ${AIETOOLS_DIR}/include
 CHESS_FLAGS = -P ${AIE_INCLUDE_DIR}
 
-CHESSCCWRAP1_FLAGS = aie -I ${AIETOOLS_DIR}/include 
+CHESSCCWRAP1_FLAGS = aie -I ${AIETOOLS_DIR}/include
 CHESSCCWRAP2_FLAGS = aie2 -I ${AIETOOLS_DIR}/include
-CHESSCCWRAP2P_FLAGS = aie2p -I ${AIETOOLS_DIR}/include 
-PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include 
-PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${AIEOPT_DIR}/include 
+CHESSCCWRAP2P_FLAGS = aie2p -I ${AIETOOLS_DIR}/include
+PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_DIR}/include
+PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_DIR}/include
 
 TEST_POWERSHELL := $(shell command -v powershell.exe >/dev/null 2>&1 && echo yes || echo no)
 ifeq ($(TEST_POWERSHELL),yes)
 	powershell = powershell.exe
 	getwslpath = wslpath -w
 else
-	powershell = 
+	powershell =
 	getwslpath = echo
 endif

--- a/programming_examples/ml/gelu/Makefile
+++ b/programming_examples/ml/gelu/Makefile
@@ -1,18 +1,18 @@
 ##===- Makefile -----------------------------------------------------------===##
-# 
+#
 # This file licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
-# 
+#
 ##===----------------------------------------------------------------------===##
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-aie2_runtime_dir = ${AIEOPT_DIR}/aie_runtime_lib/AIE2
+aie2_runtime_dir = ${MLIR_AIE_DIR}/aie_runtime_lib/AIE2
 
 devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 targetname = gelu
@@ -22,7 +22,7 @@ chans ?= 2
 
 ifeq ($(devicename),npu2)
 VPATH :=${srcdir}/../../../aie_kernels/aie2p
-else 
+else
 VPATH :=${srcdir}/../../../aie_kernels/aie2
 endif
 aie_py_src=gelu.py
@@ -74,7 +74,7 @@ ${targetname}.exe: ${srcdir}/test.cpp
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
 else
-	cp _build/${targetname} $@ 
+	cp _build/${targetname} $@
 endif
 
 run: ${targetname}.exe build/final.xclbin

--- a/programming_examples/ml/relu/Makefile
+++ b/programming_examples/ml/relu/Makefile
@@ -1,18 +1,18 @@
 ##===- Makefile -----------------------------------------------------------===##
-# 
+#
 # This file licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
-# 
+#
 ##===----------------------------------------------------------------------===##
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-aie2_runtime_dir = ${AIEOPT_DIR}/aie_runtime_lib/AIE2
+aie2_runtime_dir = ${MLIR_AIE_DIR}/aie_runtime_lib/AIE2
 
 devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 targetname = relu
@@ -21,12 +21,12 @@ cols ?= 4
 chans ?= 2
 
 # Input and output sizes in bytes is length * 2
-in1_size = ${length} * 2 
-out_size = ${length} * 2 
+in1_size = ${length} * 2
+out_size = ${length} * 2
 
 ifeq ($(devicename),npu2)
 VPATH :=${srcdir}/../../../aie_kernels/aie2
-else 
+else
 VPATH :=${srcdir}/../../../aie_kernels/aie2
 endif
 
@@ -63,7 +63,7 @@ ${targetname}.exe: ${srcdir}/test.cpp
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
 else
-	cp _build/${targetname} $@ 
+	cp _build/${targetname} $@
 endif
 
 run: ${targetname}.exe build/final.xclbin

--- a/programming_examples/ml/silu/Makefile
+++ b/programming_examples/ml/silu/Makefile
@@ -1,18 +1,18 @@
 ##===- Makefile -----------------------------------------------------------===##
-# 
+#
 # This file licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
-# 
+#
 ##===----------------------------------------------------------------------===##
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-aie2_runtime_dir = ${AIEOPT_DIR}/aie_runtime_lib/AIE2
+aie2_runtime_dir = ${MLIR_AIE_DIR}/aie_runtime_lib/AIE2
 
 devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 targetname = silu
@@ -22,7 +22,7 @@ chans ?= 2
 
 ifeq ($(devicename),npu2)
 VPATH :=${srcdir}/../../../aie_kernels/aie2p
-else 
+else
 VPATH :=${srcdir}/../../../aie_kernels/aie2
 endif
 
@@ -75,7 +75,7 @@ ${targetname}.exe: ${srcdir}/test.cpp
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
 else
-	cp _build/${targetname} $@ 
+	cp _build/${targetname} $@
 endif
 
 run: ${targetname}.exe build/final.xclbin

--- a/programming_examples/ml/softmax/Makefile
+++ b/programming_examples/ml/softmax/Makefile
@@ -1,24 +1,24 @@
 ##===- Makefile -----------------------------------------------------------===##
-# 
+#
 # This file licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Copyright (C) 2024, Advanced Micro Devices, Inc.
-# 
+# Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
+#
 ##===----------------------------------------------------------------------===##
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-aie2_runtime_dir = ${AIEOPT_DIR}/aie_runtime_lib/AIE2
+aie2_runtime_dir = ${MLIR_AIE_DIR}/aie_runtime_lib/AIE2
 
 devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 
 ifeq ($(devicename),npu2)
 VPATH :=${srcdir}/../../../aie_kernels/aie2p
-else 
+else
 VPATH :=${srcdir}/../../../aie_kernels/aie2
 endif
 
@@ -45,7 +45,7 @@ build/lut_based_ops.o: ${aie2_runtime_dir}/lut_based_ops.cpp
 	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2_FLAGS} -I. -c $< -o ${@F}
 endif
 
-	
+
 build/softmax.o: ${VPATH}/softmax.cc
 	mkdir -p ${@D}
 ifeq ($(devicename),npu)
@@ -95,7 +95,7 @@ ${targetname}.exe: ${srcdir}/test.cpp
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
 else
-	cp _build/${targetname} $@ 
+	cp _build/${targetname} $@
 endif
 
 ifeq ($(devicename),npu)
@@ -114,6 +114,6 @@ trace: ${targetname}.exe build/final_trace.xclbin
 	${srcdir}/../../utils/parse_trace.py --input trace.txt --mlir build/aie_trace.mlir --output trace_softmax.json
 	${srcdir}/../../utils/get_trace_summary.py --input trace_softmax.json
 
-clean: 
-	rm -rf build _build ${targetname}.exe 
+clean:
+	rm -rf build _build ${targetname}.exe
 

--- a/programming_examples/ml/swiglu/Makefile
+++ b/programming_examples/ml/swiglu/Makefile
@@ -1,18 +1,18 @@
 ##===- Makefile -----------------------------------------------------------===##
-# 
+#
 # This file licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
-# 
+#
 ##===----------------------------------------------------------------------===##
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
-aie2_runtime_dir = ${AIEOPT_DIR}/aie_runtime_lib/AIE2
+aie2_runtime_dir = ${MLIR_AIE_DIR}/aie_runtime_lib/AIE2
 
 devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 targetname = swiglu
@@ -21,7 +21,7 @@ cols ?= 4
 
 ifeq ($(devicename),npu2)
 VPATH :=${srcdir}/../../../aie_kernels/aie2p
-else 
+else
 VPATH :=${srcdir}/../../../aie_kernels/aie2
 endif
 
@@ -74,7 +74,7 @@ ${targetname}.exe: ${srcdir}/test.cpp
 ifeq "${powershell}" "powershell.exe"
 	cp _build/${targetname}.exe $@
 else
-	cp _build/${targetname} $@ 
+	cp _build/${targetname} $@
 endif
 
 run: ${targetname}.exe build/final.xclbin

--- a/python/utils/config.py
+++ b/python/utils/config.py
@@ -27,10 +27,16 @@ def peano_cxx_path():
         raise RuntimeError(f"Peano compiler not found in {install_dir}")
     return peano_cxx
 
+def root_path():
+    """Returns the root path of the MLIR-AIE project."""
+    root_dir = config.install_path()
+    if not os.path.isdir(root_dir):
+        raise RuntimeError(f"Invalid MLIR-AIE root directory: {root_dir}")
+    return root_dir
 
 def cxx_header_path():
     """Returns the path to the MLIR-AIE C++ headers."""
-    include_dir = os.path.join(config.install_path(), "include")
+    include_dir = os.path.join(root_path(), "include")
     if not os.path.isdir(include_dir):
         raise RuntimeError(f"MLIR-AIE C++ headers not found in {include_dir}")
     return include_dir


### PR DESCRIPTION
`aie-opt` is installed in site-packages and the wrapper in `venv/bin`. This messes up the expected directories to find header files/lib installed in the `mlir-aie` package.

We expose the root dir of `mlir-aie` via a function that can be used in scripts and other places to retrieve the correct paths.