### PR TITLE
Revert "The default `ostream` value, `AIE`, will never work in `aieccpy` (#2533)"

### DIFF
--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -111,7 +111,7 @@ LogicalResult AIETranslateToTargetArch(ModuleOp module, raw_ostream &output) {
     arch = targetOp.getTargetModel().getTargetArch();
   }
   if (arch == AIEArch::AIE1)
-    output << "AIE1\n";
+    output << "AIE\n";
   else
     output << stringifyEnum(arch) << "\n";
   return success();

--- a/test/Targets/AIEGenerateTargetArch/aie.mlir
+++ b/test/Targets/AIEGenerateTargetArch/aie.mlir
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-translate --aie-generate-target-arch %s | FileCheck --match-full-lines %s
-// CHECK: AIE1
+// CHECK: AIE
 
 module {
   %01 = aie.tile(0, 1)


### PR DESCRIPTION
This reverts commit 36935cab105ab7b6cd201d010bbeb073616198b0.

Backward compatibility: some parts still refer to AIE1 architecture as "AIE" instead of "AIE1".