### PR TITLE
Add checks on DMA region ops

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -332,7 +332,7 @@ LogicalResult HasValidBDs<ConcreteType>::verifyTrait(Operation *op) {
           .append("in this BD block");
     }
 
-    // Check exactly 2 UseLockOps per BD block (1 acquire, 1 release)
+    // Check at most 2 UseLockOps per BD block (1 acquire, 1 release)
     auto useLockOps =
         llvm::to_vector_of<UseLockOp>(block.template getOps<UseLockOp>());
     int acquireCount = 0;
@@ -344,16 +344,16 @@ LogicalResult HasValidBDs<ConcreteType>::verifyTrait(Operation *op) {
         releaseCount++;
     }
 
-    if (acquireCount != 1) {
+    if (acquireCount > 1) {
       return (op->emitOpError(
-                  "BD block must have exactly one acquire UseLockOp, found ")
+                  "BD block must have at most one acquire UseLockOp, found ")
               << acquireCount)
           .attachNote(block.front().getLoc())
           .append("in this BD block");
     }
-    if (releaseCount != 1) {
+    if (releaseCount > 1) {
       return (op->emitOpError(
-                  "BD block must have exactly one release UseLockOp, found ")
+                  "BD block must have at most one release UseLockOp, found ")
               << releaseCount)
           .attachNote(block.front().getLoc())
           .append("in this BD block");

--- a/test/dialect/AIE/badmem.mlir
+++ b/test/dialect/AIE/badmem.mlir
@@ -30,7 +30,7 @@ module @test {
   %buff = aie.buffer(%t1) : memref<16xi32>
   %lock = aie.lock(%t1, 0)
   %lock_test = aie.lock(%t1, 1)
-  // expected-error@+1 {{'aie.mem' op BD block must have exactly one acquire UseLockOp, found 2}}
+  // expected-error@+1 {{'aie.mem' op BD block must have at most one acquire UseLockOp, found 2}}
   %mem13 = aie.mem(%t1) {
     %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
     ^bd0:
@@ -54,7 +54,7 @@ module @test {
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %prod_lock_test = aie.lock(%t1, 1) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
-    // expected-error@+1 {{'aie.mem' op BD block must have exactly one acquire UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.mem' op BD block must have at most one acquire UseLockOp, found 2}}
     %mem13 = aie.mem(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -79,7 +79,7 @@ module @test {
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
     %cons_lock_test = aie.lock(%t1, 1) {init = 0 : i32}
-    // expected-error@+1 {{'aie.mem' op BD block must have exactly one release UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.mem' op BD block must have at most one release UseLockOp, found 2}}
     %mem13 = aie.mem(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -104,7 +104,7 @@ module @test {
     %buff2 = aie.buffer(%t1) : memref<16xi32>
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
-    // expected-error@+1 {{'aie.mem' op BD block must have exactly one DMABDOp, found 2}}
+    // expected-error@+1 {{'aie.mem' op BD block must have at most one DMABDOp, found 2}}
     %mem13 = aie.mem(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:

--- a/test/dialect/AIE/badmemtiledma.mlir
+++ b/test/dialect/AIE/badmemtiledma.mlir
@@ -29,7 +29,7 @@ module @test {
     %buff = aie.buffer(%t1) : memref<16xi32>
     %lock = aie.lock(%t1, 0)
     %lock_test = aie.lock(%t1, 1)
-    // expected-error@+1 {{'aie.memtile_dma' op BD block must have exactly one acquire UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.memtile_dma' op BD block must have at most one acquire UseLockOp, found 2}}
     %mem13 = aie.memtile_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -54,7 +54,7 @@ module @test {
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %prod_lock_test = aie.lock(%t1, 1) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
-    // expected-error@+1 {{'aie.memtile_dma' op BD block must have exactly one acquire UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.memtile_dma' op BD block must have at most one acquire UseLockOp, found 2}}
     %mem13 = aie.memtile_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -79,7 +79,7 @@ module @test {
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
     %cons_lock_test = aie.lock(%t1, 1) {init = 0 : i32}
-    // expected-error@+1 {{'aie.memtile_dma' op BD block must have exactly one release UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.memtile_dma' op BD block must have at most one release UseLockOp, found 2}}
     %mem13 = aie.memtile_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -104,7 +104,7 @@ module @test {
     %buff2 = aie.buffer(%t1) : memref<16xi32>
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
-    // expected-error@+1 {{'aie.memtile_dma' op BD block must have exactly one DMABDOp, found 2}}
+    // expected-error@+1 {{'aie.memtile_dma' op BD block must have at most one DMABDOp, found 2}}
     %mem13 = aie.memtile_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:

--- a/test/dialect/AIE/badshimtiledma.mlir
+++ b/test/dialect/AIE/badshimtiledma.mlir
@@ -31,17 +31,14 @@ module @test {
       ^dma2:
         %dma3 = aie.dma_start("S2MM", 2, ^bd2, ^end)
       ^bd0:
-        aie.use_lock(%lock_e, Acquire, 1)
         aie.dma_bd(%buf_e : memref<256xi32>, 1, 256)
         aie.use_lock(%lock_e, Release, 1)
         aie.next_bd ^bd0
       ^bd1:
-        aie.use_lock(%lock_l, Acquire, 1)
         aie.dma_bd(%buf_l : memref<256xi32>, 1, 256)
         aie.use_lock(%lock_l, Release, 1)
         aie.next_bd ^bd1
       ^bd2:
-        aie.use_lock(%lock_n, Acquire, 1)
         aie.dma_bd(%buf_n : memref<256xi32>, 1, 256)
         aie.use_lock(%lock_n, Release, 1)
         aie.next_bd ^bd2
@@ -59,7 +56,7 @@ module @test {
     %buff = aie.external_buffer : memref<16xi32>
     %lock = aie.lock(%t1, 0)
     %lock_test = aie.lock(%t1, 1)
-    // expected-error@+1 {{'aie.shim_dma' op BD block must have exactly one acquire UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.shim_dma' op BD block must have at most one acquire UseLockOp, found 2}}
     %mem13 = aie.shim_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -84,7 +81,7 @@ module @test {
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %prod_lock_test = aie.lock(%t1, 1) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
-    // expected-error@+1 {{'aie.shim_dma' op BD block must have exactly one acquire UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.shim_dma' op BD block must have at most one acquire UseLockOp, found 2}}
     %mem13 = aie.shim_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -109,7 +106,7 @@ module @test {
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
     %cons_lock_test = aie.lock(%t1, 1) {init = 0 : i32}
-    // expected-error@+1 {{'aie.shim_dma' op BD block must have exactly one release UseLockOp, found 2}}
+    // expected-error@+1 {{'aie.shim_dma' op BD block must have at most one release UseLockOp, found 2}}
     %mem13 = aie.shim_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
@@ -134,7 +131,7 @@ module @test {
     %buff2 = aie.external_buffer : memref<16xi32>
     %prod_lock = aie.lock(%t1, 0) {init = 2 : i32}
     %cons_lock = aie.lock(%t1, 2) {init = 0 : i32}
-    // expected-error@+1 {{'aie.shim_dma' op BD block must have exactly one DMABDOp, found 2}}
+    // expected-error@+1 {{'aie.shim_dma' op BD block must have at most one DMABDOp, found 2}}
     %mem13 = aie.shim_dma(%t1) {
       %dma0 = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:


### PR DESCRIPTION
### Summary
DMA region operations for all tile types (`MemOp`,  `MemTileDMAOp`) are missing checks that verify:
- there can only be one `DMABdOp` in each block,
- there can only be one lock acquire operation in each block,
- there can only be one lock release operation in each block.

These checks are currently only present in the high-level DMA block primitive `DMAOp`.

### Changes
- Applied these checks to the existing `HasValidBDs` trait for DMA-like Ops.
- Added unit tests for all DMA-like tile types.
- `DMAOp` verification is kept separate and unchanged due to potential refactoring as a higher-level primitive for DMA-like Ops.