### PR TITLE
ci: serialize ATB chess builds and extend their lit timeout

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -215,8 +215,17 @@ jobs:
           mkdir $NPU_CACHE_HOME
 
           ninja install
-          ninja check-reference-designs
+
+          # gemm_asymmetric_tile_buffering chess builds peak ~8 GB RSS and
+          # ~9 min wall time alone on 32 GB. They run serialized via lit's
+          # atb_chess parallelism group and need a longer timeout than the
+          # rest of the suite. Split into two invocations so the timeout
+          # extension applies only to those tests.
+          LIT_FILTER_OUT="gemm_asymmetric_tile_buffering" ninja check-reference-designs
           ninja check-programming-guide
+          LIT_OPTS="-j4 -sv --time-tests --timeout 1200 --show-unsupported --show-excluded" \
+            LIT_FILTER="gemm_asymmetric_tile_buffering" \
+            ninja check-reference-designs
           popd
 
       - name: Cleanup NPU_CACHE_HOME

--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -148,3 +148,7 @@ llvm_config.add_tool_substitutions(tools, tool_dirs)
 if config.enable_board_tests:
     lit_config.parallelism_groups["board"] = 1
     config.parallelism_group = "board"
+
+# Opt-in serialization group for chess builds whose peak RSS is large enough
+# to OOM the CI runner under -j4. Tests opt in via a lit.local.cfg.
+lit_config.parallelism_groups["atb_chess"] = 1

--- a/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/lit.local.cfg
+++ b/programming_examples/ml/block_datatypes/gemm_asymmetric_tile_buffering/lit.local.cfg
@@ -1,0 +1,1 @@
+config.parallelism_group = "atb_chess"


### PR DESCRIPTION
The new gemm_asymmetric_tile_buffering chess builds peak at ~8 GB RSS and ~9 min wall time alone on 32 GB. Under -j4 on amdhx370 (32 GB runner), four-way concurrency exhausts memory and pushes wall time past the suite's 600 s lit timeout, producing flaky failures (e.g. run 26189907468).

- Register a new `atb_chess` lit parallelism group with concurrency=1.
- Opt the three configs into it via a lit.local.cfg in the ATB directory.
- Split the CI check-reference-designs invocation into two: main run skips ATB via LIT_FILTER_OUT, then a second ATB-only run with --timeout 1200.

Suite-wide 600 s timeout is unchanged for the other 278 tests. Local single-config measurement: 537 s wall, 8.0 GB peak RSS on a quiet 32 GB box, so 1200 s provides ~2x headroom over the slowest plausible CI run.

If this doesn't work, the next step is to disable them in the lit tests entirely until we find a better fix.