### PR TITLE
Update AxCache bits for ShimDMA BD generation

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -569,8 +569,9 @@ public:
       words[4] |= op.getD1Stride() & 0xfffff;
 
       // DMA_BDX_5
-      // TODO: SIMID, AxCache, AXQoS
-      words[5] = op.getD2Stride() & 0xfffff;
+      // TODO: SIMID, AXQoS
+      words[5] |= (2 & 0xf) << 24; // AXCache = 2 to enable upsizing in NoC
+      words[5] |= op.getD2Stride() & 0xfffff;
 
       // DMA_BDX_6
       words[6] |= (op.getIterationCurrent() & 0x3f) << 26;

--- a/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
@@ -14,7 +14,7 @@
 
 // CHECK-LABEL:  aie.device(xcve2302) {
 // CHECK:     memref.global "public" @toMem : memref<65536xbf16>
-// CHECK:     memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, -2080374657, 33556479, 0, 33554432]>
+// CHECK:     memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, -2080374657, 33554463, 0, 33554432]>
 // CHECK:     aiex.runtime_sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
 // CHECK:       %0 = memref.get_global @blockwrite_data_0 : memref<8xi32>
 // CHECK:       aiex.npu.blockwrite(%0) {address = 67227648 : ui32} : memref<8xi32>

--- a/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
@@ -14,7 +14,7 @@
 
 // CHECK-LABEL:  aie.device(xcve2302) {
 // CHECK:     memref.global "public" @toMem : memref<65536xbf16>
-// CHECK:     memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, -2080374657, 31, 0, 33554432]>
+// CHECK:     memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[8192, 0, 0, 33554432, -2080374657, 33556479, 0, 33554432]>
 // CHECK:     aiex.runtime_sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
 // CHECK:       %0 = memref.get_global @blockwrite_data_0 : memref<8xi32>
 // CHECK:       aiex.npu.blockwrite(%0) {address = 67227648 : ui32} : memref<8xi32>

--- a/test/Targets/NPU/npu_dma_memcpy.mlir
+++ b/test/Targets/NPU/npu_dma_memcpy.mlir
@@ -10,7 +10,7 @@
 
 // RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
 
-// CHECK: memref.global "private" constant {{.*}} : memref<8xi32> = dense<[2048, 0, 0, 33554432, -2113929153, 2047, 0, 33554432]>
+// CHECK: memref.global "private" constant {{.*}} : memref<8xi32> = dense<[2048, 0, 0, 33554432, -2113929153, 33556479, 0, 33554432]>
 // CHECK: aiex.runtime_sequence
 // CHECK:   %[[VALUE:.*]] = memref.get_global {{.*}} : memref<8xi32>
 // CHECK:   aiex.npu.blockwrite(%[[VALUE]]) {address = 118784 : ui32} : memref<8xi32>


### PR DESCRIPTION
Set AxCache = 2 to enable upsizing in the NoC for performance

Example using `programming_examples/basic/memcpy` with suggested `task_group()` edits:

Before:

```
./memcpy.exe -x build/final.xclbin -i build/insts.bin -k MLIR_AIE -l 16777216
Name: MLIR_AIE

Latency (us): 2417

Effective Bandwidth: 55.5307 GB/s

PASS!
```


After:

```
./memcpy.exe -x build/final.xclbin -i build/insts.bin -k MLIR_AIE -l 16777216
Name: MLIR_AIE

Latency (us): 2016

Effective Bandwidth: 66.5763 GB/s

PASS!
```