### PR TITLE
Fix LinearizeContiguousBDTransfer for 4D BDs with iteration dimension 

### DIFF
--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2424,14 +2424,12 @@ struct LinearizeContiguousBDTransfer : public mlir::OpRewritePattern<DMABDOp> {
     if (dims->size() == 1 && dims->front().getStride() == 1)
       return mlir::failure();
 
-    // Compute total element count from all dimension sizes.
     int64_t product = 1;
     for (BDDimLayoutAttr dim : *dims)
       product *= dim.getSize();
 
-    // If len < product, the outermost dim is a BD iteration dim (per-
-    // iteration transfer = len, repeat count/stride from the outer dim).
-    // Linearizing would drop the iteration stride.
+    // len < product means the outermost dim is a BD iteration dim;
+    // linearizing would drop the iteration stride.
     if (auto lenVal = op.getLen())
       if (static_cast<int64_t>(*lenVal) != product)
         return mlir::failure();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2429,18 +2429,12 @@ struct LinearizeContiguousBDTransfer : public mlir::OpRewritePattern<DMABDOp> {
     for (BDDimLayoutAttr dim : *dims)
       product *= dim.getSize();
 
-    // If the op has an explicit len that disagrees with the total dims product,
-    // the outermost dimension is a BD iteration (d3) dimension — len covers
-    // only the inner dims (per-iteration transfer), while the outermost dim
-    // controls how many times the BD is re-issued with address advancement.
-    // Linearizing would collapse the iteration into len, but the iteration
-    // stride (address advancement) would be lost, causing the hardware to
-    // repeatedly transfer only the first len elements instead of sweeping
-    // across the full buffer.  Bail out in this case.
-    if (auto lenVal = op.getLen()) {
+    // If len < product, the outermost dim is a BD iteration dim (per-
+    // iteration transfer = len, repeat count/stride from the outer dim).
+    // Linearizing would drop the iteration stride.
+    if (auto lenVal = op.getLen())
       if (static_cast<int64_t>(*lenVal) != product)
         return mlir::failure();
-    }
     int32_t len = static_cast<int32_t>(product);
 
     // Drop the dimensions attribute in-place; all other attributes (offset,

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2428,8 +2428,8 @@ struct LinearizeContiguousBDTransfer : public mlir::OpRewritePattern<DMABDOp> {
     for (BDDimLayoutAttr dim : *dims)
       product *= dim.getSize();
 
-    // len < product means the outermost dim is a BD iteration dim;
-    // linearizing would drop the iteration stride.
+    // len < product: the outermost dim describes a hardware BD iteration
+    // (preserved downstream as iteration_size/stride). Don't fold it away.
     if (auto lenVal = op.getLen())
       if (static_cast<int64_t>(*lenVal) != product)
         return mlir::failure();

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2424,18 +2424,24 @@ struct LinearizeContiguousBDTransfer : public mlir::OpRewritePattern<DMABDOp> {
     if (dims->size() == 1 && dims->front().getStride() == 1)
       return mlir::failure();
 
-    // If the op has no explicit len, compute it from the total element count
-    // across all dims (product of all sizes).  This is always well-defined
-    // when dims is non-empty, so we don't need to fall back to the buffer type.
-    int32_t len;
+    // Compute total element count from all dimension sizes.
+    int64_t product = 1;
+    for (BDDimLayoutAttr dim : *dims)
+      product *= dim.getSize();
+
+    // If the op has an explicit len that disagrees with the total dims product,
+    // the outermost dimension is a BD iteration (d3) dimension — len covers
+    // only the inner dims (per-iteration transfer), while the outermost dim
+    // controls how many times the BD is re-issued with address advancement.
+    // Linearizing would collapse the iteration into len, but the iteration
+    // stride (address advancement) would be lost, causing the hardware to
+    // repeatedly transfer only the first len elements instead of sweeping
+    // across the full buffer.  Bail out in this case.
     if (auto lenVal = op.getLen()) {
-      len = *lenVal;
-    } else {
-      int64_t product = 1;
-      for (BDDimLayoutAttr dim : *dims)
-        product *= dim.getSize();
-      len = static_cast<int32_t>(product);
+      if (static_cast<int64_t>(*lenVal) != product)
+        return mlir::failure();
     }
+    int32_t len = static_cast<int32_t>(product);
 
     // Drop the dimensions attribute in-place; all other attributes (offset,
     // len, packet, burst_length, bd_id, etc.) are preserved automatically.

--- a/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
+++ b/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
@@ -9,23 +9,9 @@
 //===----------------------------------------------------------------------===//
 //
 // Regression test for LinearizeContiguousBDTransfer: a contiguous shim BD
-// whose explicit `len` is smaller than the product of its dimension sizes
-// uses the outermost dim as a hardware BD iteration dimension (len = per-
-// iteration transfer size; outermost size/stride = repeat count and address
-// advancement, programmed into the shim NoC tile's iteration_size /
-// iteration_stride registers by AIEDMATasksToNPU).  Linearizing such a BD
-// would collapse the iteration into len and drop the iteration stride,
-// causing the NPU to repeatedly transfer only the first `len` elements from
-// offset 0 instead of sweeping the whole buffer.
-//
-// Failing case exposed by IRON transpose[M_2048-N_64-m_64-n_64-s_8]: the
-// input fill BD has dims [<32, 4096>, <1, 64>, <64, 64>, <64, 1>] and
-// len = 4096, while the product of all sizes is 131072.  Before the fix,
-// 89.5% of the output was wrong (only the first column-tile was correct).
-//
-// Positive linearization behavior (full coverage, len == product, true
-// linear forms, attribute preservation, etc.) is already covered by
-// canonicalize_linear_dma_bd.mlir; this file only tests the new bail-out.
+// whose explicit `len` is smaller than the product of its dim sizes uses the
+// outermost dim as a hardware BD iteration dim. Linearizing such a BD would
+// drop the iteration stride. See PR #3036.
 //
 //===----------------------------------------------------------------------===//
 
@@ -35,23 +21,12 @@
 
 // -----
 
-// 4D contiguous BD with per-iteration len (4096) != product of all dim
-// sizes (32*1*64*64 = 131072).  The outermost dim is a BD iteration
-// dimension.  Canonicalization must NOT linearize — the iteration stride
-// (4096) carries the inter-iteration address advancement.
+// 4D BD with len (4096) < product (32*1*64*64 = 131072): must NOT linearize.
 
 // CANON-LABEL: @iter_bd_no_linearize
 // CANON:         aiex.dma_configure_task
 // CANON:           aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
 // CANON-SAME:        [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
-
-// End-to-end correctness: after canonicalize + aie-dma-tasks-to-npu, the
-// iteration must show up in the NPU writebd registers — buffer_length is
-// the per-iteration transfer (4096 bf16 = 2048 i32 words), iteration_size
-// is the (32-1)-encoded repeat count, iteration_stride is the (2048-1)-
-// encoded i32-word stride between repeats.  Before the fix, canonicalize
-// dropped the iteration dim, yielding iteration_size = 0 (no repeat) and
-// the wrong buffer_length, which is exactly the transpose bug.
 
 // LOWER-LABEL: @iter_bd_no_linearize
 // LOWER:         aiex.npu.writebd
@@ -67,6 +42,57 @@ module {
         aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
           [<size = 32, stride = 4096>, <size = 1, stride = 64>,
            <size = 64, stride = 64>, <size = 64, stride = 1>]) {bd_id = 0 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_await_task(%t)
+    }
+  }
+}
+
+// -----
+
+// 4D BD with len == product: still linearizes (no iteration dim implied).
+
+// CANON-LABEL: @iter_bd_4d_len_matches_linearizes
+// CANON:         aiex.dma_configure_task
+// CANON:           aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 131072)
+// CANON-NOT:         dimensions
+// CANON-NOT:         [<
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @of_4d_match (%tile_0_0, MM2S, 0)
+    aie.runtime_sequence @iter_bd_4d_len_matches_linearizes(%arg0 : memref<131072xbf16>) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 131072,
+          [<size = 32, stride = 4096>, <size = 64, stride = 64>,
+           <size = 64, stride = 1>, <size = 1, stride = 1>]) {bd_id = 0 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_await_task(%t)
+    }
+  }
+}
+
+// -----
+
+// 2D BD with len == product: still linearizes.
+
+// CANON-LABEL: @iter_bd_2d_len_matches_linearizes
+// CANON:         aiex.dma_configure_task
+// CANON:           aie.dma_bd(%arg0 : memref<4096xbf16>, 0, 4096)
+// CANON-NOT:         dimensions
+// CANON-NOT:         [<
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @of_2d_match (%tile_0_0, MM2S, 0)
+    aie.runtime_sequence @iter_bd_2d_len_matches_linearizes(%arg0 : memref<4096xbf16>) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<4096xbf16>, 0, 4096,
+          [<size = 64, stride = 64>, <size = 64, stride = 1>]) {bd_id = 0 : i32}
         aie.end
       } {issue_token = true}
       aiex.dma_start_task(%t)

