### PR TITLE
update reviewdog/action-suggester fail level

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -153,7 +153,7 @@ jobs:
           tool_name: clang-format
           level: error
           cleanup: true
-          fail_on_error: true
+          fail_level: any
 
       - name: Run black format
         if: success() || failure()
@@ -175,7 +175,7 @@ jobs:
         with:
           tool_name: black
           level: error
-          fail_on_error: true
+          fail_level: any
 
   code-coverage:
 


### PR DESCRIPTION
Format checking seems to be broken.

See for example https://github.com/Xilinx/mlir-aie/actions/runs/17278310277/job/49040606658?pr=2532

from logs:
```
Warning: Input 'fail_on_error' has been deprecated with message: Deprecated, use `fail_level` instead.
...
time=2025-08-27T20:45:55.804Z level=WARN msg="reviewdog: -fail-on-error is deprecated. Use -fail-level=any, or -fail-level=error for github-[pr-]check 
```