### PR TITLE
WSL Compatibility: Allow common.cmake to find repo root in WSL

### DIFF
--- a/programming_examples/common.cmake
+++ b/programming_examples/common.cmake
@@ -7,30 +7,72 @@
 # Common CMake configuration for programming examples
 # This file provides common setup for test_utils library linking
 
-# Get MLIR_AIE_DIR from Python
-execute_process(
-    COMMAND python3 -c "from aie.utils.config import root_path; print(root_path())"
-    OUTPUT_VARIABLE MLIR_AIE_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+# -----------------------------------------------------------------------------
+# Resolve MLIR-AIE root directory
+# -----------------------------------------------------------------------------
+# In WSL, CMake runs on Windows via `powershell.exe cmake`. Therefore, we must
+# prefer deterministic repo-root detection. Fall back to Python only if needed.
 
-# Set test_utils library paths
-set(TEST_UTILS_LIB_DIR "${MLIR_AIE_DIR}/runtime_lib/x86_64/test_lib/lib")
-set(TEST_UTILS_INC_DIR "${MLIR_AIE_DIR}/runtime_lib/x86_64/test_lib/include")
+get_filename_component(_mlir_aie_repo_root "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+if(EXISTS "${_mlir_aie_repo_root}/runtime_lib/test_lib/xrt_test_wrapper.h")
+  set(MLIR_AIE_DIR "${_mlir_aie_repo_root}")
+else()
+  find_package(Python3 COMPONENTS Interpreter QUIET)
+  if(Python3_Interpreter_FOUND)
+    execute_process(
+      COMMAND "${Python3_EXECUTABLE}" -c "from aie.utils.config import root_path; print(root_path())"
+      OUTPUT_VARIABLE MLIR_AIE_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_QUIET
+    )
+  endif()
+endif()
+
+if(NOT MLIR_AIE_DIR)
+  message(FATAL_ERROR "Unable to determine MLIR_AIE_DIR (repo root not found and Python probe unavailable).")
+endif()
+
+# -----------------------------------------------------------------------------
+# test_utils discovery
+# -----------------------------------------------------------------------------
+# Preferred: installed layout (from cmake --install). Fallback: build from source.
+set(TEST_UTILS_INST_LIB_DIR "${MLIR_AIE_DIR}/runtime_lib/x86_64/test_lib/lib")
+set(TEST_UTILS_INST_INC_DIR "${MLIR_AIE_DIR}/runtime_lib/x86_64/test_lib/include")
+set(TEST_UTILS_SRC_DIR     "${MLIR_AIE_DIR}/runtime_lib/test_lib")
 set(TEST_UTILS_RUNTIME_LIB_DIR "${MLIR_AIE_DIR}/runtime_lib")
 
-# Function to add test_utils library to a target
 function(target_link_test_utils target_name)
-    target_include_directories(${target_name} PUBLIC
-        ${TEST_UTILS_RUNTIME_LIB_DIR}
-        ${TEST_UTILS_INC_DIR}
-    )
-    
-    target_link_directories(${target_name} PUBLIC
-        ${TEST_UTILS_LIB_DIR}
-    )
-    
-    target_link_libraries(${target_name} PUBLIC
-        test_utils
-    )
+  target_include_directories(${target_name} PUBLIC "${TEST_UTILS_RUNTIME_LIB_DIR}")
+
+  # 1) Use installed/prebuilt if present
+  if(EXISTS "${TEST_UTILS_INST_INC_DIR}/xrt_test_wrapper.h" AND EXISTS "${TEST_UTILS_INST_LIB_DIR}")
+    target_include_directories(${target_name} PUBLIC "${TEST_UTILS_INST_INC_DIR}")
+    target_link_directories(${target_name} PUBLIC "${TEST_UTILS_INST_LIB_DIR}")
+    target_link_libraries(${target_name} PUBLIC test_utils)
+    return()
+  endif()
+
+  # 2) Otherwise build test_utils from source
+  if(NOT EXISTS "${TEST_UTILS_SRC_DIR}/test_utils.cpp")
+    message(FATAL_ERROR "test_utils source not found at: ${TEST_UTILS_SRC_DIR}")
+  endif()
+
+  target_include_directories(${target_name} PUBLIC "${TEST_UTILS_SRC_DIR}")
+
+  if(NOT TARGET test_utils)
+    add_library(test_utils STATIC "${TEST_UTILS_SRC_DIR}/test_utils.cpp")
+    target_include_directories(test_utils PUBLIC "${TEST_UTILS_SRC_DIR}" "${TEST_UTILS_RUNTIME_LIB_DIR}")
+
+    # Enable XRT helpers if the example provided an XRT include dir
+    if(DEFINED XRT_INCLUDE_DIR)
+      target_include_directories(test_utils PUBLIC "${XRT_INCLUDE_DIR}")
+      target_compile_definitions(test_utils PRIVATE TEST_UTILS_USE_XRT)
+    elseif(DEFINED XRT_INC_DIR)
+      target_include_directories(test_utils PUBLIC "${XRT_INC_DIR}")
+      target_compile_definitions(test_utils PRIVATE TEST_UTILS_USE_XRT)
+    endif()
+  endif()
+
+  target_link_libraries(${target_name} PUBLIC test_utils)
 endfunction()
+


### PR DESCRIPTION
Fixes WSL reversion from #2642 (Windows PowerShell was not seeing the correct directories). Now allows examples to be built in WSL checkouts. Mostly. There may still be issues with Python tests that will be addressed later.

Still requires the user to `source /opt/xilinx/xrt/setup.sh` before attempting compile. I am out of the loop, so I'm not sure why that was removed from environmental setup. This could also be a WSL-specific issue.