### PR TITLE
Fix case bug

### DIFF
--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -258,7 +258,6 @@ class LitConfigHelper:
 
                 # Map model to NPU generation and filter by available components
                 if model in LitConfigHelper.NPU_MODELS["npu1"]:
-                    print (vitis_components)
                     if "AIE2" in vitis_components:
                         run_on_npu1 = run_on_npu
                         config.features.extend(["ryzen_ai", "ryzen_ai_npu1"])


### PR DESCRIPTION
fix bug where tests aren't actually running in CI:

BEFORE:
```
Found Ryzen AI device: [0000:c5:00.1]
	model: 'Phoenix'
NPU1 detected but aietools for aie2 not available
```
```
Found Ryzen AI device: [0000:c6:00.1]
	model: 'Strix'
NPU2 detected but aietools for aie2p not available
```
[AFTER:
](https://github.com/Xilinx/mlir-aie/actions/runs/19078726153?pr=2681)
```
Found Ryzen AI device: [0000:c5:00.1]
	model: 'Phoenix'
Running tests on NPU1 with command line: /home/github/actions-runner/_work/mlir-aie/mlir-aie/utils/run_on_npu.sh
```
```
Found Ryzen AI device: [0000:c6:00.1]
	model: 'Strix'
Running tests on NPU2 with command line: /home/github/actions-runner/_work/mlir-aie/mlir-aie/utils/run_on_npu.sh
```