### PR TITLE
Batch control packets by tile for aie2p

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
@@ -176,6 +176,8 @@ struct AIECtrlPacketToDmaPass : AIECtrlPacketToDmaBase<AIECtrlPacketToDmaPass> {
         builder.create<AIEX::NpuSyncOp>(loc, shimCol, shimRow, dir, chan,
                                         col_num, row_num);
         ++batchIt;
+        if (batchIt == batches.end())
+          break;
       }
 
       erased.push_back(f);

--- a/test/dialect/AIEX/ctrl_pkt_to_dma.mlir
+++ b/test/dialect/AIEX/ctrl_pkt_to_dma.mlir
@@ -42,3 +42,35 @@ aie.device(npu1_1col) {
   aie.shim_dma_allocation @ctrlpkt_col0_mm2s_chan0(MM2S, 0, 0)
   memref.global "public" @ctrlpkt_col0_mm2s_chan0 : memref<2048xi32>
 }
+
+// -----
+
+// CHECK-LABEL: aie.device(npu1) {
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 3][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 3][1, 1, 1, 3][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 6][1, 1, 1, 3][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 9][1, 1, 1, 3][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 12][1, 1, 1, 3][0, 0, 0, 1])
+aie.device(npu1) {
+  aiex.runtime_sequence() {
+    aiex.control_packet {address = 0 : ui32, data = array<i32: 100>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 4 : ui32, data = array<i32: 200>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 8 : ui32, data = array<i32: 300>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 12 : ui32, data = array<i32: 400>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 16 : ui32, data = array<i32: 500>, opcode = 0 : i32, stream_id = 0 : i32}
+  }
+}
+
+// -----
+
+// CHECK-LABEL: aie.device(npu2) {
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 15][0, 0, 0, 1])
+aie.device(npu2) {
+  aiex.runtime_sequence() {
+    aiex.control_packet {address = 0 : ui32, data = array<i32: 100>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 4 : ui32, data = array<i32: 200>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 8 : ui32, data = array<i32: 300>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 12 : ui32, data = array<i32: 400>, opcode = 0 : i32, stream_id = 0 : i32}
+    aiex.control_packet {address = 16 : ui32, data = array<i32: 500>, opcode = 0 : i32, stream_id = 0 : i32}
+  }
+}


### PR DESCRIPTION
This PR adds combining of control packet data copies for aie2p.

Instead of sending and then syncing each 1-4 word control packet as individual shim dma transfers, batch them so that consecutive control packets to the same (row, col) are combined into single shim dma transfers.

For the test `npu-xrt/ctrl_packet_reconfig_4x1_cores` this reduces the number of overall `aiex.npu.dma_memcpy_nd` ops in the control packet runtime sequence from 567 to 36.

Somewhat surprisingly, the `Ctrl_Pkt_Tlast_Error_Enable` configuration bit in the tiles didn't need to be cleared for this to work.

~~TODO: this feature probably needs a standalone unit test.~~