### PR TITLE
In-memory aie-translate should not inherit aiesim flag from aiecc

### DIFF
--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -4465,7 +4465,7 @@ static LogicalResult generateCdoArtifacts(ModuleOp moduleOp,
                                                     /*bigEndian=*/false,
                                                     /*emitUnified=*/false,
                                                     /*cdoDebug=*/false,
-                                                    /*aieSim=*/aiesim,
+                                                    /*aieSim=*/false,
                                                     /*xaieDebug=*/false,
                                                     /*enableCores=*/true))) {
       llvm::errs() << "Error generating CDO files\n";


### PR DESCRIPTION
* Change `aiecc.cpp` call of `AIETranslateToCDODirect` to always use `aieSim=false`
* CDO generation is a binary artifact step, not a simulation step, regardless of what `--aiesim` is set to on the command line.
