### PR TITLE
[AIEPlacer] Read aie.lock and aie.objectfifo.allocate as memory-affinity adjacency

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -154,12 +154,29 @@ private:
     }
   };
 
+  // Generic walker: for each `CoreTile` LTO, walk its core body and use
+  // `extractOwner` to map each operand value to the owning `TileLike` (or
+  // null if the operand is irrelevant). For every distinct cross-tile owner,
+  // emit edge `(consumer, owner)`. Used by buffer and lock adjacency, both
+  // of which derive from "core body op references something attached to
+  // another tile".
+  Adjacency buildCoreBodyAdjacency(
+      llvm::ArrayRef<LogicalTileOp> logicalTiles,
+      llvm::function_ref<TileLike(mlir::Value)> extractOwner);
+
   // Cross-tile L1 buffer access: consumer LTO's core must pass
   // targetModel->isLegalMemAffinity(coreCol=consumerCol, coreRow=consumerRow,
   //                                 memCol=ownerCol,     memRow=ownerRow).
   // The first endpoint of each edge is the consumer LTO; the second is the
   // owner tile.
   Adjacency buildBufferAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
+
+  // Cross-tile L1 lock access: same `isLegalMemAffinity` rule as buffers,
+  // since AIE2 locks live in the L1 region of their owning tile and are only
+  // visible to memory-affinity neighbors. The `UsesAreAccessible` trait on
+  // `LockOp::verify` enforces this for placed `TileOp` users but skips
+  // `LogicalTileOp` users, which is exactly the gap the placer fills.
+  Adjacency buildLockAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
 
   // The first endpoint of each edge is the cascade source; the second is the
   // destination.

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -178,6 +178,15 @@ private:
   // `LogicalTileOp` users, which is exactly the gap the placer fills.
   Adjacency buildLockAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
 
+  // `aie.objectfifo.allocate @of (%delegate)` documents that every endpoint
+  // of `@of` (producer + each consumer) shares L1 with the delegate tile.
+  // Edge.first is the fifo endpoint; edge.second is the delegate. Today the
+  // objectfifo lowering pass silently degrades to a DMA fifo when this
+  // contract is violated, ignoring the user's `allocate` intent; the placer
+  // catches this earlier and steers unconstrained endpoints to satisfy it.
+  Adjacency buildObjectFifoAllocateAdjacency(
+      llvm::ArrayRef<ObjectFifoAllocateOp> allocateOps);
+
   // The first endpoint of each edge is the cascade source; the second is the
   // destination.
   Adjacency buildCascadeAdjacency(llvm::ArrayRef<CascadeFlowOp> cascadeFlows);

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -144,6 +144,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
 
   // Phase 2a: Build placement constraints
   auto bufferAdjacency = buildBufferAdjacency(logicalTiles);
+  auto lockAdjacency = buildLockAdjacency(logicalTiles);
 
   // Phase 2b: Build channel requirements from ObjectFifo and Flow connectivity,
   // and cascade adjacency constraints from CascadeFlow connectivity.
@@ -154,15 +155,19 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
   auto cascadeAdjacency = buildCascadeAdjacency(cascadeFlows);
 
   // Per-kind predicates / labelers shared by all phase-3 call sites below.
