### PR TITLE
Fix crash in object fifo lowering when error happens

### DIFF
--- a/test/objectFifo-stateful-transform/check_errors.mlir
+++ b/test/objectFifo-stateful-transform/check_errors.mlir
@@ -1,0 +1,34 @@
+//===- check_errors.mlir ---------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --verify-diagnostics --aie-objectFifo-stateful-transform %s
+
+// -----
+
+module {
+  aie.device(npu1_1col) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    aie.objectfifo @fifo_in(%shim_noc_tile_0_0, {%tile_0_2}, 2 : i32) : !aie.objectfifo<memref<32x32xi32>>
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c4294967295 = arith.constant 4294967295 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg0 = %c0 to %c4294967295 step %c1 {
+        // expected-error@+1 {{cannot release more elements than are already acquired}}
+        %0 = aie.objectfifo.acquire @fifo_in(Consume, 1) : !aie.objectfifosubview<memref<32x32xi32>>
+        %1 = aie.objectfifo.subview.access %0[0] : !aie.objectfifosubview<memref<32x32xi32>> -> memref<32x32xi32>
+        aie.objectfifo.release @fifo_in(Consume, 1)
+        aie.objectfifo.release @fifo_in(Consume, 1)
+      }
+      aie.end
+    }
+  }
+}


### PR DESCRIPTION
Modify `aie-objectFifo-stateful-transform` to exit early when error conditions occur instead of bravely continuing on then crashing.
Before:
```
$ aiecc.py test.mlir
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = xilinx::AIE::BufferOp*; _Alloc = std::allocator<xilinx::AIE::BufferOp*>; std::vector<_Tp, _Alloc>::reference = xilinx::AIE::BufferOp*&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Aborted (core dumped)
```
After:
```
$ aiecc.py test.mlir
Error running pass pipeline:  builtin.module(convert-vector-to-aievec{ aie-target=aie2 target-backend=llvmir },lower-affine,aie-canonicalize-device,aie.device(aie-assign-lock-ids,aie-register-objectFifos,aie-objectFifo-stateful-transform{ dynamic-objFifos=0 packet-sw-objFifos=0 },aie-assign-bd-ids,aie-lower-cascade-flows,aie-lower-broadcast-packet,aie-lower-multicast,aie-assign-tile-controller-ids,aie-generate-column-control-overlay{ route-shim-to-tile-ctrl=0 },aie-assign-buffer-addresses),convert-scf-to-cf) Failure while executing pass pipeline:
error: "-":11:14: 'aie.objectfifo.acquire' op cannot release more elements than are already acquired
 note: "-":11:14: see current operation: %20 = "aie.objectfifo.acquire"() <{objFifo_name = @fifo_in_cons, port = 1 : i32, size = 1 : i32}> : () -> !aie.objectfifosubview<memref<32x32xi32>>
...
```
I added a test for the error condition which was causing my crash, which will assert without this PR.