### PR TITLE
[aievec] Add `arith.addf` to llvmir lowering

### DIFF
--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -108,6 +108,15 @@ def MulConfBF16IntrOp :
                    VectorOfLengthAndType<[32], [BF16]>:$rhs,
                    I32:$conf)>;
 
+// ----- ADD -----
+
+def AddAccFloatIntrOp :
+    AIEVec2_IntrOp<"add.accfloat",
+        [TypeIs<"res", VectorOfLengthAndType<[8], [I64]>>]>,
+    Arguments<(ins VectorOfLengthAndType<[8], [I64]>:$lhs,
+                   VectorOfLengthAndType<[8], [I64]>:$rhs,
+                   I32:$conf)>;
+
 // ----- SET ----- 
 
 def VectorSetI512I128IntrOp :

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -242,7 +242,7 @@ public:
       // Float types
       if (lhsBitWidth == 32) {
         // FP32 add_elem
-        return {DecodedAddElemOp::Kind::FP32_FP32_FP32_16x1x1x1, -1};
+        return {DecodedAddElemOp::Kind::FP32_FP32_FP32_16x1x1x1, /*conf*/ 0};
       }
     }
     return {DecodedAddElemOp::Kind::UNSUPPORTED, -1};

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -205,6 +205,19 @@ void encodeConf(uint32_t conf[2], const BufferParams &x, const BufferParams &z,
   conf[1] |= sub << 17;
 }
 