-  // Buffer: consumer LTO (edge.first) must satisfy isLegalMemAffinity to the
-  // owner tile (edge.second).
-  auto bufferPred = [this](TileID consumerPos, TileID ownerPos) {
+  // Buffer & lock: consumer LTO (edge.first) must satisfy isLegalMemAffinity
+  // to the owner tile (edge.second). Locks live in the same L1 region as
+  // buffers and share the same neighbor-visibility rules.
+  auto memAffinityPred = [this](TileID consumerPos, TileID ownerPos) {
     return targetModel->isLegalMemAffinity(consumerPos.col, consumerPos.row,
                                            ownerPos.col, ownerPos.row);
   };
   auto bufferLabel = [](bool thisIsConsumer) -> StringRef {
     return thisIsConsumer ? "shared-L1 buffer owner"
                           : "shared-L1 buffer consumer";
+  };
+  auto lockLabel = [](bool thisIsConsumer) -> StringRef {
+    return thisIsConsumer ? "shared-L1 lock owner" : "shared-L1 lock consumer";
   };
   // Cascade: same predicate as AIELowerCascadeFlowsPass -- src (edge.first)
   // must be one row North or one column West of dst (edge.second); rows
@@ -184,11 +189,20 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     auto row = logicalTile.tryGetRow();
     if (col && row) {
       TileID tile{*col, *row};
-      if (!satisfiesAdjacency(logicalTile, tile, bufferAdjacency, bufferPred)) {
+      if (!satisfiesAdjacency(logicalTile, tile, bufferAdjacency,
+                              memAffinityPred)) {
         auto diag = logicalTile.emitError()
                     << "tile (" << tile.col << ", " << tile.row
                     << ") violates shared-L1 buffer adjacency";
         attachPeerNotes(diag, logicalTile, bufferAdjacency, bufferLabel);
+        return failure();
+      }
+      if (!satisfiesAdjacency(logicalTile, tile, lockAdjacency,
+                              memAffinityPred)) {
+        auto diag = logicalTile.emitError()
+                    << "tile (" << tile.col << ", " << tile.row
+                    << ") violates shared-L1 lock adjacency";
+        attachPeerNotes(diag, logicalTile, lockAdjacency, lockLabel);
         return failure();
       }
       if (!satisfiesAdjacency(logicalTile, tile, cascadeAdjacency,
@@ -228,7 +242,10 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
           continue;
         sawConstraintMatch = true;
         if (!satisfiesAdjacency(logicalTile, candidate, bufferAdjacency,
-                                bufferPred))
+                                memAffinityPred))
+          continue;
+        if (!satisfiesAdjacency(logicalTile, candidate, lockAdjacency,
+                                memAffinityPred))
           continue;
         allConstraintMatchesFailedAdjacency = false;
         if (!satisfiesAdjacency(logicalTile, candidate, cascadeAdjacency,
@@ -243,9 +260,13 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       }
 
       if (!placement) {
-        bool adjacencyWasCause =
-            sawConstraintMatch && allConstraintMatchesFailedAdjacency &&
+        bool hasBufferEdges =
             bufferAdjacency.tileToEdges.count(logicalTile.getOperation());
+        bool hasLockEdges =
+            lockAdjacency.tileToEdges.count(logicalTile.getOperation());
+        bool memAffinityWasCause = sawConstraintMatch &&
+                                   allConstraintMatchesFailedAdjacency &&
+                                   (hasBufferEdges || hasLockEdges);
         bool hasCascade =
             cascadeAdjacency.tileToEdges.count(logicalTile.getOperation());
         InFlightDiagnostic diag = logicalTile.emitError();
@@ -253,17 +274,27 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
           diag << "no compute tile available matching constraint ("
                << (col ? std::to_string(*col) : "?") << ", "
                << (row ? std::to_string(*row) : "?") << ")"
-               << (adjacencyWasCause ? " and shared-L1 buffer adjacency" : "")
+               << (memAffinityWasCause && hasBufferEdges
+                       ? " and shared-L1 buffer adjacency"
+                       : "")
+               << (memAffinityWasCause && hasLockEdges
+                       ? " and shared-L1 lock adjacency"
+                       : "")
                << (hasCascade ? " and cascade adjacency" : "");
         } else {
           diag << "no available compute tiles for placement"
-               << (adjacencyWasCause
+               << (memAffinityWasCause && hasBufferEdges
                        ? " (shared-L1 buffer adjacency unsatisfiable)"
+                       : "")
+               << (memAffinityWasCause && hasLockEdges
+                       ? " (shared-L1 lock adjacency unsatisfiable)"
                        : "")
                << (hasCascade ? " (cascade adjacency unsatisfiable)" : "");
         }
-        if (adjacencyWasCause)
+        if (memAffinityWasCause && hasBufferEdges)
           attachPeerNotes(diag, logicalTile, bufferAdjacency, bufferLabel);
+        if (memAffinityWasCause && hasLockEdges)
+          attachPeerNotes(diag, logicalTile, lockAdjacency, lockLabel);
         if (hasCascade)
           attachPeerNotes(diag, logicalTile, cascadeAdjacency, cascadeLabel);
         return failure();
@@ -498,8 +529,9 @@ resolvePeerPosition(TileLike peer, const PlacementResult &placed) {
   return std::nullopt;
 }
 
-SequentialPlacer::Adjacency
-SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
+SequentialPlacer::Adjacency SequentialPlacer::buildCoreBodyAdjacency(
+    ArrayRef<LogicalTileOp> logicalTiles,
+    llvm::function_ref<TileLike(Value)> extractOwner) {
   Adjacency adjacency;
   for (auto consumer : logicalTiles) {
     if (consumer.getTileType() != AIETileType::CoreTile)
@@ -516,10 +548,7 @@ SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
     llvm::SmallDenseSet<Operation *, 4> seenOwners;
     core.getBody().walk([&](Operation *op) {
       for (Value operand : op->getOperands()) {
-        BufferOp buf = traceToBuffer(operand);
-        if (!buf)
-          continue;
-        auto owner = dyn_cast_or_null<TileLike>(buf.getTile().getDefiningOp());
+        TileLike owner = extractOwner(operand);
         if (!owner)
           continue;
         if (owner.getOperation() == consumer.getOperation())
@@ -531,6 +560,26 @@ SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
     });
   }
   return adjacency;
+}
+
+SequentialPlacer::Adjacency
+SequentialPlacer::buildBufferAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
+  return buildCoreBodyAdjacency(logicalTiles, [](Value v) -> TileLike {
+    BufferOp buf = traceToBuffer(v);
+    if (!buf)
+      return {};
+    return dyn_cast_or_null<TileLike>(buf.getTile().getDefiningOp());
+  });
+}
+
+SequentialPlacer::Adjacency
+SequentialPlacer::buildLockAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
+  return buildCoreBodyAdjacency(logicalTiles, [](Value v) -> TileLike {
+    auto lock = dyn_cast_or_null<LockOp>(v.getDefiningOp());
+    if (!lock)
+      return {};
+    return dyn_cast_or_null<TileLike>(lock.getTile().getDefiningOp());
+  });
 }
 
 SequentialPlacer::Adjacency

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -123,6 +123,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
   SmallVector<LogicalTileOp> logicalTiles;
   SmallVector<ObjectFifoCreateOp> objectFifos;
   SmallVector<ObjectFifoLinkOp> objectFifoLinks;
+  SmallVector<ObjectFifoAllocateOp> objectFifoAllocates;
   SmallVector<CascadeFlowOp> cascadeFlows;
   SmallVector<FlowOp> flows;
   SmallVector<PacketFlowOp> pktFlows;
@@ -134,6 +135,8 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       objectFifos.push_back(of);
     if (auto link = dyn_cast<ObjectFifoLinkOp>(op))
       objectFifoLinks.push_back(link);
+    if (auto alloc = dyn_cast<ObjectFifoAllocateOp>(op))
+      objectFifoAllocates.push_back(alloc);
     if (auto cf = dyn_cast<CascadeFlowOp>(op))
       cascadeFlows.push_back(cf);
     if (auto f = dyn_cast<FlowOp>(op))
@@ -145,6 +148,8 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
   // Phase 2a: Build placement constraints
   auto bufferAdjacency = buildBufferAdjacency(logicalTiles);
   auto lockAdjacency = buildLockAdjacency(logicalTiles);
+  auto ofAllocateAdjacency =
+      buildObjectFifoAllocateAdjacency(objectFifoAllocates);
 
   // Phase 2b: Build channel requirements from ObjectFifo and Flow connectivity,
   // and cascade adjacency constraints from CascadeFlow connectivity.
@@ -168,6 +173,14 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
   };
   auto lockLabel = [](bool thisIsConsumer) -> StringRef {
     return thisIsConsumer ? "shared-L1 lock owner" : "shared-L1 lock consumer";
+  };
+  // Objectfifo with `aie.objectfifo.allocate`: the docstring of
+  // ObjectFifoAllocateOp guarantees that every fifo endpoint shares L1 with
+  // the delegate tile. Edge.first is the fifo endpoint (producer or one
+  // consumer); edge.second is the delegate tile.
+  auto ofAllocateLabel = [](bool thisIsEndpoint) -> StringRef {
+    return thisIsEndpoint ? "objectfifo.allocate delegate"
+                          : "objectfifo endpoint";
   };
   // Cascade: same predicate as AIELowerCascadeFlowsPass -- src (edge.first)
   // must be one row North or one column West of dst (edge.second); rows
@@ -203,6 +216,15 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
                     << "tile (" << tile.col << ", " << tile.row
                     << ") violates shared-L1 lock adjacency";
         attachPeerNotes(diag, logicalTile, lockAdjacency, lockLabel);
+        return failure();
+      }
+      if (!satisfiesAdjacency(logicalTile, tile, ofAllocateAdjacency,
+                              memAffinityPred)) {
+        auto diag = logicalTile.emitError()
+                    << "tile (" << tile.col << ", " << tile.row
+                    << ") violates objectfifo.allocate shared-L1 adjacency";
+        attachPeerNotes(diag, logicalTile, ofAllocateAdjacency,
+                        ofAllocateLabel);
         return failure();
       }
       if (!satisfiesAdjacency(logicalTile, tile, cascadeAdjacency,
@@ -247,6 +269,9 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
         if (!satisfiesAdjacency(logicalTile, candidate, lockAdjacency,
                                 memAffinityPred))
           continue;
+        if (!satisfiesAdjacency(logicalTile, candidate, ofAllocateAdjacency,
+                                memAffinityPred))
+          continue;
         allConstraintMatchesFailedAdjacency = false;
         if (!satisfiesAdjacency(logicalTile, candidate, cascadeAdjacency,
                                 cascadePred))
@@ -264,9 +289,11 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
             bufferAdjacency.tileToEdges.count(logicalTile.getOperation());
         bool hasLockEdges =
             lockAdjacency.tileToEdges.count(logicalTile.getOperation());
-        bool memAffinityWasCause = sawConstraintMatch &&
-                                   allConstraintMatchesFailedAdjacency &&
-                                   (hasBufferEdges || hasLockEdges);
+        bool hasOfAllocEdges =
+            ofAllocateAdjacency.tileToEdges.count(logicalTile.getOperation());
+        bool memAffinityWasCause =
+            sawConstraintMatch && allConstraintMatchesFailedAdjacency &&
+            (hasBufferEdges || hasLockEdges || hasOfAllocEdges);
         bool hasCascade =
             cascadeAdjacency.tileToEdges.count(logicalTile.getOperation());
         InFlightDiagnostic diag = logicalTile.emitError();
@@ -280,6 +307,9 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
                << (memAffinityWasCause && hasLockEdges
                        ? " and shared-L1 lock adjacency"
                        : "")
+               << (memAffinityWasCause && hasOfAllocEdges
+                       ? " and objectfifo.allocate shared-L1 adjacency"
+                       : "")
                << (hasCascade ? " and cascade adjacency" : "");
         } else {
           diag << "no available compute tiles for placement"
@@ -289,12 +319,19 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
                << (memAffinityWasCause && hasLockEdges
                        ? " (shared-L1 lock adjacency unsatisfiable)"
                        : "")
+               << (memAffinityWasCause && hasOfAllocEdges
+                       ? " (objectfifo.allocate shared-L1 adjacency "
+                         "unsatisfiable)"
+                       : "")
                << (hasCascade ? " (cascade adjacency unsatisfiable)" : "");
         }
         if (memAffinityWasCause && hasBufferEdges)
           attachPeerNotes(diag, logicalTile, bufferAdjacency, bufferLabel);
         if (memAffinityWasCause && hasLockEdges)
           attachPeerNotes(diag, logicalTile, lockAdjacency, lockLabel);
+        if (memAffinityWasCause && hasOfAllocEdges)
+          attachPeerNotes(diag, logicalTile, ofAllocateAdjacency,
+                          ofAllocateLabel);
         if (hasCascade)
           attachPeerNotes(diag, logicalTile, cascadeAdjacency, cascadeLabel);
         return failure();
@@ -580,6 +617,39 @@ SequentialPlacer::buildLockAdjacency(ArrayRef<LogicalTileOp> logicalTiles) {
       return {};
     return dyn_cast_or_null<TileLike>(lock.getTile().getDefiningOp());
   });
+}
+
+SequentialPlacer::Adjacency SequentialPlacer::buildObjectFifoAllocateAdjacency(
+    ArrayRef<ObjectFifoAllocateOp> allocateOps) {
+  Adjacency adjacency;
+  for (auto allocOp : allocateOps) {
+    auto delegate =
+        dyn_cast_or_null<TileLike>(allocOp.getDelegateTile().getDefiningOp());
+    if (!delegate)
+      continue;
+    ObjectFifoCreateOp fifo = allocOp.getObjectFifo();
+    if (!fifo)
+      continue;
+
+    // Producer endpoint.
+    if (auto producer = dyn_cast_or_null<TileLike>(
+            fifo.getProducerTile().getDefiningOp())) {
+      if (producer.getOperation() != delegate.getOperation())
+        adjacency.addEdge(producer, delegate);
+    }
+
+    // Consumer endpoints; dedup against the delegate but allow multiple
+    // distinct consumers to all add their own edges.
+    for (Value consumerVal : fifo.getConsumerTiles()) {
+      auto consumer = dyn_cast_or_null<TileLike>(consumerVal.getDefiningOp());
+      if (!consumer)
+        continue;
+      if (consumer.getOperation() == delegate.getOperation())
+        continue;
+      adjacency.addEdge(consumer, delegate);
+    }
+  }
+  return adjacency;
 }
 
 SequentialPlacer::Adjacency

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -389,3 +389,42 @@ module @buffer_adjacency_star_oversubscribed {
     }
   }
 }