--- a/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
+++ b/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
@@ -7,13 +7,8 @@
 // Copyright (C) 2026, Advanced Micro Devices, Inc.
 //
 //===----------------------------------------------------------------------===//
-//
-// Regression test for LinearizeContiguousBDTransfer: a contiguous shim BD
-// whose explicit `len` is smaller than the product of its dim sizes uses the
-// outermost dim as a hardware BD iteration dim. Linearizing such a BD would
-// drop the iteration stride. See PR #3036.
-//
-//===----------------------------------------------------------------------===//
+
+// Regression for LinearizeContiguousBDTransfer; see PR #3036.
 
 // RUN: aie-opt --canonicalize --split-input-file %s | FileCheck %s --check-prefix=CANON
 // RUN: aie-opt --pass-pipeline='any(aie.device(canonicalize,aie-dma-tasks-to-npu))' \
@@ -21,13 +16,10 @@
 
 // -----
 
-// 4D BD with len (4096) < product (32*1*64*64 = 131072): must NOT linearize.
-
+// len < product: outer dim is an iteration dim, must NOT linearize.
 // CANON-LABEL: @iter_bd_no_linearize
-// CANON:         aiex.dma_configure_task
-// CANON:           aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
+// CANON:         aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
 // CANON-SAME:        [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
