### PR TITLE
[aievec] Update the lowering strategy of `aievec.srs` to `llvm`

### DIFF
--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -72,15 +72,23 @@ static Value forceCastValueToType(OpBuilder &builder, Location loc, Value val,
   if (valTy == type)
     return val;
   auto srcVecTy = dyn_cast<VectorType>(valTy);
+  auto dstVecTy = dyn_cast<VectorType>(type);
+
   if (srcVecTy) {
-    auto dstVecTy = dyn_cast<VectorType>(type);
     assert(dstVecTy && "vector values cannot be forced into a non-vector type");
-    assert(srcVecTy.getRank() == 1 && dstVecTy.getRank() == 1 &&
-           "only flat 1D vectors can be force casted");
+
+    // Flatten source vector if it's not rank-1
+    auto flatSrcVecTy = getFlattenedVectorType(srcVecTy);
+    if (srcVecTy != flatSrcVecTy)
+      val = builder.create<vector::ShapeCastOp>(loc, flatSrcVecTy, val);
+
+    // Flatten destination type if it's not rank-1
+    auto flatDstVecTy = getFlattenedVectorType(dstVecTy);
+
     int64_t dstVecLength =
-        dstVecTy.getElementTypeBitWidth() * dstVecTy.getShape()[0];
+        flatDstVecTy.getElementTypeBitWidth() * flatDstVecTy.getShape()[0];
     int64_t srcVecLength =
-        srcVecTy.getElementTypeBitWidth() * srcVecTy.getShape()[0];
+        flatSrcVecTy.getElementTypeBitWidth() * flatSrcVecTy.getShape()[0];
     if (srcVecLength != dstVecLength) {
       assert(srcVecLength < dstVecLength &&
              "only widening forced casts are supported");
@@ -92,7 +100,19 @@ static Value forceCastValueToType(OpBuilder &builder, Location loc, Value val,
       else
         val = widen256bVectorValueTo512b(builder, loc, val);
     }
+
+    // Bitcast to flat destination type (bitcast only supports flat vectors)
+    val = bitcastValueToType(builder, loc, val, flatDstVecTy);
+
+    // Reshape back to original destination shape if needed
+    if (flatDstVecTy != dstVecTy)
+      val = builder.create<vector::ShapeCastOp>(loc, dstVecTy, val);
+
+    return val;
   }
+
+  // Non-vector types can be bitcast directly
+  assert(!dstVecTy && "cannot force cast scalar to vector type");
   return bitcastValueToType(builder, loc, val, type);
 }
 
@@ -280,9 +300,10 @@ public:
       return failure();
     }
 
-    // create bitcast for result
-    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                 addElemOp);
+    // create bitcast/shape_cast for result
+    auto resultVal = forceCastValueToType(rewriter, loc, addElemOp,
+                                          op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
     return success();
   }
 };
@@ -643,9 +664,10 @@ public:
             /*variant=*/2, /*zero_acc=*/0, /*shift16=*/1,
             /*sub_mul=*/0, /*sub_acc1=*/0, /*sub_acc2=*/0, /*sub_mask=*/0));
 
-    // create bitcast for result
-    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                 acc64Val);
+    // create bitcast/shape_cast for result
+    auto resultVal =
+        forceCastValueToType(rewriter, loc, acc64Val, op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
     return success();
   }
 
@@ -828,9 +850,10 @@ public:
                                            createMacOps(c, e, cfMul))))))));
     }
 
-    // create bitcast for result
-    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                 finalMacVal);
+    // create bitcast/shape_cast for result
+    auto resultVal = forceCastValueToType(rewriter, loc, finalMacVal,
+                                          op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
     return success();
   }
 
@@ -881,9 +904,10 @@ public:
                rewriter.getI32Type()}));
     }
 
-    // create bitcast for result
-    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                 mulElemOp);
+    // create bitcast/shape_cast for result
+    auto resultVal = forceCastValueToType(rewriter, loc, mulElemOp,
+                                          op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
     return success();
   }
 };
@@ -1186,13 +1210,10 @@ public:
       return failure();
     }
 
