### PR TITLE
ci: bump stale GitHub Actions (pre-empt Dependabot noise) 

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -41,7 +41,7 @@ runs:
         limit-access-to-actor: true
         detached: ${{ inputs.DEBUG_DETACHED }}
 
-    - uses: ilammy/msvc-dev-cmd@v1.4.1
+    - uses: ilammy/msvc-dev-cmd@v1
       if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
 
     - name: Set up Visual Studio shell
@@ -56,7 +56,7 @@ runs:
 
     - name: Free disk space
       if: contains(inputs.MATRIX_OS, 'ubuntu')
-      uses: descriptinc/free-disk-space@main
+      uses: descriptinc/free-disk-space@1b4b157593c6801212a2ed488c205e0a810b4592  # main as of 2023-09-27
       with:
         tool-cache: true
         android: true
@@ -65,7 +65,7 @@ runs:
         large-packages: true
         swap-storage: false # This frees space on the wrong partition.
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/actions/setup_ccache/action.yml
+++ b/.github/actions/setup_ccache/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.12
+      uses: hendrikmuhs/ccache-action@v1
       with:
         key: ${{ inputs.MATRIX_OS }}-${{ inputs.MATRIX_ARCH }}-${{ inputs.EXTRA_KEY }}
         max-size: "1G"

--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
       - name: Free disk space
-        uses: descriptinc/free-disk-space@main
+        uses: descriptinc/free-disk-space@1b4b157593c6801212a2ed488c205e0a810b4592  # main as of 2023-09-27
         with:
           tool-cache: true
           android: true

--- a/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
+++ b/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
       - name: Free disk space
-        uses: descriptinc/free-disk-space@main
+        uses: descriptinc/free-disk-space@1b4b157593c6801212a2ed488c205e0a810b4592  # main as of 2023-09-27
         with:
           tool-cache: true
           android: true

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 2
           submodules: "true"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 2
           submodules: "true"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -75,7 +75,7 @@ jobs:
           unzip -q mlir-*.whl
 
       - name: Ccache for C++ compilation
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1
         with:
           # Since there are now several compilation jobs running in parallel,
           # use a different key per job to avoid a ccache writing race condition

--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
 
       - name: Free disk space
-        uses: descriptinc/free-disk-space@main
+        uses: descriptinc/free-disk-space@1b4b157593c6801212a2ed488c205e0a810b4592  # main as of 2023-09-27
         with:
           tool-cache: true
           android: true

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -84,7 +84,7 @@ jobs:
 
     steps:
       - name: Free disk space
-        uses: descriptinc/free-disk-space@main
+        uses: descriptinc/free-disk-space@1b4b157593c6801212a2ed488c205e0a810b4592  # main as of 2023-09-27
         with:
           tool-cache: true
           android: true
@@ -249,7 +249,7 @@ jobs:
           submodules: "true"
   
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
           allow-prereleases: true
@@ -443,7 +443,7 @@ jobs:
 
       - name: Release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1
         with:
           artifacts: wheels_all/mlir_aie*whl
           token: "${{ secrets.GITHUB_TOKEN }}"
@@ -456,7 +456,7 @@ jobs:
 
       - name: Release latest wheels (RTTI ON)
         if: github.event_name != 'push'
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1
         with:
           artifacts: wheels_on_flat/mlir_aie*whl
           token: "${{ secrets.GITHUB_TOKEN }}"
@@ -469,7 +469,7 @@ jobs:
 
       - name: Release latest wheels (RTTI OFF)
         if: github.event_name != 'push'
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1
         with:
           artifacts: wheels_off_flat/mlir_aie*whl
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Ccache for C++ compilation
         # https://github.com/hendrikmuhs/ccache-action/releases/tag/v1.2.9
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ runner.os }}-releaseasserts-${{ steps.get-submodule-hash.outputs.hash }}
           max-size: 1G

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang-tidy ninja-build clang libelf-dev
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -131,7 +131,7 @@ jobs:
           clangformat: 17.0.1
 
       - name: Setup Python env
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -159,7 +159,7 @@ jobs:
           name: clang_format_diffs
 
       - name: Check C/C++ format
-        uses: reviewdog/action-suggester@v1.22
+        uses: reviewdog/action-suggester@v1
         with:
           tool_name: clang-format
           level: error
