### PR TITLE
update build drivers script version tag + minor changes

### DIFF
--- a/utils/build_drivers.sh
+++ b/utils/build_drivers.sh
@@ -93,7 +93,7 @@ fi
 
 echo "Setting up XDNA driver repository..."
 # Clone or update the XDNA driver repository and initialize submodules
-XDNA_TAG=1.6
+XDNA_TAG=f3293dc901d733438468cd8b055adb250fa6ced0
 if [ -d "xdna-driver" ]; then
     echo "xdna-driver directory already exists. Removing and re-cloning to ensure clean state..."
     rm -rf xdna-driver
@@ -194,7 +194,6 @@ echo "Building XDNA Driver..."
 # Build XDNA Driver
 cd "$XDNA_SRC_DIR/build"
 run_build ./build.sh -release
-run_build ./build.sh -package
 
 echo "Installing XDNA plugin..."
 # Install XDNA plugin based on Ubuntu version
@@ -233,4 +232,3 @@ echo "Installing plugin package: $plugin_pkg"
 sudo apt reinstall -y "./$plugin_pkg"
 
 echo "xdna-driver and XRT built and installed successfully."
-echo "Please reboot to apply changes."


### PR DESCRIPTION
The full ELF flow requires a more recent version of the XDNA firmware, see discussion in #2641. Fixing the current xdna-driver SHA for now, which I confirmed works with full ELF.

Two minor other changes: the `build.sh -package` step is no longer required by xdna-driver, so I removed it, and installing the deb packages automatically reloads the `xdna` kernel module without rebooting required, so removed that instruction.