+
+// -----
+
+// Lock owner and consumer pinned far apart: not memory-affinity neighbors.
+module @lock_adjacency_both_pinned_violation {
+  aie.device(npu1) {
+    // CHECK: error: tile (0, 2) violates shared-L1 lock adjacency
+    // CHECK: note: shared-L1 lock consumer peer placed at (3, 5)
+    %owner = aie.logical_tile<CoreTile>(0, 2)
+    %lock  = aie.lock(%owner, 0) {init = 1 : i32}
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(3, 5)
+    aie.core(%consumer) {
+      aie.use_lock(%lock, AcquireGreaterEqual, 1)
+      aie.use_lock(%lock, Release, 1)
+      aie.end
+    }
+  }
+}
+
+// -----
+
+// Pinned lock owner + unconstrained consumer with a column constraint that
+// has no memory-affinity slot relative to the owner.
+module @lock_adjacency_unsatisfiable_column {
+  aie.device(npu1) {
+    // CHECK: error: no compute tile available matching constraint (3, ?) and shared-L1 lock adjacency
+    // CHECK: note: shared-L1 lock owner peer placed at (0, 2)
+    %owner = aie.logical_tile<CoreTile>(0, 2)
+    %lock  = aie.lock(%owner, 0) {init = 1 : i32}
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(3, ?)
+    aie.core(%consumer) {
+      aie.use_lock(%lock, AcquireGreaterEqual, 1)
+      aie.use_lock(%lock, Release, 1)
+      aie.end
+    }
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_errors.mlir
+++ b/test/place-tiles/sequential_placer/test_place_errors.mlir
@@ -428,3 +428,44 @@ module @lock_adjacency_unsatisfiable_column {
     }
   }
 }
