### PR TITLE
Fix llvm update and mlir distro

### DIFF
--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -69,12 +69,16 @@ jobs:
             sudo apt install jq
             # Authenticated request to avoid the unauthenticated 60/hr per-IP
             # rate limit, which silently produced LLVM_PROJECT_COMMIT=null and
-            # broke the wheel build for weeks.
-            RESPONSE=$(curl -fsSL \
+            # broke the wheel build. --fail-with-body keeps the response body
+            # on HTTP error so future failures surface the actual cause in
+            # the CI log instead of hiding behind a silent curl.
+            RESPONSE=$(curl --fail-with-body -sSL \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               https://api.github.com/repos/llvm/llvm-project/commits/main) || {
-              echo "::error::Failed to fetch latest LLVM commit from GitHub API."
+              echo "::error::GitHub API request failed."
+              echo "Response body:"
+              echo "$RESPONSE"
               exit 1
             }
             LLVM_PROJECT_COMMIT=$(echo "$RESPONSE" | jq -r '.sha')

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -61,14 +61,32 @@ jobs:
     steps:
       - name: Get llvm-project commit
         id: get_llvm_project_commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          
+
           if [ x"${{ inputs.LLVM_COMMIT }}" == x"" ]; then
             sudo apt install jq
-            LLVM_PROJECT_COMMIT=$(curl -s https://api.github.com/repos/llvm/llvm-project/commits/main | jq -r '.sha')
+            # Authenticated request to avoid the unauthenticated 60/hr per-IP
+            # rate limit, which silently produced LLVM_PROJECT_COMMIT=null and
+            # broke the wheel build for weeks.
+            RESPONSE=$(curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/llvm/llvm-project/commits/main) || {
+              echo "::error::Failed to fetch latest LLVM commit from GitHub API."
+              exit 1
+            }
+            LLVM_PROJECT_COMMIT=$(echo "$RESPONSE" | jq -r '.sha')
           else
             LLVM_PROJECT_COMMIT="${{ inputs.llvm_commit }}"
           fi
+
+          if [ -z "$LLVM_PROJECT_COMMIT" ] || [ "$LLVM_PROJECT_COMMIT" = "null" ]; then
+            echo "::error::LLVM_PROJECT_COMMIT is empty or null; refusing to produce broken wheels."
+            exit 1
+          fi
+
           echo "LLVM_PROJECT_COMMIT=${LLVM_PROJECT_COMMIT}"
           echo "LLVM_PROJECT_COMMIT=${LLVM_PROJECT_COMMIT:0:8}" | tee -a $GITHUB_OUTPUT
           DATETIME=$(date +"%Y%m%d%H")

--- a/.github/workflows/update-llvm.yml
+++ b/.github/workflows/update-llvm.yml
@@ -17,10 +17,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   update-llvm:
     runs-on: ubuntu-latest
+    # Cap total runtime: mlirDistro can take ~1h, leave headroom for the rest.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
 
@@ -29,14 +32,59 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Run update script
-        id: update
+      - name: Identify target LLVM commit
+        id: identify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -n "${{ inputs.llvm_hash }}" ]; then
-            python3 utils/update_llvm_version.py --llvm-hash "${{ inputs.llvm_hash }}"
+            python3 utils/update_llvm_version.py --identify-only --llvm-hash "${{ inputs.llvm_hash }}"
           else
-            python3 utils/update_llvm_version.py
+            python3 utils/update_llvm_version.py --identify-only
           fi
+
+      - name: Trigger mlirDistro and wait for wheel
+        if: steps.identify.outputs.target_commit != '' && steps.identify.outputs.wheel_exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TARGET="${{ steps.identify.outputs.target_commit }}"
+          echo "No mlir-distro wheel for $TARGET; dispatching mlirDistro to build one."
+          # Capture timestamp before dispatch so we can disambiguate our run.
+          DISPATCH_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run mlirDistro.yml -f LLVM_COMMIT="$TARGET"
+
+          # Find the run we just dispatched. Filter by event + ref + createdAt
+          # to avoid grabbing an unrelated workflow_dispatch.
+          RUN_ID=""
+          for i in $(seq 1 12); do
+            sleep 5
+            RUN_ID=$(gh run list \
+              --workflow mlirDistro.yml \
+              --event workflow_dispatch \
+              --branch main \
+              --limit 5 \
+              --created ">=$DISPATCH_TS" \
+              --json databaseId,createdAt \
+              --jq 'sort_by(.createdAt) | .[0].databaseId // empty')
+            if [ -n "$RUN_ID" ]; then break; fi
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Could not locate dispatched mlirDistro run."
+            exit 1
+          fi
+
+          echo "Watching mlirDistro run $RUN_ID..."
+          gh run watch "$RUN_ID" --exit-status --interval 60
+
+      - name: Apply update
+        id: update
+        if: steps.identify.outputs.target_commit != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 utils/update_llvm_version.py --llvm-hash "${{ steps.identify.outputs.target_commit }}"
 
       - name: Check for changes
         id: check_changes

--- a/utils/update_llvm_version.py
+++ b/utils/update_llvm_version.py
@@ -332,6 +332,15 @@ def main():
     parser.add_argument(
         "--llvm-hash", help="Specific LLVM hash to use (overrides auto-detection)."
     )
+    parser.add_argument(
+        "--identify-only",
+        action="store_true",
+        help=(
+            "Identify target commit and check wheel availability without "
+            "modifying files. Writes target_commit, wheel_exists, and "
+            "bump_reason to $GITHUB_OUTPUT. Always exits 0."
+        ),
+    )
     args = parser.parse_args()
 
     check_token()
@@ -394,6 +403,23 @@ def main():
 
         reason = f"Bump to match {source} LLVM {target_commit[:8]} ({target_date})"
         print(f"Found update! {reason}")
+
+    if args.identify_only:
+        # Skip eudsl + file updates; just report target and wheel availability
+        # so the caller can dispatch mlirDistro and re-invoke without --identify-only.
+        wheel_exists = "false"
+        if target_commit == current_commit:
+            print("Target matches current commit; nothing to do.")
+            target_out = ""
+        else:
+            target_out = target_commit
+            wheel_exists = "true" if find_wheel_in_distro(target_commit) else "false"
+        if "GITHUB_OUTPUT" in os.environ:
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write(f"target_commit={target_out}\n")
+                f.write(f"wheel_exists={wheel_exists}\n")
+                f.write(f"bump_reason={reason}\n")
+        return
 
     # 4. Find closest eudsl version
     result = find_closest_eudsl_version(target_commit, target_date)

--- a/utils/update_llvm_version.py
+++ b/utils/update_llvm_version.py
@@ -21,6 +21,9 @@ EUDSL_INDEX_URL = "https://llvm.github.io/eudsl/"
 EUDSL_SUBMODULE_URL = (
     "https://api.github.com/repos/llvm/eudsl/contents/third_party/llvm-project?ref={}"
 )
+MLIR_DISTRO_RELEASE_URL = (
+    "https://api.github.com/repos/Xilinx/mlir-aie/releases/tags/mlir-distro"
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CLONE_LLVM_SH = REPO_ROOT / "utils" / "clone-llvm.sh"
@@ -220,11 +223,6 @@ def find_closest_eudsl_version(target_llvm_hash, target_llvm_date):
     return best_candidate
 
 
-MLIR_DISTRO_RELEASE_URL = (
-    "https://api.github.com/repos/Xilinx/mlir-aie/releases/tags/mlir-distro"
-)
-
-
 def find_wheel_in_distro(commit_hash):
     """Query the mlir-distro GitHub release for a wheel matching this LLVM commit.
 
@@ -283,27 +281,11 @@ def find_wheel_in_distro(commit_hash):
     return None
 
 
-def update_files(
-    new_commit, commit_date, eudsl_version, wheel_version=None, wheel_datetime=None
-):
-    # Use wheel-derived values when available, fall back to commit date.
-    if wheel_datetime:
-        datetime_str = wheel_datetime
-    else:
-        # Fallback: derive from LLVM commit date (may not match the actual
-        # wheel, since mlirDistro.yml uses CI build time instead).
-        datetime_str = commit_date.strftime("%Y%m%d%H")
-        print(
-            "Warning: Using LLVM commit date as DATETIME fallback. "
-            "This may not match the actual wheel version.",
-            file=sys.stderr,
-        )
-
+def update_files(new_commit, commit_date, eudsl_version, wheel_version, wheel_datetime):
     print(f"Updating to LLVM commit: {new_commit}")
     print(f"Commit Date: {commit_date}")
-    print(f"DATETIME: {datetime_str}")
-    if wheel_version:
-        print(f"WHEEL_VERSION prefix: {wheel_version}")
+    print(f"DATETIME: {wheel_datetime}")
+    print(f"WHEEL_VERSION prefix: {wheel_version}")
     print(f"EUDSL Version: {eudsl_version}")
 
     # Update utils/clone-llvm.sh
@@ -314,14 +296,12 @@ def update_files(
             f"LLVM_PROJECT_COMMIT={new_commit}",
             content,
         )
-        content = re.sub(r"DATETIME=\d+", f"DATETIME={datetime_str}", content)
-        # Update the major.minor.patch prefix in WHEEL_VERSION (e.g. 22.0.0 -> 23.0.0).
-        if wheel_version:
-            content = re.sub(
-                r"(WHEEL_VERSION=)\d+\.\d+\.\d+",
-                rf"\g<1>{wheel_version}",
-                content,
-            )
+        content = re.sub(r"DATETIME=\d+", f"DATETIME={wheel_datetime}", content)
+        content = re.sub(
+            r"(WHEEL_VERSION=)\d+\.\d+\.\d+",
+            rf"\g<1>{wheel_version}",
+            content,
+        )
         CLONE_LLVM_SH.write_text(content)
         print(f"Updated {CLONE_LLVM_SH}")
     else:
@@ -432,27 +412,27 @@ def main():
         print("Target LLVM commit matches current commit. No update needed.")
         return
 
+    # 5. Look up the actual wheel in mlir-distro to get the correct DATETIME
+    # and version. If no wheel exists, fail loudly: the resulting PR could not
+    # build, and the failure surfaces that mlir-distro is broken or behind.
+    wheel_info = find_wheel_in_distro(target_commit)
+    if not wheel_info:
+        print(
+            f"Error: No mlir-distro wheel exists for target commit "
+            f"{target_commit[:8]}. The mlir-distro build pipeline may be "
+            "broken or lagging behind upstream. Aborting to avoid creating "
+            "a PR that cannot pass CI.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    wheel_version, wheel_datetime = wheel_info
+
     # Write reason to GITHUB_OUTPUT if available
     if "GITHUB_OUTPUT" in os.environ:
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"bump_reason={reason}\n")
 
-    # 5. Look up actual wheel in mlir-distro to get correct DATETIME and version
-    wheel_version = None
-    wheel_datetime = None
-    wheel_info = find_wheel_in_distro(target_commit)
-    if wheel_info:
-        wheel_version, wheel_datetime = wheel_info
-    else:
-        print(
-            "Wheel not found in mlir-distro. DATETIME will be derived from "
-            "commit date (may not match actual wheel) and WHEEL_VERSION "
-            "major.minor.patch will not be updated.",
-            file=sys.stderr,
-        )
-
     # 6. Update files
-    # Use target_commit (from Triton/Torch/User) instead of eudsl's LLVM commit
     update_files(
         target_commit, target_date, new_eudsl_version, wheel_version, wheel_datetime
     )


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                               
Fixes two compounding bugs that caused #3018, an auto-generated LLVM-bump PR that could never pass CI.
                                                                                                                                                                                                                                                                               
### Bug 1: `mlirDistro.yml` silently produced `LLVM_PROJECT_COMMIT=null`                                                                                                                                                                                                     

- [Run 25436146719 — "Get latest LLVM commit"](https://github.com/Xilinx/mlir-aie/actions/runs/25436146719/job/74614542699) — `LLVM_PROJECT_COMMIT=null` written to outputs after curl rate-limited.
 
The "Get latest LLVM commit" step used an unauthenticated `curl` against `api.github.com`. When the per-IP rate limit hit, jq parsed the error body, returned the literal string `"null"`, and the step exited 0 — passing `null` downstream so every wheel build tried to fetch `zip/null` and failed. At least, this is my theory. I've added additional logging in case I am wrong about where the `"null"` comes from.

Fix: add an `Authorization: Bearer $GH_TOKEN` header, fail-fast on HTTP error, and reject empty/null commit values before writing them to `$GITHUB_OUTPUT`.    

### Bug 2: `update_llvm_version.py` fabricated a wheel version                                                                                                                                                                                                               
                                                            
When no mlir-distro wheel existed for the chosen Triton/Torch-MLIR commit, the script invented a `DATETIME` from the LLVM commit timestamp and proceeded anyway, producing a PR that referenced a wheel version that had never been built.                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                               
Fix: exit non-zero when no wheel exists, surfacing the gap rather than hiding it behind a fabricated value.                      
                                                                                                                                                                                                                                                                      
### Closing the loop                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                               
A fail-loud script alone leaves a manual gap: someone has to dispatch `mlirDistro.yml` by hand to publish a wheel before the next scheduled update-llvm run can succeed. To close the loop, `update_llvm_version.py` learns `--identify-only`, and `update-llvm.yml` runs in three phases:                                                                                                                                                                                                                                      
1. Identify the target commit and check wheel availability. 
2. If no wheel exists, dispatch `mlirDistro.yml` with `LLVM_COMMIT=$target` and `gh run watch` it to completion.                                                                                                                                                                                                                                      
3. Apply the update with `--llvm-hash $target`.                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                               
The orchestration is intentionally synchronous; the schedule is biweekly, so the runner-hour cost of blocking is small relative to the operational complexity of an async `workflow_run` chain.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                               
## Test plan                                                                                                                                                                                                                                                                                                                                                                                                                                                     
- [ ] On a branch with this change, `mlirDistro.yml` is exercised by the `pull_request: paths: ['.github/workflows/mlirDistro.yml']` trigger —  verify the "Get latest LLVM commit" step succeeds with auth header and that null/empty values are rejected.                                                                                                                                                                                                                               
- [ ] Manually dispatch `update-llvm.yml` (`workflow_dispatch`) on the branch and confirm:                                                                                                                                                                                                                                                    
- `--identify-only` step writes `target_commit`, `wheel_exists`, `bump_reason` to `$GITHUB_OUTPUT`.                                                                                                                                                                                                                                   
- When `wheel_exists == false`, mlirDistro is dispatched and watched through to success.
- Apply step uses `--llvm-hash` with the captured target.                                                                                                                                                                                                              
- Resulting PR points at a wheel that actually exists in mlir-distro. 