### PR TITLE
Add a pass that merges write32 operations into blockwrites

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -518,6 +518,22 @@ public:
   // DMA channels (register=CONSTANT_PAD_VALUE).
   virtual bool isMemTilePadValueSupported() const { return false; }
 
+  // Returns true if a write to `absoluteAddress` has a side effect beyond
+  // storing the value, such as a reset or a start of processing. A pass that
+  // reorders or merges writes must keep such a write in place.
+  virtual bool isSpecialRegister(uint32_t absoluteAddress) const {
+    return false;
+  }
+
+  // Returns true if a write to `offset` in tile (col, row) has a side effect
+  // beyond storing the value.
+  virtual bool isSpecialRegister(int col, int row, uint32_t offset) const {
+    uint32_t absoluteAddress = ((col & 0xff) << getColumnShift()) |
+                               ((row & 0xff) << getRowShift()) |
+                               (offset & 0xfffff);
+    return isSpecialRegister(absoluteAddress);
+  }
+
   /// Register Database API - provides access to register and event information
   /// for trace configuration and low-level register access.
 
@@ -1068,6 +1084,38 @@ public:
   bool isSupportedBlockFormat(std::string const &format) const override;
 
   bool isMemTilePadValueSupported() const override { return true; }
+
+  bool isSpecialRegister(uint32_t absoluteAddress) const override {
+    int col = (absoluteAddress >> getColumnShift()) & 0xff;
+    int row = (absoluteAddress >> getRowShift()) & 0x1f;
+    uint32_t offset = absoluteAddress & 0xfffff;
+    return isSpecialRegister(col, row, offset);
+  }
+
+  bool isSpecialRegister(int col, int row, uint32_t offset) const override {
+    if (isCoreTile(col, row))
+      return offset == 0x32000 || // Core_Control
+             offset == 0x36070 || // Memory_Control
+             offset == 0x60000 || // Module_Clock_Control
+             offset == 0x60010 || // Module_Reset_Control
+             offset == 0x60020 || // Tile_Control
+             offset == 0x1DE04 || offset == 0x1DE0C || offset == 0x1DE14 ||
+             offset == 0x1DE1C;
+    if (isShimNOCTile(col, row))
+      return (offset >= 0x15000 && offset <= 0x15010) || offset == 0x1D200 ||
+             offset == 0x1D204 || offset == 0x1D208 || offset == 0x1D20C ||
+             offset == 0x1D210 || offset == 0x1D214 || offset == 0x1D218 ||
+             offset == 0x1D21C || offset == 0x1F000 || offset == 0x1F004 ||
+             offset == 0x40000;
+    if (isMemTile(col, row))
+      return offset == 0x94008 || offset == 0x96048 || offset == 0xA0604 ||
+             offset == 0xA060C || offset == 0xA0614 || offset == 0xA061C ||
+             offset == 0xA0624 || offset == 0xA062C || offset == 0xA0634 ||
+             offset == 0xA063C || offset == 0xA0644 || offset == 0xA064C ||
+             offset == 0xA0654 || offset == 0xA065C || offset == 0xFFF00 ||
+             offset == 0xFFF10 || offset == 0xFFF20;
+    return false;
+  }
 
   static bool classof(const AIETargetModel *model) {
     return model->getKind() >= TK_AIE2_NPU2 &&

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -73,6 +73,8 @@ createAIELowerScratchpadParametersPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createAIELowerScratchpadParametersPass(
     AIELowerScratchpadParametersOptions options);
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
+createAIECoalesceWrite32sPass();
 
 /// Generate the code for registering passes.
 #define GEN_PASS_REGISTRATION

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -565,4 +565,36 @@ def AIEXInlineTraceConfig : Pass<"aie-inline-trace-config", "AIE::DeviceOp"> {
   ];
 }
 
