### PR TITLE
Disable buildAndTestAieToolsHsaBuildOnly.yml on push to main

### DIFF
--- a/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
+++ b/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
@@ -1,9 +1,9 @@
 name: Build and Test with AIE tools with HSA backend and build only tests
 
 on:
-  push:
-    branches:
-      - main
+#  push:
+#    branches:
+#      - main
 #  pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This disables the vck5000 hsa workflow. This workflow only runs on pushes to main because it is running in docker on standard github runners and takes an hour to run. It's currently broken because of external dependencies:
```
2025-11-25T03:09:56.7602372Z Cloning into '/mlir-aie/ROCR-Runtime'...
2025-11-25T03:09:56.9581707Z warning: Could not find remote branch experimental/rocm-5.6.x-air to clone.
2025-11-25T03:09:56.9582471Z fatal: Remote branch experimental/rocm-5.6.x-air not found in upstream origin
```

It tests two things,
* build with the version of rocm in https://github.com/Xilinx/ROCm-air-platforms
* build and test with Vitis 2023.2, including some simulation

The first is probably no longer needed and the second overlaps with the newer Vitis 2025.1 workflow.