@@ -182,7 +182,7 @@ jobs:
 
       - name: Check Python format
         if: success() || failure()
-        uses: reviewdog/action-suggester@v1.22
+        uses: reviewdog/action-suggester@v1
         with:
           tool_name: black
           level: error
@@ -203,7 +203,7 @@ jobs:
     steps:
 
       - name: Free disk space
-        uses: descriptinc/free-disk-space@main
+        uses: descriptinc/free-disk-space@1b4b157593c6801212a2ed488c205e0a810b4592  # main as of 2023-09-27
         with:
           tool-cache: true
           android: true
@@ -218,7 +218,7 @@ jobs:
           fetch-depth: 2
           submodules: "true"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -254,7 +254,7 @@ jobs:
 
       - name: Ccache for C++ compilation
         if: steps.changed-files.outputs.changed-files != ''
-        uses: hendrikmuhs/ccache-action@v1.2
+        uses: hendrikmuhs/ccache-action@v1
         with:
           key: ${{ runner.os }}-${{ matrix.ubuntu_version }}-${{ steps.get-llvm-commit-hash.outputs.hash }}-code-cov
           max-size: 1G
@@ -322,7 +322,7 @@ jobs:
 
       - name: Update PR with coverage results
         if: steps.changed-files.outputs.changed-files != '' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: edumserrano/find-create-or-update-comment@v2
+        uses: edumserrano/find-create-or-update-comment@v3
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: '<!--<!doctype codecov html>-->'

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -434,7 +434,7 @@ jobs:
           name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
           path: dist
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -524,7 +524,7 @@ jobs:
 
       - name: Release current commit
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*.whl"
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -191,7 +191,7 @@ jobs:
         MATRIX_ARCH: ${{ matrix.ARCH }}
         EXTRA_KEY: mlir-distro-enable-rtti-${{ matrix.ENABLE_RTTI }}
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -393,7 +393,7 @@ jobs:
           name: build_artifact_${{ matrix.OS }}_${{ matrix.ARCH }}_rtti_${{ matrix.ENABLE_RTTI }}
           path: dist
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -488,7 +488,7 @@ jobs:
 
       - name: Release current commit
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*.whl"
           token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/update-llvm.yml
+++ b/.github/workflows/update-llvm.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
## Summary
Mechanical version bumps for stale third-party Actions, intended to land before Dependabot is enabled (#3070) so its first weekly run doesn't open a wave of bump PRs for these.                                                                                                                                        
                                                                                                                                                              
## Bumped                                                                                                                                                   
- `actions/setup-python` `@v5 → @v6`                                                                                                                        
- `hendrikmuhs/ccache-action` `@v1.2`/`@v1.2.12 → @v1` (consolidates two inconsistent pin styles)
- `ilammy/msvc-dev-cmd` `@v1.4.1 → @v1`                                                                                                                     
- `ncipollo/release-action` `@v1.12.0 → @v1`                                                                                                                
- `reviewdog/action-suggester` `@v1.22 → @v1`                                                                                                               
- `edumserrano/find-create-or-update-comment` `@v2 → @v3`                                                                                                   
- `descriptinc/free-disk-space` `@main → SHA` — `@main` on a third-party action is a moving target; SHA-pinning removes that supply-chain risk (and is what Scorecard's `Pinned-Dependencies` check rewards)                                                                                                            
                                                                                                                                                              
  ## Skipped intentionally                                                                                                                                    
  - `aminya/setup-cpp*` — PR #2030 in flight; not superseding it                                                                                              
  - `actions/checkout` — already current via #2981              
  - `actions/upload-artifact` (`@v4 → @v7`), `actions/download-artifact` (`@v4 → @v8`), `microsoft/setup-msbuild` (`@v1 → @v3`),                              
  `peter-evans/create-pull-request` (`@v6 → @v8`), `peaceiris/actions-gh-pages` (`@v3 → @v4`) — major-version jumps with documented breaking changes          
  (artifact-name uniqueness, branching defaults). Safer to let Dependabot open these as individual PRs with changelog links so each can be tested in isolation
                                                                                                                                                              
  ## Interaction with other PRs                                                                                                                               
  Touches the same workflow files as #3072 and #3071 but at non-overlapping line ranges; git auto-merge handles either order cleanly. Independent of #3070.