-
 // LOWER-LABEL: @iter_bd_no_linearize
 // LOWER:         aiex.npu.writebd
 // LOWER-SAME:      buffer_length = 2048
@@ -52,12 +44,9 @@ module {
 
 // -----
 
-// 4D BD with len == product: still linearizes (no iteration dim implied).
-
+// 4D, len == product: still linearizes.
 // CANON-LABEL: @iter_bd_4d_len_matches_linearizes
-// CANON:         aiex.dma_configure_task
-// CANON:           aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 131072)
-// CANON-NOT:         dimensions
+// CANON:         aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 131072)
 // CANON-NOT:         [<
 module {
   aie.device(npu1) {
@@ -78,12 +67,9 @@ module {
 
 // -----
 
-// 2D BD with len == product: still linearizes.
-
+// 2D, len == product: still linearizes.
 // CANON-LABEL: @iter_bd_2d_len_matches_linearizes
-// CANON:         aiex.dma_configure_task
-// CANON:           aie.dma_bd(%arg0 : memref<4096xbf16>, 0, 4096)
-// CANON-NOT:         dimensions
+// CANON:         aie.dma_bd(%arg0 : memref<4096xbf16>, 0, 4096)
 // CANON-NOT:         [<
 module {
   aie.device(npu1) {

--- a/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
+++ b/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
@@ -1,0 +1,158 @@
+//===- canonicalize_no_linearize_iter_bd.mlir -------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// Regression tests for LinearizeContiguousBDTransfer: BDs with an iteration
+// dimension (outermost dim) whose explicit len covers only the inner dims
+// must NOT be linearized.  Linearizing would remove the iteration stride,
+// causing the hardware to repeatedly transfer only the first `len` elements
+// from offset 0 instead of sweeping across the full buffer.
+//
+// The failing case was exposed by IRON transpose[M_2048-N_64-m_64-n_64-s_8]:
+// the input fill BD has a contiguous 4D pattern where sizes[0] (outermost)
+// controls the iteration count and len = product of inner 3 sizes.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --canonicalize --split-input-file %s | FileCheck %s
+
+// -----
+
+// 4D contiguous BD with explicit per-iteration len (4096) != product of all
+// dims (32*1*64*64 = 131072).  The outermost dim is a BD iteration dimension.
+// Must NOT be linearized — the iteration stride (4096) would be lost.
+//
+// This is the input fill pattern from transpose[M_2048-N_64-m_64-n_64-s_8].
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK:       aiex.dma_configure_task
+// CHECK:         aie.dma_bd
+// CHECK-SAME:      [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.runtime_sequence @iter_bd_no_linearize(%arg0 : memref<131072xbf16>) {
+      %t = aiex.dma_configure_task_for(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
+          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
+           <size = 64, stride = 64>, <size = 64, stride = 1>]) {bd_id = 0 : i32}
+        aie.end
+      } {issue_token = true, repeat_count = 31 : i32}
+      aiex.dma_start_task(%t)
+      aiex.dma_await_task(%t)
+    }
+    aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)
+  }
+}
+
+// -----
+
+// Same pattern inside a ShimDMAOp: 4D contiguous with per-iteration len.
+// Must NOT be linearized.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK:       aie.shim_dma
+// CHECK:         aie.dma_bd
+// CHECK-SAME:      [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    %buf = aie.external_buffer { sym_name = "buf_iter" } : memref<131072xbf16>
+    aie.shim_dma(%tile_0_0) {
+      aie.dma_start(MM2S, 0, ^bd0, ^end)
+      ^bd0:
+        aie.dma_bd(%buf : memref<131072xbf16>, 0, 4096,
+          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
+           <size = 64, stride = 64>, <size = 64, stride = 1>])
+        aie.next_bd ^end
+      ^end:
+        aie.end
+    }
+  }
+}
+
+// -----
+
+// Positive regression: a 4D contiguous BD where len == product of all dims
+// (len = 131072 = 32*1*64*64).  This SHOULD still be linearized.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK:       aie.shim_dma
+// CHECK:         aie.dma_bd
+// CHECK-NOT:       dimensions
+// CHECK-NOT:       [<
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    %buf = aie.external_buffer { sym_name = "buf_full" } : memref<131072xbf16>
+    aie.shim_dma(%tile_0_0) {
+      aie.dma_start(MM2S, 0, ^bd0, ^end)
+      ^bd0:
+        aie.dma_bd(%buf : memref<131072xbf16>, 0, 131072,
+          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
+           <size = 64, stride = 64>, <size = 64, stride = 1>])
+        aie.next_bd ^end
+      ^end:
+        aie.end
+    }
+  }
+}
+
+// -----
+
+// Positive regression: a 4D contiguous BD with NO explicit len.
+// This SHOULD still be linearized (len computed from product).
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK:       aie.shim_dma
+// CHECK:         aie.dma_bd
+// CHECK-NOT:       dimensions
+// CHECK-NOT:       [<
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    %buf = aie.external_buffer { sym_name = "buf_nolen" } : memref<131072xbf16>
+    aie.shim_dma(%tile_0_0) {
+      aie.dma_start(MM2S, 0, ^bd0, ^end)
+      ^bd0:
+        aie.dma_bd(%buf : memref<131072xbf16>, 0,
+          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
+           <size = 64, stride = 64>, <size = 64, stride = 1>])
+        aie.next_bd ^end
+      ^end:
+        aie.end
+    }
+  }
+}
+
+// -----
+
+// Positive regression: 2D contiguous BD from the original PR #2924 test set.
+// Ensures existing linearization behavior is preserved for simple cases.
+
+// CHECK-LABEL: aie.device(npu1)
+// CHECK:       aie.shim_dma
+// CHECK:         aie.dma_bd
+// CHECK-NOT:       dimensions
+// CHECK-NOT:       [<
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    %buf = aie.external_buffer { sym_name = "buf_2d" } : memref<1024xi32>
+    aie.shim_dma(%tile_0_0) {
+      aie.dma_start(MM2S, 0, ^bd0, ^end)
+      ^bd0:
+        aie.dma_bd(%buf : memref<1024xi32>, 0, 1024,
+          [<size = 2, stride = 512>, <size = 512, stride = 1>])
+        aie.next_bd ^end
+      ^end:
+        aie.end
+    }
+  }
+}

