### PR TITLE
fix buffer size in programming guide example

### DIFF
--- a/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/test.cpp
@@ -57,8 +57,8 @@ int main(int argc, const char *argv[]) {
                           XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
   auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(DATATYPE),
                         XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
-  auto bo_inB = xrt::bo(device, 1 * sizeof(DATATYPE), XRT_BO_FLAGS_HOST_ONLY,
-                        kernel.group_id(4));
+  auto bo_inB = xrt::bo(device, IN_SIZE * sizeof(DATATYPE),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
   auto bo_outC = xrt::bo(device, OUT_SIZE * sizeof(DATATYPE),
                          XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
 


### PR DESCRIPTION
I noticed that one of the programming examples failed in the CI with two mismatches. I'm not sure if this will help or not, but this PR fixes an inconsistency in argument size between the IRON design and the test.cpp file and the python design. I didn't stumble upon anything else weird that may be causing intermittent CI errors with this example, but I'm open to suggestions.