### PR TITLE
[aievec] Separate implementations of `aievec.cast` folding for aie2 and aie2p

### DIFF
--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -4345,6 +4345,20 @@ class FoldAIECastOps : public mlir::ConvertOpToLLVMPattern<aievec::CastOp> {
   }
 };
 
+// AIE2p version of FoldAIECastOps
+class FoldAIECastOpsAIE2p
+    : public mlir::ConvertOpToLLVMPattern<aievec::CastOp> {
+  using ConvertOpToLLVMPattern<aievec::CastOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(aievec::CastOp castOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Fold the cast.
+    rewriter.replaceOp(castOp, adaptor.getSource());
+    return success();
+  }
+};
+
 class ShuffleOpConversion
     : public mlir::ConvertOpToLLVMPattern<aievec::ShuffleOp> {
   using ConvertOpToLLVMPattern<aievec::ShuffleOp>::ConvertOpToLLVMPattern;
@@ -4509,7 +4523,6 @@ void populateAIEVecToLLVMCommonConversionPatterns(
                BroadcastScalarOpConversion,
                FMAElemOpConversion,
                MatMulOpConversion,
-               FoldAIECastOps,
                ShuffleOpConversion>(converter);
   // clang-format on
 }
@@ -4525,6 +4538,7 @@ void populateAIEVecToLLVMAIE2ConversionPatterns(
   patterns.add<MaxOpConversion, MinOpConversion>(converter);
   patterns.add<ExtractElemOpConversion>(converter);
   patterns.add<ConcatOpConversion>(converter);
+  patterns.add<FoldAIECastOps>(converter);
 }
 
 // AIE2p version of ExtractElemOp conversion using LLVM extractelement
@@ -4623,6 +4637,7 @@ void populateAIEVecToLLVMAIE2pConversionPatterns(
   patterns.add<ExpOpAIE2pConversion>(converter);
   patterns.add<BroadcastScalarOpAIE2pConversion>(converter);
   patterns.add<RsqrtOpAIE2pConversion>(converter);
+  patterns.add<FoldAIECastOpsAIE2p>(converter);
 }
 
 void populateAIEVecToLLVMConversionPatterns(

--- a/test/Conversion/AIEVecToLLVM/test-cast.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-cast.mlir
@@ -8,35 +8,47 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt %s -convert-aievec-to-llvm | FileCheck %s
+// RUN: aie-opt %s -convert-aievec-to-llvm | FileCheck %s --check-prefix=CHECK-AIE2
+// RUN: aie-opt %s --convert-aievec-to-llvm='aie-target=aie2p' | FileCheck %s --check-prefix=CHECK-AIE2P
 
-// CHECK-LABEL: @test_cast_zero_acc_f32
+// CHECK-AIE2-LABEL: @test_cast_zero_acc_f32
+// CHECK-AIE2P-LABEL: @test_cast_zero_acc_f32
 func.func @test_cast_zero_acc_f32() -> vector<16xf32> {
   %cst = arith.constant dense<0.000000e+00> : vector<16xf32>
-  // CHECK: %[[ZERO_ACC:.*]] = "xllvm.intr.aie2.vbroadcast.zero.acc1024"() : () -> vector<16xi64>
-  // CHECK-NEXT: %[[SHUFFLE:.*]] = vector.shuffle %[[ZERO_ACC]], %[[ZERO_ACC]] [0, 1, 2, 3, 4, 5, 6, 7] : vector<16xi64>, vector<16xi64>
-  // CHECK-NEXT: %[[RESULT:.*]] = llvm.bitcast %[[SHUFFLE]] : vector<8xi64> to vector<16xf32>
+  // AIE2: uses vbroadcast.zero.acc1024 intrinsic for zero accumulator
+  // CHECK-AIE2: %[[ZERO_ACC:.*]] = "xllvm.intr.aie2.vbroadcast.zero.acc1024"() : () -> vector<16xi64>
+  // CHECK-AIE2-NEXT: %[[SHUFFLE:.*]] = vector.shuffle %[[ZERO_ACC]], %[[ZERO_ACC]] [0, 1, 2, 3, 4, 5, 6, 7] : vector<16xi64>, vector<16xi64>
+  // CHECK-AIE2-NEXT: %[[RESULT:.*]] = llvm.bitcast %[[SHUFFLE]] : vector<8xi64> to vector<16xf32>
+  
+  // AIE2P: simply folds the cast
+  // CHECK-AIE2P: %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<16xf32>
   %0 = aievec.cast %cst {isResAcc = true} : vector<16xf32>, vector<16xf32>
-  // CHECK: return %[[RESULT]] : vector<16xf32>
+  // CHECK-AIE2: return %[[RESULT]] : vector<16xf32>
+  // CHECK-AIE2P: return %[[CST]] : vector<16xf32>
   return %0 : vector<16xf32>
 }
 
-// CHECK-LABEL: @test_cast_nonzero_acc_f32
+// CHECK-AIE2-LABEL: @test_cast_nonzero_acc_f32
+// CHECK-AIE2P-LABEL: @test_cast_nonzero_acc_f32
 func.func @test_cast_nonzero_acc_f32(%arg0: vector<16xf32>) -> vector<16xf32> {
-  // For non-zero constants, the cast should just fold away
-  // CHECK-NOT: vbroadcast.zero.acc1024
-  // CHECK: return %arg0 : vector<16xf32>
+  // For non-zero constants, the cast should just fold away for both AIE2 and AIE2P
+  // CHECK-AIE2-NOT: vbroadcast.zero.acc1024
+  // CHECK-AIE2: return %arg0 : vector<16xf32>
+  // CHECK-AIE2P: return %arg0 : vector<16xf32>
   %0 = aievec.cast %arg0 {isResAcc = true} : vector<16xf32>, vector<16xf32>
   return %0 : vector<16xf32>
 }
 
-// CHECK-LABEL: @test_cast_non_acc
+// CHECK-AIE2-LABEL: @test_cast_non_acc
+// CHECK-AIE2P-LABEL: @test_cast_non_acc
 func.func @test_cast_non_acc() -> vector<16xf32> {
   %cst = arith.constant dense<0.000000e+00> : vector<16xf32>
-  // When isResAcc = false, should just fold away
-  // CHECK-NOT: vbroadcast.zero.acc1024
-  // CHECK: %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<16xf32>
-  // CHECK: return %[[CST]] : vector<16xf32>
+  // When isResAcc = false, should just fold away for both AIE2 and AIE2P
+  // CHECK-AIE2-NOT: vbroadcast.zero.acc1024
+  // CHECK-AIE2: %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<16xf32>
+  // CHECK-AIE2: return %[[CST]] : vector<16xf32>
+  // CHECK-AIE2P: %[[CST:.*]] = arith.constant dense<0.000000e+00> : vector<16xf32>
+  // CHECK-AIE2P: return %[[CST]] : vector<16xf32>
   %0 = aievec.cast %cst {isResAcc = false} : vector<16xf32>, vector<16xf32>
   return %0 : vector<16xf32>
 }


### PR DESCRIPTION
Only `aie2` `accfloat` vector zero fill requires special handling using dedicated intrinsics.