### PR TITLE
Pre-commit Dependency Hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      pre-commit-minor-patch:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -138,10 +138,10 @@ jobs:
       - name: Check Liquid Syntax
         run: python3 utils/check_liquid_syntax.py
 
-      - name: Install black
+      - name: Install pre-commit
         run: |
           pip install --upgrade pip
-          pip install black[jupyter]
+          pip install -r python/requirements_dev.txt
 
       - name: Run git-clang-format
         id: git-clang-format
@@ -170,7 +170,7 @@ jobs:
         if: success() || failure()
         id: black-format
         run: |
-          black . || true
+          pre-commit run black --hook-stage pre-push --all-files --color never || true
           git diff > black-format.diff
           cat black-format.diff
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
 - repo: https://github.com/kynan/nbstripout
-  rev: 0.8.0
+  rev: f42caeaf94f73a5ae54641b40a7d664cb4e03e40  # frozen: 0.8.0
   hooks:
     - id: nbstripout
       args: [--drop-empty-cells]
 
 # Formatting hooks (run on pre-push to catch issues before CI)
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v17.0.6
+  rev: 05241dc3def184dba136e62d54ff57f1c8a497a9  # frozen: v17.0.6
   hooks:
     - id: clang-format
       types_or: [c, c++]
       stages: [pre-push]
 
 - repo: https://github.com/psf/black
-  rev: 24.10.0
+  rev: 1b2427a2b785cc4aac97c19bb4b9a0de063f9547  # frozen: 24.10.0
   hooks:
     - id: black
       stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+minimum_pre_commit_version: '4.6.0'
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
 - repo: https://github.com/kynan/nbstripout
   rev: f42caeaf94f73a5ae54641b40a7d664cb4e03e40  # frozen: 0.8.0
@@ -22,6 +25,42 @@ repos:
       exclude: |
         (?x)^(
           third_party/.*|
-          build/.*|
+          (_)?build.*/.*|
+          (my_)?install.*/.*|
+          sandbox.*/.*|
+          llvm.*/.*|
+          cmakeModules.*/.*|
           ironenv/.*
         )$
+
+# Baseline hygiene: validators run on every commit, fixers gated to pre-push
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
+  hooks:
+    - id: check-yaml
+      exclude: &generated_exclude |
+        (?x)^(
+          third_party/.*|
+          (_)?build.*/.*|
+          (my_)?install.*/.*|
+          sandbox.*/.*|
+          llvm.*/.*|
+          cmakeModules.*/.*|
+          ironenv/.*
+        )$
+    - id: check-toml
+    - id: check-json
+    - id: check-merge-conflict
+    - id: check-case-conflict
+    - id: check-added-large-files
+      args: [--maxkb=1024]
+    - id: end-of-file-fixer
+      stages: [pre-push]
+      exclude: *generated_exclude
+    - id: trailing-whitespace
+      stages: [pre-push]
+      exclude: *generated_exclude
+    - id: mixed-line-ending
+      stages: [pre-push]
+      args: [--fix=lf]
+      exclude: *generated_exclude

--- a/README.md
+++ b/README.md
@@ -182,12 +182,9 @@ xrt-smi examine
    # Install Python requirements for development and testing
    python3 -m pip install -r python/requirements_dev.txt
 
-   # This installs the pre-commit hooks defined in .pre-commit-config.yaml
+   # Install the pre-commit and pre-push hooks defined in .pre-commit-config.yaml
+   # (pre-push runs clang-format/black to catch formatting issues before CI)
    pre-commit install
-
-   # Install pre-push hooks for formatting (clang-format, black)
-   # These run before push to catch formatting issues before CI
-   pre-commit install --hook-type pre-push
    ```
 
 1. Setup environment

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -133,7 +133,8 @@ xrt-smi examine
    # Install Python requirements for development and testing
    python3 -m pip install -r python/requirements_dev.txt
 
-   # This installs the pre-commit hooks defined in .pre-commit-config.yaml
+   # Install the pre-commit and pre-push hooks defined in .pre-commit-config.yaml
+   # (pre-push runs clang-format/black to catch formatting issues before CI)
    pre-commit install
    ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,7 +150,8 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
    # Install Python requirements for development and testing
    python3 -m pip install -r python/requirements_dev.txt
 
-   # This installs the pre-commit hooks defined in .pre-commit-config.yaml
+   # Install the pre-commit and pre-push hooks defined in .pre-commit-config.yaml
+   # (pre-push runs clang-format/black to catch formatting issues before CI)
    pre-commit install
    ```
 

--- a/python/requirements_dev.txt
+++ b/python/requirements_dev.txt
@@ -4,7 +4,7 @@ setuptools>=82.0.1
 wheel
 ninja!=1.13.0
 cibuildwheel
-pre-commit
+pre-commit>=4.6.0,<5.0
 nanobind>=2.12.0
 lit
 matplotlib


### PR DESCRIPTION
  Closes #2293.                                                                                                                                                                                                      
                                                                                                                                                                                                                     
Builds on the pre-push hooks from #2997 to make `.pre-commit-config.yaml` the single source of truth for every formatter version.                                                                                                                                                            
- SHA-pin all hook `rev:` values (with `# frozen: <tag>` comments) so upstream tag-retargets can't reach us. Add `pre-commit/pre-commit-hooks` v6.0.0 for baseline hygiene (yaml/toml/json/merge-conflict/case-conflict validators on commit; eof-fixer, trailing-whitespace, mixed-line-ending on pre-push).                                                                                                                                                                                                    
- Pin `pre-commit>=4.6.0,<5.0` in `requirements_dev.txt`; add the `pre-commit` ecosystem to `.github/dependabot.yml` so hook revs and framework pin both get reviewable weekly bumps.                                                                                                                                                                   - `lintAndFormat.yml`: replace unpinned `pip install black[jupyter]` + `black .` with `pre-commit run black --hook-stage pre-push --all-files`, so CI and local devs run identical versions. `git-clang-format` flow unchanged.                                                                                                                                                                                                       
- `default_install_hook_types: [pre-commit, pre-push]` lets a single `pre-commit install` wire up both stages — consolidates the README/Building.md/docs/README.md instructions.