### PR TITLE
Disable ci for event trace programming example on strix

### DIFF
--- a/programming_examples/basic/event_trace/run_strix_makefile.lit
+++ b/programming_examples/basic/event_trace/run_strix_makefile.lit
@@ -1,7 +1,7 @@
 // (c) Copyright 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// 'dont_run' here because test appears flakey on strix
+// 'dont_run' here because test appears flaky on strix
 // REQUIRES: ryzen_ai_npu2, dont_run
 //
 // RUN: mkdir -p test_npu2


### PR DESCRIPTION
It seems to be unreliable
https://github.com/Xilinx/mlir-aie/actions/runs/22692678800/job/65791836152