### PR TITLE
Add 'free disk space' step to lint and format workflow

### DIFF
--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -191,6 +191,17 @@ jobs:
       pull-requests: write
 
     steps:
+
+      - name: Free disk space
+        uses: descriptinc/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: false
+
       - name: Get the project repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The C++ test coverage has been running out of storage on the GitHub-hosted runners. This is an attempt to fix this.

<img width="2525" height="1371" alt="image" src="https://github.com/user-attachments/assets/550b5216-1803-445f-9ed5-26e5bb09b6b6" />
[example failed workflow run](https://github.com/Xilinx/mlir-aie/actions/runs/20292678054/job/58280097224)

Not sure about the root cause/what changed but hopefully this fixes it.