### PR TITLE
Make XRT binaries available in `PATH` for LIT testing

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -242,6 +242,9 @@ if config.vitis_root:
     prepend_path(config.vitis_aietools_bin)
     llvm_config.with_environment("VITIS", config.vitis_root)
 
+# Prepend path to XRT installation, which contains a more recent `aiebu-asm` than the Vitis installation.
+prepend_path(config.xrt_bin_dir)
+
 peano_tools_dir = os.path.join(config.peano_install_dir, "bin")
 prepend_path(config.llvm_tools_dir)
 prepend_path(peano_tools_dir)

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -242,6 +242,9 @@ if config.vitis_root:
     prepend_path(config.vitis_aietools_bin)
     llvm_config.with_environment("VITIS", config.vitis_root)
 
+# Prepend path to XRT installation, which contains a more recent `aiebu-asm` than the Vitis installation.
+prepend_path(config.xrt_bin_dir)
+
 peano_tools_dir = os.path.join(config.peano_install_dir, "bin")
 prepend_path(config.llvm_tools_dir)
 prepend_path(peano_tools_dir)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -237,7 +237,7 @@ if config.vitis_root:
     prepend_path(config.vitis_aietools_bin)
     llvm_config.with_environment("VITIS", config.vitis_root)
 
-# Prepend path to XRT installation, which contains more recent aiebu-asm than the Vitis installation.
+# Prepend path to XRT installation, which contains a more recent `aiebu-asm` than the Vitis installation.
 prepend_path(config.xrt_bin_dir)
 
 peano_tools_dir = os.path.join(config.peano_install_dir, "bin")


### PR DESCRIPTION
Currently, the LIT suite picks up `aiebu-asm` from the Vitis installation, which does not provide the latest features needed for the full ELF flow (#2641). Files generated from these older binaries might also be incompatible with the newer XRT and driver version we use at test time. This prepends the XRT binary path to the `PATH` during test execution, so `aiecc.py` can pick up the newer versions.