### PR TITLE
[VectorToAIEVec] Scalarize vector int<->fp conversions for LLVMIR backend

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -5263,19 +5263,26 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
 
   // AIE2/AIE2P GISel legalize only the scalar form of int<->fp conversions
   // (libcalls). Vector forms have no legalizer rule and abort with
-  // "unable to legalize G_SITOFP <N x sX>". Mark vector forms illegal here
-  // so the ScalarizeVectorIntFpConversionOpPattern handles them. The
-  // scalarize pattern emits vector.extract / vector.insert / scalar conv
-  // sequences, so those ops must be legal too.
+  // "unable to legalize G_SITOFP <N x sX>". Mark the vector forms that
+  // ScalarizeVectorIntFpConversionOpPattern can rewrite (1-D vectors) as
+  // illegal so the pattern fires. Scalar and >1-D vector forms stay legal:
+  // scalar reaches the supported libcall path directly, and >1-D forms
+  // pass through to surface a clearer error from a later stage instead of
+  // aborting this conversion. The scalarize pattern emits vector.extract /
+  // vector.insert / scalar conv sequences, so those ops must be legal too.
   if (backend == TargetBackend::LLVMIR) {
+    auto isRank1Vector = [](Type t) {
+      auto vt = dyn_cast<VectorType>(t);
+      return vt && vt.getRank() == 1;
+    };
     target.addDynamicallyLegalOp<arith::SIToFPOp>(
-        [](arith::SIToFPOp op) { return !isa<VectorType>(op.getType()); });
+        [=](arith::SIToFPOp op) { return !isRank1Vector(op.getType()); });
     target.addDynamicallyLegalOp<arith::UIToFPOp>(
-        [](arith::UIToFPOp op) { return !isa<VectorType>(op.getType()); });
+        [=](arith::UIToFPOp op) { return !isRank1Vector(op.getType()); });
     target.addDynamicallyLegalOp<arith::FPToSIOp>(
-        [](arith::FPToSIOp op) { return !isa<VectorType>(op.getType()); });
+        [=](arith::FPToSIOp op) { return !isRank1Vector(op.getType()); });
     target.addDynamicallyLegalOp<arith::FPToUIOp>(
-        [](arith::FPToUIOp op) { return !isa<VectorType>(op.getType()); });
+        [=](arith::FPToUIOp op) { return !isRank1Vector(op.getType()); });
     target.addLegalOp<vector::ExtractOp, vector::InsertOp>();
   }
 }

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3477,6 +3477,60 @@ struct LowerExtOpPattern : OpConversionPattern<SrcOpTy> {
 using LowerExtFOpPattern = LowerExtOpPattern<arith::ExtFOp>;
 using LowerExtSIOpPattern = LowerExtOpPattern<arith::ExtSIOp>;
 
+// Scalarize a vector arith int<->fp conversion (sitofp / uitofp / fptosi /
+// fptoui). The AIE2/AIE2P GISel legalizers only handle the scalar form of
+// these conversions (libcalls); there is no vector int<->fp instruction.
+// Vector forms reach the legalizer as G_SITOFP/G_FPTOSI on a vector type
+// and abort with "unable to legalize". Lower the vector form here into
+// per-lane extract -> scalar conversion -> insert so each lane goes through
+// the supported scalar path.
+template <typename SrcOpTy>
+struct ScalarizeVectorIntFpConversionOpPattern : OpConversionPattern<SrcOpTy> {
+  using OpConversionPattern<SrcOpTy>::OpConversionPattern;
+  using OpAdaptor = typename SrcOpTy::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(SrcOpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto srcType = dyn_cast<VectorType>(adaptor.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(op.getType());
+    if (!srcType || !dstType)
+      return failure(); // already scalar — let the standard path handle it
+    if (srcType.getRank() != 1 || dstType.getRank() != 1)
+      return failure(); // conservative: 1-D vectors only
+    if (srcType.getNumElements() != dstType.getNumElements())
+      return failure();
+
+    Location loc = op.getLoc();
+    Type scalarDstTy = dstType.getElementType();
+    int64_t lanes = srcType.getNumElements();
+
+    // Seed result with a zero vector of the destination type.
+    Value result = arith::ConstantOp::create(rewriter, loc, dstType,
+                                             rewriter.getZeroAttr(dstType));
+
+    for (int64_t i = 0; i < lanes; ++i) {
+      Value scalar = vector::ExtractOp::create(rewriter, loc, adaptor.getIn(),
+                                               ArrayRef<int64_t>{i});
+      Value cvt = SrcOpTy::create(rewriter, loc, scalarDstTy, scalar);
+      result = vector::InsertOp::create(rewriter, loc, cvt, result,
+                                        ArrayRef<int64_t>{i});
+    }
+
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+using ScalarizeVectorSIToFPOpPattern =
+    ScalarizeVectorIntFpConversionOpPattern<arith::SIToFPOp>;
+using ScalarizeVectorUIToFPOpPattern =
+    ScalarizeVectorIntFpConversionOpPattern<arith::UIToFPOp>;
+using ScalarizeVectorFPToSIOpPattern =
+    ScalarizeVectorIntFpConversionOpPattern<arith::FPToSIOp>;
+using ScalarizeVectorFPToUIOpPattern =
+    ScalarizeVectorIntFpConversionOpPattern<arith::FPToUIOp>;
+
 template <typename SrcOpTy>
 struct LowerTruncOpPattern : OpConversionPattern<SrcOpTy> {
   using OpConversionPattern<SrcOpTy>::OpConversionPattern;
@@ -4685,10 +4739,16 @@ populateAIEVecV2CommonConversionPatterns(RewritePatternSet &patterns,
         LowerVectorAddIOpToAIEVecAddElemOp,
         LowerVectorSubIOpToAIEVecSubElemOp
       >(patterns.getContext());
-  } else if (backend == TargetBackend::LLVMIR){
-      patterns.add<
-      LowerVectorAddFOpToAIEVecAddElemOp,
-      LowerVectorSubFOpToAIEVecSubElemOp
+  } else if (backend == TargetBackend::LLVMIR) {
+    patterns.add<
+        LowerVectorAddFOpToAIEVecAddElemOp,
+        LowerVectorSubFOpToAIEVecSubElemOp,
+        // AIE2/AIE2P have no vector int<->fp instruction; scalarize so each
+        // lane reaches the supported scalar libcall path.
+        ScalarizeVectorSIToFPOpPattern,
+        ScalarizeVectorUIToFPOpPattern,
+        ScalarizeVectorFPToSIOpPattern,
+        ScalarizeVectorFPToUIOpPattern
       >(patterns.getContext());
   }
   // Add the compound shift+clamp+trunc→SRS pattern with higher benefit
@@ -5200,6 +5260,24 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
       [](arith::SubIOp op) { return !isa<VectorType>(op.getType()); });
   target.addDynamicallyLegalOp<arith::SubFOp>(
       [](arith::SubFOp op) { return !isa<VectorType>(op.getType()); });
+
+  // AIE2/AIE2P GISel legalize only the scalar form of int<->fp conversions
+  // (libcalls). Vector forms have no legalizer rule and abort with
+  // "unable to legalize G_SITOFP <N x sX>". Mark vector forms illegal here
+  // so the ScalarizeVectorIntFpConversionOpPattern handles them. The
+  // scalarize pattern emits vector.extract / vector.insert / scalar conv
+  // sequences, so those ops must be legal too.
+  if (backend == TargetBackend::LLVMIR) {
+    target.addDynamicallyLegalOp<arith::SIToFPOp>(
+        [](arith::SIToFPOp op) { return !isa<VectorType>(op.getType()); });
+    target.addDynamicallyLegalOp<arith::UIToFPOp>(
+        [](arith::UIToFPOp op) { return !isa<VectorType>(op.getType()); });
+    target.addDynamicallyLegalOp<arith::FPToSIOp>(
+        [](arith::FPToSIOp op) { return !isa<VectorType>(op.getType()); });
+    target.addDynamicallyLegalOp<arith::FPToUIOp>(
+        [](arith::FPToUIOp op) { return !isa<VectorType>(op.getType()); });
+    target.addLegalOp<vector::ExtractOp, vector::InsertOp>();
+  }
 }
 
 static void configureAIEVecV1Legalizations(ConversionTarget &target,

--- a/test/Conversion/VectorToAIEVec/test-scalarize-int-fp-conv.mlir
+++ b/test/Conversion/VectorToAIEVec/test-scalarize-int-fp-conv.mlir
@@ -1,0 +1,103 @@
+//===- test-scalarize-int-fp-conv.mlir -----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// Verify that vector forms of arith.{sitofp,uitofp,fptosi,fptoui} are
+// scalarized into per-lane {vector.extract -> scalar conv -> reassemble}
+// for the LLVMIR backend (AIE2 and AIE2P), and left untouched for the
+// CPP backend or for scalar inputs.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p target-backend=llvmir" | FileCheck %s --check-prefixes=CHECK,LLVMIR
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=llvmir"  | FileCheck %s --check-prefixes=CHECK,LLVMIR
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2 target-backend=cpp"     | FileCheck %s --check-prefixes=CHECK,CPP
+
+// -----------------------------------------------------------------------------
+// fptosi: vector<16xbf16> -> vector<16xi32>  (the motivating mask use case)
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func @vec_fptosi_bf16_i32(
+// CHECK-SAME:    %[[A:.*]]: vector<16xbf16>
+func.func @vec_fptosi_bf16_i32(%a: vector<16xbf16>) -> vector<16xi32> {
+  // LLVMIR: %[[E0:.*]] = vector.extract %[[A]][0] : bf16 from vector<16xbf16>
+  // LLVMIR: %[[C0:.*]] = arith.fptosi %[[E0]] : bf16 to i32
+  // LLVMIR: %[[E15:.*]] = vector.extract %[[A]][15] : bf16 from vector<16xbf16>
+  // LLVMIR: %[[C15:.*]] = arith.fptosi %[[E15]] : bf16 to i32
+  // LLVMIR: %[[R:.*]] = vector.from_elements {{.*}} : vector<16xi32>
+  // LLVMIR: return %[[R]] : vector<16xi32>
+  // CPP: %[[R:.*]] = arith.fptosi %[[A]] : vector<16xbf16> to vector<16xi32>
+  // CPP: return %[[R]] : vector<16xi32>
+  %0 = arith.fptosi %a : vector<16xbf16> to vector<16xi32>
+  return %0 : vector<16xi32>
+}
+
+// -----------------------------------------------------------------------------
+// fptoui: vector<8xf32> -> vector<8xi32>
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func @vec_fptoui_f32_i32(
+// CHECK-SAME:    %[[A:.*]]: vector<8xf32>
+func.func @vec_fptoui_f32_i32(%a: vector<8xf32>) -> vector<8xi32> {
+  // LLVMIR-COUNT-8: arith.fptoui %{{.*}} : f32 to i32
+  // LLVMIR: vector.from_elements {{.*}} : vector<8xi32>
+  // CPP: arith.fptoui %[[A]] : vector<8xf32> to vector<8xi32>
+  %0 = arith.fptoui %a : vector<8xf32> to vector<8xi32>
+  return %0 : vector<8xi32>
+}
+
+// -----------------------------------------------------------------------------
+// sitofp: vector<8xi32> -> vector<8xf32>
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func @vec_sitofp_i32_f32(
+// CHECK-SAME:    %[[A:.*]]: vector<8xi32>
+func.func @vec_sitofp_i32_f32(%a: vector<8xi32>) -> vector<8xf32> {
+  // LLVMIR-COUNT-8: arith.sitofp %{{.*}} : i32 to f32
+  // LLVMIR: vector.from_elements {{.*}} : vector<8xf32>
+  // CPP: arith.sitofp %[[A]] : vector<8xi32> to vector<8xf32>
+  %0 = arith.sitofp %a : vector<8xi32> to vector<8xf32>
+  return %0 : vector<8xf32>
+}
+
+// -----------------------------------------------------------------------------
+// uitofp: vector<8xi32> -> vector<8xf32>
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func @vec_uitofp_i32_f32(
+// CHECK-SAME:    %[[A:.*]]: vector<8xi32>
+func.func @vec_uitofp_i32_f32(%a: vector<8xi32>) -> vector<8xf32> {
+  // LLVMIR-COUNT-8: arith.uitofp %{{.*}} : i32 to f32
+  // LLVMIR: vector.from_elements {{.*}} : vector<8xf32>
+  // CPP: arith.uitofp %[[A]] : vector<8xi32> to vector<8xf32>
+  %0 = arith.uitofp %a : vector<8xi32> to vector<8xf32>
+  return %0 : vector<8xf32>
+}
+
+// -----------------------------------------------------------------------------
+// Scalar form must pass through untouched on every backend.
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func @scalar_fptosi(
+// CHECK-SAME:    %[[A:.*]]: bf16
+func.func @scalar_fptosi(%a: bf16) -> i32 {
+  // CHECK-NEXT: %[[R:.*]] = arith.fptosi %[[A]] : bf16 to i32
+  // CHECK-NEXT: return %[[R]] : i32
+  %0 = arith.fptosi %a : bf16 to i32
+  return %0 : i32
+}
+
+// -----------------------------------------------------------------------------
+// Multi-dimensional vector forms are out of scope for the scalarize pattern.
+// They must pass through this conversion unchanged (clearer failure later)
+// rather than aborting here as "explicitly marked illegal".
+// -----------------------------------------------------------------------------
+// CHECK-LABEL: func @vec_2d_fptosi_passthrough(
+// CHECK-SAME:    %[[A:.*]]: vector<2x4xf32>
+func.func @vec_2d_fptosi_passthrough(%a: vector<2x4xf32>) -> vector<2x4xi32> {
+  // CHECK-NEXT: %[[R:.*]] = arith.fptosi %[[A]] : vector<2x4xf32> to vector<2x4xi32>
+  // CHECK-NEXT: return %[[R]] : vector<2x4xi32>
+  %0 = arith.fptosi %a : vector<2x4xf32> to vector<2x4xi32>
+  return %0 : vector<2x4xi32>
+}


### PR DESCRIPTION
## Summary

The AIE2/AIE2P GISel legalizers in [llvm-aie](https://github.com/Xilinx/llvm-aie) only handle the **scalar** form of \`arith.sitofp/uitofp/fptosi/fptoui\` (libcalls); there is no vector int<->fp instruction or intrinsic on either AIE2 or AIE2P. Vector forms reach the legalizer as e.g. \`G_SITOFP <16 x s32> -> <16 x s16>\` and abort with \`unable to legalize\`.

This PR adds a \`ScalarizeVectorIntFpConversionOpPattern\` that, for the LLVMIR target backend, expands a vector \`arith\` int<->fp conversion into per-lane \`{vector.extract -> scalar conversion -> vector.insert}\`. Each scalar lane goes through the supported scalar libcall path on both AIE2 and AIE2P. Mark vector forms of the four conversion ops illegal for LLVMIR so the pattern fires; mark \`vector.extract\`/\`vector.insert\` legal so the scalarized form is accepted by the target. CPP backend behavior is unchanged.

This unblocks user-side code that builds masks from per-lane bf16 values via \`fptosi\` -> bitwise -> \`select\` (e.g. an inline-MLIR sin/cos polynomial that needs per-lane quadrant detection).

## Test plan

- [x] Direct \`aie-opt --lower-vector-to-aievec=\"aie-target=aie2p target-backend=llvmir\"\` on a vector arith.fptosi: produces 16x{vector.extract + scalar arith.fptosi}
- [x] Per-lane scalar bf16 -> f32 -> i32 round-trip e2e (mlir-air \`check_scalar_sitofp.py\`): lowered ELF runs correctly on AIE2P NPU
- [x] Full mask-construction sequence (fptosi + andi + cmpi + select) end-to-end on AIE2P NPU: PASS (with #3057 also applied to unblock the bitwise op)
- [x] mlir-air \`programming_examples/attention_decode\` regression: PASS, no perf change
- [ ] CI (full LIT)

## Notes

Stacked behind / complements #3057 (which fixes the related vector \`arith.andi\` -> \`aievec.band\` blocker). Either PR can land first; in combination they let user code do per-lane integer-mask construction in inline MLIR on Peano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)