### PR TITLE
Use Peano nightly

### DIFF
--- a/programming_examples/ml/magika/inc/funcs_gelu.h
+++ b/programming_examples/ml/magika/inc/funcs_gelu.h
@@ -87,7 +87,7 @@ void gelu_getaddr_relu(int16 *pd_in, int16 *pa_out) {
       v32acc32 c = sub(ups_to_v32acc32(b, 0), offset);
 
       // shift and save to memory
-      *pa++ = srs_to_v32uint8(c, GELU_ADDRSHFT);
+      *pa++ = to_v32uint8(c, GELU_ADDRSHFT);
     }
 
   // remaining 16 words
@@ -104,7 +104,7 @@ void gelu_getaddr_relu(int16 *pd_in, int16 *pa_out) {
   v32acc32 c = sub(ups_to_v32acc32(b, 0), offset);
 
   // shift and save to memory
-  *pa++ = srs_to_v32uint8(c, GELU_ADDRSHFT);
+  *pa++ = to_v32uint8(c, GELU_ADDRSHFT);
 }
 
 //---------------------------------------------------------

--- a/programming_examples/vision/color_threshold/Makefile
+++ b/programming_examples/vision/color_threshold/Makefile
@@ -10,6 +10,11 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
+# Workaround: Peano -O2 miscompiles aie::lt/aie::select loop on AIE2P
+# (first vector iteration correct, subsequent iterations produce zeros).
+# Use -O1 until upstream llvm-aie fix is available.
+PEANOWRAP2P_FLAGS := $(subst -O2,-O1,$(PEANOWRAP2P_FLAGS))
+
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
 device ?= $(if $(filter 1,$(NPU2)),npu2,npu)

--- a/programming_examples/vision/color_threshold/run_strix_makefile.lit
+++ b/programming_examples/vision/color_threshold/run_strix_makefile.lit
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // REQUIRES: ryzen_ai_npu2, peano, opencv
-// XFAIL: *
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx

--- a/programming_examples/vision/color_threshold/run_strix_makefile_placed.lit
+++ b/programming_examples/vision/color_threshold/run_strix_makefile_placed.lit
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // REQUIRES: ryzen_ai_npu2, peano, opencv
-// XFAIL: *
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed

--- a/programming_examples/vision/edge_detect/Makefile
+++ b/programming_examples/vision/edge_detect/Makefile
@@ -10,6 +10,11 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
 
+# Workaround: Peano -O2 miscompiles aie::lt/aie::select loop on AIE2P
+# (first vector iteration correct, subsequent iterations produce zeros).
+# Use -O1 until upstream llvm-aie fix is available.
+PEANOWRAP2P_FLAGS := $(subst -O2,-O1,$(PEANOWRAP2P_FLAGS))
+
 VPATH := ${srcdir}/../../../aie_kernels/aie2
 
 device ?= $(if $(filter 1,$(NPU2)),npu2,npu)

--- a/programming_examples/vision/edge_detect/run_strix_makefile.lit
+++ b/programming_examples/vision/edge_detect/run_strix_makefile.lit
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // REQUIRES: ryzen_ai_npu2, peano, opencv
-// XFAIL: *
 //
 // RUN: mkdir -p test_stx
 // RUN: cd test_stx

--- a/programming_examples/vision/edge_detect/run_strix_makefile_placed.lit
+++ b/programming_examples/vision/edge_detect/run_strix_makefile_placed.lit
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // REQUIRES: ryzen_ai_npu2, peano, opencv
-// XFAIL: *
 //
 // RUN: mkdir -p test_stx_placed
 // RUN: cd test_stx_placed


### PR DESCRIPTION
This pull request primarily updates Peano in the `quick_setup.sh` script from the pinned old version to nightly. 

It also includes several targeted fixes and workarounds to address build, testing, and compatibility issues across the machine learning and vision programming examples. 

**Build system and compiler workarounds:**

* Added a workaround in both `programming_examples/vision/color_threshold/Makefile` and `programming_examples/vision/edge_detect/Makefile` to replace `-O2` with `-O1` in `PEANOWRAP2P_FLAGS`, addressing a miscompilation issue with Peano/llvm-aie on AIE2P hardware. This ensures correct execution until an upstream fix is available in Peano. [[1]](diffhunk://#diff-6071c3599342238497a74fc25005991069b1a3144bf49f53fe06230eb02e2ebaR13-R17) [[2]](diffhunk://#diff-8f81a3dd8e6945a81e772da65999d17ac1eb813d4af43dea624b55cbc4a8979aR13-R17)

**Installation script improvements:**

* Updated `utils/quick_setup.sh` to install the latest nightly `llvm-aie` wheel, removing the hardcoded wheel reference for better maintainability and future-proofing.

**Testing and validation adjustments:**

* Reduced the `max_errors` threshold in `programming_examples/vision/color_threshold/test.cpp` from 64000 to 50.

**Code correctness and maintenance:**

* Replaced calls to `srs_to_v32uint8` with `to_v32uint8` in `programming_examples/ml/magika/inc/funcs_gelu.h` to use the correct function for type conversion, rather than the deprecated API. [[1]](diffhunk://#diff-9fbac355d7e23f58b13d7769189241a2f159de35915c4276b2611f64753124f0L90-R90) [[2]](diffhunk://#diff-9fbac355d7e23f58b13d7769189241a2f159de35915c4276b2611f64753124f0L107-R107)

**Test infrastructure:**

* Marked `programming_examples/ml/layernorm/run_strix_makefile.lit` as expected to fail (`XFAIL: *`), until an upstream fix is available in Peano.