### PR TITLE
[AIEPlacer] Add merge-logical-tiles option to gate non-core tile collapse

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -68,7 +68,11 @@ def AIEPlaceTiles : Pass<"aie-place-tiles", "DeviceOp"> {
            "Spreads cores across columns for better trace packet routing.">,
     Option<"clMergeLogicalTiles", "merge-logical-tiles", "bool",
            /*default=*/"true",
-           "Allow mapping one or more aie.logical_tile to the same aie.tile.">
+           "When true (default), allow multiple non-core (ShimNOCTile / "
+           "MemTile) aie.logical_tile ops to share one physical aie.tile "
+           "if combined DMA channel demand fits. When false, each non-core "
+           "aie.logical_tile is pinned to its own physical tile. CoreTile "
+           "placement is unaffected.">
   ];
 }
 

--- a/include/aie/Dialect/AIE/Transforms/AIEPasses.td
+++ b/include/aie/Dialect/AIE/Transforms/AIEPasses.td
@@ -65,7 +65,10 @@ def AIEPlaceTiles : Pass<"aie-place-tiles", "DeviceOp"> {
     Option<"clCoresPerCol", "cores-per-col", "int",
            /*default=*/"-1",
            "Limit number of cores per column (-1 = no limit). "
-           "Spreads cores across columns for better trace packet routing.">
+           "Spreads cores across columns for better trace packet routing.">,
+    Option<"clMergeLogicalTiles", "merge-logical-tiles", "bool",
+           /*default=*/"true",
+           "Allow mapping one or more aie.logical_tile to the same aie.tile.">
   ];
 }
 

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -65,8 +65,13 @@ protected:
 // Core-to-core connections are NOT validated because SequentialPlacer
 // doesn't account for shared memory optimization.
 //
