### PR TITLE
[aievec] Add aievec.neg lowering and bf16 divf conversion pattern

### DIFF
--- a/test/Conversion/AIEVecToLLVM/test-neg-aie2p.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-neg-aie2p.mlir
@@ -1,0 +1,37 @@
+//===- test-neg-aie2p.mlir -----------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s -split-input-file --convert-aievec-to-llvm="aie-target=aie2p" | FileCheck %s
+
+// Test: aievec.neg → scalar llvm.fneg via extract/insert unrolling
+
+// CHECK-LABEL: @test_neg_v16f32
+// CHECK-SAME: %[[ARG:.*]]: vector<16xf32>
+func.func @test_neg_v16f32(%arg0 : vector<16xf32>) -> vector<16xf32> {
+  // CHECK: llvm.mlir.poison
+  // CHECK: llvm.extractelement
+  // CHECK: llvm.fneg
+  // CHECK: llvm.insertelement
+  %0 = aievec.neg %arg0 : vector<16xf32>
+  return %0 : vector<16xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @test_neg_v16bf16
+// CHECK-SAME: %[[ARG:.*]]: vector<16xbf16>
+func.func @test_neg_v16bf16(%arg0 : vector<16xbf16>) -> vector<16xbf16> {
+  // CHECK: llvm.mlir.poison
+  // CHECK: llvm.extractelement
+  // CHECK: llvm.fneg
+  // CHECK: llvm.insertelement
+  %0 = aievec.neg %arg0 : vector<16xbf16>
+  return %0 : vector<16xbf16>
+}

--- a/test/Conversion/VectorToAIEVec/test-bf16-divf.mlir
+++ b/test/Conversion/VectorToAIEVec/test-bf16-divf.mlir
@@ -1,0 +1,27 @@
+//===- test-bf16-divf.mlir -----------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s -split-input-file --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" | FileCheck %s
+
+// Test: bf16 vector arith.divf converted to a * inv(b) via f32 promotion.
+// a/b → ups(a) → ups(b) → inv(b_f32) → mul_elem(a_f32, inv_b) → srs → bf16
+// Note: extf/truncf lowered to ups/srs, 1.0/b lowered to aievec.inv by
+// existing patterns in the same pass.
+
+// CHECK-LABEL: func @test_bf16_divf_v16
+// CHECK: aievec.ups {{.*}} : vector<16xbf16>, vector<16xf32>
+// CHECK: aievec.ups {{.*}} : vector<16xbf16>, vector<16xf32>
+// CHECK: aievec.inv
+// CHECK: aievec.mul_elem
+// CHECK: aievec.srs {{.*}} : vector<16xf32>, i32, vector<16xbf16>
+func.func @test_bf16_divf_v16(%a: vector<16xbf16>, %b: vector<16xbf16>) -> vector<16xbf16> {
+  %0 = arith.divf %a, %b : vector<16xbf16>
+  return %0 : vector<16xbf16>
+}


### PR DESCRIPTION
## Summary
- Add `NegOpConversion`: lowers `aievec.neg` to scalar `llvm.fneg` via extract/insert unrolling (same pattern as `InvOpAIE2pConversion`)
- Add `ConvertBF16DivFToMulInvPattern`: converts bf16 `arith.divf(a, b)` to `extf → const(1.0)/b → a*inv(b) → truncf`
- Add bf16 divf legalization marking it as illegal for 16/32-lane vectors

## Known Limitations
- **NegOp**: Peano's LLVM O3 may re-vectorize scalar fneg back to vector `G_FNEG` which is not legalized. Works at `-O0`/`-O1`.
- **bf16 divf**: The intermediate `arith.divf(1.0, b)` and `arith.mulf` created during partial conversion may hit legalization issues depending on pattern ordering. Needs validation with end-to-end examples.

## Test plan
- [x] `test-neg-aie2p.mlir` — NegOp lowering for v16f32 and v16bf16
- [x] `test-bf16-divf.mlir` — bf16 divf produces ups → inv → mul_elem → srs
- [x] Build passes
- [x] Existing tests pass (`test-inv-aie2p`, `test-fdiv-aie2p`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)