### PR TITLE
[AIEPlacer] Extend tile capacity check to search both directions

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -720,22 +720,26 @@ std::optional<TileID> SequentialPlacer::findTileWithCapacity(
     int requiredOutputChannels, AIETileType requestedType) {
   int maxCol = targetModel->columns();
 
-  // Search columns rightward
-  for (int offset = 0; offset < maxCol; ++offset) {
-    int searchCol = targetCol + offset;
-    if (searchCol >= maxCol)
-      continue;
-
-    for (auto &tile : tiles) {
-      AIETileType tileType = targetModel->getTileType(tile.col, tile.row);
-      if (tileType != requestedType)
+  // Search columns outward from targetCol bidirectionally
+  for (int offset = 0; targetCol + offset < maxCol || targetCol - offset >= 0;
+       ++offset) {
+    for (int dir : {1, -1}) {
+      int searchCol = targetCol + dir * offset;
+      if (dir == -1 && offset == 0)
+        continue; // don't search targetCol twice
+      if (searchCol < 0 || searchCol >= maxCol)
         continue;
 
-      if (tile.col == searchCol) {
-        // Check if tile has capacity for both input and output channels
-        if (hasAvailableChannels(tile, requiredInputChannels,
-                                 requiredOutputChannels)) {
-          return tile;
+      for (auto &tile : tiles) {
+        AIETileType tileType = targetModel->getTileType(tile.col, tile.row);
+        if (tileType != requestedType)
+          continue;
+
+        if (tile.col == searchCol) {
+          if (hasAvailableChannels(tile, requiredInputChannels,
+                                   requiredOutputChannels)) {
+            return tile;
+          }
         }
       }
     }

--- a/test/place-tiles/sequential_placer/test_place_objectfifo.mlir
+++ b/test/place-tiles/sequential_placer/test_place_objectfifo.mlir
@@ -327,6 +327,39 @@ module @memtile_partial_overflow {
 
 // -----
 
+// Channel overflow searches leftward when rightward columns are exhausted
+// CHECK-LABEL: @channel_overflow_leftward
+module @channel_overflow_leftward {
+  aie.device(npu1) {
+    // Cores in column 3 (last column on npu1, which has cols 0-3)
+    // CHECK-DAG: %[[CORE1:.*]] = aie.tile(3, 2)
+    %core1 = aie.logical_tile<CoreTile>(3, 2)
+    // CHECK-DAG: %[[CORE2:.*]] = aie.tile(3, 3)
+    %core2 = aie.logical_tile<CoreTile>(3, 3)
+    // CHECK-DAG: %[[CORE3:.*]] = aie.tile(3, 4)
+    %core3 = aie.logical_tile<CoreTile>(3, 4)
+
+    // First two shims merge to (3, 0), using 2 output channels
+    // CHECK-DAG: %[[SHIM1:.*]] = aie.tile(3, 0)
+    %shim1 = aie.logical_tile<ShimNOCTile>(?, ?)
+    %shim2 = aie.logical_tile<ShimNOCTile>(?, ?)
+    // Third shim overflows leftward to column 2 (no column 4 exists)
+    // CHECK-DAG: %[[SHIM2:.*]] = aie.tile(2, 0)
+    %shim3 = aie.logical_tile<ShimNOCTile>(?, ?)
+
+    aie.objectfifo @lof1 (%shim1, {%core1}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @lof2 (%shim2, {%core2}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @lof3 (%shim3, {%core3}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+
+    aie.core(%core1) { aie.end }
+    aie.core(%core2) { aie.end }
+    aie.core(%core3) { aie.end }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
 // Linked fifos: memtile placed at averaged column of connected cores
 // CHECK-LABEL: @linked_fifos_averaged_column
 module @linked_fifos_averaged_column {


### PR DESCRIPTION
## Summary
Design improvement to allow `findTileWithCapacity` to search both leftwards and rightwards, preferring the nearest column in either direction.

## Changes
`lib/Dialect/AIE/Transforms/AIEPlacer.cpp `                                                                                        
  - `findTileWithCapacity`: replaced the for (offset = 0; offset < maxCol; ++offset) rightward-only loop with a bidirectional loop
  that iterates over {+offset, -offset} at each step, skipping duplicates and out-of-bounds columns                                 
                                                                                                   
`test/place-tiles/sequential_placer/test_place_objectfifo.mlir `                                                               
  - Added `@channel_overflow_leftward`: 3 cores explicitly placed to column 3. 3 unplaced shims: first two merge to (3, 0) (with centroid logic), third overflows to (2, 0) since no column=4.
