### PR TITLE
[aievec] Fixup a condition in trunc/ext op lowering

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3636,7 +3636,7 @@ static void configureAIEVecV1Legalizations(ConversionTarget &target,
 
 static void configureAIEVecV2PLegalizations(ConversionTarget &target,
                                             TargetBackend backend) {
-  // AIE2P-specific legalization: ExtFOp is always illegal
+  // AIE2P-specific legalization: ExtFOp on vector is always illegal
   target.addDynamicallyLegalOp<arith::ExtFOp>([](arith::ExtFOp extfOp) {
     auto srcType = dyn_cast<VectorType>(extfOp.getIn().getType());
     auto dstType = dyn_cast<VectorType>(extfOp.getOut().getType());
@@ -3648,14 +3648,28 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
     if (!isa<FloatType>(srcScalarType) || !isa<FloatType>(dstScalarType))
       return true;
 
-    // For aie2p, ExtFOp is always illegal
     return false;
   });
 
-  // AIE2P-specific legalization: TruncIOp is always illegal
-  target.addDynamicallyLegalOp<arith::TruncIOp>([](arith::TruncIOp trunciOp) {
-    auto srcType = dyn_cast<VectorType>(trunciOp.getIn().getType());
-    auto dstType = dyn_cast<VectorType>(trunciOp.getOut().getType());
+  // AIE2P-specific legalization: TruncFOp on vector is always illegal
+  target.addDynamicallyLegalOp<arith::TruncFOp>([](arith::TruncFOp truncfOp) {
+    auto srcType = dyn_cast<VectorType>(truncfOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(truncfOp.getOut().getType());
+    if (!srcType || !dstType)
+      return true;
+
+    Type srcScalarType = srcType.getElementType();
+    Type dstScalarType = dstType.getElementType();
+    if (!isa<FloatType>(srcScalarType) || !isa<FloatType>(dstScalarType))
+      return true;
+
+    return false;
+  });
+
+  // AIE2P-specific legalization: ExtSIOp on vector is always illegal
+  target.addDynamicallyLegalOp<arith::ExtSIOp>([](arith::ExtSIOp extsiOp) {
+    auto srcType = dyn_cast<VectorType>(extsiOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(extsiOp.getOut().getType());
     if (!srcType || !dstType)
       return true;
 
@@ -3664,11 +3678,22 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
     if (!isa<IntegerType>(srcScalarType) || !isa<IntegerType>(dstScalarType))
       return true;
 
-    // For aie2p, TruncIOp is always illegal
     return false;
   });
 
-  target.addIllegalOp<arith::ExtSIOp, arith::TruncIOp>();
+  // AIE2P-specific legalization: TruncIOp on vector is always illegal
+  target.addDynamicallyLegalOp<arith::TruncIOp>([](arith::TruncIOp trunciOp) {
+    auto srcType = dyn_cast<VectorType>(trunciOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(trunciOp.getOut().getType());
+    if (!srcType || !dstType)
+      return true;
+    Type srcScalarType = srcType.getElementType();
+    Type dstScalarType = dstType.getElementType();
+    if (!isa<IntegerType>(srcScalarType) || !isa<IntegerType>(dstScalarType))
+      return true;
+
+    return false;
+  });
 }
 
 static void configureAIEVecV2Legalizations(ConversionTarget &target,
@@ -3881,8 +3906,67 @@ static void configureAIEVecV2Legalizations(ConversionTarget &target,
         return false;
       });
 
-  target.addIllegalOp<vector::ContractionOp, vector::TransposeOp, vector::FMAOp,
-                      arith::ExtSIOp, arith::TruncIOp>();
+  // AIE2-specific legalization: ExtFOp on vector is always illegal
+  target.addDynamicallyLegalOp<arith::ExtFOp>([](arith::ExtFOp extfOp) {
+    auto srcType = dyn_cast<VectorType>(extfOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(extfOp.getOut().getType());
+    if (!srcType || !dstType)
+      return true;
+
+    Type srcScalarType = srcType.getElementType();
+    Type dstScalarType = dstType.getElementType();
+    if (!isa<FloatType>(srcScalarType) || !isa<FloatType>(dstScalarType))
+      return true;
+
+    return false;
+  });
+
+  // AIE2-specific legalization: TruncFOp on vector is always illegal
+  target.addDynamicallyLegalOp<arith::TruncFOp>([](arith::TruncFOp truncfOp) {
+    auto srcType = dyn_cast<VectorType>(truncfOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(truncfOp.getOut().getType());
+    if (!srcType || !dstType)
+      return true;
+
+    Type srcScalarType = srcType.getElementType();
+    Type dstScalarType = dstType.getElementType();
+    if (!isa<FloatType>(srcScalarType) || !isa<FloatType>(dstScalarType))
+      return true;
+
+    return false;
+  });
+
+  // AIE2-specific legalization: ExtSIOp on vector is always illegal
+  target.addDynamicallyLegalOp<arith::ExtSIOp>([](arith::ExtSIOp extsiOp) {
+    auto srcType = dyn_cast<VectorType>(extsiOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(extsiOp.getOut().getType());
+    if (!srcType || !dstType)
+      return true;
+
+    Type srcScalarType = srcType.getElementType();
+    Type dstScalarType = dstType.getElementType();
+    if (!isa<IntegerType>(srcScalarType) || !isa<IntegerType>(dstScalarType))
+      return true;
+
+    return false;
+  });
+
+  // AIE2-specific legalization: TruncIOp on vector is always illegal
+  target.addDynamicallyLegalOp<arith::TruncIOp>([](arith::TruncIOp trunciOp) {
+    auto srcType = dyn_cast<VectorType>(trunciOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(trunciOp.getOut().getType());
+    if (!srcType || !dstType)
+      return true;
+    Type srcScalarType = srcType.getElementType();
+    Type dstScalarType = dstType.getElementType();
+    if (!isa<IntegerType>(srcScalarType) || !isa<IntegerType>(dstScalarType))
+      return true;
+
+    return false;
+  });
+
+  target.addIllegalOp<vector::ContractionOp, vector::TransposeOp,
+                      vector::FMAOp>();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
- Previously, trunc/ext for i16->i64 will be incorrectly lowered to i32->i64 due to i32 being returned as acc type (should be i64).
- Ensure trunc/ext always lower to aievec, as arith dialect's direct lowerings to llvm behave unexpectedly.