### PR TITLE
NPU2 support for tiling_exploration per_tile and tile_group examples

### DIFF
--- a/programming_examples/basic/tiling_exploration/per_tile/Makefile
+++ b/programming_examples/basic/tiling_exploration/per_tile/Makefile
@@ -12,6 +12,7 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../../makefile-common
 
+devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 tensor_height = 8
 tensor_width = 8
 tile_height = 2
@@ -25,7 +26,7 @@ all: build/final_${data_str}.xclbin
 
 build/aie_${data_str}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
-	python3 $< --tensor-height ${tensor_height} --tensor-width ${tensor_width} --tile-height ${tile_height} --tile-width ${tile_width} > $@
+	python3 $< --tensor-height ${tensor_height} --tensor-width ${tensor_width} --tile-height ${tile_height} --tile-width ${tile_width} --device ${devicename} > $@
 
 build/final_${data_str}.xclbin: build/aie_${data_str}.mlir
 	mkdir -p ${@D}

--- a/programming_examples/basic/tiling_exploration/per_tile/per_tile.py
+++ b/programming_examples/basic/tiling_exploration/per_tile/per_tile.py
@@ -9,13 +9,18 @@ import argparse
 import numpy as np
 
 from aie.iron import Buffer, ObjectFifo, Program, Runtime, Worker
-from aie.iron.device import NPU1Col1
+from aie.iron.device import NPU1Col1, NPU2
 from aie.iron.controlflow import range_
 from aie.helpers.taplib import TensorTiler2D
 
 
 def generate_module(
-    tensor_height, tensor_width, tile_height, tile_width, generate_access_map=False
+    tensor_height,
+    tensor_width,
+    tile_height,
+    tile_width,
+    generate_access_map=False,
+    device="npu",
 ):
     tensor_size = tensor_height * tensor_width
     tile_size = tile_height * tile_width
@@ -57,8 +62,15 @@ def generate_module(
         for t in tiler:
             rt.drain(of_out.cons(), tensor_out, t, wait=True)
 
+    if device == "npu":
+        dev = NPU1Col1()
+    elif device == "npu2":
+        dev = NPU2()
+    else:
+        raise ValueError(f"[ERROR] Device name {device} is unknown")
+
     # Create the program from the device type and runtime
-    my_program = Program(NPU1Col1(), rt)
+    my_program = Program(dev, rt)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return my_program.resolve_program()
@@ -71,6 +83,7 @@ def main(opts):
         opts.tile_height,
         opts.tile_width,
         opts.generate_access_map,
+        opts.device,
     )
     if not opts.generate_access_map:
         print(module)
@@ -86,6 +99,13 @@ def get_arg_parser():
         "--generate-access-map",
         action="store_true",
         help="Produce a file showing data access order",
+    )
+    p.add_argument(
+        "-d",
+        "--device",
+        default="npu",
+        choices=["npu", "npu2"],
+        help="Target NPU device",
     )
     return p
 

--- a/programming_examples/basic/tiling_exploration/per_tile/run_strix_makefile.lit
+++ b/programming_examples/basic/tiling_exploration/per_tile/run_strix_makefile.lit
@@ -1,0 +1,11 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_stx
+// RUN: cd test_stx
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run_py devicename=npu2
+// CHECK: Running...

--- a/programming_examples/basic/tiling_exploration/tile_group/Makefile
+++ b/programming_examples/basic/tiling_exploration/tile_group/Makefile
@@ -12,6 +12,7 @@ srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../../makefile-common
 
+devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 tensor_height = 8
 tensor_width = 8
 tile_height = 2
@@ -25,7 +26,7 @@ all: build/final_${data_str}.xclbin
 
 build/aie_${data_str}.mlir: ${srcdir}/${aie_py_src}
 	mkdir -p ${@D}
-	python3 $< --tensor-height ${tensor_height} --tensor-width ${tensor_width} --tile-height ${tile_height} --tile-width ${tile_width} > $@
+	python3 $< --tensor-height ${tensor_height} --tensor-width ${tensor_width} --tile-height ${tile_height} --tile-width ${tile_width} --device ${devicename} > $@
 
 build/final_${data_str}.xclbin: build/aie_${data_str}.mlir
 	mkdir -p ${@D}

--- a/programming_examples/basic/tiling_exploration/tile_group/run_strix_makefile.lit
+++ b/programming_examples/basic/tiling_exploration/tile_group/run_strix_makefile.lit
@@ -1,0 +1,11 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_stx
+// RUN: cd test_stx
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run_py devicename=npu2
+// CHECK: Running...

--- a/programming_examples/basic/tiling_exploration/tile_group/tile_group.py
+++ b/programming_examples/basic/tiling_exploration/tile_group/tile_group.py
@@ -9,7 +9,7 @@ import argparse
 import numpy as np
 
 from aie.iron import ObjectFifo, Program, Runtime, Worker
-from aie.iron.device import NPU1Col1
+from aie.iron.device import NPU1Col1, NPU2
 from aie.helpers.taplib import TensorTiler2D
 from aie.iron.controlflow import range_
 import aie.extras.dialects.arith as arith
@@ -17,7 +17,12 @@ from aie.helpers.util import np_dtype_to_mlir_type
 
 
 def generate_module(
-    tensor_height, tensor_width, tile_height, tile_width, generate_access_map=False
+    tensor_height,
+    tensor_width,
+    tile_height,
+    tile_width,
+    generate_access_map=False,
+    device="npu",
 ):
     # define types
     dtype = np.int32
@@ -57,7 +62,14 @@ def generate_module(
         rt.start(worker)
         rt.drain(of_out.cons(), tensor_out, t, wait=True)
 
-    my_program = Program(NPU1Col1(), rt)
+    if device == "npu":
+        dev = NPU1Col1()
+    elif device == "npu2":
+        dev = NPU2()
+    else:
+        raise ValueError(f"[ERROR] Device name {device} is unknown")
+
+    my_program = Program(dev, rt)
 
     # Place components (assign them resources on the device) and generate an MLIR module
     return my_program.resolve_program()
@@ -70,6 +82,7 @@ def main(opts):
         opts.tile_height,
         opts.tile_width,
         opts.generate_access_map,
+        opts.device,
     )
     if not opts.generate_access_map:
         print(module)
@@ -85,6 +98,13 @@ def get_arg_parser():
         "--generate-access-map",
         action="store_true",
         help="Produce a file showing data access order",
+    )
+    p.add_argument(
+        "-d",
+        "--device",
+        default="npu",
+        choices=["npu", "npu2"],
+        help="Target NPU device",
     )
     return p
 


### PR DESCRIPTION
Closes #2092. This was the last outstanding work item — all other examples in the checklist already have working NPU2 support in the repo (some checkboxes were simply not ticked). The `introduction/` subdirectory is a taplib-only notebook with no hardware target, so it needs no changes.  