### PR TITLE
fix(cmake): require project() before find_package(XRT) in example templates

### DIFF
--- a/programming_examples/basic/chaining_channels/CMakeLists.txt
+++ b/programming_examples/basic/chaining_channels/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 # (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.30)
 
 if(NOT DEFINED TARGET_NAME)
   set(TARGET_NAME "chaining_channels")

--- a/programming_examples/basic/dma_transpose/CMakeLists.txt
+++ b/programming_examples/basic/dma_transpose/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/dma_transpose_packet/CMakeLists.txt
+++ b/programming_examples/basic/dma_transpose_packet/CMakeLists.txt
@@ -9,35 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/event_trace/CMakeLists.txt
+++ b/programming_examples/basic/event_trace/CMakeLists.txt
@@ -9,18 +9,17 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
+# event_trace uses an example-specific TARGET_NAME and a hard-wired XRT
+# install path. Setting these BEFORE mlir_aie_init_example() / common.cmake
+# means the macro's CACHE-form set(TARGET_NAME test ...) is a no-op and
+# common.cmake sees these XRT paths instead of probing.
+set(TARGET_NAME mlir_trace_example CACHE STRING "Target to be built")
 find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    set(CMAKE_C_COMPILER gcc-13)
-    set(CMAKE_CXX_COMPILER g++-13)
+if(NOT WSL)
     set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
     set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
 else()
@@ -31,17 +30,11 @@ endif()
 set(IN1_SIZE 16384 CACHE STRING "in1 buffer size")
 set(IN2_SIZE 4 CACHE STRING "in2 buffer size")
 set(OUT_SIZE 16384 CACHE STRING "out buffer size")
-set(TARGET_NAME mlir_trace_example CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_examples/basic/event_trace/CMakeLists.txt
+++ b/programming_examples/basic/event_trace/CMakeLists.txt
@@ -13,19 +13,9 @@ cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-# event_trace uses an example-specific TARGET_NAME and a hard-wired XRT
-# install path. Setting these BEFORE mlir_aie_init_example() / common.cmake
-# means the macro's CACHE-form set(TARGET_NAME test ...) is a no-op and
-# common.cmake sees these XRT paths instead of probing.
+# Set example-specific TARGET_NAME before mlir_aie_init_example() so its
+# CACHE-form default (`test`) becomes a no-op.
 set(TARGET_NAME mlir_trace_example CACHE STRING "Target to be built")
-find_program(WSL NAMES powershell.exe)
-if(NOT WSL)
-    set(XRT_INC_DIR /opt/xilinx/xrt/include CACHE STRING "Path to XRT cloned repo")
-    set(XRT_LIB_DIR /opt/xilinx/xrt/lib CACHE STRING "Path to xrt_coreutil.lib")
-else()
-    set(XRT_INC_DIR C:/Technical/XRT/src/runtime_src/core/include CACHE STRING "Path to XRT cloned repo")
-    set(XRT_LIB_DIR C:/Technical/xrtNPUfromDLL CACHE STRING "Path to xrt_coreutil.lib")
-endif()
 
 set(IN1_SIZE 16384 CACHE STRING "in1 buffer size")
 set(IN2_SIZE 4 CACHE STRING "in2 buffer size")

--- a/programming_examples/basic/matrix_multiplication/CMakeLists.txt
+++ b/programming_examples/basic/matrix_multiplication/CMakeLists.txt
@@ -9,36 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-set(CMAKE_CXX_STANDARD 23)
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget}
     ${subdir}/test.cpp

--- a/programming_examples/basic/matrix_scalar_add/CMakeLists.txt
+++ b/programming_examples/basic/matrix_scalar_add/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/memcpy/CMakeLists.txt
+++ b/programming_examples/basic/memcpy/CMakeLists.txt
@@ -9,35 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
-set(CMAKE_CXX_STANDARD 23) 
-
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/passthrough_dmas/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_dmas/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/passthrough_dmas_plio/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_dmas_plio/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/passthrough_kernel/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_kernel/CMakeLists.txt
@@ -9,28 +9,17 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
 set(IN1_SIZE 4096 CACHE STRING "in1 buffer size")
 set(OUT_SIZE 4096 CACHE STRING "out buffer size")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/passthrough_pykernel/CMakeLists.txt
+++ b/programming_examples/basic/passthrough_pykernel/CMakeLists.txt
@@ -9,27 +9,16 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
 set(PASSTHROUGH_SIZE 4096 CACHE STRING "size")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_exp/CMakeLists.txt
