### PR TITLE
Fix memtile DMA BD address missing base offset

### DIFF
--- a/test/npu-xrt/memtile_dmas/dma_configure_task_lock/run.lit
+++ b/test/npu-xrt/memtile_dmas/dma_configure_task_lock/run.lit
@@ -1,7 +1,7 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai_npu1
+// REQUIRES: ryzen_ai
 //
 // RUN: cp %S/aie.mlir aie_arch.mlir
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir

--- a/test/npu-xrt/memtile_dmas/dma_configure_task_token/run.lit
+++ b/test/npu-xrt/memtile_dmas/dma_configure_task_token/run.lit
@@ -1,7 +1,7 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// REQUIRES: ryzen_ai_npu1
+// REQUIRES: ryzen_ai
 //
 // RUN: cp %S/aie.mlir aie_arch.mlir
 // RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir


### PR DESCRIPTION
## Summary

- Fix missing memtile memory base address offset in `setAddressForSingleBD()` (`AIEDMATasksToNPU.cpp`), which caused memtile DMA hangs on NPU2
- Enable memtile DMA tests (`dma_configure_task_lock`, `dma_configure_task_token`) for NPU2 in CI
- Update 5 lit tests with corrected expected address values

## Root Cause

`setAddressForSingleBD()` was computing memtile buffer addresses without the `getMemLocalBaseAddress()` offset. Memtile DMAs address memory through an offset-based address space (west=0, internal=0x80000, east=0x100000). Without the internal offset, buffer addresses at column 0 landed in the non-existent west neighbor memory region, causing the DMA to stall and locks to never release.

The AIERT path (`AIERT.cpp:376-386`) correctly adds this offset via `getMemLocalBaseAddress()`. This PR aligns the NpuWriteBd path with the AIERT reference.

## Test plan

- [x] `memtile_dmas/dma_configure_task_lock` passes on NPU2 (was hanging)
- [x] `memtile_dmas/dma_configure_task` passes on NPU2 (was also affected)
- [x] `core_dmas/dma_configure_task_lock` still passes on NPU2
- [x] All 37 `dma-tasks-to-npu` lit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)