### PR TITLE
Add shim DMA BD reuse tests for >16 task sequences

### DIFF
--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-bd-reuse-multi-buffer.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-bd-reuse-multi-buffer.mlir
@@ -3,7 +3,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2025 Advanced Micro Devices, Inc.
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
 
 // RUN: aie-opt --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
 

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-bd-reuse-multi-buffer.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-bd-reuse-multi-buffer.mlir
@@ -20,76 +20,76 @@ module {
   aie.device(npu2) {
     %tile_0_0 = aie.tile(0, 0)
 
-    aie.runtime_sequence(%buf_a: memref<4096xbf16>, %buf_b: memref<4096xbf16>) {
+    aie.runtime_sequence(%buf_a: memref<40960xbf16>, %buf_b: memref<40960xbf16>) {
 
       // ===== Batch 1: 10 tasks, BD IDs 0-9 =====
 
-      // CHECK: aie.dma_bd(%arg0 {{.*}} offset = 0 {{.*}} {bd_id = 0 : i32}
+      // CHECK: aie.dma_bd(%arg0 : memref<40960xbf16>, 0, 4096) {bd_id = 0 : i32}
       %t0 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 0, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 0, 4096)
         aie.end
       }
       aiex.dma_start_task(%t0)
 
-      // CHECK: aie.dma_bd(%arg1 {{.*}} offset = 0 {{.*}} {bd_id = 1 : i32}
+      // CHECK: aie.dma_bd(%arg1 : memref<40960xbf16>, 0, 4096) {bd_id = 1 : i32}
       %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 0, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 0, 4096)
         aie.end
       }
       aiex.dma_start_task(%t1)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 2 : i32}
       %t2 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 4096, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 4096, 4096)
         aie.end
       }
       aiex.dma_start_task(%t2)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 3 : i32}
       %t3 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 4096, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 4096, 4096)
         aie.end
       }
       aiex.dma_start_task(%t3)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 4 : i32}
       %t4 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 8192, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 8192, 4096)
         aie.end
       }
       aiex.dma_start_task(%t4)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 5 : i32}
       %t5 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 8192, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 8192, 4096)
         aie.end
       }
       aiex.dma_start_task(%t5)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 6 : i32}
       %t6 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 12288, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 12288, 4096)
         aie.end
       }
       aiex.dma_start_task(%t6)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 7 : i32}
       %t7 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 12288, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 12288, 4096)
         aie.end
       }
       aiex.dma_start_task(%t7)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 8 : i32}
       %t8 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 16384, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 16384, 4096)
         aie.end
       }
       aiex.dma_start_task(%t8)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 9 : i32}
       %t9 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 16384, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 16384, 4096)
         aie.end
       }
       aiex.dma_start_task(%t9)
@@ -109,72 +109,72 @@ module {
 
       // ===== Batch 2: 10 more tasks, reuses BD IDs 0-9 =====
 
-      // CHECK: aie.dma_bd(%arg0 {{.*}} offset = 20480 {{.*}} {bd_id = 0 : i32}
+      // CHECK: aie.dma_bd(%arg0 : memref<40960xbf16>, 20480, 4096) {bd_id = 0 : i32}
       %t10 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 20480, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 20480, 4096)
         aie.end
       }
       aiex.dma_start_task(%t10)
 
-      // CHECK: aie.dma_bd(%arg1 {{.*}} offset = 20480 {{.*}} {bd_id = 1 : i32}
+      // CHECK: aie.dma_bd(%arg1 : memref<40960xbf16>, 20480, 4096) {bd_id = 1 : i32}
       %t11 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 20480, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 20480, 4096)
         aie.end
       }
       aiex.dma_start_task(%t11)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 2 : i32}
       %t12 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 24576, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 24576, 4096)
         aie.end
       }
       aiex.dma_start_task(%t12)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 3 : i32}
       %t13 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 24576, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 24576, 4096)
         aie.end
       }
       aiex.dma_start_task(%t13)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 4 : i32}
       %t14 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 28672, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 28672, 4096)
         aie.end
       }
       aiex.dma_start_task(%t14)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 5 : i32}
       %t15 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 28672, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 28672, 4096)
         aie.end
       }
       aiex.dma_start_task(%t15)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 6 : i32}
       %t16 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 32768, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 32768, 4096)
         aie.end
       }
       aiex.dma_start_task(%t16)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 7 : i32}
       %t17 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 32768, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 32768, 4096)
         aie.end
       }
       aiex.dma_start_task(%t17)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 8 : i32}
       %t18 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_a : memref<4096xbf16>, 36864, 4096)
