### PR TITLE
Update bf16_softmax.mlir

### DIFF
--- a/test/unit_tests/aievec_tests/aie2/bf16_softmax_2/bf16_softmax.mlir
+++ b/test/unit_tests/aievec_tests/aie2/bf16_softmax_2/bf16_softmax.mlir
@@ -6,6 +6,7 @@
 // RUN: xca_udm_dbg --aiearch aie-ml -qf -T -P %aietools/data/aie_ml/lib/ -t "%S/../../profiling.tcl ./work/a.out" >& xca_udm_dbg.stdout
 // RUN: FileCheck --input-file=./xca_udm_dbg.stdout %s
 // CHECK: TEST PASSED
+// XFAIL: *
 module {
   func.func @dut(%arg0: memref<1024xbf16>, %arg1: memref<1024xbf16>) {
     %cst = arith.constant 0.000000e+00 : f32


### PR DESCRIPTION
Test is expected to fail because legalization rules changed and would need further updates to re-enable C++ backend.