### PR TITLE
Remove strip pass from Peano opt and fix vector flatten for strided memrefs

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
@@ -373,9 +373,7 @@ static SmallVector<Value> collapseInnerMostDimIndices(PatternRewriter &b,
                                                       ValueRange indices,
                                                       ArrayRef<int64_t> shape,
                                                       AffineMap layout) {
-  // TODO: Don't assume trivial layout
-  assert(layout.isMinorIdentity() &&
-         "dimension collapse in non-identity layout is not implemented");
+  (void)layout; // Layout is verified by callers; index computation uses shape.
   auto newIdxExpr = b.getAffineDimExpr(numDims - 1);
   int64_t stride = 1;
   for (int64_t dim = numDims - 2; dim >= 0; dim--) {
@@ -402,17 +400,36 @@ static Value collapseInnerMostShapeDims(PatternRewriter &b, Location loc,
                                             1, std::multiplies<>());
   SmallVector<int64_t, 4> newShape{shape.begin(), shape.end() - numDims + 1};
   newShape[shape.size() - numDims] = newInnerMostDim;
-  auto newNumDims = newShape.size();
-  auto *ctx = b.getContext();
-  auto newMemRefTy = MemRefType::get(
-      newShape, memRefTy.getElementType(),
-      AffineMap::getMinorIdentityMap(newNumDims, newNumDims, ctx),
-      memRefTy.getMemorySpace());
   auto reassocIndices =
       getReassociationIndicesForCollapse(shape, newShape).value();
+  // Let CollapseShapeOp::inferResultType compute the correct result type,
+  // which preserves strided layout and dynamic offset from the source.
+  auto newMemRefTy =
+      memref::CollapseShapeOp::computeCollapsedType(memRefTy, reassocIndices);
   return memref::CollapseShapeOp::create(b, loc, newMemRefTy, val,
                                          reassocIndices)
       .getResult();
+}
+
+/// Check if a memref has contiguous row-major strides (each stride equals the
+/// product of trailing dimensions). Dynamic strides are accepted when the
+/// corresponding dimension size is 1. Memrefs with dynamic offsets are fine.
+static bool hasContiguousRowMajorStrides(MemRefType memRefTy) {
+  SmallVector<int64_t> strides;
+  int64_t offset;
+  if (failed(memRefTy.getStridesAndOffset(strides, offset)))
+    return false;
+  auto shape = memRefTy.getShape();
+  int64_t expected = 1;
+  for (int i = shape.size() - 1; i >= 0; --i) {
+    if (strides[i] != ShapedType::kDynamic && strides[i] != expected)
+      return false;
+    if (shape[i] != ShapedType::kDynamic)
+      expected *= shape[i];
+    else
+      expected = ShapedType::kDynamic;
+  }
+  return true;
 }
 
 // This pattern flatten multidimensional `vector.transfer_read` operations
@@ -443,6 +460,9 @@ struct FlattenMultDimTransferReadPattern
         VectorType::get({std::accumulate(vecShape.begin(), vecShape.end(), 1,
                                          std::multiplies<>())},
                         vectorTy.getElementType());
+    if (!hasContiguousRowMajorStrides(memRefTy))
+      return failure();
+
     AffineMap layout = memRefTy.getLayout().getAffineMap();
     auto newIndices =
         collapseInnerMostDimIndices(rewriter, readOp.getLoc(), vecShape.size(),
@@ -496,6 +516,9 @@ struct FlattenMultDimTransferWritePattern
       return failure();
     auto memRefShape = memRefTy.getShape();
     auto vecShape = vectorTy.getShape();
+
+    if (!hasContiguousRowMajorStrides(memRefTy))
+      return failure();
 
     auto newVectorTy =
         VectorType::get({std::accumulate(vecShape.begin(), vecShape.end(), 1,

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -2215,7 +2215,7 @@ static LogicalResult compileCore(MLIRContext &context, ModuleOp moduleOp,
     std::string optLevelStr = std::to_string(optLevel);
     SmallVector<std::string, 12> optCmd = {
         peanoOpt,
-        "--passes=default<O" + std::to_string(safeOptLevel) + ">,strip",
+        "--passes=default<O" + std::to_string(safeOptLevel) + ">",
         "-inline-threshold=10",
         "-S",
         std::string(peanohackPath),
@@ -2910,7 +2910,7 @@ compileCoresUnified(MLIRContext &context, ModuleOp moduleOp,
     std::string optLevelStr = std::to_string(optLevel);
     SmallVector<std::string, 12> optCmd = {
         peanoOpt,
-        "--passes=default<O" + std::to_string(safeOptLevel) + ">,strip",
+        "--passes=default<O" + std::to_string(safeOptLevel) + ">",
         "-inline-threshold=10",
         "-S",
         std::string(peanohackPath),


### PR DESCRIPTION
## Summary
- Remove `,strip` from Peano opt command to fix `symbol not found: core_X_Y` linker errors
- Fix `FlattenMultDimTransferRead/WritePattern` crash on strided memrefs with dynamic offsets

## Details

### Fix 1: Remove `,strip` from Peano opt
The old Python FlowRunner used `--passes=default<O{level}>` without `,strip`. The C++ aiecc added `,strip` which removes all symbol names from the object file, including `core_X_Y` that the linker script needs via `PROVIDE(main = core_X_Y)`. This broke mlir-air tests using `link_with` (e.g. `broadcast/multi_herd`).

### Fix 2: Handle strided memrefs in vector flatten patterns
The `collapseInnerMostDimIndices` function had `assert(layout.isMinorIdentity())` which crashed on memrefs like `memref<1x1x8x4x8x8xi8, strided<[2048,...,1], offset: ?>>`. The strided layout with dynamic offset has a non-identity affine map even though the strides are contiguous row-major.

Fix:
- Replace assertion with contiguous-stride verification in the pattern (return failure for non-contiguous)
- Use `CollapseShapeOp::computeCollapsedType` instead of hardcoding identity layout, preserving the strided layout with dynamic offset

## Test plan
- [x] `broadcast/multi_herd` passes locally on NPU2
- [x] `bottleneck` passes locally on NPU2 (was crashing with assertion)
- [ ] CI: all mlir-aie tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)