+def AIECoalesceWrite32s : Pass<"aie-coalesce-write32s", "AIE::DeviceOp"> {
+  let summary = "Merge runs of write32 operations into blockwrite operations";
+  let description = [{
+    Merges runs of `aiex.npu.write32` operations at contiguous addresses into a
+    single `aiex.npu.blockwrite`, which lowers the instruction count of a
+    runtime sequence.
+
+    The pass splits each runtime sequence into slices. A write to a special
+    register, a write whose address it cannot resolve, and any other operation
+    end a slice, because such an operation may depend on the order of the writes
+    around it. Within a slice the pass drops every write that a later write to
+    the same address supersedes, sorts the remaining writes by address, and
+    emits a blockwrite for each run of contiguous addresses. A masked write
+    reads the register it writes, so the pass keeps it and ends the run there.
+
+    The option `min-writes-to-coalesce` sets the length a run needs before the
+    pass merges it.
+  }];
+
+  let options = [Option<
+      "minWritesToCoalesce", "min-writes-to-coalesce", "unsigned",
+      /*default=*/"2",
+      "Number of contiguous writes a run needs before the pass merges it "
+      "into a blockwrite">];
+
+  let constructor = "xilinx::AIEX::createAIECoalesceWrite32sPass()";
+  let dependentDialects = ["mlir::memref::MemRefDialect",
+                           "xilinx::AIE::AIEDialect",
+                           "xilinx::AIEX::AIEXDialect",
+  ];
+}
+
 #endif

