### PR TITLE
[AIEPlacer] Unify objectfifo + flow placement through Adjacency

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -22,16 +22,6 @@ enum class PlacerType { SequentialPlacer };
 // maps logical tile operations to physical coordinates
 using PlacementResult = llvm::DenseMap<mlir::Operation *, TileID>;
 
-// A set of LogicalTileOps connected by some connectivity op (objectfifo,
-// flow, packet_flow, ...). `coreTiles` is used to compute the common column
-// for placing the group's `nonCoreTiles`. Both lists may contain duplicates
-// when a tile is referenced by multiple connectivity ops in the same group;
-// duplicates intentionally weight the common-column average.
-struct ConnectivityGroup {
-  llvm::SmallVector<LogicalTileOp, 4> coreTiles;
-  llvm::SmallVector<LogicalTileOp, 4> nonCoreTiles;
-};
-
 // Track available tiles and resource usage
 struct TileAvailability {
   std::vector<TileID> compTiles;
@@ -96,19 +86,6 @@ private:
 
   void limitCoresPerColumn(int maxCoresPerCol, int numColumns);
 
-  void buildObjectFifoGroups(llvm::ArrayRef<ObjectFifoCreateOp> objectFifos,
-                             llvm::ArrayRef<ObjectFifoLinkOp> objectFifoLinks,
-                             llvm::SmallVectorImpl<ConnectivityGroup> &groups);
-
-  void buildFlowGroups(llvm::ArrayRef<FlowOp> flows,
-                       llvm::ArrayRef<PacketFlowOp> pktFlows,
-                       llvm::SmallVectorImpl<ConnectivityGroup> &groups);
-
-  mlir::LogicalResult placeNonCoreTilesInGroup(
-      const ConnectivityGroup &group,
-      const llvm::DenseMap<mlir::Operation *, std::pair<int, int>>
-          &channelRequirements);
-
   std::optional<TileID> findTileWithCapacity(int targetCol,
                                              std::vector<TileID> &tiles,
                                              int requiredInputChannels,
@@ -130,20 +107,13 @@ private:
       llvm::SmallVector<ObjectFifoCreateOp> &objectFifos,
       llvm::SmallVector<ObjectFifoLinkOp> &objectFifoLinks);
 
-  // Per-LTO peer edges indexed by either endpoint. Used by both shared-L1
-  // buffer adjacency (memory affinity) and cascade adjacency (cardinal
-  // direction). `tileToEdges` indexes into `edges` only for `LogicalTileOp`
-  // endpoints (the ones the placer visits); `TileOp` peers contribute coords
-  // via `TileLike::tryGetCol`/`tryGetRow`.
+  // Per-LTO peer edges indexed by either endpoint. `tileToEdges` only
+  // indexes `LogicalTileOp` endpoints; `TileOp` peers carry their own coords.
   struct Adjacency {
     llvm::SmallVector<std::pair<TileLike, TileLike>, 4> edges;
     llvm::DenseMap<mlir::Operation *, llvm::SmallVector<unsigned, 2>>
         tileToEdges;
 
-    // Append a peer edge and index it on every `LogicalTileOp` endpoint.
-    // Centralizes the invariant that `tileToEdges[op]` lists every edge
-    // mentioning `op`, but only for LTO endpoints (`TileOp` peers carry
-    // their own coords).
     void addEdge(TileLike first, TileLike second) {
       unsigned idx = edges.size();
       edges.push_back({first, second});
@@ -152,32 +122,48 @@ private:
       if (mlir::isa<LogicalTileOp>(second.getOperation()))
         tileToEdges[second.getOperation()].push_back(idx);
     }
+
+    // Convenience for IR walkers: skip if either Value isn't a TileLike.
+    void addEdgeFromValues(mlir::Value a, mlir::Value b) {
+      auto aT = mlir::dyn_cast_or_null<TileLike>(a.getDefiningOp());
+      auto bT = mlir::dyn_cast_or_null<TileLike>(b.getDefiningOp());
+      if (aT && bT)
+        addEdge(aT, bT);
+    }
   };
 
-  // Cross-tile L1 buffer access: consumer LTO's core must pass
-  // targetModel->isLegalMemAffinity(coreCol=consumerCol, coreRow=consumerRow,
-  //                                 memCol=ownerCol,     memRow=ownerRow).
-  // The first endpoint of each edge is the consumer LTO; the second is the
-  // owner tile.
+  // Edge: (consumer LTO, owner tile). Predicate: `isLegalMemAffinity`.
   Adjacency buildBufferAdjacency(llvm::ArrayRef<LogicalTileOp> logicalTiles);
 
-  // The first endpoint of each edge is the cascade source; the second is the
-  // destination.
+  // Edge: (cascade source, dest).
   Adjacency buildCascadeAdjacency(llvm::ArrayRef<CascadeFlowOp> cascadeFlows);
 
-  // Generic adjacency predicate. `pred` returns true iff `(firstPos,
-  // secondPos)` satisfies the constraint, where `first` and `second` are
-  // `adjacency.edges[i].first` and `.second`. Unplaced peers without pin
-  // coords defer; symmetric/asymmetric predicates only need to be checked at
-  // one endpoint each.
+  // Edge: (producer, consumer_i) per fifo. Linked fifos connect transitively
+  // through the link tile (it's the consumer of every source fifo and the
+  // producer of every destination fifo), so per-fifo emission suffices.
+  Adjacency
+  buildObjectFifoAdjacency(llvm::ArrayRef<ObjectFifoCreateOp> objectFifos);
+
+  // Edge: (src, dst) per `aie.flow`; cross-product per `aie.packet_flow`.
+  Adjacency buildFlowAdjacency(llvm::ArrayRef<FlowOp> flows,
+                               llvm::ArrayRef<PacketFlowOp> pktFlows);
+
+  // Place a non-core (mem/shim) LTO near the centroid column of its placed
+  // core peers, reached transitively through `connectivityAdjacencies`.
+  mlir::LogicalResult placeNonCoreTileByCentroid(
+      LogicalTileOp logicalTile,
+      llvm::ArrayRef<const Adjacency *> connectivityAdjacencies,
+      const llvm::DenseMap<mlir::Operation *, std::pair<int, int>>
+          &channelRequirements);
+
+  // Pairwise legality check. `pred(firstPos, secondPos)` is evaluated for
+  // every edge mentioning `logicalTile`; unplaced peers defer.
   bool satisfiesAdjacency(
       LogicalTileOp logicalTile, TileID candidate, const Adjacency &adjacency,
       llvm::function_ref<bool(TileID firstPos, TileID secondPos)> pred) const;
 
-  // Generic peer-note attachment. `labelPeer(thisIsFirst)` returns the
-  // descriptive name of the peer endpoint -- when `logicalTile` is the first
-  // member of the edge, the peer is the second member, and vice versa. The
-  // attached note reads `"<label> peer placed at (col, row)"`.
+  // Diagnostic peer notes. `labelPeer(thisIsFirst)` names the peer endpoint
+  // role; the attached note reads "<label> peer placed at (col, row)".
   void attachPeerNotes(
       mlir::InFlightDiagnostic &diag, LogicalTileOp logicalTile,
       const Adjacency &adjacency,

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -683,6 +683,9 @@ LogicalResult SequentialPlacer::placeNonCoreTileByCentroid(
             sumCols += resIt->second.col;
             ++placedCoreCount;
           }
+          // Cores are leaves for centroid: they don't relay between
+          // non-core peers via core-to-core fifos.
+          continue;
         }
         queue.push_back(peerOp);
       }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -10,8 +10,6 @@
 
 #include "aie/Dialect/AIE/Transforms/AIEPlacer.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