+++ b/programming_examples/basic/vector_exp/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_reduce_add/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_add/CMakeLists.txt
@@ -9,26 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_reduce_max/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_max/CMakeLists.txt
@@ -9,38 +9,18 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
 set(IN1_SIZE 4096 CACHE STRING "in1 buffer size")
 set(OUT_SIZE 4096 CACHE STRING "out buffer size")
 set(DTYPE i32 CACHE STRING "data type")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_reduce_min/CMakeLists.txt
+++ b/programming_examples/basic/vector_reduce_min/CMakeLists.txt
@@ -9,26 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_scalar_add/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_add/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_scalar_add_runlist/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_add_runlist/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
+++ b/programming_examples/basic/vector_scalar_mul/CMakeLists.txt
@@ -9,38 +9,19 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
 set(IN1_SIZE 8192 CACHE STRING "in1 buffer size")
 set(IN2_SIZE 4 CACHE STRING "in2 buffer size")
 set(OUT_SIZE 8192 CACHE STRING "out buffer size")
 set(INT_BIT_WIDTH 16 CACHE STRING "integer bit width size")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if (WSL)
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_vector_modulo/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_modulo/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/basic/vector_vector_mul/CMakeLists.txt
+++ b/programming_examples/basic/vector_vector_mul/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/common.cmake
+++ b/programming_examples/common.cmake
@@ -8,6 +8,21 @@
 # This file provides common setup for test_utils library linking
 
 # -----------------------------------------------------------------------------
+# Guard: project() must be called before this file is included, because
+# find_package(XRT) below loads xrt-targets.cmake which calls
+# add_library(... SHARED IMPORTED). Without a prior project() call, CMake
+# has not initialised platform shared-library support and the call either
+# fails ("does not support dynamic linking") or silently downgrades to
+# STATIC. See Xilinx/mlir-aie#3048.
+# -----------------------------------------------------------------------------
+if(NOT PROJECT_NAME)
+  message(FATAL_ERROR
+    "common.cmake must be included after project(). "
+    "Call mlir_aie_init_example() (or your own project() call) first. "
+    "See https://github.com/Xilinx/mlir-aie/issues/3048")
+endif()
+
+# -----------------------------------------------------------------------------
 # Resolve MLIR-AIE root directory
 # -----------------------------------------------------------------------------
 # In WSL, CMake runs on Windows via `powershell.exe cmake`. Therefore, we must

--- a/programming_examples/ml/block_datatypes/bfp_conversion/CMakeLists.txt
+++ b/programming_examples/ml/block_datatypes/bfp_conversion/CMakeLists.txt
@@ -9,33 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/block_datatypes/matrix_multiplication/CMakeLists.txt
+++ b/programming_examples/ml/block_datatypes/matrix_multiplication/CMakeLists.txt
@@ -9,36 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-set(CMAKE_CXX_STANDARD 23)
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget}
     ${HOST_SRC}