--- a/lib/Dialect/AIEX/Transforms/AIECoalesceWrite32s.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECoalesceWrite32s.cpp
@@ -1,0 +1,270 @@
+//===- AIECoalesceWrite32s.cpp ----------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Merges runs of npu.write32 operations at contiguous addresses into a single
+// npu.blockwrite.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace xilinx::AIEX {
+#define GEN_PASS_DEF_AIECOALESCEWRITE32S
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+} // namespace xilinx::AIEX
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIEX;
+
+namespace {
+
+// One 32-bit write, together with the operation that produced it.
+struct WriteWord {
+  uint32_t address;
+  uint32_t value;
+  // Set for an npu.maskwrite32, which the pass keeps as it is.
+  std::optional<uint32_t> mask;
+  Operation *op;
+
+  bool operator<(const WriteWord &other) const {
+    return address < other.address;
+  }
+
+  bool isMaskWrite() const { return mask.has_value(); }
+};
+
+// A run of operations that the pass may reorder among themselves. A write to a
+// special register or any operation the pass does not model ends the slice.
+struct WriteSlice {
+  SmallVector<WriteWord> writes;
+
+  bool isEmpty() const { return writes.empty(); }
+};
+
+struct AIECoalesceWrite32sPass
+    : xilinx::AIEX::impl::AIECoalesceWrite32sBase<AIECoalesceWrite32sPass> {
+
+  void runOnOperation() override {
+    AIE::DeviceOp deviceOp = getOperation();
+    SmallVector<AIE::RuntimeSequenceOp> runtimeSeqs;
+    deviceOp.walk(
+        [&](AIE::RuntimeSequenceOp seqOp) { runtimeSeqs.push_back(seqOp); });
+    for (auto seqOp : runtimeSeqs)
+      coalesceWrite32sInSequence(seqOp);
+  }
+
+private:
+  void coalesceWrite32sInSequence(AIE::RuntimeSequenceOp seqOp) {
+    OpBuilder builder(seqOp.getContext());
+    auto deviceOp = seqOp->getParentOfType<AIE::DeviceOp>();
+    if (!deviceOp)
+      return;
+    const auto &tm = deviceOp.getTargetModel();
+
+    for (Block &block : seqOp.getBody()) {
+      SmallVector<WriteSlice> slices;
+      WriteSlice currentSlice;
+
+      auto endSlice = [&]() {
+        if (!currentSlice.isEmpty())
+          slices.push_back(std::move(currentSlice));
+        currentSlice = WriteSlice();
+      };
+
+      for (Operation &op : block) {
+        // A side-effect-free operation, such as the arith.constant that feeds a
+        // write or the memref.get_global that feeds a blockwrite, orders
+        // nothing by itself.
+        if (isMemoryEffectFree(&op))
+          continue;
+
+        if (auto write32Op = dyn_cast<NpuWrite32Op>(&op)) {
+          std::optional<uint32_t> addr = write32Op.getAbsoluteAddress();
+          std::optional<int64_t> value =
+              getConstantIntValue(write32Op.getValue());
+          if (!addr || !value || tm.isSpecialRegister(*addr)) {
+            endSlice();
+            continue;
+          }
+          currentSlice.writes.push_back(WriteWord{
+              *addr, static_cast<uint32_t>(*value), std::nullopt, &op});
+          continue;
+        }
+
+        if (auto maskWriteOp = dyn_cast<NpuMaskWrite32Op>(&op)) {
+          std::optional<uint32_t> addr = maskWriteOp.getAbsoluteAddress();
+          std::optional<int64_t> value =
+              getConstantIntValue(maskWriteOp.getValue());
+          std::optional<int64_t> mask =
+              getConstantIntValue(maskWriteOp.getMask());
+          if (!addr || !value || !mask || tm.isSpecialRegister(*addr)) {
+            endSlice();
+            continue;
+          }
+          currentSlice.writes.push_back(
+              WriteWord{*addr, static_cast<uint32_t>(*value),
+                        static_cast<uint32_t>(*mask), &op});
+          continue;
+        }
+
+        if (auto blockWriteOp = dyn_cast<NpuBlockWriteOp>(&op)) {
+          std::optional<uint32_t> addr = blockWriteOp.getAbsoluteAddress();
+          DenseIntElementsAttr dataWords = blockWriteOp.getDataWords();
+          if (!addr || !dataWords) {
+            endSlice();
+            continue;
+          }
+          bool touchesSpecialRegister = false;
+          for (int64_t i = 0, e = dataWords.size(); i < e; ++i)
+            if (tm.isSpecialRegister(*addr + i * 4)) {
+              touchesSpecialRegister = true;
+              break;
+            }
+          if (touchesSpecialRegister) {
+            endSlice();
+            continue;
+          }
+          int64_t idx = 0;
+          for (auto val : dataWords.getValues<APInt>()) {
+            currentSlice.writes.push_back(WriteWord{
+                static_cast<uint32_t>(*addr + idx * 4),
+                static_cast<uint32_t>(val.getZExtValue()), std::nullopt, &op});
+            ++idx;
+          }
+          continue;
+        }
+
+        endSlice();
+      }
+
+      endSlice();
+
+      for (auto &slice : slices)
+        processSlice(builder, slice, deviceOp);
+    }
+  }
+
+  void processSlice(OpBuilder &builder, WriteSlice &slice,
+                    AIE::DeviceOp deviceOp) {
+    if (slice.writes.empty())
+      return;
+
+    // Within a slice the last write to an address wins.
+    DenseMap<uint32_t, size_t> lastWriteIndex;
+    DenseSet<Operation *> supersededOps;
+    for (size_t i = 0; i < slice.writes.size(); ++i) {
+      uint32_t addr = slice.writes[i].address;
+      auto it = lastWriteIndex.find(addr);
+      if (it != lastWriteIndex.end())
+        supersededOps.insert(slice.writes[it->second].op);
+      lastWriteIndex[addr] = i;
+    }
+
+    SmallVector<WriteWord> uniqueWrites;
+    for (size_t i = 0; i < slice.writes.size(); ++i)
+      if (lastWriteIndex[slice.writes[i].address] == i)
+        uniqueWrites.push_back(slice.writes[i]);
+    slice.writes = std::move(uniqueWrites);
+
+    // A blockwrite covers one address range, so sorting by address exposes the
+    // runs the pass can merge.
+    llvm::sort(slice.writes);
+
+    SmallVector<SmallVector<WriteWord>> sequences;
+    SmallVector<WriteWord> currentSeq;
+    auto endSequence = [&]() {
+      if (currentSeq.size() >= minWritesToCoalesce)
+        sequences.push_back(currentSeq);
+      currentSeq.clear();
+    };
+
+    for (auto &write : slice.writes) {
+      // A masked write reads the register, so it stays a maskwrite32 and ends
+      // the run.
+      if (write.isMaskWrite()) {
+        endSequence();
+        continue;
+      }
+      if (!currentSeq.empty() && write.address != currentSeq.back().address + 4)
+        endSequence();
+      currentSeq.push_back(write);
+    }
+    endSequence();
+
+    DenseSet<Operation *> toErase = supersededOps;
+    for (auto &seq : sequences) {
+      createBlockWrite(builder, seq, deviceOp);
+      for (auto &write : seq)
+        toErase.insert(write.op);
+    }
+
+    for (auto *op : toErase)
+      op->erase();
+  }
+
+  void createBlockWrite(OpBuilder &builder, ArrayRef<WriteWord> sequence,
+                        AIE::DeviceOp deviceOp) {
+    if (sequence.empty())
+      return;
+
+    MLIRContext *ctx = builder.getContext();
+    uint32_t startAddr = sequence.front().address;
+    Location loc = sequence.front().op->getLoc();
+
+    SmallVector<int32_t> values;
+    for (auto &write : sequence)
+      values.push_back(static_cast<int32_t>(write.value));
+
+    auto i32Type = IntegerType::get(ctx, 32);
+    auto shape = static_cast<int64_t>(values.size());
+    auto memrefType = MemRefType::get({shape}, i32Type);
+    auto valuesAttr = DenseElementsAttr::get<int32_t>(
+        RankedTensorType::get({shape}, i32Type), ArrayRef<int32_t>(values));
+
+    std::string globalName = "coalesced_write32_" + std::to_string(startAddr) +
+                             "_" + std::to_string(globalCounter++);
+
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToStart(deviceOp.getBody());
+    memref::GlobalOp::create(
+        builder, loc, globalName,
+        /*sym_visibility=*/builder.getStringAttr("private"),
+        /*type=*/memrefType,
+        /*initial_value=*/valuesAttr,
+        /*constant=*/true,
+        /*alignment=*/nullptr);
+
+    builder.setInsertionPoint(sequence.front().op);
+    auto getGlobalOp =
+        memref::GetGlobalOp::create(builder, loc, memrefType, globalName);
+    NpuBlockWriteOp::create(builder, loc, startAddr, getGlobalOp.getResult(),
+                            /*buffer=*/nullptr, /*column=*/nullptr,
+                            /*row=*/nullptr);
+  }
+
+  unsigned globalCounter = 0;
+};
+
+} // namespace
+
+namespace xilinx::AIEX {
+std::unique_ptr<OperationPass<AIE::DeviceOp>> createAIECoalesceWrite32sPass() {
+  return std::make_unique<AIECoalesceWrite32sPass>();
+}
+} // namespace xilinx::AIEX

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIETxnToControlPacket.cpp
   AIEExpandLoadPdi.cpp
   AIEInlineTraceConfig.cpp
