### PR TITLE
python wheels: fix author field

### DIFF
--- a/utils/mlir_aie_wheels/pyproject.toml
+++ b/utils/mlir_aie_wheels/pyproject.toml
@@ -11,7 +11,8 @@ represent end-to-end compilation flows or to be particularly easy to use for sys
 """, content-type = "text/markdown" }
 dynamic = ["dependencies", "requires-python", "version", "license"]
 authors = [
-  { name="AMD Inc.", email="joseph.melber@amd.com" },
+  { name="AMD Inc." },
+  { email="joseph.melber@amd.com" },
 ]
 
 [project.urls]


### PR DESCRIPTION
```pip show mlir_aie``` author field was still blank. This should fix it by separating author/email fields by using different entries