### PR TITLE
[aievec] Extend vector.fma to 32-lane bf16 with splitting

### DIFF
--- a/test/Conversion/VectorToAIEVec/test-vector-fma.mlir
+++ b/test/Conversion/VectorToAIEVec/test-vector-fma.mlir
@@ -40,11 +40,18 @@ func.func @test_fma_f32(%v0: vector<16xbf16>,
 
 // Test 32-lane bf16 vector.fma (split into two 16-lane FMAs)
 // CHECK-LABEL: test_fma_bf16_v32
+// CHECK-SAME: %[[V0:[a-zA-Z0-9]+]]: vector<32xbf16>,
+// CHECK-SAME: %[[V1:[a-zA-Z0-9]+]]: vector<32xbf16>,
+// CHECK-SAME: %[[V2:[a-zA-Z0-9]+]]: vector<32xbf16>)
 func.func @test_fma_bf16_v32(%v0: vector<32xbf16>,
                               %v1: vector<32xbf16>,
                               %v2: vector<32xbf16>) -> vector<32xbf16> {
-  // CHECK-DAG: aievec.ext %{{.*}} {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
-  // CHECK-DAG: aievec.ext %{{.*}} {index = 1 : i8} : vector<32xbf16>, vector<16xbf16>
+  // CHECK-DAG: %[[V0_LO:.*]] = aievec.ext %[[V0]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
+  // CHECK-DAG: %[[V0_HI:.*]] = aievec.ext %[[V0]] {index = 1 : i8} : vector<32xbf16>, vector<16xbf16>
+  // CHECK-DAG: %[[V1_LO:.*]] = aievec.ext %[[V1]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
+  // CHECK-DAG: %[[V1_HI:.*]] = aievec.ext %[[V1]] {index = 1 : i8} : vector<32xbf16>, vector<16xbf16>
+  // CHECK-DAG: %[[V2_LO:.*]] = aievec.ext %[[V2]] {index = 0 : i8} : vector<32xbf16>, vector<16xbf16>
+  // CHECK-DAG: %[[V2_HI:.*]] = aievec.ext %[[V2]] {index = 1 : i8} : vector<32xbf16>, vector<16xbf16>
   // CHECK: aievec.ups %{{.*}} {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
   // CHECK: aievec.mac_elem %{{.*}}, %{{.*}}, %{{.*}} : vector<16xbf16>, vector<16xbf16>, vector<16xf32>
   // CHECK: aievec.srs %{{.*}}, %{{.*}} : vector<16xf32>, i32, vector<16xbf16>


### PR DESCRIPTION
## Summary
- Extend `ConvertVectorFMAOpToAIEVecFMAElemOpPattern` to handle `vector<32xbf16>` by splitting into two 16-lane FMAs via `splitWideVectorOp`
- Mirrors the existing `ConvertMulAddFToAIEVecFMAElemOpPattern` 32-lane approach (added in #2896)
- Previously, `vector.fma` on `vector<32xbf16>` failed with `failed to legalize operation 'vector.fma'` because the pattern hardcoded `numElems != 16`

## Test plan
- [x] New unit test `@test_fma_bf16_v32` in `test-vector-fma.mlir` passes FileCheck
- [x] Existing 16-lane `@test_fma_bf16` and `@test_fma_f32` tests still pass (no regressions)
- [x] Hardware verified on NPU2: mlir-air `vector_fma` example with VECTOR_SIZE=32 prints PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)