-    // create bitcast for result if needed
-    if (op.getResult().getType() != srsIntrOp.getType()) {
-      rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                   srsIntrOp);
-    } else {
-      rewriter.replaceOp(op, srsIntrOp);
-    }
+    // create bitcast/shape_cast for result if needed
+    auto resultVal = forceCastValueToType(rewriter, loc, srsIntrOp,
+                                          op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
 
     return success();
   }
@@ -1388,9 +1409,10 @@ public:
       return failure();
     }
 
-    // create bitcast for result
-    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                 concatOp);
+    // create bitcast/shape_cast for result
+    auto resultVal =
+        forceCastValueToType(rewriter, loc, concatOp, op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
 
     return success();
   }
@@ -1484,13 +1506,10 @@ public:
       return failure();
     }
 
-    // create bitcast for result
-    if (op.getResult().getType() != extOp.getType()) {
-      rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                   extOp);
-    } else {
-      rewriter.replaceOp(op, extOp);
-    }
+    // create bitcast/shape_cast for result
+    auto resultVal =
+        forceCastValueToType(rewriter, loc, extOp, op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
 
     return success();
   }
@@ -1964,9 +1983,10 @@ public:
                rewriter.getI32Type(), rewriter.getI32Type()}));
     }
 
-    // create bitcast for result
-    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getResult().getType(),
-                                                 shiftOp);
+    // create bitcast/shape_cast for result
+    auto resultVal =
+        forceCastValueToType(rewriter, loc, shiftOp, op.getResult().getType());
+    rewriter.replaceOp(op, resultVal);
 
     return success();
   }

--- a/test/Conversion/AIEVecToLLVM/mul_elem.mlir
+++ b/test/Conversion/AIEVecToLLVM/mul_elem.mlir
@@ -79,8 +79,7 @@ func.func @i32_i32_i32_mul_elem(%arg0 : vector<16xi32>, %arg1 : vector<16xi32>) 
 // CHECK-NEXT: %[[CST8:.*]] = llvm.mlir.constant(1114 : i32) : i32
 // CHECK-NEXT: %[[BITCAST3:.*]] = llvm.bitcast %[[SHUFF0]] : vector<16xi32> to vector<64xi8>
 // CHECK-NEXT: %[[ACC3:.*]] = "xllvm.intr.aie2.I512.I512.ACC1024.acc64.mac.conf"(%[[BITCAST3]], %[[SHUFF2]], %[[ACC2]], %[[CST8]]) : (vector<64xi8>, vector<16xi32>, vector<16xi64>, i32) -> vector<16xi64>
-// CHECK-NEXT: %[[RES:.*]] = llvm.bitcast %[[ACC3]] : vector<16xi64> to vector<16xi64>
-// CHECK-NEXT: return %[[RES]] : vector<16xi64>
+// CHECK-NEXT: return %[[ACC3]] : vector<16xi64>
 
 // -----
 