+        aie.dma_bd(%buf_a : memref<40960xbf16>, 36864, 4096)
         aie.end
       }
       aiex.dma_start_task(%t18)
 
       // CHECK: aie.dma_bd({{.*}} {bd_id = 9 : i32}
       %t19 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%buf_b : memref<4096xbf16>, 36864, 4096)
+        aie.dma_bd(%buf_b : memref<40960xbf16>, 36864, 4096)
         aie.end
       }
       aiex.dma_start_task(%t19)

--- a/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-bd-reuse-multi-buffer.mlir
+++ b/test/bd-chains-and-dma-tasks/assign-runtime-sequence-bd-ids/good-bd-reuse-multi-buffer.mlir
@@ -1,0 +1,185 @@
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025 Advanced Micro Devices, Inc.
+
+// RUN: aie-opt --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
+
+// Tests that >16 tasks on one shim tile succeed when dma_free_task
+// recycles BD IDs between batches. Two host buffers alternate on
+// the same MM2S channel (simulates RoPE LUT + V interleaving).
+//
+// Batch 1: 10 tasks → BD IDs 0-9.
+// Free all → IDs 0-9 available.
+// Batch 2: 10 tasks → reuses BD IDs 0-9.
+// Total: 20 tasks on one tile (exceeds 16 limit without reuse).
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+
+    aie.runtime_sequence(%buf_a: memref<4096xbf16>, %buf_b: memref<4096xbf16>) {
+
+      // ===== Batch 1: 10 tasks, BD IDs 0-9 =====
+
+      // CHECK: aie.dma_bd(%arg0 {{.*}} offset = 0 {{.*}} {bd_id = 0 : i32}
+      %t0 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 0, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t0)
+
+      // CHECK: aie.dma_bd(%arg1 {{.*}} offset = 0 {{.*}} {bd_id = 1 : i32}
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 0, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t1)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 2 : i32}
+      %t2 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 4096, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t2)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 3 : i32}
+      %t3 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 4096, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t3)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 4 : i32}
+      %t4 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 8192, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t4)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 5 : i32}
+      %t5 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 8192, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t5)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 6 : i32}
+      %t6 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 12288, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t6)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 7 : i32}
+      %t7 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 12288, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t7)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 8 : i32}
+      %t8 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 16384, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t8)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 9 : i32}
+      %t9 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 16384, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t9)
+
+      // Await last task (guarantees all prior sequential tasks completed),
+      // then free each task's BDs individually to recycle IDs.
+      aiex.dma_await_task(%t9)
+      aiex.dma_free_task(%t0)
+      aiex.dma_free_task(%t1)
+      aiex.dma_free_task(%t2)
+      aiex.dma_free_task(%t3)
+      aiex.dma_free_task(%t4)
+      aiex.dma_free_task(%t5)
+      aiex.dma_free_task(%t6)
+      aiex.dma_free_task(%t7)
+      aiex.dma_free_task(%t8)
+
+      // ===== Batch 2: 10 more tasks, reuses BD IDs 0-9 =====
+
+      // CHECK: aie.dma_bd(%arg0 {{.*}} offset = 20480 {{.*}} {bd_id = 0 : i32}
+      %t10 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 20480, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t10)
+
+      // CHECK: aie.dma_bd(%arg1 {{.*}} offset = 20480 {{.*}} {bd_id = 1 : i32}
+      %t11 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 20480, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t11)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 2 : i32}
+      %t12 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 24576, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t12)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 3 : i32}
+      %t13 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 24576, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t13)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 4 : i32}
+      %t14 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 28672, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t14)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 5 : i32}
+      %t15 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 28672, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t15)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 6 : i32}
+      %t16 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 32768, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t16)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 7 : i32}
+      %t17 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 32768, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t17)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 8 : i32}
+      %t18 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<4096xbf16>, 36864, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t18)
+
+      // CHECK: aie.dma_bd({{.*}} {bd_id = 9 : i32}
+      %t19 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<4096xbf16>, 36864, 4096)
+        aie.end
+      }
+      aiex.dma_start_task(%t19)
+
+      aiex.dma_await_task(%t19)
+    }
+  }
+}

