### PR TITLE
[AIECoreToStandard] Set SRS rounding mode to positive_inf

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -577,16 +577,18 @@ struct AIECoreToStandardFunc : OpConversionPattern<CoreOp> {
                                                 rewriter.getI32IntegerAttr(1));
             func::CallOp::create(rewriter, loc, ctrlRegFunc,
                                  ValueRange{c9, c1});
-            // rounding_mode::floor (register 6 = 0)
-            // Use floor (truncation) to avoid double-rounding when user
-            // code already performs explicit rounding via arith.addi
-            // before shrsi.
+            // rounding_mode::positive_inf (register 6 = 9)
+            // Match C++ kernel behavior (aie::rounding_mode::positive_inf).
+            // aievec.srs ops handle rounding internally; scalar arith.shrsi
+            // is unaffected by this register (uses floor inherently).
+            // User code with manual rounding (arith.addi before shrsi)
+            // still works because arith.shrsi ignores ctrl_reg.
             auto c6 = arith::ConstantOp::create(rewriter, loc,
                                                 rewriter.getI32IntegerAttr(6));
-            auto c0 = arith::ConstantOp::create(rewriter, loc,
-                                                rewriter.getI32IntegerAttr(0));
+            auto cPositiveInf = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI32IntegerAttr(9));
             func::CallOp::create(rewriter, loc, ctrlRegFunc,
-                                 ValueRange{c6, c0});
+                                 ValueRange{c6, cPositiveInf});
           }
         }
       }


### PR DESCRIPTION
## Summary

- Change AIE2/AIE2p SRS rounding mode control register from `floor` (0) to `positive_inf` (9) in `AIECoreToStandard.cpp`
- Matches C++ kernel behavior (`aie::rounding_mode::positive_inf`) and enables `aievec.srs` ops to handle rounding internally without manual pre-rounding
- Clarify comments on `aiecc.py` `opt` O1 cap (no functional change)

**Safety analysis:** `ctrl_reg 6` only affects `aievec.srs` hardware intrinsics. Scalar `arith.shrsi` compiles to a regular shift instruction that ignores `ctrl_reg`. Existing user code with manual rounding (`arith.addi` before `arith.shrsi`) still works correctly. The `LowerScalarShiftClampTruncToSRS` pattern replaces the entire `addi+shrsi+clamp+trunci` chain with `aievec.srs`, eliminating the manual rounding when it fires.

## Test plan

- [x] `check-aie`: 51 failures baseline = 51 with change (no regressions, all pre-existing npu-xrt/lock tests)
- [x] Bottleneck E2E on NPU hardware: PASS (with mlir-air vectorized `aievec.srs` SRS)
- [x] Bottleneck E2E original scalar SRS: PASS (manual rounding + scalar `arith.shrsi` unaffected by ctrl_reg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)