### PR TITLE
Remove `nocreateundeforpoison` attribute for backward compatibility

### DIFF
--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -542,6 +542,8 @@ def downgrade_ir_for_chess(llvmir_chesslinked):
 
 def downgrade_ir_for_peano(llvmir):
     llvmir = llvmir.replace("getelementptr inbounds nuw", "getelementptr inbounds")
+    # Remove nocreateundeforpoison attribute (not supported by older LLVM in Peano toolchain)
+    llvmir = re.sub(r"\bnocreateundeforpoison\s+", "", llvmir)
     return llvmir
 
 


### PR DESCRIPTION
… to the pined `llvm-aie` version.