### PR TITLE
[aievec] Updates on `vector.reduction` support

### DIFF
--- a/test/Conversion/VectorToAIEVec/test-reduce.mlir
+++ b/test/Conversion/VectorToAIEVec/test-reduce.mlir
@@ -347,3 +347,91 @@ func.func @reduce_max_bf16(%arg0: vector<32xbf16>) -> bf16 {
   // CHECK: return %[[EXTELEM]] : bf16
   return %0 : bf16
 }
+
+// CHECK-LABEL:func @reduce_add_f32_w_acc
+// CHECK-SAME: %[[SRC:.*]]: vector<16xf32>
+func.func @reduce_add_f32_w_acc(%arg0: vector<16xf32>) -> f32 {
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : i32
+  // CHECK-DAG: %[[C8:.*]] = arith.constant 8 : i32
+  // CHECK-DAG: %[[C16:.*]] = arith.constant 16 : i32
+  // CHECK-DAG: %[[C32:.*]] = arith.constant 32 : i32
+  // CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+  // CHECK: %[[CASTL1:.*]] = aievec.cast %[[SRC]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[CASTR1:.*]] = aievec.cast %[[SHIFT32]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[ADD1:.*]] = aievec.add_elem %[[CASTL1]], %[[CASTR1]] : vector<16xf32>
+  // CHECK: %[[CAST1:.*]] = aievec.cast %[[ADD1]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[CAST1]], %[[CAST1]], %[[C16]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+  // CHECK: %[[CASTR2:.*]] = aievec.cast %[[SHIFT16]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[ADD2:.*]] = aievec.add_elem %[[ADD1]], %[[CASTR2]] : vector<16xf32>
+  // CHECK: %[[CAST2:.*]] = aievec.cast %[[ADD2]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[CAST2]], %[[CAST2]], %[[C8]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+  // CHECK: %[[CASTR3:.*]] = aievec.cast %[[SHIFT8]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[ADD3:.*]] = aievec.add_elem %[[ADD2]], %[[CASTR3]] : vector<16xf32>
+  // CHECK: %[[CAST3:.*]] = aievec.cast %[[ADD3]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[CAST3]], %[[CAST3]], %[[C4]] {isAcc = false} : vector<16xf32>, vector<16xf32>, i32, vector<16xf32>
+  // CHECK: %[[CASTR4:.*]] = aievec.cast %[[SHIFT4]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[ADD4:.*]] = aievec.add_elem %[[ADD3]], %[[CASTR4]] : vector<16xf32>
+  // CHECK: %[[CAST4:.*]] = aievec.cast %[[ADD4]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[CAST4]], %[[C0]] : vector<16xf32>, i32, f32
+  // CHECK: %[[ADD5:.*]] = arith.addf %[[EXTELEM]], %[[CST]] : f32
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = vector.reduction <add>, %arg0, %cst : vector<16xf32> into f32
+  // CHECK: return %[[ADD5]] : f32
+  return %0 : f32
+}
+
+// CHECK-LABEL:func @reduce_min_bf16_w_acc
+// CHECK-SAME: %[[SRC:.*]]: vector<32xbf16>
+func.func @reduce_min_bf16_w_acc(%arg0: vector<32xbf16>) -> bf16 {
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : i32
+  // CHECK-DAG: %[[C8:.*]] = arith.constant 8 : i32
+  // CHECK-DAG: %[[C16:.*]] = arith.constant 16 : i32
+  // CHECK-DAG: %[[C32:.*]] = arith.constant 32 : i32
+  // CHECK-DAG: %[[CST:.*]] = arith.constant 9.982440e+08 : bf16
+  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MIN1:.*]] = aievec.min %[[SRC]], %[[SHIFT32]] : vector<32xbf16>
+  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MIN1]], %[[MIN1]], %[[C16]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MIN2:.*]] = aievec.min %[[MIN1]], %[[SHIFT16]] : vector<32xbf16>
+  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MIN2]], %[[MIN2]], %[[C8]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MIN3:.*]] = aievec.min %[[MIN2]], %[[SHIFT8]] : vector<32xbf16>
+  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MIN3]], %[[MIN3]], %[[C4]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MIN4:.*]] = aievec.min %[[MIN3]], %[[SHIFT4]] : vector<32xbf16>
+  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MIN4]], %[[MIN4]], %[[C2]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MIN5:.*]] = aievec.min %[[MIN4]], %[[SHIFT5]] : vector<32xbf16>
+  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xbf16>, i32, bf16
+  // CHECK: %[[MIN6:.*]] = arith.minimumf %[[EXTELEM]], %[[CST]] : bf16
+  %cst = arith.constant 1.0e+09 : bf16
+  %0 = vector.reduction <minimumf>, %arg0, %cst : vector<32xbf16> into bf16
+  // CHECK: return %[[MIN6]] : bf16
+  return %0 : bf16
+}
+
+// CHECK-LABEL:func @reduce_max_bf16_w_acc
+// CHECK-SAME: %[[SRC:.*]]: vector<32xbf16>
+func.func @reduce_max_bf16_w_acc(%arg0: vector<32xbf16>) -> bf16 {
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C4:.*]] = arith.constant 4 : i32
+  // CHECK-DAG: %[[C8:.*]] = arith.constant 8 : i32
+  // CHECK-DAG: %[[C16:.*]] = arith.constant 16 : i32
+  // CHECK-DAG: %[[C32:.*]] = arith.constant 32 : i32
+  // CHECK-DAG: %[[CST:.*]] = arith.constant -9.982440e+08 : bf16
+  // CHECK: %[[SHIFT32:.*]] = aievec.shift %[[SRC]], %[[SRC]], %[[C32]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MAX1:.*]] = aievec.max %[[SRC]], %[[SHIFT32]] : vector<32xbf16>
+  // CHECK: %[[SHIFT16:.*]] = aievec.shift %[[MAX1]], %[[MAX1]], %[[C16]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MAX2:.*]] = aievec.max %[[MAX1]], %[[SHIFT16]] : vector<32xbf16>
+  // CHECK: %[[SHIFT8:.*]] = aievec.shift %[[MAX2]], %[[MAX2]], %[[C8]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MAX3:.*]] = aievec.max %[[MAX2]], %[[SHIFT8]] : vector<32xbf16>
+  // CHECK: %[[SHIFT4:.*]] = aievec.shift %[[MAX3]], %[[MAX3]], %[[C4]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MAX4:.*]] = aievec.max %[[MAX3]], %[[SHIFT4]] : vector<32xbf16>
+  // CHECK: %[[SHIFT5:.*]] = aievec.shift %[[MAX4]], %[[MAX4]], %[[C2]] {isAcc = false} : vector<32xbf16>, vector<32xbf16>, i32, vector<32xbf16>
+  // CHECK: %[[MAX5:.*]] = aievec.max %[[MAX4]], %[[SHIFT5]] : vector<32xbf16>
+  // CHECK: %[[EXTELEM:.*]] = aievec.ext_elem %[[MAX5]], %[[C0]] : vector<32xbf16>, i32, bf16
+  // CHECK: %[[MAX6:.*]] = arith.maximumf %[[EXTELEM]], %[[CST]] : bf16
+  %cst = arith.constant -1.0e+09 : bf16
+  %0 = vector.reduction <maximumf>, %arg0, %cst : vector<32xbf16> into bf16
+  // CHECK: return %[[MAX6]] : bf16
+  return %0 : bf16
+}


### PR DESCRIPTION
- Add support for `MaxNumF` as one reduction kind, which behaves similarly to `MaximumF`.
- Add missing support for `vector.reduction`'s `acc` optional operand, which represents the initial value to the reduction's accumulator. See ir code [example ](url)for details.