+  AIECoalesceWrite32s.cpp
   ADDITIONAL_HEADER_DIRS
   ${AIE_BINARY_DIR}/include
 

--- a/test/dialect/AIEX/coalesce_write32s.mlir
+++ b/test/dialect/AIEX/coalesce_write32s.mlir
@@ -1,0 +1,117 @@
+//===- coalesce_write32s.mlir -----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-coalesce-write32s --split-input-file %s | FileCheck %s
+
+// Four writes at contiguous addresses become one blockwrite over the four
+// values.
+// CHECK: memref.global "private" constant @[[G:.*]] : memref<4xi32> = dense<[10, 11, 12, 13]>
+// CHECK: aie.runtime_sequence @contiguous
+// CHECK: %[[D:.*]] = memref.get_global @[[G]]
+// CHECK: aiex.npu.blockwrite(%[[D]]) {address = 1024 : ui32}
+// CHECK-NOT: aiex.npu.write32
+aie.device(npu2) {
+  aie.runtime_sequence @contiguous() {
+    %a0 = arith.constant 1024 : i32
+    %v0 = arith.constant 10 : i32
+    aiex.npu.write32(%a0, %v0) : i32, i32
+    %a1 = arith.constant 1028 : i32
+    %v1 = arith.constant 11 : i32
+    aiex.npu.write32(%a1, %v1) : i32, i32
+    %a2 = arith.constant 1032 : i32
+    %v2 = arith.constant 12 : i32
+    aiex.npu.write32(%a2, %v2) : i32, i32
+    %a3 = arith.constant 1036 : i32
+    %v3 = arith.constant 13 : i32
+    aiex.npu.write32(%a3, %v3) : i32, i32
+  }
+}
+
+// -----
+
+// A gap in the addresses ends the run, and a run shorter than the threshold of
+// two stays a write32.
+// CHECK: memref.global "private" constant @[[G:.*]] : memref<2xi32> = dense<[10, 11]>
+// CHECK: aie.runtime_sequence @gap
+// CHECK: %[[D:.*]] = memref.get_global @[[G]]
+// CHECK: aiex.npu.blockwrite(%[[D]]) {address = 1024 : ui32}
+// CHECK: aiex.npu.write32
+aie.device(npu2) {
+  aie.runtime_sequence @gap() {
+    %a0 = arith.constant 1024 : i32
+    %v0 = arith.constant 10 : i32
+    aiex.npu.write32(%a0, %v0) : i32, i32
+    %a1 = arith.constant 1028 : i32
+    %v1 = arith.constant 11 : i32
+    aiex.npu.write32(%a1, %v1) : i32, i32
+    %a2 = arith.constant 2048 : i32
+    %v2 = arith.constant 12 : i32
+    aiex.npu.write32(%a2, %v2) : i32, i32
+  }
+}
+
+// -----
+
+// A later write to the same address supersedes the earlier one, so the
+// blockwrite carries the later value.
+// CHECK: memref.global "private" constant @{{.*}} : memref<2xi32> = dense<[99, 11]>
+// CHECK: aie.runtime_sequence @duplicate
+// CHECK: aiex.npu.blockwrite(%{{.*}}) {address = 1024 : ui32}
+// CHECK-NOT: aiex.npu.write32
+aie.device(npu2) {
+  aie.runtime_sequence @duplicate() {
+    %a0 = arith.constant 1024 : i32
+    %v0 = arith.constant 10 : i32
+    aiex.npu.write32(%a0, %v0) : i32, i32
+    %a1 = arith.constant 1028 : i32
+    %v1 = arith.constant 11 : i32
+    aiex.npu.write32(%a1, %v1) : i32, i32
+    %a2 = arith.constant 1024 : i32
+    %v2 = arith.constant 99 : i32
+    aiex.npu.write32(%a2, %v2) : i32, i32
+  }
+}
+
+// -----
+
+// A write to Core_Control of tile (0, 2) ends the slice, so the two writes
+// around it stay in place.
+// CHECK: aie.runtime_sequence @special_register
+// CHECK-NOT: aiex.npu.blockwrite
+aie.device(npu2) {
+  aie.runtime_sequence @special_register() {
+    %a0 = arith.constant 1024 : i32
+    %v0 = arith.constant 10 : i32
+    aiex.npu.write32(%a0, %v0) : i32, i32
+    // Core_Control of tile (0, 2): (2 << 20) | 0x32000.
+    %a1 = arith.constant 2301952 : i32
+    %v1 = arith.constant 1 : i32
+    aiex.npu.write32(%a1, %v1) : i32, i32
+    %a2 = arith.constant 1028 : i32
+    %v2 = arith.constant 11 : i32
+    aiex.npu.write32(%a2, %v2) : i32, i32
+  }
+}
+
+// -----
+
+// A masked write reads the register it writes, so it ends the run and stays a
+// maskwrite32.
+// CHECK: aie.runtime_sequence @masked
+// CHECK-NOT: aiex.npu.blockwrite
+// CHECK: aiex.npu.maskwrite32
+aie.device(npu2) {
+  aie.runtime_sequence @masked() {
+    %a0 = arith.constant 1024 : i32
+    %v0 = arith.constant 10 : i32
+    aiex.npu.write32(%a0, %v0) : i32, i32
+    %a1 = arith.constant 1028 : i32
+    %v1 = arith.constant 11 : i32
+    %m1 = arith.constant 255 : i32
+    aiex.npu.maskwrite32(%a1, %v1, %m1) : i32, i32, i32
+  }
+}


