### PR TITLE
Fix AIE2P control register indices for saturation and rounding

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -599,14 +599,19 @@ struct AIECoreToStandardFunc : OpConversionPattern<CoreOp> {
             Block &entryBlock = coreFunc.getBody().front();
             rewriter.setInsertionPointToStart(&entryBlock);
             Location loc = op.getLoc();
-            // saturation_mode::saturate (register 9 = 1)
-            auto c9 = arith::ConstantOp::create(rewriter, loc,
-                                                rewriter.getI32IntegerAttr(9));
+            // Control register indices differ between AIE2 and AIE2P:
+            //   AIE2:  crSat=9, crRnd=6
+            //   AIE2P: crSat=0, crRnd=1
+            int satRegIdx = (arch == AIEArch::AIE2p) ? 0 : 9;
+            int rndRegIdx = (arch == AIEArch::AIE2p) ? 1 : 6;
+            // saturation_mode::saturate = 1
+            auto cSatIdx = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI32IntegerAttr(satRegIdx));
             auto c1 = arith::ConstantOp::create(rewriter, loc,
                                                 rewriter.getI32IntegerAttr(1));
             func::CallOp::create(rewriter, loc, ctrlRegFunc,
-                                 ValueRange{c9, c1});
-            // Rounding mode (register 6):
+                                 ValueRange{cSatIdx, c1});
+            // Rounding mode:
             //  - conv_even (12) for bf16 matmul: eliminates systematic
             //    negative bias from floor rounding in BFP16 arithmetic,
             //    matching ::aie::set_rounding(aie::rounding_mode::conv_even)
@@ -614,13 +619,13 @@ struct AIECoreToStandardFunc : OpConversionPattern<CoreOp> {
             //  - positive_inf (9) for integer SRS (shift-round-saturate on
             //    integer data, e.g., i32→i8).
             //  - floor (0) for float-only SRS (f32→bf16 truncation).
-            auto c6 = arith::ConstantOp::create(rewriter, loc,
-                                                rewriter.getI32IntegerAttr(6));
             int roundingMode = hasBF16Matmul ? 12 : hasIntegerSRS ? 9 : 0;
+            auto cRndIdx = arith::ConstantOp::create(
+                rewriter, loc, rewriter.getI32IntegerAttr(rndRegIdx));
             auto cRoundingMode = arith::ConstantOp::create(
                 rewriter, loc, rewriter.getI32IntegerAttr(roundingMode));
             func::CallOp::create(rewriter, loc, ctrlRegFunc,
-                                 ValueRange{c6, cRoundingMode});
+                                 ValueRange{cRndIdx, cRoundingMode});
           }
         }
       }

--- a/test/lower-to-standard/srs_rounding_mode_aie2p.mlir
+++ b/test/lower-to-standard/srs_rounding_mode_aie2p.mlir
@@ -12,13 +12,13 @@
 
 // RUN: aie-opt --aie-standard-lowering="tilecol=0 tilerow=2" %s | FileCheck --check-prefix=CHECK-BF16-AIE2P %s
 
-// BF16 matmul_aie2p: rounding mode = conv_even (register 6 = 12)
-// Uses llvm.aie2p.set.ctrl.reg instead of llvm.aie2.set.ctrl.reg
+// BF16 matmul_aie2p: AIE2P uses different control register indices than AIE2:
+//   crSat = index 0 (AIE2 uses 9), crRnd = index 1 (AIE2 uses 6)
 // CHECK-BF16-AIE2P:  func.func @core_0_2
-// CHECK-BF16-AIE2P:    call @llvm.aie2p.set.ctrl.reg(%c9_i32, %c1_i32)
-// CHECK-BF16-AIE2P:    %c6_i32 = arith.constant 6 : i32
+// CHECK-BF16-AIE2P:    call @llvm.aie2p.set.ctrl.reg(%c0_i32, %c1_i32)
+// CHECK-BF16-AIE2P:    %c1_i32_0 = arith.constant 1 : i32
 // CHECK-BF16-AIE2P:    %c12_i32 = arith.constant 12 : i32
-// CHECK-BF16-AIE2P:    call @llvm.aie2p.set.ctrl.reg(%c6_i32, %c12_i32)
+// CHECK-BF16-AIE2P:    call @llvm.aie2p.set.ctrl.reg(%c1_i32_0, %c12_i32)
 
 module @test_aie2p_rounding {
   aie.device(npu2) {


### PR DESCRIPTION
## Summary

Fix control register index mapping in `AIECoreToStandard` for AIE2P. The register indices differ between AIE2 and AIE2P:

| Register | AIE2 index | AIE2P index |
|----------|-----------|-------------|
| crSat | 9 | 0 |
| crRnd | 6 | 1 |

PR #2984 hardcoded AIE2 indices (6 for crRnd, 9 for crSat) for both architectures. On AIE2P, index 6 is `crSRSMode`, so `set_ctrl_reg(6, 12)` wrote conv_even to the wrong register.

Verified by disassembling the ELF: before this fix, `mov crsrsmode, #12`; after, `mov crrnd, #12`.

## Test plan
- [x] bf16 matmul direct-codegen 512x512x512 with random inputs: PASS on NPU2
- [x] bf16 matmul llama shapes (128x2048x2048, 128x8192x2048, etc.): PASS on NPU2
- [x] Assembly shows correct `mov crrnd, #12` instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)