### PR TITLE
[AIEPlacer] Read aie.flow / aie.packet_flow as channel-requirement and grouping sources

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -93,6 +93,18 @@ private:
       llvm::DenseMap<int, llvm::SmallVector<LogicalTileOp>>
           &groupToLogicalTiles);
 
+  // Build flow-based connectivity groups over `aie.flow` and `aie.packet_flow`.
+  // Each connected component of LogicalTileOps connected by a flow becomes one
+  // group. `groupToNonCoreTiles` holds non-core tiles per group (the ones that
+  // need placement); `groupToCoreCols` holds the columns of placed core
+  // endpoints (used to compute the common column for that group).
+  void buildFlowGroups(
+      llvm::SmallVector<FlowOp> &flows,
+      llvm::SmallVector<PacketFlowOp> &pktFlows,
+      llvm::DenseMap<int, llvm::SmallVector<LogicalTileOp>>
+          &groupToNonCoreTiles,
+      llvm::DenseMap<int, llvm::SmallVector<LogicalTileOp>> &groupToCoreTiles);
+
   std::optional<TileID> findTileWithCapacity(int targetCol,
                                              std::vector<TileID> &tiles,
                                              int requiredInputChannels,
@@ -113,6 +125,17 @@ private:
   buildChannelRequirements(
       llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
+
+  // Add per-tile DMA channel demand from `aie.flow` and `aie.packet_flow` ops
+  // to `channelRequirements`. `srcBundle == DMA` contributes one output (MM2S)
+  // channel on the source tile; `dstBundle == DMA` contributes one input
+  // (S2MM) channel on the destination tile. Only counts when the endpoint's
+  // defining op is a LogicalTileOp.
+  void addChannelRequirementsFromFlows(
+      llvm::SmallVector<FlowOp> &flows,
+      llvm::SmallVector<PacketFlowOp> &pktFlows,
+      llvm::DenseMap<mlir::Operation *, std::pair<int, int>>
+          &channelRequirements);
 };
 
 } // namespace xilinx::AIE

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -13,7 +13,6 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
-#include "llvm/ADT/MapVector.h"
 
 namespace xilinx::AIE {
 
@@ -22,6 +21,16 @@ enum class PlacerType { SequentialPlacer };
 
 // maps logical tile operations to physical coordinates
 using PlacementResult = llvm::DenseMap<mlir::Operation *, TileID>;
+
+// A set of LogicalTileOps connected by some connectivity op (objectfifo,
+// flow, packet_flow, ...). `coreTiles` is used to compute the common column
+// for placing the group's `nonCoreTiles`. Both lists may contain duplicates
+// when a tile is referenced by multiple connectivity ops in the same group;
+// duplicates intentionally weight the common-column average.
+struct ConnectivityGroup {
+  llvm::SmallVector<LogicalTileOp, 4> coreTiles;
+  llvm::SmallVector<LogicalTileOp, 4> nonCoreTiles;
+};
 
 // Track available tiles and resource usage
 struct TileAvailability {
@@ -87,19 +96,19 @@ private:
 
   void limitCoresPerColumn(int maxCoresPerCol, int numColumns);
 
-  void buildObjectFifoGroups(
-      llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
-      llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks,
-      llvm::DenseMap<int, llvm::SmallVector<ObjectFifoCreateOp>> &groupToFifos,
-      llvm::DenseMap<int, llvm::SmallVector<LogicalTileOp>>
-          &groupToLogicalTiles);
+  void
+  buildObjectFifoGroups(llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
+                        llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks,
+                        llvm::SmallVectorImpl<ConnectivityGroup> &groups);
 
-  void buildFlowGroups(
-      llvm::SmallVector<FlowOp> &flows,
-      llvm::SmallVector<PacketFlowOp> &pktFlows,
-      llvm::MapVector<int, llvm::SmallVector<LogicalTileOp>>
-          &groupToNonCoreTiles,
-      llvm::MapVector<int, llvm::SmallVector<LogicalTileOp>> &groupToCoreTiles);
+  void buildFlowGroups(llvm::SmallVector<FlowOp> &flows,
+                       llvm::SmallVector<PacketFlowOp> &pktFlows,
+                       llvm::SmallVectorImpl<ConnectivityGroup> &groups);
+
+  mlir::LogicalResult placeNonCoreTilesInGroup(
+      const ConnectivityGroup &group,
+      const llvm::DenseMap<mlir::Operation *, std::pair<int, int>>
+          &channelRequirements);
 
   std::optional<TileID> findTileWithCapacity(int targetCol,
                                              std::vector<TileID> &tiles,

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -93,11 +93,6 @@ private:
       llvm::DenseMap<int, llvm::SmallVector<LogicalTileOp>>
           &groupToLogicalTiles);
 
-  // Build flow-based connectivity groups over `aie.flow` and `aie.packet_flow`.
-  // Each connected component of LogicalTileOps connected by a flow becomes one
-  // group. `groupToNonCoreTiles` holds non-core tiles per group (the ones that
-  // need placement); `groupToCoreCols` holds the columns of placed core
-  // endpoints (used to compute the common column for that group).
   void buildFlowGroups(
       llvm::SmallVector<FlowOp> &flows,
       llvm::SmallVector<PacketFlowOp> &pktFlows,
@@ -126,11 +121,6 @@ private:
       llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
 
-  // Add per-tile DMA channel demand from `aie.flow` and `aie.packet_flow` ops
-  // to `channelRequirements`. `srcBundle == DMA` contributes one output (MM2S)
-  // channel on the source tile; `dstBundle == DMA` contributes one input
-  // (S2MM) channel on the destination tile. Only counts when the endpoint's
-  // defining op is a LogicalTileOp.
   void addChannelRequirementsFromFlows(
       llvm::SmallVector<FlowOp> &flows,
       llvm::SmallVector<PacketFlowOp> &pktFlows,

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -13,6 +13,7 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
+#include "llvm/ADT/MapVector.h"
 
 namespace xilinx::AIE {
 
@@ -96,9 +97,9 @@ private:
   void buildFlowGroups(
       llvm::SmallVector<FlowOp> &flows,
       llvm::SmallVector<PacketFlowOp> &pktFlows,
-      llvm::DenseMap<int, llvm::SmallVector<LogicalTileOp>>
+      llvm::MapVector<int, llvm::SmallVector<LogicalTileOp>>
           &groupToNonCoreTiles,
-      llvm::DenseMap<int, llvm::SmallVector<LogicalTileOp>> &groupToCoreTiles);
+      llvm::MapVector<int, llvm::SmallVector<LogicalTileOp>> &groupToCoreTiles);
 
   std::optional<TileID> findTileWithCapacity(int targetCol,
                                              std::vector<TileID> &tiles,

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -96,13 +96,12 @@ private:
 
   void limitCoresPerColumn(int maxCoresPerCol, int numColumns);
 
-  void
-  buildObjectFifoGroups(llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
-                        llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks,
-                        llvm::SmallVectorImpl<ConnectivityGroup> &groups);
+  void buildObjectFifoGroups(llvm::ArrayRef<ObjectFifoCreateOp> objectFifos,
+                             llvm::ArrayRef<ObjectFifoLinkOp> objectFifoLinks,
+                             llvm::SmallVectorImpl<ConnectivityGroup> &groups);
 
-  void buildFlowGroups(llvm::SmallVector<FlowOp> &flows,
-                       llvm::SmallVector<PacketFlowOp> &pktFlows,
+  void buildFlowGroups(llvm::ArrayRef<FlowOp> flows,
+                       llvm::ArrayRef<PacketFlowOp> pktFlows,
                        llvm::SmallVectorImpl<ConnectivityGroup> &groups);
 
   mlir::LogicalResult placeNonCoreTilesInGroup(
@@ -132,8 +131,7 @@ private:
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
 
   void addChannelRequirementsFromFlows(
-      llvm::SmallVector<FlowOp> &flows,
-      llvm::SmallVector<PacketFlowOp> &pktFlows,
+      llvm::ArrayRef<FlowOp> flows, llvm::ArrayRef<PacketFlowOp> pktFlows,
       llvm::DenseMap<mlir::Operation *, std::pair<int, int>>
           &channelRequirements);
 };

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -120,6 +120,8 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
   SmallVector<LogicalTileOp> logicalTiles;
   SmallVector<ObjectFifoCreateOp> objectFifos;
   SmallVector<ObjectFifoLinkOp> objectFifoLinks;
+  SmallVector<FlowOp> flows;
+  SmallVector<PacketFlowOp> pktFlows;
 
   device.walk([&](Operation *op) {
     if (auto lt = dyn_cast<LogicalTileOp>(op))
@@ -128,11 +130,18 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       objectFifos.push_back(of);
     if (auto link = dyn_cast<ObjectFifoLinkOp>(op))
       objectFifoLinks.push_back(link);
+    if (auto f = dyn_cast<FlowOp>(op))
+      flows.push_back(f);
+    if (auto pf = dyn_cast<PacketFlowOp>(op))
+      pktFlows.push_back(pf);
   });
 
-  // Phase 2: Build channel requirements from ObjectFifo connectivity
+  // Phase 2: Build channel requirements. ObjectFifo connectivity is the
+  // primary source; `aie.flow` / `aie.packet_flow` ops contribute additively
+  // so the placer can be channel-aware on lowered IR (e.g. AIR's DMA path).
   auto channelRequirements =
       buildChannelRequirements(objectFifos, objectFifoLinks);
+  addChannelRequirementsFromFlows(flows, pktFlows, channelRequirements);
 
   // Phase 3: Place constrained tiles then compute tiles
   size_t nextCompIdx = 0;
@@ -288,6 +297,64 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       result[logicalTile] = *maybeTile;
 
       // Update channel usage
+      if (numInputChannels > 0)
+        updateChannelUsage(*maybeTile, false, numInputChannels);
+      if (numOutputChannels > 0)
+        updateChannelUsage(*maybeTile, true, numOutputChannels);
+    }
+  }
+
+  // Phase 4b: Place mem/shim tiles by flow-based connectivity groups.
+  // Mirrors phase 4 but for non-core tiles connected to cores via `aie.flow`
+  // / `aie.packet_flow` (AIR DMA path, or any IR that has lowered objectfifos
+  // away). Tiles already placed by phase 4 are skipped.
+  llvm::DenseMap<int, SmallVector<LogicalTileOp>> flowGroupNonCore;
+  llvm::DenseMap<int, SmallVector<LogicalTileOp>> flowGroupCores;
+  buildFlowGroups(flows, pktFlows, flowGroupNonCore, flowGroupCores);
+
+  for (auto &[groupId, nonCoreTiles] : flowGroupNonCore) {
+    int groupCommonCol = 0;
+    int totalCoreEndpoints = 0;
+    int sumCols = 0;
+
+    auto coresIt = flowGroupCores.find(groupId);
+    if (coresIt != flowGroupCores.end()) {
+      for (auto coreTile : coresIt->second) {
+        if (result.count(coreTile.getOperation())) {
+          sumCols += result[coreTile.getOperation()].col;
+          totalCoreEndpoints++;
+        }
+      }
+    }
+
+    if (totalCoreEndpoints > 0)
+      groupCommonCol = (sumCols + totalCoreEndpoints / 2) / totalCoreEndpoints;
+
+    for (auto logicalTile : nonCoreTiles) {
+      if (result.count(logicalTile.getOperation()))
+        continue;
+
+      auto it = channelRequirements.find(logicalTile.getOperation());
+      int numInputChannels = 0, numOutputChannels = 0;
+      if (it != channelRequirements.end()) {
+        numInputChannels = it->second.first;
+        numOutputChannels = it->second.second;
+      }
+
+      auto colConstraint = logicalTile.tryGetCol();
+      int targetCol = colConstraint ? *colConstraint : groupCommonCol;
+
+      auto maybeTile = findTileWithCapacity(
+          targetCol, availability.nonCompTiles, numInputChannels,
+          numOutputChannels, logicalTile.getTileType());
+
+      if (!maybeTile)
+        return logicalTile.emitError()
+               << "no " << stringifyAIETileType(logicalTile.getTileType())
+               << " with sufficient DMA capacity";
+
+      result[logicalTile] = *maybeTile;
+
       if (numInputChannels > 0)
         updateChannelUsage(*maybeTile, false, numInputChannels);
       if (numOutputChannels > 0)
@@ -533,6 +600,110 @@ void SequentialPlacer::buildObjectFifoGroups(
             groupToLogicalTiles[groupId].push_back(consLogical);
           }
         }
+      }
+    }
+  }
+}
+
+// Increment per-tile DMA channel demand based on `aie.flow` /
+// `aie.packet_flow`. A flow whose source bundle is DMA consumes one MM2S
+// channel on the source tile; a flow whose dest bundle is DMA consumes one
+// S2MM channel on the dest tile. Only counts when the endpoint's defining op
+// is a LogicalTileOp (already-resolved TileOps have no placer-visible budget).
+void SequentialPlacer::addChannelRequirementsFromFlows(
+    SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
+    llvm::DenseMap<Operation *, std::pair<int, int>> &channelRequirements) {
+
+  auto incIfDMA = [&](Operation *tileOp, WireBundle bundle, bool isOutput) {
+    if (!tileOp || !isa<LogicalTileOp>(tileOp))
+      return;
+    if (bundle != WireBundle::DMA)
+      return;
+    if (isOutput)
+      channelRequirements[tileOp].second++;
+    else
+      channelRequirements[tileOp].first++;
+  };
+
+  for (auto flow : flows) {
+    Operation *srcOp = flow.getSource().getDefiningOp();
+    Operation *dstOp = flow.getDest().getDefiningOp();
+    incIfDMA(srcOp, flow.getSourceBundle(), /*isOutput=*/true);
+    incIfDMA(dstOp, flow.getDestBundle(), /*isOutput=*/false);
+  }
+
+  for (auto pktFlow : pktFlows) {
+    pktFlow.walk([&](Operation *op) {
+      if (auto src = dyn_cast<PacketSourceOp>(op)) {
+        incIfDMA(src.getTile().getDefiningOp(), src.getBundle(),
+                 /*isOutput=*/true);
+      } else if (auto dst = dyn_cast<PacketDestOp>(op)) {
+        incIfDMA(dst.getTile().getDefiningOp(), dst.getBundle(),
+                 /*isOutput=*/false);
+      }
+    });
+  }
+}
+
+// Group LogicalTileOps by connected component over flow connectivity.
+// Each `aie.flow` / `aie.packet_flow` (source, dest) endpoint pair is treated
+// as an undirected edge. Connected components are assigned dense group IDs
+// starting at 0 (independent of objectfifo groups). For each group,
+// `groupToNonCoreTiles` collects non-core LogicalTileOps that need placement;
+// `groupToCoreTiles` collects core LogicalTileOps used to compute the group's
+// common column (for placing mem/shim near connected cores).
+void SequentialPlacer::buildFlowGroups(
+    SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
+    llvm::DenseMap<int, SmallVector<LogicalTileOp>> &groupToNonCoreTiles,
+    llvm::DenseMap<int, SmallVector<LogicalTileOp>> &groupToCoreTiles) {
+
+  // Build adjacency over LogicalTileOp endpoints.
+  llvm::DenseMap<LogicalTileOp, llvm::DenseSet<LogicalTileOp>> adj;
+
+  auto addEdge = [&](Value srcVal, Value dstVal) {
+    auto srcLT = dyn_cast_or_null<LogicalTileOp>(srcVal.getDefiningOp());
+    auto dstLT = dyn_cast_or_null<LogicalTileOp>(dstVal.getDefiningOp());
+    if (!srcLT || !dstLT)
+      return;
+    adj[srcLT].insert(dstLT);
+    adj[dstLT].insert(srcLT);
+  };
+
+  for (auto flow : flows)
+    addEdge(flow.getSource(), flow.getDest());
+
+  for (auto pktFlow : pktFlows) {
+    SmallVector<Value> srcs, dsts;
+    pktFlow.walk([&](Operation *op) {
+      if (auto src = dyn_cast<PacketSourceOp>(op))
+        srcs.push_back(src.getTile());
+      else if (auto dst = dyn_cast<PacketDestOp>(op))
+        dsts.push_back(dst.getTile());
+    });
+    // Connect every source to every destination in this packet flow.
+    for (auto s : srcs)
+      for (auto d : dsts)
+        addEdge(s, d);
+  }
+
+  // BFS connected components.
+  llvm::DenseSet<LogicalTileOp> visited;
+  int nextGroupId = 0;
+  for (auto &[seed, _] : adj) {
+    if (visited.count(seed))
+      continue;
+    int gid = nextGroupId++;
+    SmallVector<LogicalTileOp> stack{seed};
+    visited.insert(seed);
+    while (!stack.empty()) {
+      LogicalTileOp cur = stack.pop_back_val();
+      if (cur.getTileType() == AIETileType::CoreTile)
+        groupToCoreTiles[gid].push_back(cur);
+      else
+        groupToNonCoreTiles[gid].push_back(cur);
+      for (auto nbr : adj[cur]) {
+        if (visited.insert(nbr).second)
+          stack.push_back(nbr);
       }
     }
   }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -9,6 +9,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "aie/Dialect/AIE/Transforms/AIEPlacer.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 
 #include <algorithm>
@@ -302,9 +304,11 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     }
   }
 
