### PR TITLE
Allow high-rank vector.transfer_read with leading unit dims

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -25,11 +25,13 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 #include "llvm/ADT/SmallSet.h"
 #include <bitset>
@@ -4888,7 +4890,14 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
                        xilinx::aievec::AIEVecDialect, arith::ArithDialect,
                        ub::UBDialect, emitc::EmitCDialect, func::FuncDialect>();
   if (backend == TargetBackend::CPP) {
-    target.addIllegalOp<vector::TransferReadOp>();
+    // Mark transfer_read as dynamically legal: illegal only when the vector
+    // rank is <= 4 (which the AIEVec patterns can lower). High-rank vectors
+    // with leading unit dims (e.g., vector<1x1x4x32x4x8xbf16>) from LLVM 23
+    // are left legal — they'll be handled by aie-vector-transfer-lowering.
+    target.addDynamicallyLegalOp<vector::TransferReadOp>(
+        [](vector::TransferReadOp op) {
+          return op.getVectorType().getRank() > 4;
+        });
   }
   target.addIllegalOp<vector::ExtractStridedSliceOp>();
   target.addLegalOp<vector::BitCastOp>();


### PR DESCRIPTION
## Summary
- Make `vector.transfer_read` dynamically legal in the CPP backend vectorizer
- Only mark illegal when rank <= 4 (which AIEVec patterns can handle)
- High-rank vectors with leading unit dims (e.g., `vector<1x1x4x32x4x8xbf16>`) are left for downstream passes

## Context
LLVM 23's `fold_unit_extent_dims_via_reshapes` pattern doesn't converge on memref IR with `IsolatedFromAbove` ops (like `air.herd`) containing unit-extent memref dimensions. This produces vectors like `vector<1x1x4x32x4x8xbf16>` that the `test-lower-vector-to-aievec` pass can't lower, causing `failed to legalize operation 'vector.transfer_read'`.

On LLVM 22, the fold pattern converged and eliminated unit dims before vectorization. On LLVM 23, the patterns oscillate (documented as "should not be used with a greedy driver" in `Transforms.h:2095`).

## Test plan
- [ ] Verify matmul programming examples compile with `--direct-codegen` on both aie2 and aie2p
- [ ] Verify existing mlir-aie tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)