### PR TITLE
[CI] Add deadsnakes PPA without add-apt-repository (avoid launchpad timeout)

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -122,9 +122,16 @@ jobs:
 
             if ! command -v python${{ matrix.python_version }} &> /dev/null; then
               echo "Python ${{ matrix.python_version }} not found, installing..."
+              # Add deadsnakes PPA without `add-apt-repository`, which calls
+              # launchpadlib and times out reliably from inside this container.
               apt-get update
-              apt-get install -y software-properties-common
-              add-apt-repository -y ppa:deadsnakes/ppa
+              apt-get install -y curl gpg ca-certificates
+              install -d -m 0755 /etc/apt/keyrings
+              curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" \
+                | gpg --dearmor -o /etc/apt/keyrings/deadsnakes.gpg
+              . /etc/os-release
+              echo "deb [signed-by=/etc/apt/keyrings/deadsnakes.gpg] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu ${VERSION_CODENAME} main" \
+                > /etc/apt/sources.list.d/deadsnakes.list
               apt-get update
               apt-get install -y python${{ matrix.python_version }} python${{ matrix.python_version }}-venv python${{ matrix.python_version }}-dev
             fi


### PR DESCRIPTION
## Summary

The Linux Python 3.14 wheel build (`Build and upload mlir_aie wheels (3.14, ON/OFF)`) fails on most main-branch nightly runs and on every PR with the same error:

```
File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 144, in _request
File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1153, in connect
    sock.connect((self.host, self.port))
TimeoutError: [Errno 110] Connection timed out
##[error]The process '/.../run-on-arch.sh' failed with exit code 1
```

`add-apt-repository -y ppa:deadsnakes/ppa` is a thin Python wrapper that uses **launchpadlib** to validate the PPA via the Launchpad REST API at `launchpad.net`. From inside the run-on-arch Docker container on GitHub-hosted runners, that HTTP call consistently times out. Only the Python 3.14 matrix entry hits this path — the base image's default apt sources already cover 3.10–3.13, so those skip the PPA install entirely.

The earlier `Error response from daemon: manifest unknown` line in the same logs is unrelated noise (run-on-arch trying to pull a non-existent incremental Docker layer cache; falls back to a fresh build cleanly).

## Fix

Bypass `add-apt-repository` and write the deadsnakes apt source + signing key directly. apt resolves the PPA via plain HTTPS to `ppa.launchpadcontent.net`, which has been reliable; no launchpadlib roundtrip needed.

## Test plan

- [ ] CI passes on this PR for all matrix entries, including Linux 3.14 ON/OFF.
- [ ] No behavioral change for 3.10–3.13 (those skip the new branch entirely; their `command -v` succeeds against the prebaked interpreter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)