--- a/test/npu-xrt/shim_dma_bd_reuse/aie.mlir
+++ b/test/npu-xrt/shim_dma_bd_reuse/aie.mlir
@@ -1,0 +1,225 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// E2E test: Shim MM2S BD reuse with >16 fire-and-forget tasks.
+//
+// The host fires 20 MM2S tasks on shim tile_0_0 channel 0 (exceeds 16-BD
+// limit), alternating between two source buffers (buf_a, buf_b). After
+// every 8 tasks, the host awaits the last issued MM2S task to reclaim
+// BDs. The core tile has a pre-configured looping S2MM→MM2S passthrough.
+// The shim S2MM side receives all 20 transfers into the output buffer.
+//
+// This matches the kv_cache_prefill pattern where VIn sends hundreds of
+// MM2S tasks (LUT + V interleaved) without any S2MM-side await.
+
+module {
+  aie.device(NPUDEVICE) {
+    %tile_0_0 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 3>}
+    %tile_0_2 = aie.tile(0, 2) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 1>}
+
+    %core_buf = aie.buffer(%tile_0_2) {sym_name = "core_buf"} : memref<256xi32>
+
+    // Input path: shim MM2S ch0 → core S2MM ch0
+    aie.flow(%tile_0_0, DMA : 0, %tile_0_2, DMA : 0)
+    // Output path: core MM2S ch0 → shim S2MM ch0
+    aie.flow(%tile_0_2, DMA : 0, %tile_0_0, DMA : 0)
+
+    // Packet flows for issue_token on shim MM2S
+    aie.packet_flow(0x3) {
+      aie.packet_source<%tile_0_0, "TileControl" : 0>
+      aie.packet_dest<%tile_0_0, "South" : 0>
+    }
+
+    // Core tile: looping S2MM→MM2S passthrough (20 iterations)
+    %lock_in = aie.lock(%tile_0_2, 0) {init = 1 : i32, sym_name = "lock_in"}
+    %lock_out = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "lock_out"}
+
+    %mem_0_2 = aie.mem(%tile_0_2) {
+      %0 = aie.dma_start(S2MM, 0, ^s2mm, ^mm2s_entry)
+    ^s2mm:
+      aie.use_lock(%lock_in, AcquireGreaterEqual, 1)
+      aie.dma_bd(%core_buf : memref<256xi32>, 0, 256)
+      aie.use_lock(%lock_out, Release, 1)
+      aie.next_bd ^s2mm
+    ^mm2s_entry:
+      %1 = aie.dma_start(MM2S, 0, ^mm2s, ^end)
+    ^mm2s:
+      aie.use_lock(%lock_out, AcquireGreaterEqual, 1)
+      aie.dma_bd(%core_buf : memref<256xi32>, 0, 256)
+      aie.use_lock(%lock_in, Release, 1)
+      aie.next_bd ^mm2s
+    ^end:
+      aie.end
+    }
+
+    // buf_a: 2560 i32 (10 slices of 256 — even-numbered transfers)
+    // buf_b: 2560 i32 (10 slices of 256 — odd-numbered transfers)
+    // output: 5120 i32 (20 slices of 256)
+    aie.runtime_sequence(%buf_a: memref<2560xi32>, %buf_b: memref<2560xi32>, %output: memref<5120xi32>) {
+
+      // Pre-configure shim S2MM ch0: looping BD that receives all 20
+      // transfers into output[0..5119]. Uses repeat_count to avoid
+      // consuming shim BDs for the receive side.
+      %recv = aiex.dma_configure_task(%tile_0_0, S2MM, 0) {
+        aie.dma_bd(%output : memref<5120xi32>, 0, 5120, [<size = 20, stride = 256>, <size = 256, stride = 1>]) {bd_id = 8 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%recv)
+
+      // ===== Batch 0: MM2S tasks 0-7, BD IDs 0-7 =====
+      // Pattern: a[0], b[0], a[1], b[1], a[2], b[2], a[3], b[3]
+
+      %t0 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 0, 256) {bd_id = 0 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t0)
+
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 0, 256) {bd_id = 1 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t1)
+
+      %t2 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 256, 256) {bd_id = 2 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t2)
+
+      %t3 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 256, 256) {bd_id = 3 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t3)
+
+      %t4 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 512, 256) {bd_id = 4 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t4)
+
+      %t5 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 512, 256) {bd_id = 5 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t5)
+
+      %t6 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 768, 256) {bd_id = 6 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t6)
+
+      %t7 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 768, 256) {bd_id = 7 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t7)
+
+      // Await last MM2S task of batch 0, then free all to reclaim BD IDs
+      aiex.dma_await_task(%t7)
+      aiex.dma_free_task(%t0)
+      aiex.dma_free_task(%t1)
+      aiex.dma_free_task(%t2)
+      aiex.dma_free_task(%t3)
+      aiex.dma_free_task(%t4)
+      aiex.dma_free_task(%t5)
+      aiex.dma_free_task(%t6)
+
+      // ===== Batch 1: MM2S tasks 8-15, BD IDs 0-7 reused =====
+
+      %t8 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 1024, 256) {bd_id = 0 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t8)
+
+      %t9 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 1024, 256) {bd_id = 1 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t9)
+
+      %t10 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 1280, 256) {bd_id = 2 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t10)
+
+      %t11 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 1280, 256) {bd_id = 3 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t11)
+
+      %t12 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 1536, 256) {bd_id = 4 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t12)
+
+      %t13 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 1536, 256) {bd_id = 5 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t13)
+
+      %t14 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 1792, 256) {bd_id = 6 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t14)
+
+      %t15 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 1792, 256) {bd_id = 7 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t15)
+
+      // Await + free batch 1
+      aiex.dma_await_task(%t15)
+      aiex.dma_free_task(%t8)
+      aiex.dma_free_task(%t9)
+      aiex.dma_free_task(%t10)
+      aiex.dma_free_task(%t11)
+      aiex.dma_free_task(%t12)
+      aiex.dma_free_task(%t13)
+      aiex.dma_free_task(%t14)
+
+      // ===== Batch 2: MM2S tasks 16-19, BD IDs 0-3 reused again =====
+
+      %t16 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 2048, 256) {bd_id = 0 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t16)
+
+      %t17 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 2048, 256) {bd_id = 1 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t17)
+
+      %t18 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_a : memref<2560xi32>, 2304, 256) {bd_id = 2 : i32}
+        aie.end
+      }
+      aiex.dma_start_task(%t18)
+
+      %t19 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%buf_b : memref<2560xi32>, 2304, 256) {bd_id = 3 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t19)
+
+      // Wait for all MM2S to complete, then wait for S2MM output
+      aiex.dma_await_task(%t19)
+      aiex.dma_await_task(%recv)
+    }
+  }
+}