--- a/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
+++ b/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
@@ -8,151 +8,69 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Regression tests for LinearizeContiguousBDTransfer: BDs with an iteration
-// dimension (outermost dim) whose explicit len covers only the inner dims
-// must NOT be linearized.  Linearizing would remove the iteration stride,
-// causing the hardware to repeatedly transfer only the first `len` elements
-// from offset 0 instead of sweeping across the full buffer.
+// Regression test for LinearizeContiguousBDTransfer: a contiguous shim BD
+// whose explicit `len` is smaller than the product of its dimension sizes
+// uses the outermost dim as a hardware BD iteration dimension (len = per-
+// iteration transfer size; outermost size/stride = repeat count and address
+// advancement, programmed into the shim NoC tile's iteration_size /
+// iteration_stride registers by AIEDMATasksToNPU).  Linearizing such a BD
+// would collapse the iteration into len and drop the iteration stride,
+// causing the NPU to repeatedly transfer only the first `len` elements from
+// offset 0 instead of sweeping the whole buffer.
 //
-// The failing case was exposed by IRON transpose[M_2048-N_64-m_64-n_64-s_8]:
-// the input fill BD has a contiguous 4D pattern where sizes[0] (outermost)
-// controls the iteration count and len = product of inner 3 sizes.
+// Failing case exposed by IRON transpose[M_2048-N_64-m_64-n_64-s_8]: the
+// input fill BD has dims [<32, 4096>, <1, 64>, <64, 64>, <64, 1>] and
+// len = 4096, while the product of all sizes is 131072.  Before the fix,
+// 89.5% of the output was wrong (only the first column-tile was correct).
+//
+// Positive linearization behavior (full coverage, len == product, true
+// linear forms, attribute preservation, etc.) is already covered by
+// canonicalize_linear_dma_bd.mlir; this file only tests the new bail-out.
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --canonicalize --split-input-file %s | FileCheck %s
+// RUN: aie-opt --canonicalize --split-input-file %s | FileCheck %s --check-prefix=CANON
+// RUN: aie-opt --pass-pipeline='any(aie.device(canonicalize,aie-dma-tasks-to-npu))' \
+// RUN:   --split-input-file %s | FileCheck %s --check-prefix=LOWER
 
 // -----
 