--- a/test/Conversion/AIEVecToLLVM/shift.mlir
+++ b/test/Conversion/AIEVecToLLVM/shift.mlir
@@ -52,8 +52,7 @@ func.func @i32_shift(%arg0 : vector<16xi32>, %shift : i32) -> vector<16xi32> {
 // CHECK-NEXT: %[[VSHIFT:.*]] = "xllvm.intr.aie2.vshift.I512.I512"(
 // CHECK-SAME: %[[ARG0]], %[[ARG0]], %[[CST]], %[[SHIFT]]) : 
 // CHECK-SAME: (vector<16xi32>, vector<16xi32>, i32, i32) -> vector<16xi32>
-// CHECK-NEXT: %[[RES:.*]] = llvm.bitcast %[[VSHIFT]] : vector<16xi32> to vector<16xi32>
-// CHECK-NEXT: return %[[RES]] : vector<16xi32>
+// CHECK-NEXT: return %[[VSHIFT]] : vector<16xi32>
 
 // -----
 
@@ -69,5 +68,4 @@ func.func @bf16_shift(%arg0 : vector<32xbf16>, %shift : i32) -> vector<32xbf16> 
 // CHECK-NEXT: %[[VSHIFT:.*]] = "xllvm.intr.aie2.vshift.bf512.bf512"(
 // CHECK-SAME: %[[ARG0]], %[[ARG0]], %[[CST]], %[[SHIFT]]) : 
 // CHECK-SAME: (vector<32xbf16>, vector<32xbf16>, i32, i32) -> vector<32xbf16>
-// CHECK-NEXT: %[[RES:.*]] = llvm.bitcast %[[VSHIFT]] : vector<32xbf16> to vector<32xbf16>
-// CHECK-NEXT: return %[[RES]] : vector<32xbf16>
+// CHECK-NEXT: return %[[VSHIFT]] : vector<32xbf16>

--- a/test/Conversion/AIEVecToLLVM/test-concat.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-concat.mlir
@@ -123,8 +123,7 @@ func.func @v16i32_concat_v8i32(%arg0 : vector<8xi32>, %arg1 : vector<8xi32>) -> 
 // CHECK: %[[CONCAT:.*]] = "xllvm.intr.aie2.concat.I512.I256"(
 // CHECK-SAME: %[[ARG0]], %[[ARG1]]) : 
 // CHECK-SAME: (vector<8xi32>, vector<8xi32>) -> vector<16xi32>
-// CHECK-NEXT: %[[RES:.*]] = llvm.bitcast %[[CONCAT]] : vector<16xi32> to vector<16xi32>
-// CHECK-NEXT: return %[[RES]] : vector<16xi32>
+// CHECK-NEXT: return %[[CONCAT]] : vector<16xi32>
 
 // -----
 
@@ -139,8 +138,7 @@ func.func @v32i32_concat_v8i32(%arg0 : vector<8xi32>, %arg1 : vector<8xi32>,
 // CHECK: %[[CONCAT:.*]] = "xllvm.intr.aie2.concat.I1024.I256"(
 // CHECK-SAME: %[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]]) : 
 // CHECK-SAME: (vector<8xi32>, vector<8xi32>, vector<8xi32>, vector<8xi32>) -> vector<32xi32>
-// CHECK-NEXT: %[[RES:.*]] = llvm.bitcast %[[CONCAT]] : vector<32xi32> to vector<32xi32>
-// CHECK-NEXT: return %[[RES]] : vector<32xi32>
+// CHECK-NEXT: return %[[CONCAT]] : vector<32xi32>
 
 // -----
 
@@ -155,8 +153,7 @@ func.func @v32i32_concat_v16i32(%arg0 : vector<16xi32>, %arg1 : vector<16xi32>) 
 // CHECK: %[[CONCAT:.*]] = "xllvm.intr.aie2.concat.I1024.I512"(
 // CHECK-SAME: %[[ARG0]], %[[ARG1]]) : 
 // CHECK-SAME: (vector<16xi32>, vector<16xi32>) -> vector<32xi32>
-// CHECK-NEXT: %[[RES:.*]] = llvm.bitcast %[[CONCAT]] : vector<32xi32> to vector<32xi32>
-// CHECK-NEXT: return %[[RES]] : vector<32xi32>
+// CHECK-NEXT: return %[[CONCAT]] : vector<32xi32>
 
 // -----
 

--- a/test/Conversion/AIEVecToLLVM/test-srs.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-srs.mlir
@@ -200,3 +200,61 @@ func.func @v32bf16_srs_v32f32(%arg0 : vector<32xf32>) {
 // CHECK-SAME: %[[BITCAST4]], %[[BITCAST5]]) :
 // CHECK-SAME: (vector<8xi32>, vector<8xi32>) -> vector<16xi32>
 // CHECK-NEXT: %[[BITCAST6:.*]] = llvm.bitcast %[[CONCAT]] : vector<16xi32> to vector<32xbf16>
+
+// -----
+
+func.func @v4x4bf16_srs_v4x4f32(%arg0 : vector<4x4xf32>) {
+  %c0 = arith.constant 0 : i32
+  %0 = aievec.srs %arg0, %c0 : vector<4x4xf32>, i32, vector<4x4xbf16>
+  return
+}
+
+// CHECK-LABEL: @v4x4bf16_srs_v4x4f32
+// CHECK-SAME: %[[ARG0:.*]]: vector<4x4xf32>
+// CHECK-NEXT: %[[SHIFT0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT: %[[FLATTEN0:.*]] = vector.shape_cast %[[ARG0]] : vector<4x4xf32> to vector<16xf32>
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[FLATTEN0]] : vector<16xf32> to vector<8xi64>
+// CHECK-NEXT: %[[SRS0:.*]] = "xllvm.intr.aie2.v16accfloat.to.v16bf16"(
+// CHECK-SAME: %[[BITCAST0]]) :
+// CHECK-SAME: (vector<8xi64>) -> vector<16xbf16>
+// CHECK-NEXT: %[[BITCAST1:.*]] = llvm.bitcast %[[SRS0]] : vector<16xbf16> to vector<16xbf16>
+// CHECK-NEXT: %[[RESHAPE0:.*]] = vector.shape_cast %[[BITCAST1]] : vector<16xbf16> to vector<4x4xbf16>
+
+// -----
+
+func.func @v1x1x4x4bf16_srs_v1x1x4x4f32(%arg0 : vector<1x1x4x4xf32>) {
+  %c0 = arith.constant 0 : i32
+  %0 = aievec.srs %arg0, %c0 : vector<1x1x4x4xf32>, i32, vector<1x1x4x4xbf16>
+  return
+}
+
+// CHECK-LABEL: @v1x1x4x4bf16_srs_v1x1x4x4f32
+// CHECK-SAME: %[[ARG0:.*]]: vector<1x1x4x4xf32>
+// CHECK-NEXT: %[[SHIFT0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT: %[[FLATTEN0:.*]] = vector.shape_cast %[[ARG0]] : vector<1x1x4x4xf32> to vector<16xf32>
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[FLATTEN0]] : vector<16xf32> to vector<8xi64>
+// CHECK-NEXT: %[[SRS0:.*]] = "xllvm.intr.aie2.v16accfloat.to.v16bf16"(
+// CHECK-SAME: %[[BITCAST0]]) :
+// CHECK-SAME: (vector<8xi64>) -> vector<16xbf16>
+// CHECK-NEXT: %[[BITCAST1:.*]] = llvm.bitcast %[[SRS0]] : vector<16xbf16> to vector<16xbf16>
+// CHECK-NEXT: %[[RESHAPE0:.*]] = vector.shape_cast %[[BITCAST1]] : vector<16xbf16> to vector<1x1x4x4xbf16>
+
+// -----
+
+func.func @v2x8i16_srs_v2x8i32(%arg0 : vector<2x8xi32>) {
+  %c0 = arith.constant 0 : i32
+  %0 = aievec.srs %arg0, %c0 : vector<2x8xi32>, i32, vector<2x8xi16>
+  return
+}
+
+// CHECK-LABEL: @v2x8i16_srs_v2x8i32
+// CHECK-SAME: %[[ARG0:.*]]: vector<2x8xi32>
+// CHECK-NEXT: %[[SHIFT0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT: %[[SIGN0:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT: %[[FLATTEN0:.*]] = vector.shape_cast %[[ARG0]] : vector<2x8xi32> to vector<16xi32>
+// CHECK-NEXT: %[[BITCAST0:.*]] = llvm.bitcast %[[FLATTEN0]] : vector<16xi32> to vector<8xi64>
+// CHECK-NEXT: %[[SRS0:.*]] = "xllvm.intr.aie2.I256.v16.acc32.srs"(
+// CHECK-SAME: %[[BITCAST0]], %[[SHIFT0]], %[[SIGN0]]) :
+// CHECK-SAME: (vector<8xi64>, i32, i32) -> vector<16xi16>
+// CHECK-NEXT: %[[BITCAST1:.*]] = llvm.bitcast %[[SRS0]] : vector<16xi16> to vector<16xi16>
+// CHECK-NEXT: %[[RESHAPE0:.*]] = vector.shape_cast %[[BITCAST1]] : vector<16xi16> to vector<2x8xi16>


### PR DESCRIPTION
- Instead of asserting on vector shapes being flattened before and after `BitcastOp`, apply `vector.shape_cast` to flatten vector shape as necessary.
- Replace all direct creation of `BitcastOp` with call to `forceCastValueToType` method, for improved code stability.