### PR TITLE
Remove redundant depth-1 exception from objectFifo lowering

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -642,7 +642,14 @@ static void printObjectFifoInitValues(OpAsmPrinter &p, ObjectFifoCreateOp op,
                                       Attribute initValues) {
   if (op.getInitValues()) {
     p << "= [";
-    int depth = llvm::dyn_cast<mlir::IntegerAttr>(numElem).getInt();
+    int depth;
+    if (isa<ArrayAttr>(numElem)) {
+      depth = llvm::dyn_cast<mlir::IntegerAttr>(
+                  llvm::dyn_cast<mlir::ArrayAttr>(numElem)[0])
+                  .getInt();
+    } else {
+      depth = llvm::dyn_cast<mlir::IntegerAttr>(numElem).getInt();
+    }
     for (int i = 0; i < depth; i++) {
       p.printStrippedAttrOrType(llvm::dyn_cast<mlir::ArrayAttr>(initValues)[i]);
       if (i < depth - 1) {

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -1726,8 +1726,6 @@ struct AIEObjectFifoStatefulTransformPass
         });
 
     if (maxAcquire > 0) {
-      if (maxAcquire == 1 && objFifo.size() == 1)
-        return 1;
       return maxAcquire + 1;
       // +1 because objectFifo size is always 1 bigger than maxAcquire to allow
       // for prefetching: simplest case scenario is at least a ping-pong buffer

--- a/programming_examples/ml/bottleneck/bottleneck.py
+++ b/programming_examples/ml/bottleneck/bottleneck.py
@@ -142,7 +142,7 @@ def bottleneck4AIEs():
     )
 
     # weights
-    inOF_wts_0_L3L2 = ObjectFifo(weightsAll_ty, depth=1, name="inOF_wts_0_L3L2")
+    inOF_wts_0_L3L2 = ObjectFifo(weightsAll_ty, depth=[1, 1], name="inOF_wts_0_L3L2")
     of_offsets = [0, weightsL1_sz, weightsL1_sz + weightsL2_sz]
     of_wts_buf_00, wts_buf_01, wts_buf_02 = inOF_wts_0_L3L2.cons().split(
         of_offsets,

--- a/programming_examples/ml/bottleneck/bottleneck_placed.py
+++ b/programming_examples/ml/bottleneck/bottleneck_placed.py
@@ -199,20 +199,20 @@ def bottleneck4AIEs():
 
             # weights
             inOF_wts_0_L3L2 = object_fifo(
-                "inOF_wts_0_L3L2", ShimTile, MemTile, 1, weightsAll_ty
+                "inOF_wts_0_L3L2", ShimTile, MemTile, [1, 1], weightsAll_ty
             )
             of_wts_buf_00 = object_fifo(
-                "wts_buf_00", MemTile, ComputeTile2, 1, weightsLayer1_ty
+                "wts_buf_00", MemTile, ComputeTile2, [1, 1], weightsLayer1_ty
             )
             wts_buf_01 = object_fifo(
                 "wts_buf_01",
                 MemTile,
                 [ComputeTile3, ComputeTile5],
-                1,
+                [1, 1, 1],
                 weightsLayer2_ty,
             )
             wts_buf_02 = object_fifo(
-                "wts_buf_02", MemTile, ComputeTile4, 1, weightsLayer3_ty
+                "wts_buf_02", MemTile, ComputeTile4, [1, 1], weightsLayer3_ty
             )
             of_offsets = [
                 0,

--- a/programming_examples/ml/conv2d/conv2d_placed.py
+++ b/programming_examples/ml/conv2d/conv2d_placed.py
@@ -77,7 +77,7 @@ def conv2dk1(
 
             # wts
             of_inOF_wts_0_L3L2 = object_fifo(
-                "inOF_wts_0_L3L2", ShimTile, [ComputeTile2], 1, weights_ty
+                "inOF_wts_0_L3L2", ShimTile, [ComputeTile2], [1, 1], weights_ty
             )
 
             # Output

--- a/programming_examples/ml/conv2d_fused_relu/conv2d_fused_relu_placed.py
+++ b/programming_examples/ml/conv2d_fused_relu/conv2d_fused_relu_placed.py
@@ -84,7 +84,7 @@ def conv2dk1(dev):
 
             # wts
             of_inOF_wts_0_L3L2 = object_fifo(
-                "inOF_wts_0_L3L2", ShimTile, [ComputeTile2], 1, weights_ty
+                "inOF_wts_0_L3L2", ShimTile, [ComputeTile2], [1, 1], weights_ty
             )
 
             # Output

--- a/programming_examples/ml/resnet/layers_conv2_x/aie.mlir
+++ b/programming_examples/ml/resnet/layers_conv2_x/aie.mlir
@@ -57,10 +57,10 @@ aie.device(npu1_3col) {
     aie.objectfifo.link[@inOF_act_L3L2]-> [@skip_buf] ()
 
     //wts
-    aie.objectfifo @inOF_wts_0_L3L2(%tile00, {%tile01}, 1 : i32) : !aie.objectfifo<memref<73728xi8>> // total buffer for weights
-    aie.objectfifo @wts_buf_00(%tile01, {%tile02}, 1 : i32) : !aie.objectfifo<memref<4096xi8>> // L1 buffer for first conv1x1 weights 256x64x1x1= 16384
-    aie.objectfifo @wts_buf_01(%tile01, {%tile03,%tile04}, 1 : i32) : !aie.objectfifo<memref<36864xi8>> // L1 buffer for middle conv3x3 weights 64x64x3x3= 36864
-    aie.objectfifo @wts_buf_02(%tile01, {%tile05}, 1 : i32) : !aie.objectfifo<memref<32768xi8>> // L1 buffer for final conv1x1 weights 64x256x1x1= 16384
+    aie.objectfifo @inOF_wts_0_L3L2(%tile00, {%tile01}, [1, 1]) : !aie.objectfifo<memref<73728xi8>> // total buffer for weights
+    aie.objectfifo @wts_buf_00(%tile01, {%tile02}, [1, 1]) : !aie.objectfifo<memref<4096xi8>> // L1 buffer for first conv1x1 weights 256x64x1x1= 16384
+    aie.objectfifo @wts_buf_01(%tile01, {%tile03,%tile04}, [1, 1, 1]) : !aie.objectfifo<memref<36864xi8>> // L1 buffer for middle conv3x3 weights 64x64x3x3= 36864
+    aie.objectfifo @wts_buf_02(%tile01, {%tile05}, [1, 1]) : !aie.objectfifo<memref<32768xi8>> // L1 buffer for final conv1x1 weights 64x256x1x1= 16384
     aie.objectfifo.link[@inOF_wts_0_L3L2]-> [@wts_buf_00,@wts_buf_01,@wts_buf_02] ()
 
     // OF for intermediate ofm between 1x1 and 3x3
@@ -71,10 +71,10 @@ aie.device(npu1_3col) {
 
   // ___________________________Bottleneck 2___________________________
     //wts
-    aie.objectfifo @inOF_wts_1_L3L2(%tile10, {%tile11}, 1 : i32) : !aie.objectfifo<memref<69632xi8>> // total buffer for weights
-    aie.objectfifo @wts_buf_10(%tile11, {%tile15}, 1 : i32) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for first conv1x1 weights 256x64x1x1= 16384
-    aie.objectfifo @wts_buf_11(%tile11, {%tile12,%tile14}, 1 : i32) : !aie.objectfifo<memref<36864xi8>> // L1 buffer for middle conv3x3 weights 64x64x3x3= 36864
-    aie.objectfifo @wts_buf_12(%tile11, {%tile13}, 1 : i32) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for final conv1x1 weights 64x256x1x1= 16384
+    aie.objectfifo @inOF_wts_1_L3L2(%tile10, {%tile11}, [1, 1]) : !aie.objectfifo<memref<69632xi8>> // total buffer for weights
+    aie.objectfifo @wts_buf_10(%tile11, {%tile15}, [1, 1]) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for first conv1x1 weights 256x64x1x1= 16384
+    aie.objectfifo @wts_buf_11(%tile11, {%tile12,%tile14}, [1, 1, 1]) : !aie.objectfifo<memref<36864xi8>> // L1 buffer for middle conv3x3 weights 64x64x3x3= 36864
+    aie.objectfifo @wts_buf_12(%tile11, {%tile13}, [1, 1]) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for final conv1x1 weights 64x256x1x1= 16384
     aie.objectfifo.link[@inOF_wts_1_L3L2]-> [@wts_buf_10,@wts_buf_11,@wts_buf_12] ()
 
     //initial activation for 1x1
@@ -92,10 +92,10 @@ aie.device(npu1_3col) {
 
   // ___________________________Bottleneck 3___________________________
     //wts
-    aie.objectfifo @inOF_wts_2_L3L2(%tile20, {%tile21}, 1 : i32) : !aie.objectfifo<memref<69632xi8>> // total buffer for weights
-    aie.objectfifo @wts_buf_20(%tile21, {%tile22}, 1 : i32) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for first conv1x1 weights 256x64x1x1= 16384
-    aie.objectfifo @wts_buf_21(%tile21, {%tile23,%tile25}, 1 : i32) : !aie.objectfifo<memref<36864xi8>> // L1 buffer for middle conv3x3 weights 64x64x3x3= 36864
-    aie.objectfifo @wts_buf_22(%tile21, {%tile24}, 1 : i32) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for final conv1x1 weights 64x256x1x1= 16384
+    aie.objectfifo @inOF_wts_2_L3L2(%tile20, {%tile21}, [1, 1]) : !aie.objectfifo<memref<69632xi8>> // total buffer for weights
+    aie.objectfifo @wts_buf_20(%tile21, {%tile22}, [1, 1]) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for first conv1x1 weights 256x64x1x1= 16384
+    aie.objectfifo @wts_buf_21(%tile21, {%tile23,%tile25}, [1, 1, 1]) : !aie.objectfifo<memref<36864xi8>> // L1 buffer for middle conv3x3 weights 64x64x3x3= 36864
+    aie.objectfifo @wts_buf_22(%tile21, {%tile24}, [1, 1]) : !aie.objectfifo<memref<16384xi8>> // L1 buffer for final conv1x1 weights 64x256x1x1= 16384
     aie.objectfifo.link[@inOF_wts_2_L3L2]-> [@wts_buf_20,@wts_buf_21,@wts_buf_22] ()
 
     //initial activation for 1x1

--- a/programming_examples/ml/resnet/layers_conv2_x/resnet.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/resnet.py
@@ -265,7 +265,7 @@ wts_fifos = []
 wts_sub_fifos = [[], [], []]
 
 for i in range(n_cols):
-    wts_fifos.append(ObjectFifo(wts_sizes[i], name=f"wts_{i}_L3L2", depth=1))
+    wts_fifos.append(ObjectFifo(wts_sizes[i], name=f"wts_{i}_L3L2", depth=[1, 1]))
     wts_offsets = [
         0,
         np.prod(np_ndarray_type_get_shape(layer1_wts_sizes[i])),
@@ -277,7 +277,7 @@ for i in range(n_cols):
         .cons()
         .split(
             wts_offsets,
-            depths=[1, 1, 1],
+            depths=[[1, 1], [1, 1], [1, 1]],
             obj_types=[layer1_wts_sizes[i], weightsLayer2_ty, layer3_wts_sizes[i]],
             names=[f"wts_buf_{i}{j}" for j in range(3)],
             placement=Tile(i, 1),

--- a/programming_examples/ml/resnet/layers_conv2_x/resnet_placed.py
+++ b/programming_examples/ml/resnet/layers_conv2_x/resnet_placed.py
@@ -521,14 +521,16 @@ def resnet_conv_x():
             for i in range(n_cols):
 
                 wts_fifos.append(
-                    object_fifo(f"wts_{i}_L3L2", shims[i], mems[i], 1, wts_sizes[i])
+                    object_fifo(
+                        f"wts_{i}_L3L2", shims[i], mems[i], [1, 1], wts_sizes[i]
+                    )
                 )
                 wts_sub_fifos[i].append(
                     object_fifo(
                         f"wts_buf_{i}0",
                         mems[i],
                         cores[i][0],
-                        1,
+                        [1, 1],
                         layer1_wts_sizes[i],
                     )
                 )
@@ -538,7 +540,7 @@ def resnet_conv_x():
                             f"wts_buf_{i}1",
                             mems[i],
                             [cores[i][3], cores[i][1]],
-                            1,
+                            [1, 1, 1],
                             weightsLayer2_ty,
                         )
                     )
@@ -548,7 +550,7 @@ def resnet_conv_x():
                             f"wts_buf_{i}1",
                             mems[i],
                             [cores[i][1], cores[i][3]],
-                            1,
+                            [1, 1, 1],
                             weightsLayer2_ty,
                         )
                     )
@@ -557,7 +559,7 @@ def resnet_conv_x():
                         f"wts_buf_{i}2",
                         mems[i],
                         cores[i][2],
-                        1,
+                        [1, 1],
                         layer3_wts_sizes[i],
                     )
                 )

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/README.md
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/README.md
@@ -10,22 +10,20 @@
 
 # <ins>Single / Double Buffer</ins>
 
-The design in [single_buffer.py](./single_buffer.py) uses an Object FIFO `of_in` to transfer the output of `my_worker` to `my_worker2` and an Object FIFO `of_out` to transfer the output of `my_worker2` to external memory. `of_in` has a depth of `1` which describes a single buffer between the two Workers as shown in the figure below. 
+The design in [single_buffer.py](./single_buffer.py) uses an Object FIFO `of_in` to transfer the output of `my_worker` to `my_worker2` and an Object FIFO `of_out` to transfer the output of `my_worker2` to external memory. `of_in` has a depth of `2` which describes a double, or ping-pong, buffer between the two Workers as shown in the figure below.
 
-<img src="../../../assets/SingleBuffer.svg" height=200 width="500">
+<img src="../../../assets/DoubleBuffer.svg" height=200 width="500">
 
 > **NOTE:**  The image above assumes that the Workers are already mapped to `ComputeTile2` and `ComputeTile3`. However, this is not the only possible mapping and when creating a Worker, its placement can be left to the compiler.
 
-Both the producer and the consumer processes in this design have trivial tasks. The producer process running on `my_worker` acquires the single buffer and writes `1` into all its entries before releasing it for consumption. The consumer process running on `my_worker2` acquires the single buffer from `of_in` as well as the single buffer from `of_out`, copies the data from the input Object FIFO to the output Object FIFO, and releases both objects for other processes.
+Both the producer and the consumer processes in this design have trivial tasks. The producer process running on `my_worker` acquires one ping-pong buffer and writes `1` into all its entries before releasing it for consumption. The consumer process running on `my_worker2` acquires one buffer from `of_in` as well as one buffer from `of_out`, copies the data from the input Object FIFO to the output Object FIFO, and releases both objects for other processes. The Object FIFO lowering takes care of properly cycling between the ping and pong buffers.
 
-To have this design use a double, or ping-pong, buffer for the data transfer instead, the user need only set the depth of the Object FIFOs to `2`. No other change is required as the Object FIFO lowering will take care of properly cycling between the ping and pong buffers. To change the depth the user should write:
-```python
-of_in = ObjectFifo(data_ty, name="in", depth=2) # double buffer
-of_out = ObjectFifo(data_ty, name="out", depth=2) # double buffer
-```
-This change effectively increases the number of available resources of the Object FIFOs as is shown in the figure below:
-
-<img src="../../../assets/DoubleBuffer.svg" height=200 width="500">
+> **NOTE:** To enforce a single buffer (no prefetching), specify the depth as an array with explicit per-endpoint depths:
+> ```python
+> of_in = ObjectFifo(data_ty, name="in", depth=[1, 1])  # single buffer
+> of_out = ObjectFifo(data_ty, name="out", depth=[1, 1])  # single buffer
+> ```
+> This uses the array-depth form to explicitly limit each endpoint to one buffer. The producer and consumer must then strictly alternate access with no overlap.
 
 All examples available in the [programming_examples](../../../../programming_examples/) contain this data movement pattern.
 

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/single_buffer.py
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/single_buffer.py
@@ -25,8 +25,8 @@ if len(sys.argv) > 1:
 data_ty = np.ndarray[(16,), np.dtype[np.int32]]
 
 # Dataflow with ObjectFifos
-of_in = ObjectFifo(data_ty, name="in", depth=1)  # single buffer
-of_out = ObjectFifo(data_ty, name="out", depth=1)  # single buffer
+of_in = ObjectFifo(data_ty, name="in", depth=2)  # double buffer (ping-pong)
+of_out = ObjectFifo(data_ty, name="out", depth=2)  # double buffer (ping-pong)
 
 
 # Task for the core to perform

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/single_buffer_placed.py
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/single_buffer_placed.py
@@ -35,12 +35,12 @@ def single_buffer():
             # AIE-array data movement with object fifos
             # Input
             of_in = object_fifo(
-                "in", ComputeTile2, ComputeTile3, 1, data_ty
-            )  # single buffer
+                "in", ComputeTile2, ComputeTile3, 2, data_ty
+            )  # double buffer (ping-pong)
             # Output
             of_out = object_fifo(
-                "out", ComputeTile3, ShimTile, 1, data_ty
-            )  # single buffer
+                "out", ComputeTile3, ShimTile, 2, data_ty
+            )  # double buffer (ping-pong)
 
             # Set up compute tiles
             # Compute tile 2

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -260,7 +260,7 @@ class ObjectFifo(Resolvable):
                 "Cannot return depths since no cons ObjectFifoHandles are created."
             )
         depths = [self._prod.depth] + [con.depth for con in self._cons]
-        if len(set(depths)) == 1:
+        if len(set(depths)) == 1 and depths[0] != 1:
             return depths[0]
         return depths
 

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -40,7 +40,7 @@ class ObjectFifo(Resolvable):
     def __init__(
         self,
         obj_type: type[np.ndarray],
-        depth: int | None = 2,
+        depth: int | list[int] | None = 2,
         name: str | None = None,
         dims_to_stream: list[Sequence[int]] | None = None,
         dims_from_stream_per_cons: list[Sequence[int]] | None = None,
@@ -51,7 +51,12 @@ class ObjectFifo(Resolvable):
 
         Args:
             obj_type (type[np.ndarray]): The type of each buffer in the ObjectFifo
-            depth (int | None, optional): The default depth of the ObjectFifo endpoints. Defaults to 2.
+            depth (int | list[int] | None, optional): The default depth of the ObjectFifo
+                endpoints. An integer specifies a scalar depth, which is subject to
+                ``findObjectFifoSize`` analysis during lowering. A list of integers
+                specifies explicit per-endpoint depths (producer first, then each
+                consumer in order), which bypasses depth analysis and are used as-is.
+                Defaults to 2.
             name (str | None, optional): The name of the ObjectFifo. If None is given, a unique name will be generated. Defaults to None.
             dims_to_stream (list[Sequence[int]] | None, optional): Data layout transformations applied when data is pushed onto the AXI stream, described as pairs of (size, stride) from highest to lowest dimension. Defaults to None.
             dims_from_stream_per_cons (list[Sequence[int]] | None, optional): List of data layout transformations applied by each consumer when data is read from the AXI stream, described as pairs of (size, stride) from highest to lowest dimension. Defaults to None.
@@ -60,7 +65,8 @@ class ObjectFifo(Resolvable):
         Raises:
             ValueError: If ``depth`` is provided and is less than 1.
         """
-        self._depth = depth
+        self._array_depth = isinstance(depth, list)
+        self._depth = depth[0] if self._array_depth else depth
         if isinstance(self._depth, int) and self._depth < 1:
             raise ValueError(
                 f"Default ObjectFifo depth must be > 0, but got {self._depth}"
@@ -260,7 +266,9 @@ class ObjectFifo(Resolvable):
                 "Cannot return depths since no cons ObjectFifoHandles are created."
             )
         depths = [self._prod.depth] + [con.depth for con in self._cons]
-        if len(set(depths)) == 1 and depths[0] != 1:
+        if self._array_depth:
+            return depths
+        if len(set(depths)) == 1:
             return depths[0]
         return depths
 
@@ -566,7 +574,7 @@ class ObjectFifoHandle(Resolvable):
         self,
         offsets: list[int],
         placement: PlacementTile = AnyMemTile,
-        depths: list[int] | None = None,
+        depths: list[int | list[int]] | None = None,
         obj_types: list[type[np.ndarray]] = None,
         names: list[str] | None = None,
         dims_to_stream: list[list[Sequence[int]]] | None = None,

--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
@@ -54,8 +54,8 @@ def compute_repeat():
             ComputeTile = tile(col, 3)
 
             # AIE-array data movement with object fifos
-            of_in = object_fifo("in", ShimTile, ComputeTile, 1, tensor_ty)
-            of_out = object_fifo("out", ComputeTile, ShimTile, 1, tensor_ty)
+            of_in = object_fifo("in", ShimTile, ComputeTile, [1, 1], tensor_ty)
+            of_out = object_fifo("out", ComputeTile, ShimTile, [1, 1], tensor_ty)
             of_out.set_repeat_count(repeat_count)
 
             # Compute tile

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
@@ -59,14 +59,14 @@ def init_values_repeat():
                 "in",
                 MemTile,
                 ComputeTile,
-                1,
+                [1, 1],
                 tensor_ty,
                 initValues=[
                     np.arange(1, N + 1, dtype=np.int32),
                 ],
             )
             of_in.set_repeat_count(memtile_repeat_count)
-            of_out = object_fifo("out", ComputeTile, ShimTile, 1, tensor_ty)
+            of_out = object_fifo("out", ComputeTile, ShimTile, [1, 1], tensor_ty)
 
             # Compute tile
             @core(ComputeTile)

--- a/test/npu-xrt/runtime_cumsum/aie.mlir
+++ b/test/npu-xrt/runtime_cumsum/aie.mlir
@@ -41,11 +41,11 @@ module {
         %mem_tile_0_1 = aie.tile(0, 1)
         %tile_0_2 = aie.tile(0, 2)
 
-        aie.objectfifo @mem_In(%shim_noc_tile_0_0, {%mem_tile_0_1}, 1 : i32) : !aie.objectfifo<memref<16xi32>> 
-        aie.objectfifo @act_In(%mem_tile_0_1, {%tile_0_2}, 1 : i32) : !aie.objectfifo<memref<16xi32>> 
+        aie.objectfifo @mem_In(%shim_noc_tile_0_0, {%mem_tile_0_1}, [1, 1]) : !aie.objectfifo<memref<16xi32>> 
+        aie.objectfifo @act_In(%mem_tile_0_1, {%tile_0_2}, [1, 1]) : !aie.objectfifo<memref<16xi32>> 
         aie.objectfifo.link [@mem_In] -> [@act_In]([] [])
-        aie.objectfifo @out(%tile_0_2, {%mem_tile_0_1}, 1 : i32) : !aie.objectfifo<memref<16xi32>> 
-        aie.objectfifo @mem_out(%mem_tile_0_1, {%shim_noc_tile_0_0}, 1 : i32) : !aie.objectfifo<memref<16xi32>> 
+        aie.objectfifo @out(%tile_0_2, {%mem_tile_0_1}, [1, 1]) : !aie.objectfifo<memref<16xi32>> 
+        aie.objectfifo @mem_out(%mem_tile_0_1, {%shim_noc_tile_0_0}, [1, 1]) : !aie.objectfifo<memref<16xi32>> 
         aie.objectfifo.link [@out] -> [@mem_out]([] [])
 
         // Buffers used to hold runtime parameters

--- a/test/objectFifo-stateful-transform/base/depth_one_array_test.mlir
+++ b/test/objectFifo-stateful-transform/base/depth_one_array_test.mlir
@@ -1,0 +1,44 @@
+//===- depth_one_array_test.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// Verify that an objectFifo with array depth [1, 1] lowers to a single buffer.
+// The array-depth form explicitly enforces per-endpoint depths, bypassing the
+// prefetch increment that the scalar depth form applies.
+
+// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_0"} : memref<16xi32>
+// CHECK-NOT: sym_name = "of_cons_buff_1"
+
+module @depth_one_array {
+    aie.device(xcve2302) {
+        %tile10 = aie.tile(1, 0)
+        %tile12 = aie.tile(1, 2)
+
+        aie.objectfifo @of (%tile12, {%tile10}, [1, 1]) : !aie.objectfifo<memref<16xi32>>
+
+        func.func @some_work(%buf : memref<16xi32>) -> () {
+            return
+        }
+
+        %core12 = aie.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %c10 = arith.constant 10 : index
+            scf.for %i = %c0 to %c10 step %c1 {
+                %subview = aie.objectfifo.acquire @of(Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+                %elem = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem) : (memref<16xi32>) -> ()
+                aie.objectfifo.release @of(Produce, 1)
+            }
+            aie.end
+        }
+    }
+}

--- a/test/objectFifo-stateful-transform/base/depth_one_array_test.mlir
+++ b/test/objectFifo-stateful-transform/base/depth_one_array_test.mlir
@@ -10,12 +10,13 @@
 
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
-// Verify that an objectFifo with array depth [1, 1] lowers to a single buffer.
-// The array-depth form explicitly enforces per-endpoint depths, bypassing the
-// prefetch increment that the scalar depth form applies.
+// Verify that an objectFifo with array depth [1, 1] lowers to a single buffer
+// on the producer side. Since the consumer is a shim tile (which has no local
+// memory), no consumer buffer is created; the shim tile side only gets locks.
 
-// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_0"} : memref<16xi32>
-// CHECK-NOT: sym_name = "of_cons_buff_1"
+// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_buff_0"} : memref<16xi32>
+// CHECK-NOT: sym_name = "of_buff_1"
+// CHECK-NOT: sym_name = "of_cons_buff_0"
 
 module @depth_one_array {
     aie.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/base/depth_one_scalar_test.mlir
+++ b/test/objectFifo-stateful-transform/base/depth_one_scalar_test.mlir
@@ -11,11 +11,13 @@
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
 
 // Verify that a scalar depth-1 objectFifo with a max acquire of 1 lowers to
-// two buffers (ping-pong). The depth-1 scalar form does not enforce a single
-// buffer; use array depth [1, 1] to explicitly enforce a single buffer.
+// two buffers (ping-pong) on the producer side. Since the consumer is a shim
+// tile (which has no local memory), no consumer buffer is created; the shim
+// tile side only gets locks.
 
-// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_0"} : memref<16xi32>
-// CHECK: %[[BUFF1:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_1"} : memref<16xi32>
+// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_buff_0"} : memref<16xi32>
+// CHECK: %[[BUFF1:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_buff_1"} : memref<16xi32>
+// CHECK-NOT: sym_name = "of_cons_buff_0"
 
 module @depth_one_scalar {
     aie.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/base/depth_one_scalar_test.mlir
+++ b/test/objectFifo-stateful-transform/base/depth_one_scalar_test.mlir
@@ -1,0 +1,44 @@
+//===- depth_one_scalar_test.mlir -------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// Verify that a scalar depth-1 objectFifo with a max acquire of 1 lowers to
+// two buffers (ping-pong). The depth-1 scalar form does not enforce a single
+// buffer; use array depth [1, 1] to explicitly enforce a single buffer.
+
+// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_0"} : memref<16xi32>
+// CHECK: %[[BUFF1:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_1"} : memref<16xi32>
+
+module @depth_one_scalar {
+    aie.device(xcve2302) {
+        %tile10 = aie.tile(1, 0)
+        %tile12 = aie.tile(1, 2)
+
+        aie.objectfifo @of (%tile12, {%tile10}, 1 : i32) : !aie.objectfifo<memref<16xi32>>
+
+        func.func @some_work(%buf : memref<16xi32>) -> () {
+            return
+        }
+
+        %core12 = aie.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %c10 = arith.constant 10 : index
+            scf.for %i = %c0 to %c10 step %c1 {
+                %subview = aie.objectfifo.acquire @of(Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+                %elem = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem) : (memref<16xi32>) -> ()
+                aie.objectfifo.release @of(Produce, 1)
+            }
+            aie.end
+        }
+    }
+}

--- a/test/objectFifo-stateful-transform/base/depth_two_scalar_test.mlir
+++ b/test/objectFifo-stateful-transform/base/depth_two_scalar_test.mlir
@@ -13,11 +13,14 @@
 // Verify that a scalar depth-2 objectFifo with a max acquire of 1 lowers to
 // two buffers (maxAcquire + 1 = 2), not three (declared depth + 1 = 3). The
 // buffer count is driven by the maximum acquire count in the core, not the
-// declared objectFifo depth.
+// declared objectFifo depth. Since the consumer is a shim tile (which has no
+// local memory), buffers are only created on the producer side; the shim tile
+// side only gets locks.
 
-// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_0"} : memref<16xi32>
-// CHECK: %[[BUFF1:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_1"} : memref<16xi32>
-// CHECK-NOT: sym_name = "of_cons_buff_2"
+// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_buff_0"} : memref<16xi32>
+// CHECK: %[[BUFF1:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_buff_1"} : memref<16xi32>
+// CHECK-NOT: sym_name = "of_buff_2"
+// CHECK-NOT: sym_name = "of_cons_buff_0"
 
 module @depth_two_scalar {
     aie.device(xcve2302) {

--- a/test/objectFifo-stateful-transform/base/depth_two_scalar_test.mlir
+++ b/test/objectFifo-stateful-transform/base/depth_two_scalar_test.mlir
@@ -1,0 +1,46 @@
+//===- depth_two_scalar_test.mlir -------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2025, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
+
+// Verify that a scalar depth-2 objectFifo with a max acquire of 1 lowers to
+// two buffers (maxAcquire + 1 = 2), not three (declared depth + 1 = 3). The
+// buffer count is driven by the maximum acquire count in the core, not the
+// declared objectFifo depth.
+
+// CHECK: %[[BUFF0:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_0"} : memref<16xi32>
+// CHECK: %[[BUFF1:.*]] = aie.buffer(%{{.*}}tile_1_0) {sym_name = "of_cons_buff_1"} : memref<16xi32>
+// CHECK-NOT: sym_name = "of_cons_buff_2"
+
+module @depth_two_scalar {
+    aie.device(xcve2302) {
+        %tile10 = aie.tile(1, 0)
+        %tile12 = aie.tile(1, 2)
+
+        aie.objectfifo @of (%tile12, {%tile10}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+        func.func @some_work(%buf : memref<16xi32>) -> () {
+            return
+        }
+
+        %core12 = aie.core(%tile12) {
+            %c0 = arith.constant 0 : index
+            %c1 = arith.constant 1 : index
+            %c10 = arith.constant 10 : index
+            scf.for %i = %c0 to %c10 step %c1 {
+                %subview = aie.objectfifo.acquire @of(Produce, 1) : !aie.objectfifosubview<memref<16xi32>>
+                %elem = aie.objectfifo.subview.access %subview[0] : !aie.objectfifosubview<memref<16xi32>> -> memref<16xi32>
+                func.call @some_work(%elem) : (memref<16xi32>) -> ()
+                aie.objectfifo.release @of(Produce, 1)
+            }
+            aie.end
+        }
+    }
+}

--- a/test/objectFifo-stateful-transform/dynamic_lowering/depth_one_objectfifo_test.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering/depth_one_objectfifo_test.mlir
@@ -68,7 +68,7 @@ module {
     %tile_0_0 = aie.tile(0, 0)
     %tile_0_2 = aie.tile(0, 2)
     %tile_0_4 = aie.tile(0, 4)
-    aie.objectfifo @input_fifo(%tile_0_0, {%tile_0_2}, 1 : i32) : !aie.objectfifo<memref<10xi32>>
+    aie.objectfifo @input_fifo(%tile_0_0, {%tile_0_2}, [1, 1]) : !aie.objectfifo<memref<10xi32>>
 
     %core_0_2 = aie.core(%tile_0_2) {
       %c0 = arith.constant 0 : index

--- a/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
@@ -17,7 +17,7 @@
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32> 
 // CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
 // CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32> 
+// CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
 // CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
@@ -73,7 +73,7 @@ module @repeatCount {
     %tile12 = aie.tile(1, 2)
     %tile13 = aie.tile(1, 3)
 
-    aie.objectfifo @of1 (%tile12, {%tile13}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile12, {%tile13}, [1, 1]) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
        return

--- a/test/objectFifo-stateful-transform/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count_test.mlir
@@ -18,7 +18,7 @@
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32> 
 // CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
 // CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32> 
+// CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_2, 2) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
 // CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_2, 3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     %[[VAL_6:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_cons_buff_0"} : memref<16xi32> 
@@ -97,8 +97,8 @@ module @repeatCount {
     %tile12 = aie.tile(1, 2)
     %tile13 = aie.tile(1, 3)
 
-    aie.objectfifo @of0 (%tile11, {%tile12}, 1 : i32) : !aie.objectfifo<memref<16xi32>>
-    aie.objectfifo @of1 (%tile12, {%tile13}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of0 (%tile11, {%tile12}, [1, 1]) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile12, {%tile13}, [1, 1]) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
 
     %core33 = aie.core(%tile12) {
       %c0 = arith.constant 0 : index


### PR DESCRIPTION
The `findObjectFifoSize()` function in AIEObjectFifoStatefulTransform had a special case that returned 1 buffer when both the declared scalar depth and the max acquire count were 1, suppressing the usual `maxAcquire + 1` ping-pong increment. This exception was redundant because the array-depth form (e.g. `[1, 1]`) already provides a way to explicitly enforce per-endpoint depths. Remove the exception so that a scalar depth-1 objectFifo consistently lowers to two buffers like any other scalar depth, and document that `[1, 1]` is the correct way to enforce a single buffer.

Changes:
- Remove the `maxAcquire == 1 && objFifo.size() == 1` guard from `findObjectFifoSize()` in AIEObjectFifoStatefulTransform.cpp
- Update `depth_one_objectfifo_test.mlir` to use `[1, 1]` array depth so the test continues to verify single-buffer lowering via the explicit array-depth mechanism
- Add `depth_one_scalar_test.mlir`: scalar depth 1 now lowers to 2 buffers (ping-pong)
- Add `depth_one_array_test.mlir`: array depth `[1, 1]` still lowers to 1 buffer, confirming the enforcement mechanism works
- Add `depth_two_scalar_test.mlir`: scalar depth 2 with max acquire 1 lowers to 2 buffers (not 3), confirming buffer count is driven by maxAcquire rather than the declared size
- Update `01_single_double_buffer/` example designs to use depth 2 (ping-pong) and add a note that `[1, 1]` enforces a single buffer