### PR TITLE
fix AIEVec dependency

### DIFF
--- a/lib/Targets/AIEVecToCpp/CMakeLists.txt
+++ b/lib/Targets/AIEVecToCpp/CMakeLists.txt
@@ -17,4 +17,5 @@ add_mlir_translation_library(MLIRTargetAIEVecCpp
   MLIRAIEVecDialect
   MLIRIR
   MLIRSupport
+  AIE
 )


### PR DESCRIPTION
My build just failed with:

```
[66/665] Building CXX object lib/Targets/AIEVecToCpp/CMakeFiles/obj.MLIRTargetAIEVecCpp.dir/TranslateAIEVecToCpp.cpp.o
FAILED: lib/Targets/AIEVecToCpp/CMakeFiles/obj.MLIRTargetAIEVecCpp.dir/TranslateAIEVecToCpp.cpp.o 
/usr/bin/c++ -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__SHORT_FILE__=\"TranslateAIEVecToCpp.cpp\" -I/workspace/llvm-wheel/mlir/include -I/workspace/mlir-aie/include -I/workspace/mlir-aie/build/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -Wimplicit-fallthrough -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -Werror=sign-compare -Werror=unused -Werror=return-type -Werror=mismatched-tags -O3 -DNDEBUG -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden   -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fno-exceptions -funwind-tables -UNDEBUG -MD -MT lib/Targets/AIEVecToCpp/CMakeFiles/obj.MLIRTargetAIEVecCpp.dir/TranslateAIEVecToCpp.cpp.o -MF lib/Targets/AIEVecToCpp/CMakeFiles/obj.MLIRTargetAIEVecCpp.dir/TranslateAIEVecToCpp.cpp.o.d -o lib/Targets/AIEVecToCpp/CMakeFiles/obj.MLIRTargetAIEVecCpp.dir/TranslateAIEVecToCpp.cpp.o -c /workspace/mlir-aie/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp
In file included from /workspace/mlir-aie/lib/Targets/AIEVecToCpp/TranslateAIEVecToCpp.cpp:16:
/workspace/mlir-aie/include/aie/Dialect/AIE/IR/AIEDialect.h:101:10: fatal error: aie/Dialect/AIE/IR/AIEAttrs.h.inc: No such file or directory
  101 | #include "aie/Dialect/AIE/IR/AIEAttrs.h.inc"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

I must have gotten a really unlucky scheduling for this to happen. It looks like those files were last touched two years ago.

I don't know CMake well, so don't know if this is the proper fix. But I think we either need a `DEPENDS` on the AIE dialect or this proposed change in there.
