### PR TITLE
Deps fixup for 'ninja python/dialects/_aie_ops_gen.py'

### DIFF
--- a/include/aie/Dialect/AIE/IR/CMakeLists.txt
+++ b/include/aie/Dialect/AIE/IR/CMakeLists.txt
@@ -77,9 +77,6 @@ add_custom_target(GenerateAIEEventsTD
   DEPENDS ${GENERATED_EVENTS_TD_FILES}
 )
 
-# Ensure generated event enums exist before any headers that depend on them
-add_dependencies(aie-headers GenerateAIEEventsTD)
-
 # Add AIE attributes
 set(LLVM_TARGET_DEFINITIONS AIEAttrs.td)
 mlir_tablegen(AIEAttrs.h.inc -gen-attrdef-decls)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -72,6 +72,8 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME aie
   GEN_ENUM_BINDINGS_TD_FILE
     "dialects/AIEBinding.td"
+  DEPENDS
+    aie-headers
 )
 
 declare_mlir_dialect_python_bindings(
@@ -81,6 +83,8 @@ declare_mlir_dialect_python_bindings(
   SOURCES
     dialects/aiex.py
   DIALECT_NAME aiex
+  DEPENDS
+    aie-headers
 )
 
 declare_mlir_dialect_python_bindings(
@@ -90,6 +94,8 @@ declare_mlir_dialect_python_bindings(
   SOURCES
     dialects/aievec.py
   DIALECT_NAME aievec
+  DEPENDS
+    aie-headers
 )
 
 configure_file(compiler/aiecc/configure.py.in aie/compiler/aiecc/configure.py)


### PR DESCRIPTION
Make sure aie dialect includes are generated before building python binding tablegen files. Follow-on to #2799. Without this `ninja clean && ninja python/dialects/_aie_ops_gen.py` will fail.