### PR TITLE
Explicitly cleanup IRON_CACHE_HOME in runners

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -129,12 +129,17 @@ jobs:
             $CMAKE_ARGS
 
           # Create runner-specific cache directory
-          mkdir -p $IRON_CACHE_HOME
+          rm -rf $IRON_CACHE_HOME
+          mkdir $IRON_CACHE_HOME
 
           ninja install
           ninja check-aie
           ninja check-aie-concurrency
           popd
+
+      - name: Cleanup IRON_CACHE_HOME
+        if: always()
+        run: rm -rf $IRON_CACHE_HOME
 
   build-quick-setup:
     name: Run Examples on Ryzen AI
@@ -192,9 +197,14 @@ jobs:
           fi
 
           # Create runner-specific cache directory
-          mkdir -p $IRON_CACHE_HOME
+          rm -rf $IRON_CACHE_HOME
+          mkdir $IRON_CACHE_HOME
 
           ninja install
           ninja check-reference-designs
           ninja check-programming-guide
           popd
+
+      - name: Cleanup IRON_CACHE_HOME
+        if: always()
+        run: rm -rf $IRON_CACHE_HOME

--- a/.github/workflows/buildAndTestVitis.yml
+++ b/.github/workflows/buildAndTestVitis.yml
@@ -124,9 +124,13 @@ jobs:
             $CMAKE_ARGS
 
           # Create runner-specific cache directory
-          mkdir -p $IRON_CACHE_HOME
+          rm -rf $IRON_CACHE_HOME
+          mkdir $IRON_CACHE_HOME
 
           ninja install
           ninja check-aie
           popd
 
+      - name: Cleanup IRON_CACHE_HOME
+        if: always()
+        run: rm -rf $IRON_CACHE_HOME


### PR DESCRIPTION
This PR ensures the IRON_CACHE_HOME is cleaned by the runners. Previous work tried to ensure this was unique per run, but even with this, it seems reasonable to run explicit cleanup tasks too.