--- a/test/npu-xrt/shim_dma_bd_reuse/aie.mlir
+++ b/test/npu-xrt/shim_dma_bd_reuse/aie.mlir
@@ -34,7 +34,7 @@ module {
       aie.packet_dest<%tile_0_0, "South" : 0>
     }
 
-    // Core tile: looping S2MM→MM2S passthrough (20 iterations)
+    // Core tile: continuously looping S2MM→MM2S passthrough
     %lock_in = aie.lock(%tile_0_2, 0) {init = 1 : i32, sym_name = "lock_in"}
     %lock_out = aie.lock(%tile_0_2, 1) {init = 0 : i32, sym_name = "lock_out"}
 

--- a/test/npu-xrt/shim_dma_bd_reuse/run.lit
+++ b/test/npu-xrt/shim_dma_bd_reuse/run.lit
@@ -1,0 +1,12 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai
+//
+// RUN: cp %S/aie.mlir aie_arch.mlir
+// RUN: %run_on_npu1% sed 's/NPUDEVICE/npu1_1col/g' -i aie_arch.mlir
+// RUN: %run_on_npu2% sed 's/NPUDEVICE/npu2_1col/g' -i aie_arch.mlir
+// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --aie-generate-npu-insts --no-compile-host --xclbin-name=aie.xclbin --npu-insts-name=insts.bin aie_arch.mlir
+// RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
+// RUN: %run_on_npu1% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin
+// RUN: %run_on_npu2% ./test.exe -x aie.xclbin -k MLIR_AIE -i insts.bin

