### PR TITLE
add retry logic to xrt device fetching

### DIFF
--- a/python/utils/hostruntime/xrtruntime/hostruntime.py
+++ b/python/utils/hostruntime/xrtruntime/hostruntime.py
@@ -78,7 +78,17 @@ class XRTHostRuntime(HostRuntime):
         """
         Initialize the XRTHostRuntime.
         """
-        self._device = pyxrt.device(0)
+        # Retry logic for device acquisition to handle transient failures
+        max_retries = 5
+        for attempt in range(max_retries):
+            try:
+                self._device = pyxrt.device(0)
+                break
+            except RuntimeError as e:
+                if attempt == max_retries - 1:
+                    raise e
+                time.sleep(1)
+
         self._device_type_str = self._device.get_info(pyxrt.xrt_info_device.name)
 
         self.npu_str = None


### PR DESCRIPTION
I'm not sure why this happens, but the CI in another PR had this error:
```
     from aie.utils.trace.utils import (
  File "/home/github/actions-runner/_work/mlir-aie/mlir-aie/build/python/aie/utils/__init__.py", line 157, in <module>
    DefaultNPURuntime = CachedXRTRuntime()
                        ^^^^^^^^^^^^^^^^^^
  File "/home/github/actions-runner/_work/mlir-aie/mlir-aie/build/python/aie/utils/hostruntime/xrtruntime/hostruntime.py", line 318, in __init__
    super().__init__()
  File "/home/github/actions-runner/_work/mlir-aie/mlir-aie/build/python/aie/utils/hostruntime/xrtruntime/hostruntime.py", line 81, in __init__
    self._device = pyxrt.device(0)
                   ^^^^^^^^^^^^^^^
RuntimeError:  No such device with index '0'
make: *** [/home/github/actions-runner/_work/mlir-aie/mlir-aie/programming_examples/basic/passthrough_kernel/Makefile:85: trace] Error 1
```

This PR didn't make any relevant changes that may have created this failure, so I assume that occasionally the driver may be in a bad state and cause this error. 

This PR adds retry logic to try to handle a transient error such as this more smoothly.