### PR TITLE
Add pre-push hooks for clang-format and black formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,5 +2,26 @@ repos:
 - repo: https://github.com/kynan/nbstripout
   rev: 0.8.0
   hooks:
-    - id: nbstripout 
+    - id: nbstripout
       args: [--drop-empty-cells]
+
+# Formatting hooks (run on pre-push to catch issues before CI)
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v17.0.6
+  hooks:
+    - id: clang-format
+      types_or: [c, c++]
+      stages: [pre-push]
+
+- repo: https://github.com/psf/black
+  rev: 24.10.0
+  hooks:
+    - id: black
+      stages: [pre-push]
+      # Exclude generated files and third-party code
+      exclude: |
+        (?x)^(
+          third_party/.*|
+          build/.*|
+          ironenv/.*
+        )$

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
    # This installs the pre-commit hooks defined in .pre-commit-config.yaml
    pre-commit install
+
+   # Install pre-push hooks for formatting (clang-format, black)
+   # These run before push to catch formatting issues before CI
+   pre-commit install --hook-type pre-push
    ```
 
 1. Setup environment


### PR DESCRIPTION
CI requires proper formatting with clang-format 17 and black. This adds pre-push hooks that run these formatters on changed files before pushing, helping catch formatting issues before they fail in CI.

Hooks only run on pre-push (not pre-commit) to avoid slowing down local development while still catching issues before they reach CI.