+
+// -----
+
+// objectfifo.allocate with three pinned endpoints: delegate at (0, 3) shares
+// L1 with producer (0, 2), but consumer at (3, 5) is far away. Placer
+// visits the delegate first; its edge to the consumer fails, so the
+// violation is reported there with peer notes for both endpoints.
+module @of_allocate_consumer_violation {
+  aie.device(npu1) {
+    // CHECK: error: tile (0, 3) violates objectfifo.allocate shared-L1 adjacency
+    // CHECK-DAG: note: objectfifo endpoint peer placed at (0, 2)
+    // CHECK-DAG: note: objectfifo endpoint peer placed at (3, 5)
+    %delegate = aie.logical_tile<CoreTile>(0, 3)
+    %producer = aie.logical_tile<CoreTile>(0, 2)
+    %consumer = aie.logical_tile<CoreTile>(3, 5)
+    aie.core(%delegate) { aie.end }
+    aie.core(%producer) { aie.end }
+    aie.core(%consumer) { aie.end }
+    aie.objectfifo @of_bad_alloc (%producer, {%consumer}, 2 : i32)
+        : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.allocate @of_bad_alloc (%delegate)
+  }
+}
+
+// -----
+
+// objectfifo.allocate with pinned delegate + unconstrained consumer that has
+// a column constraint with no memory-affinity slot relative to the delegate.
+module @of_allocate_unsatisfiable_column {
+  aie.device(npu1) {
+    // CHECK: error: no compute tile available matching constraint (3, ?) and objectfifo.allocate shared-L1 adjacency
+    // CHECK: note: objectfifo.allocate delegate peer placed at (0, 2)
+    %producer = aie.logical_tile<CoreTile>(0, 2)
+    %consumer = aie.logical_tile<CoreTile>(3, ?)
+    aie.core(%producer) { aie.end }
+    aie.core(%consumer) { aie.end }
+    aie.objectfifo @of_unsat (%producer, {%consumer}, 2 : i32)
+        : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.allocate @of_unsat (%producer)
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_lock_adjacency.mlir
+++ b/test/place-tiles/sequential_placer/test_place_lock_adjacency.mlir
@@ -1,0 +1,121 @@
+//===- test_place_lock_adjacency.mlir ------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-place-tiles %s | FileCheck %s
+
+// Owner pinned at (2, 3); unconstrained consumer acquires its lock. Greedy
+// column-major would place the consumer at (0, 2); the lock-affinity check
+// rejects that and steers to (2, 2) (north of owner -- first affinity slot
+// in greedy sweep order). Same predicate as buffer adjacency, since AIE2
+// locks live in L1 alongside buffers.
+// CHECK-LABEL: @lock_adjacency_steers_unconstrained_consumer
+module @lock_adjacency_steers_unconstrained_consumer {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    %owner = aie.logical_tile<CoreTile>(2, 3)
+    %lock  = aie.lock(%owner, 0) {init = 1 : i32}
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%consumer) {
+      aie.use_lock(%lock, AcquireGreaterEqual, 1)
+      aie.use_lock(%lock, Release, 1)
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Both endpoints pinned at compatible positions: owner at (0, 2), consumer
+// at (0, 3) (consumer's S-affinity slot). Placer is a pass-through.
+// CHECK-LABEL: @lock_adjacency_both_pinned_compatible
+module @lock_adjacency_both_pinned_compatible {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    // CHECK-DAG: aie.tile(0, 3)
+    %owner = aie.logical_tile<CoreTile>(0, 2)
+    %lock  = aie.lock(%owner, 0) {init = 1 : i32}
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(0, 3)
+    aie.core(%consumer) {
+      aie.use_lock(%lock, AcquireGreaterEqual, 1)
+      aie.use_lock(%lock, Release, 1)
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Self-reference: consumer acquires a lock attached to its own LTO. Not a
+// cross-tile constraint; placer behaves as if no adjacency edge existed.
+// CHECK-LABEL: @lock_adjacency_self_reference_no_constraint
+module @lock_adjacency_self_reference_no_constraint {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    %lt = aie.logical_tile<CoreTile>(?, ?)
+    %lock = aie.lock(%lt, 0) {init = 1 : i32}
+    aie.core(%lt) {
+      aie.use_lock(%lock, AcquireGreaterEqual, 1)
+      aie.use_lock(%lock, Release, 1)
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Mixed buffer + lock from the same owner: both edges agree, consumer is
+// steered to a memory-affinity neighbor of the owner.
+// CHECK-LABEL: @lock_and_buffer_agree
+module @lock_and_buffer_agree {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    %owner = aie.logical_tile<CoreTile>(2, 3)
+    %buf   = aie.buffer(%owner) : memref<16xi32>
+    %lock  = aie.lock(%owner, 0) {init = 1 : i32}
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%consumer) {
+      aie.use_lock(%lock, AcquireGreaterEqual, 1)
+      %i = arith.constant 0 : index
+      %v = memref.load %buf[%i] : memref<16xi32>
+      aie.use_lock(%lock, Release, 1)
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// AIE2P (npu2) target-model dispatch: same affinity rules apply.
+// CHECK-LABEL: @lock_adjacency_npu2_target_model
+module @lock_adjacency_npu2_target_model {
+  aie.device(npu2) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    %owner = aie.logical_tile<CoreTile>(2, 3)
+    %lock  = aie.lock(%owner, 0) {init = 1 : i32}
+    aie.core(%owner) { aie.end }
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%consumer) {
+      aie.use_lock(%lock, AcquireGreaterEqual, 1)
+      aie.use_lock(%lock, Release, 1)
+      aie.end
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_objectfifo_allocate_adjacency.mlir
+++ b/test/place-tiles/sequential_placer/test_place_objectfifo_allocate_adjacency.mlir
@@ -1,0 +1,106 @@
+//===- test_place_objectfifo_allocate_adjacency.mlir ----------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-place-tiles %s | FileCheck %s
+
+// `aie.objectfifo.allocate @of (%delegate)` documents that every endpoint of
+// `@of` (producer + each consumer) shares L1 with the delegate. Today the
+// objectfifo lowering pass silently degrades to a DMA fifo when this
+// contract is violated; the placer catches it earlier and steers
+// unconstrained endpoints to satisfy it.
+
+// Delegate pinned at (2, 3); producer and consumer are unconstrained. Greedy
+// column-major would place them both at column 0; the allocate-adjacency
+// check rejects that and steers each endpoint into a memory-affinity
+// neighbor of the delegate.
+// CHECK-LABEL: @of_allocate_steers_endpoints
+module @of_allocate_steers_endpoints {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    // CHECK-DAG: aie.tile(2, 4)
+    %delegate = aie.logical_tile<CoreTile>(2, 3)
+    %producer = aie.logical_tile<CoreTile>(?, ?)
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%delegate) { aie.end }
+    aie.core(%producer) { aie.end }
+    aie.core(%consumer) { aie.end }
+    aie.objectfifo @of_steers (%producer, {%consumer}, 2 : i32)
+        : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.allocate @of_steers (%delegate)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// All three endpoints pinned at compatible positions: delegate at (0, 3),
+// producer at (0, 2) (S of delegate), consumer at (0, 4) (N of delegate).
+// Placer is a pass-through.
+// CHECK-LABEL: @of_allocate_all_pinned_compatible
+module @of_allocate_all_pinned_compatible {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    // CHECK-DAG: aie.tile(0, 3)
+    // CHECK-DAG: aie.tile(0, 4)
+    %delegate = aie.logical_tile<CoreTile>(0, 3)
+    %producer = aie.logical_tile<CoreTile>(0, 2)
+    %consumer = aie.logical_tile<CoreTile>(0, 4)
+    aie.core(%delegate) { aie.end }
+    aie.core(%producer) { aie.end }
+    aie.core(%consumer) { aie.end }
+    aie.objectfifo @of_pinned (%producer, {%consumer}, 2 : i32)
+        : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.allocate @of_pinned (%delegate)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Delegate is the producer itself: no cross-tile edge for the producer
+// (self-reference); consumer still gets steered into a memory-affinity slot.
+// CHECK-LABEL: @of_allocate_self_delegate
+module @of_allocate_self_delegate {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    %producer = aie.logical_tile<CoreTile>(2, 3)
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%producer) { aie.end }
+    aie.core(%consumer) { aie.end }
+    aie.objectfifo @of_self (%producer, {%consumer}, 2 : i32)
+        : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.allocate @of_self (%producer)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// AIE2P (npu2) target-model dispatch: same affinity rules.
+// CHECK-LABEL: @of_allocate_npu2_target_model
+module @of_allocate_npu2_target_model {
+  aie.device(npu2) {
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(2, 2)
+    // CHECK-DAG: aie.tile(2, 4)
+    %delegate = aie.logical_tile<CoreTile>(2, 3)
+    %producer = aie.logical_tile<CoreTile>(?, ?)
+    %consumer = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%delegate) { aie.end }
+    aie.core(%producer) { aie.end }
+    aie.core(%consumer) { aie.end }
+    aie.objectfifo @of_npu2 (%producer, {%consumer}, 2 : i32)
+        : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.allocate @of_npu2 (%delegate)
+    // CHECK-NOT: aie.logical_tile
+  }
+}


### PR DESCRIPTION
## Summary

Follows on from #3046 (buffer adjacency). Closes two more memory-affinity gaps that today either fail at lowering or silently degrade. Both reuse the `Adjacency` machinery from #3046 with the same `isLegalMemAffinity` predicate; the only new code is the walkers and labels.

| Constraint | Today | After this PR |
|---|---|---|
| `aie.use_lock(%lock_at_other_LTO, ...)` in core body | `LockOp::verify` skips LTO users -- violation surfaces later as a verifier error on the resolved `TileOp` | Caught at placement; unconstrained consumer steered into a memory-affinity neighbor |
| `aie.objectfifo.allocate @of (%delegate)` with non-adjacent endpoints | `AIEObjectFifoStatefulTransform` silently degrades to a DMA fifo, ignoring the user's `allocate` intent | Caught at placement; unconstrained endpoints steered to satisfy delegate affinity |

Reference: `LockOp::verify` skips LTO users at [AIEDialect.cpp:251-254](https://github.com/Xilinx/mlir-aie/blob/main/lib/Dialect/AIE/IR/AIEDialect.cpp#L251-L254). The objectfifo.allocate contract is documented in `ObjectFifoAllocateOp`'s docstring ("Only works if all the objectfifo's tiles, producer and consumers, have shared memory access to the specified tile's memory module"); the silent-DMA fallback is in `requiresDMAs` at [AIEObjectFifoStatefulTransform.cpp:339-348](https://github.com/Xilinx/mlir-aie/blob/main/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp#L339-L348).

## What changes

### Lock adjacency (commit 1)

- New `buildCoreBodyAdjacency(logicalTiles, extractOwner)` private helper that owns the "walk every core body, dedup cross-tile owners, emit edge" scaffolding. `buildBufferAdjacency` (refactored from #3046) and the new `buildLockAdjacency` are 5-line wrappers that just supply the `Value -> TileLike` extraction. Pre-empts duplication that would otherwise grow with each new "core body op references X attached to another tile" constraint.
- New `buildLockAdjacency` walker: traces each `aie.use_lock`'s lock operand to its defining `LockOp`, then to the owner `TileLike`. Same cross-tile / dedup rules as buffer.

### ObjectFifo.allocate adjacency (commit 2)

- Phase 1 walk also collects `ObjectFifoAllocateOp`.
- New `buildObjectFifoAllocateAdjacency` walker: for each `allocate`, emits edges `(producer, delegate)` and `(consumer_i, delegate)` for every cross-tile endpoint.

### Phase 3 wiring (both commits)

- Lock and objectfifo.allocate share the `memAffinityPred` lambda with buffer (same `isLegalMemAffinity` rule), each with its own edges and labels.
- Diagnostic suffix and peer-note attachment extended to cover both new edge kinds. The unconstrained-placement "memory-affinity was cause" flag triggers when buffer, lock, or objectfifo.allocate fails.

## Behavior preserved

- IR with no `aie.lock` and no `aie.objectfifo.allocate` is unchanged.
- IR whose locks/allocates are already memory-affinity-compatible is unchanged.
- Pure `aie.objectfifo` (no `allocate`) is intentionally **not** constrained -- without an `allocate`, lowering is free to pick DMA or shared-L1 based on post-placement positions, so adding edges would over-constrain valid designs.
- AIE1 / AIE2 / AIE2P pick up the right affinity rules via the target model.

## Test plan

- [x] New `test/place-tiles/sequential_placer/test_place_lock_adjacency.mlir` (5 positive cases): unconstrained consumer steered to N of pinned owner; both endpoints pinned at compatible coords; self-reference (no constraint); buffer + lock from same owner agree; npu2 target-model dispatch.
- [x] New `test/place-tiles/sequential_placer/test_place_objectfifo_allocate_adjacency.mlir` (4 positive cases): two unconstrained endpoints steered to memory-affinity slots around pinned delegate; all three endpoints pinned-compatible; producer-as-delegate self-reference; npu2 target-model dispatch.
- [x] New error cases in `test_place_errors.mlir`: lock pinned-far-apart violation; lock unconstrained-consumer-with-column-constraint unsatisfiable; objectfifo.allocate three-pinned with one far away (peer notes for all endpoints); objectfifo.allocate pinned-delegate + unsatisfiable column.
- [x] All 11 lit-files in `test/place-tiles/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)