-// 4D contiguous BD with explicit per-iteration len (4096) != product of all
-// dims (32*1*64*64 = 131072).  The outermost dim is a BD iteration dimension.
-// Must NOT be linearized — the iteration stride (4096) would be lost.
-//
-// This is the input fill pattern from transpose[M_2048-N_64-m_64-n_64-s_8].
+// 4D contiguous BD with per-iteration len (4096) != product of all dim
+// sizes (32*1*64*64 = 131072).  The outermost dim is a BD iteration
+// dimension.  Canonicalization must NOT linearize — the iteration stride
+// (4096) carries the inter-iteration address advancement.
 
-// CHECK-LABEL: aie.device(npu1)
-// CHECK:       aiex.dma_configure_task
-// CHECK:         aie.dma_bd
-// CHECK-SAME:      [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
+// CANON-LABEL: @iter_bd_no_linearize
+// CANON:         aiex.dma_configure_task
+// CANON:           aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
+// CANON-SAME:        [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
+
+// End-to-end correctness: after canonicalize + aie-dma-tasks-to-npu, the
+// iteration must show up in the NPU writebd registers — buffer_length is
+// the per-iteration transfer (4096 bf16 = 2048 i32 words), iteration_size
+// is the (32-1)-encoded repeat count, iteration_stride is the (2048-1)-
+// encoded i32-word stride between repeats.  Before the fix, canonicalize
+// dropped the iteration dim, yielding iteration_size = 0 (no repeat) and
+// the wrong buffer_length, which is exactly the transpose bug.
+
+// LOWER-LABEL: @iter_bd_no_linearize
+// LOWER:         aiex.npu.writebd
+// LOWER-SAME:      buffer_length = 2048
+// LOWER-SAME:      iteration_size = 31
+// LOWER-SAME:      iteration_stride = 2047
 module {
   aie.device(npu1) {
     %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @of_iter (%tile_0_0, MM2S, 0)
     aie.runtime_sequence @iter_bd_no_linearize(%arg0 : memref<131072xbf16>) {
-      %t = aiex.dma_configure_task_for(%tile_0_0, MM2S, 0) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
         aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
           [<size = 32, stride = 4096>, <size = 1, stride = 64>,
            <size = 64, stride = 64>, <size = 64, stride = 1>]) {bd_id = 0 : i32}
         aie.end
-      } {issue_token = true, repeat_count = 31 : i32}
+      } {issue_token = true}
       aiex.dma_start_task(%t)
       aiex.dma_await_task(%t)