-  // Phase 4b: Place mem/shim tiles by Flow-based connectivity groups
-  llvm::DenseMap<int, SmallVector<LogicalTileOp>> flowGroupNonCore;
-  llvm::DenseMap<int, SmallVector<LogicalTileOp>> flowGroupCores;
+  // Phase 4b: Place mem/shim tiles by Flow-based connectivity groups.
+  // MapVector keeps group iteration deterministic so placement is reproducible
+  // when multiple groups compete for the same physical tiles.
+  llvm::MapVector<int, SmallVector<LogicalTileOp>> flowGroupNonCore;
+  llvm::MapVector<int, SmallVector<LogicalTileOp>> flowGroupCores;
   buildFlowGroups(flows, pktFlows, flowGroupNonCore, flowGroupCores);
 
   for (auto &[groupId, nonCoreTiles] : flowGroupNonCore) {
@@ -637,12 +641,14 @@ void SequentialPlacer::addChannelRequirementsFromFlows(
   }
 }
 
+// MapVector / SetVector preserve insertion order, which keeps group IDs and
+// per-group tile order stable across runs even when DMA capacity is tight.
 void SequentialPlacer::buildFlowGroups(
     SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
-    llvm::DenseMap<int, SmallVector<LogicalTileOp>> &groupToNonCoreTiles,
-    llvm::DenseMap<int, SmallVector<LogicalTileOp>> &groupToCoreTiles) {
+    llvm::MapVector<int, SmallVector<LogicalTileOp>> &groupToNonCoreTiles,
+    llvm::MapVector<int, SmallVector<LogicalTileOp>> &groupToCoreTiles) {
 
-  llvm::DenseMap<LogicalTileOp, llvm::DenseSet<LogicalTileOp>> adj;
+  llvm::MapVector<LogicalTileOp, llvm::SetVector<LogicalTileOp>> adj;
 
   auto addEdge = [&](Value srcVal, Value dstVal) {
     auto srcLT = dyn_cast_or_null<LogicalTileOp>(srcVal.getDefiningOp());
@@ -671,7 +677,8 @@ void SequentialPlacer::buildFlowGroups(
 
   llvm::DenseSet<LogicalTileOp> visited;
   int nextGroupId = 0;
-  for (auto &[seed, _] : adj) {
+  for (auto &entry : adj) {
+    LogicalTileOp seed = entry.first;
     if (visited.count(seed))
       continue;
     int gid = nextGroupId++;

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -398,8 +398,8 @@ SequentialPlacer::buildChannelRequirements(
 }
 
 void SequentialPlacer::buildObjectFifoGroups(
-    SmallVector<ObjectFifoCreateOp> &objectFifos,
-    SmallVector<ObjectFifoLinkOp> &objectFifoLinks,
+    ArrayRef<ObjectFifoCreateOp> objectFifos,
+    ArrayRef<ObjectFifoLinkOp> objectFifoLinks,
     SmallVectorImpl<ConnectivityGroup> &groups) {
 
   // Linked fifos share a group ID. Unlinked fifos each get their own.
@@ -448,7 +448,7 @@ void SequentialPlacer::buildObjectFifoGroups(
 // Already-resolved TileOps have no placer-visible budget, so only flows whose
 // endpoints are LogicalTileOps contribute to channelRequirements.
 void SequentialPlacer::addChannelRequirementsFromFlows(
-    SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
+    ArrayRef<FlowOp> flows, ArrayRef<PacketFlowOp> pktFlows,
     llvm::DenseMap<Operation *, std::pair<int, int>> &channelRequirements) {
 
   auto incIfDMA = [&](Operation *tileOp, WireBundle bundle, bool isOutput) {
@@ -485,10 +485,10 @@ void SequentialPlacer::addChannelRequirementsFromFlows(
 // MapVector / SetVector preserve insertion order so that group identity and
 // per-group tile order are stable across runs even when DMA capacity is tight.
 void SequentialPlacer::buildFlowGroups(
-    SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
+    ArrayRef<FlowOp> flows, ArrayRef<PacketFlowOp> pktFlows,
     SmallVectorImpl<ConnectivityGroup> &groups) {
 
-  llvm::MapVector<LogicalTileOp, llvm::SetVector<LogicalTileOp>> adj;
+  llvm::MapVector<LogicalTileOp, llvm::SmallSetVector<LogicalTileOp, 4>> adj;
 
   auto addEdge = [&](Value srcVal, Value dstVal) {
     auto srcLT = dyn_cast_or_null<LogicalTileOp>(srcVal.getDefiningOp());

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -446,15 +446,27 @@ void SequentialPlacer::buildObjectFifoGroups(
 }
 
 // Already-resolved TileOps have no placer-visible budget, so only flows whose
-// endpoints are LogicalTileOps contribute to channelRequirements.
+// endpoints are LogicalTileOps contribute to channelRequirements. A DMA
+// channel is a hardware resource: a broadcast (one source channel feeding
+// multiple destinations) consumes one MM2S channel on the producer regardless
+// of the number of `aie.flow` ops it lowers to, and a merge (multiple sources
+// landing on one destination channel) consumes one S2MM channel on the
+// consumer. Dedup by (tile, channel) so the producer-of-broadcast and
+// consumer-of-merge sides are each counted once.
 void SequentialPlacer::addChannelRequirementsFromFlows(
     ArrayRef<FlowOp> flows, ArrayRef<PacketFlowOp> pktFlows,
     llvm::DenseMap<Operation *, std::pair<int, int>> &channelRequirements) {
 
-  auto incIfDMA = [&](Operation *tileOp, WireBundle bundle, bool isOutput) {
+  llvm::DenseSet<std::tuple<Operation *, int>> seenSrc, seenDst;
+
+  auto incIfDMA = [&](Operation *tileOp, WireBundle bundle, int channel,
+                      bool isOutput) {
     if (!tileOp || !isa<LogicalTileOp>(tileOp))
       return;
     if (bundle != WireBundle::DMA)
+      return;
+    auto &seen = isOutput ? seenSrc : seenDst;
+    if (!seen.insert({tileOp, channel}).second)
       return;
     if (isOutput)
       channelRequirements[tileOp].second++;
@@ -463,20 +475,20 @@ void SequentialPlacer::addChannelRequirementsFromFlows(
   };
 
   for (auto flow : flows) {
-    Operation *srcOp = flow.getSource().getDefiningOp();
-    Operation *dstOp = flow.getDest().getDefiningOp();
-    incIfDMA(srcOp, flow.getSourceBundle(), /*isOutput=*/true);
-    incIfDMA(dstOp, flow.getDestBundle(), /*isOutput=*/false);
+    incIfDMA(flow.getSource().getDefiningOp(), flow.getSourceBundle(),
+             flow.getSourceChannel(), /*isOutput=*/true);
+    incIfDMA(flow.getDest().getDefiningOp(), flow.getDestBundle(),
+             flow.getDestChannel(), /*isOutput=*/false);
   }
 
   for (auto pktFlow : pktFlows) {
     pktFlow.walk([&](Operation *op) {
       if (auto src = dyn_cast<PacketSourceOp>(op)) {
         incIfDMA(src.getTile().getDefiningOp(), src.getBundle(),
-                 /*isOutput=*/true);
+                 src.getChannel(), /*isOutput=*/true);
       } else if (auto dst = dyn_cast<PacketDestOp>(op)) {
         incIfDMA(dst.getTile().getDefiningOp(), dst.getBundle(),
-                 /*isOutput=*/false);
+                 dst.getChannel(), /*isOutput=*/false);
       }
     });
   }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -209,156 +209,16 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     }
   }
 
-  // Phase 4: Place mem/shim tiles by ObjectFifo groups
-  llvm::DenseMap<int, SmallVector<ObjectFifoCreateOp>> groupToFifos;
-  llvm::DenseMap<int, SmallVector<LogicalTileOp>> groupToLogicalTiles;
-  buildObjectFifoGroups(objectFifos, objectFifoLinks, groupToFifos,
-                        groupToLogicalTiles);
+  // Phase 4: Place mem/shim tiles by connectivity groups (ObjectFifo + Flow).
+  // Vector iteration order is stable, so placement is reproducible when
+  // multiple groups compete for the same physical tiles.
+  SmallVector<ConnectivityGroup> groups;
+  buildObjectFifoGroups(objectFifos, objectFifoLinks, groups);
+  buildFlowGroups(flows, pktFlows, groups);
 
-  // Process each group's logical tiles together
-  llvm::DenseSet<int> processedGroups;
-
-  for (auto &[groupId, logicalTiles] : groupToLogicalTiles) {
-    if (processedGroups.count(groupId))
-      continue;
-    processedGroups.insert(groupId);
-
-    // Compute common column from ALL fifos in this group
-    int groupCommonCol = 0;
-    int totalCoreEndpoints = 0;
-    int sumCols = 0;
-
-    auto fifosIt = groupToFifos.find(groupId);
-    if (fifosIt != groupToFifos.end()) {
-      for (auto ofOp : fifosIt->second) {
-        // Get core tile endpoints for this fifo
-        Value producerTile = ofOp.getProducerTile();
-        if (auto *producerOp = producerTile.getDefiningOp()) {
-          if (auto prodLogical = dyn_cast<LogicalTileOp>(producerOp)) {
-            if (prodLogical.getTileType() == AIETileType::CoreTile) {
-              if (result.count(prodLogical.getOperation())) {
-                sumCols += result[prodLogical.getOperation()].col;
-                totalCoreEndpoints++;
-              }
-            }
-          }
-        }
-
-        for (Value consumerTile : ofOp.getConsumerTiles()) {
-          if (auto *consumerOp = consumerTile.getDefiningOp()) {
-            if (auto consLogical = dyn_cast<LogicalTileOp>(consumerOp)) {
-              if (consLogical.getTileType() == AIETileType::CoreTile) {
-                if (result.count(consLogical.getOperation())) {
-                  sumCols += result[consLogical.getOperation()].col;
-                  totalCoreEndpoints++;
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    // Compute common column as rounded average of all core tile endpoints.
-    // This places mem/shim tiles near the center of their connected cores
-    // to minimize routing distance.
-    if (totalCoreEndpoints > 0) {
-      groupCommonCol = (sumCols + totalCoreEndpoints / 2) / totalCoreEndpoints;
-    }
-
-    // Place each logical tile from this group
-    for (auto logicalTile : logicalTiles) {
-      // Skip if already placed (e.g., constrained)
-      if (result.count(logicalTile.getOperation()))
-        continue;
-
-      // Get channel requirements for this tile
-      auto it = channelRequirements.find(logicalTile.getOperation());
-      int numInputChannels = 0, numOutputChannels = 0;
-      if (it != channelRequirements.end()) {
-        numInputChannels = it->second.first;
-        numOutputChannels = it->second.second;
-      }
-
-      // Use column constraint if specified, otherwise use group's common column
-      auto colConstraint = logicalTile.tryGetCol();
-      int targetCol = colConstraint ? *colConstraint : groupCommonCol;
-
-      // Find tile with capacity near target column
-      auto maybeTile = findTileWithCapacity(
-          targetCol, availability.nonCompTiles, numInputChannels,
-          numOutputChannels, logicalTile.getTileType());
-
-      if (!maybeTile)
-        return logicalTile.emitError()
-               << "no " << stringifyAIETileType(logicalTile.getTileType())
-               << " with sufficient DMA capacity";
-
-      result[logicalTile] = *maybeTile;
-
-      // Update channel usage
-      if (numInputChannels > 0)
-        updateChannelUsage(*maybeTile, false, numInputChannels);
-      if (numOutputChannels > 0)
-        updateChannelUsage(*maybeTile, true, numOutputChannels);
-    }
-  }
-
-  // Phase 4b: Place mem/shim tiles by Flow-based connectivity groups.
-  // MapVector keeps group iteration deterministic so placement is reproducible
-  // when multiple groups compete for the same physical tiles.
-  llvm::MapVector<int, SmallVector<LogicalTileOp>> flowGroupNonCore;
-  llvm::MapVector<int, SmallVector<LogicalTileOp>> flowGroupCores;
-  buildFlowGroups(flows, pktFlows, flowGroupNonCore, flowGroupCores);
-
-  for (auto &[groupId, nonCoreTiles] : flowGroupNonCore) {
-    int groupCommonCol = 0;
-    int totalCoreEndpoints = 0;
-    int sumCols = 0;
-
-    auto coresIt = flowGroupCores.find(groupId);
-    if (coresIt != flowGroupCores.end()) {
-      for (auto coreTile : coresIt->second) {
-        if (result.count(coreTile.getOperation())) {
-          sumCols += result[coreTile.getOperation()].col;
-          totalCoreEndpoints++;
-        }
-      }
-    }
-
-    if (totalCoreEndpoints > 0)
-      groupCommonCol = (sumCols + totalCoreEndpoints / 2) / totalCoreEndpoints;
-
-    for (auto logicalTile : nonCoreTiles) {
-      if (result.count(logicalTile.getOperation()))
-        continue;
-
-      auto it = channelRequirements.find(logicalTile.getOperation());
-      int numInputChannels = 0, numOutputChannels = 0;
-      if (it != channelRequirements.end()) {
-        numInputChannels = it->second.first;
-        numOutputChannels = it->second.second;
-      }
-
-      auto colConstraint = logicalTile.tryGetCol();
-      int targetCol = colConstraint ? *colConstraint : groupCommonCol;
-
-      auto maybeTile = findTileWithCapacity(
-          targetCol, availability.nonCompTiles, numInputChannels,
-          numOutputChannels, logicalTile.getTileType());
-
-      if (!maybeTile)
-        return logicalTile.emitError()
-               << "no " << stringifyAIETileType(logicalTile.getTileType())
-               << " with sufficient DMA capacity";
-
-      result[logicalTile] = *maybeTile;
-
-      if (numInputChannels > 0)
-        updateChannelUsage(*maybeTile, false, numInputChannels);
-      if (numOutputChannels > 0)
-        updateChannelUsage(*maybeTile, true, numOutputChannels);
-    }
+  for (auto &group : groups) {
+    if (failed(placeNonCoreTilesInGroup(group, channelRequirements)))
+      return failure();
   }
 
   // Phase 5: Fallback for remaining unplaced non-core tiles
@@ -540,67 +400,48 @@ SequentialPlacer::buildChannelRequirements(
 void SequentialPlacer::buildObjectFifoGroups(
     SmallVector<ObjectFifoCreateOp> &objectFifos,
     SmallVector<ObjectFifoLinkOp> &objectFifoLinks,
-    llvm::DenseMap<int, SmallVector<ObjectFifoCreateOp>> &groupToFifos,
-    llvm::DenseMap<int, SmallVector<LogicalTileOp>> &groupToLogicalTiles) {
+    SmallVectorImpl<ConnectivityGroup> &groups) {
 
-  // Build map: ObjectFifo name -> group ID (for linked fifos)
+  // Linked fifos share a group ID. Unlinked fifos each get their own.
   llvm::StringMap<int> fifoToGroup;
   int nextGroupId = 0;
-
-  // Group ObjectFifos that are linked together
   for (auto linkOp : objectFifoLinks) {
     int groupId = nextGroupId++;
-
-    // All source fifos belong to same group
-    for (auto srcFifoAttr : linkOp.getFifoIns()) {
-      auto srcFifoName = cast<FlatSymbolRefAttr>(srcFifoAttr).getValue();
-      fifoToGroup[srcFifoName] = groupId;
-    }
-
-    // All dest fifos belong to same group
-    for (auto dstFifoAttr : linkOp.getFifoOuts()) {
-      auto dstFifoName = cast<FlatSymbolRefAttr>(dstFifoAttr).getValue();
-      fifoToGroup[dstFifoName] = groupId;
-    }
+    for (auto fifoAttr : linkOp.getFifoIns())
+      fifoToGroup[cast<FlatSymbolRefAttr>(fifoAttr).getValue()] = groupId;
+    for (auto fifoAttr : linkOp.getFifoOuts())
+      fifoToGroup[cast<FlatSymbolRefAttr>(fifoAttr).getValue()] = groupId;
   }
 
-  // Build maps: group ID -> logical tiles and fifos
+  // Map group ID -> index into `groups`. Insertion order = first-encountered
+  // fifo order, which matches IR walk order.
+  llvm::DenseMap<int, size_t> groupIdToIndex;
+
+  auto getOrCreateGroup = [&](int groupId) -> ConnectivityGroup & {
+    auto [it, inserted] = groupIdToIndex.try_emplace(groupId, groups.size());
+    if (inserted)
+      groups.emplace_back();
+    return groups[it->second];
+  };
+
+  auto recordEndpoint = [&](Value tileVal, ConnectivityGroup &group) {
+    auto lt = dyn_cast_or_null<LogicalTileOp>(tileVal.getDefiningOp());
+    if (!lt)
+      return;
+    if (lt.getTileType() == AIETileType::CoreTile)
+      group.coreTiles.push_back(lt);
+    else
+      group.nonCoreTiles.push_back(lt);
+  };
+
   int unlinkedGroupId = nextGroupId;
-
   for (auto ofOp : objectFifos) {
-    int groupId;
-    auto groupIt = fifoToGroup.find(ofOp.getSymName());
-
-    // Linked fifos share a group, unlinked fifos get individual entries
-    if (groupIt != fifoToGroup.end()) {
-      groupId = groupIt->second;
-    } else {
-      groupId = unlinkedGroupId++;
-    }
-
-    groupToFifos[groupId].push_back(ofOp);
-
-    // Collect non-core tiles from this fifo
-    // Check producer tile
-    Value producerTile = ofOp.getProducerTile();
-    if (auto *producerOp = producerTile.getDefiningOp()) {
-      if (auto prodLogical = dyn_cast<LogicalTileOp>(producerOp)) {
-        if (prodLogical.getTileType() != AIETileType::CoreTile) {
-          groupToLogicalTiles[groupId].push_back(prodLogical);
-        }
-      }
-    }
-
-    // Check consumer tiles
-    for (Value consumerTile : ofOp.getConsumerTiles()) {
-      if (auto *consumerOp = consumerTile.getDefiningOp()) {
-        if (auto consLogical = dyn_cast<LogicalTileOp>(consumerOp)) {
-          if (consLogical.getTileType() != AIETileType::CoreTile) {
-            groupToLogicalTiles[groupId].push_back(consLogical);
-          }
-        }
-      }
-    }
+    auto it = fifoToGroup.find(ofOp.getSymName());
+    int groupId = (it != fifoToGroup.end()) ? it->second : unlinkedGroupId++;
+    ConnectivityGroup &group = getOrCreateGroup(groupId);
+    recordEndpoint(ofOp.getProducerTile(), group);
+    for (Value consumerTile : ofOp.getConsumerTiles())
+      recordEndpoint(consumerTile, group);
   }
 }
 
@@ -641,12 +482,11 @@ void SequentialPlacer::addChannelRequirementsFromFlows(
   }
 }
 
-// MapVector / SetVector preserve insertion order, which keeps group IDs and
-// per-group tile order stable across runs even when DMA capacity is tight.
+// MapVector / SetVector preserve insertion order so that group identity and
+// per-group tile order are stable across runs even when DMA capacity is tight.
 void SequentialPlacer::buildFlowGroups(
     SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
-    llvm::MapVector<int, SmallVector<LogicalTileOp>> &groupToNonCoreTiles,
-    llvm::MapVector<int, SmallVector<LogicalTileOp>> &groupToCoreTiles) {
+    SmallVectorImpl<ConnectivityGroup> &groups) {
 
   llvm::MapVector<LogicalTileOp, llvm::SetVector<LogicalTileOp>> adj;
 
@@ -676,26 +516,76 @@ void SequentialPlacer::buildFlowGroups(
   }
 
   llvm::DenseSet<LogicalTileOp> visited;
-  int nextGroupId = 0;
   for (auto &entry : adj) {
     LogicalTileOp seed = entry.first;
     if (visited.count(seed))
       continue;
-    int gid = nextGroupId++;
+    ConnectivityGroup &group = groups.emplace_back();
     SmallVector<LogicalTileOp> stack{seed};
     visited.insert(seed);
     while (!stack.empty()) {
       LogicalTileOp cur = stack.pop_back_val();
       if (cur.getTileType() == AIETileType::CoreTile)
-        groupToCoreTiles[gid].push_back(cur);
+        group.coreTiles.push_back(cur);
       else
-        groupToNonCoreTiles[gid].push_back(cur);
+        group.nonCoreTiles.push_back(cur);
       for (auto nbr : adj[cur]) {
         if (visited.insert(nbr).second)
           stack.push_back(nbr);
       }
     }
   }
+}
+
+LogicalResult SequentialPlacer::placeNonCoreTilesInGroup(
+    const ConnectivityGroup &group,
+    const llvm::DenseMap<Operation *, std::pair<int, int>>
+        &channelRequirements) {
+
+  // Common column = rounded average of placed core endpoints' columns.
+  int sumCols = 0;
+  int totalCoreEndpoints = 0;
+  for (auto coreTile : group.coreTiles) {
+    auto it = result.find(coreTile.getOperation());
+    if (it == result.end())
+      continue;
+    sumCols += it->second.col;
+    ++totalCoreEndpoints;
+  }
+  int groupCommonCol =
+      totalCoreEndpoints > 0
+          ? (sumCols + totalCoreEndpoints / 2) / totalCoreEndpoints
+          : 0;
+
+  for (auto logicalTile : group.nonCoreTiles) {
+    if (result.count(logicalTile.getOperation()))
+      continue;
+
+    auto it = channelRequirements.find(logicalTile.getOperation());
+    int numInputChannels =
+        it != channelRequirements.end() ? it->second.first : 0;
+    int numOutputChannels =
+        it != channelRequirements.end() ? it->second.second : 0;
+
+    auto colConstraint = logicalTile.tryGetCol();
+    int targetCol = colConstraint ? *colConstraint : groupCommonCol;
+
+    auto maybeTile = findTileWithCapacity(targetCol, availability.nonCompTiles,
+                                          numInputChannels, numOutputChannels,
+                                          logicalTile.getTileType());
+
+    if (!maybeTile)
+      return logicalTile.emitError()
+             << "no " << stringifyAIETileType(logicalTile.getTileType())
+             << " with sufficient DMA capacity";
+
+    result[logicalTile] = *maybeTile;
+    if (numInputChannels > 0)
+      updateChannelUsage(*maybeTile, false, numInputChannels);
+    if (numOutputChannels > 0)
+      updateChannelUsage(*maybeTile, true, numOutputChannels);
+  }
+  return success();
 }
 
 std::optional<TileID> SequentialPlacer::findTileWithCapacity(

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -136,9 +136,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       pktFlows.push_back(pf);
   });
 
-  // Phase 2: Build channel requirements. ObjectFifo connectivity is the
-  // primary source; `aie.flow` / `aie.packet_flow` ops contribute additively
-  // so the placer can be channel-aware on lowered IR (e.g. AIR's DMA path).
+  // Phase 2: Build channel requirements from ObjectFifo and Flow connectivity
   auto channelRequirements =
       buildChannelRequirements(objectFifos, objectFifoLinks);
   addChannelRequirementsFromFlows(flows, pktFlows, channelRequirements);
@@ -304,10 +302,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     }
   }
 
-  // Phase 4b: Place mem/shim tiles by flow-based connectivity groups.
-  // Mirrors phase 4 but for non-core tiles connected to cores via `aie.flow`
-  // / `aie.packet_flow` (AIR DMA path, or any IR that has lowered objectfifos
-  // away). Tiles already placed by phase 4 are skipped.
+  // Phase 4b: Place mem/shim tiles by Flow-based connectivity groups
   llvm::DenseMap<int, SmallVector<LogicalTileOp>> flowGroupNonCore;
   llvm::DenseMap<int, SmallVector<LogicalTileOp>> flowGroupCores;
   buildFlowGroups(flows, pktFlows, flowGroupNonCore, flowGroupCores);
@@ -605,11 +600,8 @@ void SequentialPlacer::buildObjectFifoGroups(
   }
 }
 
-// Increment per-tile DMA channel demand based on `aie.flow` /
-// `aie.packet_flow`. A flow whose source bundle is DMA consumes one MM2S
-// channel on the source tile; a flow whose dest bundle is DMA consumes one
-// S2MM channel on the dest tile. Only counts when the endpoint's defining op
-// is a LogicalTileOp (already-resolved TileOps have no placer-visible budget).
+// Already-resolved TileOps have no placer-visible budget, so only flows whose
+// endpoints are LogicalTileOps contribute to channelRequirements.
 void SequentialPlacer::addChannelRequirementsFromFlows(
     SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
     llvm::DenseMap<Operation *, std::pair<int, int>> &channelRequirements) {
@@ -645,19 +637,11 @@ void SequentialPlacer::addChannelRequirementsFromFlows(
   }
 }
 
-// Group LogicalTileOps by connected component over flow connectivity.
-// Each `aie.flow` / `aie.packet_flow` (source, dest) endpoint pair is treated
-// as an undirected edge. Connected components are assigned dense group IDs
-// starting at 0 (independent of objectfifo groups). For each group,
-// `groupToNonCoreTiles` collects non-core LogicalTileOps that need placement;
-// `groupToCoreTiles` collects core LogicalTileOps used to compute the group's
-// common column (for placing mem/shim near connected cores).
 void SequentialPlacer::buildFlowGroups(
     SmallVector<FlowOp> &flows, SmallVector<PacketFlowOp> &pktFlows,
     llvm::DenseMap<int, SmallVector<LogicalTileOp>> &groupToNonCoreTiles,
     llvm::DenseMap<int, SmallVector<LogicalTileOp>> &groupToCoreTiles) {
 
-  // Build adjacency over LogicalTileOp endpoints.
   llvm::DenseMap<LogicalTileOp, llvm::DenseSet<LogicalTileOp>> adj;
 
   auto addEdge = [&](Value srcVal, Value dstVal) {
@@ -680,13 +664,11 @@ void SequentialPlacer::buildFlowGroups(
       else if (auto dst = dyn_cast<PacketDestOp>(op))
         dsts.push_back(dst.getTile());
     });
-    // Connect every source to every destination in this packet flow.
     for (auto s : srcs)
       for (auto d : dsts)
         addEdge(s, d);
   }
 
-  // BFS connected components.
   llvm::DenseSet<LogicalTileOp> visited;
   int nextGroupId = 0;
   for (auto &[seed, _] : adj) {

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -198,6 +198,25 @@ module @flow_shim_output_exceeds_capacity {
 
 // -----
 
+// Distinct source DMA channels are NOT deduplicated: three flows on channels
+// 0, 1, 2 still consume three MM2S budgets (only same-channel broadcasts
+// dedup). This guards against an over-eager dedup that would mask real
+// capacity overflows.
+module @flow_distinct_channels_no_dedup {
+  aie.device(npu1) {
+    // CHECK: error: tile (0, 0) requires 0 input/3 output DMA channels, but only 2 input/2 output available
+    %shim = aie.logical_tile<ShimNOCTile>(0, 0)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    %c3 = aie.logical_tile<CoreTile>(?, ?)
+    aie.flow(%shim, DMA : 0, %c1, DMA : 0)
+    aie.flow(%shim, DMA : 1, %c2, DMA : 0)
+    aie.flow(%shim, DMA : 2, %c3, DMA : 0)
+  }
+}
+
+// -----
+
 // Mixed input/output exceeds capacity
 module @mixed_channels_exceed_capacity {
   aie.device(npu1) {

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -182,6 +182,22 @@ module @compute_tiles_exhausted {
 
 // -----
 
+// Flow-derived MM2S demand exceeds shim capacity.
+module @flow_shim_output_exceeds_capacity {
+  aie.device(npu1) {
+    // CHECK: error: tile (0, 0) requires 0 input/3 output DMA channels, but only 2 input/2 output available
+    %shim = aie.logical_tile<ShimNOCTile>(0, 0)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    %c3 = aie.logical_tile<CoreTile>(?, ?)
+    aie.flow(%shim, DMA : 0, %c1, DMA : 0)
+    aie.flow(%shim, DMA : 1, %c2, DMA : 0)
+    aie.flow(%shim, DMA : 2, %c3, DMA : 0)
+  }
+}
+
+// -----
+
 // Mixed input/output exceeds capacity
 module @mixed_channels_exceed_capacity {
   aie.device(npu1) {

--- a/test/place-tiles/sequential_placer/test_place_flows.mlir
+++ b/test/place-tiles/sequential_placer/test_place_flows.mlir
@@ -138,3 +138,62 @@ module @flow_core_bundle_no_dma {
     // CHECK-NOT: aie.logical_tile
   }
 }
+
+// -----
+
+// Objectfifo and flow on the same tiles contribute additively.
+// CHECK-LABEL: @mixed_objfifo_and_flow
+module @mixed_objfifo_and_flow {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(0, 2)
+    %core = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem  = aie.logical_tile<MemTile>(?, ?)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(0, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+
+    aie.objectfifo @of1 (%shim, {%mem}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.flow(%mem, DMA : 0, %core, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Packet flow with one source and two destinations: every src x dst pair
+// becomes a connectivity edge, and both destinations land in the source's
+// connected component.
+// CHECK-LABEL: @packet_flow_one_to_many
+module @packet_flow_one_to_many {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(0, 3)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+    aie.packet_flow(0x1) {
+      aie.packet_source<%mem, DMA : 0>
+      aie.packet_dest<%c1,  DMA : 0>
+      aie.packet_dest<%c2,  DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// A flow with one already-resolved TileOp endpoint and one LogicalTileOp
+// endpoint: the TileOp side contributes nothing (no placer-visible budget),
+// the LogicalTileOp side still placement-validates and gets placed.
+// CHECK-LABEL: @flow_mixed_logical_and_tile
+module @flow_mixed_logical_and_tile {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(0, 0)
+    %shim = aie.tile(0, 0)
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(0, 2)
+    %core = aie.logical_tile<CoreTile>(?, ?)
+    aie.flow(%shim, DMA : 0, %core, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_flows.mlir
+++ b/test/place-tiles/sequential_placer/test_place_flows.mlir
@@ -68,6 +68,27 @@ module @flow_memtile_two_cores {
 
 // -----
 
+// Cores pinned to columns 0 and 2: memtile lands at the rounded average (col 1).
+// CHECK-LABEL: @flow_memtile_averaging
+module @flow_memtile_averaging {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[C0:.*]] = aie.tile(0, 2)
+    %c0 = aie.logical_tile<CoreTile>(0, 2)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(2, 2)
+    %c2 = aie.logical_tile<CoreTile>(2, 2)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(1, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+
+    aie.flow(%mem, DMA : 0, %c0, DMA : 0)
+    aie.flow(%mem, DMA : 1, %c2, DMA : 0)
+    aie.core(%c0) { aie.end }
+    aie.core(%c2) { aie.end }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
 // Two MM2S flows fit within a npu1 shim's 2 source DMA channels.
 // CHECK-LABEL: @flow_shim_channel_capacity
 module @flow_shim_channel_capacity {

--- a/test/place-tiles/sequential_placer/test_place_flows.mlir
+++ b/test/place-tiles/sequential_placer/test_place_flows.mlir
@@ -8,19 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Tests that --aie-place-tiles is connectivity-aware on lowered IR using
-// `aie.flow` and `aie.packet_flow` (no `aie.objectfifo` involved).
-
 // RUN: aie-opt --split-input-file --aie-place-tiles %s | FileCheck %s
 
-// MemTile placed near connected core via aie.flow (mirrors the objectfifo
-// `memtile_near_core` test in test_place_basic.mlir).
+// MemTile placed near connected core via aie.flow.
 // CHECK-LABEL: @flow_memtile_near_core
 module @flow_memtile_near_core {
   aie.device(npu1) {
     // CHECK-DAG: %[[CORE:.*]] = aie.tile(0, 2)
     %core = aie.logical_tile<CoreTile>(?, ?)
-    // MemTile placed near core's column (0).
     // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
     %mem = aie.logical_tile<MemTile>(?, ?)
     // CHECK: aie.flow(%[[MEM]], DMA : 0, %[[CORE]], DMA : 0)
@@ -31,8 +26,7 @@ module @flow_memtile_near_core {
 
 // -----
 
-// Shim --DMA flow--> Mem --DMA flow--> Core: connected component places mem
-// and shim near the core's column (column 0 by default).
+// Shim->Mem->Core: connected component places mem and shim in the core's column.
 // CHECK-LABEL: @flow_chain_shim_mem_core
 module @flow_chain_shim_mem_core {
   aie.device(npu1) {
@@ -53,11 +47,7 @@ module @flow_chain_shim_mem_core {
 
 // -----
 
-// Two unconstrained cores in different columns share a memtile via flows.
-// The memtile's common column is the rounded average of the two cores'
-// placed columns. With sequential column-major placement on npu1, the two
-// cores land in (0,2) and (0,3) — both column 0 — so the memtile lands in
-// column 0 too.
+// Memtile shared by two cores: common column is the rounded average.
 // CHECK-LABEL: @flow_memtile_two_cores
 module @flow_memtile_two_cores {
   aie.device(npu1) {
@@ -78,13 +68,10 @@ module @flow_memtile_two_cores {
 
 // -----
 
-// Channel capacity is enforced from flows: a constrained shim with too many
-// MM2S flows out of it errors out.
+// Two MM2S flows fit within a npu1 shim's 2 source DMA channels.
 // CHECK-LABEL: @flow_shim_channel_capacity
 module @flow_shim_channel_capacity {
   aie.device(npu1) {
-    // npu1 ShimMux has 2 source DMA channels per shim. Two flows out from a
-    // pinned shim should succeed.
     // CHECK-DAG: %[[SHIM:.*]] = aie.tile(0, 0)
     %shim = aie.logical_tile<ShimNOCTile>(0, 0)
     // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
@@ -118,9 +105,7 @@ module @packet_flow_memtile_near_core {
 
 // -----
 
-// Non-DMA bundles do NOT contribute to channel demand. A core-to-core flow
-// over the Core bundle places without consuming any DMA channels — capacity
-// check should not fire even though both endpoints are on the same column.
+// Non-DMA bundles do not contribute to channel demand.
 // CHECK-LABEL: @flow_core_bundle_no_dma
 module @flow_core_bundle_no_dma {
   aie.device(npu1) {

--- a/test/place-tiles/sequential_placer/test_place_flows.mlir
+++ b/test/place-tiles/sequential_placer/test_place_flows.mlir
@@ -1,0 +1,134 @@
+//===- test_place_flows.mlir ----------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests that --aie-place-tiles is connectivity-aware on lowered IR using
+// `aie.flow` and `aie.packet_flow` (no `aie.objectfifo` involved).
+
+// RUN: aie-opt --split-input-file --aie-place-tiles %s | FileCheck %s
+
+// MemTile placed near connected core via aie.flow (mirrors the objectfifo
+// `memtile_near_core` test in test_place_basic.mlir).
+// CHECK-LABEL: @flow_memtile_near_core
+module @flow_memtile_near_core {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(0, 2)
+    %core = aie.logical_tile<CoreTile>(?, ?)
+    // MemTile placed near core's column (0).
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+    // CHECK: aie.flow(%[[MEM]], DMA : 0, %[[CORE]], DMA : 0)
+    aie.flow(%mem, DMA : 0, %core, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Shim --DMA flow--> Mem --DMA flow--> Core: connected component places mem
+// and shim near the core's column (column 0 by default).
+// CHECK-LABEL: @flow_chain_shim_mem_core
+module @flow_chain_shim_mem_core {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(0, 2)
+    %core = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem  = aie.logical_tile<MemTile>(?, ?)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(0, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+
+    // CHECK-DAG: aie.flow(%[[SHIM]], DMA : 0, %[[MEM]], DMA : 0)
+    aie.flow(%shim, DMA : 0, %mem,  DMA : 0)
+    // CHECK-DAG: aie.flow(%[[MEM]], DMA : 1, %[[CORE]], DMA : 0)
+    aie.flow(%mem,  DMA : 1, %core, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Two unconstrained cores in different columns share a memtile via flows.
+// The memtile's common column is the rounded average of the two cores'
+// placed columns. With sequential column-major placement on npu1, the two
+// cores land in (0,2) and (0,3) — both column 0 — so the memtile lands in
+// column 0 too.
+// CHECK-LABEL: @flow_memtile_two_cores
+module @flow_memtile_two_cores {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(0, 3)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+
+    aie.flow(%mem, DMA : 0, %c1, DMA : 0)
+    aie.flow(%mem, DMA : 1, %c2, DMA : 0)
+    aie.core(%c1) { aie.end }
+    aie.core(%c2) { aie.end }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Channel capacity is enforced from flows: a constrained shim with too many
+// MM2S flows out of it errors out.
+// CHECK-LABEL: @flow_shim_channel_capacity
+module @flow_shim_channel_capacity {
+  aie.device(npu1) {
+    // npu1 ShimMux has 2 source DMA channels per shim. Two flows out from a
+    // pinned shim should succeed.
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(0, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(0, 0)
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(0, 3)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+
+    aie.flow(%shim, DMA : 0, %c1, DMA : 0)
+    aie.flow(%shim, DMA : 1, %c2, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Packet flow sources/dests are walked too.
+// CHECK-LABEL: @packet_flow_memtile_near_core
+module @packet_flow_memtile_near_core {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(0, 2)
+    %core = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+    aie.packet_flow(0x1) {
+      aie.packet_source<%mem, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Non-DMA bundles do NOT contribute to channel demand. A core-to-core flow
+// over the Core bundle places without consuming any DMA channels — capacity
+// check should not fire even though both endpoints are on the same column.
+// CHECK-LABEL: @flow_core_bundle_no_dma
+module @flow_core_bundle_no_dma {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(0, 3)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    aie.flow(%c1, Core : 0, %c2, Core : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_flows.mlir
+++ b/test/place-tiles/sequential_placer/test_place_flows.mlir
@@ -197,3 +197,81 @@ module @flow_mixed_logical_and_tile {
     // CHECK-NOT: aie.logical_tile
   }
 }
+
+// -----
+
+// Broadcast on the source side: three flows fan out from the same shim DMA
+// channel 0. Hardware-wise this is one MM2S channel, so the shim's MM2S
+// budget should account for 1 (not 3). Without dedup, the shim would be
+// counted as needing 3 MM2S channels and exceed npu1's 2-channel limit.
+// CHECK-LABEL: @flow_source_broadcast_dedup
+module @flow_source_broadcast_dedup {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(0, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(0, 0)
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(0, 3)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C3:.*]] = aie.tile(0, 4)
+    %c3 = aie.logical_tile<CoreTile>(?, ?)
+
+    // Three flows share source DMA channel 0 -> 1 MM2S consumed on shim.
+    aie.flow(%shim, DMA : 0, %c1, DMA : 0)
+    aie.flow(%shim, DMA : 0, %c2, DMA : 0)
+    aie.flow(%shim, DMA : 0, %c3, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Merge on the destination side: two flows from distinct sources land on the
+// same memtile S2MM channel. Hardware-wise this is one S2MM channel, so the
+// memtile's S2MM budget should account for 1 (not 2).
+// CHECK-LABEL: @flow_dest_merge_dedup
+module @flow_dest_merge_dedup {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(0, 3)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+
+    // Both flows merge onto memtile S2MM channel 0 -> 1 S2MM consumed.
+    aie.flow(%c1, DMA : 0, %mem, DMA : 0)
+    aie.flow(%c2, DMA : 0, %mem, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Packet flow broadcast to many destinations on the same dest DMA channel:
+// the source side counts once per (tile, channel) and each PacketDestOp's
+// (tile, channel) pair is also deduplicated.
+// CHECK-LABEL: @packet_flow_dedup
+module @packet_flow_dedup {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(0, 2)
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C2:.*]] = aie.tile(0, 3)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK-DAG: %[[C3:.*]] = aie.tile(0, 4)
+    %c3 = aie.logical_tile<CoreTile>(?, ?)
+    // Two packet flows share the same memtile MM2S channel 0 -> count once.
+    aie.packet_flow(0x1) {
+      aie.packet_source<%mem, DMA : 0>
+      aie.packet_dest<%c1, DMA : 0>
+      aie.packet_dest<%c2, DMA : 0>
+    }
+    aie.packet_flow(0x2) {
+      aie.packet_source<%mem, DMA : 0>
+      aie.packet_dest<%c3, DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}


### PR DESCRIPTION
## Summary

Extends `SequentialPlacer` to read `aie.flow` and `aie.packet_flow` ops as additional connectivity sources, alongside the existing `aie.objectfifo` reader. Frontends that lower channels directly to `aie.flow` (without going through objectfifo) now get the same channel-aware placement that the objectfifo path enjoys today.

This is the first of a planned series (companion issue forthcoming, related to #2864) to make `--aie-place-tiles` work from any combination of high-level (`aie.objectfifo`) and lowered (`aie.flow`, `aie.packet_flow`, `aie.cascade_flow`, `aie.buffer`) connectivity ops.

### Motivation

The placer's current input contract (single `device.walk` over `LogicalTileOp` + `ObjectFifoCreateOp` + `ObjectFifoLinkOp`) means any IR that reaches the placer without objectfifos is treated as having zero connectivity:

- channel capacity is never validated → no error if a tile is over-subscribed
- mem/shim tiles fall through to the column-0 fallback → no proximity to connected cores

This affects callers that lower channels straight to `aie.flow` / `aie.dma_bd` / `aie.lock` / `aie.buffer` (e.g. mlir-air's DMA path).

## What this PR does

Additive. The objectfifo path is unchanged; pure-objectfifo IR produces bit-identical placement.

- **Phase 1**: also collect `FlowOp` and `PacketFlowOp`.
- **`addChannelRequirementsFromFlows`**: for each flow, if the source bundle is `DMA` and the source's defining op is a `LogicalTileOp`, increment its MM2S counter; symmetrically for `dst` and S2MM. `PacketFlowOp` is walked into for `PacketSourceOp` / `PacketDestOp`. Results are summed into the same `channelRequirements` map produced by the objectfifo path.
- **`buildFlowGroups`**: BFS over the flow graph treating each `LogicalTileOp` as a node and each flow as an undirected edge. Each connected component is one group; non-core tiles in the group need placement, core tiles in the group define the group's common column.
- **Phase 4b**: mirrors phase 4 but iterates flow groups instead of objectfifo groups. Tiles already placed in phase 4 are skipped, so objectfifo + flow IR coexists cleanly.

## Test plan

- [x] New lit test `test/place-tiles/sequential_placer/test_place_flows.mlir` (6 cases): mem-near-core via flow, shim→mem→core chain, multi-core grouping, channel capacity from flows, packet flows, non-DMA bundle (no demand).
- [x] All 7 tests in `test/place-tiles/` pass (6 existing + 1 new).
- [x] All 108 tests in `test/dialect/AIE/` pass (+ 1 pre-existing XFAIL).
- [x] Downstream verification: rebuilt mlir-air against this change; all 368 tests in `check-air-mlir` pass (+ 7 pre-existing XFAIL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)