### PR TITLE
ci: fix scorecard codeql-action SHA to real v3.35.4 commit

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@52485aec7be33610227643b0fe83936b8b5f061a  # v3.35.4
+        uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4  # v3.35.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Follow-up to #3097. The Scorecard workflow still fails on every push to main because the SHA pinned for `github/codeql-action/upload-sarif` does not exist in that repository.
                                                                                                                                           
When `ossf/scorecard-action` publishes results, the OSSF webapp walks every `uses:` line in the workflow yaml and rejects the publish with `imposter commit` if any SHA can't be verified. #3097 fixed the same issue on the `scorecard-action` line; this PR fixes the remaining one.                                                                                                                                      
                                                                                                                                            
I also linted every other SHA pin across `.github/workflows/` — all five remaining pins resolve to real commits, so hopefully this should be the last PR of this type.