### PR TITLE
[aievec] Add math.tanh lowering to AIE2P hardware tanh intrinsic

### DIFF
--- a/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
+++ b/include/aie/Dialect/AIEVec/IR/AIEVecOps.td
@@ -519,6 +519,23 @@ def AIEVec_ExpOp:
   let hasVerifier = 0;
 }
 
+def AIEVec_TanhOp:
+  AIEVec_Op<"tanh", [
+    Pure,
+    AllTypesMatch<["source", "result"]>
+  ]>,
+  Arguments<(ins AnyVectorOfNonZeroRank:$source)>,
+  Results<(outs AnyVectorOfNonZeroRank:$result)> {
+  let summary = "AIE vector hyperbolic tangent";
+  let description = [{
+    AMD-specific intrinsic that computes the hyperbolic tangent of the input
+    vector. For AIE2P, this is lowered to the hardware tanh intrinsic.
+    `$result = tanh(`$source`).
+  }];
+  let assemblyFormat = "$source attr-dict `:` type($result)";
+  let hasVerifier = 0;
+}
+
 def AIEVec_InvOp:
   AIEVec_Op<"inv", [
     Pure,

--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -619,6 +619,13 @@ def Exp2AIE2pIntrOp :
         [TypeIs<"res", VectorOfLengthAndType<[16], [BF16]>>]>,
     Arguments<(ins VectorOfLengthAndType<[16], [F32]>:$src)>;
 
+// ----- TANH -----
+
+def TanhAIE2pIntrOp :
+    AIEVec2p_IntrOp<"tanh",
+        [TypeIs<"res", VectorOfLengthAndType<[16], [BF16]>>]>,
+    Arguments<(ins VectorOfLengthAndType<[16], [F32]>:$src)>;
+
 // ----- INVSQRT (Reciprocal Square Root) -----
 
 def InvsqrtAIE2pIntrOp :

--- a/test/Conversion/AIEVecToLLVM/test-tanh-aie2p.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-tanh-aie2p.mlir
@@ -1,0 +1,40 @@
+//===- test-tanh-aie2p.mlir ----------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s -split-input-file --convert-aievec-to-llvm="aie-target=aie2p" | FileCheck %s
+
+func.func @v16bf16_tanh(%arg0 : vector<16xbf16>) -> vector<16xbf16> {
+  %0 = aievec.tanh %arg0 : vector<16xbf16>
+  return %0 : vector<16xbf16>
+}
+
+// CHECK-LABEL: @v16bf16_tanh
+// CHECK-SAME: %[[ARG0:.*]]: vector<16xbf16>
+// CHECK: %[[F32:.*]] = "xllvm.intr.aie2p.v16bf16.to.v16accfloat"(%[[ARG0]]) : (vector<16xbf16>) -> vector<16xf32>
+// CHECK: %[[TANH:.*]] = "xllvm.intr.aie2p.tanh"(%[[F32]]) : (vector<16xf32>) -> vector<16xbf16>
+// CHECK: return %[[TANH]] : vector<16xbf16>
+
+// -----
+
+func.func @v32bf16_tanh(%arg0 : vector<32xbf16>) -> vector<32xbf16> {
+  %0 = aievec.tanh %arg0 : vector<32xbf16>
+  return %0 : vector<32xbf16>
+}
+
+// CHECK-LABEL: @v32bf16_tanh
+// CHECK-SAME: %[[ARG0:.*]]: vector<32xbf16>
+// CHECK: %[[LOWER_BF16:.*]] = vector.shuffle %[[ARG0]], %[[ARG0]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] : vector<32xbf16>, vector<32xbf16>
+// CHECK: %[[UPPER_BF16:.*]] = vector.shuffle %[[ARG0]], %[[ARG0]] [16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] : vector<32xbf16>, vector<32xbf16>
+// CHECK: %[[LOWER_F32:.*]] = "xllvm.intr.aie2p.v16bf16.to.v16accfloat"(%[[LOWER_BF16]]) : (vector<16xbf16>) -> vector<16xf32>
+// CHECK: %[[UPPER_F32:.*]] = "xllvm.intr.aie2p.v16bf16.to.v16accfloat"(%[[UPPER_BF16]]) : (vector<16xbf16>) -> vector<16xf32>
+// CHECK: %[[TANH0:.*]] = "xllvm.intr.aie2p.tanh"(%[[LOWER_F32]]) : (vector<16xf32>) -> vector<16xbf16>
+// CHECK: %[[TANH1:.*]] = "xllvm.intr.aie2p.tanh"(%[[UPPER_F32]]) : (vector<16xf32>) -> vector<16xbf16>
+// CHECK: %[[RESULT:.*]] = vector.shuffle %[[TANH0]], %[[TANH1]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] : vector<16xbf16>, vector<16xbf16>
+// CHECK: return %[[RESULT]] : vector<32xbf16>

--- a/test/Conversion/VectorToAIEVec/test-tanh-aie2p.mlir
+++ b/test/Conversion/VectorToAIEVec/test-tanh-aie2p.mlir
@@ -1,0 +1,29 @@
+//===- test-tanh-aie2p.mlir ----------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" | FileCheck %s
+
+// CHECK-LABEL: func @test_tanh_aie2p
+// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<16xbf16>
+func.func @test_tanh_aie2p(%a: vector<16xbf16>) -> vector<16xbf16> {
+    // CHECK: %[[TANH:.*]] = aievec.tanh %[[A]] : vector<16xbf16>
+    %0 = math.tanh %a : vector<16xbf16>
+    // CHECK: return %[[TANH]] : vector<16xbf16>
+    return %0 : vector<16xbf16>
+}
+
+// CHECK-LABEL: func @test_tanh_v32bf16_aie2p
+// CHECK-SAME: %[[A:[A-Za-z0-9]+]]: vector<32xbf16>
+func.func @test_tanh_v32bf16_aie2p(%a: vector<32xbf16>) -> vector<32xbf16> {
+    // CHECK: %[[TANH:.*]] = aievec.tanh %[[A]] : vector<32xbf16>
+    %0 = math.tanh %a : vector<32xbf16>
+    // CHECK: return %[[TANH]] : vector<32xbf16>
+    return %0 : vector<32xbf16>
+}


### PR DESCRIPTION
## Summary
- Add end-to-end lowering of `math.tanh` on bf16 vectors to the AIE2P hardware tanh intrinsic (`__builtin_aie2p_tanh`)
- Lowering chain: `math.tanh` (v16bf16/v32bf16) → `aievec.tanh` (new op) → `xllvm.intr.aie2p.tanh` (new intrinsic)
- Input bf16→f32 conversion uses `MulElemOp(x, 1.0)` since Peano does not support vector `fpext` for bf16
- For v32bf16, splits into two v16 operations (same pattern as `ExpOpAIE2pConversion`)
- AIE2P pattern registered with `benefit=2` to take priority over the existing AIE2 LUT-based `ComputeTanhOpByLUTPattern`

## Motivation
This enables SiLU and GELU programming examples in mlir-air to use tanh-based formulations matching the IRON project's approach:
- **SiLU**: `x * 0.5 * (tanh(x/2) + 1)` — no exp or division
- **GELU**: `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715*x^3)))` — no exp or division

The previous exp+div approach had two issues:
1. Scalar `fdiv` helper generates incorrect machine code on AIE2P (corrupted output values)
2. `exp2` lowering stores `log2(e)` as bf16 with 0.18% constant error

Hardware-tested on NPU2: compiles and runs correctly.

## Test plan
- [x] Existing `check-aie-mlir` tests pass
- [x] SiLU/GELU programming examples in mlir-air compile and run on NPU2 hardware
- [x] MLIR generation verified: `math.tanh` on `vector<16xbf16>` lowers to `llvm.aie2p.tanh` intrinsic

🤖 Generated with [Claude Code](https://claude.com/claude-code)