### PR TITLE
[aiecc.py] Enable some recent passes that optimizes vectorized code's schedule

### DIFF
--- a/python/compiler/aiecc/cl_arguments.py
+++ b/python/compiler/aiecc/cl_arguments.py
@@ -205,6 +205,14 @@ def parse_args(args=None):
         help="Compile cores independently in separate processes",
     )
     parser.add_argument(
+        "-O",
+        "--opt-level",
+        dest="opt_level",
+        default="2",
+        choices=["0", "1", "2", "3"],
+        help="Optimization level for AIE core compilation (default: 2)",
+    )
+    parser.add_argument(
         "-n",
         dest="execute",
         default=True,

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -46,48 +46,59 @@ from aie.passmanager import PassManager
 
 
 def _create_input_with_addresses_pipeline(
-    scheme, dynamic_objFifos, packet_sw_objFifos, ctrl_pkt_overlay, aie_target
+    scheme,
+    dynamic_objFifos,
+    packet_sw_objFifos,
+    ctrl_pkt_overlay,
+    aie_target,
+    opt_level="2",
 ):
     pipeline = Pipeline()
 
     # Only add convert-vector-to-aievec for AIE2 and later targets
     # AIE1 ("aie") does not support target_backend="llvmir"
     if aie_target.lower() in ["aie2", "aieml", "aie2p"]:
-        # Hoist vector transfer pointers before scf-to-cf conversion
+        # Hoist vector transfer pointers before scf-to-cf conversion (O3 and above only)
         # This runs on the module and walks into aie.core regions
-        pipeline.add_pass("aie-hoist-vector-transfer-pointers")
+        if int(opt_level) >= 3:
+            pipeline.add_pass("aie-hoist-vector-transfer-pointers")
         pipeline.add_pass(
             "convert-vector-to-aievec",
             aie_target=aie_target.lower(),
             target_backend="llvmir",
         )
 
+    # Build nested device pipeline with conditional passes
+    device_pipeline = (
+        Pipeline()
+        .add_pass("aie-assign-lock-ids")
+        .add_pass("aie-register-objectFifos")
+        .add_pass(
+            "aie-objectFifo-stateful-transform",
+            dynamic_objFifos=dynamic_objFifos,
+            packet_sw_objFifos=packet_sw_objFifos,
+        )
+        .add_pass("aie-assign-bd-ids")
+        .add_pass("aie-lower-cascade-flows")
+        .add_pass("aie-lower-broadcast-packet")
+        .add_pass("aie-lower-multicast")
+        .add_pass("aie-assign-tile-controller-ids")
+        .add_pass(
+            "aie-generate-column-control-overlay",
+            route_shim_to_tile_ctrl=ctrl_pkt_overlay,
+        )
+        .add_pass("aie-assign-buffer-addresses", alloc_scheme=scheme)
+        .add_pass("aie-vector-transfer-lowering", max_transfer_rank=1)
+    )
+
+    # Only add vector-to-pointer-loops for O3 and above
+    if int(opt_level) >= 3:
+        device_pipeline.add_pass("aie-vector-to-pointer-loops")
+
     return (
         pipeline.lower_affine()
         .add_pass("aie-canonicalize-device")
-        .Nested(
-            "aie.device",
-            Pipeline()
-            .add_pass("aie-assign-lock-ids")
-            .add_pass("aie-register-objectFifos")
-            .add_pass(
-                "aie-objectFifo-stateful-transform",
-                dynamic_objFifos=dynamic_objFifos,
-                packet_sw_objFifos=packet_sw_objFifos,
-            )
-            .add_pass("aie-assign-bd-ids")
-            .add_pass("aie-lower-cascade-flows")
-            .add_pass("aie-lower-broadcast-packet")
-            .add_pass("aie-lower-multicast")
-            .add_pass("aie-assign-tile-controller-ids")
-            .add_pass(
-                "aie-generate-column-control-overlay",
-                route_shim_to_tile_ctrl=ctrl_pkt_overlay,
-            )
-            .add_pass("aie-assign-buffer-addresses", alloc_scheme=scheme)
-            .add_pass("aie-vector-transfer-lowering", max_transfer_rank=1)
-            .add_pass("aie-vector-to-pointer-loops"),
-        )
+        .Nested("aie.device", device_pipeline)
         .convert_scf_to_cf()
     )
 
@@ -108,8 +119,11 @@ LOWER_TO_LLVM_PIPELINE = (
     .cse()
 )
 
-AIE_LOWER_TO_LLVM = (
-    lambda device_name=None, col=None, row=None, aie_target="aie2": (
+
+def _create_aie_lower_to_llvm_pipeline(
+    device_name=None, col=None, row=None, aie_target="aie2", opt_level="2"
+):
+    pipeline = (
         Pipeline()
         .Nested(
             "aie.device",
@@ -120,11 +134,18 @@ AIE_LOWER_TO_LLVM = (
         )
         .add_pass("aie-standard-lowering", device=device_name, tilecol=col, tilerow=row)
         .add_pass("aiex-standard-lowering")
-        .add_pass("aievec-split-load-ups-chains")
-        .add_pass("convert-aievec-to-llvm", aie_target=aie_target.lower())
     )
-    + LOWER_TO_LLVM_PIPELINE
-)
+
+    # Only add aievec-split-load-ups-chains for O3 and above
+    if int(opt_level) >= 3:
+        pipeline.add_pass("aievec-split-load-ups-chains")
+
+    pipeline.add_pass("convert-aievec-to-llvm", aie_target=aie_target.lower())
+
+    return pipeline + LOWER_TO_LLVM_PIPELINE
+
+
+AIE_LOWER_TO_LLVM = _create_aie_lower_to_llvm_pipeline
 
 # pipeline to lower and legalize runtime sequence for NPU
 NPU_LOWERING_PIPELINE = Pipeline().Nested(
@@ -682,7 +703,7 @@ class FlowRunner:
         # fmt: off
         if opts.unified:
             file_opt_with_addresses = self.prepend_tmp(f"{device_name}_input_opt_with_addresses.mlir")
-            await self.do_call(parent_task_id, ["aie-opt", f"--pass-pipeline={AIE_LOWER_TO_LLVM(device_name, aie_target=aie_target)}", file_with_addresses, "-o", file_opt_with_addresses])
+            await self.do_call(parent_task_id, ["aie-opt", f"--pass-pipeline={AIE_LOWER_TO_LLVM(device_name, aie_target=aie_target, opt_level=opts.opt_level)}", file_with_addresses, "-o", file_opt_with_addresses])
 
             file_llvmir = self.prepend_tmp(f"{device_name}_input.ll")
             await self.do_call(parent_task_id, ["aie-translate", "--mlir-to-llvmir", file_opt_with_addresses, "-o", file_llvmir])
@@ -694,8 +715,15 @@ class FlowRunner:
             elif opts.compile:
                 file_llvmir_hacked = await self.peanohack(file_llvmir)
                 file_llvmir_opt = self.prepend_tmp(f"{device_name}_input.opt.ll")
-                await self.do_call(parent_task_id, [self.peano_opt_path, "--passes=default<O2>", "-inline-threshold=10", "-S", file_llvmir_hacked, "-o", file_llvmir_opt])
-                await self.do_call(parent_task_id, [self.peano_llc_path, file_llvmir_opt, "-O2", "--march=" + aie_target.lower(), "--function-sections", "--filetype=obj", "-o", unified_file_core_obj])
+                opt_level = opts.opt_level
+                # Disable loop idiom memset for O3 and above.
+                # Rationale: memset is executed as scalar operation, while zeroinitializer will be executed as vector
+                opt_flags = [f"--passes=default<O{opt_level}>"]
+                if int(opt_level) >= 3:
+                    opt_flags.append("-disable-loop-idiom-memset")
+                opt_flags.extend(["-inline-threshold=10", "-S", file_llvmir_hacked, "-o", file_llvmir_opt])
+                await self.do_call(parent_task_id, [self.peano_opt_path] + opt_flags)
+                await self.do_call(parent_task_id, [self.peano_llc_path, file_llvmir_opt, f"-O{opt_level}", "--march=" + aie_target.lower(), "--function-sections", "--filetype=obj", "-o", unified_file_core_obj])
         else:
             unified_file_core_obj = None
         # fmt: on
@@ -769,7 +797,7 @@ class FlowRunner:
             if not opts.unified:
                 file_core = corefile(self.tmpdirname, device_name, core, "mlir")
                 file_opt_core = corefile(self.tmpdirname, device_name, core, "opt.mlir")
-                await self.do_call(task, ["aie-opt", f"--pass-pipeline={AIE_LOWER_TO_LLVM(device_name, corecol, corerow, aie_target)}", file_with_addresses, "-o", file_opt_core])
+                await self.do_call(task, ["aie-opt", f"--pass-pipeline={AIE_LOWER_TO_LLVM(device_name, corecol, corerow, aie_target, opts.opt_level)}", file_with_addresses, "-o", file_opt_core])
             if self.opts.xbridge:
                 file_core_bcf = corefile(self.tmpdirname, device_name, core, "bcf")
                 await self.do_call(task, ["aie-translate", file_with_addresses, "--aie-generate-bcf", "--aie-device-name", device_name, "--tilecol=%d" % corecol, "--tilerow=%d" % corerow, "-o", file_core_bcf])
@@ -791,21 +819,30 @@ class FlowRunner:
                         await self.do_call(task, ["xchesscc_wrapper", aie_target.lower(), "+w", self.prepend_tmp("work"), "-d", "+Wclang,-xir", "-f", file_core_llvmir_chesslinked, link_with_obj, "+l", file_core_bcf, "-o", file_core_elf])
                     elif self.opts.link:
                         await self.do_call(task, ["xchesscc_wrapper", aie_target.lower(), "+w", self.prepend_tmp("work"), "-c", "-d", "+Wclang,-xir", "-f", file_core_llvmir_chesslinked, "-o", file_core_obj])
-                        await self.do_call(task, [self.peano_clang_path, "-O2", "--target=" + aie_peano_target, file_core_obj, *clang_link_args, "-Wl,-T," + file_core_ldscript, "-o", file_core_elf])
+                        opt_level = opts.opt_level
+                        await self.do_call(task, [self.peano_clang_path, f"-O{opt_level}", "--target=" + aie_peano_target, file_core_obj, *clang_link_args, "-Wl,-T," + file_core_ldscript, "-o", file_core_elf])
                 else:
                     file_core_obj = unified_file_core_obj
                     if opts.link and opts.xbridge:
                         link_with_obj = await extract_input_files(file_core_bcf)
                         await self.do_call(task, ["xchesscc_wrapper", aie_target.lower(), "+w", self.prepend_tmp("work"), "-d", "-f", file_core_obj, link_with_obj, "+l", file_core_bcf, "-o", file_core_elf])
                     elif opts.link:
-                        await self.do_call(task, [self.peano_clang_path, "-O2", "--target=" + aie_peano_target, file_core_obj, *clang_link_args, "-Wl,-T," + file_core_ldscript, "-o", file_core_elf])
+                        opt_level = opts.opt_level
+                        await self.do_call(task, [self.peano_clang_path, f"-O{opt_level}", "--target=" + aie_peano_target, file_core_obj, *clang_link_args, "-Wl,-T," + file_core_ldscript, "-o", file_core_elf])
 
             elif opts.compile:
                 if not opts.unified:
                     file_core_llvmir_peanohacked = await self.peanohack(file_core_llvmir)
                     file_core_llvmir_stripped = corefile(self.tmpdirname, device_name, core, "stripped.ll")
-                    await self.do_call(task, [self.peano_opt_path, "--passes=default<O2>,strip", "-S", file_core_llvmir_peanohacked, "-o", file_core_llvmir_stripped])
-                    await self.do_call(task, [self.peano_llc_path, file_core_llvmir_stripped, "-O2", "--march=" + aie_target.lower(), "--function-sections", "--filetype=obj", "-o", file_core_obj])
+                    opt_level = opts.opt_level
+                    # Disable loop idiom memset for O3 and above.
+                    # Rationale: memset is executed as scalar operation, while zeroinitializer will be executed as vector
+                    opt_flags = [f"--passes=default<O{opt_level}>,strip"]
+                    if int(opt_level) >= 3:
+                        opt_flags.append("-disable-loop-idiom-memset")
+                    opt_flags.extend(["-S", file_core_llvmir_peanohacked, "-o", file_core_llvmir_stripped])
+                    await self.do_call(task, [self.peano_opt_path] + opt_flags)
+                    await self.do_call(task, [self.peano_llc_path, file_core_llvmir_stripped, f"-O{opt_level}", "--march=" + aie_target.lower(), "--function-sections", "--filetype=obj", "-o", file_core_obj])
                 else:
                     file_core_obj = unified_file_core_obj
 
@@ -813,7 +850,8 @@ class FlowRunner:
                     link_with_obj = await extract_input_files(file_core_bcf)
                     await self.do_call(task, ["xchesscc_wrapper", aie_target.lower(), "+w", self.prepend_tmp("work"), "-d", "-f", file_core_obj, link_with_obj, "+l", file_core_bcf, "-o", file_core_elf])
                 elif opts.link:
-                    await self.do_call(task, [self.peano_clang_path, "-O2", "--target=" + aie_peano_target, file_core_obj, *clang_link_args, "-Wl,-T," + file_core_ldscript, "-o", file_core_elf])
+                    opt_level = opts.opt_level
+                    await self.do_call(task, [self.peano_clang_path, f"-O{opt_level}", "--target=" + aie_peano_target, file_core_obj, *clang_link_args, "-Wl,-T," + file_core_ldscript, "-o", file_core_elf])
 
             self.progress_bar.update(parent_task_id, advance=1)
             self.progress_bar.update(task, advance=0, visible=False)
@@ -1580,6 +1618,7 @@ class FlowRunner:
                 opts.packet_sw_objFifos,
                 opts.ctrl_pkt_overlay,
                 aie_target,
+                opts.opt_level,
             ).materialize(module=True)
 
             self.progress_bar.update(task1, advance=1, command=pass_pipeline[0:30])


### PR DESCRIPTION
Add a new option, "optimization level" (-O) to `aiecc.py` to control the level of aggressiveness on schedule optimization passes.

All recent passes optimizing the vector code's schedule go to `-O3`, whereas `-O2` (default) gives the same behavior as the existing workflow.

This option now also drives the `-O` flags in peano `opt`, `llc` and `clang`.