### PR TITLE
[AIEPlacer] Read shared-L1 aie.buffer references as memory-affinity adjacency

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -137,6 +137,10 @@ private:
   // Adjacency<Predicate> once both have landed.
   struct BufferAdjacency {
     llvm::SmallVector<std::pair<LogicalTileOp, TileLike>, 4> edges;
+    llvm::DenseMap<mlir::Operation *, llvm::SmallVector<unsigned, 2>>
+        tileToEdges;
+  };
+
   // `tileToEdges` indexes into `edges` only for `LogicalTileOp` endpoints
   // (the ones the placer visits); `TileOp` peers contribute coords via
   // `TileLike::tryGetCol`/`tryGetRow`.

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -113,6 +113,36 @@ private:
   buildChannelRequirements(
       llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
+
+  // Adjacency constraints inferred from cross-tile L1 buffer accesses.
+  //
+  // When `aie.core(%lt_consumer)` reads or writes an `aie.buffer(%owner)`
+  // attached to a different tile, the consumer's physical placement must
+  // satisfy `targetModel->isLegalMemAffinity(consumerPos, ownerPos)` so the
+  // L1 access actually resolves to a reachable neighbor-memory window.
+  //
+  // `edges` records each cross-tile reference once; `tileToEdges` indexes by
+  // any LogicalTileOp endpoint so a check at either side catches the
+  // violation regardless of placement order. Owners that are physical TileOps
+  // contribute their fixed coords via `TileLike::tryGetCol/tryGetRow` and are
+  // not indexed (the placer never visits them).
+  struct BufferAdjacency {
+    llvm::SmallVector<std::pair<LogicalTileOp, TileLike>, 4> edges;
+    llvm::DenseMap<mlir::Operation *, llvm::SmallVector<unsigned, 2>>
+        tileToEdges;
+  };
+
+  BufferAdjacency
+  buildBufferAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
+
+  // Defers when a peer is unplaced and unpinned; symmetric so a check at one
+  // endpoint suffices once the other endpoint resolves.
+  bool satisfiesBufferAdjacency(LogicalTileOp logicalTile, TileID candidate,
+                                const BufferAdjacency &adjacency) const;
+
+  void attachBufferPeerNotes(mlir::InFlightDiagnostic &diag,
+                             LogicalTileOp logicalTile,
+                             const BufferAdjacency &adjacency) const;
 };
 
 } // namespace xilinx::AIE

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -114,18 +114,9 @@ private:
       llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
 