-#include "llvm/ADT/MapVector.h"
-#include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 
 #include <algorithm>
@@ -283,43 +281,24 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
     }
   }
 
-  // Phase 4: Place mem/shim tiles by connectivity groups (ObjectFifo + Flow).
-  // Vector iteration order is stable, so placement is reproducible when
-  // multiple groups compete for the same physical tiles.
-  SmallVector<ConnectivityGroup> groups;
-  buildObjectFifoGroups(objectFifos, objectFifoLinks, groups);
-  buildFlowGroups(flows, pktFlows, groups);
+  // Phase 4: Place each remaining non-core (mem/shim) LTO at the centroid
+  // column of its placed core peers, reached transitively through any
+  // connectivity adjacency.
+  auto objectFifoAdjacency = buildObjectFifoAdjacency(objectFifos);
+  auto flowAdjacency = buildFlowAdjacency(flows, pktFlows);
+  SmallVector<const Adjacency *, 2> connectivityAdjacencies = {
+      &objectFifoAdjacency, &flowAdjacency};
 
-  for (auto &group : groups) {
-    if (failed(placeNonCoreTilesInGroup(group, channelRequirements)))
-      return failure();
-  }
-
-  // Phase 5: Fallback for remaining unplaced non-core tiles
   for (auto logicalTile : logicalTiles) {
-    // Skip already placed tiles
     if (result.count(logicalTile.getOperation()))
       continue;
-
-    // Skip core tiles (handled above) and ShimPLTile (unsupported)
     AIETileType tileType = logicalTile.getTileType();
     if (tileType == AIETileType::CoreTile ||
         tileType == AIETileType::ShimPLTile)
       continue;
-
-    // Use column constraint if specified, otherwise start from column 0
-    auto colConstraint = logicalTile.tryGetCol();
-    int targetCol = colConstraint ? *colConstraint : 0;
-
-    // Find first available tile of matching type (no DMA requirements)
-    auto maybeTile = findTileWithCapacity(targetCol, availability.nonCompTiles,
-                                          0, 0, tileType);
-
-    if (!maybeTile)
-      return logicalTile.emitError()
-             << "no " << stringifyAIETileType(tileType) << " available";
-
-    result[logicalTile] = *maybeTile;
+    if (failed(placeNonCoreTileByCentroid(logicalTile, connectivityAdjacencies,
+                                          channelRequirements)))
+      return failure();
   }
 
   return success();
