### PR TITLE
Add upstream XRT package install instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
 ### Install the XDNA™ Driver and XRT
 
-#### Install from upstream packages (Ubuntu 24.04)
+#### Install from upstream packages (Ubuntu 24.04 with Linux 6.17+)
 
 Install the XDNA driver and XRT runtime from the AMD PPA:
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -23,7 +23,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 
 ### Install the XDNA™ Driver and XRT
 
-#### Install from upstream packages (Ubuntu 24.04)
+#### Install from upstream packages (Ubuntu 24.04 with Linux 6.17+)
 
 Install the XDNA driver and XRT runtime from the AMD PPA:
 


### PR DESCRIPTION
Add instructions for installing the XDNA driver and XRT from the AMD PPA (ppa:amd-team/xrt) as the primary method in both README.md and docs/Building.md. Move the existing build_drivers.sh approach to an "Alternative: Build from source" section at the bottom, with a cross-reference note for users on unsupported kernels or distributions.