### PR TITLE
Fix incorrect matmul output for small m on AIE2

### DIFF
--- a/aie_kernels/aie2/mm.cc
+++ b/aie_kernels/aie2/mm.cc
@@ -89,9 +89,11 @@ static inline void matmul_vectorized_2x2_mmul(const T_in *__restrict pA,
 
   event0();
 
-  AIE_PREPARE_FOR_PIPELINING
-  AIE_LOOP_MIN_ITERATION_COUNT(4)
-  for (unsigned z = 0; z < rowA; z += 2) {
+  // Outer-loop body factored into a lambda so the same code can be wrapped
+  // by three differently-parameterised loops below. Per-instantiation iter
+  // count must match the actual count: the clang loop pragma takes a literal
+  // and silently misbehaves on template-dependent expressions.
+  auto outer_body = [&](unsigned z) [[gnu::always_inline]] {
     T_out *__restrict pC1;
     T_out *__restrict pC2;
     if constexpr (c_row_maj) {
@@ -209,6 +211,24 @@ static inline void matmul_vectorized_2x2_mmul(const T_in *__restrict pA,
           pC2 += MMUL::size_C;
         }
       }
+  };
+
+  constexpr unsigned outer_iters = rowA / 2;
+  if constexpr (outer_iters >= 4) {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(4)
+    for (unsigned z = 0; z < rowA; z += 2)
+      outer_body(z);
+  } else if constexpr (outer_iters >= 2) {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(2)
+    for (unsigned z = 0; z < rowA; z += 2)
+      outer_body(z);
+  } else {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(1)
+    for (unsigned z = 0; z < rowA; z += 2)
+      outer_body(z);
   }
 
   event1();
@@ -230,9 +250,7 @@ static inline void matmul_vectorized_4x2_mmul(const T_in *__restrict pA,
 
   event0();
 
-  AIE_PREPARE_FOR_PIPELINING
-  AIE_LOOP_MIN_ITERATION_COUNT(4)
-  for (unsigned z = 0; z < rowA; z += 4) {
+  auto outer_body = [&](unsigned z) [[gnu::always_inline]] {
     T_out *__restrict pC1;
     T_out *__restrict pC2;
     T_out *__restrict pC3;
@@ -400,6 +418,24 @@ static inline void matmul_vectorized_4x2_mmul(const T_in *__restrict pA,
           pC2 += MMUL::size_C;
         }
       }
+  };
+
+  constexpr unsigned outer_iters = rowA / 4;
+  if constexpr (outer_iters >= 4) {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(4)
+    for (unsigned z = 0; z < rowA; z += 4)
+      outer_body(z);
+  } else if constexpr (outer_iters >= 2) {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(2)
+    for (unsigned z = 0; z < rowA; z += 4)
+      outer_body(z);
+  } else {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(1)
+    for (unsigned z = 0; z < rowA; z += 4)
+      outer_body(z);
   }
 
   event1();
@@ -421,9 +457,7 @@ static inline void matmul_vectorized_4x4(const T_in *__restrict pA,
 
   event0();
 
-  AIE_PREPARE_FOR_PIPELINING
-  AIE_LOOP_MIN_ITERATION_COUNT(2)
-  for (unsigned z = 0; z < rowA; z += 4) {
+  auto outer_body = [&](unsigned z) [[gnu::always_inline]] {
     T_out *__restrict pC1;
     T_out *__restrict pC2;
     T_out *__restrict pC3;
@@ -713,6 +747,24 @@ static inline void matmul_vectorized_4x4(const T_in *__restrict pA,
           pC4 += MMUL::size_C;
         }
       }
+  };
+
+  constexpr unsigned outer_iters = rowA / 4;
+  if constexpr (outer_iters >= 4) {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(4)
+    for (unsigned z = 0; z < rowA; z += 4)
+      outer_body(z);
+  } else if constexpr (outer_iters >= 2) {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(2)
+    for (unsigned z = 0; z < rowA; z += 4)
+      outer_body(z);
+  } else {
+    AIE_PREPARE_FOR_PIPELINING
+    AIE_LOOP_MIN_ITERATION_COUNT(1)
+    for (unsigned z = 0; z < rowA; z += 4)
+      outer_body(z);
   }
 
   event1();

--- a/programming_examples/basic/matrix_multiplication/single_core/tests/run_makefile_small_m.lit
+++ b/programming_examples/basic/matrix_multiplication/single_core/tests/run_makefile_small_m.lit
@@ -1,0 +1,15 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu1, peano
+//
+// Regression for mlir-aie #2793: vectorized matmul produced all-zero output
+// for tilings with m=16 (i16/i32). The clang loop pragma min_iteration_count
+// was set to 4 in matmul_vectorized_2x2_mmul, which is violated when m=16
+// (outer z-loop runs only 2 iterations). Guard the smallest valid m here.
+//
+// RUN: mkdir -p test_small_m
+// RUN: cd test_small_m
+// RUN: make -f %S/../Makefile clean
+// RUN: env dtype_in=i16 dtype_out=i32 m=16 k=64 n=16 M=512 K=512 N=512 make -f %S/../Makefile
+// RUN: %run_on_npu1% env dtype_in=i16 dtype_out=i32 m=16 k=64 n=16 M=512 K=512 N=512 make -f %S/../Makefile run


### PR DESCRIPTION
Closes #2793

Bug: For certain tilings (e.g. m=16, k=64, n=16 i16/i32) the vectorized matmul on Phoenix/XDNA1 returns an all-zero output. Worked in                                                                                       
                                                                                                                                     
  Root cause                                                                                                                         
  - aie_kernels/aie2/mm.cc uses AIE_LOOP_MIN_ITERATION_COUNT(N) on the outer z-loop of matmul_vectorized_{2x2_mmul, 4x2_mmul, 4x4}.
  - The hint values (4, 4, 2) were sized for larger tilings. Smaller m (still satisfying the kernel's static_asserts) makes the loop run fewer iterations than promised.                              
  - The hint expands (under peano) to #pragma clang loop min_iteration_count(N), which requires a literal integer; a                 
  template-dependent constexpr like rowA / 2 is silently mishandled.
                                                                                                                                     
  Fix                                                       
  - Wrap each outer-loop body in a [[gnu::always_inline]] lambda.                                                                    
  - Dispatch on outer_iters (a constexpr unsigned derived from rowA) via if constexpr into one of three branches with literal hints (4), (2), (1). Each branch's hint matches its actual iteration count.                                                            
  - Lambda inlines fully — confirmed by llvm-objdump: the i16/i32 m=32 hot path keeps the same symbol table and basic-block layout as before.    