-  // Adjacency constraints inferred from cross-tile L1 buffer accesses.
-  //
-  // When `aie.core(%lt_consumer)` reads or writes an `aie.buffer(%owner)`
-  // attached to a different tile, the consumer's physical placement must
-  // satisfy `targetModel->isLegalMemAffinity(consumerPos, ownerPos)` so the
-  // L1 access actually resolves to a reachable neighbor-memory window.
-  //
-  // `edges` records each cross-tile reference once; `tileToEdges` indexes by
-  // any LogicalTileOp endpoint so a check at either side catches the
-  // violation regardless of placement order. Owners that are physical TileOps
-  // contribute their fixed coords via `TileLike::tryGetCol/tryGetRow` and are
-  // not indexed (the placer never visits them).
+  // Cross-tile L1 buffer accesses: consumer must satisfy isLegalMemAffinity
+  // of owner. Same shape as CascadeAdjacency in #3042; TODO: factor a generic
+  // Adjacency<Predicate> once both have landed.
   struct BufferAdjacency {
     llvm::SmallVector<std::pair<LogicalTileOp, TileLike>, 4> edges;
     llvm::DenseMap<mlir::Operation *, llvm::SmallVector<unsigned, 2>>
@@ -135,8 +126,6 @@ private:
   BufferAdjacency
   buildBufferAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
 
-  // Defers when a peer is unplaced and unpinned; symmetric so a check at one
-  // endpoint suffices once the other endpoint resolves.
   bool satisfiesBufferAdjacency(LogicalTileOp logicalTile, TileID candidate,
                                 const BufferAdjacency &adjacency) const;
 

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -114,8 +114,10 @@ private:
       llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
 
-  // Cross-tile L1 buffer accesses: consumer must satisfy isLegalMemAffinity
-  // of owner. Same shape as CascadeAdjacency in #3042; TODO: factor a generic
+  // Cross-tile L1 buffer access: consumer LTO's core must pass
+  // targetModel->isLegalMemAffinity(coreCol=consumerCol, coreRow=consumerRow,
+  //                                 memCol=ownerCol,     memRow=ownerRow).
+  // Same shape as CascadeAdjacency (#3042); TODO: factor a generic
   // Adjacency<Predicate> once both have landed.
   struct BufferAdjacency {
     llvm::SmallVector<std::pair<LogicalTileOp, TileLike>, 4> edges;

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -130,46 +130,46 @@ private:
       llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
 
-  // Cross-tile L1 buffer access: consumer LTO's core must pass
-  // targetModel->isLegalMemAffinity(coreCol=consumerCol, coreRow=consumerRow,
-  //                                 memCol=ownerCol,     memRow=ownerRow).
-  // Same shape as CascadeAdjacency (#3042); TODO: factor a generic
-  // Adjacency<Predicate> once both have landed.
-  struct BufferAdjacency {
-    llvm::SmallVector<std::pair<LogicalTileOp, TileLike>, 4> edges;
-    llvm::DenseMap<mlir::Operation *, llvm::SmallVector<unsigned, 2>>
-        tileToEdges;
-  };
-
-  // `tileToEdges` indexes into `edges` only for `LogicalTileOp` endpoints
-  // (the ones the placer visits); `TileOp` peers contribute coords via
-  // `TileLike::tryGetCol`/`tryGetRow`.
-  struct CascadeAdjacency {
+  // Per-LTO peer edges indexed by either endpoint. Used by both shared-L1
+  // buffer adjacency (memory affinity) and cascade adjacency (cardinal
+  // direction). `tileToEdges` indexes into `edges` only for `LogicalTileOp`
+  // endpoints (the ones the placer visits); `TileOp` peers contribute coords
+  // via `TileLike::tryGetCol`/`tryGetRow`.
+  struct Adjacency {
     llvm::SmallVector<std::pair<TileLike, TileLike>, 4> edges;
     llvm::DenseMap<mlir::Operation *, llvm::SmallVector<unsigned, 2>>
         tileToEdges;
   };
 
-  BufferAdjacency
-  buildBufferAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
+  // Cross-tile L1 buffer access: consumer LTO's core must pass
+  // targetModel->isLegalMemAffinity(coreCol=consumerCol, coreRow=consumerRow,
+  //                                 memCol=ownerCol,     memRow=ownerRow).
+  // The first endpoint of each edge is the consumer LTO; the second is the
+  // owner tile.
+  Adjacency buildBufferAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
 
-  bool satisfiesBufferAdjacency(LogicalTileOp logicalTile, TileID candidate,
-                                const BufferAdjacency &adjacency) const;
+  // The first endpoint of each edge is the cascade source; the second is the
+  // destination.
+  Adjacency buildCascadeAdjacency(llvm::ArrayRef<CascadeFlowOp> cascadeFlows);
 
-  void attachBufferPeerNotes(mlir::InFlightDiagnostic &diag,
-                             LogicalTileOp logicalTile,
-                             const BufferAdjacency &adjacency) const;
-  CascadeAdjacency
-  buildCascadeAdjacency(llvm::ArrayRef<CascadeFlowOp> cascadeFlows);
+  // Generic adjacency predicate. `pred` returns true iff `(firstPos,
+  // secondPos)` satisfies the constraint, where `first` and `second` are
+  // `adjacency.edges[i].first` and `.second`. Unplaced peers without pin
+  // coords defer; symmetric/asymmetric predicates only need to be checked at
+  // one endpoint each.
+  bool satisfiesAdjacency(
+      LogicalTileOp logicalTile, TileID candidate, const Adjacency &adjacency,
+      llvm::function_ref<bool(TileID firstPos, TileID secondPos)> pred) const;
 
-  // Unplaced peers without pin coords defer; symmetric predicate makes one
-  // check per endpoint sufficient.
-  bool satisfiesCascadeAdjacency(LogicalTileOp logicalTile, TileID candidate,
-                                 const CascadeAdjacency &adjacency) const;
+  // Generic peer-note attachment. `labelPeer(thisIsFirst)` returns the
+  // descriptive name of the peer endpoint -- when `logicalTile` is the first
+  // member of the edge, the peer is the second member, and vice versa. The
+  // attached note reads `"<label> peer placed at (col, row)"`.
+  void attachPeerNotes(
+      mlir::InFlightDiagnostic &diag, LogicalTileOp logicalTile,
+      const Adjacency &adjacency,
+      llvm::function_ref<llvm::StringRef(bool thisIsFirst)> labelPeer) const;
 
-  void attachCascadePeerNotes(mlir::InFlightDiagnostic &diag,
-                              LogicalTileOp logicalTile,
-                              const CascadeAdjacency &adjacency) const;
   void addChannelRequirementsFromFlows(
       llvm::ArrayRef<FlowOp> flows, llvm::ArrayRef<PacketFlowOp> pktFlows,
       llvm::DenseMap<mlir::Operation *, std::pair<int, int>>

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -139,6 +139,19 @@ private:
     llvm::SmallVector<std::pair<TileLike, TileLike>, 4> edges;
     llvm::DenseMap<mlir::Operation *, llvm::SmallVector<unsigned, 2>>
         tileToEdges;
+
+    // Append a peer edge and index it on every `LogicalTileOp` endpoint.
+    // Centralizes the invariant that `tileToEdges[op]` lists every edge
+    // mentioning `op`, but only for LTO endpoints (`TileOp` peers carry
+    // their own coords).
+    void addEdge(TileLike first, TileLike second) {
+      unsigned idx = edges.size();
+      edges.push_back({first, second});
+      if (mlir::isa<LogicalTileOp>(first.getOperation()))
+        tileToEdges[first.getOperation()].push_back(idx);
+      if (mlir::isa<LogicalTileOp>(second.getOperation()))
+        tileToEdges[second.getOperation()].push_back(idx);
+    }
   };
 
   // Cross-tile L1 buffer access: consumer LTO's core must pass

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -199,8 +199,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
           diag << "no compute tile available matching constraint ("
                << (col ? std::to_string(*col) : "?") << ", "
                << (row ? std::to_string(*row) : "?") << ")"
-               << (adjacencyWasCause ? " with valid shared-L1 buffer adjacency"
-                                     : "");
+               << (adjacencyWasCause ? " and shared-L1 buffer adjacency" : "");
         } else {
           diag << "no available compute tiles for placement"
                << (adjacencyWasCause
@@ -602,8 +601,8 @@ void SequentialPlacer::attachBufferPeerNotes(
     if (!peerPos)
       continue;
     diag.attachNote(peer.getLoc())
-        << "buffer-affinity " << (thisIsConsumer ? "owner" : "consumer")
-        << " peer at (" << peerPos->col << ", " << peerPos->row << ")";
+        << "shared-L1 buffer " << (thisIsConsumer ? "owner" : "consumer")
+        << " peer placed at (" << peerPos->col << ", " << peerPos->row << ")";
   }
 }
 

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -153,6 +153,29 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
 
   auto cascadeAdjacency = buildCascadeAdjacency(cascadeFlows);
 
+  // Per-kind predicates / labelers shared by all phase-3 call sites below.
+  // Buffer: consumer LTO (edge.first) must satisfy isLegalMemAffinity to the
+  // owner tile (edge.second).
+  auto bufferPred = [this](TileID consumerPos, TileID ownerPos) {
+    return targetModel->isLegalMemAffinity(consumerPos.col, consumerPos.row,
+                                           ownerPos.col, ownerPos.row);
+  };
+  auto bufferLabel = [](bool thisIsConsumer) -> StringRef {
+    return thisIsConsumer ? "shared-L1 buffer owner"
+                          : "shared-L1 buffer consumer";
+  };
+  // Cascade: same predicate as AIELowerCascadeFlowsPass -- src (edge.first)
+  // must be one row North or one column West of dst (edge.second); rows
+  // increase upward, so isSouth(src,dst) means dst is south of src.
+  auto cascadePred = [this](TileID srcPos, TileID dstPos) {
+    return targetModel->isSouth(srcPos.col, srcPos.row, dstPos.col,
+                                dstPos.row) ||
+           targetModel->isEast(srcPos.col, srcPos.row, dstPos.col, dstPos.row);
+  };
+  auto cascadeLabel = [](bool thisIsSrc) -> StringRef {
+    return thisIsSrc ? "cascade destination" : "cascade source";
+  };
+
   // Phase 3: Place constrained tiles then compute tiles
   size_t nextCompIdx = 0;
   for (auto logicalTile : logicalTiles) {
@@ -161,18 +184,19 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     auto row = logicalTile.tryGetRow();
     if (col && row) {
       TileID tile{*col, *row};
-      if (!satisfiesBufferAdjacency(logicalTile, tile, bufferAdjacency)) {
+      if (!satisfiesAdjacency(logicalTile, tile, bufferAdjacency, bufferPred)) {
         auto diag = logicalTile.emitError()
                     << "tile (" << tile.col << ", " << tile.row
                     << ") violates shared-L1 buffer adjacency";
-        attachBufferPeerNotes(diag, logicalTile, bufferAdjacency);
+        attachPeerNotes(diag, logicalTile, bufferAdjacency, bufferLabel);
         return failure();
       }
-      if (!satisfiesCascadeAdjacency(logicalTile, tile, cascadeAdjacency)) {
+      if (!satisfiesAdjacency(logicalTile, tile, cascadeAdjacency,
+                              cascadePred)) {
         auto diag = logicalTile.emitError()
                     << "tile (" << tile.col << ", " << tile.row
                     << ") violates cascade adjacency";
-        attachCascadePeerNotes(diag, logicalTile, cascadeAdjacency);
+        attachPeerNotes(diag, logicalTile, cascadeAdjacency, cascadeLabel);
         return failure();
       }
       if (failed(validateAndUpdateChannelUsage(logicalTile, tile,
@@ -203,11 +227,12 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
         if (row && candidate.row != *row)
           continue;
         sawConstraintMatch = true;
-        if (!satisfiesBufferAdjacency(logicalTile, candidate, bufferAdjacency))
+        if (!satisfiesAdjacency(logicalTile, candidate, bufferAdjacency,
+                                bufferPred))
           continue;
         allConstraintMatchesFailedAdjacency = false;
-        if (!satisfiesCascadeAdjacency(logicalTile, candidate,
-                                       cascadeAdjacency))
+        if (!satisfiesAdjacency(logicalTile, candidate, cascadeAdjacency,
+                                cascadePred))
           continue;
 
         // Found valid tile - swap to nextCompIdx position and use
@@ -238,9 +263,9 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
                << (hasCascade ? " (cascade adjacency unsatisfiable)" : "");
         }
         if (adjacencyWasCause)
-          attachBufferPeerNotes(diag, logicalTile, bufferAdjacency);
+          attachPeerNotes(diag, logicalTile, bufferAdjacency, bufferLabel);
         if (hasCascade)
-          attachCascadePeerNotes(diag, logicalTile, cascadeAdjacency);
+          attachPeerNotes(diag, logicalTile, cascadeAdjacency, cascadeLabel);
         return failure();
       }
 
@@ -473,9 +498,9 @@ resolvePeerPosition(TileLike peer, const PlacementResult &placed) {
   return std::nullopt;
 }
 
-SequentialPlacer::BufferAdjacency
+SequentialPlacer::Adjacency
 SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
-  BufferAdjacency adjacency;
+  Adjacency adjacency;
   for (auto consumer : logicalTiles) {
     if (consumer.getTileType() != AIETileType::CoreTile)
       continue;
@@ -502,7 +527,7 @@ SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
         if (!seenOwners.insert(owner.getOperation()).second)
           continue;
         unsigned idx = adjacency.edges.size();
-        adjacency.edges.push_back({consumer, owner});
+        adjacency.edges.push_back({TileLike(consumer), owner});
         adjacency.tileToEdges[consumer.getOperation()].push_back(idx);
         if (isa<LogicalTileOp>(owner.getOperation()))
           adjacency.tileToEdges[owner.getOperation()].push_back(idx);
@@ -512,9 +537,9 @@ SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
   return adjacency;
 }
 
-SequentialPlacer::CascadeAdjacency
+SequentialPlacer::Adjacency
 SequentialPlacer::buildCascadeAdjacency(ArrayRef<CascadeFlowOp> cascadeFlows) {
-  CascadeAdjacency adjacency;
+  Adjacency adjacency;
   for (auto cf : cascadeFlows) {
     TileLike src = cf.getSourceTileLike();
     TileLike dst = cf.getDestTileLike();
@@ -530,90 +555,46 @@ SequentialPlacer::buildCascadeAdjacency(ArrayRef<CascadeFlowOp> cascadeFlows) {
   return adjacency;
 }
 
-bool SequentialPlacer::satisfiesBufferAdjacency(
-    LogicalTileOp logicalTile, TileID candidate,
-    const BufferAdjacency &adjacency) const {
+bool SequentialPlacer::satisfiesAdjacency(
+    LogicalTileOp logicalTile, TileID candidate, const Adjacency &adjacency,
+    llvm::function_ref<bool(TileID firstPos, TileID secondPos)> pred) const {
   auto it = adjacency.tileToEdges.find(logicalTile.getOperation());
   if (it == adjacency.tileToEdges.end())
     return true;
 
   for (unsigned idx : it->second) {
-    auto [consumer, owner] = adjacency.edges[idx];
-    bool thisIsConsumer = consumer.getOperation() == logicalTile.getOperation();
-    TileLike peer = thisIsConsumer ? owner : TileLike(consumer);
+    auto [edgeFirst, edgeSecond] = adjacency.edges[idx];
+    bool thisIsFirst = edgeFirst.getOperation() == logicalTile.getOperation();
+    TileLike peer = thisIsFirst ? edgeSecond : edgeFirst;
     auto peerPos = resolvePeerPosition(peer, result);
     if (!peerPos)
       continue;
-    TileID consumerPos = thisIsConsumer ? candidate : *peerPos;
-    TileID ownerPos = thisIsConsumer ? *peerPos : candidate;
-    if (!targetModel->isLegalMemAffinity(consumerPos.col, consumerPos.row,
-                                         ownerPos.col, ownerPos.row))
+    TileID firstPos = thisIsFirst ? candidate : *peerPos;
+    TileID secondPos = thisIsFirst ? *peerPos : candidate;
+    if (!pred(firstPos, secondPos))
       return false;
   }
   return true;
 }
 
-void SequentialPlacer::attachBufferPeerNotes(
+void SequentialPlacer::attachPeerNotes(
     InFlightDiagnostic &diag, LogicalTileOp logicalTile,
-    const BufferAdjacency &adjacency) const {
+    const Adjacency &adjacency,
+    llvm::function_ref<StringRef(bool thisIsFirst)> labelPeer) const {
   auto it = adjacency.tileToEdges.find(logicalTile.getOperation());
   if (it == adjacency.tileToEdges.end())
     return;
   for (unsigned idx : it->second) {
-    auto [consumer, owner] = adjacency.edges[idx];
-    bool thisIsConsumer = consumer.getOperation() == logicalTile.getOperation();
-    TileLike peer = thisIsConsumer ? owner : TileLike(consumer);
+    auto [edgeFirst, edgeSecond] = adjacency.edges[idx];
+    bool thisIsFirst = edgeFirst.getOperation() == logicalTile.getOperation();
+    TileLike peer = thisIsFirst ? edgeSecond : edgeFirst;
     auto peerPos = resolvePeerPosition(peer, result);
     if (!peerPos)
       continue;
     diag.attachNote(peer.getLoc())
-        << "shared-L1 buffer " << (thisIsConsumer ? "owner" : "consumer")
-        << " peer placed at (" << peerPos->col << ", " << peerPos->row << ")";
+        << labelPeer(thisIsFirst) << " peer placed at (" << peerPos->col << ", "
+        << peerPos->row << ")";
   }
-}
-
-void SequentialPlacer::attachCascadePeerNotes(
-    InFlightDiagnostic &diag, LogicalTileOp logicalTile,
-    const CascadeAdjacency &adjacency) const {
-  auto it = adjacency.tileToEdges.find(logicalTile.getOperation());
-  if (it == adjacency.tileToEdges.end())
-    return;
-  for (unsigned idx : it->second) {
-    auto [edgeSrc, edgeDst] = adjacency.edges[idx];
-    bool thisIsSrc = edgeSrc.getOperation() == logicalTile.getOperation();
-    TileLike peer = thisIsSrc ? edgeDst : edgeSrc;
-    auto peerPos = resolvePeerPosition(peer, result);
-    if (!peerPos)
-      continue;
-    diag.attachNote(peer.getLoc())
-        << "cascade " << (thisIsSrc ? "destination" : "source")
-        << " peer placed at (" << peerPos->col << ", " << peerPos->row << ")";
-  }
-}
-
-bool SequentialPlacer::satisfiesCascadeAdjacency(
-    LogicalTileOp logicalTile, TileID candidate,
-    const CascadeAdjacency &adjacency) const {
-  auto it = adjacency.tileToEdges.find(logicalTile.getOperation());
-  if (it == adjacency.tileToEdges.end())
-    return true;
-
-  // Same predicate as AIELowerCascadeFlowsPass: src must be one row North
-  // or one column West of dst (rows increase upward).
-  for (unsigned idx : it->second) {
-    auto [edgeSrc, edgeDst] = adjacency.edges[idx];
-    bool thisIsSrc = edgeSrc.getOperation() == logicalTile.getOperation();
-    TileLike peer = thisIsSrc ? edgeDst : edgeSrc;
-    auto peerPos = resolvePeerPosition(peer, result);
-    if (!peerPos)
-      continue;
-    TileID srcPos = thisIsSrc ? candidate : *peerPos;
-    TileID dstPos = thisIsSrc ? *peerPos : candidate;
-    if (!targetModel->isSouth(srcPos.col, srcPos.row, dstPos.col, dstPos.row) &&
-        !targetModel->isEast(srcPos.col, srcPos.row, dstPos.col, dstPos.row))
-      return false;
-  }
-  return true;
 }
 
 void SequentialPlacer::buildObjectFifoGroups(

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "aie/Dialect/AIE/Transforms/AIEPlacer.h"
+#include "mlir/Interfaces/ViewLikeInterface.h"
 #include "llvm/Support/Debug.h"
 
 #include <algorithm>
@@ -130,9 +131,12 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       objectFifoLinks.push_back(link);
   });
 
-  // Phase 2: Build channel requirements from ObjectFifo connectivity
+  // Phase 2: Build channel requirements from ObjectFifo connectivity, and
+  // memory-affinity adjacency from cross-tile L1 buffer accesses.
   auto channelRequirements =
       buildChannelRequirements(objectFifos, objectFifoLinks);
+
+  auto bufferAdjacency = buildBufferAdjacency(logicalTiles);
 
   // Phase 3: Place constrained tiles then compute tiles
   size_t nextCompIdx = 0;
@@ -142,6 +146,13 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     auto row = logicalTile.tryGetRow();
     if (col && row) {
       TileID tile{*col, *row};
+      if (!satisfiesBufferAdjacency(logicalTile, tile, bufferAdjacency)) {
+        auto diag = logicalTile.emitError()
+                    << "tile (" << tile.col << ", " << tile.row
+                    << ") violates shared-L1 buffer adjacency";
+        attachBufferPeerNotes(diag, logicalTile, bufferAdjacency);
+        return failure();
+      }
       if (failed(validateAndUpdateChannelUsage(logicalTile, tile,
                                                channelRequirements, true)))
         return failure();
@@ -158,6 +169,8 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     // Place compute tiles with partial constraint support
     if (logicalTile.getTileType() == AIETileType::CoreTile) {
       std::optional<TileID> placement = std::nullopt;
+      bool sawConstraintMatch = false;
+      bool allConstraintMatchesFailedAdjacency = true;
 
       for (size_t i = nextCompIdx; i < availability.compTiles.size(); ++i) {
         TileID candidate = availability.compTiles[i];
@@ -167,6 +180,10 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
           continue;
         if (row && candidate.row != *row)
           continue;
+        sawConstraintMatch = true;
+        if (!satisfiesBufferAdjacency(logicalTile, candidate, bufferAdjacency))
+          continue;
+        allConstraintMatchesFailedAdjacency = false;
 
         // Found valid tile - swap to nextCompIdx position and use
         std::swap(availability.compTiles[i],
@@ -176,14 +193,25 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       }
 
       if (!placement) {
+        bool adjacencyWasCause =
+            sawConstraintMatch && allConstraintMatchesFailedAdjacency &&
+            bufferAdjacency.tileToEdges.count(logicalTile.getOperation());
+        InFlightDiagnostic diag = logicalTile.emitError();
         if (col || row) {
-          return logicalTile.emitError()
-                 << "no compute tile available matching constraint ("
-                 << (col ? std::to_string(*col) : "?") << ", "
-                 << (row ? std::to_string(*row) : "?") << ")";
+          diag << "no compute tile available matching constraint ("
+               << (col ? std::to_string(*col) : "?") << ", "
+               << (row ? std::to_string(*row) : "?") << ")"
+               << (adjacencyWasCause ? " with valid shared-L1 buffer adjacency"
+                                     : "");
+        } else {
+          diag << "no available compute tiles for placement"
+               << (adjacencyWasCause
+                       ? " (shared-L1 buffer adjacency unsatisfiable)"
+                       : "");
         }
-        return logicalTile.emitError(
-            "no available compute tiles for placement");
+        if (adjacencyWasCause)
+          attachBufferPeerNotes(diag, logicalTile, bufferAdjacency);
+        return failure();
       }
 
       if (failed(validateAndUpdateChannelUsage(logicalTile, *placement,
@@ -469,6 +497,122 @@ SequentialPlacer::buildChannelRequirements(
   }
 
   return channelRequirements;
+}
+
+// Walk view-like aliasing memref ops back to the underlying BufferOp; stop at
+// anything else (block argument, function call, unrecognized producer).
+static BufferOp traceToBuffer(Value val) {
+  for (Operation *op = val.getDefiningOp(); op;) {
+    if (auto buf = dyn_cast<BufferOp>(op))
+      return buf;
+    if (auto view = dyn_cast<ViewLikeOpInterface>(op)) {
+      val = view.getViewSource();
+      op = val.getDefiningOp();
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+// Look up a peer's known position: from this placement run if already placed,
+// otherwise from a fully-pinned `(col, row)` constraint. Unconstrained and
+// not-yet-placed peers return nullopt and the predicate defers.
+static std::optional<TileID>
+resolvePeerPosition(TileLike peer, const PlacementResult &placed) {
+  auto it = placed.find(peer.getOperation());
+  if (it != placed.end())
+    return it->second;
+  auto col = peer.tryGetCol();
+  auto row = peer.tryGetRow();
+  if (col && row)
+    return TileID{*col, *row};
+  return std::nullopt;
+}
+
+SequentialPlacer::BufferAdjacency
+SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
+  BufferAdjacency adjacency;
+
+  // Cores attached to physical TileOps don't need placement and therefore
+  // don't contribute consumer-side adjacency constraints either.
+  for (auto consumer : logicalTiles) {
+    if (consumer.getTileType() != AIETileType::CoreTile)
+      continue;
+    CoreOp core = nullptr;
+    for (Operation *user : consumer.getResult().getUsers())
+      if (auto c = dyn_cast<CoreOp>(user)) {
+        core = c;
+        break;
+      }
+    if (!core)
+      continue;
+
+    // De-dup multiple references to the same owner from one consumer body.
+    llvm::SmallDenseSet<Operation *, 4> seenOwners;
+    core.getBody().walk([&](Operation *op) {
+      for (Value operand : op->getOperands()) {
+        BufferOp buf = traceToBuffer(operand);
+        if (!buf)
+          continue;
+        auto owner = dyn_cast_or_null<TileLike>(buf.getTile().getDefiningOp());
+        if (!owner)
+          continue;
+        if (owner.getOperation() == consumer.getOperation())
+          continue;
+        if (!seenOwners.insert(owner.getOperation()).second)
+          continue;
+        unsigned idx = adjacency.edges.size();
+        adjacency.edges.push_back({consumer, owner});
+        adjacency.tileToEdges[consumer.getOperation()].push_back(idx);
+        if (isa<LogicalTileOp>(owner.getOperation()))
+          adjacency.tileToEdges[owner.getOperation()].push_back(idx);
+      }
+    });
+  }
+  return adjacency;
+}
+
+bool SequentialPlacer::satisfiesBufferAdjacency(
+    LogicalTileOp logicalTile, TileID candidate,
+    const BufferAdjacency &adjacency) const {
+  auto it = adjacency.tileToEdges.find(logicalTile.getOperation());
+  if (it == adjacency.tileToEdges.end())
+    return true;
+
+  for (unsigned idx : it->second) {
+    auto [consumer, owner] = adjacency.edges[idx];
+    bool thisIsConsumer = consumer.getOperation() == logicalTile.getOperation();
+    TileLike peer = thisIsConsumer ? owner : TileLike(consumer);
+    auto peerPos = resolvePeerPosition(peer, result);
+    if (!peerPos)
+      continue;
+    TileID consumerPos = thisIsConsumer ? candidate : *peerPos;
+    TileID ownerPos = thisIsConsumer ? *peerPos : candidate;
+    if (!targetModel->isLegalMemAffinity(consumerPos.col, consumerPos.row,
+                                         ownerPos.col, ownerPos.row))
+      return false;
+  }
+  return true;
+}
+
+void SequentialPlacer::attachBufferPeerNotes(
+    InFlightDiagnostic &diag, LogicalTileOp logicalTile,
+    const BufferAdjacency &adjacency) const {
+  auto it = adjacency.tileToEdges.find(logicalTile.getOperation());
+  if (it == adjacency.tileToEdges.end())
+    return;
+  for (unsigned idx : it->second) {
+    auto [consumer, owner] = adjacency.edges[idx];
+    bool thisIsConsumer = consumer.getOperation() == logicalTile.getOperation();
+    TileLike peer = thisIsConsumer ? owner : TileLike(consumer);
+    auto peerPos = resolvePeerPosition(peer, result);
+    if (!peerPos)
+      continue;
+    diag.attachNote(peer.getLoc())
+        << "buffer-affinity " << (thisIsConsumer ? "owner" : "consumer")
+        << " peer at (" << peerPos->col << ", " << peerPos->row << ")";
+  }
 }
 
 void SequentialPlacer::buildObjectFifoGroups(

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -526,11 +526,7 @@ SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
           continue;
         if (!seenOwners.insert(owner.getOperation()).second)
           continue;
-        unsigned idx = adjacency.edges.size();
-        adjacency.edges.push_back({TileLike(consumer), owner});
-        adjacency.tileToEdges[consumer.getOperation()].push_back(idx);
-        if (isa<LogicalTileOp>(owner.getOperation()))
-          adjacency.tileToEdges[owner.getOperation()].push_back(idx);
+        adjacency.addEdge(TileLike(consumer), owner);
       }
     });
   }
@@ -545,12 +541,7 @@ SequentialPlacer::buildCascadeAdjacency(ArrayRef<CascadeFlowOp> cascadeFlows) {
     TileLike dst = cf.getDestTileLike();
     if (!src || !dst)
       continue;
-    unsigned idx = adjacency.edges.size();
-    adjacency.edges.push_back({src, dst});
-    if (isa<LogicalTileOp>(src.getOperation()))
-      adjacency.tileToEdges[src.getOperation()].push_back(idx);
-    if (isa<LogicalTileOp>(dst.getOperation()))
-      adjacency.tileToEdges[dst.getOperation()].push_back(idx);
+    adjacency.addEdge(src, dst);
   }
   return adjacency;
 }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -166,6 +166,8 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
                     << "tile (" << tile.col << ", " << tile.row
                     << ") violates shared-L1 buffer adjacency";
         attachBufferPeerNotes(diag, logicalTile, bufferAdjacency);
+        return failure();
+      }
       if (!satisfiesCascadeAdjacency(logicalTile, tile, cascadeAdjacency)) {
         auto diag = logicalTile.emitError()
                     << "tile (" << tile.col << ", " << tile.row
@@ -226,20 +228,17 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
           diag << "no compute tile available matching constraint ("
                << (col ? std::to_string(*col) : "?") << ", "
                << (row ? std::to_string(*row) : "?") << ")"
-               << (adjacencyWasCause ? " and shared-L1 buffer adjacency" : "");
+               << (adjacencyWasCause ? " and shared-L1 buffer adjacency" : "")
+               << (hasCascade ? " and cascade adjacency" : "");
         } else {
           diag << "no available compute tiles for placement"
                << (adjacencyWasCause
                        ? " (shared-L1 buffer adjacency unsatisfiable)"
-                       : "");
+                       : "")
+               << (hasCascade ? " (cascade adjacency unsatisfiable)" : "");
         }
         if (adjacencyWasCause)
           attachBufferPeerNotes(diag, logicalTile, bufferAdjacency);
-               << (hasCascade ? " and cascade adjacency" : "");
-        } else {
-          diag << "no available compute tiles for placement"
-               << (hasCascade ? " (cascade adjacency unsatisfiable)" : "");
-        }
         if (hasCascade)
           attachCascadePeerNotes(diag, logicalTile, cascadeAdjacency);
         return failure();
@@ -447,6 +446,21 @@ SequentialPlacer::buildChannelRequirements(
   return channelRequirements;
 }
 
+// Walk view-like aliasing memref ops back to the underlying BufferOp.
+static BufferOp traceToBuffer(Value val) {
+  for (Operation *op = val.getDefiningOp(); op;) {
+    if (auto buf = dyn_cast<BufferOp>(op))
+      return buf;
+    if (auto view = dyn_cast<ViewLikeOpInterface>(op)) {
+      val = view.getViewSource();
+      op = val.getDefiningOp();
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
 static std::optional<TileID>
 resolvePeerPosition(TileLike peer, const PlacementResult &placed) {
   auto it = placed.find(peer.getOperation());
@@ -494,6 +508,10 @@ SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
           adjacency.tileToEdges[owner.getOperation()].push_back(idx);
       }
     });
+  }
+  return adjacency;
+}
+
 SequentialPlacer::CascadeAdjacency
 SequentialPlacer::buildCascadeAdjacency(ArrayRef<CascadeFlowOp> cascadeFlows) {
   CascadeAdjacency adjacency;
@@ -552,6 +570,8 @@ void SequentialPlacer::attachBufferPeerNotes(
         << "shared-L1 buffer " << (thisIsConsumer ? "owner" : "consumer")
         << " peer placed at (" << peerPos->col << ", " << peerPos->row << ")";
   }
+}
+
 void SequentialPlacer::attachCascadePeerNotes(
     InFlightDiagnostic &diag, LogicalTileOp logicalTile,
     const CascadeAdjacency &adjacency) const {

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -131,11 +131,9 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       objectFifoLinks.push_back(link);
   });
 
-  // Phase 2: Build channel requirements from ObjectFifo connectivity, and
-  // memory-affinity adjacency from cross-tile L1 buffer accesses.
+  // Phase 2: Build placement constraints
   auto channelRequirements =
       buildChannelRequirements(objectFifos, objectFifoLinks);
-
   auto bufferAdjacency = buildBufferAdjacency(logicalTiles);
 
   // Phase 3: Place constrained tiles then compute tiles
@@ -499,8 +497,7 @@ SequentialPlacer::buildChannelRequirements(
   return channelRequirements;
 }
 
-// Walk view-like aliasing memref ops back to the underlying BufferOp; stop at
-// anything else (block argument, function call, unrecognized producer).
+// Walk view-like aliasing memref ops back to the underlying BufferOp.
 static BufferOp traceToBuffer(Value val) {
   for (Operation *op = val.getDefiningOp(); op;) {
     if (auto buf = dyn_cast<BufferOp>(op))
@@ -515,9 +512,8 @@ static BufferOp traceToBuffer(Value val) {
   return nullptr;
 }
 
-// Look up a peer's known position: from this placement run if already placed,
-// otherwise from a fully-pinned `(col, row)` constraint. Unconstrained and
-// not-yet-placed peers return nullopt and the predicate defers.
+// TODO: identical to the helper introduced by the cascade-adjacency PR
+// (#3042). Hoist to a shared internal header once both have landed.
 static std::optional<TileID>
 resolvePeerPosition(TileLike peer, const PlacementResult &placed) {
   auto it = placed.find(peer.getOperation());
@@ -533,9 +529,6 @@ resolvePeerPosition(TileLike peer, const PlacementResult &placed) {
 SequentialPlacer::BufferAdjacency
 SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
   BufferAdjacency adjacency;
-
-  // Cores attached to physical TileOps don't need placement and therefore
-  // don't contribute consumer-side adjacency constraints either.
   for (auto consumer : logicalTiles) {
     if (consumer.getTileType() != AIETileType::CoreTile)
       continue;
@@ -548,7 +541,6 @@ SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
     if (!core)
       continue;
 
-    // De-dup multiple references to the same owner from one consumer body.
     llvm::SmallDenseSet<Operation *, 4> seenOwners;
     core.getBody().walk([&](Operation *op) {
       for (Value operand : op->getOperands()) {

--- a/test/place-tiles/sequential_placer/test_place_buffer_adjacency.mlir
+++ b/test/place-tiles/sequential_placer/test_place_buffer_adjacency.mlir
@@ -1,0 +1,155 @@
+//===- test_place_buffer_adjacency.mlir ----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-place-tiles %s | FileCheck %s
+
+// Owner pinned at (2, 3); unconstrained consumer reads its buffer. Greedy
+// column-major would place the consumer at (0, 2); the adjacency check
+// rejects that and steers to (2, 2) (north of owner — first affinity slot
+// in greedy sweep order).
+// CHECK-LABEL: @adjacency_steers_unconstrained_consumer
+module @adjacency_steers_unconstrained_consumer {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    %owner = aie.logical_tile<CoreTile>(2, 3)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%consumer) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Star: pinned owner at (1, 3) plus three unconstrained consumers. Each
+// consumer must be a memory-affinity neighbor of (1, 3): S (1, 2), N (1, 4),
+// or W-of-buffer (2, 3). All three slots are filled.
+// CHECK-LABEL: @adjacency_star_three_consumers
+module @adjacency_star_three_consumers {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(1, 3)
+    // CHECK-DAG: aie.tile(1, 2)
+    // CHECK-DAG: aie.tile(1, 4)
+    // CHECK-DAG: aie.tile(2, 3)
+    %owner = aie.logical_tile<CoreTile>(1, 3)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    %c3 = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%c1) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    aie.core(%c2) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    aie.core(%c3) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Both endpoints pinned at compatible positions: owner at (0, 2), consumer
+// at (0, 3) (consumer's S-affinity slot). Placer is a pass-through.
+// CHECK-LABEL: @adjacency_both_pinned_compatible
+module @adjacency_both_pinned_compatible {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    // CHECK-DAG: aie.tile(0, 3)
+    %owner = aie.logical_tile<CoreTile>(0, 2)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(0, 3)
+    aie.core(%consumer) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Buffer accessed via memref.subview is still traced back to the owning
+// LogicalTileOp. Adjacency steers the consumer just as in the direct case.
+// CHECK-LABEL: @adjacency_through_view_op
+module @adjacency_through_view_op {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    %owner = aie.logical_tile<CoreTile>(2, 3)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%consumer) {
+      %sub = memref.subview %buf[0][8][1] : memref<16xi32> to memref<8xi32, strided<[1]>>
+      %i = arith.constant 0 : index
+      %v = memref.load %sub[%i] : memref<8xi32, strided<[1]>>
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Self-reference: consumer reads a buffer attached to its own LTO. Not a
+// cross-tile constraint; placer behaves as if no adjacency edge existed.
+// CHECK-LABEL: @adjacency_self_reference_no_constraint
+module @adjacency_self_reference_no_constraint {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    %lt = aie.logical_tile<CoreTile>(?, ?)
+    %buf = aie.buffer(%lt) : memref<16xi32>
+    aie.core(%lt) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// AIE2P (npu2) target-model dispatch: same affinity rules apply.
+// CHECK-LABEL: @adjacency_npu2_target_model
+module @adjacency_npu2_target_model {
+  aie.device(npu2) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    %owner = aie.logical_tile<CoreTile>(2, 3)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%consumer) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -205,3 +205,81 @@ module @mixed_channels_exceed_capacity {
     aie.core(%core) { aie.end }
   }
 }
+
+// -----
+
+// Both endpoints pinned far apart: not memory-affinity neighbors.
+module @buffer_adjacency_both_pinned_violation {
+  aie.device(npu1) {
+    // CHECK: error: tile (0, 2) violates shared-L1 buffer adjacency
+    // CHECK: note: buffer-affinity consumer peer at (3, 5)
+    %owner = aie.logical_tile<CoreTile>(0, 2)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(3, 5)
+    aie.core(%consumer) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+  }
+}
+
+// -----
+
+// Pinned owner + unconstrained consumer with a column constraint that has no
+// memory-affinity slot relative to the owner.
+module @buffer_adjacency_unsatisfiable_column {
+  aie.device(npu1) {
+    // CHECK: error: no compute tile available matching constraint (3, ?) with valid shared-L1 buffer adjacency
+    // CHECK: note: buffer-affinity owner peer at (0, 2)
+    %owner = aie.logical_tile<CoreTile>(0, 2)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(3, ?)
+    aie.core(%consumer) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+  }
+}
+
+// -----
+
+// Star with too many consumers: an owner can host at most 3 cross-tile
+// consumers (W, N, S — E is internal in AIE2). A 4th unconstrained consumer
+// has no affinity slot left.
+module @buffer_adjacency_star_oversubscribed {
+  aie.device(npu1) {
+    %owner = aie.logical_tile<CoreTile>(1, 3)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    aie.core(%owner) { aie.end }
+    %c1 = aie.logical_tile<CoreTile>(?, ?)
+    %c2 = aie.logical_tile<CoreTile>(?, ?)
+    %c3 = aie.logical_tile<CoreTile>(?, ?)
+    // CHECK: error: no available compute tiles for placement (shared-L1 buffer adjacency unsatisfiable)
+    // CHECK: note: buffer-affinity owner peer at (1, 3)
+    %c4 = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%c1) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    aie.core(%c2) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    aie.core(%c3) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+    aie.core(%c4) {
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.end
+    }
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -212,7 +212,7 @@ module @mixed_channels_exceed_capacity {
 module @buffer_adjacency_both_pinned_violation {
   aie.device(npu1) {
     // CHECK: error: tile (0, 2) violates shared-L1 buffer adjacency
-    // CHECK: note: buffer-affinity consumer peer at (3, 5)
+    // CHECK: note: shared-L1 buffer consumer peer placed at (3, 5)
     %owner = aie.logical_tile<CoreTile>(0, 2)
     %buf   = aie.buffer(%owner) : memref<16xi32>
     aie.core(%owner) { aie.end }
@@ -231,8 +231,8 @@ module @buffer_adjacency_both_pinned_violation {
 // memory-affinity slot relative to the owner.
 module @buffer_adjacency_unsatisfiable_column {
   aie.device(npu1) {
-    // CHECK: error: no compute tile available matching constraint (3, ?) with valid shared-L1 buffer adjacency
-    // CHECK: note: buffer-affinity owner peer at (0, 2)
+    // CHECK: error: no compute tile available matching constraint (3, ?) and shared-L1 buffer adjacency
+    // CHECK: note: shared-L1 buffer owner peer placed at (0, 2)
     %owner = aie.logical_tile<CoreTile>(0, 2)
     %buf   = aie.buffer(%owner) : memref<16xi32>
     aie.core(%owner) { aie.end }
@@ -259,7 +259,7 @@ module @buffer_adjacency_star_oversubscribed {
     %c2 = aie.logical_tile<CoreTile>(?, ?)
     %c3 = aie.logical_tile<CoreTile>(?, ?)
     // CHECK: error: no available compute tiles for placement (shared-L1 buffer adjacency unsatisfiable)
-    // CHECK: note: buffer-affinity owner peer at (1, 3)
+    // CHECK: note: shared-L1 buffer owner peer placed at (1, 3)
     %c4 = aie.logical_tile<CoreTile>(?, ?)
     aie.core(%c1) {
       %i = arith.constant 0 : index


### PR DESCRIPTION
## Summary

Teaches `SequentialPlacer` to honor memory-affinity adjacency when an `aie.core(%lt_consumer)` reads or writes an `aie.buffer(%owner)` attached to a different tile. The consumer's physical position must satisfy `targetModel->isLegalMemAffinity(consumerPos, ownerPos)` so the L1 access actually resolves to a reachable neighbor-memory window. Today the placer doesn't model this; cross-tile buffer accesses survive placement and only break later in lowering.

This is the third of the planned reader series after #3041 (`flow` / `packet_flow` channel-requirements) and #3042 (`cascade_flow` adjacency), completing the path for IR that reaches the placer with raw buffers instead of objectfifos. Companion to #2864.

## What changes

- New `BufferAdjacency` struct (parallel to `CascadeAdjacency` from #3042): per-LTO peer edges indexed by either endpoint.
- New `buildBufferAdjacency()` walks each `aie.core` body, traces each operand back to its underlying `BufferOp` through view-like memref ops via `ViewLikeOpInterface::getViewSource`, records edges `(consumer LTO, owner TileLike)` — de-duplicated per consumer/owner pair. Self-references and same-LTO accesses are skipped.
- New `satisfiesBufferAdjacency()` checks each edge using `isLegalMemAffinity`; defers when a peer is unplaced and unpinned, so one symmetric predicate at either endpoint catches any violation.
- New `attachBufferPeerNotes()` decorates the diagnostic with peer positions.
- Phase 3 fully-constrained branch validates adjacency before placing.
- Phase 3 partial / unconstrained branch filters candidates by adjacency, with a `(shared-L1 buffer adjacency unsatisfiable)` diagnostic suffix when the filter was the cause of failure.

## Behavior preserved

- IR with no `aie.buffer` is unchanged.
- IR whose buffers are all attached to the same tile as the consuming core is unchanged (no cross-tile edges built).
- Pure objectfifo IR is unchanged (objectfifo-derived buffers are materialized after the placer runs).
- AIE1 / AIE2 / AIE2P pick up the right affinity rules automatically via the target model.

## Test plan

- [x] New `test/place-tiles/sequential_placer/test_place_buffer_adjacency.mlir` (6 positive cases): unconstrained consumer steered to N of pinned owner; 3-consumer star around pinned owner filling W/N/S slots; both endpoints pinned at compatible coords; access through `memref.subview`; self-reference (no constraint); npu2 target-model dispatch.
- [x] New error cases in `test_place_errors.mlir`: both endpoints pinned far apart (peer-note diagnostic), unconstrained consumer with column constraint that has no affinity slot, 4-consumer star oversubscribing the owner's affinity neighborhood.
- [x] All 7 lit-files in `test/place-tiles/` pass.
- [x] All 110 tests in `test/dialect/AIE/` pass (1 pre-existing XFAIL).
- [x] Downstream: rebuilt mlir-air against this change; no API breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)