### PR DESCRIPTION
This PR adds `--aie-coalesce-write32s`. The pass merges runs of `aiex.npu.write32` operations at contiguous addresses into a single `aiex.npu.blockwrite`, which lowers the instruction count of a runtime sequence.

The pass splits each runtime sequence into slices. A write to a special register, a write whose address or value it cannot resolve, and any other operation with a side effect end a slice, because such an operation may depend on the order of the writes around it. Within a slice the pass drops every write that a later write to the same address supersedes, sorts the remaining writes by address, and emits a blockwrite for each run of contiguous addresses. A masked write reads the register it writes, so the pass keeps it and ends the run there.

The option `min-writes-to-coalesce` sets the length a run needs before the pass merges it. It defaults to 2.

`AIETargetModel` gains `isSpecialRegister`, which reports whether a write to an address has a side effect beyond storing the value. The NPU2 target model lists the control, reset and clock registers of the core, shim and mem tiles. Other target models report no special register, so the pass leaves their sequences unchanged.

`test/dialect/AIEX/coalesce_write32s.mlir` covers a contiguous run, a gap in the addresses, a superseded write, a special register and a masked write.

This branch previously carried the reconfiguration work of #2775, which has since landed on main in a different form. The branch now holds the coalescing pass alone, rebuilt on current main.