### PR TITLE
Forward source locations across AIE/AIEX transform passes

### DIFF
--- a/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
+++ b/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
@@ -13,6 +13,7 @@
 #ifndef AIE_REGISTER_DATABASE_H
 #define AIE_REGISTER_DATABASE_H
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
@@ -68,6 +69,14 @@ public:
   const RegisterInfo *lookupRegister(llvm::StringRef name,
                                      llvm::StringRef module) const;
 
+  /// Lookup register by tile-relative offset and module name. Used by the
+  /// transaction-binary locmap to decorate each transaction word with its
+  /// semantic register name. Module names are the JSON keys in
+  /// aie_registers_aie2.json (e.g. "core_module", "memory_module",
+  /// "mem_tile_module", "pl_module"). Returns nullptr if no register matches.
+  const RegisterInfo *lookupRegisterByOffset(uint32_t offset,
+                                             llvm::StringRef module) const;
+
   /// Lookup event by name and module
   std::optional<uint32_t> lookupEvent(llvm::StringRef name,
                                       llvm::StringRef module) const;
@@ -80,8 +89,17 @@ private:
 
   bool loadFromJSON(llvm::StringRef registerPath, llvm::StringRef eventPath);
 
+  // Build the offset-keyed reverse index from `registers_`. Called once at
+  // load time after `loadFromJSON` finishes populating `registers_`.
+  void buildOffsetIndex();
+
   llvm::StringMap<RegisterInfo> registers_;
   llvm::StringMap<EventInfo> events_;
+  // (lowercased module name) -> (offset -> *RegisterInfo). Pointers into
+  // entries owned by `registers_`; safe because `registers_` is never
+  // mutated after construction.
+  llvm::StringMap<llvm::DenseMap<uint32_t, const RegisterInfo *>>
+      registersByOffset_;
 };
 
 } // namespace AIE

--- a/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
+++ b/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
@@ -72,8 +72,8 @@ public:
   /// Lookup register by tile-relative offset and module name. Used by the
   /// transaction-binary locmap to decorate each transaction word with its
   /// semantic register name. Module names are the JSON keys in
-  /// aie_registers_aie2.json (e.g. "core_module", "memory_module",
-  /// "mem_tile_module", "pl_module"). Returns nullptr if no register matches.
+  /// aie_registers_aie2.json: "core", "memory", "memory_tile", "shim".
+  /// Returns nullptr if no register matches.
   const RegisterInfo *lookupRegisterByOffset(uint32_t offset,
                                              llvm::StringRef module) const;
 

--- a/include/aie/Targets/AIERT.h
+++ b/include/aie/Targets/AIERT.h
@@ -15,13 +15,36 @@
 #include "aie/Dialect/AIE/IR/AIEEnums.h"
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
 