--- a/test/npu-xrt/shim_dma_bd_reuse/test.cpp
+++ b/test/npu-xrt/shim_dma_bd_reuse/test.cpp
@@ -1,0 +1,118 @@
+//===- test.cpp -------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// E2E test: Shim MM2S BD reuse with >16 fire-and-forget tasks.
+// 20 MM2S tasks on one shim tile, alternating buf_a and buf_b.
+// Core tile passthrough. Verifies output matches interleaved source data.
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "cxxopts.hpp"
+#include "test_utils.h"
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+int main(int argc, const char *argv[]) {
+  cxxopts::Options options("shim_dma_bd_reuse");
+  test_utils::add_default_options(options);
+
+  cxxopts::ParseResult vm;
+  test_utils::parse_options(argc, argv, options, vm);
+
+  std::vector<uint32_t> instr_v =
+      test_utils::load_instr_binary(vm["instr"].as<std::string>());
+  int verbosity = vm["verbosity"].as<int>();
+
+  constexpr int SLICE = 256;
+  constexpr int NUM_TRANSFERS = 20;
+  constexpr int SLICES_PER_SRC = 10; // 10 from buf_a, 10 from buf_b
+  constexpr int SRC_SIZE = SLICES_PER_SRC * SLICE; // 2560
+  constexpr int OUT_SIZE = NUM_TRANSFERS * SLICE;   // 5120
+
+  auto device = xrt::device(0);
+  auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
+  std::string Node = vm["kernel"].as<std::string>();
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [Node](xrt::xclbin::kernel &k) {
+                                 return k.get_name().rfind(Node, 0) == 0;
+                               });
+  device.register_xclbin(xclbin);
+  xrt::hw_context context(device, xclbin.get_uuid());
+  auto kernel = xrt::kernel(context, xkernel.get_name());
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_a = xrt::bo(device, SRC_SIZE * sizeof(int32_t),
+                      XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
+  auto bo_b = xrt::bo(device, SRC_SIZE * sizeof(int32_t),
+                      XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(int32_t),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+
+  // buf_a: 1, 2, 3, ... 2560
+  // buf_b: 10001, 10002, ... 12560
+  int32_t *a = bo_a.map<int32_t *>();
+  int32_t *b = bo_b.map<int32_t *>();
+  for (int i = 0; i < SRC_SIZE; i++) {
+    a[i] = i + 1;
+    b[i] = 10000 + i + 1;
+  }
+
+  void *bufInstr = bo_instr.map<void *>();
+  memcpy(bufInstr, instr_v.data(), instr_v.size() * sizeof(int));
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_a.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_b.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  if (verbosity >= 1)
+    std::cout << "Running: 20 MM2S tasks (>16 BD limit), BD reuse via await."
+              << std::endl;
+
+  auto run = kernel(3, bo_instr, instr_v.size(), bo_a, bo_b, bo_out);
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Status: " << r << "\n";
+    return 1;
+  }
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+  int32_t *out = bo_out.map<int32_t *>();
+
+  // Transfer pattern: t0=a[0:256], t1=b[0:256], t2=a[256:512], t3=b[256:512]...
+  // Even transfers from buf_a, odd from buf_b. Each pair shares an offset.
+  int errors = 0;
+  for (int t = 0; t < NUM_TRANSFERS; t++) {
+    bool is_b = (t & 1);
+    int src_slice = t / 2;
+    for (int j = 0; j < SLICE; j++) {
+      int32_t expected = is_b ? (10000 + src_slice * SLICE + j + 1)
+                              : (src_slice * SLICE + j + 1);
+      int32_t actual = out[t * SLICE + j];
+      if (actual != expected) {
+        errors++;
+        if (errors <= 10 && verbosity >= 1)
+          std::cout << "Transfer " << t << "[" << j << "]: expected "
+                    << expected << ", got " << actual << std::endl;
+      }
+    }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS! (20 MM2S fire-and-forget, BD reuse, 2 src buffers)\n"
+              << std::endl;
+    return 0;
+  } else {
+    std::cout << "\n" << errors << " mismatches.\nfail.\n" << std::endl;
+    return 1;
+  }
+}

