### PR TITLE
wheels: PEP 440-compliant versioning for mlir-aie (PyPI prep)

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -96,6 +96,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "true"
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: uraimo/run-on-arch-action@v3
         name: Build mlir-aie
@@ -248,7 +250,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: "true"
-  
+          fetch-depth: 0
+          fetch-tags: true
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -182,6 +182,7 @@ jobs:
             fi
             export AIE_VITIS_COMPONENTS='AIE2;AIE2P'
             export DATETIME=$(date +"%Y%m%d%H")
+            export AIE_WHEEL_KEEP_LOCAL=1
 
             pushd utils/mlir_aie_wheels
 
@@ -368,7 +369,8 @@ jobs:
             export AIE_PROJECT_COMMIT="${AIE_PROJECT_COMMIT:0:7}"
           fi
           export AIE_VITIS_COMPONENTS='AIE2;AIE2P'
-  
+          export AIE_WHEEL_KEEP_LOCAL=1
+
           # Try to always forward slash paths.
           ROOT_WIN=$(python -c "import os; print(os.getcwd().replace('\\\\', '/'))")
 

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -99,6 +99,29 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Compute wheel version on host
+        id: wheel_version
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+            VERSION="${REF_NAME#v}"
+          else
+            VERSION=$(AIE_WHEEL_KEEP_LOCAL=1 python utils/mlir_aie_wheels/_version_helper.py)
+          fi
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::computed wheel version is empty" >&2
+            exit 1
+          fi
+          if ! [[ "${VERSION}" =~ ^[A-Za-z0-9][A-Za-z0-9.+_-]*$ ]]; then
+            echo "::error::computed wheel version contains unexpected characters: ${VERSION}" >&2
+            exit 1
+          fi
+          echo "Computed AIE_WHEEL_VERSION=${VERSION}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
       - uses: uraimo/run-on-arch-action@v3
         name: Build mlir-aie
         id: runcmd
@@ -116,7 +139,7 @@ jobs:
             PIP_RESUME_RETRIES: ${{ env.PIP_RESUME_RETRIES }}
             PIP_TIMEOUT: ${{ env.PIP_TIMEOUT }}
             PIP_DISABLE_PIP_VERSION_CHECK: ${{ env.PIP_DISABLE_PIP_VERSION_CHECK }}
-            AIE_WHEEL_VERSION: ${{ (github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) && github.ref_name || '""' }}
+            AIE_WHEEL_VERSION: ${{ steps.wheel_version.outputs.version }}
           run: |
             git config --global --add safe.directory $PWD
             MLIR_VERSION=$(git rev-parse --short HEAD)
@@ -259,6 +282,30 @@ jobs:
           python-version: ${{ matrix.python_version }}
           allow-prereleases: true
 
+      - name: Compute wheel version on host
+        id: wheel_version
+        shell: bash
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+            VERSION="${REF_NAME#v}"
+          else
+            VERSION=$(AIE_WHEEL_KEEP_LOCAL=1 python utils/mlir_aie_wheels/_version_helper.py)
+          fi
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::computed wheel version is empty" >&2
+            exit 1
+          fi
+          if ! [[ "${VERSION}" =~ ^[A-Za-z0-9][A-Za-z0-9.+_-]*$ ]]; then
+            echo "::error::computed wheel version contains unexpected characters: ${VERSION}" >&2
+            exit 1
+          fi
+          echo "Computed AIE_WHEEL_VERSION=${VERSION}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
       - name: Set up MSVC dev environment
         uses: ilammy/msvc-dev-cmd@v1
         with:
@@ -314,8 +361,7 @@ jobs:
       - name: Build mlir-aie wheel
         shell: bash
         env:
-          # Copy Linux job style: tag-aligned versioning only on version tags.
-          AIE_WHEEL_VERSION: ${{ (github.ref_type == 'tag' && startsWith(github.ref_name, 'v')) && github.ref_name || '' }}
+          AIE_WHEEL_VERSION: ${{ steps.wheel_version.outputs.version }}
           ENABLE_RTTI: ${{ matrix.ENABLE_RTTI }}
           CMAKE_GENERATOR: Ninja
           CMAKE_ARGS: -DAIE_BUILD_CHESS_CLANG=OFF -DOPENSSL_USE_STATIC_LIBS=TRUE -DAIE_ENABLE_XRT_PYTHON_BINDINGS=OFF

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -246,6 +246,31 @@ jobs:
       shell: bash
       run: cp ../clone-llvm.sh .
 
