### PR TITLE
Replace hardcoded register values in AIEInsertTraceFlows fully with database lookup

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -406,6 +406,12 @@ public:
   /// Return nullopt if the field does not fit in a 32-bit register.
   std::optional<uint32_t> getFieldMask(const BitFieldInfo &field) const;
 
+  /// Return a mapping from tile coordinates to controller IDs.
+  /// When columnWiseUniqueIDs is true (default), IDs are unique within each
+  /// column. Otherwise they are globally unique across the device.
+  llvm::DenseMap<TileID, int>
+  getTileToControllerIdMap(bool columnWiseUniqueIDs = true) const;
+
   /// Resolve stream switch port specification to port index.
   /// Return Port index for stream switch register, or nullopt if invalid
   std::optional<uint32_t> resolvePortValue(llvm::StringRef value, TileID tile,

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -105,9 +105,9 @@ AIETargetModel::getTileToControllerIdMap(bool columnWiseUniqueIDs) const {
     // single-level LUT bit-masking on packet header. Shim tile ids are < 16
     // because the TCT actor id field is only 4 bits.
     SmallVector<SmallVector<int>> validTileIds = {{15, 26, 27, 29, 30, 31},
-                                                   {14, 21, 22, 23, 24, 25},
-                                                   {13, 11, 17, 18, 19, 20},
-                                                   {12, 28, 7, 8, 9, 10}};
+                                                  {14, 21, 22, 23, 24, 25},
+                                                  {13, 11, 17, 18, 19, 20},
+                                                  {12, 28, 7, 8, 9, 10}};
     DenseMap<TileID, int> tileIDMap;
     for (int col = 0; col < columns(); col++) {
       for (int row = 0; row < rows(); row++) {

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -108,6 +108,12 @@ AIETargetModel::getTileToControllerIdMap(bool columnWiseUniqueIDs) const {
                                                   {14, 21, 22, 23, 24, 25},
                                                   {13, 11, 17, 18, 19, 20},
                                                   {12, 28, 7, 8, 9, 10}};
+    if (!columnWiseUniqueIDs && columns() > (int)validTileIds.size())
+      llvm::report_fatal_error(
+          "Device has " + llvm::Twine(columns()) + " columns but only " +
+          llvm::Twine(validTileIds.size()) +
+          " globally-unique controller ID sets are defined; "
+          "use column-wise unique IDs mode.");
     DenseMap<TileID, int> tileIDMap;
     for (int col = 0; col < columns(); col++) {
       for (int row = 0; row < rows(); row++) {

--- a/lib/Dialect/AIE/IR/AIETargetModel.cpp
+++ b/lib/Dialect/AIE/IR/AIETargetModel.cpp
@@ -98,6 +98,43 @@ AIETargetModel::getFieldMask(const BitFieldInfo &field) const {
   return static_cast<uint32_t>(mask);
 }
 
+DenseMap<TileID, int>
+AIETargetModel::getTileToControllerIdMap(bool columnWiseUniqueIDs) const {
+  if (rows() <= 6) {
+    // Controller id combinations chosen to avoid packet flow deadlock due to
+    // single-level LUT bit-masking on packet header. Shim tile ids are < 16
+    // because the TCT actor id field is only 4 bits.
+    SmallVector<SmallVector<int>> validTileIds = {{15, 26, 27, 29, 30, 31},
+                                                   {14, 21, 22, 23, 24, 25},
+                                                   {13, 11, 17, 18, 19, 20},
+                                                   {12, 28, 7, 8, 9, 10}};
+    DenseMap<TileID, int> tileIDMap;
+    for (int col = 0; col < columns(); col++) {
+      for (int row = 0; row < rows(); row++) {
+        if (columnWiseUniqueIDs)
+          tileIDMap[{col, row}] = validTileIds[0][row];
+        else
+          tileIDMap[{col, row}] = validTileIds[col][row];
+      }
+    }
+    return tileIDMap;
+  }
+
+  // Devices with more than 6 rows use sequential assignment.
+  assert(columnWiseUniqueIDs &&
+         "Device has more tiles than candidate packet ids; "
+         "use column-wise unique IDs mode.");
+  DenseMap<TileID, int> tileIDMap;
+  int unusedPacketIdFrom = 0;
+  for (int col = 0; col < columns(); col++) {
+    if (columnWiseUniqueIDs)
+      unusedPacketIdFrom = 0;
+    for (int row = 0; row < rows(); row++)
+      tileIDMap[{col, row}] = unusedPacketIdFrom++;
+  }
+  return tileIDMap;
+}
+
 std::optional<uint32_t> AIETargetModel::resolvePortValue(llvm::StringRef value,
                                                          TileID tile,
                                                          bool master) const {

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -45,56 +45,11 @@ int getUnusedPacketIdFrom(DeviceOp device) {
   return unusedPacketIdFrom + 1;
 }
 
-// AIE arch-specific tile id to controller id mapping. Users can use those
-// packet ids for design but run into risk of deadlocking control packet flows.
-DenseMap<AIE::TileID, int>
-getTileToControllerIdMap6RowsOrLess(bool clColumnWiseUniqueIDs,
-                                    const AIETargetModel &targetModel) {
-  // Below column controller id combinations were chosen to avoid packet flow
-  // deadlock due to single-level LUT bit-masking on packet header, which could
-  // fail to differentiate certain packet id combinations. Controller ids for
-  // shim tiles were chosen to be < 16, because when they act as actor id in TCT
-  // tokens, the actor id field only has 4 bits.
-  // FIXME
-  SmallVector<SmallVector<int>> validTileIds = {{15, 26, 27, 29, 30, 31},
-                                                {14, 21, 22, 23, 24, 25},
-                                                {13, 11, 17, 18, 19, 20},
-                                                {12, 28, 7, 8, 9, 10}};
-  DenseMap<AIE::TileID, int> tileIDMap;
-  for (int col = 0; col < targetModel.columns(); col++) {
-    for (int row = 0; row < targetModel.rows(); row++) {
-      if (clColumnWiseUniqueIDs)
-        tileIDMap[{col, row}] = validTileIds[0][row];
-      else
-        tileIDMap[{col, row}] = validTileIds[col][row];
-    }
-  }
-
-  return tileIDMap;
-}
+// Delegate to AIETargetModel::getTileToControllerIdMap.
 DenseMap<AIE::TileID, int>
 getTileToControllerIdMap(bool clColumnWiseUniqueIDs,
                          const AIETargetModel &targetModel) {
-  if (targetModel.rows() <= 6)
-    return getTileToControllerIdMap6RowsOrLess(clColumnWiseUniqueIDs,
-                                               targetModel);
-
-  // Controller id assignment strategy for devices with more than 6 rows.
-  if (!clColumnWiseUniqueIDs)
-    assert(false && "Device has more tiles than the total number of candidate "
-                    "packet ids permitted by the device. Please switch to "
-                    "clColumnWiseUniqueIDs mode for AIEAssignTileCtrlIDsPass.");
-  DenseMap<AIE::TileID, int> tileIDMap;
-
-  int unusedPacketIdFrom = 0;
-  for (int col = 0; col < targetModel.columns(); col++) {
-    if (clColumnWiseUniqueIDs)
-      unusedPacketIdFrom = 0;
-    for (int row = 0; row < targetModel.rows(); row++)
-      tileIDMap[{col, row}] = unusedPacketIdFrom++;
-  }
-
-  return tileIDMap;
+  return targetModel.getTileToControllerIdMap(clColumnWiseUniqueIDs);
 }
 
 // AIE arch-specific row id to shim dma mm2s channel mapping. All shim mm2s

--- a/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
@@ -631,10 +631,19 @@ struct AIEInsertTraceFlowsPass
             (chanDesc.channel == 0) ? "DMA_S2MM_0_Ctrl" : "DMA_S2MM_1_Ctrl";
         const RegisterInfo *ctrlReg = targetModel.lookupRegister(
             ctrlRegName, shimInfo.shimTile.getTileID());
+        if (!ctrlReg)
+          llvm::report_fatal_error(llvm::Twine("Failed to lookup ") +
+                                   ctrlRegName);
         const BitFieldInfo *ctrlIdField = ctrlReg->getField("Controller_ID");
+        if (!ctrlIdField)
+          llvm::report_fatal_error("Failed to lookup Controller_ID field in " +
+                                   llvm::Twine(ctrlRegName));
         uint32_t ctrlIdValue =
             targetModel.encodeFieldValue(*ctrlIdField, ctrlIdAttr.getPktId());
         auto ctrlIdMask = targetModel.getFieldMask(*ctrlIdField);
+        if (!ctrlIdMask)
+          llvm::report_fatal_error(
+              "Controller_ID field does not fit in 32-bit register");
         xilinx::AIEX::NpuMaskWrite32Op::create(
             builder, runtimeSeq.getLoc(), ctrlAddr, ctrlIdValue, *ctrlIdMask,
             nullptr, builder.getI32IntegerAttr(shimCol),

--- a/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
@@ -559,7 +559,16 @@ struct AIEInsertTraceFlowsPass
                                  << broadcastEventName << "'";
         return signalPassFailure();
       }
-      uint32_t timerCtrlValue = *broadcastEvent << 8;
+      const RegisterInfo *timerReg = targetModel.lookupRegister(
+          "Timer_Control", info.tile.getTileID(), isMemTrace);
+      if (!timerReg)
+        llvm::report_fatal_error("Failed to lookup Timer_Control register");
+      const BitFieldInfo *resetField = timerReg->getField("Reset_Event");
+      if (!resetField)
+        llvm::report_fatal_error(
+            "Failed to lookup Reset_Event field in Timer_Control");
+      uint32_t timerCtrlValue =
+          targetModel.encodeFieldValue(*resetField, *broadcastEvent);
 
       xilinx::AIEX::NpuWrite32Op::create(
           builder, runtimeSeq.getLoc(), timerCtrlAddr, timerCtrlValue, nullptr,
@@ -611,22 +620,46 @@ struct AIEInsertTraceFlowsPass
                                                 bdAddress, chanDesc.argIdx,
                                                 chanDesc.bufferOffset);
 
-        // 4e. DMA channel configuration
+        // 4e. DMA channel configuration — set Controller_ID from tile attribute
         uint32_t ctrlAddr =
             computeCtrlAddress(DMAChannelDir::S2MM, chanDesc.channel,
                                shimInfo.shimTile, targetModel);
+        ensureControllerIdAttr(shimInfo.shimTile, targetModel);
+        auto ctrlIdAttr =
+            shimInfo.shimTile->getAttrOfType<PacketInfoAttr>("controller_id");
+        std::string ctrlRegName =
+            (chanDesc.channel == 0) ? "DMA_S2MM_0_Ctrl" : "DMA_S2MM_1_Ctrl";
+        const RegisterInfo *ctrlReg =
+            targetModel.lookupRegister(ctrlRegName, shimInfo.shimTile.getTileID());
+        const BitFieldInfo *ctrlIdField = ctrlReg->getField("Controller_ID");
+        uint32_t ctrlIdValue =
+            targetModel.encodeFieldValue(*ctrlIdField, ctrlIdAttr.getPktId());
+        auto ctrlIdMask = targetModel.getFieldMask(*ctrlIdField);
         xilinx::AIEX::NpuMaskWrite32Op::create(
-            builder, runtimeSeq.getLoc(), ctrlAddr, 3840, 7936, // value, mask
+            builder, runtimeSeq.getLoc(), ctrlAddr, ctrlIdValue, *ctrlIdMask,
             nullptr, builder.getI32IntegerAttr(shimCol),
             builder.getI32IntegerAttr(0));
 
         // Push BD to task queue
-        uint32_t taskQueueAddr =
-            computeTaskQueueAddress(DMAChannelDir::S2MM, chanDesc.channel,
-                                    shimInfo.shimTile, targetModel);
-        uint32_t bdIdWithToken = (1U << 31) | chanDesc.bdId; // enable_token = 1
+        std::string taskQueueRegName = (chanDesc.channel == 0)
+                                           ? "DMA_S2MM_0_Task_Queue"
+                                           : "DMA_S2MM_1_Task_Queue";
+        const RegisterInfo *queueReg = targetModel.lookupRegister(
+            taskQueueRegName, shimInfo.shimTile.getTileID());
+        if (!queueReg)
+          llvm::report_fatal_error(llvm::Twine("Failed to lookup ") +
+                                   taskQueueRegName);
+        const BitFieldInfo *tokenField =
+            queueReg->getField("Enable_Token_Issue");
+        const BitFieldInfo *bdIdField = queueReg->getField("Start_BD_ID");
+        if (!tokenField || !bdIdField)
+          llvm::report_fatal_error(
+              "Failed to lookup Enable_Token_Issue or Start_BD_ID fields");
+        uint32_t queueValue =
+            targetModel.encodeFieldValue(*tokenField, 1) |
+            targetModel.encodeFieldValue(*bdIdField, chanDesc.bdId);
         xilinx::AIEX::NpuWrite32Op::create(
-            builder, runtimeSeq.getLoc(), taskQueueAddr, bdIdWithToken, nullptr,
+            builder, runtimeSeq.getLoc(), queueReg->offset, queueValue, nullptr,
             builder.getI32IntegerAttr(shimCol), builder.getI32IntegerAttr(0));
       }
 
@@ -640,8 +673,19 @@ struct AIEInsertTraceFlowsPass
 
         uint32_t shimTimerCtrlAddr =
             computeTimerCtrlAddress(shimInfo.shimTile, targetModel, false);
+        const RegisterInfo *shimTimerReg = targetModel.lookupRegister(
+            "Timer_Control", shimInfo.shimTile.getTileID(), false);
+        if (!shimTimerReg)
+          llvm::report_fatal_error("Failed to lookup shim Timer_Control");
+        const BitFieldInfo *shimResetField =
+            shimTimerReg->getField("Reset_Event");
+        if (!shimResetField)
+          llvm::report_fatal_error(
+              "Failed to lookup Reset_Event in shim Timer_Control");
+        uint32_t shimTimerCtrlValue =
+            targetModel.encodeFieldValue(*shimResetField, *userEvent1);
         xilinx::AIEX::NpuWrite32Op::create(
-            builder, runtimeSeq.getLoc(), shimTimerCtrlAddr, *userEvent1 << 8,
+            builder, runtimeSeq.getLoc(), shimTimerCtrlAddr, shimTimerCtrlValue,
             nullptr, builder.getI32IntegerAttr(shimCol),
             builder.getI32IntegerAttr(0));
 
@@ -711,19 +755,22 @@ struct AIEInsertTraceFlowsPass
   }
 
 private:
-  // Compute buffer descriptor base address for the buffer address field
+  /// Ensure a tile has a controller_id attribute. If missing, assign one
+  /// using the target model's mapping.
+  void ensureControllerIdAttr(TileOp tile, const AIETargetModel &tm) {
+    if (tile->hasAttr("controller_id"))
+      return;
+    auto idMap = tm.getTileToControllerIdMap();
+    int pktId = idMap[{tile.colIndex(), tile.rowIndex()}];
+    auto pktInfoAttr = PacketInfoAttr::get(tile->getContext(), 0, pktId);
+    tile->setAttr("controller_id", pktInfoAttr);
+  }
+
   uint32_t computeBDAddress(int col, int bdId, TileOp shimTile,
                             const AIETargetModel &tm) {
-    // Use register database to lookup BD0 address, then add stride * bdId
-    // The buffer address field is at offset +4 within each BD descriptor
-    const RegisterInfo *bdReg =
-        tm.lookupRegister("DMA_BD0_0", shimTile.getTileID());
-    if (!bdReg)
-      llvm::report_fatal_error("Failed to lookup DMA_BD0_0 register");
-    const uint32_t BD_STRIDE = 0x20;
-    const uint32_t BUFFER_ADDR_OFFSET = 4; // buffer address is 2nd word in BD
-    return (col << tm.getColumnShift()) |
-           (bdReg->offset + bdId * BD_STRIDE + BUFFER_ADDR_OFFSET);
+    int row = shimTile.getRow();
+    return tm.getDmaBdAddress(col, row, bdId) +
+           tm.getDmaBdAddressOffset(col, row);
   }
 
   // Compute DMA task queue address

--- a/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
@@ -629,8 +629,8 @@ struct AIEInsertTraceFlowsPass
             shimInfo.shimTile->getAttrOfType<PacketInfoAttr>("controller_id");
         std::string ctrlRegName =
             (chanDesc.channel == 0) ? "DMA_S2MM_0_Ctrl" : "DMA_S2MM_1_Ctrl";
-        const RegisterInfo *ctrlReg =
-            targetModel.lookupRegister(ctrlRegName, shimInfo.shimTile.getTileID());
+        const RegisterInfo *ctrlReg = targetModel.lookupRegister(
+            ctrlRegName, shimInfo.shimTile.getTileID());
         const BitFieldInfo *ctrlIdField = ctrlReg->getField("Controller_ID");
         uint32_t ctrlIdValue =
             targetModel.encodeFieldValue(*ctrlIdField, ctrlIdAttr.getPktId());

--- a/test/dialect/AIE/trace/test_insert_trace_flows_controller_id.mlir
+++ b/test/dialect/AIE/trace/test_insert_trace_flows_controller_id.mlir
@@ -1,0 +1,105 @@
+//===- test_insert_trace_flows_controller_id.mlir ------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --split-input-file -aie-insert-trace-flows | FileCheck %s
+
+// -----
+
+// Test: Pass auto-assigns controller_id=15 for shim on <=6 row device
+// CHECK-LABEL: module @ctrl_id_auto_assign
+module @ctrl_id_auto_assign {
+  aie.device(npu1_1col) {
+    // CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %tile00 = aie.tile(0, 0)
+    %tile02 = aie.tile(0, 2)
+    aie.trace @core_trace(%tile02) {
+      aie.trace.packet id=1 type=core
+      aie.trace.event<"INSTR_EVENT_0">
+      aie.trace.start broadcast=15
+      aie.trace.stop broadcast=14
+    }
+    aie.runtime_sequence(%arg0: memref<16xi32>) {
+      // controller_id=15: value = 15 << 8 = 3840, mask = 0xFF00 = 65280
+      // CHECK: aiex.npu.maskwrite32 {{{.*}}mask = 65280{{.*}}value = 3840{{.*}}}
+      aie.trace.host_config buffer_size = 65536
+      aie.trace.start_config @core_trace
+    }
+  }
+}
+
+// -----
+
+// Test: Pass respects user-specified controller_id (does not overwrite)
+// CHECK-LABEL: module @ctrl_id_user_specified
+module @ctrl_id_user_specified {
+  aie.device(npu1_1col) {
+    // CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
+    %tile00 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 5>}
+    %tile02 = aie.tile(0, 2)
+    aie.trace @core_trace(%tile02) {
+      aie.trace.packet id=1 type=core
+      aie.trace.event<"INSTR_EVENT_0">
+      aie.trace.start broadcast=15
+      aie.trace.stop broadcast=14
+    }
+    aie.runtime_sequence(%arg0: memref<16xi32>) {
+      // controller_id=5: value = 5 << 8 = 1280, mask = 0xFF00 = 65280
+      // CHECK: aiex.npu.maskwrite32 {{{.*}}mask = 65280{{.*}}value = 1280{{.*}}}
+      aie.trace.host_config buffer_size = 65536
+      aie.trace.start_config @core_trace
+    }
+  }
+}
+
+// -----
+
+// Test: Pass auto-assigns controller_id when shim tile is created (no shim in input)
+// CHECK-LABEL: module @ctrl_id_created_shim
+module @ctrl_id_created_shim {
+  aie.device(npu1_1col) {
+    // CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
+    %tile02 = aie.tile(0, 2)
+    aie.trace @core_trace(%tile02) {
+      aie.trace.packet id=1 type=core
+      aie.trace.event<"INSTR_EVENT_0">
+      aie.trace.start broadcast=15
+      aie.trace.stop broadcast=14
+    }
+    aie.runtime_sequence(%arg0: memref<16xi32>) {
+      // CHECK: aiex.npu.maskwrite32 {{{.*}}mask = 65280{{.*}}value = 3840{{.*}}}
+      aie.trace.host_config buffer_size = 65536
+      aie.trace.start_config @core_trace
+    }
+  }
+}
+
+// -----
+
+// Test: NPU2 (AIE2P) device uses same register DB for controller_id encoding
+// CHECK-LABEL: module @ctrl_id_npu2
+module @ctrl_id_npu2 {
+  aie.device(npu2_1col) {
+    // CHECK: aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 10>}
+    %tile00 = aie.tile(0, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 10>}
+    %tile02 = aie.tile(0, 2)
+    aie.trace @core_trace(%tile02) {
+      aie.trace.packet id=1 type=core
+      aie.trace.event<"INSTR_EVENT_0">
+      aie.trace.start broadcast=15
+      aie.trace.stop broadcast=14
+    }
+    aie.runtime_sequence(%arg0: memref<16xi32>) {
+      // controller_id=10: value = 10 << 8 = 2560, mask = 0xFF00 = 65280
+      // CHECK: aiex.npu.maskwrite32 {{{.*}}mask = 65280{{.*}}value = 2560{{.*}}}
+      aie.trace.host_config buffer_size = 65536
+      aie.trace.start_config @core_trace
+    }
+  }
+}

--- a/test/dialect/AIE/trace/test_insert_trace_flows_lateral.mlir
+++ b/test/dialect/AIE/trace/test_insert_trace_flows_lateral.mlir
@@ -160,6 +160,7 @@ module @lateral_fallback_full_shim {
     }
 
     // Trace redirects to column 1 (spare, both channels free)
+    // CHECK: aie.tile(1, 0) {controller_id = #aie.packet_info<pkt_type = 0, pkt_id = 15>}
     // CHECK: aiex.npu.writebd {{{.*}}column = 1
     // CHECK: aie.packet_dest<%{{.*}}1_0{{.*}}, DMA : 1>
   }


### PR DESCRIPTION
### Summary
Previous implementation still made some hardcode assumptions about architecture-specific values in `AIEInsertTraceFlows.cpp`

### Changes
- Replace 5 hardcoded values with register database lookups based on device.

| Hardcode | Value | Replaced with |
| -------- | -------- | -------- |
| BD stride   | 0x20   | getDmaBdAddress() |
| BD address offset   | 4   | getDMABdAddressOffset() |
| Timer control | << 8 | Register DB `Reset_Event` field |
| Task queue token | (1U << 31) BitwiseOR bdId | Register DB `Enable_Token_issue` + `Start_BD_ID` fields | 
- Auto-assign controller_id attribute on trace destination shim tiles to keep the DMA control register and tile attribute         
consistent.
 - While working on aie2ps support, noticed `AIEInsertTraceFlows` hardcoded controller_id=15 in the `NpuMaskWrite32Op` that configures the DMA control register on the trace destination shim, but never set the controller_id attribute on the shim tile itself. When `AIEAssignTileCtrlIDsPass` runs later, it assigns controller_id from the tile-to-controller-id map, which returns 0 (not 15) for shim tiles on >6-row devices. `AIEGenerateColumnControlOverlay` then uses that attribute for control packet routing causing mismatch.
 - Move `getTileToControllerIdMap` into AIETargetModel.
 - Test `test_insert_trace_flows_controller_id.mlir` verifies controller_id attribute for selected trace destination shim.