### PR TITLE
Improve some error propagation and handling

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.h
@@ -73,9 +73,9 @@ struct AIEPathfinderPass : AIERoutePathfinderFlowsBase<AIEPathfinderPass> {
   AIEPathfinderPass() = default;
 
   void runOnOperation() override;
-  void runOnFlow(DeviceOp d, DynamicTileAnalysis &analyzer);
-  void runOnPacketFlow(DeviceOp d, mlir::OpBuilder &builder,
-                       DynamicTileAnalysis &analyzer);
+  mlir::LogicalResult runOnFlow(DeviceOp d, DynamicTileAnalysis &analyzer);
+  mlir::LogicalResult runOnPacketFlow(DeviceOp d, mlir::OpBuilder &builder,
+                                      DynamicTileAnalysis &analyzer);
 
   typedef std::pair<TileID, Port> PhysPort;
 

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -325,11 +325,13 @@ struct AIEGenerateColumnControlOverlayPass
         ctrlPktFlowID = tileIDMap[{tOp.colIndex(), tOp.rowIndex()}];
       // Check shim channel availability
       if (!llvm::is_contained(availableShimChans,
-                              rowToShimChanMap[tOp.rowIndex()]))
+                              rowToShimChanMap[tOp.rowIndex()])) {
         device->emitOpError(
             "failed to generate column control overlay from shim dma to tile "
             "ctrl ports, because some shim mm2s dma channels were reserved "
             "from routing control packets.");
+        return signalPassFailure();
+      }
 
       auto keep_pkt_header = builder.getBoolAttr(true);
       auto ctrl_pkt_flow = builder.getBoolAttr(true);

--- a/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
@@ -56,7 +56,7 @@ struct AIELowerCascadeFlowsPass
         // TODO: remove when this pass supports routing
         cascadeFlow.emitOpError(
             "source tile must be to the North or West of the destination tile");
-        return;
+        return signalPassFailure();
       }
     }
 

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -429,8 +429,10 @@ public:
     if (targetModel.isMemTile(tileCol, tileRow) && (!isMM2S) &&
         (op.getD0ZeroBefore() != 0 || op.getD0ZeroAfter() != 0 ||
          op.getD1ZeroBefore() != 0 || op.getD1ZeroAfter() != 0 ||
-         op.getD2ZeroBefore() != 0 || op.getD2ZeroAfter() != 0))
+         op.getD2ZeroBefore() != 0 || op.getD2ZeroAfter() != 0)) {
       op->emitOpError("MemTile supports zero padding only on MM2S direction");
+      return failure();
+    }
 
     // write the buffer descriptor to the array
     NpuWriteBdOp::create(

--- a/test/dialect/AIE/bad_column_control_overlay.mlir
+++ b/test/dialect/AIE/bad_column_control_overlay.mlir
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt %s -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" --split-input-file 2>&1 | FileCheck %s
+// RUN: not aie-opt %s -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" 2>&1 | FileCheck %s
 
 // CHECK: error: 'aie.device' op failed to generate column control overlay from shim dma to tile ctrl ports, because some shim mm2s dma channels were reserved from routing control packets.
 


### PR DESCRIPTION
While debugging #2474 I found some cases where `emitOpError` is called but the error is not propagated and compilation continues. This led to at least one case where `aie-opt` reported an error and exited correctly in some builds but segfaulted in other builds. I grepped for other such cases and found the ones in this PR. In a few cases functions were refactored to propagate the errors up to the caller for handling.