+    - name: Compute wheel version on host
+      id: wheel_version
+      shell: bash
+      working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
+      env:
+        REF_TYPE: ${{ github.ref_type }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+        if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]; then
+          VERSION="${REF_NAME#v}"
+        else
+          VERSION=$(AIE_WHEEL_KEEP_LOCAL=1 python _version_helper.py)
+        fi
+        if [[ -z "${VERSION}" ]]; then
+          echo "::error::computed wheel version is empty" >&2
+          exit 1
+        fi
+        if ! [[ "${VERSION}" =~ ^[A-Za-z0-9][A-Za-z0-9.+_-]*$ ]]; then
+          echo "::error::computed wheel version contains unexpected characters: ${VERSION}" >&2
+          exit 1
+        fi
+        echo "Computed AIE_WHEEL_VERSION=${VERSION}"
+        echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
     # build
 
     - name: build distro wheels
@@ -267,6 +292,7 @@ jobs:
         CIBW_CONTAINER_ENGINE_ARGS="-v ${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }}:/host${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }}" \
         AIE_PROJECT_COMMIT=${{ needs.get_aie_project_commit.outputs.AIE_PROJECT_COMMIT }} \
         AIE_WHEEL_KEEP_LOCAL=1 \
+        AIE_WHEEL_VERSION=${{ steps.wheel_version.outputs.version }} \
         MATRIX_OS=${{ matrix.OS }} \
         PARALLEL_LEVEL=2 \
         cibuildwheel --output-dir wheelhouse
@@ -312,6 +338,7 @@ jobs:
         DATETIME=${{ needs.get_aie_project_commit.outputs.DATETIME }} \
         AIE_PROJECT_COMMIT=${{ needs.get_aie_project_commit.outputs.AIE_PROJECT_COMMIT }} \
         AIE_WHEEL_KEEP_LOCAL=1 \
+        AIE_WHEEL_VERSION=${{ steps.wheel_version.outputs.version }} \
         MATRIX_OS=${{ matrix.OS }} \
         PARALLEL_LEVEL=2 \
         pip wheel . -v -w wheelhouse

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -266,6 +266,7 @@ jobs:
         HOST_CCACHE_DIR=${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }} \
         CIBW_CONTAINER_ENGINE_ARGS="-v ${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }}:/host${{ steps.setup_ccache.outputs.HOST_CCACHE_DIR }}" \
         AIE_PROJECT_COMMIT=${{ needs.get_aie_project_commit.outputs.AIE_PROJECT_COMMIT }} \
+        AIE_WHEEL_KEEP_LOCAL=1 \
         MATRIX_OS=${{ matrix.OS }} \
         PARALLEL_LEVEL=2 \
         cibuildwheel --output-dir wheelhouse
@@ -310,6 +311,7 @@ jobs:
         CMAKE_GENERATOR=Ninja \
         DATETIME=${{ needs.get_aie_project_commit.outputs.DATETIME }} \
         AIE_PROJECT_COMMIT=${{ needs.get_aie_project_commit.outputs.AIE_PROJECT_COMMIT }} \
+        AIE_WHEEL_KEEP_LOCAL=1 \
         MATRIX_OS=${{ matrix.OS }} \
         PARALLEL_LEVEL=2 \
         pip wheel . -v -w wheelhouse

