### PR TITLE
Fix llvm update and mlir distro

### DIFF
--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -32,6 +32,14 @@ on:
         required: false
         default: ''
 
+concurrency:
+  # PR runs from the same PR cancel earlier in-flight runs (standard supersede).
+  # workflow_dispatch serializes per-event so the second publish waits for the
+  # first — preventing the upload race that PR #2789 worked around with
+  # `replacesArtifacts: false`.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   get_aie_project_commit:

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -492,16 +492,38 @@ jobs:
           name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
           path: dist
 
+      # See mlirDistro.yml for the rationale: a PEP 427 build tag makes the
+      # uploaded asset name unique per CI run so concurrent uploads cannot
+      # collide. Skipped on workflow_dispatch so the canonical `latest-wheels`
+      # release keeps deterministic filenames.
+      - name: Inject build tag for non-canonical wheel uploads
+        if: github.event_name != 'workflow_dispatch'
+        shell: bash
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          wheels=( *.whl )
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "::error::No wheels found in dist/; cannot inject build tag."
+            exit 1
+          fi
+          BUILD_TAG="${{ github.run_id }}_${{ github.run_attempt }}"
+          for w in "${wheels[@]}"; do
+            newname=$(echo "$w" | sed -E "s/-(py3-none-[^-]+)\.whl$/-${BUILD_TAG}-\1.whl/")
+            if [ "$w" != "$newname" ]; then mv "$w" "$newname"; fi
+          done
+          ls -la
+
       - name: Release current commit
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: ncipollo/release-action@v1.12.0
         with:
-          artifacts: "dist/*.whl,dist/*.tar.xz"
+          artifacts: "dist/*.whl"
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag: ${{ github.event_name == 'workflow_dispatch' && 'latest-wheels' || 'dev-wheels' }}
           name: ${{ github.event_name == 'workflow_dispatch' && 'latest-wheels' || 'dev-wheels' }}
           removeArtifacts: false
           allowUpdates: true
-          replacesArtifacts: true
+          replacesArtifacts: false
           omitBodyDuringUpdate: true
           makeLatest: false

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -69,12 +69,16 @@ jobs:
             sudo apt install jq
             # Authenticated request to avoid the unauthenticated 60/hr per-IP
             # rate limit, which silently produced LLVM_PROJECT_COMMIT=null and
