### PR TITLE
Update run_vck5000.lit

### DIFF
--- a/programming_examples/basic/matrix_scalar_add/run_vck5000.lit
+++ b/programming_examples/basic/matrix_scalar_add/run_vck5000.lit
@@ -6,4 +6,3 @@
 // RUN: make -f %S/Makefile clean
 // RUN: make -f %S/Makefile vck5000
 // RUN: %run_on_vck5000 ./test.elf
-// XFAIL: *


### PR DESCRIPTION
un-XFAIL test. It seems to have started passing on `main` a few commits back.