-// Shim/Mem tiles with identical placement constraints and sufficient
-// DMA capacity are merged to the same physical tile.
+// By default (mergeLogicalTiles == true), Shim/Mem logical tiles with
+// identical placement constraints and sufficient combined DMA capacity
+// are merged to the same physical tile via TileOp::getOrCreate during
+// the conversion pattern. CoreTile placement is column-major sequential
+// and never merges. Callers that pre-aggregate non-core logical tiles
+// can pass mergeLogicalTiles == false to make the placer pin each
+// non-core LTO to its own physical tile.
 class SequentialPlacer : public Placer {
 public:
   SequentialPlacer(std::optional<int> coresPerCol = std::nullopt,

--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -69,8 +69,9 @@ protected:
 // DMA capacity are merged to the same physical tile.
 class SequentialPlacer : public Placer {
 public:
-  SequentialPlacer(std::optional<int> coresPerCol = std::nullopt)
-      : coresPerCol(coresPerCol) {}
+  SequentialPlacer(std::optional<int> coresPerCol = std::nullopt,
+                   bool mergeLogicalTiles = true)
+      : coresPerCol(coresPerCol), mergeLogicalTiles(mergeLogicalTiles) {}
 
   void initialize(const AIETargetModel &targetModel) override;
 
@@ -80,6 +81,11 @@ public:
 
 private:
   std::optional<int> coresPerCol;
+  bool mergeLogicalTiles;
+  // Physical tiles already assigned to a non-core aie.logical_tile. Used
+  // only when mergeLogicalTiles == false to forbid mapping a second
+  // non-core aie.logical_tile onto a tile that already hosts one.
+  llvm::DenseSet<TileID> assignedNonCoreTiles;
   int deviceCoresPerCol = 0; // Actual cores per column in device
   TileAvailability availability;
   const AIETargetModel *targetModel = nullptr;

--- a/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlaceTiles.cpp
@@ -63,6 +63,7 @@ struct AIEPlaceTilesPass
 
   AIEPlaceTilesPass(const AIEPlaceTilesOptions &options) {
     clCoresPerCol = options.clCoresPerCol;
+    clMergeLogicalTiles = options.clMergeLogicalTiles;
   }
 
   void runOnOperation() override {
@@ -75,7 +76,8 @@ struct AIEPlaceTilesPass
       std::optional<int> coresPerCol = std::nullopt;
       if (clCoresPerCol >= 0)
         coresPerCol = clCoresPerCol;
-      placer = std::make_shared<SequentialPlacer>(coresPerCol);
+      placer =
+          std::make_shared<SequentialPlacer>(coresPerCol, clMergeLogicalTiles);
       break;
     }
     }

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -708,6 +708,7 @@ LogicalResult SequentialPlacer::placeNonCoreTileByCentroid(
            << " with sufficient DMA capacity";
 
   result[logicalTile] = *maybeTile;
+  assignedNonCoreTiles.insert(*maybeTile);
   if (numInputChannels > 0)
     updateChannelUsage(*maybeTile, false, numInputChannels);
   if (numOutputChannels > 0)
@@ -736,6 +737,11 @@ std::optional<TileID> SequentialPlacer::findTileWithCapacity(
           continue;
 
         if (tile.col == searchCol) {
+          // When merge-logical-tiles is disabled, a tile that already
+          // hosts a non-core aie.logical_tile is off-limits even if it
+          // has spare DMA capacity.
+          if (!mergeLogicalTiles && assignedNonCoreTiles.contains(tile))
+            continue;
           if (hasAvailableChannels(tile, requiredInputChannels,
                                    requiredOutputChannels)) {
             return tile;

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -22,6 +22,7 @@ using namespace xilinx::AIE;
 
 void SequentialPlacer::initialize(const AIETargetModel &targetModel) {
   this->targetModel = &targetModel;
+  assignedNonCoreTiles.clear();
 
   // Collect all available physical tiles from device
   for (int col = 0; col < targetModel.columns(); col++) {
@@ -708,7 +709,8 @@ LogicalResult SequentialPlacer::placeNonCoreTileByCentroid(
            << " with sufficient DMA capacity";
 
   result[logicalTile] = *maybeTile;
-  assignedNonCoreTiles.insert(*maybeTile);
+  if (!mergeLogicalTiles)
+    assignedNonCoreTiles.insert(*maybeTile);
   if (numInputChannels > 0)
     updateChannelUsage(*maybeTile, false, numInputChannels);
   if (numOutputChannels > 0)

--- a/test/place-tiles/sequential_placer/test_place_merge_logical_tiles.mlir
+++ b/test/place-tiles/sequential_placer/test_place_merge_logical_tiles.mlir
@@ -1,0 +1,124 @@
+//===- test_place_merge_logical_tiles.mlir ---------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Exercises the `merge-logical-tiles` pass option on aie-place-tiles. The
+// option gates whether multiple non-core aie.logical_tile ops may share
+// one physical aie.tile when DMA channel capacity permits. The default
+// (true) keeps existing behavior. With false, findTileWithCapacity rejects
+// any tile that already hosts a non-core LTO. The option only affects
+// ShimNOCTile and MemTile placement; CoreTile placement is unchanged.
+
+// RUN: aie-opt --split-input-file --aie-place-tiles %s | FileCheck %s --check-prefix=MERGE
+// RUN: aie-opt --split-input-file --aie-place-tiles='merge-logical-tiles=true' %s | FileCheck %s --check-prefix=MERGE
+// RUN: aie-opt --split-input-file --aie-place-tiles='merge-logical-tiles=false' %s | FileCheck %s --check-prefix=NOMERGE
+
+// Two ShimNOC LTOs each carrying one packet flow to a different core.
+// The placer dedups channel requirements by (LTO, channel), so each LTO
+// reports needing only 1 output channel; with merging on, both fit on one
+// physical shim. With merging off, each gets its own.
+
+// MERGE-LABEL:   @two_shim_packet_flows
+// MERGE:         aie.tile(0, 0)
+// MERGE-NOT:     aie.tile(1, 0)
+
+// NOMERGE-LABEL: @two_shim_packet_flows
+// NOMERGE-DAG:   aie.tile(0, 0)
+// NOMERGE-DAG:   aie.tile(1, 0)
+// NOMERGE-NOT:   aie.tile(2, 0)
+module @two_shim_packet_flows {
+  aie.device(npu1) {
+    %shim_a = aie.logical_tile<ShimNOCTile>(?, ?)
+    %shim_b = aie.logical_tile<ShimNOCTile>(?, ?)
+    %core_a = aie.tile(0, 2)
+    %core_b = aie.tile(1, 2)
+    aie.packet_flow(0) {
+      aie.packet_source<%shim_a, DMA : 0>
+      aie.packet_dest<%core_a, DMA : 0>
+    }
+    aie.packet_flow(1) {
+      aie.packet_source<%shim_b, DMA : 0>
+      aie.packet_dest<%core_b, DMA : 0>
+    }
+  }
+}
+
+// -----
+
+// Same idea for memtiles. Merging on -> one memtile col; off -> spread.
+
+// MERGE-LABEL:   @two_memtile_flows
+// MERGE:         aie.tile(0, 1)
+// MERGE-NOT:     aie.tile(1, 1)
+
+// NOMERGE-LABEL: @two_memtile_flows
+// NOMERGE-DAG:   aie.tile(0, 1)
+// NOMERGE-DAG:   aie.tile(1, 1)
+// NOMERGE-NOT:   aie.tile(2, 1)
+module @two_memtile_flows {
+  aie.device(npu1) {
+    %mem_a = aie.logical_tile<MemTile>(?, ?)
+    %mem_b = aie.logical_tile<MemTile>(?, ?)
+    %core_a = aie.tile(0, 2)
+    %core_b = aie.tile(1, 2)
+    aie.flow(%mem_a, DMA : 0, %core_a, DMA : 0)
+    aie.flow(%mem_b, DMA : 0, %core_b, DMA : 0)
+  }
+}
+
+// -----
+
+// Mixing both LTO types: 2 shim + 2 memtile. Each pair behaves as above.
+
+// MERGE-LABEL:   @mixed_shim_memtile
+// MERGE-DAG:     aie.tile(0, 0)
+// MERGE-DAG:     aie.tile(0, 1)
+// MERGE-NOT:     aie.tile(1, 0)
+// MERGE-NOT:     aie.tile(1, 1)
+
+// NOMERGE-LABEL: @mixed_shim_memtile
+// NOMERGE-DAG:   aie.tile(0, 0)
+// NOMERGE-DAG:   aie.tile(1, 0)
+// NOMERGE-DAG:   aie.tile(0, 1)
+// NOMERGE-DAG:   aie.tile(1, 1)
+module @mixed_shim_memtile {
+  aie.device(npu1) {
+    %shim_a = aie.logical_tile<ShimNOCTile>(?, ?)
+    %shim_b = aie.logical_tile<ShimNOCTile>(?, ?)
+    %mem_a = aie.logical_tile<MemTile>(?, ?)
+    %mem_b = aie.logical_tile<MemTile>(?, ?)
+    %core_a = aie.tile(0, 2)
+    %core_b = aie.tile(1, 2)
+    aie.flow(%shim_a, DMA : 0, %mem_a, DMA : 0)
+    aie.flow(%mem_a, DMA : 1, %core_a, DMA : 0)
+    aie.flow(%shim_b, DMA : 0, %mem_b, DMA : 0)
+    aie.flow(%mem_b, DMA : 1, %core_b, DMA : 0)
+  }
+}
+
+// -----
+
+// CoreTile placement is unaffected by merge-logical-tiles. Two unhinted
+// cores land at distinct (col, row) under both settings (column-major).
+
+// MERGE-LABEL:   @cores_unaffected
+// MERGE-DAG:     aie.tile(0, 2)
+// MERGE-DAG:     aie.tile(0, 3)
+
+// NOMERGE-LABEL: @cores_unaffected
+// NOMERGE-DAG:   aie.tile(0, 2)
+// NOMERGE-DAG:   aie.tile(0, 3)
+module @cores_unaffected {
+  aie.device(npu1) {
+    %core_a = aie.logical_tile<CoreTile>(?, ?)
+    %core_b = aie.logical_tile<CoreTile>(?, ?)
+    aie.core(%core_a) { aie.end }
+    aie.core(%core_b) { aie.end }
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_merge_logical_tiles_overflow.mlir
+++ b/test/place-tiles/sequential_placer/test_place_merge_logical_tiles_overflow.mlir
@@ -1,0 +1,45 @@
+//===- test_place_merge_logical_tiles_overflow.mlir ------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// merge-logical-tiles=false errors when there are more LTOs than physical
+// non-core tiles can host without sharing. npu1 has 4 ShimNOC cols (0..3);
+// 5 unhinted shim LTOs cannot all be placed on distinct shims when merging
+// is forbidden.
+//
+// With merging enabled (default), the same module places successfully —
+// LTOs collapse onto fewer physical tiles within the channel budget.
+
+// RUN: not aie-opt --aie-place-tiles='merge-logical-tiles=false' %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=NOMERGE-OOC
+// RUN: aie-opt --aie-place-tiles %s | FileCheck %s --check-prefix=MERGE-OK
+
+// NOMERGE-OOC: error: no ShimNOCTile with sufficient DMA capacity
+
+// MERGE-OK-LABEL: @nomerge_overflow
+// MERGE-OK:       aie.device(npu1)
+// MERGE-OK-NOT:   aie.logical_tile
+module @nomerge_overflow {
+  aie.device(npu1) {
+    %s0 = aie.logical_tile<ShimNOCTile>(?, ?)
+    %s1 = aie.logical_tile<ShimNOCTile>(?, ?)
+    %s2 = aie.logical_tile<ShimNOCTile>(?, ?)
+    %s3 = aie.logical_tile<ShimNOCTile>(?, ?)
+    %s4 = aie.logical_tile<ShimNOCTile>(?, ?)
+    %c0 = aie.tile(0, 2)
+    %c1 = aie.tile(1, 2)
+    %c2 = aie.tile(2, 2)
+    %c3 = aie.tile(3, 2)
+    aie.flow(%s0, DMA : 0, %c0, DMA : 0)
+    aie.flow(%s1, DMA : 0, %c1, DMA : 0)
+    aie.flow(%s2, DMA : 0, %c2, DMA : 0)
+    aie.flow(%s3, DMA : 0, %c3, DMA : 0)
+    aie.flow(%s4, DMA : 0, %c0, DMA : 1)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `merge-logical-tiles` option (default `true`, preserves existing behavior) to the `aie-place-tiles` pass that lets callers opt out of the placer's implicit merging of multiple non-core `aie.logical_tile` ops onto the same physical `aie.tile`.

## Motivation

`SequentialPlacer::findTileWithCapacity` returns the first physical tile in its bidirectional sweep that has free DMA channel capacity. When two non-core LTOs both target the same column and the first tile still has free channels after placing the first LTO, the second LTO collapses onto the same physical tile via `TileOp::getOrCreate` in the conversion pattern.

This is correct for callers (e.g. the ObjectFifo lowering) that want multiple logical tiles to share one physical tile when capacity permits.

Some callers, however, pre-aggregate their logical tiles before emission — each emitted LTO is meant to land on its own physical tile. For those callers, the placer's "fill until full" behavior silently merges distinct LTOs that weren't meant to be merged.

## Behavior

| Mode | Effect |
|------|--------|
| `merge-logical-tiles=true` (default) | unchanged — multiple non-core LTOs may share a physical tile if combined channel demand fits |
| `merge-logical-tiles=false` | `findTileWithCapacity` skips any physical tile that already hosts a non-core LTO; each non-core LTO lands on its own tile, or the placer reports `no <type> with sufficient DMA capacity` |

The option only affects ShimNOCTile and MemTile placement (the path through `placeNonCoreTileByCentroid`). CoreTile placement is column-major sequential and never merges; ShimPLTile placement is unaffected.

## Implementation

- `AIEPasses.td`: new `merge-logical-tiles` bool option
- `AIEPlacer.h/.cpp`: `SequentialPlacer` ctor takes a `mergeLogicalTiles` bool; tracks `assignedNonCoreTiles` set; `findTileWithCapacity` skips already-assigned tiles when disabled
- `AIEPlaceTiles.cpp`: plumbs the option through to the placer constructor

~18 LoC behavioral change.

## Tests

- `test_place_merge_logical_tiles.mlir`: default behavior, both explicit option settings, shim-only, memtile-only, mixed shim+memtile, and verifies CoreTile placement is unchanged.
- `test_place_merge_logical_tiles_overflow.mlir`: error path when more LTOs are emitted than there are physical non-core tiles to host without sharing; same module compiles cleanly with merging enabled.

`ninja check-aie` passes (11/11 in `place-tiles/sequential_placer/`, no other regressions).

## Test plan
- [x] CI: full check-aie on Linux + Windows
- [x] Manual verification on downstream consumers (mlir-air's aircc will use this option once merged)