### PR TITLE
[bugfix] better mlir wheels validation and fix wheels overwrite race condition

### DIFF
--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -378,9 +378,50 @@ jobs:
         shell: bash
         run: |
           pip install numpy PyYAML
-          unzip -o -q dist/mlir\*.whl
           
-          PYTHONPATH=$(find . -name mlir_core) python -c 'import mlir.ir'
+          # Validate wheel format
+          python -m zipfile -t dist/mlir*.whl
+          
+          # Install the wheel
+          pip install dist/mlir*.whl
+          
+          # Functional test
+          python -c '
+          import mlir.ir
+          with mlir.ir.Context():
+              module = mlir.ir.Module.parse(r"""
+                  module {
+                      func.func @test() {
+                          return
+                      }
+                  }
+              """)
+              print(module)
+          '
+          
+          # Check for binaries in the installed package
+          import os
+          import mlir
+          mlir_path = os.path.dirname(mlir.__file__)
+          print(f"MLIR installed at: {mlir_path}")
+          
+          bin_dir = os.path.join(mlir_path, "bin")
+          if not os.path.exists(bin_dir):
+              print(f"Error: bin directory not found at {bin_dir}")
+              exit(1)
+              
+          if "${{ matrix.OS }}" == "windows-2022":
+              exe_suffix = ".exe"
+          else:
+              exe_suffix = ""
+              
+          for tool in ["mlir-opt", "mlir-translate"]:
+              tool_path = os.path.join(bin_dir, tool + exe_suffix)
+              if not os.path.exists(tool_path):
+                  print(f"Error: {tool} not found at {tool_path}")
+                  exit(1)
+              print(f"Found {tool} at {tool_path}")
+          '
 
   upload_distro_wheels:
 
@@ -441,5 +482,5 @@ jobs:
           name: ${{ github.event_name == 'workflow_dispatch' && 'mlir-distro' || 'dev-wheels' }}
           removeArtifacts: false
           allowUpdates: true
-          replacesArtifacts: true
+          replacesArtifacts: false
           makeLatest: false


### PR DESCRIPTION
Currently, the mlir-distro wheels are broken:
```bash
pip -q download mlir==22.0.0.2025120518+ebf5d9ef -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
ERROR: Wheel 'mlir' located at /tmp/pip-unpack-qwpb4eis/mlir-22.0.0.2025120518+ebf5d9ef-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl is invalid.
```

I believe this is because there is a race condition in the mlirdistro workflow that causes the wheels file to be overwritten by more than one job when more than mlirdistro workflow completes within the same hour. I've fixed a potential cause of that error in this PR, and I've also added additional checks to the wheels to ensure they are valid before upload.