### PR TITLE
Remove unneeded dependency

### DIFF
--- a/python/requirements_extras.txt
+++ b/python/requirements_extras.txt
@@ -1,3 +1,2 @@
-mlir-python-bindings==20251205+e067be338
 eudsl-python-extras==0.1.0.20251215.1800+3c7ac1b
 -f https://llvm.github.io/eudsl


### PR DESCRIPTION
```mlir-python-extras``` dependencies expire (are removed) after 30 days. I believe this is the cause of the CI error I'm getting elsewhere:
```
Successfully installed aiofiles-25.1.0 dataclasses-0.6 markdown-it-py-4.0.0 mdurl-0.1.2 ml_dtypes-0.5.4 numpy-1.26.4 pygments-2.19.2 rich-14.2.0
Looking in links: https://llvm.github.io/eudsl
ERROR: Could not find a version that satisfies the requirement mlir-python-bindings==20251205+e067be338 (from versions: 20251206+6d8714b52, 20251207+315c904e3, 20251208+315c904e3, 20251208+fc92e4dec, 20251209+cdb525d2e, 20251212+16e605527, 20251212+e760d0619, 20251213+9878bac3a, 20251214+b33354f27, 20251216+1ea201d73, 20251216+b9d143221, 20251217+8a6fae420, 20251218+88461e8f5, 20251219+6e7a44986, 20251220+a8f19259e, 20251221+da98be133, 20251223+4ef602d44, 20251225+e135447bd, 20251226+016c0b50c, 20251227+c9eb572b1, 20251228+f59e2b20e, 20251229+2c72af882, 20260101+6f0d05f7c, 20260102+d3960db44, 20260104+b45603959, 20260105+112df6ab8)
ERROR: No matching distribution found for mlir-python-bindings==20251205+e067be338
```

It turns out, this dependency is also not needed, so I just removed it to fix this issue.