--- a/programming_examples/ml/block_datatypes/vector_passthrough/CMakeLists.txt
+++ b/programming_examples/ml/block_datatypes/vector_passthrough/CMakeLists.txt
@@ -9,33 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/bottleneck/CMakeLists.txt
+++ b/programming_examples/ml/bottleneck/CMakeLists.txt
@@ -10,35 +10,24 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
-endif ()
+endif()
 
 set(EDGEDETECT_WIDTH 1920 CACHE STRING "image width")
 set(EDGEDETECT_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/ml/conv2d/CMakeLists.txt
+++ b/programming_examples/ml/conv2d/CMakeLists.txt
@@ -10,35 +10,24 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
-endif ()
+endif()
 
 set(EDGEDETECT_WIDTH 1920 CACHE STRING "image width")
 set(EDGEDETECT_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/ml/conv2d_14x14/CMakeLists.txt
+++ b/programming_examples/ml/conv2d_14x14/CMakeLists.txt
@@ -10,36 +10,24 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
-endif ()
+endif()
 
 set(EDGEDETECT_WIDTH 1920 CACHE STRING "image width")
 set(EDGEDETECT_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/ml/conv2d_fused_relu/CMakeLists.txt
+++ b/programming_examples/ml/conv2d_fused_relu/CMakeLists.txt
@@ -10,35 +10,24 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
-endif ()
+endif()
 
 set(EDGEDETECT_WIDTH 1920 CACHE STRING "image width")
 set(EDGEDETECT_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/ml/eltwise_add/CMakeLists.txt
+++ b/programming_examples/ml/eltwise_add/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/eltwise_mul/CMakeLists.txt
+++ b/programming_examples/ml/eltwise_mul/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/gelu/CMakeLists.txt
+++ b/programming_examples/ml/gelu/CMakeLists.txt
@@ -9,35 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
-set(CMAKE_CXX_STANDARD 23) 
-
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/layernorm/CMakeLists.txt
+++ b/programming_examples/ml/layernorm/CMakeLists.txt
@@ -9,36 +9,17 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
 set(ROWS 64 CACHE STRING "row size of tensor")
 set(COLS 64 CACHE STRING "col size of tensor")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/relu/CMakeLists.txt
+++ b/programming_examples/ml/relu/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
-set(CMAKE_CXX_STANDARD 23) 
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/resnet/layers_conv2_x/CMakeLists.txt
+++ b/programming_examples/ml/resnet/layers_conv2_x/CMakeLists.txt
@@ -10,35 +10,24 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
-endif ()
+endif()
 
 set(EDGEDETECT_WIDTH 1920 CACHE STRING "image width")
 set(EDGEDETECT_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/ml/rmsnorm/CMakeLists.txt
+++ b/programming_examples/ml/rmsnorm/CMakeLists.txt
@@ -9,36 +9,17 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
 set(ROWS 16 CACHE STRING "row size of tensor")
 set(COLS 64 CACHE STRING "col size of tensor")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/rope/CMakeLists.txt
+++ b/programming_examples/ml/rope/CMakeLists.txt
@@ -9,36 +9,17 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
 set(ROWS 16 CACHE STRING "row size of tensor")
 set(COLS 64 CACHE STRING "col size of tensor")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/scale_shift/CMakeLists.txt
+++ b/programming_examples/ml/scale_shift/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/silu/CMakeLists.txt
+++ b/programming_examples/ml/silu/CMakeLists.txt
@@ -9,35 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
-set(CMAKE_CXX_STANDARD 23) 
-
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/softmax/CMakeLists.txt
+++ b/programming_examples/ml/softmax/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/ml/swiglu/CMakeLists.txt
+++ b/programming_examples/ml/swiglu/CMakeLists.txt
@@ -9,35 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
-set(CMAKE_CXX_STANDARD 23) 
-
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget} test.cpp)
 

--- a/programming_examples/mlir_aie_init.cmake
+++ b/programming_examples/mlir_aie_init.cmake
@@ -1,0 +1,51 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# Encapsulates the pre-project() preamble shared by every example
+# CMakeLists.txt under programming_examples/. Must be a macro (not a
+# function) so that CMAKE_*_COMPILER settings and the cache/local
+# variables it sets are visible in the caller's scope before project()
+# runs.
+#
+# Intended usage in a template:
+#
+#   cmake_minimum_required(VERSION 3.30)
+#   include(<path-to>/mlir_aie_init.cmake)
+#   mlir_aie_init_example()       # WSL + compilers + ProjectName/currentTarget
+#   project(${ProjectName})       # MUST be a literal call in the top-level
+#                                 # CMakeLists.txt (CMake requirement)
+#   include(<path-to>/common.cmake)
+#
+# Why this exists: common.cmake calls find_package(XRT), which loads
+# xrt-targets.cmake and runs add_library(... SHARED IMPORTED). That
+# requires project() to have been called first. Centralising the
+# preamble here keeps the ordering rule in one place rather than
+# duplicated across ~50 templates. See Xilinx/mlir-aie#3048.
+#
+# Templates that need to override anything (extra cache vars, a
+# different default TARGET_NAME, custom XRT paths, etc.) should set it
+# BEFORE calling this macro. The CACHE-form set() calls below are no-ops
+# if the value is already in the cache.
+
+macro(mlir_aie_init_example)
+  find_program(WSL NAMES powershell.exe)
+
+  if(NOT WSL)
+    if(NOT DEFINED CMAKE_C_COMPILER)
+      set(CMAKE_C_COMPILER gcc-13)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_COMPILER)
+      set(CMAKE_CXX_COMPILER g++-13)
+    endif()
+  else()
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
+    add_compile_options(/Zc:__cplusplus)
+  endif()
+
+  set(TARGET_NAME test CACHE STRING "Target to be built")
+  set(ProjectName proj_${TARGET_NAME})
+  set(currentTarget ${TARGET_NAME})
+endmacro()

--- a/programming_examples/vision/color_detect/CMakeLists.txt
+++ b/programming_examples/vision/color_detect/CMakeLists.txt
@@ -10,36 +10,25 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     add_compile_options("/std:c++17")
-endif ()
+endif()
 
 set(COLORDETECT_WIDTH 1920 CACHE STRING "image width")
 set(COLORDETECT_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/vision/color_threshold/CMakeLists.txt
+++ b/programming_examples/vision/color_threshold/CMakeLists.txt
@@ -10,36 +10,25 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     add_compile_options("/std:c++17")
-endif ()
+endif()
 
 set(COLORTHRESHOLD_WIDTH 128 CACHE STRING "image width")
 set(COLORTHRESHOLD_HEIGHT 64 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/vision/edge_detect/CMakeLists.txt
+++ b/programming_examples/vision/edge_detect/CMakeLists.txt
@@ -10,36 +10,25 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     add_compile_options("/std:c++17")
-endif ()
+endif()
 
 set(EDGEDETECT_WIDTH 1920 CACHE STRING "image width")
 set(EDGEDETECT_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_examples/vision/vision_passthrough/CMakeLists.txt
+++ b/programming_examples/vision/vision_passthrough/CMakeLists.txt
@@ -10,37 +10,26 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
-
-include(../../common.cmake)
 
 #set(CMAKE_CXX_STANDARD 23)
 #set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-find_program(WSL NAMES powershell.exe)
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 
-if (NOT WSL)
+if(NOT WSL)
     set(OpenCV_DIR /usr/include/opencv4 CACHE STRING "Path to OpenCV install")
 else()
     set(OpenCV_DIR C:/Technical/thirdParty/opencv/build CACHE STRING "Path to OpenCV install")
     add_compile_options("/std:c++17")
-endif ()
+endif()
 
 set(PASSTHROUGH_WIDTH 1920 CACHE STRING "image width")
 set(PASSTHROUGH_HEIGHT 1080 CACHE STRING "image height")
 
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
 project(${ProjectName})
+include(../../common.cmake)
 
 # Find packages
 find_package(OpenCV REQUIRED)

--- a/programming_guide/common.cmake
+++ b/programming_guide/common.cmake
@@ -8,6 +8,21 @@
 # This file provides common setup for test_utils library linking
 
 # -----------------------------------------------------------------------------
+# Guard: project() must be called before this file is included, because
+# find_package(XRT) below loads xrt-targets.cmake which calls
+# add_library(... SHARED IMPORTED). Without a prior project() call, CMake
+# has not initialised platform shared-library support and the call either
+# fails ("does not support dynamic linking") or silently downgrades to
+# STATIC. See Xilinx/mlir-aie#3048.
+# -----------------------------------------------------------------------------
+if(NOT PROJECT_NAME)
+  message(FATAL_ERROR
+    "common.cmake must be included after project(). "
+    "Call mlir_aie_init_example() (or your own project() call) first. "
+    "See https://github.com/Xilinx/mlir-aie/issues/3048")
+endif()
+
+# -----------------------------------------------------------------------------
 # Resolve MLIR-AIE root directory
 # -----------------------------------------------------------------------------
 # In WSL, CMake runs on Windows via `powershell.exe cmake`. Therefore, we must

--- a/programming_guide/mlir_aie_init.cmake
+++ b/programming_guide/mlir_aie_init.cmake
@@ -1,0 +1,51 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# Encapsulates the pre-project() preamble shared by every example
+# CMakeLists.txt under programming_guide/. Must be a macro (not a
+# function) so that CMAKE_*_COMPILER settings and the cache/local
+# variables it sets are visible in the caller's scope before project()
+# runs.
+#
+# Intended usage in a template:
+#
+#   cmake_minimum_required(VERSION 3.30)
+#   include(<path-to>/mlir_aie_init.cmake)
+#   mlir_aie_init_example()       # WSL + compilers + ProjectName/currentTarget
+#   project(${ProjectName})       # MUST be a literal call in the top-level
+#                                 # CMakeLists.txt (CMake requirement)
+#   include(<path-to>/common.cmake)
+#
+# Why this exists: common.cmake calls find_package(XRT), which loads
+# xrt-targets.cmake and runs add_library(... SHARED IMPORTED). That
+# requires project() to have been called first. Centralising the
+# preamble here keeps the ordering rule in one place rather than
+# duplicated across ~50 templates. See Xilinx/mlir-aie#3048.
+#
+# Templates that need to override anything (extra cache vars, a
+# different default TARGET_NAME, custom XRT paths, etc.) should set it
+# BEFORE calling this macro. The CACHE-form set() calls below are no-ops
+# if the value is already in the cache.
+
+macro(mlir_aie_init_example)
+  find_program(WSL NAMES powershell.exe)
+
+  if(NOT WSL)
+    if(NOT DEFINED CMAKE_C_COMPILER)
+      set(CMAKE_C_COMPILER gcc-13)
+    endif()
+    if(NOT DEFINED CMAKE_CXX_COMPILER)
+      set(CMAKE_CXX_COMPILER g++-13)
+    endif()
+  else()
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
+    add_compile_options(/Zc:__cplusplus)
+  endif()
+
+  set(TARGET_NAME test CACHE STRING "Target to be built")
+  set(ProjectName proj_${TARGET_NAME})
+  set(currentTarget ${TARGET_NAME})
+endmacro()

--- a/programming_guide/section-2/section-2c/from_stream_transformations/CMakeLists.txt
+++ b/programming_guide/section-2/section-2c/from_stream_transformations/CMakeLists.txt
@@ -9,30 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    set(CMAKE_C_COMPILER gcc-13)
-    set(CMAKE_CXX_COMPILER g++-13)
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-2/section-2c/to_stream_transformations/CMakeLists.txt
+++ b/programming_guide/section-2/section-2c/to_stream_transformations/CMakeLists.txt
@@ -9,30 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    set(CMAKE_C_COMPILER gcc-13)
-    set(CMAKE_CXX_COMPILER g++-13)
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-2/section-2f/01_single_double_buffer/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/01_single_double_buffer/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-2/section-2f/02_external_mem_to_core/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/02_external_mem_to_core/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/03_external_mem_to_core_L2/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-2/section-2f/05_join_L2/CMakeLists.txt
+++ b/programming_guide/section-2/section-2f/05_join_L2/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName proj_${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-3/CMakeLists.txt
+++ b/programming_guide/section-3/CMakeLists.txt
@@ -9,34 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-4/section-4a/CMakeLists.txt
+++ b/programming_guide/section-4/section-4a/CMakeLists.txt
@@ -9,26 +9,14 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-set(TARGET_NAME test CACHE STRING "Target to be built")
-
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp

--- a/programming_guide/section-4/section-4b/CMakeLists.txt
+++ b/programming_guide/section-4/section-4b/CMakeLists.txt
@@ -9,37 +9,18 @@
 # -DXRT_LIB_DIR: Path to xrt_coreutil.lib
 # -DTARGET_NAME: Target name to be built
 
-# cmake needs this line
 cmake_minimum_required(VERSION 3.30)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-include(../../common.cmake)
-
-find_program(WSL NAMES powershell.exe)
-
-if (NOT WSL)
-    if(NOT DEFINED CMAKE_C_COMPILER)
-        set(CMAKE_C_COMPILER gcc-13)
-    endif()
-    if(NOT DEFINED CMAKE_CXX_COMPILER)
-        set(CMAKE_CXX_COMPILER g++-13)
-    endif()
-endif()
 set(IN1_SIZE 8192 CACHE STRING "in1 buffer size")
 set(IN2_SIZE 4 CACHE STRING "in2 buffer size")
 set(OUT_SIZE 8192 CACHE STRING "out buffer size")
-set(TARGET_NAME test CACHE STRING "Target to be built")
 
-SET (ProjectName ${TARGET_NAME})
-SET (currentTarget ${TARGET_NAME})
-
-if ( WSL )
-	set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR})
-    add_compile_options(/Zc:__cplusplus)
-endif ()
-
+include(../../mlir_aie_init.cmake)
+mlir_aie_init_example()
 project(${ProjectName})
+include(../../common.cmake)
 
 add_executable(${currentTarget}
     test.cpp


### PR DESCRIPTION
Summary
- `common.cmake`'s `find_package(XRT)` was being called before `project()` in example templates, causing `add_library(... SHARED IMPORTED)` to fail on cmake 4.3.2 / Ubuntu 26.04 ("does not support dynamic linking") and silently downgrade SHARED→STATIC on older cmake/XRT.                                                                                                                                                                                                                                                          
- Hoisted the pre-project boilerplate (WSL detect, gcc-13 fallback, ProjectName/currentTarget setup) into a shared `mlir_aie_init_example()` macro — 53 templates each drop ~25 lines.                                                                                       
- Added a `FATAL_ERROR` guard at the top of `common.cmake` so the bug class can't regress silently. Aligned `cmake_minimum_required` at 3.30 across templates.                        
                                                                                                                                                                           

Fixes #3048