### PR TITLE
Revert merge queue concurrency changes from #2976

### DIFF
--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -23,15 +23,11 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 concurrency:
-  # Merge queue runs share a single group key (serialized, never cancelled).
-  # PR runs use a per-PR key (cancelled when the same PR gets a new push).
-  # Push/schedule/workflow_dispatch runs use the SHA-based key.
-  group: >-
-    ci-build-test-multi-cpp-linux-${{
-    github.event_name == 'merge_group' && 'merge-queue' ||
-    github.event.number || github.sha
-    }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ci-build-test-multi-cpp-linux-${{ github.event.number || github.sha }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   build-repo:

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -18,15 +18,11 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 concurrency:
-  # Merge queue runs share a single group key (serialized, never cancelled).
-  # PR runs use a per-PR key (cancelled when the same PR gets a new push).
-  # Push/schedule/workflow_dispatch runs use the SHA-based key.
-  group: >-
-    ci-build-test-pythons-cpp-linux-${{
-    github.event_name == 'merge_group' && 'merge-queue' ||
-    github.event.number || github.sha
-    }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ci-build-test-pythons-cpp-linux-${{ github.event.number || github.sha }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   build-repo:

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -32,15 +32,11 @@ defaults:
     shell: bash
 
 concurrency:
-  # Merge queue runs share a single group key (serialized, never cancelled).
-  # PR runs use a per-PR key (cancelled when the same PR gets a new push).
-  # Push/schedule/workflow_dispatch runs use the SHA-based key.
-  group: >-
-    ci-build-test-ryzenai-${{
-    github.event_name == 'merge_group' && 'merge-queue' ||
-    github.event.number || github.sha
-    }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ci-build-test-ryzenai-${{ github.event.number || github.sha }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 env:
   DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -22,16 +22,11 @@ defaults:
     shell: bash
 
 concurrency:
-  # Merge queue runs share a single group key (serialized, never cancelled).
-  # PR runs use a per-PR key (cancelled when the same PR gets a new push).
-  # Push/schedule/workflow_dispatch runs use the SHA-based key.
-  # Appending event_name prevents schedule and tag-push collisions on the same SHA.
-  group: >-
-    ci-build-test-ryzenai-experimental-${{
-    github.event_name == 'merge_group' && 'merge-queue' ||
-    github.event.number || github.sha
-    }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
+  group: ci-build-test-ryzenai-experimental-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
 
 env:
   DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -9,17 +9,6 @@ on:
     # Runs at midnight (00:00) every day
     - cron: '0 0 * * *'
 
-concurrency:
-  # Merge queue runs share a single group key (serialized, never cancelled).
-  # PR runs use a per-PR key (cancelled when the same PR gets a new push).
-  # Push/schedule/workflow_dispatch runs use the SHA-based key.
-  group: >-
-    ci-lint-and-format-${{
-    github.event_name == 'merge_group' && 'merge-queue' ||
-    github.event.number || github.sha
-    }}-${{ github.event_name }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
-
 env:
   # Run apt package manager in the CI in non-interactive mode.
   # Otherwise, on Ubuntu 20.04 the installation of tzdata asking question


### PR DESCRIPTION
The merge queue has been seeing frequent job ejections due to no runner response. Reverting the concurrency group changes introduced in #2976 as a potential cause. The vendor_eudsl.py pip install changes from that PR are kept.