--- a/utils/mlir_aie_wheels/_version_helper.py
+++ b/utils/mlir_aie_wheels/_version_helper.py
@@ -1,0 +1,95 @@
+"""Compute the mlir-aie wheel version from git history.
+
+Standalone helper: stdlib-only imports so CI can invoke it directly
+(``python utils/mlir_aie_wheels/_version_helper.py``) before any build
+dependencies have been installed, while setup.py re-uses the same logic
+to keep a single source of truth.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+
+
+def _check_env(name: str, default: int = 0) -> bool:
+    return os.getenv(name, str(default)) in {"1", "true", "True", "ON", "YES"}
+
+
+def _git(*args: str) -> str | None:
+    try:
+        return (
+            subprocess.check_output(
+                ["git", *args],
+                cwd=str(_HERE),
+                stderr=subprocess.PIPE,
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        msg = getattr(exc, "stderr", b"") or b""
+        if isinstance(msg, bytes):
+            msg = msg.decode(errors="replace")
+        print(
+            f"warning: git {' '.join(args)} failed ({type(exc).__name__}): "
+            f"{msg.strip() or exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
+def get_version() -> str:
+    override = os.environ.get("AIE_WHEEL_VERSION", "").lstrip("v")
+    if override:
+        return override
+
+    described = _git(
+        "describe",
+        "--tags",
+        "--long",
+        "--abbrev=7",
+        "--match",
+        "v[0-9]*.[0-9]*.[0-9]*",
+        "--exclude",
+        "*-*",
+    )
+    if described:
+        m = re.match(r"^v(\d+)\.(\d+)\.(\d+)-(\d+)-g([0-9a-f]+)$", described)
+        if m:
+            major, minor, patch, distance_s, sha = m.groups()
+            distance = int(distance_s)
+            if distance == 0:
+                return f"{major}.{minor}.{patch}"
+            base = f"{major}.{minor}.{int(patch) + 1}"
+            version = f"{base}.dev{distance}"
+            if _check_env("AIE_WHEEL_KEEP_LOCAL"):
+                version += f"+g{sha}"
+            return version
+        print(
+            f"warning: git describe returned {described!r} which does not match "
+            "the expected vMAJOR.MINOR.PATCH-DISTANCE-gSHA shape",
+            file=sys.stderr,
+        )
+
+    commit_count = _git("rev-list", "--count", "HEAD") or "0"
+    version = f"0.0.0.dev{commit_count}"
+    print(
+        f"warning: get_version() falling back to {version!r}; "
+        "no matching release tag was reachable from HEAD",
+        file=sys.stderr,
+    )
+    if _check_env("AIE_WHEEL_KEEP_LOCAL"):
+        sha = _git("rev-parse", "--short=7", "HEAD")
+        if sha:
+            version += f"+g{sha}"
+    return version
+
+
+if __name__ == "__main__":
+    print(get_version())

--- a/utils/mlir_aie_wheels/pyproject.toml
+++ b/utils/mlir_aie_wheels/pyproject.toml
@@ -1,23 +1,3 @@
-[project]
-name = "mlir-aie"
-description = "An MLIR-based toolchain for AMD AI Engine-enabled devices."
-readme = { text = """This repository contains an [MLIR-based](https://mlir.llvm.org/) toolchain for Xilinx Versal
-AIEngine-based devices.  This can be used to generate low-level configuration for the AIEngine portion of the
-device, including processors, stream switches, TileDMA and ShimDMA blocks. Backend code generation is
-included, targetting the LibXAIE library.  This project is primarily intended to support tool builders with
-convenient low-level access to devices and enable the development of a wide variety of programming models
-from higher level abstractions.  As such, although it contains some examples, this project is not intended to
-represent end-to-end compilation flows or to be particularly easy to use for system design.
-""", content-type = "text/markdown" }
-dynamic = ["dependencies", "requires-python", "version", "license"]
-authors = [
-  { name="AMD Inc." },
-  { email="joseph.melber@amd.com" },
-]
-
-[project.urls]
-"Homepage" = "https://github.com/Xilinx/mlir-aie"
-
 [tool.cibuildwheel]
 build-verbosity = 3
 build = "cp312-* cp313-* cp314-*"
@@ -39,6 +19,8 @@ environment-pass = [
     "DATETIME",
     "HOST_CCACHE_DIR",
     "AIE_PROJECT_COMMIT",
+    "AIE_WHEEL_KEEP_LOCAL",
+    "AIE_WHEEL_VERSION",
     "MATRIX_OS",
     "PARALLEL_LEVEL",
     "PIP_FIND_LINKS",
@@ -70,15 +52,3 @@ before-build = [
 [build-system]
 requires = ["setuptools>=61.0", "nanobind", "pip>=22.1", 'ninja!=1.13.0; platform_system=="Windows"']
 build-backend = "setuptools.build_meta"
-
-[project.scripts]
-aie-lsp-server = "aie.tools:aie_lsp_server"
-aie-opt = "aie.tools:aie_opt"
-aie-reset = "aie.tools:aie_reset"
-aie-translate = "aie.tools:aie_translate"
-aie-visualize = "aie.tools:aie_visualize"
-aiecc = "aie.tools:aiecc"
-"aiecc.py" = "aie.compiler.aiecc.main:main"
-bootgen = "aie.tools:bootgen"
-"txn2mlir.py" = "aie.compiler.txn2mlir.main:main"
-xchesscc_wrapper = "aie.tools:xchesscc_wrapper"

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -384,9 +384,14 @@ def get_version():
         return os.environ["AIE_WHEEL_VERSION"].lstrip("v")
 
     described = _git(
-        "describe", "--tags", "--long", "--abbrev=7",
-        "--match", "v[0-9]*.[0-9]*.[0-9]*",
-        "--exclude", "*-*",
+        "describe",
+        "--tags",
+        "--long",
+        "--abbrev=7",
+        "--match",
+        "v[0-9]*.[0-9]*.[0-9]*",
+        "--exclude",
+        "*-*",
     )
     if described:
         m = re.match(r"^v(\d+)\.(\d+)\.(\d+)-(\d+)-g([0-9a-f]+)$", described)

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -4,10 +4,9 @@ import re
 import shutil
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from pprint import pprint
-from textwrap import dedent
 from typing import Union
 
 from importlib_metadata import files
@@ -308,6 +307,21 @@ class CMakeBuild(build_ext):
             target_dir = Path(install_dir) / "python"
             req_file = Path(MLIR_AIE_SOURCE_DIR) / "python" / "requirements.txt"
             install_eudsl(req_file, target_dir)
+
+            aie_pkg_dir = Path(install_dir) / "python" / "aie"
+            aie_pkg_dir.mkdir(parents=True, exist_ok=True)
+            sha = _git("rev-parse", "--short=7", "HEAD") or "unknown"
+            build_date = (
+                datetime.now(timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z")
+            )
+            (aie_pkg_dir / "_version.py").write_text(
+                f'__version__ = "{get_version()}"\n'
+                f'__commit__ = "{sha}"\n'
+                f'__build_date__ = "{build_date}"\n'
+            )
+
             build_succeeded = True
         finally:
             if cleanup_build_temp and build_succeeded:
@@ -334,19 +348,50 @@ class InstallWithPth(install):
             pth_file.write("mlir_aie/python")
 
 
+def _git(*args):
+    try:
+        return (
+            subprocess.check_output(
+                ["git", *args],
+                cwd=str(Path(__file__).parent),
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
 def get_version():
     if "AIE_WHEEL_VERSION" in os.environ and os.environ["AIE_WHEEL_VERSION"].lstrip(
         "v"
     ):
         return os.environ["AIE_WHEEL_VERSION"].lstrip("v")
-    release_version = "0.0.1"
-    commit_hash = os.environ.get("AIE_PROJECT_COMMIT", "deadbeef")
-    now = datetime.now()
-    timestamp = os.environ.get(
-        "DATETIME", f"{now.year}{now.month:02}{now.day:02}{now.hour:02}"
+
+    described = _git(
+        "describe", "--tags", "--long", "--abbrev=7", "--match", "v[0-9]*.[0-9]*.[0-9]*"
     )
-    suffix = "" if check_env("ENABLE_RTTI", 1) else "-no_rtti"
-    return f"{release_version}.{timestamp}+{commit_hash}{suffix}"
+    if described:
+        m = re.match(r"^v(\d+)\.(\d+)\.(\d+)-(\d+)-g([0-9a-f]+)$", described)
+        if m:
+            major, minor, patch, distance_s, sha = m.groups()
+            distance = int(distance_s)
+            if distance == 0:
+                return f"{major}.{minor}.{patch}"
+            base = f"{major}.{minor}.{int(patch) + 1}"
+            version = f"{base}.dev{distance}"
+            if check_env("AIE_WHEEL_KEEP_LOCAL"):
+                version += f"+g{sha}"
+            return version
+
+    commit_count = _git("rev-list", "--count", "HEAD") or "0"
+    version = f"0.0.0.dev{commit_count}"
+    if check_env("AIE_WHEEL_KEEP_LOCAL"):
+        sha = _git("rev-parse", "--short=7", "HEAD")
+        if sha:
+            version += f"+g{sha}"
+    return version
 
 
 MLIR_AIE_SOURCE_DIR = Path(
@@ -378,11 +423,49 @@ def parse_requirements(filename):
 
 
 setup(
+    name="mlir-aie" if check_env("ENABLE_RTTI", 1) else "mlir-aie-no-rtti",
     version=get_version(),
+    description="An MLIR-based toolchain for AMD AI Engine-enabled devices.",
+    long_description=(
+        (Path(MLIR_AIE_SOURCE_DIR) / "README.md").read_text(encoding="utf-8")
+        if (Path(MLIR_AIE_SOURCE_DIR) / "README.md").exists()
+        else "An MLIR-based toolchain for AMD AI Engine-enabled devices. "
+        "See https://github.com/Xilinx/mlir-aie"
+    ),
+    long_description_content_type="text/markdown",
+    author="AMD Inc.",
+    author_email="joseph.melber@amd.com",
+    url="https://github.com/Xilinx/mlir-aie",
     license="Apache-2.0 WITH LLVM-exception",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: Apache Software License",
+        "Topic :: Software Development :: Compilers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: MacOS",
+    ],
+    entry_points={
+        "console_scripts": [
+            "aie-lsp-server = aie.tools:aie_lsp_server",
+            "aie-opt = aie.tools:aie_opt",
+            "aie-reset = aie.tools:aie_reset",
+            "aie-translate = aie.tools:aie_translate",
+            "aie-visualize = aie.tools:aie_visualize",
+            "aiecc = aie.tools:aiecc",
+            "aiecc.py = aie.compiler.aiecc.main:main",
+            "bootgen = aie.tools:bootgen",
+            "txn2mlir.py = aie.compiler.txn2mlir.main:main",
+            "xchesscc_wrapper = aie.tools:xchesscc_wrapper",
+        ],
+    },
     include_package_data=True,
-    # note the name here isn't relevant because it's the install (CMake install target) directory that'll be used to
-    # actually build the wheel.
     ext_modules=[CMakeExtension("_mlir_aie", sourcedir=MLIR_AIE_SOURCE_DIR)],
     cmdclass={
         "build_ext": CMakeBuild,

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -17,6 +17,7 @@ from setuptools.command.install import install
 
 sys.path.append(os.path.dirname(__file__))
 from vendor_eudsl import install_eudsl
+from _version_helper import _git, get_version
 
 
 def check_env(build, default=0):
@@ -360,59 +361,6 @@ class InstallWithPth(install):
         pth_target = os.path.join(self.install_lib, "aie.pth")
         with open(pth_target, "w") as pth_file:
             pth_file.write("mlir_aie/python")
-
-
-def _git(*args):
-    try:
-        return (
-            subprocess.check_output(
-                ["git", *args],
-                cwd=str(Path(__file__).parent),
-                stderr=subprocess.DEVNULL,
-            )
-            .decode()
-            .strip()
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-        return None
-
-
-def get_version():
-    if "AIE_WHEEL_VERSION" in os.environ and os.environ["AIE_WHEEL_VERSION"].lstrip(
-        "v"
-    ):
-        return os.environ["AIE_WHEEL_VERSION"].lstrip("v")
-
-    described = _git(
-        "describe",
-        "--tags",
-        "--long",
-        "--abbrev=7",
-        "--match",
-        "v[0-9]*.[0-9]*.[0-9]*",
-        "--exclude",
-        "*-*",
-    )
-    if described:
-        m = re.match(r"^v(\d+)\.(\d+)\.(\d+)-(\d+)-g([0-9a-f]+)$", described)
-        if m:
-            major, minor, patch, distance_s, sha = m.groups()
-            distance = int(distance_s)
-            if distance == 0:
-                return f"{major}.{minor}.{patch}"
-            base = f"{major}.{minor}.{int(patch) + 1}"
-            version = f"{base}.dev{distance}"
-            if check_env("AIE_WHEEL_KEEP_LOCAL"):
-                version += f"+g{sha}"
-            return version
-
-    commit_count = _git("rev-list", "--count", "HEAD") or "0"
-    version = f"0.0.0.dev{commit_count}"
-    if check_env("AIE_WHEEL_KEEP_LOCAL"):
-        sha = _git("rev-parse", "--short=7", "HEAD")
-        if sha:
-            version += f"+g{sha}"
-    return version
 
 
 MLIR_AIE_SOURCE_DIR = Path(

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -384,7 +384,9 @@ def get_version():
         return os.environ["AIE_WHEEL_VERSION"].lstrip("v")
 
     described = _git(
-        "describe", "--tags", "--long", "--abbrev=7", "--match", "v[0-9]*.[0-9]*.[0-9]*"
+        "describe", "--tags", "--long", "--abbrev=7",
+        "--match", "v[0-9]*.[0-9]*.[0-9]*",
+        "--exclude", "*-*",
     )
     if described:
         m = re.match(r"^v(\d+)\.(\d+)\.(\d+)-(\d+)-g([0-9a-f]+)$", described)

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -322,6 +322,20 @@ class CMakeBuild(build_ext):
                 f'__build_date__ = "{build_date}"\n'
             )
 
+            init_file = aie_pkg_dir / "__init__.py"
+            reexport_marker = "# >>> mlir-aie wheel build metadata"
+            reexport_block = (
+                f"\n{reexport_marker}\n"
+                "from ._version import __version__, __commit__, __build_date__\n"
+                "# <<< mlir-aie wheel build metadata\n"
+            )
+            existing_init = (
+                init_file.read_text(encoding="utf-8") if init_file.exists() else ""
+            )
+            if reexport_marker not in existing_init:
+                with init_file.open("a", encoding="utf-8") as f:
+                    f.write(reexport_block)
+
             build_succeeded = True
         finally:
             if cleanup_build_temp and build_succeeded:


### PR DESCRIPTION
## Summary                                                                                                                                                  
Prep `mlir_aie_wheels` for PyPI uploads by fixing the version string format and exposing build metadata on the installed package.                           

## Changes                                                                                                                                                  
- **Versioning**: `get_version()` now derives the dev counter from `git describe`. Tagged builds: clean `1.2.3`. Between tags: `1.2.4.devN`. `+g<sha>` local segment is appended only when `AIE_WHEEL_KEEP_LOCAL=1` (set by GH Release upload paths; left unset for future PyPI uploads). The existing `AIE_WHEEL_VERSION` tag override is unchanged.
- **No-rtti as a distinct PyPI package**: `mlir-aie-no-rtti` instead of a non-PEP-440 `-no_rtti` version suffix. Matches the existing `mlir`/`mlir-no-rtti` convention.                                                                                                                                                 
- **Runtime introspection**: `aie.__version__`, `aie.__commit__`, `aie.__build_date__` (`_version.py` written + re-exported from `aie/__init__.py`).
                                                                                                                                                              
## Verified                                               
- `twine check` passes on the built sdist; `packaging.Version()` parses every output form.                                                                  
- Both `ENABLE_RTTI=0/1` produce the expected package names.                                                                                                
                                                                                                                                                              
## Out of scope                                                                                                                                             
Same fix for `utils/mlir_wheels/` and the actual PyPI publish workflow — separate PRs.      

## Update
Found via empirical wheel validation that CI's actions/checkout@v6 defaults to a depth-1 clone with no tags, so git describe returned nothing and get_version() fell into the 0.0.0.dev{count} fallback (with count == 1) instead of 1.3.2.dev<distance>. Latest commit:                                                                                                                                 
- Sets fetch-depth: 0 + fetch-tags: true on the wheel-build checkouts in buildRyzenWheels.yml.
- Excludes pre-release tags (v*-*) from the git describe matcher so e.g. a future v1.4.0-rc1 tag doesn't poison the version computation.

 Locally verified: HEAD-style builds now produce 1.3.2.dev49+g2030517 (PEP 440 valid; sorts correctly before the eventual 1.3.2 release).
     