### PR TITLE
[aievec] Allow f32 mulf→addf to convert independently of FMA

### DIFF
--- a/test/Conversion/VectorToAIEVec/test-f32-mul-add.mlir
+++ b/test/Conversion/VectorToAIEVec/test-f32-mul-add.mlir
@@ -1,0 +1,35 @@
+//===- test-f32-mul-add.mlir ----------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s -split-input-file --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" | FileCheck %s
+
+// Test: f32 mulf→addf should NOT be deferred to FMA (FMA only handles bf16).
+// The addf should be independently converted to aievec.add_elem instead of
+// failing to legalize.
+
+// CHECK-LABEL: func @test_f32_mul_add
+// CHECK: arith.mulf
+// CHECK: aievec.add_elem
+func.func @test_f32_mul_add(%a: vector<16xf32>, %b: vector<16xf32>, %c: vector<16xf32>) -> vector<16xf32> {
+  %0 = arith.mulf %a, %b : vector<16xf32>
+  %1 = arith.addf %0, %c : vector<16xf32>
+  return %1 : vector<16xf32>
+}
+
+// -----
+
+// bf16 mulf→addf should still be deferred to FMA (existing behavior)
+// CHECK-LABEL: func @test_bf16_mul_add_fma
+// CHECK: aievec.mac_elem
+func.func @test_bf16_mul_add_fma(%a: vector<16xbf16>, %b: vector<16xbf16>, %c: vector<16xbf16>) -> vector<16xbf16> {
+  %0 = arith.mulf %a, %b : vector<16xbf16>
+  %1 = arith.addf %0, %c : vector<16xbf16>
+  return %1 : vector<16xbf16>
+}


### PR DESCRIPTION
## Summary
- Fix legalization failure for f32 `mulf→addf` chains (e.g., variance `acc + x²` in layer_norm/rms_norm)
- The FMA pattern only handles bf16 — gate the FMA deferral on `isBF16()` for floats
- Preserve integer MAC deferral for i32 (`muli→addi`) using `!isF32()` guard
- f32 path now produces `arith.mulf` + `aievec.add_elem` independently

## Test plan
- [x] New test: `test-f32-mul-add.mlir` — f32 produces `add_elem`, bf16 still fuses to `mac_elem`
- [x] Regression: `test_mac_elem.mlir` — integer MAC fusion preserved
- [x] Regression: `test-vector-fma.mlir`, `test-float-fma-fusion.mlir` — bf16 FMA unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)