### PR TITLE
Enable `DataLayoutOpInterface` on `DeviceOp`

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -15,6 +15,7 @@
 
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
 
+#include "mlir/Dialect/DLTI/Traits.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinAttributes.h"

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -16,9 +16,11 @@ include "aie/Dialect/AIE/IR/AIEAttrs.td"
 include "aie/Dialect/AIE/IR/AIEInterfaces.td"
 include "aie/Dialect/AIE/IR/AIETypes.td"
 
+include "mlir/Dialect/DLTI/DLTIBase.td"
 include "mlir/IR/CommonAttrConstraints.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CallInterfaces.td"
+include "mlir/Interfaces/DataLayoutInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
@@ -32,7 +34,9 @@ def AIE_DeviceOp: AIE_Op<"device", [
     HasParent<"mlir::ModuleOp">,
     SymbolTable, 
     SingleBlockImplicitTerminator<"EndOp">, 
-    IsolatedFromAbove
+    IsolatedFromAbove,
+    DataLayoutOpInterface,
+    HasDefaultDLTIDataLayout
   ]> {
   let summary = "Define an AIE design targetting a complete device";
   let description = [{


### PR DESCRIPTION
- Enables mlir compilation passes (e.g. `convert-to-llvm`) to be customized with AIE-specific constraints, via the data layout attributes on `aie.device`.
- Motivation is to customize the width of `index` type to 32 bits (default is 64 bits), which yields better performance with the peano compiler's pipeliner.
- More info: https://mlir.llvm.org/docs/DataLayout/#datalayoutopinterface-datalayoutopinterface 

Code example for customizing the `index` width:
```
aie.device(npu2) @matmul_seg {
  ...
} {dlti.dl_spec = #dlti.dl_spec<index = 32 : i64>}
```