### PR TITLE
ci: unstick scorecard upload and wheels RTTI-OFF publish       

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -473,8 +473,8 @@ jobs:
         with:
           artifacts: wheels_off_flat/mlir_aie*whl
           token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: latest-wheels-no-rtti
-          name: latest-wheels-no-rtti
+          tag: latest-wheels-no-rtti-2
+          name: latest-wheels-no-rtti-2
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2  # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Two tiny, independent CI unsticks bundled because they're both one-liners and both have been red on main.                                                                                                           
                                                                                                                                            
- **`scorecard.yml`**: re-pin `ossf/scorecard-action@v2.4.3` to the underlying **commit** SHA (`4eaacf0…`) instead of the **tag-object** SHA (`99c09fe…`). The annotated-tag SHA is what GitHub's API returns for `refs/tags/v2.4.3`, but scorecard.dev's verifier dereferences and rejects it as `imposter commit ... does not belong to ossf/scorecard-action`. The analysis itself runs fine — only the upload-to-webapp step fails, which fails the job. Verified upstream:                                                                                                 
    `GET /repos/ossf/scorecard-action/commits/99c09fe…` → 422;                                                                              
    `GET /git/tags/99c09fe…` → `object.sha = 4eaacf0…`.                                                                                     
                                                                                                                                            
- **`buildRyzenWheels.yml`**: bump RTTI-OFF release tag from `latest-wheels-no-rtti` → `latest-wheels-no-rtti-2`. The existing release is at GitHub's 1000-asset-per-release cap (newest asset there s dated 2026-01-07), so the publish step has been silently failing for a while; `ncipollo/release-action` with `replacesArtifacts: false` can't append once the cap is hit. Bumping the tag is the same pattern RTTI-ON already follows (currently on `latest-wheels-3`). Only self-referenced inside this workflow file — README / `env_setup.sh` / `iron_setup.py` / `quick_setup.sh` all point at `latest-wheels-3`, so no consumer-side updates needed. 