-    }
-    aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)
-  }
-}
-
-// -----
-
-// Same pattern inside a ShimDMAOp: 4D contiguous with per-iteration len.
-// Must NOT be linearized.
-
-// CHECK-LABEL: aie.device(npu1)
-// CHECK:       aie.shim_dma
-// CHECK:         aie.dma_bd
-// CHECK-SAME:      [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
-module {
-  aie.device(npu1) {
-    %tile_0_0 = aie.tile(0, 0)
-    %buf = aie.external_buffer { sym_name = "buf_iter" } : memref<131072xbf16>
-    aie.shim_dma(%tile_0_0) {
-      aie.dma_start(MM2S, 0, ^bd0, ^end)
-      ^bd0:
-        aie.dma_bd(%buf : memref<131072xbf16>, 0, 4096,
-          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
-           <size = 64, stride = 64>, <size = 64, stride = 1>])
-        aie.next_bd ^end
-      ^end:
-        aie.end
-    }
-  }
-}
-
-// -----
-
-// Positive regression: a 4D contiguous BD where len == product of all dims
-// (len = 131072 = 32*1*64*64).  This SHOULD still be linearized.
-
-// CHECK-LABEL: aie.device(npu1)
-// CHECK:       aie.shim_dma
-// CHECK:         aie.dma_bd
-// CHECK-NOT:       dimensions
-// CHECK-NOT:       [<
-module {
-  aie.device(npu1) {
-    %tile_0_0 = aie.tile(0, 0)
-    %buf = aie.external_buffer { sym_name = "buf_full" } : memref<131072xbf16>
-    aie.shim_dma(%tile_0_0) {
-      aie.dma_start(MM2S, 0, ^bd0, ^end)
-      ^bd0:
-        aie.dma_bd(%buf : memref<131072xbf16>, 0, 131072,
-          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
-           <size = 64, stride = 64>, <size = 64, stride = 1>])
-        aie.next_bd ^end
-      ^end:
-        aie.end
-    }
-  }
-}
-
-// -----
-
-// Positive regression: a 4D contiguous BD with NO explicit len.
-// This SHOULD still be linearized (len computed from product).
-
-// CHECK-LABEL: aie.device(npu1)
-// CHECK:       aie.shim_dma
-// CHECK:         aie.dma_bd
-// CHECK-NOT:       dimensions
-// CHECK-NOT:       [<
-module {
-  aie.device(npu1) {
-    %tile_0_0 = aie.tile(0, 0)
-    %buf = aie.external_buffer { sym_name = "buf_nolen" } : memref<131072xbf16>
-    aie.shim_dma(%tile_0_0) {
-      aie.dma_start(MM2S, 0, ^bd0, ^end)
-      ^bd0:
-        aie.dma_bd(%buf : memref<131072xbf16>, 0,
-          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
-           <size = 64, stride = 64>, <size = 64, stride = 1>])
-        aie.next_bd ^end
-      ^end:
-        aie.end
-    }
-  }
-}
-
-// -----
-
-// Positive regression: 2D contiguous BD from the original PR #2924 test set.
-// Ensures existing linearization behavior is preserved for simple cases.
-
-// CHECK-LABEL: aie.device(npu1)
-// CHECK:       aie.shim_dma
-// CHECK:         aie.dma_bd
-// CHECK-NOT:       dimensions
-// CHECK-NOT:       [<
-module {
-  aie.device(npu1) {
-    %tile_0_0 = aie.tile(0, 0)
-    %buf = aie.external_buffer { sym_name = "buf_2d" } : memref<1024xi32>
-    aie.shim_dma(%tile_0_0) {
-      aie.dma_start(MM2S, 0, ^bd0, ^end)
-      ^bd0:
-        aie.dma_bd(%buf : memref<1024xi32>, 0, 1024,
-          [<size = 2, stride = 512>, <size = 512, stride = 1>])
-        aie.next_bd ^end
-      ^end:
-        aie.end
     }
   }
 }


### PR DESCRIPTION
Edit: description rewritten after feedback, thanks @andrej !

## Bug

`LinearizeContiguousBDTransfer` collapsed any contiguous shim BD into a linear transfer. For a 4D shim BD this is wrong: the outermost dim is the hardware **iteration** dim (programmed into `iteration_size` / `iteration_stride` by
`AIEDMATasksToNPU`), and `len` covers only the inner three dims. Linearizing dropped the iteration stride, so the NPU re-read the same `len` bytes from offset 0 every repeat.

Surfaced by IRON `transpose[M_2048-N_64-m_64-n_64-s_8]`: BD with `dims = [<32, 4096>, <1, 64>, <64, 64>, <64, 1>]`, `len = 4096`, canonicalized into a 4096-byte transfer repeated 32 times → 89.5% wrong.

## Fix

Bail when `dims.size() == 4 && dims.front().size() > 1`. Outer-size 1 is a trivial iteration and remains foldable. Structural, not length-based: a 4D BD with `len == product` still bails because outer-size > 1 implies iteration semantics.