+#include "mlir/IR/Location.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <map>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace xilinx::AIE {
+struct AIERTControl;
+
+// RAII helper. Constructs while AIERTControl is recording an aie-rt
+// transaction, captures the current XAie_TxnInst command count at entry, and
+// at scope end attributes every aie-rt command produced during the scope to
+// `loc`. The captured ranges are stored on AIERTControl::txnInstrLocs and read
+// out by the AIEToConfiguration round-trip so re-emitted aiex.npu.* ops carry
+// the source op's MLIR Location instead of the device's fallback location.
+class TxnLocBracket {
+public:
+  TxnLocBracket(AIERTControl &ctl, mlir::Location loc);
+  ~TxnLocBracket();
+  TxnLocBracket(const TxnLocBracket &) = delete;
+  TxnLocBracket &operator=(const TxnLocBracket &) = delete;
+
+private:
+  AIERTControl &ctl;
+  mlir::Location loc;
+  uint32_t startCmds;
+};
+
 struct AIERTControl {
 
   AIERTControl(const xilinx::AIE::AIETargetModel &tm);
@@ -46,6 +69,21 @@ struct AIERTControl {
   void startTransaction();
   void dmaUpdateBdAddr(int col, int row, size_t addr, size_t bdId);
   std::vector<uint8_t> exportSerializedTransaction();
+
+  // Per-aie-rt-command source locations, indexed by command order in the
+  // serialized transaction. Populated by TxnLocBracket scopes around each
+  // per-source-op block in the AIERT methods. Empty entries fall back to
+  // mlir::UnknownLoc.
+  const std::vector<mlir::Location> &getTxnInstrLocs() const;
+
+  // Current XAie_TxnInst::NumCmds for the active transaction (zero if no
+  // transaction is being recorded). Used by TxnLocBracket.
+  uint32_t getCurrentTxnNumCmds() const;
+
+  // Append `loc` to txnInstrLocs at indices [startCmds, endCmds). Used by
+  // TxnLocBracket on scope exit.
+  void recordTxnLocRange(uint32_t startCmds, uint32_t endCmds,
+                         mlir::Location loc);
   mlir::LogicalResult resetPartition();
   mlir::LogicalResult resetDMA(int col, int row, bool on);
   mlir::LogicalResult resetCore(int col, int row);

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -40,7 +40,7 @@ struct TxnLocEntry {
   std::string sourceOpName;   // "aiex.npu.write32", etc.
   std::optional<uint64_t> address; // absolute device address when applicable
   std::string registerName;   // regdb-resolved register name; empty if unknown
-  std::string registerModule; // regdb module: "core_module", "memory_module", etc.
+  std::string registerModule; // regdb module: "core", "memory", "memory_tile", "shim"
   std::optional<mlir::Location> loc;
 };
 

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -10,15 +10,46 @@
 #define AIE_TARGETS_AIETARGETS_H
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace xilinx {
 namespace AIE {
+
+// One entry in the sidecar location map produced by AIETranslateNpuToBinary
+// (and AIETranslateControlPacketsToUI32Vec). Each entry describes one
+// transaction operation in the .bin: the byte range it occupies, its opcode,
+// the absolute device address it touches (when applicable), the originating
+// aiex.npu.* op's MLIR Location, and an optional regdb register name resolved
+// from (address, tile-module). The vector is written alongside the .bin as a
+// JSON sidecar (see emitNpuLocmapJSON) so consumers can correlate transaction
+// words back to IRON Python source.
+struct TxnLocEntry {
+  uint32_t byteOffset = 0;
+  uint32_t byteSize = 0;
+  std::string opcodeName;     // "WRITE32", "BLOCKWRITE", etc.
+  std::string sourceOpName;   // "aiex.npu.write32", etc.
+  std::optional<uint64_t> address; // absolute device address when applicable
+  std::string registerName;   // regdb-resolved register name; empty if unknown
+  std::string registerModule; // regdb module: "core_module", "memory_module", etc.
+  std::optional<mlir::Location> loc;
+};
+
+// Serialize a vector of TxnLocEntry as JSON to `output`, with the given
+// device name and binary file basename for the JSON header.
+void emitNpuLocmapJSON(llvm::raw_ostream &output,
+                       llvm::StringRef deviceName,
+                       llvm::StringRef binaryName,
+                       const std::vector<TxnLocEntry> &locmap);
 
 mlir::LogicalResult AIETranslateToXAIEV2(mlir::ModuleOp module,
                                          llvm::raw_ostream &output,
@@ -42,14 +73,16 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
 mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp,
                                             std::vector<uint32_t> &,
                                             llvm::StringRef deviceName = "",
-                                            llvm::StringRef sequenceName = "");
+                                            llvm::StringRef sequenceName = "",
+                                            std::vector<TxnLocEntry> *locmap = nullptr);
 mlir::LogicalResult AIETranslateToUcDma(mlir::ModuleOp module,
                                         llvm::raw_ostream &output);
 mlir::LogicalResult AIETranslateToUcDma(mlir::ModuleOp, std::string &assembly);
 mlir::LogicalResult
 AIETranslateControlPacketsToUI32Vec(mlir::ModuleOp, std::vector<uint32_t> &,
                                     llvm::StringRef deviceName = "",
-                                    llvm::StringRef sequenceName = "");
+                                    llvm::StringRef sequenceName = "",
+                                    std::vector<TxnLocEntry> *locmap = nullptr);
 mlir::LogicalResult AIETranslateToLdScript(mlir::ModuleOp module,
                                            llvm::raw_ostream &output,
                                            int tileCol, int tileRow,

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -32,7 +32,7 @@ namespace AIE {
 // aiex.npu.* op's MLIR Location, and an optional regdb register name resolved
 // from (address, tile-module). The vector is written alongside the .bin as a
 // JSON sidecar (see emitNpuLocmapJSON) so consumers can correlate transaction
-// words back to IRON Python source.
+// words back to the source op's MLIR Location.
 struct TxnLocEntry {
   uint32_t byteOffset = 0;
   uint32_t byteSize = 0;

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -36,18 +36,18 @@ namespace AIE {
 struct TxnLocEntry {
   uint32_t byteOffset = 0;
   uint32_t byteSize = 0;
-  std::string opcodeName;     // "WRITE32", "BLOCKWRITE", etc.
-  std::string sourceOpName;   // "aiex.npu.write32", etc.
+  std::string opcodeName;          // "WRITE32", "BLOCKWRITE", etc.
+  std::string sourceOpName;        // "aiex.npu.write32", etc.
   std::optional<uint64_t> address; // absolute device address when applicable
-  std::string registerName;   // regdb-resolved register name; empty if unknown
-  std::string registerModule; // regdb module: "core", "memory", "memory_tile", "shim"
+  std::string registerName; // regdb-resolved register name; empty if unknown
+  std::string
+      registerModule; // regdb module: "core", "memory", "memory_tile", "shim"
   std::optional<mlir::Location> loc;
 };
 
 // Serialize a vector of TxnLocEntry as JSON to `output`, with the given
 // device name and binary file basename for the JSON header.
-void emitNpuLocmapJSON(llvm::raw_ostream &output,
-                       llvm::StringRef deviceName,
+void emitNpuLocmapJSON(llvm::raw_ostream &output, llvm::StringRef deviceName,
                        llvm::StringRef binaryName,
                        const std::vector<TxnLocEntry> &locmap);
 
@@ -70,11 +70,11 @@ mlir::LogicalResult AIETranslateShimSolution(mlir::ModuleOp module,
                                              llvm::StringRef deviceName = "");
 mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
                                          llvm::raw_ostream &, llvm::StringRef);
-mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp,
-                                            std::vector<uint32_t> &,
-                                            llvm::StringRef deviceName = "",
-                                            llvm::StringRef sequenceName = "",
-                                            std::vector<TxnLocEntry> *locmap = nullptr);
+mlir::LogicalResult
+AIETranslateNpuToBinary(mlir::ModuleOp, std::vector<uint32_t> &,
+                        llvm::StringRef deviceName = "",
+                        llvm::StringRef sequenceName = "",
+                        std::vector<TxnLocEntry> *locmap = nullptr);
 mlir::LogicalResult AIETranslateToUcDma(mlir::ModuleOp module,
                                         llvm::raw_ostream &output);
 mlir::LogicalResult AIETranslateToUcDma(mlir::ModuleOp, std::string &assembly);

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -74,6 +74,7 @@ struct TransactionBinaryOperation {
   std::optional<SyncPayload> sync;
   std::optional<LoadPdiPayload> loadPdi;
   std::optional<AddressPatchPayload> addressPatch;
+  std::optional<mlir::Location> sourceLoc;
 
   TransactionBinaryOperation() = default;
 
@@ -448,14 +449,17 @@ static LogicalResult generateTransactions(AIERTControl &ctl,
 }
 
 // Translate vector of TransactionBinaryOperation to a sequence of transaction
-// ops (npu.write32, npu.maskwrite32, npu.blockwrite).
+// ops (npu.write32, npu.maskwrite32, npu.blockwrite). Each emitted op gets the
+// per-op `sourceLoc` from AIERT's instruction-range bracketing if available;
+// otherwise it falls back to `fallbackLoc` (typically the device location).
 static LogicalResult
-emitTransactionOps(OpBuilder &builder, Location loc,
+emitTransactionOps(OpBuilder &builder, Location fallbackLoc,
                    std::vector<TransactionBinaryOperation> &operations,
                    std::vector<memref::GlobalOp> &global_data) {
 
   // create the txn ops
   for (auto [op, payload] : llvm::zip(operations, global_data)) {
+    Location loc = op.sourceLoc.value_or(fallbackLoc);
 
     if (op.cmd.Opcode == XAie_TxnOpcode::XAIE_IO_WRITE) {
       AIEX::NpuWrite32Op::create(builder, loc, op.cmd.RegOff, op.cmd.Value,
@@ -527,9 +531,11 @@ emitTransactionOps(OpBuilder &builder, Location loc,
 }
 
 // Translate vector of TransactionBinaryOperation to a sequence of control
-// packet ops.
+// packet ops. Each emitted op gets the per-op `sourceLoc` from AIERT's
+// instruction-range bracketing if available; otherwise it falls back to
+// `fallbackLoc`.
 static LogicalResult
-emitControlPacketOps(OpBuilder &builder, Location loc,
+emitControlPacketOps(OpBuilder &builder, Location fallbackLoc,
                      std::vector<TransactionBinaryOperation> &operations,
                      std::vector<memref::GlobalOp> &global_data) {
 
@@ -537,6 +543,7 @@ emitControlPacketOps(OpBuilder &builder, Location loc,
 
   // create the control packet ops
   for (auto [op, payload] : llvm::zip(operations, global_data)) {
+    Location loc = op.sourceLoc.value_or(fallbackLoc);
 
     if (op.cmd.Opcode == XAie_TxnOpcode::XAIE_IO_WRITE) {
       AIEX::NpuControlPacketOp::create(
@@ -764,6 +771,17 @@ LogicalResult xilinx::AIE::generateAndInsertConfigOps(
   if (!parseTransactionBinary(txn_data, operations)) {
     llvm::errs() << "Failed to parse binary\n";
     return failure();
+  }
+
+  // Attach per-op source locations from AIERT's instruction-range bracketing.
+  // The aie-rt TxnList records one XAie_TxnCmd per serialized binary
+  // operation, so the indices align. Operations beyond the recorded range
+  // (or where no bracket fired) keep std::nullopt and inherit the device
+  // fallback location at emit time.
+  const std::vector<mlir::Location> &instrLocs = ctl.getTxnInstrLocs();
+  for (size_t i = 0, e = operations.size(); i < e; ++i) {
+    if (i < instrLocs.size())
+      operations[i].sourceLoc = instrLocs[i];
   }
 
   if (failed(convertTransactionOpsToMLIR(builder, outputType, operations,

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -450,11 +450,9 @@ static LogicalResult generateTransactions(AIERTControl &ctl,
 // Translate vector of TransactionBinaryOperation to a sequence of transaction
 // ops (npu.write32, npu.maskwrite32, npu.blockwrite).
 static LogicalResult
-emitTransactionOps(OpBuilder &builder,
+emitTransactionOps(OpBuilder &builder, Location loc,
                    std::vector<TransactionBinaryOperation> &operations,
                    std::vector<memref::GlobalOp> &global_data) {
-
-  auto loc = builder.getUnknownLoc();
 
   // create the txn ops
   for (auto [op, payload] : llvm::zip(operations, global_data)) {
@@ -531,11 +529,10 @@ emitTransactionOps(OpBuilder &builder,
 // Translate vector of TransactionBinaryOperation to a sequence of control
 // packet ops.
 static LogicalResult
-emitControlPacketOps(OpBuilder &builder,
+emitControlPacketOps(OpBuilder &builder, Location loc,
                      std::vector<TransactionBinaryOperation> &operations,
                      std::vector<memref::GlobalOp> &global_data) {
 
-  auto loc = builder.getUnknownLoc();
   auto ctx = builder.getContext();
 
   // create the control packet ops
@@ -636,17 +633,15 @@ static LogicalResult convertTransactionOpsToMLIR(
     std::vector<TransactionBinaryOperation> &operations,
     std::string blockwrite_prefix = "config_blockwrite_data_") {
 
-  auto loc = builder.getUnknownLoc();
-
   // for each blockwrite in the binary, create a GlobalOp with the data at the
   // device level
   std::vector<memref::GlobalOp> global_data;
+  DeviceOp device = llvm::dyn_cast<DeviceOp>(builder.getBlock()->getParentOp());
+  if (!device) {
+    device = builder.getBlock()->getParentOp()->getParentOfType<DeviceOp>();
+  }
+  Location loc = device.getLoc();
   {
-    DeviceOp device =
-        llvm::dyn_cast<DeviceOp>(builder.getBlock()->getParentOp());
-    if (!device) {
-      device = builder.getBlock()->getParentOp()->getParentOfType<DeviceOp>();
-    }
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(device.getBody());
     unsigned id = 0;
@@ -674,10 +669,10 @@ static LogicalResult convertTransactionOpsToMLIR(
 
   // create the txn ops
   if (outputType == AIE::AIEToConfigurationOutputType::Transaction) {
-    if (failed(emitTransactionOps(builder, operations, global_data)))
+    if (failed(emitTransactionOps(builder, loc, operations, global_data)))
       return failure();
   } else if (outputType == AIE::AIEToConfigurationOutputType::ControlPacket) {
-    if (failed(emitControlPacketOps(builder, operations, global_data)))
+    if (failed(emitControlPacketOps(builder, loc, operations, global_data)))
       return failure();
     // resolve mask writes; control packet doesn't natively support mask write.
     if (failed(orConsecutiveWritesOnSameAddr(builder.getBlock())))
@@ -782,7 +777,7 @@ convertAIEToConfiguration(AIE::DeviceOp device, StringRef clElfDir,
   // and collect them in a vector. If there are none, create a new runtime
   // sequence. Otherwise assume the insertion point is the first
   // aiex.configure op.
-  auto loc = builder.getUnknownLoc();
+  auto loc = device.getLoc();
   SmallVector<AIEX::ConfigureOp> configureOps;
   device.walk([&](AIEX::ConfigureOp op) { configureOps.push_back(op); });
 

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -636,9 +636,15 @@ static LogicalResult convertTransactionOpsToMLIR(
   // for each blockwrite in the binary, create a GlobalOp with the data at the
   // device level
   std::vector<memref::GlobalOp> global_data;
-  DeviceOp device = llvm::dyn_cast<DeviceOp>(builder.getBlock()->getParentOp());
+  Operation *parentOp = builder.getBlock()->getParentOp();
+  DeviceOp device = llvm::dyn_cast<DeviceOp>(parentOp);
   if (!device) {
-    device = builder.getBlock()->getParentOp()->getParentOfType<DeviceOp>();
+    device = parentOp->getParentOfType<DeviceOp>();
+  }
+  if (!device) {
+    parentOp->emitError(
+        "expected insertion point to be nested under an aie.device op");
+    return failure();
   }
   Location loc = device.getLoc();
   {

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -779,6 +779,14 @@ LogicalResult xilinx::AIE::generateAndInsertConfigOps(
   // (or where no bracket fired) keep std::nullopt and inherit the device
   // fallback location at emit time.
   const std::vector<mlir::Location> &instrLocs = ctl.getTxnInstrLocs();
+  // Sharp edge: index alignment relies on the recorder's XAie_TxnCmd count
+  // (instrLocs) and the parser's op count (operations) covering the same set
+  // of opcodes. instrLocs may be shorter (trailing cmds with no bracket), but
+  // if it is *longer* the recorder saw a command the parser dropped and every
+  // index past that point is mislabeled -- fail loudly instead of silently.
+  assert(instrLocs.size() <= operations.size() &&
+         "txn loc/op count mismatch: aie-rt recorded more commands than the "
+         "transaction parser reproduced; opcode coverage has drifted");
   for (size_t i = 0, e = operations.size(); i < e; ++i) {
     if (i < instrLocs.size())
       operations[i].sourceLoc = instrLocs[i];

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1668,8 +1668,8 @@ TileOp TileOp::getOrCreate(mlir::OpBuilder builder, DeviceOp device, int col,
     OpBuilder::InsertionGuard guard(builder);
     mlir::Block &device_start_block = *device.getBodyRegion().begin();
     builder.setInsertionPointToStart(&device_start_block);
-    tile = TileOp::create(builder, builder.getUnknownLoc(),
-                          builder.getIndexType(), col, row);
+    tile = TileOp::create(builder, device.getLoc(), builder.getIndexType(), col,
+                          row);
   }
   return tile;
 }

--- a/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
@@ -42,7 +42,7 @@ struct AIECanonicalizeDevicePass
     // the new op quite yet.
     OpBuilder builder(moduleOp->getContext());
 
-    Location location = builder.getUnknownLoc();
+    Location location = moduleOp.getLoc();
     auto deviceOp = DeviceOp::create(
         builder, location,
         AIEDeviceAttr::get(builder.getContext(), AIEDevice::xcvc1902),

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -211,7 +211,7 @@ struct AIEDebugOpToStdLowering : OpConversionPattern<DebugOp> {
              << funcName;
     SmallVector<Value, 1> args;
     args.push_back(op.getArg());
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), func, args);
+    func::CallOp::create(rewriter, op.getLoc(), func, args);
     rewriter.eraseOp(op);
     return success();
   }
@@ -259,7 +259,7 @@ struct AIEPutStreamToStdLowering : OpConversionPattern<PutStreamOp> {
           rewriter, op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(0))); // tlast
     }
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), putMSFunc, args);
+    func::CallOp::create(rewriter, op.getLoc(), putMSFunc, args);
     rewriter.eraseOp(op);
     return success();
   }
@@ -300,8 +300,8 @@ struct AIEGetStreamToStdLowering : OpConversionPattern<GetStreamOp> {
     SmallVector<Value, 2> args;
     if (targetModel.getTargetArch() == AIEArch::AIE1)
       args.push_back(op.getChannel());
-    auto getSSCall = func::CallOp::create(rewriter, rewriter.getUnknownLoc(),
-                                          getSSFunc, args);
+    auto getSSCall =
+        func::CallOp::create(rewriter, op.getLoc(), getSSFunc, args);
     rewriter.replaceOp(op, getSSCall.getResult(0));
     // Capture TLAST in AIEv2?
     return success();
@@ -352,7 +352,7 @@ struct AIEPutCascadeToStdLowering : OpConversionPattern<PutCascadeOp> {
           rewriter, op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(1))); // enable
 
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), putMCDFunc, args);
+    func::CallOp::create(rewriter, op.getLoc(), putMCDFunc, args);
     rewriter.eraseOp(op);
     return success();
   }
@@ -388,8 +388,8 @@ struct AIEGetCascadeToStdLowering : OpConversionPattern<GetCascadeOp> {
           rewriter, op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(1))); // enable
 
-    auto getSCDCall = func::CallOp::create(rewriter, rewriter.getUnknownLoc(),
-                                           getSCDFunc, args);
+    auto getSCDCall =
+        func::CallOp::create(rewriter, op.getLoc(), getSCDFunc, args);
     Value result = getSCDCall.getResult(0);
 
     // Check if we need a bitcast
@@ -459,8 +459,7 @@ struct AIEUseLockToStdLowering : OpConversionPattern<UseLockOp> {
                                     IntegerType::get(rewriter.getContext(), 32),
                                     rewriter.getI32IntegerAttr(lockValue)));
 
-      func::CallOp::create(rewriter, rewriter.getUnknownLoc(), useLockFunc,
-                           args);
+      func::CallOp::create(rewriter, useLock.getLoc(), useLockFunc, args);
     }
     rewriter.eraseOp(useLock);
     return success();
@@ -490,7 +489,7 @@ struct AIEBufferToStandard : OpConversionPattern<BufferOp> {
     // prevent duplication in the data section of the elf/object file)
     if ((tileRow != row && tileRow != -1) || (tileCol != col && tileCol != -1))
       initValue = nullptr;
-    memref::GlobalOp::create(rewriter, rewriter.getUnknownLoc(), symName,
+    memref::GlobalOp::create(rewriter, buffer.getLoc(), symName,
                              rewriter.getStringAttr("public"), buffer.getType(),
                              initValue, /*constant*/ false,
                              /*alignment*/ nullptr);
@@ -498,11 +497,11 @@ struct AIEBufferToStandard : OpConversionPattern<BufferOp> {
     for (auto &use : make_early_inc_range(buffer.getResult().getUses())) {
       Operation *user = use.getOwner();
       rewriter.setInsertionPoint(user);
-      auto allocated = memref::GetGlobalOp::create(
-          rewriter, rewriter.getUnknownLoc(), t, symName);
+      auto allocated =
+          memref::GetGlobalOp::create(rewriter, buffer.getLoc(), t, symName);
       // Assume that buffers are aligned so they can be vectorized.
-      memref::AssumeAlignmentOp::create(rewriter, rewriter.getUnknownLoc(),
-                                        allocated, 32);
+      memref::AssumeAlignmentOp::create(rewriter, buffer.getLoc(), allocated,
+                                        32);
 
       use.set(allocated.getResult());
     }
@@ -547,7 +546,7 @@ struct AIECoreToStandardFunc : OpConversionPattern<CoreOp> {
     std::string coreName("core_" + std::to_string(col) + "_" +
                          std::to_string(row));
     auto coreFunc =
-        func::FuncOp::create(rewriter, rewriter.getUnknownLoc(), coreName,
+        func::FuncOp::create(rewriter, op.getLoc(), coreName,
                              FunctionType::get(rewriter.getContext(), {}, {}));
 
     rewriter.cloneRegionBefore(op.getBody(), coreFunc.getBody(),
@@ -641,8 +640,7 @@ struct AIECoreToStandardFunc : OpConversionPattern<CoreOp> {
       rewriter.setInsertionPointAfter(childOp);
 
       if (isa<EndOp>(childOp)) {
-        func::ReturnOp::create(rewriter, rewriter.getUnknownLoc(),
-                               ValueRange({}));
+        func::ReturnOp::create(rewriter, childOp->getLoc(), ValueRange({}));
         rewriter.eraseOp(childOp);
       }
     });
@@ -701,7 +699,7 @@ struct AIEEventOpToStdLowering : OpConversionPattern<EventOp> {
     if (!eventFunc)
       return op.emitOpError("Could not find the intrinsic function ")
              << funcName;
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), eventFunc, args);
+    func::CallOp::create(rewriter, op.getLoc(), eventFunc, args);
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -46,8 +46,8 @@ struct ConvertFlowsToInterconnect : OpConversionPattern<FlowOp> {
     auto point = rewriter.saveInsertionPoint();
     rewriter.setInsertionPoint(b.getTerminator());
 
-    ConnectOp::create(rewriter, rewriter.getUnknownLoc(), inBundle, inIndex,
-                      outBundle, outIndex);
+    ConnectOp::create(rewriter, flowOp.getLoc(), inBundle, inIndex, outBundle,
+                      outIndex);
 
     rewriter.restoreInsertionPoint(point);
 
@@ -832,13 +832,13 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     Operation *tileOp = map.second;
     TileOp tile = cast<TileOp>(map.second);
     TileID tileId = tile.getTileID();
+    Location tileLoc = tile.getLoc();
 
     // Create a switchbox for the routes and insert inside it.
     builder.setInsertionPointAfter(tileOp);
     SwitchboxOp swbox =
         analyzer.getSwitchbox(builder, tile.colIndex(), tile.rowIndex());
-    SwitchboxOp::ensureTerminator(swbox.getConnections(), builder,
-                                  builder.getUnknownLoc());
+    SwitchboxOp::ensureTerminator(swbox.getConnections(), builder, tileLoc);
     Block &b = swbox.getConnections().front();
     builder.setInsertionPoint(b.getTerminator());
 
@@ -859,8 +859,7 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         if (amselOpNeededVector[amselValue]) {
           int arbiterID = a;
           int msel = i;
-          auto amsel = AMSelOp::create(builder, builder.getUnknownLoc(),
-                                       arbiterID, msel);
+          auto amsel = AMSelOp::create(builder, tileLoc, arbiterID, msel);
           amselOps[amselValue] = amsel;
         }
       }
@@ -885,8 +884,8 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         amsels.push_back(amselOps[msel]);
       }
 
-      MasterSetOp::create(builder, builder.getUnknownLoc(),
-                          builder.getIndexType(), bundle, channel, amsels,
+      MasterSetOp::create(builder, tileLoc, builder.getIndexType(), bundle,
+                          channel, amsels,
                           keepPktHeaderAttr[{tileId, tileMaster}]);
     }
 
@@ -915,10 +914,9 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
 
       PacketRulesOp packetrules;
       if (slaveRules.count(slave) == 0) {
-        packetrules = PacketRulesOp::create(builder, builder.getUnknownLoc(),
-                                            bundle, channel);
+        packetrules = PacketRulesOp::create(builder, tileLoc, bundle, channel);
         PacketRulesOp::ensureTerminator(packetrules.getRules(), builder,
-                                        builder.getUnknownLoc());
+                                        tileLoc);
         slaveRules[slave] = packetrules;
       } else
         packetrules = slaveRules[slave];
@@ -939,7 +937,7 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       }
 
       builder.setInsertionPoint(rules.getTerminator());
-      PacketRuleOp::create(builder, builder.getUnknownLoc(), mask, ID, amsel);
+      PacketRuleOp::create(builder, tileLoc, mask, ID, amsel);
     }
   }
 
@@ -996,13 +994,13 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
           pktrules.setSourceBundle(WireBundle::South);
           if (pktrules.getSourceChannel() == 0) {
             pktrules.setSourceChannel(3);
-            ConnectOp::create(builder, builder.getUnknownLoc(), WireBundle::DMA,
-                              0, WireBundle::North, 3);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::DMA, 0,
+                              WireBundle::North, 3);
           }
           if (pktrules.getSourceChannel() == 1) {
             pktrules.setSourceChannel(7);
-            ConnectOp::create(builder, builder.getUnknownLoc(), WireBundle::DMA,
-                              1, WireBundle::North, 7);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::DMA, 1,
+                              WireBundle::North, 7);
           }
         }
       }
@@ -1027,13 +1025,13 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
           mtset.setDestBundle(WireBundle::South);
           if (mtset.getDestChannel() == 0) {
             mtset.setDestChannel(2);
-            ConnectOp::create(builder, builder.getUnknownLoc(),
-                              WireBundle::North, 2, WireBundle::DMA, 0);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::North, 2,
+                              WireBundle::DMA, 0);
           }
           if (mtset.getDestChannel() == 1) {
             mtset.setDestChannel(3);
-            ConnectOp::create(builder, builder.getUnknownLoc(),
-                              WireBundle::North, 3, WireBundle::DMA, 1);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::North, 3,
+                              WireBundle::DMA, 1);
           }
         }
       }
@@ -1084,54 +1082,55 @@ void AIEPathfinderPass::runOnOperation() {
         sw = analyzer.coordToSwitchbox[{col, row}];
       else
         continue;
+      Location loc = tile.getLoc();
       if (col > 0) {
         // connections east-west between stream switches
         if (analyzer.coordToSwitchbox.count({col - 1, row})) {
           auto westsw = analyzer.coordToSwitchbox[{col - 1, row}];
-          WireOp::create(builder, builder.getUnknownLoc(), westsw,
-                         WireBundle::East, sw, WireBundle::West);
+          WireOp::create(builder, loc, westsw, WireBundle::East, sw,
+                         WireBundle::West);
         }
       }
       if (row > 0) {
         // connections between abstract 'core' of tile
-        WireOp::create(builder, builder.getUnknownLoc(), tile, WireBundle::Core,
-                       sw, WireBundle::Core);
+        WireOp::create(builder, loc, tile, WireBundle::Core, sw,
+                       WireBundle::Core);
         // connections between abstract 'dma' of tile
-        WireOp::create(builder, builder.getUnknownLoc(), tile, WireBundle::DMA,
-                       sw, WireBundle::DMA);
+        WireOp::create(builder, loc, tile, WireBundle::DMA, sw,
+                       WireBundle::DMA);
         // connections north-south inside array ( including connection to shim
         // row)
         if (analyzer.coordToSwitchbox.count({col, row - 1})) {
           auto southsw = analyzer.coordToSwitchbox[{col, row - 1}];
-          WireOp::create(builder, builder.getUnknownLoc(), southsw,
-                         WireBundle::North, sw, WireBundle::South);
+          WireOp::create(builder, loc, southsw, WireBundle::North, sw,
+                         WireBundle::South);
         }
       } else if (row == 0) {
         if (tile.isShimNOCTile()) {
           if (analyzer.coordToShimMux.count({col, 0})) {
             auto shimsw = analyzer.coordToShimMux[{col, 0}];
             WireOp::create(
-                builder, builder.getUnknownLoc(), shimsw,
+                builder, loc, shimsw,
                 WireBundle::North, // Changed to connect into the north
                 sw, WireBundle::South);
             // PLIO is attached to shim mux
             if (analyzer.coordToPLIO.count(col)) {
               auto plio = analyzer.coordToPLIO[col];
-              WireOp::create(builder, builder.getUnknownLoc(), plio,
-                             WireBundle::North, shimsw, WireBundle::South);
+              WireOp::create(builder, loc, plio, WireBundle::North, shimsw,
+                             WireBundle::South);
             }
 
             // abstract 'DMA' connection on tile is attached to shim mux ( in
             // row 0 )
-            WireOp::create(builder, builder.getUnknownLoc(), tile,
-                           WireBundle::DMA, shimsw, WireBundle::DMA);
+            WireOp::create(builder, loc, tile, WireBundle::DMA, shimsw,
+                           WireBundle::DMA);
           }
         } else if (tile.isShimPLTile()) {
           // PLIO is attached directly to switch
           if (analyzer.coordToPLIO.count(col)) {
             auto plio = analyzer.coordToPLIO[col];
-            WireOp::create(builder, builder.getUnknownLoc(), plio,
-                           WireBundle::North, sw, WireBundle::South);
+            WireOp::create(builder, loc, plio, WireBundle::North, sw,
+                           WireBundle::South);
           }
         }
       }

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -201,8 +201,8 @@ struct AIEGenerateColumnControlOverlayPass
     }
   }
 
-  AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, int &flowID,
-                                       Value source,
+  AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, Location loc,
+                                       int &flowID, Value source,
                                        xilinx::AIE::WireBundle sourceBundle,
                                        uint32_t sourceChannel, Value dest,
                                        xilinx::AIE::WireBundle destBundle,
@@ -211,17 +211,15 @@ struct AIEGenerateColumnControlOverlayPass
                                        mlir::BoolAttr ctrl_pkt_flow = nullptr) {
     OpBuilder::InsertionGuard guard(builder);
 
-    AIE::PacketFlowOp pktFlow =
-        AIE::PacketFlowOp::create(builder, builder.getUnknownLoc(), flowID++,
-                                  keep_pkt_header, ctrl_pkt_flow);
+    AIE::PacketFlowOp pktFlow = AIE::PacketFlowOp::create(
+        builder, loc, flowID++, keep_pkt_header, ctrl_pkt_flow);
     Region &r_pktFlow = pktFlow.getPorts();
     Block *b_pktFlow = builder.createBlock(&r_pktFlow);
     builder.setInsertionPointToStart(b_pktFlow);
-    AIE::PacketSourceOp::create(builder, builder.getUnknownLoc(), source,
-                                sourceBundle, sourceChannel);
-    AIE::PacketDestOp::create(builder, builder.getUnknownLoc(), dest,
-                              destBundle, destChannel);
-    AIE::EndOp::create(builder, builder.getUnknownLoc());
+    AIE::PacketSourceOp::create(builder, loc, source, sourceBundle,
+                                sourceChannel);
+    AIE::PacketDestOp::create(builder, loc, dest, destBundle, destChannel);
+    AIE::EndOp::create(builder, loc);
     return pktFlow;
   }
 
@@ -299,14 +297,14 @@ struct AIEGenerateColumnControlOverlayPass
       auto ctrl_pkt_flow = builder.getBoolAttr(true);
       if (isShimMM2S)
         (void)createPacketFlowOp(
-            builder, ctrlPktFlowID, shimTile, shimWireBundle,
+            builder, tOp.getLoc(), ctrlPktFlowID, shimTile, shimWireBundle,
             rowToShimChanMap[tOp.rowIndex()], tOp, ctrlWireBundle,
             coreOrMemChanId, keep_pkt_header, ctrl_pkt_flow);
       else
-        (void)createPacketFlowOp(builder, ctrlPktFlowID, tOp, ctrlWireBundle,
-                                 coreOrMemChanId, shimTile, shimWireBundle,
-                                 rowToShimChanMap[tOp.rowIndex()],
-                                 keep_pkt_header, ctrl_pkt_flow);
+        (void)createPacketFlowOp(
+            builder, tOp.getLoc(), ctrlPktFlowID, tOp, ctrlWireBundle,
+            coreOrMemChanId, shimTile, shimWireBundle,
+            rowToShimChanMap[tOp.rowIndex()], keep_pkt_header, ctrl_pkt_flow);
 
       // Generate shim dma alloc ops as handle for runtime sequence to pickup,
       // when issuing control packets
@@ -327,9 +325,8 @@ struct AIEGenerateColumnControlOverlayPass
         continue;
 
       AIE::ShimDMAAllocationOp::create(
-          builder, builder.getUnknownLoc(), StringRef(dma_name),
-          shimTile.getResult(), dir, rowToShimChanMap[tOp.rowIndex()], false,
-          nullptr);
+          builder, tOp.getLoc(), StringRef(dma_name), shimTile.getResult(), dir,
+          rowToShimChanMap[tOp.rowIndex()], false, nullptr);
     }
   }
 

--- a/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp
+++ b/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp
@@ -80,7 +80,7 @@ struct AIELocalizeLocksPass
                 OpBuilder::atBlockBegin(&coreOp.getBody().front());
 
             Value coreLockIDValue = arith::ConstantIndexOp::create(
-                builder, builder.getUnknownLoc(), localLockIndex);
+                builder, lock.getLoc(), localLockIndex);
             lock.getResult().replaceUsesWithIf(
                 coreLockIDValue, [&](OpOperand &opOperand) {
                   return opOperand.getOwner()->getParentOp() == coreOp;

--- a/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
@@ -79,7 +79,7 @@ struct AIELowerCascadeFlowsPass
       } else {
         outputDir = WireBundle::South;
       }
-      ConfigureCascadeOp::create(builder, builder.getUnknownLoc(), tile,
+      ConfigureCascadeOp::create(builder, tile.getLoc(), tile,
                                  static_cast<CascadeDir>(inputDir),
                                  static_cast<CascadeDir>(outputDir));
     }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -42,15 +42,15 @@ struct AIEObjectFifoRegisterProcessPass
     : xilinx::AIE::impl::AIEObjectFifoRegisterProcessBase<
           AIEObjectFifoRegisterProcessPass> {
 
-  scf::ForOp createForLoop(OpBuilder &builder, int length) {
-    auto lowerBound = arith::ConstantOp::create(
-        builder, builder.getUnknownLoc(), builder.getIndexAttr(0));
-    auto upperBound = arith::ConstantOp::create(
-        builder, builder.getUnknownLoc(), builder.getIndexAttr(length));
-    auto step = arith::ConstantOp::create(builder, builder.getUnknownLoc(),
-                                          builder.getIndexAttr(1));
-    auto forLoop = scf::ForOp::create(builder, builder.getUnknownLoc(),
-                                      lowerBound, upperBound, step);
+  scf::ForOp createForLoop(OpBuilder &builder, Location loc, int length) {
+    auto lowerBound =
+        arith::ConstantOp::create(builder, loc, builder.getIndexAttr(0));
+    auto upperBound =
+        arith::ConstantOp::create(builder, loc, builder.getIndexAttr(length));
+    auto step =
+        arith::ConstantOp::create(builder, loc, builder.getIndexAttr(1));
+    auto forLoop =
+        scf::ForOp::create(builder, loc, lowerBound, upperBound, step);
     return forLoop;
   }
 
@@ -58,10 +58,11 @@ struct AIEObjectFifoRegisterProcessPass
                      ObjectFifoRegisterProcessOp regOp, MemRefType elementType,
                      IntegerAttr acqNumber, IntegerAttr relNumber, int length) {
     auto ctx = device->getContext();
+    Location loc = regOp.getLoc();
     // create for loop
     scf::ForOp forLoop;
     if (length > 1) {
-      forLoop = createForLoop(builder, length);
+      forLoop = createForLoop(builder, loc, length);
       Region &forRegion = forLoop.getRegion();
       builder.setInsertionPointToStart(&forRegion.back());
     }
@@ -70,13 +71,13 @@ struct AIEObjectFifoRegisterProcessPass
     if (acqNumber.getInt() > 0) {
       auto acqType = AIEObjectFifoSubviewType::get(elementType);
       auto acqOp = ObjectFifoAcquireOp::create(
-          builder, builder.getUnknownLoc(), acqType, regOp.getPortAttr(),
+          builder, loc, acqType, regOp.getPortAttr(),
           SymbolRefAttr::get(ctx, regOp.getObjFifoName()), acqNumber);
 
       // subview accesses
       for (int i = 0; i < acqNumber.getInt(); i++)
         (void)ObjectFifoSubviewAccessOp::create(
-            builder, builder.getUnknownLoc(), elementType, acqOp.getSubview(),
+            builder, loc, elementType, acqOp.getSubview(),
             builder.getIntegerAttr(builder.getI32Type(), i));
 
       // apply kernel
@@ -87,14 +88,13 @@ struct AIEObjectFifoRegisterProcessPass
           break;
         }
       }
-      func::CallOp::create(builder, builder.getUnknownLoc(),
-                           func /*, acc.output()*/);
+      func::CallOp::create(builder, loc, func /*, acc.output()*/);
     }
 
     // releases
     if (relNumber.getInt() > 0) {
       auto relOp = ObjectFifoReleaseOp::create(
-          builder, builder.getUnknownLoc(), regOp.getPortAttr(),
+          builder, loc, regOp.getPortAttr(),
           SymbolRefAttr::get(ctx, regOp.getObjFifoName()), relNumber);
       builder.setInsertionPointAfter(relOp);
     }
@@ -143,13 +143,13 @@ struct AIEObjectFifoRegisterProcessPass
           /*AllowRepeats=*/false);
       // retrieve core associated to above tile or create new one
       if (!op) {
-        CoreOp coreOp = CoreOp::create(builder, builder.getUnknownLoc(),
+        CoreOp coreOp = CoreOp::create(builder, registerOp.getLoc(),
                                        builder.getIndexType(), tile);
         Region &r = coreOp.getBody();
         r.push_back(new Block);
         Block &block = r.back();
         builder.setInsertionPointToStart(&block);
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, registerOp.getLoc());
         builder.setInsertionPointToStart(&block);
       } else {
         CoreOp coreOp = llvm::dyn_cast<CoreOp>(op);

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -378,14 +378,14 @@ struct AIEObjectFifoStatefulTransformPass
   }
 
   ObjectFifoCreateOp
-  createObjectFifo(OpBuilder &builder, AIEObjectFifoType datatype,
+  createObjectFifo(OpBuilder &builder, Location loc, AIEObjectFifoType datatype,
                    std::string name, Value prodTile, Value consTile,
                    Attribute depth, BDDimLayoutArrayAttr dimensionsToStream,
                    BDDimLayoutArrayArrayAttr dimensionsFromStreamPerConsumer) {
     auto ofName = builder.getStringAttr(name);
     auto fifo = ObjectFifoCreateOp::create(
-        builder, builder.getUnknownLoc(), ofName, prodTile, consTile, depth,
-        datatype, dimensionsToStream, dimensionsFromStreamPerConsumer);
+        builder, loc, ofName, prodTile, consTile, depth, datatype,
+        dimensionsToStream, dimensionsFromStreamPerConsumer);
     return fifo;
   }
 
@@ -414,14 +414,15 @@ struct AIEObjectFifoStatefulTransformPass
       if (!state.externalBuffersPerFifo[op].empty())
         numElem = state.externalBuffersPerFifo[op].size();
     }
+    Location ofLoc = op.getLoc();
     if (target.getTargetArch() == AIEArch::AIE1) {
       for (int i = 0; i < numElem; i++) {
         // create corresponding aie1 locks
         int initValue = op.getInitValues().has_value() ? 1 : 0;
         int lockID = lockAnalysis.getLockID(creation_tile);
         assert(lockID >= 0 && "No more locks to allocate!");
-        auto lock = LockOp::create(builder, builder.getUnknownLoc(),
-                                   creation_tile, lockID, initValue);
+        auto lock =
+            LockOp::create(builder, ofLoc, creation_tile, lockID, initValue);
         lock.getOperation()->setAttr(SymbolTable::getSymbolAttrName(),
                                      builder.getStringAttr(op.name().str() +
                                                            "_lock_" +
@@ -437,9 +438,8 @@ struct AIEObjectFifoStatefulTransformPass
         int prodLockID = lockAnalysis.getLockID(creation_tile);
         assert(prodLockID >= 0 && "No more locks to allocate!");
         int prodLockValue = (numElem - initValues) * repeatCount;
-        auto prodLock =
-            LockOp::create(builder, builder.getUnknownLoc(), creation_tile,
-                           prodLockID, prodLockValue);
+        auto prodLock = LockOp::create(builder, ofLoc, creation_tile,
+                                       prodLockID, prodLockValue);
         prodLock.getOperation()->setAttr(
             SymbolTable::getSymbolAttrName(),
             builder.getStringAttr(op.name().str() + "_prod_lock_" +
@@ -449,9 +449,8 @@ struct AIEObjectFifoStatefulTransformPass
         int consLockID = lockAnalysis.getLockID(creation_tile);
         assert(consLockID >= 0 && "No more locks to allocate!");
         int consLockValue = initValues * repeatCount;
-        auto consLock =
-            LockOp::create(builder, builder.getUnknownLoc(), creation_tile,
-                           consLockID, consLockValue);
+        auto consLock = LockOp::create(builder, ofLoc, creation_tile,
+                                       consLockID, consLockValue);
         consLock.getOperation()->setAttr(
             SymbolTable::getSymbolAttrName(),
             builder.getStringAttr(op.name().str() + "_cons_lock_" +
@@ -583,7 +582,7 @@ struct AIEObjectFifoStatefulTransformPass
     }
 
     builder.setInsertionPointAfter(insertAfter);
-    auto newTile = TileOp::create(builder, builder.getUnknownLoc(), col, row);
+    auto newTile = TileOp::create(builder, hostTile.getLoc(), col, row);
 
     builder.restoreInsertionPoint(savedInsertionPoint);
 
@@ -783,8 +782,7 @@ struct AIEObjectFifoStatefulTransformPass
           }
         }
         auto buff = BufferOp::create(
-            builder, builder.getUnknownLoc(), elemType,
-            current_buf_allocation_tile,
+            builder, op.getLoc(), elemType, current_buf_allocation_tile,
             builder.getStringAttr(op.name().str() + "_buff_" +
                                   std::to_string(of_elem_index)),
             /*address*/ nullptr, initValues,
@@ -826,31 +824,27 @@ struct AIEObjectFifoStatefulTransformPass
 
   /// Function used to create a Bd block.
   template <typename MyOp>
-  void createBd(OpBuilder &builder, LockOp acqLock, int acqMode,
+  void createBd(OpBuilder &builder, Location loc, LockOp acqLock, int acqMode,
                 LockAction acqLockAction, LockOp relLock, int relMode,
                 MyOp buff, int offset, int len, Block *succ,
                 BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr padDimensions,
                 std::optional<PacketInfoAttr> bdPacket) {
     if (acqLock)
-      UseLockOp::create(builder, builder.getUnknownLoc(), acqLock,
-                        acqLockAction, acqMode);
+      UseLockOp::create(builder, loc, acqLock, acqLockAction, acqMode);
     if (bdPacket) {
-      DMABDPACKETOp::create(builder, builder.getUnknownLoc(),
-                            bdPacket->getPktType(), bdPacket->getPktId());
+      DMABDPACKETOp::create(builder, loc, bdPacket->getPktType(),
+                            bdPacket->getPktId());
     }
     if (!dims.getValue().empty() && padDimensions) {
-      DMABDOp::create(builder, builder.getUnknownLoc(), buff, offset, len, dims,
-                      padDimensions);
+      DMABDOp::create(builder, loc, buff, offset, len, dims, padDimensions);
     } else if (!dims.getValue().empty()) {
-      DMABDOp::create(builder, builder.getUnknownLoc(), buff, offset, len,
-                      dims);
+      DMABDOp::create(builder, loc, buff, offset, len, dims);
     } else {
-      DMABDOp::create(builder, builder.getUnknownLoc(), buff, offset, len);
+      DMABDOp::create(builder, loc, buff, offset, len);
     }
     if (acqLock)
-      UseLockOp::create(builder, builder.getUnknownLoc(), relLock,
-                        LockAction::Release, relMode);
-    NextBDOp::create(builder, builder.getUnknownLoc(), succ);
+      UseLockOp::create(builder, loc, relLock, LockAction::Release, relMode);
+    NextBDOp::create(builder, loc, succ);
   }
 
   /// Function used to create a Bd block.
@@ -906,8 +900,8 @@ struct AIEObjectFifoStatefulTransformPass
                       : state.locksPerFifo[op][prodLockIndex];
       }
     }
-    createBd(builder, acqLock, acqMode, acqLockAction, relLock, relMode, buff,
-             offset, len, succ, dims, padDimensions, bdPacket);
+    createBd(builder, op.getLoc(), acqLock, acqMode, acqLockAction, relLock,
+             relMode, buff, offset, len, succ, dims, padDimensions, bdPacket);
   }
 
   /// Function that either calls createAIETileDMA(), createShimDMA() or
@@ -985,12 +979,11 @@ struct AIEObjectFifoStatefulTransformPass
     if (producerMem == nullptr) {
       OpBuilder::InsertionGuard g(builder);
       builder.setInsertionPoint(device.getBody()->getTerminator());
-      auto newMemOp =
-          MemOp::create(builder, builder.getUnknownLoc(), objFifoTileOp);
+      auto newMemOp = MemOp::create(builder, op.getLoc(), objFifoTileOp);
       {
         OpBuilder::InsertionGuard g(builder);
         builder.setInsertionPointToStart(&newMemOp.getRegion().emplaceBlock());
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, op.getLoc());
       }
       producerMem = newMemOp.getOperation();
     }
@@ -1006,8 +999,8 @@ struct AIEObjectFifoStatefulTransformPass
     int dmaRepeatCount = useHwRepeat ? repeatCount - 1 : 0;
     int bdRepeatCount = useHwRepeat ? 1 : repeatCount;
     builder.setInsertionPointToStart(dmaBlock);
-    DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
-                       channelIndex, dmaRepeatCount, bdBlock, endBlock);
+    DMAStartOp::create(builder, op.getLoc(), channelDir, channelIndex,
+                       dmaRepeatCount, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
       lastDmaBlock->getTerminator()->setSuccessor(dmaBlock, 1);
 
@@ -1065,12 +1058,12 @@ struct AIEObjectFifoStatefulTransformPass
     if (producerDMA == nullptr) {
       OpBuilder::InsertionGuard g(builder);
       builder.setInsertionPoint(device.getBody()->getTerminator());
-      auto newDMAOp = ShimDMAOp::create(builder, builder.getUnknownLoc(),
+      auto newDMAOp = ShimDMAOp::create(builder, op.getLoc(),
                                         builder.getIndexType(), objFifoTileOp);
       {
         OpBuilder::InsertionGuard g(builder);
         builder.setInsertionPointToStart(&newDMAOp.getRegion().emplaceBlock());
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, op.getLoc());
       }
       producerDMA = newDMAOp.getOperation();
     }
@@ -1082,8 +1075,8 @@ struct AIEObjectFifoStatefulTransformPass
 
     // create DMA channel
     builder.setInsertionPointToStart(dmaBlock);
-    DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
-                       channelIndex, /*repeatCout*/ 0, bdBlock, endBlock);
+    DMAStartOp::create(builder, op.getLoc(), channelDir, channelIndex,
+                       /*repeatCout*/ 0, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
       lastDmaBlock->getTerminator()->setSuccessor(dmaBlock, 1);
 
@@ -1228,12 +1221,11 @@ struct AIEObjectFifoStatefulTransformPass
     if (producerDMA == nullptr) {
       OpBuilder::InsertionGuard g(builder);
       builder.setInsertionPoint(device.getBody()->getTerminator());
-      auto newDMAOp =
-          MemTileDMAOp::create(builder, builder.getUnknownLoc(), objFifoTileOp);
+      auto newDMAOp = MemTileDMAOp::create(builder, op.getLoc(), objFifoTileOp);
       {
         OpBuilder::InsertionGuard g(builder);
         builder.setInsertionPointToStart(&newDMAOp.getRegion().emplaceBlock());
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, op.getLoc());
       }
       producerDMA = newDMAOp.getOperation();
     }
@@ -1259,8 +1251,8 @@ struct AIEObjectFifoStatefulTransformPass
     if (useHwRepeat)
       taskCount = repeatCount - 1;
     int bdRepeatFactor = useHwRepeat ? 1 : repeatCount;
-    DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
-                       channelIndex, taskCount, bdBlock, endBlock);
+    DMAStartOp::create(builder, op.getLoc(), channelDir, channelIndex,
+                       taskCount, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
       lastDmaBlock->getTerminator()->setSuccessor(dmaBlock, 1);
 
@@ -1284,7 +1276,7 @@ struct AIEObjectFifoStatefulTransformPass
             // Create a separate terminating block with aie.end for this
             // specific DMA channel
             builder.setInsertionPointToStart(succ);
-            EndOp::create(builder, builder.getUnknownLoc());
+            EndOp::create(builder, op.getLoc());
           } else {
             succ = bdBlock;
           }
@@ -1451,9 +1443,9 @@ struct AIEObjectFifoStatefulTransformPass
                              BufferOp globalNextIndex, arith::ConstantOp index,
                              arith::ConstantOp size) {
     builder.setInsertionPointAfter(relOp);
-    Value oldCounter = memref::LoadOp::create(
-        builder, builder.getUnknownLoc(), globalNextIndex,
-        ValueRange(ArrayRef({index.getResult()})));
+    Value oldCounter =
+        memref::LoadOp::create(builder, relOp.getLoc(), globalNextIndex,
+                               ValueRange(ArrayRef({index.getResult()})));
     Value val =
         arith::ConstantOp::create(builder, oldCounter.getLoc(),
                                   builder.getI32IntegerAttr(relOp.getSize()));
@@ -1493,8 +1485,8 @@ struct AIEObjectFifoStatefulTransformPass
 
         int index = 0;
         builder.setInsertionPointToStart(&(coreOp.getBody().front()));
-        Value initVal = arith::ConstantOp::create(
-            builder, builder.getUnknownLoc(), builder.getI32IntegerAttr(0));
+        Value initVal = arith::ConstantOp::create(builder, coreOp.getLoc(),
+                                                  builder.getI32IntegerAttr(0));
         coreOp.walk([&](ObjectFifoAcquireOp acqOp) {
           ObjectFifoCreateOp op = acqOp.getObjectFifo();
           ObjectFifoPort port = acqOp.getPort();
@@ -1515,7 +1507,7 @@ struct AIEObjectFifoStatefulTransformPass
             MemRefType::get(SmallVector<int64_t>{(int64_t)fifoSizes.size()},
                             builder.getI32Type());
         auto globalNextIndex = BufferOp::create(
-            builder, builder.getUnknownLoc(), memrefTy, coreOp.getTile(),
+            builder, coreOp.getLoc(), memrefTy, coreOp.getTile(),
             /*sym_name*/ nullptr, /*address*/ nullptr,
             /*initial_value*/ nullptr, /*mem_bank*/ nullptr,
             /*aligned*/ nullptr);
@@ -1524,7 +1516,7 @@ struct AIEObjectFifoStatefulTransformPass
         for (auto i : constantSizes) {
           builder.setInsertionPointAfter(i.second);
           memref::StoreOp::create(
-              builder, builder.getUnknownLoc(), initVal, globalNextIndex,
+              builder, coreOp.getLoc(), initVal, globalNextIndex,
               ValueRange(ArrayRef({globalIndices[i.first].getResult()})));
         }
 
@@ -1559,11 +1551,11 @@ struct AIEObjectFifoStatefulTransformPass
               // Create a switch for each subview access
               builder.setInsertionPointAfter(accessOp);
               auto switchIndexAsInteger = memref::LoadOp::create(
-                  builder, builder.getUnknownLoc(), globalNextIndex,
+                  builder, acqOp.getLoc(), globalNextIndex,
                   ValueRange(
                       ArrayRef({globalIndices[{createOp, port}].getResult()})));
               auto switchIndex = arith::IndexCastOp::create(
-                  builder, builder.getUnknownLoc(), builder.getIndexType(),
+                  builder, acqOp.getLoc(), builder.getIndexType(),
                   switchIndexAsInteger);
               unsigned caseRegionCounts = fifoSizes[{createOp, port}];
               SmallVector<int64_t, 4> caseValues;
@@ -1581,7 +1573,7 @@ struct AIEObjectFifoStatefulTransformPass
               auto bufferIndex = (accessOp.getIndex()) % createOp.size();
               builder.setInsertionPointToStart(&(switchOp.getDefaultBlock()));
               scf::YieldOp::create(
-                  builder, builder.getUnknownLoc(),
+                  builder, accessOp.getLoc(),
                   state.buffersPerFifo[createOp][bufferIndex].getResult());
               for (int i = 0; i < fifoSizes[{createOp, port}]; ++i) {
                 // Create other cases of IndexSwitchOp
@@ -1645,7 +1637,7 @@ struct AIEObjectFifoStatefulTransformPass
         lockMode = 1;
       for (int i = 0; i < numLocks; i++) {
         int lockID = acc[{op, portNum}];
-        UseLockOp::create(builder, builder.getUnknownLoc(),
+        UseLockOp::create(builder, op.getLoc(),
                           state.locksPerFifo[target][lockID], lockAction,
                           lockMode);
         acc[{op, portNum}] =
@@ -1675,8 +1667,7 @@ struct AIEObjectFifoStatefulTransformPass
         else
           lock = state.locksPerFifo[target][0];
       }
-      UseLockOp::create(builder, builder.getUnknownLoc(), lock, lockAction,
-                        numLocks);
+      UseLockOp::create(builder, op.getLoc(), lock, lockAction, numLocks);
       acc[{op, portNum}] = (acc[{op, portNum}] + numLocks) %
                            op.size(); // update to next objFifo elem
     }
@@ -1788,7 +1779,7 @@ struct AIEObjectFifoStatefulTransformPass
     std::string alloc_name = getShimAllocationName(objFifoOp.getName());
     // SymbolRefAttr::get(ctx, objFifoOp.getName())
     ShimDMAAllocationOp::create(
-        builder, builder.getUnknownLoc(), StringAttr::get(ctx, alloc_name),
+        builder, objFifoOp.getLoc(), StringAttr::get(ctx, alloc_name),
         shimTile.getResult(), DMAChannelDirAttr::get(ctx, channelDir),
         builder.getI64IntegerAttr(channelIndex), builder.getBoolAttr(plio),
         packetInfo);
@@ -1952,9 +1943,10 @@ struct AIEObjectFifoStatefulTransformPass
             BDDimLayoutArrayArrayAttr::get(builder.getContext(),
                                            singletonFromStreamDims);
 
-        ObjectFifoCreateOp consumerFifo = createObjectFifo(
-            builder, datatype, consumerFifoName, consumerTile, consumerTile,
-            consumerObjFifoSize, emptyDims, fromStreamDims);
+        ObjectFifoCreateOp consumerFifo =
+            createObjectFifo(builder, createOp.getLoc(), datatype,
+                             consumerFifoName, consumerTile, consumerTile,
+                             consumerObjFifoSize, emptyDims, fromStreamDims);
         if (createOp.getDisableSynchronization())
           consumerFifo.setDisableSynchronization(true);
         // Propagate iter_count attribute from the original createOp
@@ -2149,14 +2141,14 @@ struct AIEObjectFifoStatefulTransformPass
           // create packet flow
           builder.setInsertionPointAfter(producer);
           packetflow = builder.create<PacketFlowOp>(
-              builder.getUnknownLoc(),
+              producer.getLoc(),
               builder.getIntegerAttr(builder.getI8Type(), bdPacket->getPktId()),
               nullptr, nullptr);
           {
             OpBuilder::InsertionGuard g(builder);
             builder.setInsertionPointToStart(
                 &packetflow.getRegion().emplaceBlock());
-            builder.create<EndOp>(builder.getUnknownLoc());
+            builder.create<EndOp>(producer.getLoc());
           }
         }
       }
@@ -2200,7 +2192,7 @@ struct AIEObjectFifoStatefulTransformPass
 
           if (clPacketSwObjectFifos) {
             builder.setInsertionPointToStart(&packetflow.getPorts().front());
-            builder.create<PacketDestOp>(builder.getUnknownLoc(),
+            builder.create<PacketDestOp>(consumer.getLoc(),
                                          consumer.getProducerTile(),
                                          WireBundle::DMA, consumerChan.channel);
           }
@@ -2232,16 +2224,16 @@ struct AIEObjectFifoStatefulTransformPass
         if (!clPacketSwObjectFifos) {
           // create flow
           builder.setInsertionPointAfter(producer);
-          FlowOp::create(builder, builder.getUnknownLoc(),
-                         producer.getProducerTile(), producerWireType,
-                         producerChan.channel, consumer.getProducerTile(),
-                         consumerWireType, consumerChan.channel);
+          FlowOp::create(builder, producer.getLoc(), producer.getProducerTile(),
+                         producerWireType, producerChan.channel,
+                         consumer.getProducerTile(), consumerWireType,
+                         consumerChan.channel);
         }
       }
 
       if (clPacketSwObjectFifos) {
         builder.setInsertionPointToStart(&packetflow.getPorts().front());
-        PacketSourceOp::create(builder, builder.getUnknownLoc(),
+        PacketSourceOp::create(builder, producer.getLoc(),
                                producer.getProducerTile(), WireBundle::DMA,
                                producerChan.channel);
       }

--- a/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
+++ b/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
@@ -81,6 +81,7 @@ std::unique_ptr<RegisterDatabase> RegisterDatabase::loadAIE2() {
   auto db = std::unique_ptr<RegisterDatabase>(new RegisterDatabase());
   if (!db->loadFromJSON(*registerPath, *eventPath))
     return nullptr;
+  db->buildOffsetIndex();
 
   return db;
 }
@@ -259,6 +260,30 @@ const RegisterInfo *RegisterDatabase::lookupRegister(StringRef name,
   std::transform(key.begin(), key.end(), key.begin(), ::tolower);
   auto it = registers_.find(key);
   return it != registers_.end() ? &it->second : nullptr;
+}
+
+void RegisterDatabase::buildOffsetIndex() {
+  registersByOffset_.clear();
+  for (const auto &entry : registers_) {
+    const RegisterInfo &info = entry.second;
+    std::string moduleKey = info.module;
+    std::transform(moduleKey.begin(), moduleKey.end(), moduleKey.begin(),
+                   ::tolower);
+    registersByOffset_[moduleKey][info.offset] = &info;
+  }
+}
+
+const RegisterInfo *
+RegisterDatabase::lookupRegisterByOffset(uint32_t offset,
+                                         StringRef module) const {
+  std::string moduleKey = module.lower();
+  auto modIt = registersByOffset_.find(moduleKey);
+  if (modIt == registersByOffset_.end())
+    return nullptr;
+  auto offIt = modIt->second.find(offset);
+  if (offIt == modIt->second.end())
+    return nullptr;
+  return offIt->second;
 }
 
 std::optional<uint32_t> RegisterDatabase::lookupEvent(StringRef name,

--- a/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
@@ -72,11 +72,11 @@ struct AIEBroadcastPacketPass
           int flowID = bpid.IDInt();
           builder.setInsertionPointAfter(broadcastpacket);
           PacketFlowOp pkFlow = PacketFlowOp::create(
-              builder, builder.getUnknownLoc(), flowID, nullptr, nullptr);
+              builder, broadcastpacket.getLoc(), flowID, nullptr, nullptr);
           Region &r_pkFlow = pkFlow.getPorts();
           Block *b_pkFlow = builder.createBlock(&r_pkFlow);
           builder.setInsertionPointToStart(b_pkFlow);
-          PacketSourceOp::create(builder, builder.getUnknownLoc(), srcTile,
+          PacketSourceOp::create(builder, broadcastpacket.getLoc(), srcTile,
                                  sourcePort.bundle, sourcePort.channel);
           for (Operation &op : b_bpid.getOperations()) {
             if (BPDestOp bpdest = dyn_cast<BPDestOp>(op)) {
@@ -84,12 +84,12 @@ struct AIEBroadcastPacketPass
                   dyn_cast<TileOp>(bpdest.getTile().getDefiningOp());
               Port destPort = bpdest.port();
               builder.setInsertionPointToEnd(b_pkFlow);
-              PacketDestOp::create(builder, builder.getUnknownLoc(), destTile,
+              PacketDestOp::create(builder, bpdest.getLoc(), destTile,
                                    destPort.bundle, destPort.channel);
             }
           }
           builder.setInsertionPointToEnd(b_pkFlow);
-          EndOp::create(builder, builder.getUnknownLoc());
+          EndOp::create(builder, broadcastpacket.getLoc());
         }
       }
     }

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -106,8 +106,8 @@ struct AIECreateCoresPass
       // get or create TileOp
       if (!tiles[{colIndex, rowIndex}]) {
         builder.setInsertionPointToStart(device.getBody());
-        TileOp tile = TileOp::create(builder, builder.getUnknownLoc(), colIndex,
-                                     rowIndex);
+        TileOp tile =
+            TileOp::create(builder, callOp.getLoc(), colIndex, rowIndex);
         tiles[{colIndex, rowIndex}] = tile;
       }
       Operation *tileOp = tiles[{colIndex, rowIndex}];
@@ -130,21 +130,21 @@ struct AIECreateCoresPass
           assert(t && "Unsupported type!");
           coreBufTypes.push_back({t, i});
           BufferOp buf = BufferOp::create(
-              builder, builder.getUnknownLoc(), t, tile, /*sym_name*/ nullptr,
+              builder, callOp.getLoc(), t, tile, /*sym_name*/ nullptr,
               /*address*/ nullptr, /*initial_value*/ nullptr,
               /*mem_bank*/ nullptr, /*aligned*/ nullptr);
           buffers[callOperands[i]] = buf;
           operand.replaceAllUsesWith(buf.getResult());
         }
 
-        MemOp mem = MemOp::create(builder, builder.getUnknownLoc(),
+        MemOp mem = MemOp::create(builder, callOp.getLoc(),
                                   builder.getIndexType(), tile);
         Region &r = mem.getBody();
         Block *endBlock = builder.createBlock(&r);
 
         // block terminator
         builder.setInsertionPointToStart(endBlock);
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, callOp.getLoc());
         mems[tileOp] = mem;
       }
 
@@ -163,7 +163,7 @@ struct AIECreateCoresPass
           Block *currentBlock;
 
           if (!cores[tileOp]) {
-            core = CoreOp::create(builder, builder.getUnknownLoc(), tile);
+            core = CoreOp::create(builder, callOp.getLoc(), tile);
             Region &r = core.getBody();
             currentBlock = builder.createBlock(&r);
             builder.setInsertionPointToStart(currentBlock);
@@ -187,10 +187,10 @@ struct AIECreateCoresPass
               assert(pair.first.getShape()[0] == 1 &&
                      "Expected MemRefType of single element");
 
-              Value zero = arith::ConstantIndexOp::create(
-                  builder, builder.getUnknownLoc(), 0);
-              auto loadOp = memref::LoadOp::create(
-                  builder, builder.getUnknownLoc(), arg.getType(), buf, zero);
+              Value zero =
+                  arith::ConstantIndexOp::create(builder, callOp.getLoc(), 0);
+              auto loadOp = memref::LoadOp::create(builder, callOp.getLoc(),
+                                                   arg.getType(), buf, zero);
               mapper.map(arg, loadOp);
             } else {
               mapper.map(arg, buf);
@@ -207,7 +207,7 @@ struct AIECreateCoresPass
           }
           if (!cores[tileOp]) {
             // block terminator
-            EndOp::create(builder, builder.getUnknownLoc());
+            EndOp::create(builder, callOp.getLoc());
             cores[tileOp] = core;
           }
         }
@@ -233,7 +233,7 @@ struct AIECreateCoresPass
     //          "Could not allocate more than two dest. channel when creating
     //          FlowOp");
     //   // WireBundle[1] = DMA
-    //   FlowOp::create(builder, builder.getUnknownLoc(), srcTile, 1, 0,
+    //   FlowOp::create(builder, callOp.getLoc(), srcTile, 1, 0,
     //   dstTile, 1, destChannel[op.dstTile()]); destChannel[op.dstTile()]++;
     // }
 

--- a/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
@@ -200,8 +200,7 @@ struct AIECreateLocksPass
       LLVM_DEBUG(llvm::dbgs() << "Shared tile \n"; tileOp->print(llvm::dbgs()));
       LLVM_DEBUG(llvm::dbgs() << " LockID: " << lockID << '\n');
       builder.setInsertionPointAfter(tileOp);
-      LockOp lock =
-          LockOp::create(builder, builder.getUnknownLoc(), tile, lockID, 0);
+      LockOp lock = LockOp::create(builder, tile.getLoc(), tile, lockID, 0);
 
       lockChains[std::make_pair(release, acquire)] = std::make_pair(lock, 1);
 

--- a/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
@@ -192,7 +192,7 @@ struct AIECtrlPacketToDmaPass
 
         SymbolRefAttr metadata =
             SymbolRefAttr::get(builder.getContext(), batchIt->shimDmaAllocName);
-        NpuDmaMemcpyNdOp::create(builder, builder.getUnknownLoc(), newBlockArg,
+        NpuDmaMemcpyNdOp::create(builder, loc, newBlockArg,
                                  SmallVector<Value>{}, SmallVector<Value>{},
                                  SmallVector<Value>{}, ArrayRef(staticOffsets),
                                  ArrayRef(staticSizes), ArrayRef(staticStrides),

--- a/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
@@ -68,7 +68,7 @@ static LogicalResult transformLoadPdi(NpuLoadPdiOp loadPdiOp, ModuleOp moduleOp,
   AIE::DeviceOp emptyDevice = moduleOp.lookupSymbol<AIE::DeviceOp>(emptyName);
   if (!emptyDevice) {
     auto deviceType = referencedDevice.getDevice();
-    auto loc = builder.getUnknownLoc();
+    auto loc = loadPdiOp.getLoc();
     emptyDevice = AIE::DeviceOp::create(builder, loc, deviceType,
                                         builder.getStringAttr(emptyName));
     emptyDevice.getRegion().emplaceBlock();

--- a/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
@@ -304,15 +304,12 @@ struct AIEHerdRoutingPass
 
       builder.setInsertionPoint(device.getBody()->getTerminator());
 
-      auto iterx =
-          IterOp::create(builder, builder.getUnknownLoc(), x, x + 1, 1);
-      auto itery =
-          IterOp::create(builder, builder.getUnknownLoc(), y, y + 1, 1);
-      auto sel = SelectOp::create(builder, builder.getUnknownLoc(), herd, iterx,
-                                  itery);
-      auto swbox = SwitchboxOp::create(builder, builder.getUnknownLoc(), sel);
-      SwitchboxOp::ensureTerminator(swbox.getConnections(), builder,
-                                    builder.getUnknownLoc());
+      Location loc = herdOp->getLoc();
+      auto iterx = IterOp::create(builder, loc, x, x + 1, 1);
+      auto itery = IterOp::create(builder, loc, y, y + 1, 1);
+      auto sel = SelectOp::create(builder, loc, herd, iterx, itery);
+      auto swbox = SwitchboxOp::create(builder, loc, sel);
+      SwitchboxOp::ensureTerminator(swbox.getConnections(), builder, loc);
       Block &b = swbox.getConnections().front();
       builder.setInsertionPoint(b.getTerminator());
 
@@ -322,8 +319,8 @@ struct AIEHerdRoutingPass
         WireBundle destBundle = destPort.bundle;
         int destChannel = destPort.channel;
 
-        ConnectOp::create(builder, builder.getUnknownLoc(), sourceBundle,
-                          sourceChannel, destBundle, destChannel);
+        ConnectOp::create(builder, loc, sourceBundle, sourceChannel, destBundle,
+                          destChannel);
       }
     }
 

--- a/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
@@ -46,9 +46,10 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
   LowerAIEMemcpy(MLIRContext *context, PatternBenefit benefit = 1)
       : OpConversionPattern<MemcpyOp>(context, benefit) {}
 
-  void createDMABlocksAndOps(MemOp &mem, StringRef tokenName, int acquireTknVal,
-                             int releaseTknVal, Value buf, int offset, int len,
-                             DMAChannelDir dmaDir, int channelIndex,
+  void createDMABlocksAndOps(MemOp &mem, Location loc, StringRef tokenName,
+                             int acquireTknVal, int releaseTknVal, Value buf,
+                             int offset, int len, DMAChannelDir dmaDir,
+                             int channelIndex,
                              ConversionPatternRewriter &rewriter) const {
 
     Region &r = mem.getBody();
@@ -57,7 +58,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     Block *bdBlock = rewriter.createBlock(&endBlock);
 
     rewriter.setInsertionPointToStart(dmaBlock);
-    DMAStartOp::create(rewriter, rewriter.getUnknownLoc(), dmaDir, channelIndex,
+    DMAStartOp::create(rewriter, loc, dmaDir, channelIndex,
                        /*repeatCount*/ 0, bdBlock, &endBlock);
 
     // Setup bd Block
@@ -65,12 +66,12 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     // for specifying DMA Block description (which buffer type (A/B), transfer
     // length/address, etc.)
     rewriter.setInsertionPointToStart(bdBlock);
-    UseTokenOp::create(rewriter, rewriter.getUnknownLoc(), tokenName,
-                       acquireTknVal, LockAction::Acquire);
-    DMABDOp::create(rewriter, rewriter.getUnknownLoc(), buf, offset, len);
-    UseTokenOp::create(rewriter, rewriter.getUnknownLoc(), tokenName,
-                       releaseTknVal, LockAction::Release);
-    NextBDOp::create(rewriter, rewriter.getUnknownLoc(), &endBlock);
+    UseTokenOp::create(rewriter, loc, tokenName, acquireTknVal,
+                       LockAction::Acquire);
+    DMABDOp::create(rewriter, loc, buf, offset, len);
+    UseTokenOp::create(rewriter, loc, tokenName, releaseTknVal,
+                       LockAction::Release);
+    NextBDOp::create(rewriter, loc, &endBlock);
   }
 
   LogicalResult
@@ -90,12 +91,12 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     MemOp srcMem = srcTileOp(op).getMemOp();
     MemOp dstMem = dstTileOp(op).getMemOp();
 
-    createDMABlocksAndOps(srcMem, tokenName, acquireTknVal, releaseTknVal,
-                          srcBuf, srcOffset, srcLen, DMAChannelDir::MM2S, 0,
-                          rewriter);
-    createDMABlocksAndOps(dstMem, tokenName, acquireTknVal, releaseTknVal,
-                          dstBuf, dstOffset, dstLen, DMAChannelDir::S2MM, 0,
-                          rewriter);
+    createDMABlocksAndOps(srcMem, op.getLoc(), tokenName, acquireTknVal,
+                          releaseTknVal, srcBuf, srcOffset, srcLen,
+                          DMAChannelDir::MM2S, 0, rewriter);
+    createDMABlocksAndOps(dstMem, op.getLoc(), tokenName, acquireTknVal,
+                          releaseTknVal, dstBuf, dstOffset, dstLen,
+                          DMAChannelDir::S2MM, 0, rewriter);
 
     rewriter.eraseOp(op);
     return success();
@@ -126,8 +127,8 @@ struct AIELowerMemcpyPass
       assert(destChannel[op.getDstTile()] <= 2 &&
              "Could not allocate more than two dest. channel when creating "
              "FlowOp");
-      FlowOp::create(builder, builder.getUnknownLoc(), srcTile, WireBundle::DMA,
-                     0, dstTile, WireBundle::DMA, destChannel[op.getDstTile()]);
+      FlowOp::create(builder, op.getLoc(), srcTile, WireBundle::DMA, 0, dstTile,
+                     WireBundle::DMA, destChannel[op.getDstTile()]);
       destChannel[op.getDstTile()]++;
     }
 

--- a/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
@@ -67,7 +67,7 @@ struct AIELowerMulticastPass
           TileOp destTile =
               dyn_cast<TileOp>(multiDest.getTile().getDefiningOp());
           Port destPort = multiDest.port();
-          FlowOp::create(builder, builder.getUnknownLoc(), srcTile,
+          FlowOp::create(builder, multiDest.getLoc(), srcTile,
                          sourcePort.bundle, sourcePort.channel, destTile,
                          destPort.bundle, destPort.channel);
         }

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -199,7 +199,40 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 struct xilinx::AIE::AIERTControl::AIERtImpl {
   XAie_Config configPtr;
   XAie_DevInst devInst;
+
+  // One Location per recorded XAie_TxnCmd. Populated by TxnLocBracket scopes.
+  // Indexed by command position in the serialized transaction binary.
+  std::vector<mlir::Location> txnInstrLocs;
 };
+
+// Walk DevInst->TxnList to find the active XAie_TxnInst (single-threaded
+// compilation: at most one) and return its NumCmds. Returns 0 if no
+// transaction is being recorded. The XAie_TxnInst struct and TxnList layout
+// are part of aie-rt's public xaiegbl.h, so this only depends on the public
+// header.
+static uint32_t getActiveTxnNumCmds(XAie_DevInst &devInst) {
+  XAie_List *node = devInst.TxnList.Next;
+  if (!node)
+    return 0;
+  XAie_TxnInst *inst = reinterpret_cast<XAie_TxnInst *>(
+      reinterpret_cast<char *>(node) - offsetof(XAie_TxnInst, Node));
+  return inst->NumCmds;
+}
+
+xilinx::AIE::TxnLocBracket::TxnLocBracket(AIERTControl &c, mlir::Location l)
+    : ctl(c), loc(l), startCmds(c.getCurrentTxnNumCmds()) {}
+
+xilinx::AIE::TxnLocBracket::~TxnLocBracket() {
+  uint32_t endCmds = ctl.getCurrentTxnNumCmds();
+  if (endCmds <= startCmds)
+    return;
+  // Only record meaningful locations. Falling through (no entry) lets the
+  // downstream emitter use its fallback (device.getLoc()), which preserves
+  // the pre-existing behavior for source ops that don't carry a real loc.
+  if (mlir::isa<mlir::UnknownLoc>(loc))
+    return;
+  ctl.recordTxnLocRange(startCmds, endCmds, loc);
+}
 
 xilinx::AIE::AIERTControl::~AIERTControl() = default;
 
@@ -494,6 +527,7 @@ LogicalResult configureBdInBlock(const AIE::AIETargetModel &targetModel,
 LogicalResult xilinx::AIE::AIERTControl::pushToBdQueueAndEnable(
     Operation &op, int col, int row, int chNum, const DMAChannelDir &channelDir,
     int bdId, int repeatCount) {
+  TxnLocBracket bracket(*this, op.getLoc());
   XAie_DmaDirection direction =
       channelDir == DMAChannelDir::S2MM ? DMA_S2MM : DMA_MM2S;
   auto tileLoc = XAie_TileLoc(col, row);
@@ -515,6 +549,7 @@ LogicalResult xilinx::AIE::AIERTControl::configureLocksAndBd(Block &block,
   assert(bd.getBdId().has_value() &&
          "DMABDOp must have assigned bd_id; did you forget to run "
          "aie-assign-bd-ids?");
+  TxnLocBracket bracket(*this, bd.getLoc());
   XAie_DmaDesc dmaTileBd;
   auto tileLoc = XAie_TileLoc(col, row);
   TRY_XAIE_API_EMIT_ERROR(bd, XAie_DmaDescInit, &aiert->devInst, &dmaTileBd,
@@ -534,6 +569,7 @@ LogicalResult xilinx::AIE::AIERTControl::initLocks(DeviceOp &targetOp) {
   for (auto tileOp : targetOp.getOps<TileOp>()) {
     auto tileLoc = XAie_TileLoc(tileOp.colIndex(), tileOp.rowIndex());
     if (!tileOp.isShimTile() && tileOp.getCoreOp()) {
+      TxnLocBracket bracket(*this, tileOp.getLoc());
       TRY_XAIE_API_EMIT_ERROR(tileOp, XAie_CoreReset, &aiert->devInst, tileLoc);
       TRY_XAIE_API_EMIT_ERROR(tileOp, XAie_CoreUnreset, &aiert->devInst,
                               tileLoc);
@@ -549,6 +585,7 @@ LogicalResult xilinx::AIE::AIERTControl::initLocks(DeviceOp &targetOp) {
   // Set locks with explicit initializers
   targetOp.walk<WalkOrder::PreOrder>([&](LockOp lockOp) {
     if (lockOp.getLockID() && lockOp.getInit()) {
+      TxnLocBracket bracket(*this, lockOp.getLoc());
       auto tileLoc = XAie_TileLoc(lockOp.getTileOp().colIndex(),
                                   lockOp.getTileOp().rowIndex());
       auto locInit = XAie_LockInit(*lockOp.getLockID(), *lockOp.getInit());
@@ -567,6 +604,7 @@ LogicalResult xilinx::AIE::AIERTControl::initBuffers(DeviceOp &targetOp) {
     auto initialValue = bufferOp.getInitialValue();
     if (!initialValue)
       return;
+    TxnLocBracket bracket(*this, bufferOp.getLoc());
     mlir::DenseElementsAttr denseInit =
         dyn_cast<mlir::DenseElementsAttr>(initialValue.value());
     if (!denseInit)
@@ -624,15 +662,18 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
            "Only NPU currently supported");
 
     Block &b = switchboxOp.getConnections().front();
-    for (auto connectOp : b.getOps<ConnectOp>())
+    for (auto connectOp : b.getOps<ConnectOp>()) {
+      TxnLocBracket bracket(*this, connectOp.getLoc());
       TRY_XAIE_API_EMIT_ERROR(
           switchboxOp, XAie_StrmConnCctEnable, &aiert->devInst, tileLoc,
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getSourceBundle()),
           connectOp.sourceIndex(),
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getDestBundle()),
           connectOp.destIndex());
+    }
 
     for (auto masterSetOp : b.getOps<MasterSetOp>()) {
+      TxnLocBracket bracket(*this, masterSetOp.getLoc());
       int mask = 0;
       int arbiter = -1;
 
@@ -667,6 +708,7 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
     }
 
     for (auto packetRulesOp : b.getOps<PacketRulesOp>()) {
+      TxnLocBracket bracket(*this, packetRulesOp.getLoc());
       int slot = 0;
       Block &block = packetRulesOp.getRules().front();
       for (auto slotOp : block.getOps<PacketRuleOp>()) {
@@ -698,6 +740,7 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
         XAie_TileLoc(muxOp.getTileOp().getCol(), muxOp.getTileOp().getRow());
     Block &b = muxOp.getConnections().front();
     for (auto connectOp : b.getOps<ConnectOp>()) {
+      TxnLocBracket bracket(*this, connectOp.getLoc());
       // demux!
       if (connectOp.getSourceBundle() == WireBundle::North)
         TRY_XAIE_API_EMIT_ERROR(muxOp, XAie_EnableAieToShimDmaStrmPort,
@@ -714,18 +757,21 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
   for (auto switchboxOp : targetOp.getOps<ShimSwitchboxOp>()) {
     Block &b = switchboxOp.getConnections().front();
     auto tileLoc = XAie_TileLoc(switchboxOp.getCol(), 0);
-    for (auto connectOp : b.getOps<ConnectOp>())
+    for (auto connectOp : b.getOps<ConnectOp>()) {
+      TxnLocBracket bracket(*this, connectOp.getLoc());
       TRY_XAIE_API_EMIT_ERROR(
           switchboxOp, XAie_StrmConnCctEnable, &aiert->devInst, tileLoc,
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getSourceBundle()),
           connectOp.sourceIndex(),
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getDestBundle()),
           connectOp.destIndex());
+    }
   }
 
   // Cascade configuration
   if (isa<AIE2TargetModel>(targetModel)) {
     for (auto configOp : targetOp.getOps<ConfigureCascadeOp>()) {
+      TxnLocBracket bracket(*this, configOp.getLoc());
       TileOp tile = cast<TileOp>(configOp.getTile().getDefiningOp());
       auto tileLoc = XAie_TileLoc(tile.getCol(), tile.getRow());
       TRY_XAIE_API_EMIT_ERROR(
@@ -816,9 +862,11 @@ LogicalResult xilinx::AIE::AIERTControl::addCoreEnable(DeviceOp &targetOp) {
   // Start execution of all the cores.
   for (auto tileOp : targetOp.getOps<TileOp>()) {
     auto tileLoc = XAie_TileLoc(tileOp.colIndex(), tileOp.rowIndex());
-    if (!tileOp.isShimTile() && tileOp.getCoreOp())
+    if (!tileOp.isShimTile() && tileOp.getCoreOp()) {
+      TxnLocBracket bracket(*this, tileOp.getCoreOp().getLoc());
       TRY_XAIE_API_EMIT_ERROR(targetOp, XAie_CoreEnable, &aiert->devInst,
                               tileLoc);
+    }
   }
   return success();
 }
@@ -1019,6 +1067,7 @@ void xilinx::AIE::AIERTControl::dmaUpdateBdAddr(int col, int row, size_t addr,
 }
 
 void xilinx::AIE::AIERTControl::startTransaction() {
+  aiert->txnInstrLocs.clear();
   TRY_XAIE_API_FATAL_ERROR(XAie_StartTransaction, &aiert->devInst,
                            XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
 }
@@ -1029,4 +1078,24 @@ std::vector<uint8_t> xilinx::AIE::AIERTControl::exportSerializedTransaction() {
   XAie_TxnHeader *hdr = (XAie_TxnHeader *)txn_ptr;
   std::vector<uint8_t> txn_data(txn_ptr, txn_ptr + hdr->TxnSize);
   return txn_data;
+}
+
+const std::vector<mlir::Location> &
+xilinx::AIE::AIERTControl::getTxnInstrLocs() const {
+  return aiert->txnInstrLocs;
+}
+
+uint32_t xilinx::AIE::AIERTControl::getCurrentTxnNumCmds() const {
+  return getActiveTxnNumCmds(aiert->devInst);
+}
+
+void xilinx::AIE::AIERTControl::recordTxnLocRange(uint32_t startCmds,
+                                                  uint32_t endCmds,
+                                                  mlir::Location loc) {
+  if (endCmds <= startCmds)
+    return;
+  if (aiert->txnInstrLocs.size() < endCmds)
+    aiert->txnInstrLocs.resize(endCmds, mlir::UnknownLoc::get(loc.getContext()));
+  for (uint32_t i = startCmds; i < endCmds; ++i)
+    aiert->txnInstrLocs[i] = loc;
 }

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -1095,7 +1095,8 @@ void xilinx::AIE::AIERTControl::recordTxnLocRange(uint32_t startCmds,
   if (endCmds <= startCmds)
     return;
   if (aiert->txnInstrLocs.size() < endCmds)
-    aiert->txnInstrLocs.resize(endCmds, mlir::UnknownLoc::get(loc.getContext()));
+    aiert->txnInstrLocs.resize(endCmds,
+                               mlir::UnknownLoc::get(loc.getContext()));
   for (uint32_t i = startCmds; i < endCmds; ++i)
     aiert->txnInstrLocs[i] = loc;
 }

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -525,9 +525,9 @@ LogicalResult xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
   return success();
 }
 
-// Render an mlir::Location as a JSON object, recursing into NameLoc and
-// FusedLoc to recover the file:line:col + IRON name structure produced by
-// Phase-1 capture (see python/iron/_loc.py).
+// Render an mlir::Location as a JSON object, recursing into NameLoc, FusedLoc,
+// and CallSiteLoc so a consumer can reconstruct the file:line:col + named
+// location structure carried by the source op.
 static llvm::json::Value locToJSON(mlir::Location loc) {
   using namespace llvm;
   if (auto f = dyn_cast<mlir::FileLineColLoc>(loc))

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -276,21 +276,22 @@ lookupRegisterByAddress(uint64_t address, const AIETargetModel &tm,
   uint64_t baseMask = (uint64_t{1} << rowShift) - 1;
   uint32_t offset = static_cast<uint32_t>(address & baseMask);
 
-  // Determine module from tile type.
+  // Determine module from tile type. Module names must match the JSON keys in
+  // aie_registers_aie2.json: "core", "memory", "memory_tile", "shim".
   StringRef moduleName;
   if (tm.isShimNOCTile(col, row) || tm.isShimPLTile(col, row)) {
-    moduleName = "pl_module";
+    moduleName = "shim";
   } else if (tm.isMemTile(col, row)) {
-    moduleName = "mem_tile_module";
+    moduleName = "memory_tile";
   } else {
-    // For aie tiles, regdb has both core_module and memory_module. The
-    // offset alone disambiguates. Try core first then memory.
-    if (auto *r = regdb->lookupRegisterByOffset(offset, "core_module")) {
-      outModule = "core_module";
+    // For aie tiles, regdb has both core and memory modules. The offset alone
+    // disambiguates. Try core first then memory.
+    if (auto *r = regdb->lookupRegisterByOffset(offset, "core")) {
+      outModule = "core";
       return r->name;
     }
-    if (auto *r = regdb->lookupRegisterByOffset(offset, "memory_module")) {
-      outModule = "memory_module";
+    if (auto *r = regdb->lookupRegisterByOffset(offset, "memory")) {
+      outModule = "memory";
       return r->name;
     }
     return {};

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -11,6 +11,8 @@
 #include "aie/Targets/AIETargets.h"
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/IR/AIETargetModel.h"
+#include "aie/Dialect/AIE/Util/AIERegisterDatabase.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -20,7 +22,11 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
 
+#include <memory>
 #include <vector>
 
 extern "C" {
@@ -239,9 +245,93 @@ void appendUpdateRegFromScratchpad(std::vector<uint32_t> &instructions,
 
 } // namespace
 
+namespace {
+
+// Lazy-loaded regdb for register-name decoration. Loaded once per process,
+// returns nullptr if the JSON files cannot be located (e.g. install dir not
+// set). Decoration is best-effort.
+static const xilinx::AIE::RegisterDatabase *getRegDB() {
+  static std::unique_ptr<xilinx::AIE::RegisterDatabase> db = []() {
+    return xilinx::AIE::RegisterDatabase::loadAIE2();
+  }();
+  return db.get();
+}
+
+// Decompose an absolute device address into (col, row, offset) using the
+// target model's column/row shifts, then derive the regdb module name from
+// the row's tile type. Looks the (module, offset) up in regdb. Returns the
+// register name on success and writes the module name to *outModule. On any
+// failure returns empty StringRef.
+static llvm::StringRef
+lookupRegisterByAddress(uint64_t address, const AIETargetModel &tm,
+                        const xilinx::AIE::RegisterDatabase *regdb,
+                        std::string &outModule) {
+  outModule.clear();
+  if (!regdb)
+    return {};
+  uint32_t colShift = tm.getColumnShift();
+  uint32_t rowShift = tm.getRowShift();
+  uint8_t col = static_cast<uint8_t>((address >> colShift) & 0xFF);
+  uint8_t row = static_cast<uint8_t>((address >> rowShift) & 0xFF);
+  uint64_t baseMask = (uint64_t{1} << rowShift) - 1;
+  uint32_t offset = static_cast<uint32_t>(address & baseMask);
+
+  // Determine module from tile type.
+  StringRef moduleName;
+  if (tm.isShimNOCTile(col, row) || tm.isShimPLTile(col, row)) {
+    moduleName = "pl_module";
+  } else if (tm.isMemTile(col, row)) {
+    moduleName = "mem_tile_module";
+  } else {
+    // For aie tiles, regdb has both core_module and memory_module. The
+    // offset alone disambiguates. Try core first then memory.
+    if (auto *r = regdb->lookupRegisterByOffset(offset, "core_module")) {
+      outModule = "core_module";
+      return r->name;
+    }
+    if (auto *r = regdb->lookupRegisterByOffset(offset, "memory_module")) {
+      outModule = "memory_module";
+      return r->name;
+    }
+    return {};
+  }
+  if (auto *r = regdb->lookupRegisterByOffset(offset, moduleName)) {
+    outModule = moduleName.str();
+    return r->name;
+  }
+  return {};
+}
+
+static void pushLocEntry(std::vector<TxnLocEntry> *locmap,
+                         uint32_t byteOffsetBefore, uint32_t byteOffsetAfter,
+                         StringRef opcodeName, StringRef sourceOpName,
+                         std::optional<uint64_t> address, mlir::Operation *op,
+                         const AIETargetModel &tm) {
+  if (!locmap)
+    return;
+  TxnLocEntry e;
+  e.byteOffset = byteOffsetBefore;
+  e.byteSize = byteOffsetAfter - byteOffsetBefore;
+  e.opcodeName = opcodeName.str();
+  e.sourceOpName = sourceOpName.str();
+  e.address = address;
+  e.loc = op->getLoc();
+  if (address) {
+    if (auto regName =
+            lookupRegisterByAddress(*address, tm, getRegDB(), e.registerModule);
+        !regName.empty()) {
+      e.registerName = regName.str();
+    }
+  }
+  locmap->push_back(std::move(e));
+}
+
+} // namespace
+
 LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
     mlir::ModuleOp moduleOp, std::vector<uint32_t> &instructions,
-    StringRef deviceName, StringRef sequenceName) {
+    StringRef deviceName, StringRef sequenceName,
+    std::vector<TxnLocEntry> *locmap) {
 
   DeviceOp deviceOp =
       DeviceOp::getForSymbolInModuleOrError(moduleOp, deviceName);
@@ -272,44 +362,79 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
   if (!seq) {
     return failure();
   }
+
+  auto byteOffset = [&]() -> uint32_t {
+    return static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
+  };
+
   for (Block &block : seq.getBody()) {
     for (Operation &o : block) {
       llvm::TypeSwitch<Operation *>(&o)
           .Case<NpuSyncOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendSync(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "TCT",
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuWrite32Op>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
+            uint64_t addr = op.getAbsoluteAddress().value_or(0);
             appendWrite32(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "WRITE32",
+                         op->getName().getStringRef(), addr, op, tm);
           })
           .Case<NpuBlockWriteOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
+            uint64_t addr = op.getAbsoluteAddress().value_or(0);
             appendBlockWrite(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "BLOCKWRITE",
+                         op->getName().getStringRef(), addr, op, tm);
           })
           .Case<NpuMaskWrite32Op>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
+            uint64_t addr = op.getAbsoluteAddress().value_or(0);
             appendMaskWrite32(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "MASKWRITE",
+                         op->getName().getStringRef(), addr, op, tm);
           })
           .Case<NpuLoadPdiOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendLoadPdi(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "LOAD_PDI",
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuAddressPatchOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendAddressPatch(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "ADDRESS_PATCH",
+                         op->getName().getStringRef(), op.getAddr(), op, tm);
           })
           .Case<NpuPreemptOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendPreempt(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "PREEMPT",
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuCreateScratchpadOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendCreateScratchpad(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "CREATE_SCRATCHPAD",
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuUpdateFromScratchpadOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendUpdateRegFromScratchpad(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "UPDATE_FROM_SCRATCHPAD",
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           });
     }
   }
@@ -322,7 +447,7 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
 
 LogicalResult xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
     ModuleOp module, std::vector<uint32_t> &instructions, StringRef deviceName,
-    StringRef sequenceName) {
+    StringRef sequenceName, std::vector<TxnLocEntry> *locmap) {
   DeviceOp deviceOp =
       AIE::DeviceOp::getForSymbolInModuleOrError(module, deviceName);
   if (!deviceOp) {
@@ -336,11 +461,15 @@ LogicalResult xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
     return failure();
   }
 
+  const AIETargetModel &tm = deviceOp.getTargetModel();
   Block &entry = seq.getBody().front();
   for (auto &o : entry) {
     auto packetOp = dyn_cast<AIEX::NpuControlPacketOp>(o);
     if (!packetOp)
       continue;
+
+    uint32_t before =
+        static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
 
     uint32_t size = 0;
     auto data = packetOp.getData();
@@ -385,6 +514,78 @@ LogicalResult xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
     if (opc == 0x0 || opc == 0x2)
       for (unsigned i = 0; i < size; i++)
         words[i + 2] = data.value()[i];
+
+    uint32_t after =
+        static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
+    pushLocEntry(locmap, before, after, "CONTROL_PACKET",
+                 packetOp->getName().getStringRef(), packetOp.getAddress(),
+                 packetOp, tm);
   }
   return success();
+}
+
+// Render an mlir::Location as a JSON object, recursing into NameLoc and
+// FusedLoc to recover the file:line:col + IRON name structure produced by
+// Phase-1 capture (see python/iron/_loc.py).
+static llvm::json::Value locToJSON(mlir::Location loc) {
+  using namespace llvm;
+  if (auto f = dyn_cast<mlir::FileLineColLoc>(loc))
+    return json::Value(json::Object{
+        {"kind", "file"},
+        {"file", f.getFilename().str()},
+        {"line", static_cast<int64_t>(f.getLine())},
+        {"col", static_cast<int64_t>(f.getColumn())},
+    });
+  if (auto n = dyn_cast<mlir::NameLoc>(loc)) {
+    json::Object o{{"kind", "name"}, {"name", n.getName().str()}};
+    o["child"] = locToJSON(n.getChildLoc());
+    return json::Value(std::move(o));
+  }
+  if (auto fused = dyn_cast<mlir::FusedLoc>(loc)) {
+    json::Array children;
+    for (mlir::Location c : fused.getLocations())
+      children.push_back(locToJSON(c));
+    return json::Value(
+        json::Object{{"kind", "fused"}, {"children", std::move(children)}});
+  }
+  if (auto cs = dyn_cast<mlir::CallSiteLoc>(loc))
+    return json::Value(json::Object{
+        {"kind", "callsite"},
+        {"callee", locToJSON(cs.getCallee())},
+        {"caller", locToJSON(cs.getCaller())},
+    });
+  if (isa<mlir::OpaqueLoc>(loc))
+    return json::Value(json::Object{{"kind", "opaque"}});
+  return json::Value(json::Object{{"kind", "unknown"}});
+}
+
+void xilinx::AIE::emitNpuLocmapJSON(llvm::raw_ostream &output,
+                                    llvm::StringRef deviceName,
+                                    llvm::StringRef binaryName,
+                                    const std::vector<TxnLocEntry> &locmap) {
+  llvm::json::Object root;
+  root["version"] = 1;
+  root["device"] = deviceName.str();
+  root["binary"] = binaryName.str();
+
+  llvm::json::Array opsArr;
+  for (const auto &e : locmap) {
+    llvm::json::Object o;
+    o["byte_offset"] = static_cast<int64_t>(e.byteOffset);
+    o["byte_size"] = static_cast<int64_t>(e.byteSize);
+    o["opcode"] = e.opcodeName;
+    o["source_op"] = e.sourceOpName;
+    if (e.address)
+      o["address"] = llvm::formatv("{0:X}", *e.address).str();
+    if (!e.registerName.empty()) {
+      o["register"] = e.registerName;
+      o["register_module"] = e.registerModule;
+    }
+    if (e.loc)
+      o["loc"] = locToJSON(*e.loc);
+    opsArr.push_back(std::move(o));
+  }
+  root["operations"] = std::move(opsArr);
+
+  output << llvm::formatv("{0:2}\n", llvm::json::Value(std::move(root)));
 }

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -105,9 +105,8 @@ void writeBufferMap(raw_ostream &output, BufferOp buf, int offset) {
   std::string bufName(buf.name().getValue());
   int bufferBaseAddr = getBufferBaseAddress(buf);
   int numBytes = buf.getAllocationSize();
-  output << "_symbol " << bufName << " "
-         << "0x" << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes
-         << '\n';
+  output << "_symbol " << bufName << " " << "0x"
+         << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes << '\n';
 }
 
 LogicalResult AIETranslateToTargetArch(ModuleOp module, raw_ostream &output,
@@ -393,9 +392,9 @@ void registerAIETranslations() {
           for (auto w : instructions)
             output << llvm::format("%08X\n", w);
         }
-        // With -aie-npu-emit-locmap=<file>, additionally write the JSON location
-        // sidecar (mapping each transaction word's byte offset to its source
-        // MLIR Location) to that file.
+        // With -aie-npu-emit-locmap=<file>, additionally write the JSON
+        // location sidecar (mapping each transaction word's byte offset to its
+        // source MLIR Location) to that file.
         if (emitLocmap) {
           std::error_code ec;
           llvm::raw_fd_ostream locFile(npuEmitLocmap, ec,

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -105,8 +105,9 @@ void writeBufferMap(raw_ostream &output, BufferOp buf, int offset) {
   std::string bufName(buf.name().getValue());
   int bufferBaseAddr = getBufferBaseAddress(buf);
   int numBytes = buf.getAllocationSize();
-  output << "_symbol " << bufName << " " << "0x"
-         << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes << '\n';
+  output << "_symbol " << bufName << " "
+         << "0x" << llvm::utohexstr(offset + bufferBaseAddr) << " " << numBytes
+         << '\n';
 }
 
 LogicalResult AIETranslateToTargetArch(ModuleOp module, raw_ostream &output,

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -383,6 +383,22 @@ void registerAIETranslations() {
         return success();
       },
       registerDialects);
+  TranslateFromMLIRRegistration registrationNPULocmap(
+      "aie-npu-to-binary-locmap",
+      "Translate npu instructions to a JSON sidecar mapping each transaction "
+      "word's byte offset to its source MLIR Location (and regdb register "
+      "name where applicable). The .bin itself is not emitted.",
+      [](ModuleOp module, raw_ostream &output) {
+        std::vector<uint32_t> instructions;
+        std::vector<TxnLocEntry> locmap;
+        auto r = AIETranslateNpuToBinary(module, instructions, deviceName,
+                                         sequenceName, &locmap);
+        if (failed(r))
+          return r;
+        emitNpuLocmapJSON(output, deviceName, /*binaryName=*/"", locmap);
+        return success();
+      },
+      registerDialects);
   TranslateFromMLIRRegistration registrationCtrlPkt(
       "aie-ctrlpkt-to-bin", "Translate aiex.control_packet ops to binary",
       [](ModuleOp module, raw_ostream &output) {

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -37,6 +37,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <fstream>
 #include <iostream>
@@ -168,9 +169,16 @@ void registerAIETranslations() {
   static llvm::cl::opt<bool> npuEmitLocmap(
       "aie-npu-emit-locmap", llvm::cl::init(false),
       llvm::cl::desc(
-          "For aie-npu-to-binary, emit a JSON sidecar mapping each transaction "
-          "word's byte offset to its source MLIR Location (and regdb register "
-          "name where applicable) instead of the binary itself."));
+          "For aie-npu-to-binary, also write a JSON sidecar mapping each "
+          "transaction word's byte offset to its source MLIR Location (and "
+          "regdb register name where applicable) to the file given by "
+          "-aie-npu-locmap-file. The binary is still emitted to the main "
+          "output."));
+  static llvm::cl::opt<std::string> npuLocmapFile(
+      "aie-npu-locmap-file", llvm::cl::init(""),
+      llvm::cl::desc(
+          "Destination file for the JSON location sidecar emitted when "
+          "-aie-npu-emit-locmap is set (required with that flag)."));
 
   TranslateFromMLIRRegistration registrationMMap(
       "aie-generate-mmap", "Generate AIE memory map",
@@ -376,24 +384,36 @@ void registerAIETranslations() {
       [](ModuleOp module, raw_ostream &output) {
         std::vector<uint32_t> instructions;
         std::vector<TxnLocEntry> locmap;
+        if (npuEmitLocmap && npuLocmapFile.empty()) {
+          llvm::errs() << "-aie-npu-emit-locmap requires -aie-npu-locmap-file\n";
+          return failure();
+        }
         auto r = AIETranslateNpuToBinary(module, instructions, deviceName,
                                          sequenceName,
                                          npuEmitLocmap ? &locmap : nullptr);
         if (failed(r))
           return r;
-        // With -aie-npu-emit-locmap, emit the JSON location sidecar mapping
-        // each transaction word's byte offset to its source MLIR Location
-        // instead of the binary itself.
-        if (npuEmitLocmap) {
-          emitNpuLocmapJSON(output, deviceName, /*binaryName=*/"", locmap);
-          return success();
-        }
+        // The binary (or hex text) is always emitted to the main output.
         if (outputBinary) {
           output.write(reinterpret_cast<const char *>(instructions.data()),
                        instructions.size() * sizeof(uint32_t));
         } else {
           for (auto w : instructions)
             output << llvm::format("%08X\n", w);
+        }
+        // With -aie-npu-emit-locmap, additionally write the JSON location
+        // sidecar (mapping each transaction word's byte offset to its source
+        // MLIR Location) to the file named by -aie-npu-locmap-file.
+        if (npuEmitLocmap) {
+          std::error_code ec;
+          llvm::raw_fd_ostream locFile(npuLocmapFile, ec,
+                                       llvm::sys::fs::OF_Text);
+          if (ec) {
+            llvm::errs() << "Error opening locmap file '" << npuLocmapFile
+                         << "': " << ec.message() << "\n";
+            return failure();
+          }
+          emitNpuLocmapJSON(locFile, deviceName, /*binaryName=*/"", locmap);
         }
         return success();
       },

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -166,19 +166,14 @@ void registerAIETranslations() {
       "aie-sequence-name", llvm::cl::init(""),
       llvm::cl::desc(
           "Specify the name of the aiex.runtime_sequence to translate"));
-  static llvm::cl::opt<bool> npuEmitLocmap(
-      "aie-npu-emit-locmap", llvm::cl::init(false),
+  static llvm::cl::opt<std::string> npuEmitLocmap(
+      "aie-npu-emit-locmap", llvm::cl::init(""),
+      llvm::cl::value_desc("filename"),
       llvm::cl::desc(
           "For aie-npu-to-binary, also write a JSON sidecar mapping each "
           "transaction word's byte offset to its source MLIR Location (and "
-          "regdb register name where applicable) to the file given by "
-          "-aie-npu-locmap-file. The binary is still emitted to the main "
-          "output."));
-  static llvm::cl::opt<std::string> npuLocmapFile(
-      "aie-npu-locmap-file", llvm::cl::init(""),
-      llvm::cl::desc(
-          "Destination file for the JSON location sidecar emitted when "
-          "-aie-npu-emit-locmap is set (required with that flag)."));
+          "regdb register name where applicable) to the given file. The binary "
+          "is still emitted to the main output."));
 
   TranslateFromMLIRRegistration registrationMMap(
       "aie-generate-mmap", "Generate AIE memory map",
@@ -384,13 +379,10 @@ void registerAIETranslations() {
       [](ModuleOp module, raw_ostream &output) {
         std::vector<uint32_t> instructions;
         std::vector<TxnLocEntry> locmap;
-        if (npuEmitLocmap && npuLocmapFile.empty()) {
-          llvm::errs() << "-aie-npu-emit-locmap requires -aie-npu-locmap-file\n";
-          return failure();
-        }
+        bool emitLocmap = !npuEmitLocmap.empty();
         auto r = AIETranslateNpuToBinary(module, instructions, deviceName,
                                          sequenceName,
-                                         npuEmitLocmap ? &locmap : nullptr);
+                                         emitLocmap ? &locmap : nullptr);
         if (failed(r))
           return r;
         // The binary (or hex text) is always emitted to the main output.
@@ -401,15 +393,15 @@ void registerAIETranslations() {
           for (auto w : instructions)
             output << llvm::format("%08X\n", w);
         }
-        // With -aie-npu-emit-locmap, additionally write the JSON location
+        // With -aie-npu-emit-locmap=<file>, additionally write the JSON location
         // sidecar (mapping each transaction word's byte offset to its source
-        // MLIR Location) to the file named by -aie-npu-locmap-file.
-        if (npuEmitLocmap) {
+        // MLIR Location) to that file.
+        if (emitLocmap) {
           std::error_code ec;
-          llvm::raw_fd_ostream locFile(npuLocmapFile, ec,
+          llvm::raw_fd_ostream locFile(npuEmitLocmap, ec,
                                        llvm::sys::fs::OF_Text);
           if (ec) {
-            llvm::errs() << "Error opening locmap file '" << npuLocmapFile
+            llvm::errs() << "Error opening locmap file '" << npuEmitLocmap
                          << "': " << ec.message() << "\n";
             return failure();
           }

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -165,6 +165,12 @@ void registerAIETranslations() {
       "aie-sequence-name", llvm::cl::init(""),
       llvm::cl::desc(
           "Specify the name of the aiex.runtime_sequence to translate"));
+  static llvm::cl::opt<bool> npuEmitLocmap(
+      "aie-npu-emit-locmap", llvm::cl::init(false),
+      llvm::cl::desc(
+          "For aie-npu-to-binary, emit a JSON sidecar mapping each transaction "
+          "word's byte offset to its source MLIR Location (and regdb register "
+          "name where applicable) instead of the binary itself."));
 
   TranslateFromMLIRRegistration registrationMMap(
       "aie-generate-mmap", "Generate AIE memory map",
@@ -369,10 +375,19 @@ void registerAIETranslations() {
       "aie-npu-to-binary", "Translate npu instructions to binary",
       [](ModuleOp module, raw_ostream &output) {
         std::vector<uint32_t> instructions;
+        std::vector<TxnLocEntry> locmap;
         auto r = AIETranslateNpuToBinary(module, instructions, deviceName,
-                                         sequenceName);
+                                         sequenceName,
+                                         npuEmitLocmap ? &locmap : nullptr);
         if (failed(r))
           return r;
+        // With -aie-npu-emit-locmap, emit the JSON location sidecar mapping
+        // each transaction word's byte offset to its source MLIR Location
+        // instead of the binary itself.
+        if (npuEmitLocmap) {
+          emitNpuLocmapJSON(output, deviceName, /*binaryName=*/"", locmap);
+          return success();
+        }
         if (outputBinary) {
           output.write(reinterpret_cast<const char *>(instructions.data()),
                        instructions.size() * sizeof(uint32_t));
@@ -380,22 +395,6 @@ void registerAIETranslations() {
           for (auto w : instructions)
             output << llvm::format("%08X\n", w);
         }
-        return success();
-      },
-      registerDialects);
-  TranslateFromMLIRRegistration registrationNPULocmap(
-      "aie-npu-to-binary-locmap",
-      "Translate npu instructions to a JSON sidecar mapping each transaction "
-      "word's byte offset to its source MLIR Location (and regdb register "
-      "name where applicable). The .bin itself is not emitted.",
-      [](ModuleOp module, raw_ostream &output) {
-        std::vector<uint32_t> instructions;
-        std::vector<TxnLocEntry> locmap;
-        auto r = AIETranslateNpuToBinary(module, instructions, deviceName,
-                                         sequenceName, &locmap);
-        if (failed(r))
-          return r;
-        emitNpuLocmapJSON(output, deviceName, /*binaryName=*/"", locmap);
         return success();
       },
       registerDialects);

--- a/test/Conversion/AIEToConfiguration/loc_preservation.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_preservation.mlir
@@ -8,24 +8,31 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Verifies --convert-aie-to-control-packets attaches the source DeviceOp's
-// loc to the synthesized aie.runtime_sequence and aiex.control_packet ops.
+// Verifies --convert-aie-to-control-packets propagates source op locations
+// onto the synthesized aiex.control_packet ops via AIERTControl's
+// instruction-range bracketing (Phase 3). The runtime_sequence itself
+// inherits the device loc when synthesized on demand.
 
 // RUN: aie-opt --convert-aie-to-control-packets="elf-dir=%S/convert_aie_to_ctrl_pkts_elfs/" --mlir-print-debuginfo %s | FileCheck %s
 
 #device_loc = loc("user_design.py":42:4)
+#core_user_loc = loc("user_design.py":80:4)
+#core_named = loc("worker_2"(#core_user_loc))
 
 aie.device(npu1_1col) {
   %12 = aie.tile(0, 2)
   %buf = aie.buffer(%12) : memref<256xi32>
   %4 = aie.core(%12) {
     aie.end
-  } { elf_file = "core_0_2.elf" }
+  } { elf_file = "core_0_2.elf" } loc(#core_named)
 } loc(#device_loc)
 
-// At least one synthesized aiex.control_packet inside the new
-// runtime_sequence carries the device's loc, and the runtime_sequence
-// itself does too. (The pass creates the runtime_sequence on demand.)
+// runtime_sequence is synthesized on demand and inherits the device loc.
 // CHECK-DAG: aie.runtime_sequence @configure() {{[{][[:space:]]*$}}
-// CHECK-DAG: aiex.control_packet {{.*}} loc(#[[DEVLOC:loc[0-9]*]])
-// CHECK-DAG: #[[DEVLOC]] = loc("user_design.py":42:4)
+
+// At least one synthesized control_packet carries the CoreOp's IRON-style
+// NameLoc — produced by AIERTControl::addCoreEnable's TxnLocBracket around
+// the XAie_CoreEnable call.
+// CHECK-DAG: #[[USERLOC:loc[0-9]*]] = loc("user_design.py":80:4)
+// CHECK-DAG: #[[CORELOC:loc[0-9]*]] = loc("worker_2"(#[[USERLOC]]))
+// CHECK-DAG: aiex.control_packet {{.*}} loc(#[[CORELOC]])

--- a/test/Conversion/AIEToConfiguration/loc_preservation.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_preservation.mlir
@@ -1,0 +1,31 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies --convert-aie-to-control-packets attaches the source DeviceOp's
+// loc to the synthesized aie.runtime_sequence and aiex.control_packet ops.
+
+// RUN: aie-opt --convert-aie-to-control-packets="elf-dir=%S/convert_aie_to_ctrl_pkts_elfs/" --mlir-print-debuginfo %s | FileCheck %s
+
+#device_loc = loc("user_design.py":42:4)
+
+aie.device(npu1_1col) {
+  %12 = aie.tile(0, 2)
+  %buf = aie.buffer(%12) : memref<256xi32>
+  %4 = aie.core(%12) {
+    aie.end
+  } { elf_file = "core_0_2.elf" }
+} loc(#device_loc)
+
+// At least one synthesized aiex.control_packet inside the new
+// runtime_sequence carries the device's loc, and the runtime_sequence
+// itself does too. (The pass creates the runtime_sequence on demand.)
+// CHECK-DAG: aie.runtime_sequence @configure() {{[{][[:space:]]*$}}
+// CHECK-DAG: aiex.control_packet {{.*}} loc(#[[DEVLOC:loc[0-9]*]])
+// CHECK-DAG: #[[DEVLOC]] = loc("user_design.py":42:4)

--- a/test/Conversion/AIEToConfiguration/loc_preservation.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_preservation.mlir
@@ -10,8 +10,8 @@
 
 // Verifies --convert-aie-to-control-packets propagates source op locations
 // onto the synthesized aiex.control_packet ops via AIERTControl's
-// instruction-range bracketing (Phase 3). The runtime_sequence itself
-// inherits the device loc when synthesized on demand.
+// instruction-range bracketing. The runtime_sequence itself inherits the
+// device loc when synthesized on demand.
 
 // RUN: aie-opt --convert-aie-to-control-packets="elf-dir=%S/convert_aie_to_ctrl_pkts_elfs/" --mlir-print-debuginfo %s | FileCheck %s
 
@@ -30,9 +30,9 @@ aie.device(npu1_1col) {
 // runtime_sequence is synthesized on demand and inherits the device loc.
 // CHECK-DAG: aie.runtime_sequence @configure() {{[{][[:space:]]*$}}
 
-// At least one synthesized control_packet carries the CoreOp's IRON-style
-// NameLoc — produced by AIERTControl::addCoreEnable's TxnLocBracket around
-// the XAie_CoreEnable call.
+// At least one synthesized control_packet carries the CoreOp's NameLoc —
+// produced by AIERTControl::addCoreEnable's TxnLocBracket around the
+// XAie_CoreEnable call.
 // CHECK-DAG: #[[USERLOC:loc[0-9]*]] = loc("user_design.py":80:4)
 // CHECK-DAG: #[[CORELOC:loc[0-9]*]] = loc("worker_2"(#[[USERLOC]]))
 // CHECK-DAG: aiex.control_packet {{.*}} loc(#[[CORELOC]])

--- a/test/Conversion/AIEToConfiguration/loc_roundtrip.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_roundtrip.mlir
@@ -1,0 +1,35 @@
+//===- loc_roundtrip.mlir ----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that --convert-aie-to-transaction preserves source op locations
+// across the aie-rt round-trip. AIERTControl::TxnLocBracket scopes capture
+// the lock op's loc around the XAie_LockSetValue call; AIEToConfiguration
+// then reads ctl.getTxnInstrLocs() and applies those locations to the
+// re-emitted aiex.npu.write32 ops instead of the device fallback location.
+
+// RUN: aie-opt --convert-aie-to-transaction="elf-dir=%S/convert_aie_to_ctrl_pkts_elfs/" --mlir-print-debuginfo %s | FileCheck %s
+
+#device_loc = loc("device.mlir":1:1)
+#user_lock_loc = loc("user_program.py":17:8)
+#user_lock_name = loc("of_in_lock0"(#user_lock_loc))
+
+aie.device(npu1_1col) {
+  %t02 = aie.tile(0, 2)
+  %lock = aie.lock(%t02, 0) { init = 1 : i32, sym_name = "lk" } loc(#user_lock_name)
+  %4 = aie.core(%t02) {
+    aie.end
+  } { elf_file = "core_0_2.elf" }
+} loc(#device_loc)
+
+// At least one synthesized aiex.npu.write32 (from XAie_LockSetValue) carries
+// the IRON-style NameLoc pointing at user_program.py:17, NOT the device loc
+// fallback. The bracketing in AIERT::initLocks attributes the cmds produced
+// by the explicit-init lock walk to the LockOp's loc.
+// CHECK-DAG: #[[USERLOC:loc[0-9]*]] = loc("user_program.py":17:8)
+// CHECK-DAG: #[[LOCKLOC:loc[0-9]*]] = loc("of_in_lock0"(#[[USERLOC]]))
+// CHECK-DAG: aiex.npu.write32{{.*}}loc(#[[LOCKLOC]])

--- a/test/Conversion/AIEToConfiguration/loc_roundtrip.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_roundtrip.mlir
@@ -27,7 +27,7 @@ aie.device(npu1_1col) {
 } loc(#device_loc)
 
 // At least one synthesized aiex.npu.write32 (from XAie_LockSetValue) carries
-// the IRON-style NameLoc pointing at user_program.py:17, NOT the device loc
+// the LockOp's NameLoc pointing at user_program.py:17, NOT the device loc
 // fallback. The bracketing in AIERT::initLocks attributes the cmds produced
 // by the explicit-init lock walk to the LockOp's loc.
 // CHECK-DAG: #[[USERLOC:loc[0-9]*]] = loc("user_program.py":17:8)

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Verifies aie-translate --aie-npu-to-binary --aie-npu-emit-locmap writes a JSON
-// sidecar (to the -aie-npu-locmap-file path) keying each transaction word's
-// byte_offset to the source aiex.npu.* op's MLIR Location, including IRON-style
-// NameLoc names from Phase 1 capture. The main output still holds the binary.
+// Verifies aie-translate --aie-npu-to-binary --aie-npu-emit-locmap=<file> writes
+// a JSON sidecar (to <file>) keying each transaction word's byte_offset to the
+// source aiex.npu.* op's MLIR Location, including IRON-style NameLoc names from
+// Phase 1 capture. The main output still holds the binary.
 
-// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap --aie-npu-locmap-file=%t.json %s
+// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap=%t.json %s
 // RUN: FileCheck %s < %t.json
 
 #user_w32 = loc("user.py":42:4)

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Verifies aie-translate --aie-npu-to-binary-locmap emits a JSON sidecar
-// keying each transaction word's byte_offset to the source aiex.npu.* op's
-// MLIR Location, including IRON-style NameLoc names from Phase 1 capture.
+// Verifies aie-translate --aie-npu-to-binary --aie-npu-emit-locmap emits a JSON
+// sidecar keying each transaction word's byte_offset to the source aiex.npu.*
+// op's MLIR Location, including IRON-style NameLoc names from Phase 1 capture.
 
-// RUN: aie-translate --aie-npu-to-binary-locmap %s | FileCheck %s
+// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap %s | FileCheck %s
 
 #user_w32 = loc("user.py":42:4)
 #user_bw  = loc("user.py":50:4)

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -6,11 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Verifies aie-translate --aie-npu-to-binary --aie-npu-emit-locmap emits a JSON
-// sidecar keying each transaction word's byte_offset to the source aiex.npu.*
-// op's MLIR Location, including IRON-style NameLoc names from Phase 1 capture.
+// Verifies aie-translate --aie-npu-to-binary --aie-npu-emit-locmap writes a JSON
+// sidecar (to the -aie-npu-locmap-file path) keying each transaction word's
+// byte_offset to the source aiex.npu.* op's MLIR Location, including IRON-style
+// NameLoc names from Phase 1 capture. The main output still holds the binary.
 
-// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap %s | FileCheck %s
+// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap --aie-npu-locmap-file=%t.json %s
+// RUN: FileCheck %s < %t.json
 
 #user_w32 = loc("user.py":42:4)
 #user_bw  = loc("user.py":50:4)

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -8,8 +8,8 @@
 
 // Verifies aie-translate --aie-npu-to-binary --aie-npu-emit-locmap=<file> writes
 // a JSON sidecar (to <file>) keying each transaction word's byte_offset to the
-// source aiex.npu.* op's MLIR Location, including IRON-style NameLoc names from
-// Phase 1 capture. The main output still holds the binary.
+// source aiex.npu.* op's MLIR Location, including NameLoc names when the source
+// op carries one. The main output still holds the binary.
 
 // RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap=%t.json %s
 // RUN: FileCheck %s < %t.json
@@ -39,7 +39,7 @@ module {
 // CHECK-DAG: "operations":
 
 // Per-op entries: opcode, source op name, address, source location with
-// the IRON NameLoc carrying the user file:line.
+// the NameLoc carrying the user file:line.
 // CHECK-DAG: "opcode": "WRITE32"
 // CHECK-DAG: "source_op": "aiex.npu.write32"
 // CHECK-DAG: "address": "0xABC00DEF"

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -1,0 +1,57 @@
+//===- loc_sidecar.mlir -----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies aie-translate --aie-npu-to-binary-locmap emits a JSON sidecar
+// keying each transaction word's byte_offset to the source aiex.npu.* op's
+// MLIR Location, including IRON-style NameLoc names from Phase 1 capture.
+
+// RUN: aie-translate --aie-npu-to-binary-locmap %s | FileCheck %s
+
+#user_w32 = loc("user.py":42:4)
+#user_bw  = loc("user.py":50:4)
+#user_zero = loc("user.py":60:4)
+#name_w32 = loc("of_in"(#user_w32))
+#name_bw  = loc("dma_task"(#user_bw))
+#name_zero = loc("zero_reg"(#user_zero))
+
+module {
+  aie.device(npu1) {
+    memref.global "private" constant @write_data : memref<4xi32> = dense<[1, 2, 3, 4]>
+    aie.runtime_sequence(%arg0: memref<16xf32>) {
+      aiex.npu.write32 { address = 0xabc00def : ui32, value = 0x42 : ui32 } loc(#name_w32)
+      aiex.npu.write32 { address = 0x0 : ui32, value = 0x1 : ui32 } loc(#name_zero)
+      %0 = memref.get_global @write_data : memref<4xi32>
+      aiex.npu.blockwrite (%0) { address = 0x12345678 : ui32 } : memref<4xi32> loc(#name_bw)
+    }
+  }
+}
+
+// JSON header
+// CHECK-DAG: "version": 1
+// CHECK-DAG: "device":
+// CHECK-DAG: "operations":
+
+// Per-op entries: opcode, source op name, address, source location with
+// the IRON NameLoc carrying the user file:line.
+// CHECK-DAG: "opcode": "WRITE32"
+// CHECK-DAG: "source_op": "aiex.npu.write32"
+// CHECK-DAG: "address": "0xABC00DEF"
+// CHECK-DAG: "name": "of_in"
+// CHECK-DAG: "file": "user.py"
+// CHECK-DAG: "line": 42
+
+// Address zero is a real address, not the "no address" sentinel.
+// CHECK-DAG: "address": "0x0"
+// CHECK-DAG: "name": "zero_reg"
+// CHECK-DAG: "line": 60
+
+// CHECK-DAG: "opcode": "BLOCKWRITE"
+// CHECK-DAG: "source_op": "aiex.npu.blockwrite"
+// CHECK-DAG: "address": "0x12345678"
+// CHECK-DAG: "name": "dma_task"
+// CHECK-DAG: "line": 50

--- a/test/Targets/NPU/loc_sidecar_regdb.mlir
+++ b/test/Targets/NPU/loc_sidecar_regdb.mlir
@@ -12,7 +12,8 @@
 // "memory_tile", "shim"); a mismatch makes lookupRegisterByOffset silently
 // return null and drops the "register"/"register_module" fields entirely.
 
-// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap %s | FileCheck %s
+// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap --aie-npu-locmap-file=%t.json %s
+// RUN: FileCheck %s < %t.json
 
 module {
   aie.device(npu1) {

--- a/test/Targets/NPU/loc_sidecar_regdb.mlir
+++ b/test/Targets/NPU/loc_sidecar_regdb.mlir
@@ -12,7 +12,7 @@
 // "memory_tile", "shim"); a mismatch makes lookupRegisterByOffset silently
 // return null and drops the "register"/"register_module" fields entirely.
 
-// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap --aie-npu-locmap-file=%t.json %s
+// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap=%t.json %s
 // RUN: FileCheck %s < %t.json
 
 module {

--- a/test/Targets/NPU/loc_sidecar_regdb.mlir
+++ b/test/Targets/NPU/loc_sidecar_regdb.mlir
@@ -1,0 +1,43 @@
+//===- loc_sidecar_regdb.mlir -----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that the locmap sidecar decorates each transaction word with its
+// regdb-resolved semantic register name and module. The module names emitted
+// must match the JSON keys in aie_registers_aie2.json ("core", "memory",
+// "memory_tile", "shim"); a mismatch makes lookupRegisterByOffset silently
+// return null and drops the "register"/"register_module" fields entirely.
+
+// RUN: aie-translate --aie-npu-to-binary --aie-npu-emit-locmap %s | FileCheck %s
+
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<16xf32>) {
+      // col 0, row 2 (core tile), tile-relative offset 0x32000 -> Core_Control.
+      aiex.npu.write32 { address = 0x232000 : ui32, value = 0x1 : ui32 }
+      // col 0, row 0 (shim tile), tile-relative offset 0x14000 -> Lock0_value.
+      aiex.npu.write32 { address = 0x14000 : ui32, value = 0x2 : ui32 }
+      // col 0, row 1 (mem tile), tile-relative offset 0x91000 -> Performance_Control0.
+      aiex.npu.write32 { address = 0x191000 : ui32, value = 0x3 : ui32 }
+    }
+  }
+}
+
+// Core tile register in the "core" module.
+// CHECK-DAG: "address": "0x232000"
+// CHECK-DAG: "register": "Core_Control"
+// CHECK-DAG: "register_module": "core"
+
+// Shim tile register in the "shim" module.
+// CHECK-DAG: "address": "0x14000"
+// CHECK-DAG: "register": "Lock0_value"
+// CHECK-DAG: "register_module": "shim"
+
+// Mem tile register in the "memory_tile" module.
+// CHECK-DAG: "address": "0x191000"
+// CHECK-DAG: "register": "Performance_Control0"
+// CHECK-DAG: "register_module": "memory_tile"

--- a/test/aiecc/cpp_ctrlpkt.mlir
+++ b/test/aiecc/cpp_ctrlpkt.mlir
@@ -12,15 +12,20 @@
 
 // Preprocess with overlay (matching ctrl_packet_reconfig test flow)
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %s -o %t_overlay.mlir
-// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose %t_overlay.mlir 2>&1 | FileCheck %s
+// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --keep-loc --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose --ctrlpkt-name=%t_ctrlpkt.bin --ctrlpkt-dma-seq-name=%t_dma_seq.bin %t_overlay.mlir 2>&1 | FileCheck %s
 // RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
 // RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/input_with_addresses.mlir
+// RUN: test -f %t_ctrlpkt.bin.locmap.json
+// RUN: test -f %t_dma_seq.bin.locmap.json
+// RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
 
 // CHECK: Generating control packets for device
 // CHECK: Running control packet pipeline in-memory
 // CHECK: Wrote {{[0-9]+}} control packet instructions to
+// CHECK: Wrote {{[0-9]+}} locmap entries to: {{.*}}ctrlpkt.bin.locmap.json
 // CHECK: Running control packet DMA pipeline in-memory
 // CHECK: Wrote {{[0-9]+}} DMA sequence instructions to
+// CHECK: Wrote {{[0-9]+}} locmap entries to: {{.*}}dma_seq.bin.locmap.json
 // CHECK: Compilation completed successfully
 
 // DUMP: loc(

--- a/test/aiecc/cpp_ctrlpkt.mlir
+++ b/test/aiecc/cpp_ctrlpkt.mlir
@@ -12,7 +12,9 @@
 
 // Preprocess with overlay (matching ctrl_packet_reconfig test flow)
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %s -o %t_overlay.mlir
-// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --verbose %t_overlay.mlir 2>&1 | FileCheck %s
+// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose %t_overlay.mlir 2>&1 | FileCheck %s
+// RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
+// RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/input_with_addresses.mlir
 
 // CHECK: Generating control packets for device
 // CHECK: Running control packet pipeline in-memory
@@ -20,6 +22,8 @@
 // CHECK: Running control packet DMA pipeline in-memory
 // CHECK: Wrote {{[0-9]+}} DMA sequence instructions to
 // CHECK: Compilation completed successfully
+
+// DUMP: loc(
 
 module {
   aie.device(npu1) {

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -47,16 +47,22 @@ module @loc_test {
  }
 }
 
-// AIECreateCores: synthesized core / mem / buffer for the call op carry
+// AIECreateCores: synthesized tile / core / end / mem / buffer for the call
+// op carry
 // the call's loc.
+// CHECK-DAG: aie.tile({{.*}}) loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.mem({{.*}})
 // CHECK-DAG: aie.core({{.*}}) {{[{][[:space:]]*$}}
-// CHECK-DAG: } loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.end loc(#[[CALLLOC]])
+// CHECK-DAG: } loc(#[[CALLLOC]])
 // CHECK-DAG: aie.buffer({{.*}}) : memref<256xi32> loc(#[[CALLLOC]])
 
 // AIELowerMemcpy: synthesized aie.flow / dma_start / dma_bd / use_token /
 // next_bd carry the memcpy's loc.
 // CHECK-DAG: aie.flow({{.*}}) loc(#[[MCLOC:loc[0-9]*]])
+// CHECK-DAG: aie.dma_start({{.*}}) loc(#[[MCLOC]])
 // CHECK-DAG: aie.dma_bd({{.*}}) loc(#[[MCLOC]])
+// CHECK-DAG: aie.next_bd {{.*}} loc(#[[MCLOC]])
 // CHECK-DAG: aiex.useToken {{.*}} loc(#[[MCLOC]])
 
 // CHECK-DAG: #[[CALLLOC]] = loc("user_design.py":42:4)

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -55,7 +55,7 @@ module @loc_test {
 // AIECreateCores: synthesized tile / core / end / mem / buffer for the call
 // op carry
 // the call's loc.
-// CHECK-DAG: aie.tile({{.*}}) loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.tile(3, 3) loc(#[[CALLLOC:loc[0-9]*]])
 // CHECK-DAG: aie.mem({{.*}})
 // CHECK-DAG: aie.core({{.*}}) {{[{][[:space:]]*$}}
 // CHECK-DAG: aie.end loc(#[[CALLLOC]])

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -27,6 +27,7 @@ module @loc_test {
 
   %buf0 = memref.alloc() : memref<256xi32>
   %buf1 = memref.alloc() : memref<256xi32>
+  %buf2 = memref.alloc() : memref<256xi32>
 
   aiex.token(0) { sym_name = "token0" }
 
@@ -40,10 +41,14 @@ module @loc_test {
     aiex.useToken @token0(Release, 3)
     return
   }
+  func.func @task2(%arg0: memref<256xi32>) -> () {
+    return
+  }
 
   func.call @task0(%buf0) { aie.x = 1, aie.y = 1 } : (memref<256xi32>) -> () loc(#call_loc)
   aiex.memcpy @token0(1, 2) (%t11 : <%buf0, 0, 256>, %t22 : <%buf1, 0, 256>) : (memref<256xi32>, memref<256xi32>) loc(#memcpy_loc)
   func.call @task1(%buf1) { aie.x = 2, aie.y = 2 } : (memref<256xi32>) -> ()
+  func.call @task2(%buf2) { aie.x = 3, aie.y = 3 } : (memref<256xi32>) -> () loc(#call_loc)
  }
 }
 

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -1,0 +1,63 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that:
+//  - --aie-create-cores forwards the source func.call op's location to the
+//    synthesized aie.tile / aie.buffer / aie.mem / aie.core / aie.end ops.
+//  - --aie-lower-memcpy forwards the source aiex.memcpy op's location to
+//    the synthesized aie.flow / aie.dma_start / aie.dma_bd / aiex.useToken
+//    / aie.next_bd ops.
+
+// RUN: aie-opt --aie-create-cores --aie-lower-memcpy --mlir-print-debuginfo %s | FileCheck %s
+
+#call_loc = loc("user_design.py":42:4)
+#memcpy_loc = loc("user_design.py":50:4)
+
+module @loc_test {
+ aie.device(xcvc1902) {
+  %t11 = aie.tile(1, 1)
+  %t22 = aie.tile(2, 2)
+
+  %buf0 = memref.alloc() : memref<256xi32>
+  %buf1 = memref.alloc() : memref<256xi32>
+
+  aiex.token(0) { sym_name = "token0" }
+
+  func.func @task0(%arg0: memref<256xi32>) -> () {
+    aiex.useToken @token0(Acquire, 0)
+    aiex.useToken @token0(Release, 1)
+    return
+  }
+  func.func @task1(%arg0: memref<256xi32>) -> () {
+    aiex.useToken @token0(Acquire, 2)
+    aiex.useToken @token0(Release, 3)
+    return
+  }
+
+  func.call @task0(%buf0) { aie.x = 1, aie.y = 1 } : (memref<256xi32>) -> () loc(#call_loc)
+  aiex.memcpy @token0(1, 2) (%t11 : <%buf0, 0, 256>, %t22 : <%buf1, 0, 256>) : (memref<256xi32>, memref<256xi32>) loc(#memcpy_loc)
+  func.call @task1(%buf1) { aie.x = 2, aie.y = 2 } : (memref<256xi32>) -> ()
+ }
+}
+
+// AIECreateCores: synthesized core / mem / buffer for the call op carry
+// the call's loc.
+// CHECK-DAG: aie.core({{.*}}) {{[{][[:space:]]*$}}
+// CHECK-DAG: } loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.buffer({{.*}}) : memref<256xi32> loc(#[[CALLLOC]])
+
+// AIELowerMemcpy: synthesized aie.flow / dma_start / dma_bd / use_token /
+// next_bd carry the memcpy's loc.
+// CHECK-DAG: aie.flow({{.*}}) loc(#[[MCLOC:loc[0-9]*]])
+// CHECK-DAG: aie.dma_bd({{.*}}) loc(#[[MCLOC]])
+// CHECK-DAG: aiex.useToken {{.*}} loc(#[[MCLOC]])
+
+// CHECK-DAG: #[[CALLLOC]] = loc("user_design.py":42:4)
+// CHECK-DAG: #[[MCLOC]] = loc("user_design.py":50:4)

--- a/test/create-flows/loc_preservation.mlir
+++ b/test/create-flows/loc_preservation.mlir
@@ -1,0 +1,33 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies --aie-create-pathfinder-flows propagates the source FlowOp's
+// location to the synthesized ConnectOps inside switchboxes, and that
+// per-tile WireOps inherit the corresponding tile's location.
+
+// RUN: aie-opt --aie-create-pathfinder-flows --mlir-print-debuginfo %s | FileCheck %s
+
+#flow_loc = loc("user_design.py":42:4)
+#tile_loc = loc("user_design.py":50:8)
+
+module {
+  aie.device(xcvc1902) {
+    %0 = aie.tile(2, 3) loc(#tile_loc)
+    %1 = aie.tile(3, 2) loc(#tile_loc)
+    aie.flow(%0, Core : 1, %1, DMA : 0) loc(#flow_loc)
+  }
+}
+
+// Synthesized aie.connect ops inside switchboxes carry the FlowOp's loc.
+// CHECK-DAG: aie.connect<{{.*}}> loc(#[[FLOWLOC:loc[0-9]*]])
+// Synthesized aie.wire ops between switchboxes/tiles carry the tile's loc.
+// CHECK-DAG: aie.wire({{.*}}) loc(#[[TILELOC:loc[0-9]*]])
+// CHECK-DAG: #[[FLOWLOC]] = loc("user_design.py":42:4)
+// CHECK-DAG: #[[TILELOC]] = loc("user_design.py":50:8)

--- a/test/herd-routing/loc_preservation.mlir
+++ b/test/herd-routing/loc_preservation.mlir
@@ -1,0 +1,46 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies --aie-herd-routing forwards the source HerdOp's location onto
+// the synthesized iter / select / switchbox / connect ops produced when
+// expanding a route.
+
+// The herd-routing pass produces an IR shape that the verifier rejects under
+// the current placement model (aie.switchbox expects a placed tile). The
+// location forwarding under test is independent of that — disable the
+// after-pass verifier so we can inspect the synthesized ops.
+
+// RUN: aie-opt --verify-each=false --aie-herd-routing --mlir-print-debuginfo %s | FileCheck %s
+
+#herd_loc = loc("user_design.py":42:4)
+
+// Use distinct, non-default locs on the user-written ops (iter, select) so
+// the test can isolate the locs that --aie-herd-routing synthesizes from
+// the pre-existing user-written ones.
+#scaffold_loc = loc("scaffold.mlir":1:1)
+
+module @loc_test {
+  aie.device(xcvc1902) {
+    %t = aiex.herd[1][1] { sym_name = "t" } loc(#herd_loc)
+    %s = aiex.herd[1][1] { sym_name = "s" } loc(#herd_loc)
+
+    %i0 = aiex.iter(0, 1, 1) loc(#scaffold_loc)
+
+    %sel_t = aiex.select(%t, %i0, %i0) loc(#scaffold_loc)
+    %sel_s = aiex.select(%s, %i0, %i0) loc(#scaffold_loc)
+    aiex.place(%t, %s, 3, 3) loc(#scaffold_loc)
+    aiex.route(<%sel_t, DMA: 0>, <%sel_s, DMA: 0>) loc(#scaffold_loc)
+  }
+}
+
+// Synthesized aie.connect ops (only present after the pass) inherit the
+// herd's source loc rather than loc(unknown) or the scaffold loc.
+// CHECK-DAG: "aie.connect"() {{.*}} loc(#[[HERDLOC:loc[0-9]*]])
+// CHECK-DAG: #[[HERDLOC]] = loc("user_design.py":42:4)

--- a/test/lower-to-standard/loc_preservation.mlir
+++ b/test/lower-to-standard/loc_preservation.mlir
@@ -1,0 +1,42 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that --aie-standard-lowering forwards the source op's location
+// onto its lowered standard-dialect ops.
+
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering --mlir-print-debuginfo %s | FileCheck %s
+
+#user_loc = loc("user_design.py":42:4)
+#buf_loc = loc("user_design.py":50:4)
+
+module @loc_test {
+ aie.device(xcve2302) {
+  %tile13 = aie.tile(1, 3)
+  %lock13 = aie.lock(%tile13, 0) loc(#user_loc)
+  %buf13 = aie.buffer(%tile13) {sym_name = "my_buf"} : memref<16xi32> loc(#buf_loc)
+
+  func.func private @kernel(%lock : index) {
+    aie.use_lock(%lock, "Acquire", 0) loc(#user_loc)
+    return
+  }
+
+  %core13 = aie.core(%tile13) {
+    func.call @kernel(%lock13) : (index) -> ()
+    aie.end
+  }
+ }
+}
+
+// The lowered call to llvm.aie2.acquire and the memref.global for the
+// buffer must reference the user's source location, not loc(unknown).
+// CHECK-DAG: call @llvm.aie2.acquire({{.*}}) : (i32, i32) -> () loc(#[[ULOC:loc[0-9]*]])
+// CHECK-DAG: memref.global "public" @my_buf : memref<16xi32> loc(#[[BUFLOC:loc[0-9]*]])
+// CHECK-DAG: #[[ULOC]] = loc("user_design.py":42:4)
+// CHECK-DAG: #[[BUFLOC]] = loc("user_design.py":50:4)

--- a/test/objectFifo-stateful-transform/base/loc_preservation.mlir
+++ b/test/objectFifo-stateful-transform/base/loc_preservation.mlir
@@ -1,0 +1,36 @@
+//===- loc_preservation.mlir ------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that --aie-objectFifo-stateful-transform forwards the source
+// objectfifo.create op's Location onto the synthesized buffer / lock ops.
+// See docs/SourceLocations.md for the broader plan.
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform --mlir-print-debuginfo %s | FileCheck %s
+
+#user_loc = loc("user_design.py":42:4)
+
+module @loc_test {
+ aie.device(xcve2302) {
+    %tile12 = aie.tile(1, 2) loc(unknown)
+    %tile13 = aie.tile(1, 3) loc(unknown)
+    aie.objectfifo @of0 (%tile12, {%tile13}, 4 : i32) : !aie.objectfifo<memref<16xi32>> loc(#user_loc)
+ }
+}
+
+// MLIR pretty-prints with location aliases (loc(#locN)) at the end of the
+// module. Capture the alias used on the source objectfifo, then assert that
+// the synthesized buffers / locks reference the same alias and that the
+// alias resolves to user_design.py:42:4 (and is *not* loc(unknown)).
+
+// CHECK: aie.buffer({{.*}}) {sym_name = "of0_buff_0"} : memref<16xi32>{{ +}}loc(#[[USERLOC:loc[0-9]*]])
+// CHECK: aie.buffer({{.*}}) {sym_name = "of0_buff_1"} : memref<16xi32>{{ +}}loc(#[[USERLOC]])
+// CHECK: aie.lock({{.*}}) {init = 4 : i32, sym_name = "of0_prod_lock_0"} loc(#[[USERLOC]])
+// CHECK: aie.lock({{.*}}) {init = 0 : i32, sym_name = "of0_cons_lock_0"} loc(#[[USERLOC]])
+// CHECK: #[[USERLOC]] = loc("user_design.py":42:4)

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -375,6 +375,14 @@ static cl::opt<bool> dumpIntermediates(
     cl::desc("Dump intermediate MLIR files for debugging (default: off)"),
     cl::init(false), cl::cat(aieCompilerOptions));
 
+static cl::opt<bool> keepLoc(
+    "keep-loc",
+    cl::desc("Emit a <bin>.locmap.json sidecar next to each NPU instruction "
+             "binary, mapping each transaction word back to its IRON Python "
+             "source location. Also keeps debug-info on intermediate MLIR "
+             "dumps. Off by default."),
+    cl::init(false), cl::cat(aieCompilerOptions));
+
 static cl::opt<unsigned> numThreads(
     "j", cl::Prefix,
     cl::desc("Number of parallel threads for core compilation (0 = auto-detect "
@@ -3826,8 +3834,10 @@ static LogicalResult generateNpuInstructions(ModuleOp moduleOp,
       // Generate NPU instructions using direct C++ API call.
       // This replaces the subprocess call to aie-translate --aie-npu-to-binary.
       std::vector<uint32_t> instructions;
+      std::vector<xilinx::AIE::TxnLocEntry> locmap;
       if (failed(xilinx::AIE::AIETranslateNpuToBinary(
-              *clonedModule, instructions, devName, seqName))) {
+              *clonedModule, instructions, devName, seqName,
+              keepLoc ? &locmap : nullptr))) {
         llvm::errs() << "Error generating NPU instructions for sequence: "
                      << seqName << "\n";
         result = failure();
@@ -3850,6 +3860,27 @@ static LogicalResult generateNpuInstructions(ModuleOp moduleOp,
       if (verbose) {
         llvm::outs() << "Wrote " << instructions.size()
                      << " instructions to: " << outputPath << "\n";
+      }
+
+      // Emit the JSON sidecar when --keep-loc is on. Sidecar path is the
+      // .bin path with ".locmap.json" appended, so the .bin itself is
+      // unchanged for downstream XRT consumers.
+      if (keepLoc) {
+        SmallString<128> locmapPath(outputPath);
+        locmapPath.append(".locmap.json");
+        std::error_code locEc;
+        raw_fd_ostream locFile(locmapPath, locEc, sys::fs::OpenFlags::OF_Text);
+        if (locEc) {
+          llvm::errs() << "Error opening locmap sidecar: " << locEc.message()
+                       << "\n";
+          result = failure();
+          return;
+        }
+        StringRef binBaseName = sys::path::filename(outputPath);
+        xilinx::AIE::emitNpuLocmapJSON(locFile, devName, binBaseName, locmap);
+        if (verbose)
+          llvm::outs() << "Wrote " << locmap.size()
+                       << " locmap entries to: " << locmapPath << "\n";
       }
     });
   }
@@ -3984,8 +4015,10 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   }
 
   std::vector<uint32_t> ctrlPktInstructions;
+  std::vector<xilinx::AIE::TxnLocEntry> ctrlPktLocmap;
   if (failed(xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
-          *clonedModule, ctrlPktInstructions, devName, ""))) {
+          *clonedModule, ctrlPktInstructions, devName, "",
+          keepLoc ? &ctrlPktLocmap : nullptr))) {
     llvm::errs() << "Error generating control packet binary for device: "
                  << devName << "\n";
     return failure();
@@ -4008,6 +4041,24 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
     llvm::outs() << "Wrote " << ctrlPktInstructions.size()
                  << " control packet instructions to: " << ctrlPktBinPath
                  << "\n";
+  }
+
+  if (keepLoc) {
+    SmallString<128> locmapPath(ctrlPktBinPath);
+    locmapPath.append(".locmap.json");
+    std::error_code locEc;
+    raw_fd_ostream locFile(locmapPath, locEc, sys::fs::OpenFlags::OF_Text);
+    if (locEc) {
+      llvm::errs() << "Error opening locmap sidecar: " << locEc.message()
+                   << "\n";
+      return failure();
+    }
+    StringRef binBaseName = sys::path::filename(ctrlPktBinPath);
+    xilinx::AIE::emitNpuLocmapJSON(locFile, devName, binBaseName,
+                                   ctrlPktLocmap);
+    if (verbose)
+      llvm::outs() << "Wrote " << ctrlPktLocmap.size()
+                   << " locmap entries to: " << locmapPath << "\n";
   }
 
   // Step 2: Run control packet DMA lowering pipeline in-memory.
@@ -4045,9 +4096,10 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   }
 
   std::vector<uint32_t> dmaSeqInstructions;
-  if (failed(xilinx::AIE::AIETranslateNpuToBinary(*clonedModule,
-                                                  dmaSeqInstructions, devName,
-                                                  "" /* all sequences */))) {
+  std::vector<xilinx::AIE::TxnLocEntry> dmaSeqLocmap;
+  if (failed(xilinx::AIE::AIETranslateNpuToBinary(
+          *clonedModule, dmaSeqInstructions, devName, "" /* all sequences */,
+          keepLoc ? &dmaSeqLocmap : nullptr))) {
     llvm::errs() << "Error generating control packet DMA sequence for device: "
                  << devName << "\n";
     return failure();
@@ -4069,6 +4121,25 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   if (verbose) {
     llvm::outs() << "Wrote " << dmaSeqInstructions.size()
                  << " DMA sequence instructions to: " << dmaSeqBinPath << "\n";
+  }
+
+  if (keepLoc) {
+    SmallString<128> locmapPath(dmaSeqBinPath);
+    locmapPath.append(".locmap.json");
+    std::error_code locEc;
+    raw_fd_ostream locFile(locmapPath, locEc, sys::fs::OpenFlags::OF_Text);
+    if (!locEc) {
+      StringRef binBaseName = sys::path::filename(dmaSeqBinPath);
+      xilinx::AIE::emitNpuLocmapJSON(locFile, devName, binBaseName,
+                                     dmaSeqLocmap);
+      if (verbose)
+        llvm::outs() << "Wrote " << dmaSeqLocmap.size()
+                     << " locmap entries to: " << locmapPath << "\n";
+    } else {
+      llvm::errs() << "Error opening locmap sidecar: " << locEc.message()
+                   << "\n";
+      return failure();
+    }
   }
 
   // Step 3: Generate combined ELF using aiebu-asm (if available)

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -378,9 +378,10 @@ static cl::opt<bool> dumpIntermediates(
 static cl::opt<bool> keepLoc(
     "keep-loc",
     cl::desc("Emit a <bin>.locmap.json sidecar next to each NPU instruction "
-             "binary, mapping each transaction word back to its IRON Python "
-             "source location. Also keeps debug-info on intermediate MLIR "
-             "dumps. Off by default."),
+             "binary, mapping each transaction word back to the MLIR Location "
+             "of the op that produced it (and its regdb register name where "
+             "applicable). Also keeps debug-info on intermediate MLIR dumps. "
+             "Off by default."),
     cl::init(false), cl::cat(aieCompilerOptions));
 
 static cl::opt<unsigned> numThreads(

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllExtensions.h"
 #include "mlir/InitAllPasses.h"
@@ -535,6 +536,12 @@ static std::vector<std::string> getHostSourceFiles() {
   return hostFiles;
 }
 
+static void printModuleWithDebugInfo(ModuleOp moduleOp, raw_ostream &os) {
+  OpPrintingFlags flags;
+  flags.enableDebugInfo(/*enable=*/true);
+  moduleOp->print(os, flags);
+}
+
 /// Dump an MLIR module to a file if --dump-intermediates is enabled.
 /// Returns true on success, false on failure.
 static bool dumpModuleToFile(ModuleOp moduleOp, StringRef filePath,
@@ -549,7 +556,7 @@ static bool dumpModuleToFile(ModuleOp moduleOp, StringRef filePath,
                  << filePath << ": " << ec.message() << "\n";
     return false;
   }
-  moduleOp->print(file);
+  printModuleWithDebugInfo(moduleOp, file);
   file.close();
 
   if (verbose) {
@@ -5262,7 +5269,11 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
                    << "\n";
       return failure();
     }
-    moduleOp->print(file);
+    if (dumpIntermediates) {
+      printModuleWithDebugInfo(moduleOp, file);
+    } else {
+      moduleOp->print(file);
+    }
 
     if (verbose) {
       llvm::outs() << "Wrote module with addresses to: " << withAddressesPath


### PR DESCRIPTION
Replace builder.getUnknownLoc() with the source op's location at op- creation sites across the AIE and AIEX transform passes, so that ops synthesized during lowering inherit a useful Location instead of "unknown". This is purely mechanical: every replacement uses the loc of the op being lowered (or a contextually-appropriate parent op such as the surrounding tile, device, or originating flow).

Passes updated:
  AIEObjectFifoStatefulTransform   AIECreateBroadcastPacket
  AIECoreToStandard                AIECreateCores
  AIECreatePathFindFlows           AIECreateLocks
  AIEObjectFifoRegisterProcess     AIECtrlPacketToDma
  AIEGenerateColumnControlOverlay  AIEExpandLoadPdi
  AIECanonicalizeDevice            AIEHerdRouting
  AIELocalizeLocks                 AIELowerMemcpy
  AIELowerCascadeFlows             AIELowerMulticast
  AIEDialect (TileOp helper)       AIEToConfiguration

The few remaining getUnknownLoc() sites (declareAIEIntrinsics, DynamicTileAnalysis helpers, parsed-binary ModuleOp creation) have no source op to attribute and are left alone intentionally.

Adds one focused loc_preservation.mlir lit test per converted pass to guard against regression:
  test/Conversion/AIEToConfiguration/loc_preservation.mlir
  test/create-cores/loc_preservation.mlir
  test/create-flows/loc_preservation.mlir
  test/herd-routing/loc_preservation.mlir
  test/lower-to-standard/loc_preservation.mlir
  test/objectFifo-stateful-transform/base/loc_preservation.mlir