### PR TITLE
Enable vectorized matvec kernel with correct A-tile transform (#2747)

### DIFF
--- a/programming_examples/basic/matrix_multiplication/matrix_vector/Makefile
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/Makefile
@@ -39,6 +39,10 @@ ifeq (${b_col_maj}, 1)
 	KERNEL_DEFINES+=-DB_COL_MAJ
 endif
 
+ifeq (${use_scalar}, 1)
+	aieargs+=--scalar
+endif
+
 SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include ${SELF_DIR}../makefile-common
 

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector.py
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector.py
@@ -14,7 +14,7 @@ from aie.helpers.taplib import TensorTiler2D
 from aie.iron.controlflow import range_
 
 
-def my_matmul(dev):
+def my_matmul(dev, vectorized):
     M = 288
     K = 288
     m = 32
@@ -33,9 +33,6 @@ def my_matmul(dev):
 
     m_x_k = m * k
     m_x_K = m * K
-
-    # FIXME vectorized kernel is currently erroneous
-    vectorized = False
 
     dtype_in = np.dtype[np.int16]
     dtype_in_str = "i16"
@@ -95,6 +92,11 @@ def my_matmul(dev):
                 memA_fifos.append(
                     object_fifo(f"memA{i}", ShimTiles[i], MemTiles[i], 2, inA_ty)
                 )
+                # The vectorized kernel reads A in a "32-bit-word transposed"
+                # layout (see aie_kernels/aie2/mv.cc). For 2-byte elements
+                # the transpose granularity is 2 elements; the resulting layout
+                # packs rows of each 2-column word slowly, m rows then next
+                # 2-col word. Applied here on the compute-tile read side.
                 inA_fifos.append(
                     object_fifo(
                         f"inA{i}",
@@ -102,15 +104,9 @@ def my_matmul(dev):
                         cores[i],
                         2,
                         A_ty,
-                        (
-                            [
-                                (k // 2 // 2, 2),
-                                (m, k),
-                                (2, 1),
-                            ]
-                            if vectorized
-                            else []
-                        ),  # transpose at 4-byte (2xbf16) granularity
+                        dimensionsFromStreamPerConsumer=(
+                            [[(m, 2), (k // 2, 2 * m), (2, 1)]] if vectorized else None
+                        ),
                     )
                 )
                 object_fifo_link(memA_fifos[i], inA_fifos[i])
@@ -182,6 +178,6 @@ if __name__ == "__main__":
         prog="AIE Matrix Vector Multiplication MLIR Design",
     )
     argparser.add_argument("--dev", type=str, choices=["npu", "npu2"], default="npu")
+    argparser.add_argument("--scalar", action="store_true", help="use scalar kernel")
     args, _ = argparser.parse_known_args()  # <- ignore the rest args in makefile-common
-    dev = args.dev
-    my_matmul(dev)
+    my_matmul(args.dev, vectorized=not args.scalar)

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector_iron.py
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector_iron.py
@@ -13,7 +13,7 @@ from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorTiler2D
 
 
-def my_matmul(dev):
+def my_matmul(dev, vectorized):
     M = 288
     K = 288
     m = 32
@@ -24,9 +24,6 @@ def my_matmul(dev):
     M_div_n_cores = M // n_cores
     M_div_m_div_n_cores = M // (m * n_cores)
     K_div_k = K // k
-
-    # FIXME vectorized kernel is currently erroneous
-    vectorized = False
 
     # Define types
     dtype_in = np.dtype[np.int16]
@@ -62,6 +59,12 @@ def my_matmul(dev):
             of_b.release(1)
         of_c.release(1)
 
+    # The vectorized kernel reads A from local memory in a "32-bit-word
+    # transposed" layout (see aie_kernels/aie2/mv.cc). For 2-byte elements
+    # the transpose granularity is 2 elements; the resulting layout packs
+    # rows of each 2-column word slowly, m rows then next 2-col word.
+    a_transform = [(m, 2), (k // 2, 2 * m), (2, 1)] if vectorized else None
+
     # Create object fifos and workers for each core
     memA_fifos = []
     coreA_fifos = []
@@ -71,7 +74,7 @@ def my_matmul(dev):
     for i in range(n_cores):
         a_fifo = ObjectFifo(inA_ty, name=f"memA{i}")
         memA_fifos.append(a_fifo)
-        coreA_fifos.append(a_fifo.cons().forward())  # TODO: transform if vectorized
+        coreA_fifos.append(a_fifo.cons().forward(dims_from_stream=a_transform))
         outC_fifos.append(ObjectFifo(outC_ty, name=f"outC{i}"))
         w = Worker(
             core_fn,
@@ -119,6 +122,6 @@ if __name__ == "__main__":
         prog="AIE Matrix Vector Multiplication MLIR Design",
     )
     argparser.add_argument("--dev", type=str, choices=["npu", "npu2"], default="npu")
+    argparser.add_argument("--scalar", action="store_true", help="use scalar kernel")
     args, _ = argparser.parse_known_args()  # <- ignore the rest args in makefile-common
-    dev = args.dev
-    my_matmul(dev)
+    my_matmul(args.dev, vectorized=not args.scalar)

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector_placed.py
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/matrix_vector_placed.py
@@ -14,7 +14,7 @@ from aie.helpers.taplib import TensorTiler2D
 from aie.iron.controlflow import range_
 
 
-def my_matmul(dev):
+def my_matmul(dev, vectorized):
     M = 288
     K = 288
     m = 32
@@ -33,9 +33,6 @@ def my_matmul(dev):
 
     m_x_k = m * k
     m_x_K = m * K
-
-    # FIXME vectorized kernel is currently erroneous
-    vectorized = False
 
     dtype_in = np.dtype[np.int16]
     dtype_in_str = "i16"
@@ -95,6 +92,11 @@ def my_matmul(dev):
                 memA_fifos.append(
                     object_fifo(f"memA{i}", ShimTiles[i], MemTiles[i], 2, inA_ty)
                 )
+                # The vectorized kernel reads A in a "32-bit-word transposed"
+                # layout (see aie_kernels/aie2/mv.cc). For 2-byte elements
+                # the transpose granularity is 2 elements; the resulting layout
+                # packs rows of each 2-column word slowly, m rows then next
+                # 2-col word. Applied here on the compute-tile read side.
                 inA_fifos.append(
                     object_fifo(
                         f"inA{i}",
@@ -102,15 +104,9 @@ def my_matmul(dev):
                         cores[i],
                         2,
                         A_ty,
-                        (
-                            [
-                                (k // 2 // 2, 2),
-                                (m, k),
-                                (2, 1),
-                            ]
-                            if vectorized
-                            else []
-                        ),  # transpose at 4-byte (2xbf16) granularity
+                        dimensionsFromStreamPerConsumer=(
+                            [[(m, 2), (k // 2, 2 * m), (2, 1)]] if vectorized else None
+                        ),
                     )
                 )
                 object_fifo_link(memA_fifos[i], inA_fifos[i])
@@ -196,6 +192,6 @@ if __name__ == "__main__":
         prog="AIE Matrix Vector Multiplication MLIR Design",
     )
     argparser.add_argument("--dev", type=str, choices=["npu", "npu2"], default="npu")
+    argparser.add_argument("--scalar", action="store_true", help="use scalar kernel")
     args, _ = argparser.parse_known_args()  # <- ignore the rest args in makefile-common
-    dev = args.dev
-    my_matmul(dev)
+    my_matmul(args.dev, vectorized=not args.scalar)

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_makefile_iron_scalar.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_makefile_iron_scalar.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_iron_scalar
 // RUN: cd test_iron_scalar
 // RUN: make -f %S/../Makefile clean
-// RUN: env use_iron=1 make -f %S/../Makefile aieargs+=--scalar
-// RUN: %run_on_npu1% env use_iron=1 make -f %S/../Makefile run aieargs+=--scalar
+// RUN: env use_iron=1 make -f %S/../Makefile use_scalar=1
+// RUN: %run_on_npu1% env use_iron=1 make -f %S/../Makefile run use_scalar=1

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_makefile_iron_scalar.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_makefile_iron_scalar.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu1, peano
+//
+// RUN: mkdir -p test_iron_scalar
+// RUN: cd test_iron_scalar
+// RUN: make -f %S/../Makefile clean
+// RUN: env use_iron=1 make -f %S/../Makefile aieargs+=--scalar
+// RUN: %run_on_npu1% env use_iron=1 make -f %S/../Makefile run aieargs+=--scalar

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_strix_makefile_iron_scalar.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_strix_makefile_iron_scalar.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2024 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_iron_scalar_stx
+// RUN: cd test_iron_scalar_stx
+// RUN: make -f %S/../Makefile clean
+// RUN: env use_iron=1 make -f %S/../Makefile devicename=npu2 aieargs+=--scalar
+// RUN: %run_on_npu2% env use_iron=1 make -f %S/../Makefile run devicename=npu2 aieargs+=--scalar

--- a/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_strix_makefile_iron_scalar.lit
+++ b/programming_examples/basic/matrix_multiplication/matrix_vector/tests/run_strix_makefile_iron_scalar.lit
@@ -6,5 +6,5 @@
 // RUN: mkdir -p test_iron_scalar_stx
 // RUN: cd test_iron_scalar_stx
 // RUN: make -f %S/../Makefile clean
-// RUN: env use_iron=1 make -f %S/../Makefile devicename=npu2 aieargs+=--scalar
-// RUN: %run_on_npu2% env use_iron=1 make -f %S/../Makefile run devicename=npu2 aieargs+=--scalar
+// RUN: env use_iron=1 make -f %S/../Makefile devicename=npu2 use_scalar=1
+// RUN: %run_on_npu2% env use_iron=1 make -f %S/../Makefile run devicename=npu2 use_scalar=1


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
Resolves #2747. Wires the correct A-tile layout transform through the matrix-vector designs so the existing `aie_kernels/aie2/mv.cc::matvec_vectorized` kernel produces correct output, removing the long-standing `# FIXME vectorized kernel is currently erroneous` from `matrix_vector.py`, `matrix_vector_placed.py`, and `matrix_vector_iron.py`.                                                                                                                                                            
                                                                                                                                                                                                                     
The kernel reads its A tile in a "32-bit-word transposed" layout (documented in `mv.cc`). For 2-byte elements the correct `dims_from_stream` is:                             

```python                                          
[(m, 2), (k // 2, 2 * m), (2, 1)]                  
```
derived from the kernel's pointer arithmetic (a_ptr += 2*m between column pairs, a_ptr += 2*r between row blocks, a_ptr += 6*m between 8-column groups). The transform is applied on the compute-tile read side via dims_from_stream / dimensionsFromStreamPerConsumer, so no memtile-side restructuring is needed.              

The default kernel selection is now vectorized; the --scalar flag remains as an explicit opt-out for debugging or perf comparison.                                        

Thanks to @MaoxinYee for the initial  investigation in #2747.