+class AddOpConversion
+    : public mlir::ConvertOpToLLVMPattern<aievec::aie1::AddOp> {
+public:
+  using ConvertOpToLLVMPattern<aievec::aie1::AddOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(aievec::aie1::AddOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    op.emitWarning() << "aie.add conversion is not implemented\n";
+    return failure();
+  }
+};
+
 class AddElemOpConversion
     : public mlir::ConvertOpToLLVMPattern<aievec::AddElemOp> {
 public:
@@ -2381,7 +2394,8 @@ void populateAIEVecToLLVMConversionPatterns(
     mlir::LLVMTypeConverter &converter, mlir::RewritePatternSet &patterns,
     Aie2Fp32Emulation aie2Fp32EmulationOption) {
   // clang-format off
-  patterns.add<AddElemOpConversion,
+  patterns.add<AddOpConversion,
+               AddElemOpConversion,
                SubOpConversion,
                FMAOpConversion,
                MulOpConversion,

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -205,16 +205,72 @@ void encodeConf(uint32_t conf[2], const BufferParams &x, const BufferParams &z,
   conf[1] |= sub << 17;
 }
 
-class AddOpConversion
-    : public mlir::ConvertOpToLLVMPattern<aievec::aie1::AddOp> {
+class AddElemOpConversion
+    : public mlir::ConvertOpToLLVMPattern<aievec::AddElemOp> {
 public:
-  using ConvertOpToLLVMPattern<aievec::aie1::AddOp>::ConvertOpToLLVMPattern;
+  using ConvertOpToLLVMPattern<aievec::AddElemOp>::ConvertOpToLLVMPattern;
+
+  struct DecodedAddElemOp {
+    enum class Kind { FP32_FP32_FP32_16x1x1x1, UNSUPPORTED };
+    Kind kind;
+    int conf;
+  };
+
+  static DecodedAddElemOp decodeAddElemOp(OpAdaptor op) {
+    auto lhs = op.getLhs();
+    auto lhsVecTy = cast<VectorType>(lhs.getType());
+    auto lhsScaTy = lhsVecTy.getElementType();
+    unsigned lhsBitWidth = lhsScaTy.getIntOrFloatBitWidth();
+
+    // Integer types
+    if (llvm::isa<IntegerType>(lhsScaTy)) {
+      return {DecodedAddElemOp::Kind::UNSUPPORTED, -1};
+    } else {
+      // Float types
+      if (lhsBitWidth == 32) {
+        // FP32 add_elem
+        return {DecodedAddElemOp::Kind::FP32_FP32_FP32_16x1x1x1, -1};
+      }
+    }
+    return {DecodedAddElemOp::Kind::UNSUPPORTED, -1};
+  }
 
   LogicalResult
-  matchAndRewrite(aievec::aie1::AddOp op, OpAdaptor adaptor,
+  matchAndRewrite(aievec::AddElemOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    op.emitWarning() << "aie.add conversion is not implemented\n";
-    return failure();
+    Location loc = op.getLoc();
+    auto decodedAddElemOp = decodeAddElemOp(adaptor);
+
+    if (decodedAddElemOp.kind == DecodedAddElemOp::Kind::UNSUPPORTED) {
+      op.emitWarning() << "aievec.add_elem conversion is not supported.\n";
+      return failure();
+    }
+
+    auto confCst = rewriter.create<LLVM::ConstantOp>(
+        loc, rewriter.getI32Type(),
+        rewriter.getI32IntegerAttr(decodedAddElemOp.conf));
+    Value addElemOp = nullptr;
+    SmallVector<Value> operands({adaptor.getLhs(), adaptor.getRhs(), confCst});
+
+    // Handle the FP32 add_elem
+    if (decodedAddElemOp.kind ==
+        DecodedAddElemOp::Kind::FP32_FP32_FP32_16x1x1x1) {
+      addElemOp = rewriter.create<xllvm::AddAccFloatIntrOp>(
+          loc, VectorType::get({8}, rewriter.getI64Type()),
+          forceCastOperandsToSignature(
+              rewriter, loc, operands,
+              {VectorType::get({8}, rewriter.getI64Type()),
+               VectorType::get({8}, rewriter.getI64Type()),
+               rewriter.getI32Type()}));
+    } else {
+      op.emitWarning() << "aievec.add_elem conversion is not supported.\n";
+      return failure();
+    }
+
+    // create bitcast for result
+    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
+                                                 addElemOp);
+    return success();
   }
 };
 
@@ -2325,7 +2381,7 @@ void populateAIEVecToLLVMConversionPatterns(
     mlir::LLVMTypeConverter &converter, mlir::RewritePatternSet &patterns,
     Aie2Fp32Emulation aie2Fp32EmulationOption) {
   // clang-format off
-  patterns.add<AddOpConversion,
+  patterns.add<AddElemOpConversion,
                SubOpConversion,
                FMAOpConversion,
                MulOpConversion,

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3100,7 +3100,7 @@ static void populateAIEVecV2ConversionPatterns(RewritePatternSet &patterns,
       >(patterns.getContext());
   } else if (backend == TargetBackend::LLVMIR){
       patterns.add<
-      ComputeExpOpByLUTLLVMPattern
+      ComputeExpOpByLUTLLVMPattern, LowerVectorAddFOpToAIEVecAddElemOp
       >(patterns.getContext());
   }
   patterns.add<

--- a/test/Conversion/AIEVecToLLVM/test-add_elem.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-add_elem.mlir
@@ -1,0 +1,24 @@
+//===- test-add_elem.mlir --------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s -convert-aievec-to-llvm -split-input-file | FileCheck %s
+
+// CHECK-LABEL: add_elem_flat_fp32
+// CHECK-SAME: %[[LHS:[a-zA-Z0-9]+]]: vector<16xf32>
+// CHECK-SAME: %[[RHS:[a-zA-Z0-9]+]]: vector<16xf32>
+func.func @add_elem_flat_fp32(%lhs : vector<16xf32>, %rhs : vector<16xf32>) -> vector<16xf32> {
+  // CHECK: %[[CONF:.*]] = llvm.mlir.constant(-1 : i32) : i32
+  // CHECK: %[[LHS_BC:.*]] = llvm.bitcast %[[LHS]] : vector<16xf32> to vector<8xi64>
+  // CHECK: %[[RHS_BC:.*]] = llvm.bitcast %[[RHS]] : vector<16xf32> to vector<8xi64>
+  // CHECK: %[[ADD:.*]] = "xllvm.intr.aie2.add.accfloat"(%[[LHS_BC]], %[[RHS_BC]], %[[CONF]]) : (vector<8xi64>, vector<8xi64>, i32) -> vector<8xi64>
+  // CHECK: %[[RES:.*]] = llvm.bitcast %[[ADD]] : vector<8xi64> to vector<16xf32>
+  %0 = aievec.add_elem %lhs, %rhs : vector<16xf32>
+  return %0 : vector<16xf32>
+}

--- a/test/Conversion/AIEVecToLLVM/test-add_elem.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-add_elem.mlir
@@ -14,7 +14,7 @@
 // CHECK-SAME: %[[LHS:[a-zA-Z0-9]+]]: vector<16xf32>
 // CHECK-SAME: %[[RHS:[a-zA-Z0-9]+]]: vector<16xf32>
 func.func @add_elem_flat_fp32(%lhs : vector<16xf32>, %rhs : vector<16xf32>) -> vector<16xf32> {
-  // CHECK: %[[CONF:.*]] = llvm.mlir.constant(-1 : i32) : i32
+  // CHECK: %[[CONF:.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK: %[[LHS_BC:.*]] = llvm.bitcast %[[LHS]] : vector<16xf32> to vector<8xi64>
   // CHECK: %[[RHS_BC:.*]] = llvm.bitcast %[[RHS]] : vector<16xf32> to vector<8xi64>
   // CHECK: %[[ADD:.*]] = "xllvm.intr.aie2.add.accfloat"(%[[LHS_BC]], %[[RHS_BC]], %[[CONF]]) : (vector<8xi64>, vector<8xi64>, i32) -> vector<8xi64>


### PR DESCRIPTION
- Add `AddAccFloatIntrOp` to xllvm dialect, which lowers to `aie2.add.accfloat` intrinsic.
- Add `arith.addf` to llvmir lowering pattern to `-vector-to-aievec` pipeline.
~~- TODO: Add mlir ir test for lowering to xllvm~~