### PR TITLE
Bump eudsl-python-extras to 0.1.0.20260308.1929+09d24cd

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,6 +4,6 @@ numpy>=1.19.5, <2.0 # 2.1 would be nice for typing improvements, but it doesn't 
 rich
 ml_dtypes
 cloudpickle # required by eudsl when it is vendored instead of installed
-eudsl-python-extras==0.1.0.20260211.1045+549fd26 \
+eudsl-python-extras==0.1.0.20260308.1929+09d24cd \
   --config-settings="EUDSL_PYTHON_EXTRAS_HOST_PACKAGE_PREFIX=aie"
 -f https://llvm.github.io/eudsl


### PR DESCRIPTION
## Summary
- Bumps `eudsl-python-extras` from `0.1.0.20260211.1045+549fd26` to `0.1.0.20260308.1929+09d24cd`
- Picks up latest upstream fixes including `memref.reinterpret_cast` mixed static/dynamic offsets/sizes/strides fix (llvm/eudsl#355)
- The new version continues to use Python `isinstance()` for type checks (compatible with LLVM 23.0.0), ensuring no import errors as reported in #2937

## Background
Issue #2937 reported `ImportError: cannot import name '_is_integer_like_type'` when using the IRON API. Investigation showed the root cause was the old eudsl-python-extras (`3c7ac1b`, Dec 2025) importing helper functions that LLVM 23.0.0 removed from `arith.py` and `emitter.py`. The fix was already applied in #2918 by updating the eudsl pin to `549fd26`, which uses Python `isinstance()` instead of helper function imports — compatible with LLVM 23.0.0's proper Python type hierarchy (`F32Type → FloatType → Type`).

This PR bumps to the latest eudsl release for forward compatibility.

## Test plan
- [x] Reproduced original issue: old eudsl `3c7ac1b` + LLVM 23.0.0 → `ImportError: cannot import name '_is_integer_like_type'`
- [x] Verified fix: new eudsl `09d24cd` + LLVM 23.0.0 wheel → imports succeed
- [x] Ran `vendor_eudsl.py` with new version — vendored `arith.py` uses `isinstance()` (not removed helper functions)
- [x] e2e design tests pass: `code_region.py` (ObjectFifo MLIR gen), `aie_ops.py` (device configs), `npu.py` (matmul/edge_detect designs)
- [x] Type hierarchy verified: `isinstance(F32Type, FloatType)` and `isinstance(MemRefType, ShapedType)` both work

Closes #2937

🤖 Generated with [Claude Code](https://claude.com/claude-code)