### PR TITLE
Add new gh pages documentation dependency

### DIFF
--- a/include/aie/Dialect/AIE/IR/CMakeLists.txt
+++ b/include/aie/Dialect/AIE/IR/CMakeLists.txt
@@ -87,3 +87,6 @@ mlir_tablegen(AIEAttrs.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(MLIRAIEAttrDefsIncGen)
 add_dependencies(aie-headers MLIRAIEAttrDefsIncGen)
 add_dependencies(MLIRAIEAttrDefsIncGen GenerateAIEEventsTD)
+
+# Ensure generated event enums exist before generating documentation
+add_dependencies(AIEDialectDocGen GenerateAIEEventsTD)


### PR DESCRIPTION
It looks like https://github.com/Xilinx/mlir-aie/pull/2696 introduced a new dependency to the documentation, so the CI started producing this error:
```
aie/include/aie/Dialect/AIE/IR/AIEAttrs.td:213:9: error: could not find include file 'AIEEvents.td.inc'
include "AIEEvents.td.inc"
        ^
Included from /home/runner/work/mlir-aie/mlir-aie/include/aie/Dialect/AIE/IR/AIEDocs.td:14:
/home/runner/work/mlir-aie/mlir-aie/include/aie/Dialect/AIE/IR/AIEAttrs.td:213:9: error: Unexpected token at top level
include "AIEEvents.td.inc"
        ^
make[3]: *** [include/aie/Dialect/AIE/IR/CMakeFiles/AIEDialectDocGen.dir/build.make:84: include/aie/Dialect/AIE/IR/AIEDialect.md] Error 1
make[2]: *** [CMakeFiles/Makefile2:3681: include/aie/Dialect/AIE/IR/CMakeFiles/AIEDialectDocGen.dir/all] Error 2
```

In my local tests, the changes in this PR fixed the issue.