### PR TITLE
Add `parse_trace.py` to mlir-aie wheel

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,6 +41,7 @@ declare_mlir_python_sources(AIEPythonSources.Utils
     utils/trace.py
     utils/trace_events_enum.py
     utils/config.py
+    ../programming_examples/utils/parse_trace.py
 )
 
 declare_mlir_python_sources(AIEPythonSources.Helpers


### PR DESCRIPTION
... so that trace can be parsed using the wheel only, without requiring a clone of mlir-aie.