@@ -588,52 +567,35 @@ void SequentialPlacer::attachPeerNotes(
   }
 }
 
-void SequentialPlacer::buildObjectFifoGroups(
-    ArrayRef<ObjectFifoCreateOp> objectFifos,
-    ArrayRef<ObjectFifoLinkOp> objectFifoLinks,
-    SmallVectorImpl<ConnectivityGroup> &groups) {
+SequentialPlacer::Adjacency SequentialPlacer::buildObjectFifoAdjacency(
+    ArrayRef<ObjectFifoCreateOp> objectFifos) {
+  Adjacency adjacency;
+  for (auto ofOp : objectFifos)
+    for (Value consumer : ofOp.getConsumerTiles())
+      adjacency.addEdgeFromValues(ofOp.getProducerTile(), consumer);
+  return adjacency;
+}
 
-  // Linked fifos share a group ID. Unlinked fifos each get their own.
-  llvm::StringMap<int> fifoToGroup;
-  int nextGroupId = 0;
-  for (auto linkOp : objectFifoLinks) {
-    int groupId = nextGroupId++;
-    for (auto fifoAttr : linkOp.getFifoIns())
-      fifoToGroup[cast<FlatSymbolRefAttr>(fifoAttr).getValue()] = groupId;
-    for (auto fifoAttr : linkOp.getFifoOuts())
-      fifoToGroup[cast<FlatSymbolRefAttr>(fifoAttr).getValue()] = groupId;
+SequentialPlacer::Adjacency
+SequentialPlacer::buildFlowAdjacency(ArrayRef<FlowOp> flows,
+                                     ArrayRef<PacketFlowOp> pktFlows) {
+  Adjacency adjacency;
+  for (auto flow : flows)
+    adjacency.addEdgeFromValues(flow.getSource(), flow.getDest());
+
+  for (auto pktFlow : pktFlows) {
+    SmallVector<Value> srcs, dsts;
+    pktFlow.walk([&](Operation *op) {
+      if (auto src = dyn_cast<PacketSourceOp>(op))
+        srcs.push_back(src.getTile());
+      else if (auto dst = dyn_cast<PacketDestOp>(op))
+        dsts.push_back(dst.getTile());
+    });
+    for (auto s : srcs)
+      for (auto d : dsts)
+        adjacency.addEdgeFromValues(s, d);
   }
-
-  // Map group ID -> index into `groups`. Insertion order = first-encountered
-  // fifo order, which matches IR walk order.
-  llvm::DenseMap<int, size_t> groupIdToIndex;
-
-  auto getOrCreateGroup = [&](int groupId) -> ConnectivityGroup & {
-    auto [it, inserted] = groupIdToIndex.try_emplace(groupId, groups.size());
-    if (inserted)
-      groups.emplace_back();
-    return groups[it->second];
-  };
-
-  auto recordEndpoint = [&](Value tileVal, ConnectivityGroup &group) {
-    auto lt = dyn_cast_or_null<LogicalTileOp>(tileVal.getDefiningOp());
-    if (!lt)
-      return;
-    if (lt.getTileType() == AIETileType::CoreTile)
-      group.coreTiles.push_back(lt);
-    else
-      group.nonCoreTiles.push_back(lt);
-  };
-
-  int unlinkedGroupId = nextGroupId;
-  for (auto ofOp : objectFifos) {
-    auto it = fifoToGroup.find(ofOp.getSymName());
-    int groupId = (it != fifoToGroup.end()) ? it->second : unlinkedGroupId++;
-    ConnectivityGroup &group = getOrCreateGroup(groupId);
-    recordEndpoint(ofOp.getProducerTile(), group);
-    for (Value consumerTile : ofOp.getConsumerTiles())
-      recordEndpoint(consumerTile, group);
-  }
+  return adjacency;
 }
 
 // Already-resolved TileOps have no placer-visible budget, so only flows whose
@@ -685,109 +647,73 @@ void SequentialPlacer::addChannelRequirementsFromFlows(
   }
 }
 
-// MapVector / SetVector preserve insertion order so that group identity and
-// per-group tile order are stable across runs even when DMA capacity is tight.
-void SequentialPlacer::buildFlowGroups(
-    ArrayRef<FlowOp> flows, ArrayRef<PacketFlowOp> pktFlows,
-    SmallVectorImpl<ConnectivityGroup> &groups) {
-
-  llvm::MapVector<LogicalTileOp, llvm::SmallSetVector<LogicalTileOp, 4>> adj;
-
-  auto addEdge = [&](Value srcVal, Value dstVal) {
-    auto srcLT = dyn_cast_or_null<LogicalTileOp>(srcVal.getDefiningOp());
-    auto dstLT = dyn_cast_or_null<LogicalTileOp>(dstVal.getDefiningOp());
-    if (!srcLT || !dstLT)
-      return;
-    adj[srcLT].insert(dstLT);
-    adj[dstLT].insert(srcLT);
-  };
-
-  for (auto flow : flows)
-    addEdge(flow.getSource(), flow.getDest());
-
-  for (auto pktFlow : pktFlows) {
-    SmallVector<Value> srcs, dsts;
-    pktFlow.walk([&](Operation *op) {
-      if (auto src = dyn_cast<PacketSourceOp>(op))
-        srcs.push_back(src.getTile());
-      else if (auto dst = dyn_cast<PacketDestOp>(op))
-        dsts.push_back(dst.getTile());
-    });
-    for (auto s : srcs)
-      for (auto d : dsts)
-        addEdge(s, d);
-  }
-
-  llvm::DenseSet<LogicalTileOp> visited;
-  for (auto &entry : adj) {
-    LogicalTileOp seed = entry.first;
-    if (visited.count(seed))
-      continue;
-    ConnectivityGroup &group = groups.emplace_back();
-    SmallVector<LogicalTileOp> stack{seed};
-    visited.insert(seed);
-    while (!stack.empty()) {
-      LogicalTileOp cur = stack.pop_back_val();
-      if (cur.getTileType() == AIETileType::CoreTile)
-        group.coreTiles.push_back(cur);
-      else
-        group.nonCoreTiles.push_back(cur);
-      for (auto nbr : adj[cur]) {
-        if (visited.insert(nbr).second)
-          stack.push_back(nbr);
-      }
-    }
-  }
-}
-
-LogicalResult SequentialPlacer::placeNonCoreTilesInGroup(
-    const ConnectivityGroup &group,
+LogicalResult SequentialPlacer::placeNonCoreTileByCentroid(
+    LogicalTileOp logicalTile,
+    ArrayRef<const Adjacency *> connectivityAdjacencies,
     const llvm::DenseMap<Operation *, std::pair<int, int>>
         &channelRequirements) {
 
-  // Common column = rounded average of placed core endpoints' columns.
+  // BFS the connected component, summing placed-core columns. Walks
+  // through unplaced LTO peers so the centroid sees cores reachable
+  // transitively; TileOp peers terminate the walk.
+  llvm::DenseSet<Operation *> visited;
+  SmallVector<Operation *, 8> queue{logicalTile.getOperation()};
+  visited.insert(logicalTile.getOperation());
+
   int sumCols = 0;
-  int totalCoreEndpoints = 0;
-  for (auto coreTile : group.coreTiles) {
-    auto it = result.find(coreTile.getOperation());
-    if (it == result.end())
-      continue;
-    sumCols += it->second.col;
-    ++totalCoreEndpoints;
+  int placedCoreCount = 0;
+  while (!queue.empty()) {
+    Operation *current = queue.pop_back_val();
+    for (const Adjacency *adj : connectivityAdjacencies) {
+      auto it = adj->tileToEdges.find(current);
+      if (it == adj->tileToEdges.end())
+        continue;
+      for (unsigned idx : it->second) {
+        auto [first, second] = adj->edges[idx];
+        Operation *peerOp = (first.getOperation() == current)
+                                ? second.getOperation()
+                                : first.getOperation();
+        if (!visited.insert(peerOp).second)
+          continue;
+        auto peerLT = dyn_cast<LogicalTileOp>(peerOp);
+        if (!peerLT)
+          continue; // TileOp peer: don't BFS through it.
+        if (peerLT.getTileType() == AIETileType::CoreTile) {
+          if (auto resIt = result.find(peerOp); resIt != result.end()) {
+            sumCols += resIt->second.col;
+            ++placedCoreCount;
+          }
+        }
+        queue.push_back(peerOp);
+      }
+    }
   }
-  int groupCommonCol =
-      totalCoreEndpoints > 0
-          ? (sumCols + totalCoreEndpoints / 2) / totalCoreEndpoints
-          : 0;
 
-  for (auto logicalTile : group.nonCoreTiles) {
-    if (result.count(logicalTile.getOperation()))
-      continue;
+  auto colConstraint = logicalTile.tryGetCol();
+  int centroidCol = placedCoreCount > 0
+                        ? (sumCols + placedCoreCount / 2) / placedCoreCount
+                        : 0;
+  int targetCol = colConstraint ? *colConstraint : centroidCol;
 
-    auto it = channelRequirements.find(logicalTile.getOperation());
-    int numInputChannels =
-        it != channelRequirements.end() ? it->second.first : 0;
-    int numOutputChannels =
-        it != channelRequirements.end() ? it->second.second : 0;
+  auto chanIt = channelRequirements.find(logicalTile.getOperation());
+  int numInputChannels =
+      chanIt != channelRequirements.end() ? chanIt->second.first : 0;
+  int numOutputChannels =
+      chanIt != channelRequirements.end() ? chanIt->second.second : 0;
 
-    auto colConstraint = logicalTile.tryGetCol();
-    int targetCol = colConstraint ? *colConstraint : groupCommonCol;
+  auto maybeTile = findTileWithCapacity(targetCol, availability.nonCompTiles,
+                                        numInputChannels, numOutputChannels,
+                                        logicalTile.getTileType());
+  if (!maybeTile)
+    return logicalTile.emitError()
+           << "no " << stringifyAIETileType(logicalTile.getTileType())
+           << " with sufficient DMA capacity";
 
-    auto maybeTile = findTileWithCapacity(targetCol, availability.nonCompTiles,
-                                          numInputChannels, numOutputChannels,
-                                          logicalTile.getTileType());
-
-    if (!maybeTile)
-      return logicalTile.emitError()
-             << "no " << stringifyAIETileType(logicalTile.getTileType())
-             << " with sufficient DMA capacity";
-
-    result[logicalTile] = *maybeTile;
-    if (numInputChannels > 0)
-      updateChannelUsage(*maybeTile, false, numInputChannels);
-    if (numOutputChannels > 0)
-      updateChannelUsage(*maybeTile, true, numOutputChannels);
-  }
+  result[logicalTile] = *maybeTile;
+  if (numInputChannels > 0)
+    updateChannelUsage(*maybeTile, false, numInputChannels);
+  if (numOutputChannels > 0)
+    updateChannelUsage(*maybeTile, true, numOutputChannels);
   return success();
 }
 


### PR DESCRIPTION
Replaces the parallel `ConnectivityGroup` / DFS-grouping path in the placer with the same `Adjacency` representation already used by buffer / cascade constraints (#3041, #3042, #3046). After this PR there is one canonical "tile-to-tile relation" representation across all sources: `aie.buffer`, `aie.cascade_flow`, `aie.objectfifo`, `aie.flow` / `aie.packet_flow`.

## What changes

- New `buildObjectFifoAdjacency(objectFifos)` -> `Adjacency`: emits one edge per `(producer, consumer_i)` pair. Linked fifos do not need a special case -- the link tile naturally appears as consumer of every source fifo and producer of every destination fifo, so per-fifo edge emission already connects all sibling endpoints transitively through that shared tile.
- New `buildFlowAdjacency(flows, pktFlows)` -> `Adjacency`: one edge per `aie.flow`; per `aie.packet_flow`, cross-product of its `aie.packet_source`s and `aie.packet_dest`s.
- New `placeNonCoreTileByCentroid`: walks both adjacencies via BFS from the LTO, accumulating columns of placed `CoreTile` peers, places at the centroid (or pinned column).
- Phase 4 + Phase 5 in `place()` collapse into a single iteration over unplaced non-core LTOs.
- Small `Adjacency::addEdgeFromValues(Value, Value)` helper so both new builders share the `dyn_cast_or_null<TileLike>` step.

## Removals

- `struct ConnectivityGroup`
- `buildObjectFifoGroups`, `buildFlowGroups`, `placeNonCoreTilesInGroup`

## Behavior

Identical placements on all 9 existing `test/place-tiles/` lit tests. Channel-requirements path is untouched -- it's a per-tile resource counter, fundamentally not a pairwise relation.

Net diff: +131 / -219 (-88 lines).