### PR TITLE
[VectorToAIEVec] Scope vector arith.{andi,ori,xori} conversions to CPP backend

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3904,10 +3904,9 @@ struct ComputeBxorAndBnegOpPattern : OpConversionPattern<arith::XOrIOp> {
     if (laneSize * elWidth != 512)
       return failure();
 
-    auto lhsConstOp =
-        dyn_cast<arith::ConstantOp>(xorOp.getLhs().getDefiningOp());
-    auto rhsConstOp =
-        dyn_cast<arith::ConstantOp>(xorOp.getRhs().getDefiningOp());
+    // Operands may be block arguments (no defining op); guard before casting.
+    auto lhsConstOp = xorOp.getLhs().getDefiningOp<arith::ConstantOp>();
+    auto rhsConstOp = xorOp.getRhs().getDefiningOp<arith::ConstantOp>();
 
     // If one of operands in xorOp is a constant -1, xorOp will be replaced with
     // aievec::BnegOp.
@@ -4683,7 +4682,14 @@ populateAIEVecV2CommonConversionPatterns(RewritePatternSet &patterns,
         LowerVectorAddFOpToAIEVecAddElemOp,
         LowerVectorSubFOpToAIEVecSubElemOp,
         LowerVectorAddIOpToAIEVecAddElemOp,
-        LowerVectorSubIOpToAIEVecSubElemOp
+        LowerVectorSubIOpToAIEVecSubElemOp,
+        // Bitwise vector arith → aievec.{bxor,bor,band,bneg} only on CPP:
+        // AIEVecToLLVM has no lowering for those aievec ops, and AIE2/AIE2P
+        // legalize standard G_AND/G_OR/G_XOR on every vector type, so the
+        // LLVMIR path takes the standard arith→llvm route instead.
+        ComputeBxorAndBnegOpPattern,
+        ComputeBorOpPattern,
+        ComputeBandOpPattern
       >(patterns.getContext());
   } else if (backend == TargetBackend::LLVMIR){
       patterns.add<
@@ -4708,9 +4714,6 @@ populateAIEVecV2CommonConversionPatterns(RewritePatternSet &patterns,
       ComputeCeilOpPattern,
       ComputeFloorOpPattern,
       ComputeNegOpPattern,
-      ComputeBxorAndBnegOpPattern,
-      ComputeBorOpPattern,
-      ComputeBandOpPattern,
       ComputeSignedIntRightShiftOpPattern,
       LowerScalarShRSIToAIEVecUPSSRS,
       ConvertMulIToAIEVecMulElemOpPattern,
@@ -5124,35 +5127,25 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
 
   // Only convert bitwise vector ops to aievec.{bxor,bor,band,bneg} on the
   // CPP (chess) backend. AIEVecToLLVM has no lowering for those aievec ops,
-  // and AIE2/AIE2P legalize standard G_AND/G_OR/G_XOR on every vector type.
+  // and AIE2/AIE2P legalize standard G_AND/G_OR/G_XOR on every vector type,
+  // so the LLVMIR path takes the standard arith→llvm route instead.
   if (backend == TargetBackend::CPP) {
-    target.addDynamicallyLegalOp<arith::XOrIOp>([](arith::XOrIOp xorOp) {
-      auto srcType = dyn_cast<VectorType>(xorOp.getLhs().getType());
+    // Shared predicate for arith.{andi,ori,xori}: illegal iff the operands
+    // are a 512-bit integer vector (then a aievec.{band,bor,bxor} pattern
+    // takes over). Anything else stays legal.
+    auto isNon512BitIntVecBitwiseOp = [](Operation *op) {
+      auto srcType = dyn_cast<VectorType>(op->getOperand(0).getType());
       if (!srcType)
         return true;
-      Type scalarType = srcType.getElementType();
-      if (!isa<IntegerType>(scalarType))
+      if (!isa<IntegerType>(srcType.getElementType()))
         return true;
-
       unsigned laneSize = getVectorLaneSize(srcType);
-      unsigned elWidth = scalarType.getIntOrFloatBitWidth();
-
+      unsigned elWidth = srcType.getElementTypeBitWidth();
       return laneSize * elWidth != 512;
-    });
-
-    target.addDynamicallyLegalOp<arith::OrIOp>([](arith::OrIOp orOp) {
-      auto srcType = dyn_cast<VectorType>(orOp.getLhs().getType());
-      if (!srcType)
-        return true;
-      Type scalarType = srcType.getElementType();
-      if (!isa<IntegerType>(scalarType))
-        return true;
-
-      unsigned laneSize = getVectorLaneSize(srcType);
-      unsigned elWidth = scalarType.getIntOrFloatBitWidth();
-
-      return laneSize * elWidth != 512;
-    });
+    };
+    target.addDynamicallyLegalOp<arith::XOrIOp>(isNon512BitIntVecBitwiseOp);
+    target.addDynamicallyLegalOp<arith::OrIOp>(isNon512BitIntVecBitwiseOp);
+    target.addDynamicallyLegalOp<arith::AndIOp>(isNon512BitIntVecBitwiseOp);
   }
 
   target.addDynamicallyLegalOp<arith::ShRSIOp>([](arith::ShRSIOp rsOp) {
@@ -5180,22 +5173,6 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
 
     return laneSize * elWidth != 512;
   });
-
-  if (backend == TargetBackend::CPP) {
-    target.addDynamicallyLegalOp<arith::AndIOp>([](arith::AndIOp andOp) {
-      auto srcType = dyn_cast<VectorType>(andOp.getLhs().getType());
-      if (!srcType)
-        return true;
-      Type scalarType = srcType.getElementType();
-      if (!isa<IntegerType>(scalarType))
-        return true;
-
-      unsigned laneSize = getVectorLaneSize(srcType);
-      unsigned elWidth = scalarType.getIntOrFloatBitWidth();
-
-      return laneSize * elWidth != 512;
-    });
-  }
 
   if (backend == TargetBackend::CPP) {
     target.addDynamicallyLegalOp<arith::AddIOp>(

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -5122,33 +5122,38 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
     return laneSize != 16;
   });
 
-  target.addDynamicallyLegalOp<arith::XOrIOp>([](arith::XOrIOp xorOp) {
-    auto srcType = dyn_cast<VectorType>(xorOp.getLhs().getType());
-    if (!srcType)
-      return true;
-    Type scalarType = srcType.getElementType();
-    if (!isa<IntegerType>(scalarType))
-      return true;
+  // Only convert bitwise vector ops to aievec.{bxor,bor,band,bneg} on the
+  // CPP (chess) backend. AIEVecToLLVM has no lowering for those aievec ops,
+  // and AIE2/AIE2P legalize standard G_AND/G_OR/G_XOR on every vector type.
+  if (backend == TargetBackend::CPP) {
+    target.addDynamicallyLegalOp<arith::XOrIOp>([](arith::XOrIOp xorOp) {
+      auto srcType = dyn_cast<VectorType>(xorOp.getLhs().getType());
+      if (!srcType)
+        return true;
+      Type scalarType = srcType.getElementType();
+      if (!isa<IntegerType>(scalarType))
+        return true;
 
-    unsigned laneSize = getVectorLaneSize(srcType);
-    unsigned elWidth = scalarType.getIntOrFloatBitWidth();
+      unsigned laneSize = getVectorLaneSize(srcType);
+      unsigned elWidth = scalarType.getIntOrFloatBitWidth();
 
-    return laneSize * elWidth != 512;
-  });
+      return laneSize * elWidth != 512;
+    });
 
-  target.addDynamicallyLegalOp<arith::OrIOp>([](arith::OrIOp orOp) {
-    auto srcType = dyn_cast<VectorType>(orOp.getLhs().getType());
-    if (!srcType)
-      return true;
-    Type scalarType = srcType.getElementType();
-    if (!isa<IntegerType>(scalarType))
-      return true;
+    target.addDynamicallyLegalOp<arith::OrIOp>([](arith::OrIOp orOp) {
+      auto srcType = dyn_cast<VectorType>(orOp.getLhs().getType());
+      if (!srcType)
+        return true;
+      Type scalarType = srcType.getElementType();
+      if (!isa<IntegerType>(scalarType))
+        return true;
 
-    unsigned laneSize = getVectorLaneSize(srcType);
-    unsigned elWidth = scalarType.getIntOrFloatBitWidth();
+      unsigned laneSize = getVectorLaneSize(srcType);
+      unsigned elWidth = scalarType.getIntOrFloatBitWidth();
 
-    return laneSize * elWidth != 512;
-  });
+      return laneSize * elWidth != 512;
+    });
+  }
 
   target.addDynamicallyLegalOp<arith::ShRSIOp>([](arith::ShRSIOp rsOp) {
     auto srcType = dyn_cast<VectorType>(rsOp.getLhs().getType());
@@ -5176,19 +5181,21 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
     return laneSize * elWidth != 512;
   });
 
-  target.addDynamicallyLegalOp<arith::AndIOp>([](arith::AndIOp andOp) {
-    auto srcType = dyn_cast<VectorType>(andOp.getLhs().getType());
-    if (!srcType)
-      return true;
-    Type scalarType = srcType.getElementType();
-    if (!isa<IntegerType>(scalarType))
-      return true;
+  if (backend == TargetBackend::CPP) {
+    target.addDynamicallyLegalOp<arith::AndIOp>([](arith::AndIOp andOp) {
+      auto srcType = dyn_cast<VectorType>(andOp.getLhs().getType());
+      if (!srcType)
+        return true;
+      Type scalarType = srcType.getElementType();
+      if (!isa<IntegerType>(scalarType))
+        return true;
 
-    unsigned laneSize = getVectorLaneSize(srcType);
-    unsigned elWidth = scalarType.getIntOrFloatBitWidth();
+      unsigned laneSize = getVectorLaneSize(srcType);
+      unsigned elWidth = scalarType.getIntOrFloatBitWidth();
 
-    return laneSize * elWidth != 512;
-  });
+      return laneSize * elWidth != 512;
+    });
+  }
 
   if (backend == TargetBackend::CPP) {
     target.addDynamicallyLegalOp<arith::AddIOp>(

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3904,7 +3904,6 @@ struct ComputeBxorAndBnegOpPattern : OpConversionPattern<arith::XOrIOp> {
     if (laneSize * elWidth != 512)
       return failure();
 
-    // Operands may be block arguments (no defining op); guard before casting.
     auto lhsConstOp = xorOp.getLhs().getDefiningOp<arith::ConstantOp>();
     auto rhsConstOp = xorOp.getRhs().getDefiningOp<arith::ConstantOp>();
 
@@ -4683,10 +4682,7 @@ populateAIEVecV2CommonConversionPatterns(RewritePatternSet &patterns,
         LowerVectorSubFOpToAIEVecSubElemOp,
         LowerVectorAddIOpToAIEVecAddElemOp,
         LowerVectorSubIOpToAIEVecSubElemOp,
-        // Bitwise vector arith → aievec.{bxor,bor,band,bneg} only on CPP:
-        // AIEVecToLLVM has no lowering for those aievec ops, and AIE2/AIE2P
-        // legalize standard G_AND/G_OR/G_XOR on every vector type, so the
-        // LLVMIR path takes the standard arith→llvm route instead.
+        // CPP-only: AIEVecToLLVM has no lowering for aievec.{bxor,bor,band}.
         ComputeBxorAndBnegOpPattern,
         ComputeBorOpPattern,
         ComputeBandOpPattern
@@ -5125,14 +5121,8 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
     return laneSize != 16;
   });
 
-  // Only convert bitwise vector ops to aievec.{bxor,bor,band,bneg} on the
-  // CPP (chess) backend. AIEVecToLLVM has no lowering for those aievec ops,
-  // and AIE2/AIE2P legalize standard G_AND/G_OR/G_XOR on every vector type,
-  // so the LLVMIR path takes the standard arith→llvm route instead.
+  // CPP-only: rewrite 512-bit int vector arith.{andi,ori,xori} to aievec.
   if (backend == TargetBackend::CPP) {
-    // Shared predicate for arith.{andi,ori,xori}: illegal iff the operands
-    // are a 512-bit integer vector (then a aievec.{band,bor,bxor} pattern
-    // takes over). Anything else stays legal.
     auto isNon512BitIntVecBitwiseOp = [](Operation *op) {
       auto srcType = dyn_cast<VectorType>(op->getOperand(0).getType());
       if (!srcType)

--- a/test/Conversion/VectorToAIEVec/test-bitwise-backend.mlir
+++ b/test/Conversion/VectorToAIEVec/test-bitwise-backend.mlir
@@ -1,17 +1,21 @@
-// On the CPP (chess) backend, 512-bit integer vector arith.{andi,ori,xori}
-// must be lowered to aievec.{band,bor,bxor}, which the chess emitter knows
-// how to print. On the LLVMIR (Peano) backend, AIEVecToLLVM has no lowering
-// for those aievec ops -- the standard arith→llvm route handles vector AND/OR/XOR
-// natively -- so the arith ops must remain illegal-targeted only on CPP and
-// pass through unchanged on LLVMIR.
+//===- test-bitwise-backend.mlir - bitwise vector legalization per backend -*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// 512-bit integer vector arith.{andi,ori,xori} → aievec.{band,bor,bxor} only on
+// the CPP (chess) backend; on the LLVMIR (Peano) backend the arith ops must
+// pass through unchanged.
 
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=cpp" \
 // RUN:   | FileCheck %s --check-prefix=CPP
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=llvmir" \
 // RUN:   | FileCheck %s --check-prefix=LLVM
-// AIE2P/LLVMIR is the path the original failure was reported on -- exercise
-// it explicitly so the legalization regression cannot be silently
-// reintroduced.
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" \
 // RUN:   | FileCheck %s --check-prefix=LLVM
 // RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" \
@@ -51,7 +55,7 @@ func.func @vec_xori_512(%a: vector<16xi32>, %b: vector<16xi32>) -> vector<16xi32
   return %r : vector<16xi32>
 }
 
-// Non-512-bit vectors stay legal on both backends (no aievec promotion).
+// Non-512-bit vectors and scalars stay legal on both backends.
 
 // CPP-LABEL: func @vec_andi_256(
 // LLVM-LABEL: func @vec_andi_256(
@@ -64,8 +68,6 @@ func.func @vec_andi_256(%a: vector<8xi32>, %b: vector<8xi32>) -> vector<8xi32> {
   return %r : vector<8xi32>
 }
 
-// Scalar bitwise ops are unaffected on both backends.
-
 // CPP-LABEL: func @scalar_andi(
 // LLVM-LABEL: func @scalar_andi(
 func.func @scalar_andi(%a: i32, %b: i32) -> i32 {
@@ -77,9 +79,6 @@ func.func @scalar_andi(%a: i32, %b: i32) -> i32 {
   return %r : i32
 }
 
-// Belt-and-braces global check for the AIE2P/LLVMIR run: no aievec.{band,bor,
-// bxor,bneg} ops anywhere in the output. Anchored by the file-level CHECK so
-// FileCheck won't claim vacuous success.
 // NO-BITWISE-AIEVEC: module
 // NO-BITWISE-AIEVEC-NOT: aievec.band
 // NO-BITWISE-AIEVEC-NOT: aievec.bor

--- a/test/Conversion/VectorToAIEVec/test-bitwise-backend.mlir
+++ b/test/Conversion/VectorToAIEVec/test-bitwise-backend.mlir
@@ -1,0 +1,87 @@
+// On the CPP (chess) backend, 512-bit integer vector arith.{andi,ori,xori}
+// must be lowered to aievec.{band,bor,bxor}, which the chess emitter knows
+// how to print. On the LLVMIR (Peano) backend, AIEVecToLLVM has no lowering
+// for those aievec ops -- the standard arith→llvm route handles vector AND/OR/XOR
+// natively -- so the arith ops must remain illegal-targeted only on CPP and
+// pass through unchanged on LLVMIR.
+
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=cpp" \
+// RUN:   | FileCheck %s --check-prefix=CPP
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=llvmir" \
+// RUN:   | FileCheck %s --check-prefix=LLVM
+// AIE2P/LLVMIR is the path the original failure was reported on -- exercise
+// it explicitly so the legalization regression cannot be silently
+// reintroduced.
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" \
+// RUN:   | FileCheck %s --check-prefix=LLVM
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" \
+// RUN:   | FileCheck %s --check-prefix=NO-BITWISE-AIEVEC
+
+// CPP-LABEL: func @vec_andi_512(
+// CPP-SAME:    %[[LHS:.*]]: vector<16xi32>,
+// CPP-SAME:    %[[RHS:.*]]: vector<16xi32>)
+// LLVM-LABEL: func @vec_andi_512(
+func.func @vec_andi_512(%a: vector<16xi32>, %b: vector<16xi32>) -> vector<16xi32> {
+  // CPP:  %[[R:.*]] = aievec.band %[[LHS]], %[[RHS]] : vector<16xi32>
+  // CPP:  return %[[R]]
+  // LLVM-NOT: aievec.band
+  // LLVM:  %[[R:.*]] = arith.andi %{{.*}}, %{{.*}} : vector<16xi32>
+  // LLVM:  return %[[R]]
+  %r = arith.andi %a, %b : vector<16xi32>
+  return %r : vector<16xi32>
+}
+
+// CPP-LABEL: func @vec_ori_512(
+// LLVM-LABEL: func @vec_ori_512(
+func.func @vec_ori_512(%a: vector<16xi32>, %b: vector<16xi32>) -> vector<16xi32> {
+  // CPP:  aievec.bor %{{.*}}, %{{.*}} : vector<16xi32>
+  // LLVM-NOT: aievec.bor
+  // LLVM:  arith.ori %{{.*}}, %{{.*}} : vector<16xi32>
+  %r = arith.ori %a, %b : vector<16xi32>
+  return %r : vector<16xi32>
+}
+
+// CPP-LABEL: func @vec_xori_512(
+// LLVM-LABEL: func @vec_xori_512(
+func.func @vec_xori_512(%a: vector<16xi32>, %b: vector<16xi32>) -> vector<16xi32> {
+  // CPP:  aievec.bxor %{{.*}}, %{{.*}} : vector<16xi32>
+  // LLVM-NOT: aievec.bxor
+  // LLVM:  arith.xori %{{.*}}, %{{.*}} : vector<16xi32>
+  %r = arith.xori %a, %b : vector<16xi32>
+  return %r : vector<16xi32>
+}
+
+// Non-512-bit vectors stay legal on both backends (no aievec promotion).
+
+// CPP-LABEL: func @vec_andi_256(
+// LLVM-LABEL: func @vec_andi_256(
+func.func @vec_andi_256(%a: vector<8xi32>, %b: vector<8xi32>) -> vector<8xi32> {
+  // CPP-NOT: aievec.band
+  // LLVM-NOT: aievec.band
+  // CPP:  arith.andi %{{.*}}, %{{.*}} : vector<8xi32>
+  // LLVM: arith.andi %{{.*}}, %{{.*}} : vector<8xi32>
+  %r = arith.andi %a, %b : vector<8xi32>
+  return %r : vector<8xi32>
+}
+
+// Scalar bitwise ops are unaffected on both backends.
+
+// CPP-LABEL: func @scalar_andi(
+// LLVM-LABEL: func @scalar_andi(
+func.func @scalar_andi(%a: i32, %b: i32) -> i32 {
+  // CPP-NOT: aievec.band
+  // LLVM-NOT: aievec.band
+  // CPP:  arith.andi %{{.*}}, %{{.*}} : i32
+  // LLVM: arith.andi %{{.*}}, %{{.*}} : i32
+  %r = arith.andi %a, %b : i32
+  return %r : i32
+}
+
+// Belt-and-braces global check for the AIE2P/LLVMIR run: no aievec.{band,bor,
+// bxor,bneg} ops anywhere in the output. Anchored by the file-level CHECK so
+// FileCheck won't claim vacuous success.
+// NO-BITWISE-AIEVEC: module
+// NO-BITWISE-AIEVEC-NOT: aievec.band
+// NO-BITWISE-AIEVEC-NOT: aievec.bor
+// NO-BITWISE-AIEVEC-NOT: aievec.bxor
+// NO-BITWISE-AIEVEC-NOT: aievec.bneg


### PR DESCRIPTION
## Summary

The lowering of vector `arith.andi/ori/xori` (at 512 bits) to `aievec.{band,bor,bxor}` is only useful for the chess C++ emitter (`TranslateAIEVecToCpp.cpp:1763`). The Peano LLVM path has no `aievec.band/bor/bxor` → `llvm` pattern in `AIEVecToLLVM.cpp`, and the conversion target marks every `aievec` op illegal:

```cpp
target.addIllegalDialect<xilinx::aievec::AIEVecDialect, ...>();
```

So any 512-bit vector `arith.andi` (e.g. `vector<16xi32>`) that runs through the LLVM/Peano flow currently fails with:

```
failed to legalize operation 'aievec.band' that was explicitly marked illegal:
  %25 = "aievec.band"(%24, %7) : (vector<16xi32>, vector<16xi32>) -> vector<16xi32>
```

even though Peano's AIE2/AIE2P GISel legalizer lists `G_AND`/`G_OR` as legal on every AIE2P vector type ([`AIE2PLegalizerInfo.cpp:272`](https://github.com/Xilinx/llvm-aie/blob/main/llvm/lib/Target/AIE/aie2p/AIE2PLegalizerInfo.cpp#L272)). The `aievec.band` detour is unnecessary on that path — leaving the `arith.andi` alone lets it lower via the standard arith → `llvm.and` route to a native vector AND.

This PR wraps the legality predicates for `arith.{andi,ori,xori}` with `if (backend == TargetBackend::CPP)`, mirroring the existing pattern for `arith.addi` just below. No behavioral change for the chess flow; the LLVM/Peano flow now compiles vector bitwise ops cleanly.

## Test plan

- [x] Regression run on a vector-bitwise-touching workload (attention_decode in mlir-air): PASS, no perf change
- [x] Standalone repro for the previously-failing pattern (`vector<16xi32>` `arith.andi`): no longer triggers `aievec.band illegal`
- [ ] CI (full LIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)