### PR TITLE
Add -dialect to aie and aie in add_mlir_doc cmake

### DIFF
--- a/include/aie/Dialect/ADF/CMakeLists.txt
+++ b/include/aie/Dialect/ADF/CMakeLists.txt
@@ -6,5 +6,5 @@
 # (c) Copyright 2021 Xilinx Inc.
 
 add_mlir_dialect(ADF ADF)
-add_mlir_doc(ADF ADFDialect ./ -gen-dialect-doc)
+add_mlir_doc(ADF ADFDialect ./ -gen-dialect-doc -dialect=ADF)
 set(LLVM_TARGET_DEFINITIONS ADF.td)

--- a/include/aie/Dialect/AIE/IR/CMakeLists.txt
+++ b/include/aie/Dialect/AIE/IR/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 # Use a simplified version AIEDocs.td to generate the AIEDialect.md ending up as
 # https://xilinx.github.io/mlir-aie/AIEDialect.html
-add_mlir_doc(AIEDocs AIEDialect ./ -gen-dialect-doc)
+add_mlir_doc(AIEDocs AIEDialect ./ -gen-dialect-doc -dialect=aie)
 
 # Add AIE dialect
 set(LLVM_TARGET_DEFINITIONS AIE.td)


### PR DESCRIPTION
An attempt fix failing documentation workflow, e.g.:
https://github.com/Xilinx/mlir-aie/actions/runs/19212434910/job/54916693405