### PR TITLE
Remove use of xbutil in lit script

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -121,10 +121,7 @@ if config.xrt_lib_dir:
         config.xrt_include_dir, config.xrt_lib_dir
     )
     try:
-        # xbutil is deprecated/renamed to xrt-smi, leaving it xbutil for now for
-        # compatibility with older versions of XRT
-        # xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
-        xrtsmi = os.path.join(config.xrt_bin_dir, "xbutil")
+        xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
         result = subprocess.run(
             [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -121,10 +121,7 @@ if config.xrt_lib_dir:
         config.xrt_include_dir, config.xrt_lib_dir
     )
     try:
-        # xbutil is deprecated/renamed to xrt-smi, leaving it xbutil for now for
-        # compatibility with older versions of XRT
-        # xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
-        xrtsmi = os.path.join(config.xrt_bin_dir, "xbutil")
+        xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
         result = subprocess.run(
             [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -142,10 +142,7 @@ if config.xrt_lib_dir:
         config.xrt_include_dir, config.xrt_lib_dir
     )
     try:
-        # xbutil is deprecated/renamed to xrt-smi, leaving it xbutil for now for
-        # compatibility with older versions of XRT
-        # xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
-        xrtsmi = os.path.join(config.xrt_bin_dir, "xbutil")
+        xrtsmi = os.path.join(config.xrt_bin_dir, "xrt-smi")
         result = subprocess.run(
             [xrtsmi, "examine"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )


### PR DESCRIPTION
xbutil is no longer present in xdna-driver v1.6 branch. It was long ago replaced with xrt-smi.