### PR TITLE
Add Dependabot, OSSF Scorecard, and SECURITY.md for supply-chain hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "pip"
+    directory: "/utils/mlir_aie_wheels"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "pip"
+    directory: "/utils/mlir_wheels"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 7 * * 2'
+  push:
+    branches: [ "main" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736  # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8  # v4.3.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@012739e5082ff0c22ca6d6ab32e07c36df03c4a4  # v3.22.12
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,25 +20,25 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736  # v2.3.1
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8  # v4.3.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@012739e5082ff0c22ca6d6ab32e07c36df03c4a4  # v3.22.12
+        uses: github/codeql-action/upload-sarif@52485aec7be33610227643b0fe83936b8b5f061a  # v3.35.4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,7 @@ on:
     - cron: '32 7 * * 2'
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions: read-all
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in mlir-aie, please
+report it privately rather than opening a public issue.
+
+The preferred channel is GitHub's private vulnerability reporting:
+
+  https://github.com/Xilinx/mlir-aie/security/advisories/new
+
+This opens a private advisory thread visible only to the maintainers. We
+will acknowledge reports as soon as we are able.
+
+Please include, where possible:
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a minimal proof-of-concept.
+- The commit hash or release tag the issue was observed against.
+- Any suggested mitigation.
+
+## Supported Versions
+
+mlir-aie tracks the tip of `main`. Security fixes are applied to `main`
+as soon as feasible; prior releases are not patched in place.
+
+## Scope
+
+In-scope: code in this repository, including build tooling, Python
+bindings, and CI workflows.
+
+Out-of-scope: vulnerabilities in upstream LLVM/MLIR (please report to the
+LLVM project) or in third-party dependencies (please report to the
+respective project).


### PR DESCRIPTION
## Summary                                                                                                                                                  
- Adds `.github/dependabot.yml` covering GitHub Actions and the four pip manifest dirs (`python/`, `utils/mlir_aie_wheels/`, `utils/mlir_wheels/`), with grouped weekly minor/patch updates to keep PR volume sane.                                                                                           
- Adds `.github/workflows/scorecard.yml` running OSSF Scorecard on a weekly cron + `workflow_dispatch`, with SARIF uploaded to the Security tab. Action pins are by SHA (rather than tag, the convention #2981 chose for build workflows) because this workflow's job is to grade the repo on Pinned-Dependencies; tag pinning would weaken its own score.                                                                                              
- Adds `SECURITY.md` pointing reporters at GitHub's private vulnerability reporting (already enabled on this repo).                                                                                                                 
                                                                                                                                                              
## Why                                                                                                                                                      
Closes the highest-value gaps in the current Scorecard baseline (3.9/10): `Dependency-Update-Tool`, `Token-Permissions`, `Pinned-Dependencies`, and `Security-Policy`. Estimated post-merge baseline ~5–6/10, with Dependabot  security alerts then chipping at the `Vulnerabilities` score over time.                                                                                     
                                                                                                                                                              
## Test plan                                                                                                                                                
- [x] YAML / dependabot v2 schema / actionlint clean locally                                                                                                
- [x] Scorecard CLI dry-run against current main (~3.9/10 baseline confirmed)                                                                               
- [x] End-to-end exercised on hunhoffe/mlir-aie fork: Scorecard workflow ran green and uploaded SARIF; Dependabot recognized all four manifest directories and started its first update jobs                                                                                                         
- [ ] Maintainer to enable Dependabot version updates in repo Settings (UI toggle; the file alone is inert until enabled)                                                                                                    
- [ ] Maintainer to confirm Dependabot security updates and Secret scanning push protection are also on (orthogonal to this PR but recommended)                                                                                   
                                                                                                                                                              
## Follow-ups (not in this PR)                                                                                                                              
- Reconcile remaining `actions/checkout` / `setup-python` version drift in older workflows                                                                                                                                        
- Discuss Dependabot settings