### PR TITLE
Expose set_aie_stream() on IRON ObjectFifo class

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -1812,11 +1812,20 @@ struct AIEObjectFifoStatefulTransformPass
                                        : !crossTileInfos.at(producer);
 
       if (shouldProcessProducer) {
-        bool requiresAdjacentTileAccessChannels = crossTileInfos.at(producer);
-        int channelIndex = dmaAnalysis.getDMAChannelIndex(
-            producer.getProducerTileOp(), DMAChannelDir::MM2S,
-            requiresAdjacentTileAccessChannels);
-        fifo_dma_channel_index[producer] = channelIndex;
+        // Skip stream-port producers — they use Core ports, not DMA channels
+        bool prodIsStream = false;
+        if (producer.getAieStream()) {
+          int streamEnd = producer.getAieStream().value();
+          prodIsStream = (streamEnd == 0 || streamEnd == 2);
+        }
+        if (!prodIsStream) {
+          bool requiresAdjacentTileAccessChannels =
+              crossTileInfos.at(producer);
+          int channelIndex = dmaAnalysis.getDMAChannelIndex(
+              producer.getProducerTileOp(), DMAChannelDir::MM2S,
+              requiresAdjacentTileAccessChannels);
+          fifo_dma_channel_index[producer] = channelIndex;
+        }
       }
 
       for (auto consumer : consumers) {
@@ -1827,6 +1836,12 @@ struct AIEObjectFifoStatefulTransformPass
                                          : !crossTileInfos.at(consumer);
 
         if (shouldProcessConsumer) {
+          // Skip stream-port consumers — they use Core ports, not DMA channels
+          if (consumer.getAieStream()) {
+            int streamEnd = consumer.getAieStream().value();
+            if (streamEnd == 1 || streamEnd == 2)
+              continue;
+          }
           bool requiresAdjacentTileAccessChannels = crossTileInfos.at(consumer);
           int channelIndex = dmaAnalysis.getDMAChannelIndex(
               consumer.getProducerTileOp(), DMAChannelDir::S2MM,

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -79,6 +79,8 @@ class ObjectFifo(Resolvable):
         self._cons: list[ObjectFifoHandle] = []
         self._resolving = False
         self._iter_count: int | None = None
+        self._aie_stream: int | None = None
+        self._aie_stream_port: int | None = None
 
     @classmethod
     def __get_index(cls) -> int:
@@ -136,6 +138,19 @@ class ObjectFifo(Resolvable):
             raise ValueError("Iter count must be in [1, 256] range.")
 
         self._iter_count = iter_count
+
+    def set_aie_stream(self, stream_end: int, stream_port: int = 0):
+        """Configure one end of this ObjectFifo to use a Core stream port
+        instead of DMA, bypassing L1 buffering.
+
+        Args:
+            stream_end: 0 (producer stream), 1 (consumer stream), 2 (both)
+            stream_port: Core stream port index (default 0)
+        """
+        if stream_end not in (0, 1, 2):
+            raise ValueError("stream_end must be 0 (producer), 1 (consumer), or 2 (both)")
+        self._aie_stream = stream_end
+        self._aie_stream_port = stream_port
 
     def __str__(self) -> str:
         prod_endpoint = None
@@ -299,6 +314,9 @@ class ObjectFifo(Resolvable):
                 padDimensions=self._pad_dimensions,
                 iter_count=self._iter_count,
             )
+
+            if self._aie_stream is not None:
+                self._op.set_aie_stream(self._aie_stream, self._aie_stream_port)
 
             if isinstance(self._prod.endpoint, ObjectFifoLink):
                 self._prod.endpoint.resolve()


### PR DESCRIPTION
Add set_aie_stream(stream_end, stream_port) method to the IRON-level ObjectFifo class, plumbing through to the existing low-level object_fifo.set_aie_stream() during resolve().

This allows IRON designs to use Core stream ports instead of DMA channels for ObjectFifo connections, enabling tiles with more than 2 input data flows (2 DMA + N stream ports).

The low-level dialect already supports aie_stream (PR #2693) but it was not exposed at the IRON Python API level.