### PR TITLE
Deprecate Python 3.10 support

### DIFF
--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -82,7 +82,7 @@ jobs:
 
             git submodule update --init --recursive
 
-            apt install python3.10-venv
+            apt install python3.12-venv
             python -m venv aie-venv
             source aie-venv/bin/activate
             pip install --upgrade pip

--- a/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
+++ b/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
@@ -82,7 +82,7 @@ jobs:
               echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' \
                 | tee /etc/apt/preferences.d/rocm-pin-600
             apt update
-            apt install -y rocm-hip-runtime-dev5.6.0 python3.10-venv \
+            apt install -y rocm-hip-runtime-dev5.6.0 python3.12-venv \
                            pkg-config libelf-dev elfutils \
                            libdwarf-dev libsysfs-dev clang libssl-dev uuid-dev
             apt-get clean
@@ -106,7 +106,7 @@ jobs:
             cp -a third_party/aie-rt/driver/src/*.so* /install/aie-rt/lib
             cp -a third_party/aie-rt/driver/include /install/aie-rt
 
-            apt install python3.10-venv
+            apt install python3.12-venv
             python -m venv aie-venv
             source aie-venv/bin/activate
             pip install --upgrade pip

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -76,7 +76,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install Python packages
         run: |

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         build_type: [ Assert, Release ]
         ubuntu_version: [ 22.04, 24.04 ]
-        python_version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        python_version: [ "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       # Clone the repo and its submodules. Do shallow clone to save clone

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -52,12 +52,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            ENABLE_RTTI: ON
-
-          - python_version: "3.10"
-            ENABLE_RTTI: OFF
-
           - python_version: "3.11"
             ENABLE_RTTI: ON
 
@@ -213,27 +207,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python_version: "3.10"
-            ENABLE_RTTI: ON
-  
-          - python_version: "3.10"
-            ENABLE_RTTI: OFF
-  
           - python_version: "3.11"
             ENABLE_RTTI: ON
-  
+
           - python_version: "3.11"
             ENABLE_RTTI: OFF
-  
+
           - python_version: "3.12"
             ENABLE_RTTI: ON
-  
+
           - python_version: "3.12"
             ENABLE_RTTI: OFF
-  
+
           - python_version: "3.13"
             ENABLE_RTTI: ON
-  
+
           - python_version: "3.13"
             ENABLE_RTTI: OFF
   

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install Python packages
         run: |
@@ -133,7 +133,7 @@ jobs:
       - name: Setup Python env
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Check Liquid Syntax
         run: python3 utils/check_liquid_syntax.py
@@ -220,7 +220,7 @@ jobs:
 
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install Python and other packages
         run: |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ xrt-smi examine
 1. Install the following packages needed for MLIR-AIE:
 
     ```bash
-    # Python versions 3.10, 3.11, 3.12, 3.13 and 3.14 are currently supported by our wheels
+    # Python versions 3.11, 3.12, 3.13, and 3.14 are currently supported by our wheels
     sudo apt install \
     build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip
     ```

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -101,7 +101,7 @@ xrt-smi examine
 1. Install the following packages needed for MLIR-AIE:
 
     ```bash
-    # Python versions 3.10, 3.12 and 3.13 are currently supported by our wheels
+    # Python versions 3.11, 3.12, 3.13, and 3.14 are currently supported by our wheels
     sudo apt install \
     build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip
     ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
 1. Install the following packages needed for MLIR-AIE:
 
     ```bash
-    # Python versions 3.10, 3.12 and 3.13 are currently supported by our wheels
+    # Python versions 3.11, 3.12, 3.13, and 3.14 are currently supported by our wheels
     sudo apt install \
     build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip
     ```

--- a/utils/mlir_aie_wheels/python_bindings/pyproject.toml
+++ b/utils/mlir_aie_wheels/python_bindings/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 environment = { PIP_NO_BUILD_ISOLATION = "false" }
 build-verbosity = 3
-build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
+build = "cp311-* cp312-* cp313-* cp314-*"
 manylinux-aarch64-image = "manylinux_2_28"
 manylinux-x86_64-image = "manylinux_2_28"
 

--- a/utils/mlir_aie_wheels/python_bindings/setup.py
+++ b/utils/mlir_aie_wheels/python_bindings/setup.py
@@ -313,7 +313,7 @@ setup(
     ext_modules=[CMakeExtension("_aie", sourcedir=Path(__file__).parent.absolute())],
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     entry_points={
         "console_scripts": [
             "aiecc=aie.compiler.aiecc.main:main",

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -391,7 +391,7 @@ setup(
     },
     zip_safe=False,
     packages=find_packages(exclude=["wheelhouse", "python_bindings", "mlir-aie"]),
-    python_requires=">=3.10",
+    python_requires=">=3.11",
     install_requires=parse_requirements(
         Path(MLIR_AIE_SOURCE_DIR) / "python" / "requirements.txt"
     ),

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -44,11 +44,8 @@ fi
 if hash python3.12; then
    echo "Using python version `python3.12 --version`"
    my_python=python3.12
-elif hash python3.10; then
-   echo "Using python version `python3.10 --version`"
-   my_python=python3.10
 else
-   echo "This script requires python3.10 or python3.12"
+   echo "This script requires python3.12"
    return 1
 fi
 


### PR DESCRIPTION
Python 3.10 reaches upstream end-of-life in October 2026, and the rest of our CI matrix (3.11 → 3.14) is healthy, so this seems like a good time to drop it.  

* Drop 3.10 from the buildAndTestPythons matrix and from both Linux/Windows buildRyzenWheels matrices.
* Drop cp310 from the cibuildwheel build targets and raise python_requires to >=3.11 in both wheel setup.py files, so a pip install on 3.10 fails fast at resolution time.
* Bump the lintAndFormat, buildAndTestMulti, buildAndTestAieTools, and buildAndTestAieToolsHsaBuildOnly jobs from python3.10 to python3.12 (they use Python as a runtime, not a test target).
* Drop the python3.10 fallback branch from utils/quick_setup.sh.
* Update the supported-versions comment in docs/Building.md to match the post-change wheel matrix (3.11, 3.12, 3.13, 3.14).

buildAndTestRyzenAISw is intentionally left unchanged: it tests a cmake/ninja build inside a frozen Ryzen AI 1.3 SDK image whose venv is cp310-only, and the workflow does not pip-install the mlir-aie wheel, so python_requires never gates it.