--- a/test/npu-xrt/shim_dma_bd_reuse/test.cpp
+++ b/test/npu-xrt/shim_dma_bd_reuse/test.cpp
@@ -36,16 +36,21 @@ int main(int argc, const char *argv[]) {
   constexpr int NUM_TRANSFERS = 20;
   constexpr int SLICES_PER_SRC = 10; // 10 from buf_a, 10 from buf_b
   constexpr int SRC_SIZE = SLICES_PER_SRC * SLICE; // 2560
-  constexpr int OUT_SIZE = NUM_TRANSFERS * SLICE;   // 5120
+  constexpr int OUT_SIZE = NUM_TRANSFERS * SLICE;  // 5120
 
   auto device = xrt::device(0);
   auto xclbin = xrt::xclbin(vm["xclbin"].as<std::string>());
   std::string Node = vm["kernel"].as<std::string>();
   auto xkernels = xclbin.get_kernels();
-  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
-                               [Node](xrt::xclbin::kernel &k) {
-                                 return k.get_name().rfind(Node, 0) == 0;
-                               });
+  auto xkernel_it = std::find_if(xkernels.begin(), xkernels.end(),
+                                 [Node](xrt::xclbin::kernel &k) {
+                                   return k.get_name().rfind(Node, 0) == 0;
+                                 });
+  if (xkernel_it == xkernels.end()) {
+    std::cout << "Kernel '" << Node << "' not found in xclbin\n";
+    return 1;
+  }
+  auto xkernel = *xkernel_it;
   device.register_xclbin(xclbin);
   xrt::hw_context context(device, xclbin.get_uuid());
   auto kernel = xrt::kernel(context, xkernel.get_name());


### PR DESCRIPTION
## Summary
- Add pass-level test proving `aie-assign-runtime-sequence-bd-ids` accepts >16 tasks per tile when `dma_await_task` + `dma_free_task` recycle BD IDs between batches
- Add E2E hardware test that fires 20 MM2S fire-and-forget tasks on one shim channel (exceeds 16-BD limit), alternating two source buffers, with BD IDs 0-7 recycled 3 times via periodic await+free
- Verified on NPU2 hardware: all 20 transfers arrive correctly

## Test plan
- [x] `aie-opt --aie-assign-runtime-sequence-bd-ids good-bd-reuse-multi-buffer.mlir` passes (BD IDs reused)
- [x] `aiecc.py` compiles `shim_dma_bd_reuse/aie.mlir` successfully
- [x] E2E test passes on NPU2 hardware: `PASS! (20 MM2S fire-and-forget, BD reuse, 2 src buffers)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)