### PR TITLE
Fix doc generation

### DIFF
--- a/include/aie/Dialect/AIEVec/TransformOps/CMakeLists.txt
+++ b/include/aie/Dialect/AIEVec/TransformOps/CMakeLists.txt
@@ -10,4 +10,3 @@ mlir_tablegen(AIEVecTransformOps.h.inc -gen-op-decls)
 mlir_tablegen(AIEVecTransformOps.cpp.inc -gen-op-defs)
 add_public_tablegen_target(MLIRAIEVecTransformOpsIncGen)
 
-add_mlir_doc(AIEVecTransformOps AIEVecTransformOps ./ -gen-op-doc)


### PR DESCRIPTION
In main, the Generate Documentation action appears to be failing (https://github.com/Xilinx/mlir-aie/actions/runs/23564898069/job/68613896773). I believe this should fix it.