-            # broke the wheel build for weeks.
-            RESPONSE=$(curl -fsSL \
+            # broke the wheel build. --fail-with-body keeps the response body
+            # on HTTP error so future failures surface the actual cause in
+            # the CI log instead of hiding behind a silent curl.
+            RESPONSE=$(curl --fail-with-body -sSL \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               https://api.github.com/repos/llvm/llvm-project/commits/main) || {
-              echo "::error::Failed to fetch latest LLVM commit from GitHub API."
+              echo "::error::GitHub API request failed."
+              echo "Response body:"
+              echo "$RESPONSE"
               exit 1
             }
             LLVM_PROJECT_COMMIT=$(echo "$RESPONSE" | jq -r '.sha')

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -1,5 +1,10 @@
 name: MLIR Distro
 
+# When dispatched with DISPATCH_NONCE set, embed the nonce in the run title so
+# callers (e.g. update-llvm.yml) can identify *their* dispatched run via
+# `gh run list --json displayTitle` instead of guessing by timestamp.
+run-name: ${{ inputs.DISPATCH_NONCE && format('MLIR Distro [{0}]', inputs.DISPATCH_NONCE) || 'MLIR Distro' }}
+
 on:
   pull_request:
     paths:
@@ -36,6 +41,11 @@ on:
         type: string
         required: false
         default: 'true'
+      DISPATCH_NONCE:
+        description: 'Optional unique identifier echoed into the run title so callers can locate this dispatched run.'
+        type: string
+        required: false
+        default: ''
 
 
   schedule:

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -61,14 +61,32 @@ jobs:
     steps:
       - name: Get llvm-project commit
         id: get_llvm_project_commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          
+
           if [ x"${{ inputs.LLVM_COMMIT }}" == x"" ]; then
             sudo apt install jq
-            LLVM_PROJECT_COMMIT=$(curl -s https://api.github.com/repos/llvm/llvm-project/commits/main | jq -r '.sha')
+            # Authenticated request to avoid the unauthenticated 60/hr per-IP
+            # rate limit, which silently produced LLVM_PROJECT_COMMIT=null and
+            # broke the wheel build for weeks.
+            RESPONSE=$(curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/llvm/llvm-project/commits/main) || {
+              echo "::error::Failed to fetch latest LLVM commit from GitHub API."
+              exit 1
+            }
+            LLVM_PROJECT_COMMIT=$(echo "$RESPONSE" | jq -r '.sha')
           else
             LLVM_PROJECT_COMMIT="${{ inputs.llvm_commit }}"
           fi
+
+          if [ -z "$LLVM_PROJECT_COMMIT" ] || [ "$LLVM_PROJECT_COMMIT" = "null" ]; then
+            echo "::error::LLVM_PROJECT_COMMIT is empty or null; refusing to produce broken wheels."
+            exit 1
+          fi
+
           echo "LLVM_PROJECT_COMMIT=${LLVM_PROJECT_COMMIT}"
           echo "LLVM_PROJECT_COMMIT=${LLVM_PROJECT_COMMIT:0:8}" | tee -a $GITHUB_OUTPUT
           DATETIME=$(date +"%Y%m%d%H")

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -56,6 +56,14 @@ on:
   # comment it out when you're not working on these yamls
 #  pull_request:
 
+concurrency:
+  # PR runs from the same PR cancel earlier in-flight runs (standard supersede).
+  # workflow_dispatch and schedule serialize per-event so the second publish
+  # waits for the first — preventing the upload race that PR #2789 worked
+  # around with `replacesArtifacts: false`.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   get_llvm_project_commit:

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -443,10 +443,36 @@ jobs:
           name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
           path: dist
 
+      # Inject a PEP 427 build tag so concurrent CI runs (PR re-pushes, sibling
+      # PRs, cron) cannot collide on a release-asset name. The build tag does
+      # not change the wheel's PEP 440 version, so PIP_FIND_LINKS consumers
+      # asking for `mlir==<version>` keep matching; pip uses the build tag only
+      # to break ties among wheels of the same version (higher tag wins).
+      # Skipped on workflow_dispatch so the canonical `mlir-distro` release
+      # keeps deterministic filenames that `find_wheel_in_distro` looks up.
+      - name: Inject build tag for non-canonical wheel uploads
+        if: github.event_name != 'workflow_dispatch'
+        shell: bash
+        working-directory: dist
+        run: |
+          shopt -s nullglob
+          wheels=( *.whl )
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "::error::No wheels found in dist/; cannot inject build tag."
+            exit 1
+          fi
+          BUILD_TAG="${{ github.run_id }}_${{ github.run_attempt }}"
+          for w in "${wheels[@]}"; do
+            newname=$(echo "$w" | sed -E "s/-(py3-none-[^-]+)\.whl$/-${BUILD_TAG}-\1.whl/")
+            if [ "$w" != "$newname" ]; then mv "$w" "$newname"; fi
+          done
+          ls -la
+
       - name: Release current commit
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: ncipollo/release-action@v1.12.0
         with:
-          artifacts: "dist/*.whl,dist/*.tar.xz"
+          artifacts: "dist/*.whl"
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag: ${{ github.event_name == 'workflow_dispatch' && 'mlir-distro' || 'dev-wheels' }}
           name: ${{ github.event_name == 'workflow_dispatch' && 'mlir-distro' || 'dev-wheels' }}

--- a/.github/workflows/pruneReleaseAssets.yml
+++ b/.github/workflows/pruneReleaseAssets.yml
@@ -1,0 +1,60 @@
+name: Prune release assets
+
+on:
+  schedule:
+    # Daily at 04:17 UTC. Off-the-hour to avoid the GH Actions traffic spike.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Delete dev-wheels assets older than this many days'
+        type: string
+        default: '30'
+      dry_run:
+        description: 'List what would be deleted without actually deleting'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  prune-dev-wheels:
+    # Why: dev-wheels accumulates indefinitely because PR builds inject a unique
+    # PEP 427 build tag (run_id_attempt) into wheel names — every PR run lands
+    # net-new assets that never collide with existing ones, so nothing is ever
+    # replaced. Without this janitor we hit GitHub's 1000-asset-per-release cap
+    # (already happened, see PR #3054).
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune assets older than ${{ inputs.max_age_days || '30' }} days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_AGE_DAYS: ${{ inputs.max_age_days || '30' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          cutoff=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
+          echo "cutoff: $(date -u -d "@$cutoff" --iso-8601=seconds)"
+
+          gh api "repos/${{ github.repository }}/releases/tags/dev-wheels" --paginate \
+            -q '.assets[] | "\(.created_at)\t\(.id)\t\(.name)"' > /tmp/assets.tsv
+
+          total=$(wc -l < /tmp/assets.tsv)
+          echo "total dev-wheels assets: $total"
+
+          deleted=0
+          while IFS=$'\t' read -r created_at id name; do
+            asset_ts=$(date -u -d "$created_at" +%s)
+            if [ "$asset_ts" -lt "$cutoff" ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "would delete: $created_at $name"
+              else
+                gh api -X DELETE "repos/${{ github.repository }}/releases/assets/$id" >/dev/null
+                echo "deleted: $created_at $name"
+              fi
+              deleted=$((deleted+1))
+            fi
+          done < /tmp/assets.tsv
+
+          echo "::notice::pruned $deleted of $total dev-wheels assets (dry_run=$DRY_RUN)"

--- a/.github/workflows/update-llvm.yml
+++ b/.github/workflows/update-llvm.yml
@@ -17,10 +17,13 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   update-llvm:
     runs-on: ubuntu-latest
+    # Cap total runtime: mlirDistro can take ~1h, leave headroom for the rest.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@v4
 
@@ -29,14 +32,59 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Run update script
-        id: update
+      - name: Identify target LLVM commit
+        id: identify
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -n "${{ inputs.llvm_hash }}" ]; then
-            python3 utils/update_llvm_version.py --llvm-hash "${{ inputs.llvm_hash }}"
+            python3 utils/update_llvm_version.py --identify-only --llvm-hash "${{ inputs.llvm_hash }}"
           else
-            python3 utils/update_llvm_version.py
+            python3 utils/update_llvm_version.py --identify-only
           fi
+
+      - name: Trigger mlirDistro and wait for wheel
+        if: steps.identify.outputs.target_commit != '' && steps.identify.outputs.wheel_exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TARGET="${{ steps.identify.outputs.target_commit }}"
+          echo "No mlir-distro wheel for $TARGET; dispatching mlirDistro to build one."
+          # Capture timestamp before dispatch so we can disambiguate our run.
+          DISPATCH_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run mlirDistro.yml -f LLVM_COMMIT="$TARGET"
+
+          # Find the run we just dispatched. Filter by event + ref + createdAt
+          # to avoid grabbing an unrelated workflow_dispatch.
+          RUN_ID=""
+          for i in $(seq 1 12); do
+            sleep 5
+            RUN_ID=$(gh run list \
+              --workflow mlirDistro.yml \
+              --event workflow_dispatch \
+              --branch main \
+              --limit 5 \
+              --created ">=$DISPATCH_TS" \
+              --json databaseId,createdAt \
+              --jq 'sort_by(.createdAt) | .[0].databaseId // empty')
+            if [ -n "$RUN_ID" ]; then break; fi
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Could not locate dispatched mlirDistro run."
+            exit 1
+          fi
+
+          echo "Watching mlirDistro run $RUN_ID..."
+          gh run watch "$RUN_ID" --exit-status --interval 60
+
+      - name: Apply update
+        id: update
+        if: steps.identify.outputs.target_commit != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 utils/update_llvm_version.py --llvm-hash "${{ steps.identify.outputs.target_commit }}"
 
       - name: Check for changes
         id: check_changes

--- a/.github/workflows/update-llvm.yml
+++ b/.github/workflows/update-llvm.yml
@@ -43,35 +43,54 @@ jobs:
             python3 utils/update_llvm_version.py --identify-only
           fi
 
+      # Defensive: identify is contractually required to write wheel_exists
+      # (true|false). An unset value means the script took an unexpected
+      # branch; refuse to proceed silently rather than skip downstream steps.
+      - name: Verify identify outputs
+        run: |
+          if [ -z "${{ steps.identify.outputs.wheel_exists }}" ]; then
+            echo "::error::identify step did not set wheel_exists; refusing to proceed."
+            exit 1
+          fi
+
       - name: Trigger mlirDistro and wait for wheel
         if: steps.identify.outputs.target_commit != '' && steps.identify.outputs.wheel_exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TARGET="${{ steps.identify.outputs.target_commit }}"
-          echo "No mlir-distro wheel for $TARGET; dispatching mlirDistro to build one."
-          # Capture timestamp before dispatch so we can disambiguate our run.
+          # Per-call nonce so we can deterministically locate the dispatched
+          # run by its display title, even if other workflow_dispatch events
+          # for mlirDistro fire in the same second.
+          NONCE="update-llvm-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-$(date +%s)-$RANDOM"
+          echo "No mlir-distro wheel for $TARGET; dispatching mlirDistro (nonce=$NONCE)."
           DISPATCH_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          gh workflow run mlirDistro.yml -f LLVM_COMMIT="$TARGET"
+          # `gh workflow run` defaults to the repo's default branch, so the
+          # dispatched mlirDistro run lands on `main` regardless of where this
+          # update-llvm run was triggered. The `--branch main` filter below
+          # mirrors that assumption.
+          gh workflow run mlirDistro.yml -f LLVM_COMMIT="$TARGET" -f DISPATCH_NONCE="$NONCE"
 
-          # Find the run we just dispatched. Filter by event + ref + createdAt
-          # to avoid grabbing an unrelated workflow_dispatch.
+          # Poll up to 5 minutes; GitHub can take a while to materialize a
+          # dispatched run under load. Filter by displayTitle containing our
+          # nonce so we can never pick up an unrelated dispatch.
           RUN_ID=""
-          for i in $(seq 1 12); do
+          for i in $(seq 1 60); do
             sleep 5
             RUN_ID=$(gh run list \
               --workflow mlirDistro.yml \
               --event workflow_dispatch \
               --branch main \
-              --limit 5 \
+              --limit 20 \
               --created ">=$DISPATCH_TS" \
-              --json databaseId,createdAt \
-              --jq 'sort_by(.createdAt) | .[0].databaseId // empty')
+              --json databaseId,displayTitle \
+              --jq ".[] | select(.displayTitle | contains(\"$NONCE\")) | .databaseId" \
+              | head -n1)
             if [ -n "$RUN_ID" ]; then break; fi
           done
 
           if [ -z "$RUN_ID" ]; then
-            echo "::error::Could not locate dispatched mlirDistro run."
+            echo "::error::Could not locate dispatched mlirDistro run with nonce $NONCE after 5 minutes."
             exit 1
           fi
 

--- a/utils/update_llvm_version.py
+++ b/utils/update_llvm_version.py
@@ -332,6 +332,15 @@ def main():
     parser.add_argument(
         "--llvm-hash", help="Specific LLVM hash to use (overrides auto-detection)."
     )
+    parser.add_argument(
+        "--identify-only",
+        action="store_true",
+        help=(
+            "Identify target commit and check wheel availability without "
+            "modifying files. Writes target_commit, wheel_exists, and "
+            "bump_reason to $GITHUB_OUTPUT. Always exits 0."
+        ),
+    )
     args = parser.parse_args()
 
     check_token()
@@ -394,6 +403,23 @@ def main():
 
         reason = f"Bump to match {source} LLVM {target_commit[:8]} ({target_date})"
         print(f"Found update! {reason}")
+
+    if args.identify_only:
+        # Skip eudsl + file updates; just report target and wheel availability
+        # so the caller can dispatch mlirDistro and re-invoke without --identify-only.
+        wheel_exists = "false"
+        if target_commit == current_commit:
+            print("Target matches current commit; nothing to do.")
+            target_out = ""
+        else:
+            target_out = target_commit
+            wheel_exists = "true" if find_wheel_in_distro(target_commit) else "false"
+        if "GITHUB_OUTPUT" in os.environ:
+            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                f.write(f"target_commit={target_out}\n")
+                f.write(f"wheel_exists={wheel_exists}\n")
+                f.write(f"bump_reason={reason}\n")
+        return
 
     # 4. Find closest eudsl version
     result = find_closest_eudsl_version(target_commit, target_date)

--- a/utils/update_llvm_version.py
+++ b/utils/update_llvm_version.py
@@ -21,6 +21,9 @@ EUDSL_INDEX_URL = "https://llvm.github.io/eudsl/"
 EUDSL_SUBMODULE_URL = (
     "https://api.github.com/repos/llvm/eudsl/contents/third_party/llvm-project?ref={}"
 )
+MLIR_DISTRO_RELEASE_URL = (
+    "https://api.github.com/repos/Xilinx/mlir-aie/releases/tags/mlir-distro"
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CLONE_LLVM_SH = REPO_ROOT / "utils" / "clone-llvm.sh"
@@ -220,11 +223,6 @@ def find_closest_eudsl_version(target_llvm_hash, target_llvm_date):
     return best_candidate
 
 
-MLIR_DISTRO_RELEASE_URL = (
-    "https://api.github.com/repos/Xilinx/mlir-aie/releases/tags/mlir-distro"
-)
-
-
 def find_wheel_in_distro(commit_hash):
     """Query the mlir-distro GitHub release for a wheel matching this LLVM commit.
 
@@ -283,27 +281,11 @@ def find_wheel_in_distro(commit_hash):
     return None
 
 
-def update_files(
-    new_commit, commit_date, eudsl_version, wheel_version=None, wheel_datetime=None
-):
-    # Use wheel-derived values when available, fall back to commit date.
-    if wheel_datetime:
-        datetime_str = wheel_datetime
-    else:
-        # Fallback: derive from LLVM commit date (may not match the actual
-        # wheel, since mlirDistro.yml uses CI build time instead).
-        datetime_str = commit_date.strftime("%Y%m%d%H")
-        print(
-            "Warning: Using LLVM commit date as DATETIME fallback. "
-            "This may not match the actual wheel version.",
-            file=sys.stderr,
-        )
-
+def update_files(new_commit, commit_date, eudsl_version, wheel_version, wheel_datetime):
     print(f"Updating to LLVM commit: {new_commit}")
     print(f"Commit Date: {commit_date}")
-    print(f"DATETIME: {datetime_str}")
-    if wheel_version:
-        print(f"WHEEL_VERSION prefix: {wheel_version}")
+    print(f"DATETIME: {wheel_datetime}")
+    print(f"WHEEL_VERSION prefix: {wheel_version}")
     print(f"EUDSL Version: {eudsl_version}")
 
     # Update utils/clone-llvm.sh
@@ -314,14 +296,12 @@ def update_files(
             f"LLVM_PROJECT_COMMIT={new_commit}",
             content,
         )
-        content = re.sub(r"DATETIME=\d+", f"DATETIME={datetime_str}", content)
-        # Update the major.minor.patch prefix in WHEEL_VERSION (e.g. 22.0.0 -> 23.0.0).
-        if wheel_version:
-            content = re.sub(
-                r"(WHEEL_VERSION=)\d+\.\d+\.\d+",
-                rf"\g<1>{wheel_version}",
-                content,
-            )
+        content = re.sub(r"DATETIME=\d+", f"DATETIME={wheel_datetime}", content)
+        content = re.sub(
+            r"(WHEEL_VERSION=)\d+\.\d+\.\d+",
+            rf"\g<1>{wheel_version}",
+            content,
+        )
         CLONE_LLVM_SH.write_text(content)
         print(f"Updated {CLONE_LLVM_SH}")
     else:
@@ -432,27 +412,27 @@ def main():
         print("Target LLVM commit matches current commit. No update needed.")
         return
 
+    # 5. Look up the actual wheel in mlir-distro to get the correct DATETIME
+    # and version. If no wheel exists, fail loudly: the resulting PR could not
+    # build, and the failure surfaces that mlir-distro is broken or behind.
+    wheel_info = find_wheel_in_distro(target_commit)
+    if not wheel_info:
+        print(
+            f"Error: No mlir-distro wheel exists for target commit "
+            f"{target_commit[:8]}. The mlir-distro build pipeline may be "
+            "broken or lagging behind upstream. Aborting to avoid creating "
+            "a PR that cannot pass CI.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    wheel_version, wheel_datetime = wheel_info
+
     # Write reason to GITHUB_OUTPUT if available
     if "GITHUB_OUTPUT" in os.environ:
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"bump_reason={reason}\n")
 
-    # 5. Look up actual wheel in mlir-distro to get correct DATETIME and version
-    wheel_version = None
-    wheel_datetime = None
-    wheel_info = find_wheel_in_distro(target_commit)
-    if wheel_info:
-        wheel_version, wheel_datetime = wheel_info
-    else:
-        print(
-            "Wheel not found in mlir-distro. DATETIME will be derived from "
-            "commit date (may not match actual wheel) and WHEEL_VERSION "
-            "major.minor.patch will not be updated.",
-            file=sys.stderr,
-        )
-
     # 6. Update files
-    # Use target_commit (from Triton/Torch/User) instead of eudsl's LLVM commit
     update_files(
         target_commit, target_date, new_eudsl_version, wheel_version, wheel_datetime
     )

--- a/utils/update_llvm_version.py
+++ b/utils/update_llvm_version.py
@@ -21,9 +21,6 @@ EUDSL_INDEX_URL = "https://llvm.github.io/eudsl/"
 EUDSL_SUBMODULE_URL = (
     "https://api.github.com/repos/llvm/eudsl/contents/third_party/llvm-project?ref={}"
 )
-MLIR_DISTRO_RELEASE_URL = (
-    "https://api.github.com/repos/Xilinx/mlir-aie/releases/tags/mlir-distro"
-)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CLONE_LLVM_SH = REPO_ROOT / "utils" / "clone-llvm.sh"
@@ -223,6 +220,11 @@ def find_closest_eudsl_version(target_llvm_hash, target_llvm_date):
     return best_candidate
 
 
+MLIR_DISTRO_RELEASE_URL = (
+    "https://api.github.com/repos/Xilinx/mlir-aie/releases/tags/mlir-distro"
+)
+
+
 def find_wheel_in_distro(commit_hash):
     """Query the mlir-distro GitHub release for a wheel matching this LLVM commit.
 
@@ -239,8 +241,13 @@ def find_wheel_in_distro(commit_hash):
     """
     commit_short = commit_hash[:8]
     # Match base 'mlir-' wheels (not mlir_no_rtti or mlir_native_tools).
+    # The optional `-<digits>(_<digits>)?` segment tolerates the PEP 427 build
+    # tag that mlirDistro.yml stamps on non-canonical (PR / cron) uploads to
+    # keep their asset names unique. Canonical workflow_dispatch wheels in the
+    # mlir-distro release have no build tag, so this remains a noop for them.
     pattern = re.compile(
-        rf"^mlir-(\d+\.\d+\.\d+)\.(\d{{10}})\+{re.escape(commit_short)}-"
+        rf"^mlir-(\d+\.\d+\.\d+)\.(\d{{10}})\+{re.escape(commit_short)}"
+        rf"(?:-\d+(?:_\d+)?)?-py3-none-"
     )
     try:
         # First, get the release ID.

--- a/utils/update_llvm_version.py
+++ b/utils/update_llvm_version.py
@@ -344,8 +344,8 @@ def main():
         action="store_true",
         help=(
             "Identify target commit and check wheel availability without "
-            "modifying files. Writes target_commit, wheel_exists, and "
-            "bump_reason to $GITHUB_OUTPUT. Always exits 0."
+            "modifying files. Reports target_commit, wheel_exists, and "
+            "bump_reason via $GITHUB_OUTPUT instead of mutating files."
         ),
     )
     args = parser.parse_args()
@@ -465,7 +465,9 @@ def main():
         with open(os.environ["GITHUB_OUTPUT"], "a") as f:
             f.write(f"bump_reason={reason}\n")
 
-    # 6. Update files
+    # 6. Update files. Use target_commit (from Triton/Torch/User) instead of
+    # eudsl's LLVM commit: eudsl is allowed to lag, but we want our LLVM commit
+    # to track the upstream we resolved against.
     update_files(
         target_commit, target_date, new_eudsl_version, wheel_version, wheel_datetime
     )


### PR DESCRIPTION
Supersedes #3052

Round 2, this PR should have better permissions for CI tasks since it's not from a fork.

**update-llvm orchestration.** `utils/update_llvm_version.py` and `.github/workflows/update-llvm.yml` now follow an identify-then-build-then-apply flow. A new `--identify-only` mode resolves the target LLVM commit and reports `target_commit` / `wheel_exists` / `bump_reason` via `$GITHUB_OUTPUT` without mutating files; if no `mlir-distro` wheel exists yet, the workflow dispatches `mlirDistro.yml` itself (passing a `DISPATCH_NONCE` input echoed into `mlirDistro`'s `run-name`), polls `gh run list` filtering by that nonce in `displayTitle` to deterministically locate its run, then `gh run watch`es it to completion before re-invoking the script to mutate `clone-llvm.sh` etc. The previous silent-fallback in `update_files()` (use commit date when wheel is missing) is gone; missing wheel is now a hard error since the orchestration step is supposed to have built it. `find_wheel_in_distro`'s regex is widened to tolerate the optional `-<run_id>(_<attempt>)?` build-tag segment introduced below, so it matches both canonical and PR-built wheels.

**mlirDistro hardening + race-free, bounded wheel uploads.** `mlirDistro.yml`'s previous unauthenticated `curl` against `api.github.com/repos/llvm/llvm-project/commits/main` was hitting the 60/hr per-IP limit and silently producing `LLVM_PROJECT_COMMIT=null`, which then built broken wheels — the fetch is now authenticated with `--fail-with-body` and an explicit empty/`null` check that hard-fails the run, and the `Release current commit` step is gated to skip on fork PRs (no token write access anyway, just a confusing 403). Three layered fixes then make uploads both race-free and bounded: (1) **PEP 427 build tags on PR builds** in both Distro workflows rename wheels to embed `<run_id>_<attempt>` so concurrent CI runs can never collide on a `dev-wheels` asset name — the build tag is invisible to `pip install mlir==<version>`, and canonical `workflow_dispatch` builds keep deterministic filenames so `find_wheel_in_distro` still works; (2) **`concurrency:` blocks** on both workflows serialize `workflow_dispatch` (and `schedule`) so two publishes can't overlap on the consumer-facing tags — structural fix for the race PR #2789 worked around with `replacesArtifacts: false`, which stays as defense-in-depth (and `mlirAIEDistro.yml` is brought in line, it was still `true`); (3) **`pruneReleaseAssets.yml`** janitor runs daily and deletes `dev-wheels` assets older than 30 days, since (1) means new uploads never overwrite old ones and `dev-wheels` would otherwise grow until it hit GitHub's 1000-asset-per-release cap (exactly what's been failing this PR's upload jobs).