### PR TITLE
Reduce non-determinism in router

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -154,6 +154,12 @@ using Connect = struct Connect {
   bool operator==(const Connect &rhs) const {
     return std::tie(src, dst) == std::tie(rhs.src, rhs.dst);
   }
+
+  bool operator!=(const Connect &rhs) const { return !(*this == rhs); }
+
+  bool operator<(const Connect &rhs) const {
+    return std::tie(src, dst) < std::tie(rhs.src, rhs.dst);
+  }
 };
 
 using DMAChannel = struct DMAChannel {

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.h
@@ -70,7 +70,7 @@ struct AIEPathfinderPass : AIERoutePathfinderFlowsBase<AIEPathfinderPass> {
   void runOnPacketFlow(DeviceOp d, mlir::OpBuilder &builder,
                        DynamicTileAnalysis &analyzer);
 
-  typedef std::pair<mlir::Operation *, Port> PhysPort;
+  typedef std::pair<TileID, Port> PhysPort;
 
   bool findPathToDest(SwitchSettings settings, TileID currTile,
                       WireBundle currDestBundle, int currDestChannel,

--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -254,6 +254,7 @@ public:
   int getMaxRow() const { return maxRow; }
 
   TileOp getTile(mlir::OpBuilder &builder, int col, int row);
+  TileOp getTile(mlir::OpBuilder &builder, const TileID &tileId);
 
   SwitchboxOp getSwitchbox(mlir::OpBuilder &builder, int col, int row);
 

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -144,6 +144,10 @@ TileOp DynamicTileAnalysis::getTile(OpBuilder &builder, int col, int row) {
   return tileOp;
 }
 
+TileOp DynamicTileAnalysis::getTile(OpBuilder &builder, const TileID &tileId) {
+  return getTile(builder, tileId.col, tileId.row);
+}
+
 SwitchboxOp DynamicTileAnalysis::getSwitchbox(OpBuilder &builder, int col,
                                               int row) {
   assert(col >= 0);
@@ -339,38 +343,17 @@ void Pathfinder::sortFlows(const int maxCol, const int maxRow) {
     else
       normalFlows.push_back(f);
   }
-  // Get unique int identifier from a vector if pairs of int properties and
-  // their maximums.
-  auto getUniqueIdFromVecOfProperties =
-      [](std::vector<std::pair<int, int>> propertiesAndLimits) {
-        int uniqueId = 0;
-        int multiplier = 1;
-        for (auto pair : propertiesAndLimits) {
-          uniqueId += pair.first * multiplier;
-          multiplier *= pair.second;
-        }
-        return uniqueId;
-      };
   std::sort(priorityFlows.begin(), priorityFlows.end(),
-            [maxCol, maxRow, getUniqueIdFromVecOfProperties](const auto &lhs,
-                                                             const auto &rhs) {
-              // List of properties used in sorting: src col, src row, src
-              // wirebundle and src channel.
-              std::vector<std::pair<int, int>> lhsProperties = {
-                  {lhs.src.coords.col, maxCol},
-                  {lhs.src.coords.row, maxRow},
-                  {getWireBundleAsInt(lhs.src.port.bundle),
-                   AIE::getMaxEnumValForWireBundle()},
-                  {lhs.src.port.channel, /*don't care*/ 0}};
-              int lhsUniqueID = getUniqueIdFromVecOfProperties(lhsProperties);
-              std::vector<std::pair<int, int>> rhsProperties = {
-                  {rhs.src.coords.col, maxCol},
-                  {rhs.src.coords.row, maxRow},
-                  {getWireBundleAsInt(rhs.src.port.bundle),
-                   AIE::getMaxEnumValForWireBundle()},
-                  {rhs.src.port.channel, /*don't care*/ 0}};
-              int rhsUniqueID = getUniqueIdFromVecOfProperties(rhsProperties);
-              return lhsUniqueID < rhsUniqueID;
+            [](const auto &lhs, const auto &rhs) {
+              // Compare tuple of properties in priority order:
+              // (col, row, bundle, channel)
+              auto lhsKey = std::make_tuple(lhs.src.coords.col, lhs.src.coords.row,
+                                            getWireBundleAsInt(lhs.src.port.bundle),
+                                            lhs.src.port.channel);
+              auto rhsKey = std::make_tuple(rhs.src.coords.col, rhs.src.coords.row,
+                                            getWireBundleAsInt(rhs.src.port.bundle),
+                                            rhs.src.port.channel);
+              return lhsKey < rhsKey;
             });
   flows = priorityFlows;
   flows.insert(flows.end(), normalFlows.begin(), normalFlows.end());

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -347,12 +347,14 @@ void Pathfinder::sortFlows(const int maxCol, const int maxRow) {
             [](const auto &lhs, const auto &rhs) {
               // Compare tuple of properties in priority order:
               // (col, row, bundle, channel)
-              auto lhsKey = std::make_tuple(lhs.src.coords.col, lhs.src.coords.row,
-                                            getWireBundleAsInt(lhs.src.port.bundle),
-                                            lhs.src.port.channel);
-              auto rhsKey = std::make_tuple(rhs.src.coords.col, rhs.src.coords.row,
-                                            getWireBundleAsInt(rhs.src.port.bundle),
-                                            rhs.src.port.channel);
+              auto lhsKey =
+                  std::make_tuple(lhs.src.coords.col, lhs.src.coords.row,
+                                  getWireBundleAsInt(lhs.src.port.bundle),
+                                  lhs.src.port.channel);
+              auto rhsKey =
+                  std::make_tuple(rhs.src.coords.col, rhs.src.coords.row,
+                                  getWireBundleAsInt(rhs.src.port.bundle),
+                                  rhs.src.port.channel);
               return lhsKey < rhsKey;
             });
   flows = priorityFlows;


### PR DESCRIPTION
This replaces `DenseMap` with `std::map` for anything which is iterated over in `AIECreatePathFindFlows`.

Without this I experience non-deterministic `aie.amsel` allocation. Here is an example of one mlir file with two identical set of flows generating two different configurations at a memtile:
```
$ aie-opt --aie-create-pathfinder-flows build/aie/test/npu-xrt/ctrl_packet_reconfig_elf/aie_overlay.mlir | grep 'aie.switchbox(%mem_tile_0_1)' -A29

    %switchbox_0_1 = aie.switchbox(%mem_tile_0_1) {
      %0 = aie.amsel<0> (0)
      %1 = aie.amsel<1> (0)
      %2 = aie.amsel<2> (0)
      %3 = aie.amsel<3> (0)
      %4 = aie.amsel<4> (3)
      %5 = aie.amsel<5> (3)
      %6 = aie.masterset(DMA : 0, %2)
      %7 = aie.masterset(DMA : 1, %3)
      %8 = aie.masterset(South : 2, %0)
      %9 = aie.masterset(North : 1, %5)
      %10 = aie.masterset(North : 5, %1)
      %11 = aie.masterset(TileControl : 0, %4) {keep_pkt_header = true}
      aie.packet_rules(South : 1) {
        aie.rule(31, 27, %5)
      }
      aie.packet_rules(South : 4) {
        aie.rule(31, 26, %4)
        aie.rule(31, 3, %2)
      }
      aie.packet_rules(DMA : 1) {
        aie.rule(31, 2, %0)
      }
      aie.packet_rules(North : 0) {
        aie.rule(31, 1, %3)
      }
      aie.packet_rules(DMA : 0) {
        aie.rule(31, 0, %1)
      }
    }
--
    %switchbox_0_1 = aie.switchbox(%mem_tile_0_1) {
      %0 = aie.amsel<0> (0)
      %1 = aie.amsel<1> (0)
      %2 = aie.amsel<2> (0)
      %3 = aie.amsel<3> (0)
      %4 = aie.amsel<4> (3)
      %5 = aie.amsel<5> (3)
      %6 = aie.masterset(DMA : 0, %3)
      %7 = aie.masterset(DMA : 1, %2)
      %8 = aie.masterset(South : 2, %1)
      %9 = aie.masterset(North : 1, %5)
      %10 = aie.masterset(North : 5, %0)
      %11 = aie.masterset(TileControl : 0, %4) {keep_pkt_header = true}
      aie.packet_rules(South : 1) {
        aie.rule(31, 27, %5)
      }
      aie.packet_rules(South : 4) {
        aie.rule(31, 26, %4)
        aie.rule(31, 3, %3)
      }
      aie.packet_rules(DMA : 1) {
        aie.rule(31, 2, %1)
      }
      aie.packet_rules(North : 0) {
        aie.rule(31, 1, %2)
      }
      aie.packet_rules(DMA : 0) {
        aie.rule(31, 0, %0)
      }
    }
```
When I re-run repeatedly, the two configurations randomly change between the two outcomes shown above, sometimes matching, sometimes not. With this PR I cannot reproduce the problem.

~~Currently this PR contains #2532. The new commit for this PR is https://github.com/Xilinx/mlir-aie/commit/94fcfcd7cdfc77621973479f97fa7c2de8c414a5~~