### PR TITLE
[AIEPlacer] Fix swap-based search for partial-constraint compute tiles

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -217,8 +217,9 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       bool sawConstraintMatch = false;
       bool allConstraintMatchesFailedAdjacency = true;
 
+      // compTiles stays sorted column-major / ascending-row, so the first
+      // match is the lowest-row tile in the requested column.
       for (const TileID &candidate : availability.compTiles) {
-        // Check partial constraints
         if (col && candidate.col != *col)
           continue;
         if (row && candidate.row != *row)
@@ -231,15 +232,6 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
         if (!satisfiesAdjacency(logicalTile, candidate, cascadeAdjacency,
                                 cascadePred))
           continue;
-
-        // Found valid tile. Walk the array in sort order (column-major,
-        // ascending row within column) so the first match is the
-        // lowest-row tile in the requested column. The previous
-        // swap-to-front scheme could displace lower-row candidates past
-        // a moving cursor and produce non-contiguous row placement when
-        // partial-constraint hints interleaved columns. The chosen tile
-        // is removed from availability after channel validation, mirroring
-        // the fully-constrained path above.
         placement = candidate;
         break;
       }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -177,7 +177,6 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
   };
 
   // Phase 3: Place constrained tiles then compute tiles
-  size_t nextCompIdx = 0;
   for (auto logicalTile : logicalTiles) {
     // Place fully constrained tiles at their specified coordinates
     auto col = logicalTile.tryGetCol();
@@ -218,9 +217,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       bool sawConstraintMatch = false;
       bool allConstraintMatchesFailedAdjacency = true;
 
-      for (size_t i = nextCompIdx; i < availability.compTiles.size(); ++i) {
-        TileID candidate = availability.compTiles[i];
-
+      for (TileID candidate : availability.compTiles) {
         // Check partial constraints
         if (col && candidate.col != *col)
           continue;
@@ -235,12 +232,18 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
                                 cascadePred))
           continue;
 
-        // Found valid tile - swap to nextCompIdx position and use
-        std::swap(availability.compTiles[i],
-                  availability.compTiles[nextCompIdx]);
-        placement = availability.compTiles[nextCompIdx++];
+        // Found valid tile. Walk the array in sort order (column-major,
+        // ascending row within column) so the first match is the
+        // lowest-row tile in the requested column. Remove from
+        // availability to prevent re-allocation; the previous
+        // swap-to-front scheme could displace lower-row candidates past
+        // a moving cursor and produce non-contiguous row placement when
+        // partial-constraint hints interleaved columns.
+        placement = candidate;
         break;
       }
