### PR TITLE
Skip vector.reduction in bf16-emulation pass

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToVectorConversions.cpp
@@ -911,17 +911,6 @@ static Value smartTruncF32ToBF16(PatternRewriter &rewriter, Location loc,
   return arith::TruncFOp::create(rewriter, loc, bf16Type, val);
 }
 
-// Smart truncation for scalar values (used by reduction patterns).
-static Value smartTruncScalarF32ToBF16(PatternRewriter &rewriter, Location loc,
-                                       Value val) {
-  Type bf16Ty = rewriter.getBF16Type();
-  if (auto extfOp = val.getDefiningOp<arith::ExtFOp>()) {
-    if (extfOp.getIn().getType() == bf16Ty)
-      return extfOp.getIn();
-  }
-  return arith::TruncFOp::create(rewriter, loc, bf16Ty, val);
-}
-
 /// Pattern to emulate f32 binary vector arithmetic ops in bf16.
 /// For an op like: %r = arith.addf %a, %b : vector<16xf32>
 /// Produces:
@@ -1066,39 +1055,6 @@ struct EmulateUnaryF32InBF16Pattern : public OpRewritePattern<OpTy> {
   }
 };
 
-/// Pattern to emulate f32 vector.reduction in bf16.
-struct EmulateReductionF32InBF16Pattern
-    : public OpRewritePattern<vector::ReductionOp> {
-  using OpRewritePattern::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(vector::ReductionOp op,
-                                PatternRewriter &rewriter) const override {
-    if (!op.getType().isF32())
-      return failure();
-    auto vectorType = dyn_cast<VectorType>(op.getVector().getType());
-    if (!vectorType || !vectorType.getElementType().isF32())
-      return failure();
-
-    Location loc = op.getLoc();
-    auto bf16VecType =
-        VectorType::get(vectorType.getShape(), rewriter.getBF16Type());
-
-    Value vectorBF16 =
-        smartTruncF32ToBF16(rewriter, loc, op.getVector(), bf16VecType);
-
-    Value accBF16 = nullptr;
-    if (op.getAcc())
-      accBF16 = smartTruncScalarF32ToBF16(rewriter, loc, op.getAcc());
-
-    Value newResult = vector::ReductionOp::create(rewriter, loc, op.getKind(),
-                                                  vectorBF16, accBF16);
-    auto extOp =
-        arith::ExtFOp::create(rewriter, loc, rewriter.getF32Type(), newResult);
-    rewriter.replaceOp(op, extOp);
-    return success();
-  }
-};
-
 struct BF16EmulationPass
     : public PassWrapper<BF16EmulationPass, OperationPass<>> {
 
@@ -1117,10 +1073,12 @@ struct BF16EmulationPass
     // Note: arith.divf is NOT demoted because bf16 vector divf is unsupported
     // on all AIE targets (Peano does not legalize G_FDIV on <16 x s16>).
 
-    // Special-case ops
+    // Special-case ops (excluding ReductionOp — its scalar accumulator
+    // and result lower to fp_to_bf16/bf16_to_fp which older Peano versions
+    // cannot select on AIE2P; reductions are intentionally left in f32
+    // to avoid these scalar bf16 conversions)
     patterns.add<EmulateCmpFF32InBF16Pattern, EmulateSelectF32InBF16Pattern,
-                 EmulateFMAF32InBF16Pattern, EmulateReductionF32InBF16Pattern>(
-        context);
+                 EmulateFMAF32InBF16Pattern>(context);
 
     // Unary ops
     patterns.add<EmulateUnaryF32InBF16Pattern<arith::NegFOp>>(context);

--- a/test/Conversion/VectorToAIEVec/test-bf16-emulation.mlir
+++ b/test/Conversion/VectorToAIEVec/test-bf16-emulation.mlir
@@ -176,6 +176,31 @@ func.func @test_scalar_unchanged(%a: f32, %b: f32) -> f32 {
 
 // -----
 
+// Test: vector.reduction is NOT demoted (scalar bf16_to_fp unsupported on
+// older Peano; keeping reductions in f32 is safe since vector inputs are
+// already demoted by binary patterns)
+// CHECK-LABEL: func @test_reduction_not_demoted
+// CHECK-NOT: arith.truncf
+// CHECK: vector.reduction <add>, %{{.*}} : vector<16xf32> into f32
+// CHECK-NOT: arith.extf
+func.func @test_reduction_not_demoted(%a: vector<16xf32>) -> f32 {
+  %0 = vector.reduction <add>, %a : vector<16xf32> into f32
+  return %0 : f32
+}
+
+// -----
+
+// Test: vector.multi_reduction is NOT demoted
+// CHECK-LABEL: func @test_multi_reduction_not_demoted
+// CHECK-NOT: arith.truncf {{.*}} : vector<4x16xf32> to vector<4x16xbf16>
+// CHECK: vector.multi_reduction <add>, %{{.*}}, %{{.*}} [1] : vector<4x16xf32> to vector<4xf32>
+func.func @test_multi_reduction_not_demoted(%a: vector<4x16xf32>, %acc: vector<4xf32>) -> vector<4xf32> {
+  %0 = vector.multi_reduction <add>, %a, %acc [1] : vector<4x16xf32> to vector<4xf32>
+  return %0 : vector<4xf32>
+}
+
+// -----
+
 // Test: negf demotion
 // CHECK-LABEL: func @test_negf
 // CHECK: arith.truncf {{.*}} : vector<16xf32> to vector<16xbf16>


### PR DESCRIPTION
## Summary
Remove `EmulateReductionF32InBF16Pattern` from the bf16-emulation pass to avoid generating scalar `fp_to_bf16`/`bf16_to_fp` intrinsics that older Peano versions cannot select.

## Problem
The bf16-emulation pass demotes `vector.reduction` ops by truncating the scalar accumulator and result to bf16. This produces scalar `arith.truncf f32→bf16` and `arith.extf bf16→f32` ops that lower to `fp_to_bf16`/`bf16_to_fp` SelectionDAG nodes. Peano 19.0.0 (used by CI) cannot select these on AIE2P, causing:
```
fatal error: error in backend: Cannot select: f32 = bf16_to_fp ...
```

This was discovered when testing `--bf16-emulation` on the mlir-air layernorm example (xrt/43_triton_layernorm).

## Fix
Remove `EmulateReductionF32InBF16Pattern` from the pattern list. Reductions stay in f32:
- Vector inputs are already demoted to bf16 by the binary arithmetic patterns
- Scalar accumulation benefits from f32 precision
- No scalar `fp_to_bf16`/`bf16_to_fp` intrinsics generated

## Test plan
- [x] Unit test: `vector.reduction` NOT demoted (`test-bf16-emulation.mlir`)
- [x] Unit test: `vector.multi_reduction` NOT demoted
- [x] All existing bf16-emulation tests still pass
- [x] mlir-air layernorm with `--bf16-emulation` passes on NPU2
- [ ] CI: all mlir-aie tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)