### PR TITLE
Change XDNA driver commit

### DIFF
--- a/utils/build_drivers.sh
+++ b/utils/build_drivers.sh
@@ -93,7 +93,8 @@ fi
 
 echo "Setting up XDNA driver repository..."
 # Clone or update the XDNA driver repository and initialize submodules
-XDNA_TAG=f3293dc901d733438468cd8b055adb250fa6ced0
+XDNA_TAG=beb9e450fe123ecdf395453971576179cedcf1dd
+# (1.7 tag as of 2026/02/17) 
 if [ -d "xdna-driver" ]; then
     echo "xdna-driver directory already exists. Removing and re-cloning to ensure clean state..."
     rm -rf xdna-driver


### PR DESCRIPTION
The commit I put in there a bit ago already 404s for the firmware version when I just tried rebuilding the driver. This is the `1.7` tag which also seems to work and might be more stable in terms of firmware version. It seems to include full ELF support (why we needed a newer driver/XRT in the first place) but using this PR to run the CI and fully test.