+      if (placement)
+        availability.removeTile(*placement, AIETileType::CoreTile);
 
       if (!placement) {
         bool adjacencyWasCause =

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -217,7 +217,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
       bool sawConstraintMatch = false;
       bool allConstraintMatchesFailedAdjacency = true;
 
-      for (TileID candidate : availability.compTiles) {
+      for (const TileID &candidate : availability.compTiles) {
         // Check partial constraints
         if (col && candidate.col != *col)
           continue;
@@ -234,16 +234,15 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
 
         // Found valid tile. Walk the array in sort order (column-major,
         // ascending row within column) so the first match is the
-        // lowest-row tile in the requested column. Remove from
-        // availability to prevent re-allocation; the previous
+        // lowest-row tile in the requested column. The previous
         // swap-to-front scheme could displace lower-row candidates past
         // a moving cursor and produce non-contiguous row placement when
-        // partial-constraint hints interleaved columns.
+        // partial-constraint hints interleaved columns. The chosen tile
+        // is removed from availability after channel validation, mirroring
+        // the fully-constrained path above.
         placement = candidate;
         break;
       }
-      if (placement)
-        availability.removeTile(*placement, AIETileType::CoreTile);
 
       if (!placement) {
         bool adjacencyWasCause =
@@ -277,6 +276,7 @@ LogicalResult SequentialPlacer::place(DeviceOp device) {
         return failure();
 
       result[logicalTile] = *placement;
+      availability.removeTile(*placement, AIETileType::CoreTile);
     }
 
     if (logicalTile.getTileType() == AIETileType::ShimPLTile) {

--- a/test/place-tiles/sequential_placer/test_place_basic.mlir
+++ b/test/place-tiles/sequential_placer/test_place_basic.mlir
@@ -204,3 +204,105 @@ module @shimtile_col_constraint {
     // CHECK-NOT: aie.logical_tile
   }
 }
+
+// -----
+
+// Interleaved partial-column hints across two columns must produce
+// row-contiguous packing per column. Regression test for a swap-to-front
+// search bug that could leak (col, row+1) candidates past a moving cursor
+// and place at (col, row+2) instead.
+// CHECK-LABEL: @interleaved_partial_cols_2x2
+module @interleaved_partial_cols_2x2 {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    // CHECK-DAG: aie.tile(1, 2)
+    // CHECK-DAG: aie.tile(0, 3)
+    // CHECK-DAG: aie.tile(1, 3)
+    // CHECK-NOT: aie.tile(0, 4)
+    // CHECK-NOT: aie.tile(1, 4)
+    %t1 = aie.logical_tile<CoreTile>(0, ?)
+    %t2 = aie.logical_tile<CoreTile>(1, ?)
+    %t3 = aie.logical_tile<CoreTile>(0, ?)
+    %t4 = aie.logical_tile<CoreTile>(1, ?)
+    aie.core(%t1) { aie.end }
+    aie.core(%t2) { aie.end }
+    aie.core(%t3) { aie.end }
+    aie.core(%t4) { aie.end }
+  }
+}
+
+// -----
+
+// Generalizes the 2-column case to three columns: requests are issued in
+// row-major order across columns, and each column must pack from row 2 up.
+// CHECK-LABEL: @interleaved_partial_cols_3x2
+module @interleaved_partial_cols_3x2 {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    // CHECK-DAG: aie.tile(1, 2)
+    // CHECK-DAG: aie.tile(2, 2)
+    // CHECK-DAG: aie.tile(0, 3)
+    // CHECK-DAG: aie.tile(1, 3)
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-NOT: aie.tile({{.*}}, 4)
+    %t1 = aie.logical_tile<CoreTile>(0, ?)
+    %t2 = aie.logical_tile<CoreTile>(1, ?)
+    %t3 = aie.logical_tile<CoreTile>(2, ?)
+    %t4 = aie.logical_tile<CoreTile>(0, ?)
+    %t5 = aie.logical_tile<CoreTile>(1, ?)
+    %t6 = aie.logical_tile<CoreTile>(2, ?)
+    aie.core(%t1) { aie.end }
+    aie.core(%t2) { aie.end }
+    aie.core(%t3) { aie.end }
+    aie.core(%t4) { aie.end }
+    aie.core(%t5) { aie.end }
+    aie.core(%t6) { aie.end }
+  }
+}
+
+// -----
+
+// Column visit order in the request stream should not affect per-column
+// packing. Requesting col 2 before col 0 still packs each column from row 2.
+// CHECK-LABEL: @interleaved_partial_cols_out_of_order
+module @interleaved_partial_cols_out_of_order {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(2, 2)
+    // CHECK-DAG: aie.tile(0, 2)
+    // CHECK-DAG: aie.tile(2, 3)
+    // CHECK-DAG: aie.tile(0, 3)
+    // CHECK-NOT: aie.tile({{.*}}, 4)
+    %t1 = aie.logical_tile<CoreTile>(2, ?)
+    %t2 = aie.logical_tile<CoreTile>(0, ?)
+    %t3 = aie.logical_tile<CoreTile>(2, ?)
+    %t4 = aie.logical_tile<CoreTile>(0, ?)
+    aie.core(%t1) { aie.end }
+    aie.core(%t2) { aie.end }
+    aie.core(%t3) { aie.end }
+    aie.core(%t4) { aie.end }
+  }
+}
+
+// -----
+
+// Interleaved partial-column requests followed by a fully constrained tile
+// in one of the same columns. The partial path runs first and must still
+// pack contiguously; the fully constrained tile then occupies its exact slot.
+// CHECK-LABEL: @mixed_partial_then_full
+module @mixed_partial_then_full {
+  aie.device(npu1) {
+    // CHECK-DAG: aie.tile(0, 2)
+    // CHECK-DAG: aie.tile(1, 2)
+    // CHECK-DAG: aie.tile(0, 3)
+    // CHECK-DAG: aie.tile(1, 3)
+    // CHECK-NOT: aie.tile(0, 4)
+    %t1 = aie.logical_tile<CoreTile>(0, ?)
+    %t2 = aie.logical_tile<CoreTile>(1, ?)
+    %t3 = aie.logical_tile<CoreTile>(0, ?)
+    %t4 = aie.logical_tile<CoreTile>(1, 3)
+    aie.core(%t1) { aie.end }
+    aie.core(%t2) { aie.end }
+    aie.core(%t3) { aie.end }
+    aie.core(%t4) { aie.end }
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_basic.mlir
+++ b/test/place-tiles/sequential_placer/test_place_basic.mlir
@@ -207,10 +207,7 @@ module @shimtile_col_constraint {
 
 // -----
 
-// Interleaved partial-column hints across two columns must produce
-// row-contiguous packing per column. Regression test for a swap-to-front
-// search bug that could leak (col, row+1) candidates past a moving cursor
-// and place at (col, row+2) instead.
+// Interleaved partial-column hints must pack contiguously per column.
 // CHECK-LABEL: @interleaved_partial_cols_2x2
 module @interleaved_partial_cols_2x2 {
   aie.device(npu1) {
@@ -233,8 +230,7 @@ module @interleaved_partial_cols_2x2 {
 
 // -----
 
-// Generalizes the 2-column case to three columns: requests are issued in
-// row-major order across columns, and each column must pack from row 2 up.
+// Three-column generalization.
 // CHECK-LABEL: @interleaved_partial_cols_3x2
 module @interleaved_partial_cols_3x2 {
   aie.device(npu1) {
@@ -262,8 +258,7 @@ module @interleaved_partial_cols_3x2 {
 
 // -----
 
-// Column visit order in the request stream should not affect per-column
-// packing. Requesting col 2 before col 0 still packs each column from row 2.
+// Request order across columns shouldn't affect per-column packing.
 // CHECK-LABEL: @interleaved_partial_cols_out_of_order
 module @interleaved_partial_cols_out_of_order {
   aie.device(npu1) {
@@ -285,9 +280,7 @@ module @interleaved_partial_cols_out_of_order {
 
 // -----
 
-// Interleaved partial-column requests followed by a fully constrained tile
-// in one of the same columns. The partial path runs first and must still
-// pack contiguously; the fully constrained tile then occupies its exact slot.
+// Partial requests interleaved with a fully constrained tile.
 // CHECK-LABEL: @mixed_partial_then_full
 module @mixed_partial_then_full {
   aie.device(npu1) {


### PR DESCRIPTION
## Summary

`SequentialPlacer`'s Phase 3 placed compute tiles with partial constraints (e.g. `(col, ?)`) by walking `availability.compTiles` from a moving `nextCompIdx` cursor, finding the first match, then swap-to-front. The swap could displace a lower-row candidate past `nextCompIdx`, after which the next request for the same column would skip it.

## Concrete failure

A 2x2 herd asking `[(0,?), (1,?), (0,?), (1,?)]`:

```
compTiles initially: [(0,2),(0,3),(0,4),(0,5),(1,2),(1,3),(1,4),(1,5)]
Place (0,?): use (0,2) at idx 0, nextCompIdx=1.
Place (1,?): walk to idx 4=(1,2), swap with idx 1, use (1,2).
  compTiles now: [(0,2),(1,2),(0,4),(0,5),(0,3),(1,3),(1,4),(1,5)]
  nextCompIdx=2.
Place (0,?): walk from idx 2, find (0,4) at idx 2. Use (0,4).
  BUG: (0,3) at idx 4 is the better match (lower row in col 0)
  but is past nextCompIdx and gets skipped.
Result: (0,2),(1,2),(0,4),(1,3) instead of (0,2),(1,2),(0,3),(1,3).
```

## Fix

Walk the full sorted vector from the start (it stays column-major ascending-row throughout), use the first match, and remove the placed tile via `removeTile`. The vector remains sorted; the next request sees the next-lowest-row candidate in its column. `nextCompIdx` is gone.

Walk cost is now O(N) per placement instead of O(N - nextCompIdx), but N is the device's compute tile count (tens) and the vector erase cost dominates regardless.

## Why now

Identical placements on existing \`test/place-tiles/\` lit suite (9/9). The bug only manifests with multi-column partial constraints, which existing tests don't exercise. This opens the door for AIR's RFC #1567 milestone 5 to emit \`(col, ?)\` compute-tile hints from \`outlineAIECores\` (Xilinx/mlir-air#1567).

## Test plan

- [x] \`check-aie\` passes (1267/1269; 2 unrelated pre-existing python failures missing pytest)
- [x] \`test/place-tiles/\` 9/9 (identical placements)
- [x] AIR's M5 PR exercises the new (col, ?) path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)