### PR TITLE
[WIP] Share BD size/stride verification between AIE and AIEX dialects (#2566)

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -238,6 +238,18 @@ void collectBuffers(
 // linearized by the compiler.
 bool isContiguousBDTransfer(llvm::ArrayRef<BDDimLayoutAttr> dims);
 
+// Verify that a BD's per-dimension sizes and strides (innermost-first) are
+// realizable for hardware with the given address generation granularity.
+// Checks: positive sizes; innermost contiguous run is a granularity multiple;
+// positive strides for non-repeat dims (last stride may be zero); each
+// non-innermost stride byte-aligned to granularity (innermost stride==1 is
+// always allowed); for elemWidth > granularity, innermost stride must be 1.
+mlir::LogicalResult verifyBDSizesStrides(mlir::Operation *forOp,
+                                         unsigned elemWidthBits,
+                                         uint32_t addressGranularityBits,
+                                         llvm::ArrayRef<int64_t> inputSizes,
+                                         llvm::ArrayRef<int64_t> inputStrides);
+
 } // namespace xilinx::AIE
 
 namespace llvm {

--- a/include/aie/Dialect/AIE/IR/AIEDialect.h
+++ b/include/aie/Dialect/AIE/IR/AIEDialect.h
@@ -238,17 +238,27 @@ void collectBuffers(
 // linearized by the compiler.
 bool isContiguousBDTransfer(llvm::ArrayRef<BDDimLayoutAttr> dims);
 
-// Verify that a BD's per-dimension sizes and strides (innermost-first) are
-// realizable for hardware with the given address generation granularity.
-// Checks: positive sizes; innermost contiguous run is a granularity multiple;
-// positive strides for non-repeat dims (last stride may be zero); each
-// non-innermost stride byte-aligned to granularity (innermost stride==1 is
-// always allowed); for elemWidth > granularity, innermost stride must be 1.
-mlir::LogicalResult verifyBDSizesStrides(mlir::Operation *forOp,
-                                         unsigned elemWidthBits,
-                                         uint32_t addressGranularityBits,
-                                         llvm::ArrayRef<int64_t> inputSizes,
-                                         llvm::ArrayRef<int64_t> inputStrides);
+// Verify that a DMA buffer descriptor's data-layout transform and explicit
+// iteration are realizable on the given tile type. The data-layout dims
+// (`inputSizes`/`inputStrides`, innermost-first, in element-width units) are
+// pure access dims: all sizes positive, all strides positive (no magic stride-0
+// "repeat" -- iteration is a separate input here). Iteration is described by
+// logical `iterSize`/`iterStride` (element-width units, iterSize == 0 means no
+// iteration). The tile type selects the dimension-count limit and the wrap /
+// step / iteration register bit-widths from the target model.
+//
+// Checks: dim count within getDmaBdMaxDims(tileType); positive sizes/strides;
+// innermost contiguous run is a granularity multiple; sub-word innermost runs
+// rejected; each non-innermost stride byte-aligned to granularity (innermost
+// stride==1 always allowed); for elemWidth > granularity innermost stride must
+// be 1; per-dimension wrap/step ranges (skipped when skipTransformationChecks,
+// e.g. a contiguous shim transfer lowered to linear mode); iteration wrap/step
+// ranges and positive iterStride when iterSize > 1.
+mlir::LogicalResult verifyBDDataLayoutAndIteration(
+    mlir::Operation *forOp, const AIETargetModel &targetModel,
+    AIETileType tileType, unsigned elemWidthBits,
+    llvm::ArrayRef<int64_t> inputSizes, llvm::ArrayRef<int64_t> inputStrides,
+    int64_t iterSize, int64_t iterStride, bool skipTransformationChecks);
 
 } // namespace xilinx::AIE
 

--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1023,6 +1023,17 @@ def AIE_DMABDOp: AIE_Op<"dma_bd", []> {
         // state-table index whose value is used as the BD address offset.
         // After lowering, $offset_parameter is removed in favor of this attribute.
         OptionalAttr<UI8Attr>:$offset_state_table_idx,
+        // Explicit buffer-descriptor iteration ("repeat with stride"). These
+        // are logical (1-based) values, denominated -- like the data-layout
+        // strides -- in multiples of the element width. iter_size is the
+        // iteration wrap (number of replays of the BD); iter_size == 0 means no
+        // iteration. iter_stride is the address step added between iterations.
+        // iter_current is the starting iteration index (almost always 0).
+        // Iteration is a separate hardware feature from the $dimensions
+        // data-layout transform; do not encode repeats inside $dimensions.
+        DefaultValuedOptionalAttr<AIEI32Attr, "0">:$iter_size,
+        DefaultValuedOptionalAttr<AIEI32Attr, "0">:$iter_stride,
+        DefaultValuedOptionalAttr<AIEI32Attr, "0">:$iter_current,
         // should never be assigned by user...
         OptionalAttr<AIEI32Attr>:$next_bd_id
   );
@@ -1858,8 +1869,10 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
         // disable_synchronization==true will skip lock generation for
         // objectfifo synchronous accesses
         DefaultValuedAttr<BoolAttr, "false">:$disable_synchronization,
-        // repeat_count==1 means "do it once"
-        OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<1>]>>:$repeat_count,
+        // repeat_count counts EXTRA replays of the BD chain; 0 means "do it
+        // once" (no repeat), matching aie.dma_start / the dma_task ops /
+        // aiex.npu.dma_memcpy_nd. So N replays the chain N+1 times total.
+        OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>>:$repeat_count,
         // aie_stream==0 means enable aie stream port on producer tile
         // aie_stream==1 means enable aie stream port on consumer tile
         // aie_stream==2 means enable aie stream ports on producer and consumer tiles

--- a/include/aie/Dialect/AIE/IR/AIETargetModel.h
+++ b/include/aie/Dialect/AIE/IR/AIETargetModel.h
@@ -294,6 +294,18 @@ public:
   /// Return the number of buffer descriptors for a given tile type.
   virtual uint32_t getNumBDs(AIETileType tileType) const = 0;
 
+  /// Return the maximum number of data-layout transformation dimensions a DMA
+  /// buffer descriptor supports on the given tile type. Iteration/repeat is a
+  /// separate buffer-descriptor feature and is not counted here.
+  virtual uint32_t getDmaBdMaxDims(AIETileType tileType) const = 0;
+
+  /// Return the bit width of, respectively, the wrap (size), step (stride), and
+  /// iteration-wrap registers in a DMA buffer descriptor for the given tile
+  /// type. A value of N means the field holds an unsigned [0, 2^N - 1].
+  virtual uint32_t getDmaBdWrapBits(AIETileType tileType) const = 0;
+  virtual uint32_t getDmaBdStepBits(AIETileType tileType) const = 0;
+  virtual uint32_t getDmaBdIterBits(AIETileType tileType) const = 0;
+
   /// Get stream switch port index for a given port specification
   /// Return port index for Stream_Switch_Event_Port_Selection register, or
   /// nullopt if invalid
@@ -480,6 +492,10 @@ public:
   uint32_t getNumBDs(AIETileType tileType) const override {
     return 16; // AIE1 has no MemTiles, always 16
   }
+  uint32_t getDmaBdMaxDims(AIETileType tileType) const override { return 3; }
+  uint32_t getDmaBdWrapBits(AIETileType tileType) const override { return 10; }
+  uint32_t getDmaBdStepBits(AIETileType tileType) const override { return 20; }
+  uint32_t getDmaBdIterBits(AIETileType tileType) const override { return 6; }
   bool isBdChannelAccessible(int col, int row, uint32_t bd_id,
                              int channel) const override {
     return true;
@@ -585,6 +601,24 @@ public:
   uint32_t getNumBDs(AIETileType tileType) const override {
     return tileType == AIETileType::MemTile ? 48 : 16;
   }
+
+  uint32_t getDmaBdMaxDims(AIETileType tileType) const override {
+    return tileType == AIETileType::MemTile ? 4 : 3;
+  }
+  uint32_t getDmaBdWrapBits(AIETileType tileType) const override {
+    return tileType == AIETileType::CoreTile ? 8 : 10;
+  }
+  uint32_t getDmaBdStepBits(AIETileType tileType) const override {
+    switch (tileType) {
+    case AIETileType::CoreTile:
+      return 13;
+    case AIETileType::MemTile:
+      return 17;
+    default: // ShimNOC / ShimPL
+      return 20;
+    }
+  }
+  uint32_t getDmaBdIterBits(AIETileType tileType) const override { return 6; }
 
   bool isBdChannelAccessible(int col, int row, uint32_t bd_id,
                              int channel) const override {

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -651,16 +651,24 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
     The hardware only supports a single static offset, and this offset is calculated at compile time.
     Thus, all offsets can be equivalently expressed with the lowest dimension only.
 
+    #### Iteration and Repeat
+
+    `sizes`/`strides` describe up to three pure data-layout dimensions. To replay
+    the whole transfer, use `repeat_count` (a pure repeat, no address increment;
+    `repeat_count == 0` means a single pass) or the explicit `iter_size` /
+    `iter_stride` / `iter_current` attributes (a strided iteration). This matches
+    `aie.dma_bd` and the `dma_task` ops; there is no magic stride-0 dimension.
+
     #### Automatic Linearization of Contiguous Accesses
 
     A canonicalization pattern automatically folds a contiguous row-major access pattern into
-    the canonical linear form `[s3, 1, 1, N][st3, 0, 0, 1]`, where N is the product of the
-    inner three sizes. An access is contiguous when `strides[0] == 1` and each outer stride
+    the canonical linear form `[1, 1, N][0, 0, 1]`, where N is the product of the
+    three sizes. An access is contiguous when `strides[0] == 1` and each outer stride
     equals the product of the inner sizes (i.e. a standard row-major scan).
 
     This means users can express naturally multidimensional accesses such as a 2D image
-    `[1, 1, height, width][0, 0, width, 1]` or a 3D activation tensor
-    `[1, H, W, C][0, W*C, C, 1]` without worrying about hardware dimension size limits.
+    `[1, height, width][0, width, 1]` or a 3D activation tensor
+    `[H, W, C][W*C, C, 1]` without worrying about hardware dimension size limits.
     The compiler will fold them to the linear form, which uses a wider hardware register
     and avoids the 10-bit d0 wrap-size constraint that applies to ND transfers.
 
@@ -673,13 +681,16 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
 
   let arguments = (
     ins AnyRankedOrUnrankedMemRef:$memref,
-        // NOTE: these are in reverse order: offset3, offset2, ...
+        // NOTE: these are in reverse order: offset2, offset1, offset0
+        // These describe up to three pure data-layout dimensions. Iteration and
+        // repeat are expressed separately (see iter_* and repeat_count below),
+        // consistent with aie.dma_bd and the dma_task ops.
         Variadic<I64>:$offsets,
         Variadic<I64>:$sizes,
         Variadic<I64>:$strides,
-        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_offsets,
-        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_sizes,
-        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<4>]>:$static_strides,
+        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<3>]>:$static_offsets,
+        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<3>]>:$static_sizes,
+        ConfinedAttr<DenseI64ArrayAttr, [DenseArrayCount<3>]>:$static_strides,
         OptionalAttr<PacketInfoAttr>:$packet,
         SymbolRefAttr:$metadata,
         I64Attr:$id,
@@ -696,7 +707,18 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
         // Set by --aie-lower-scratchpad-parameters from $offset_parameter: the scratchpad
         // state-table index whose value is used as the BD address offset.
         // After lowering, $offset_parameter is removed in favor of this attribute.
-        OptionalAttr<UI8Attr>:$offset_state_table_idx
+        OptionalAttr<UI8Attr>:$offset_state_table_idx,
+        // Explicit buffer-descriptor iteration ("repeat with stride"), logical
+        // (1-based) values in element-width units, matching aie.dma_bd's iter_*.
+        // iter_size == 0 means no iteration. Mutually exclusive with a non-zero
+        // repeat_count.
+        DefaultValuedOptionalAttr<I64Attr, "0">:$iter_size,
+        DefaultValuedOptionalAttr<I64Attr, "0">:$iter_stride,
+        DefaultValuedOptionalAttr<I64Attr, "0">:$iter_current,
+        // Number of extra times to replay the whole buffer descriptor with no
+        // address increment (a pure repeat). The default 0 means a single pass
+        // (no repeat); this matches the convention on aie.dma_bd / dma_task.
+        DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count
   );
 
   let assemblyFormat = [{
@@ -726,7 +748,7 @@ def AIE_NpuDmaMemcpyNdOp: AIEX_Op<"npu.dma_memcpy_nd", [
 
   let extraClassDefinition = [{
     unsigned $cppClass::getOffsetSizeAndStrideStartOperandIndex() { return 1; }
-    std::array<unsigned, 3> $cppClass::getArrayAttrMaxRanks() { return {4, 4, 4}; }
+    std::array<unsigned, 3> $cppClass::getArrayAttrMaxRanks() { return {3, 3, 3}; }
     uint64_t $cppClass::getElementTypeBitwidth() {
       DataLayout dataLayout = DataLayout::closest(*this);
       return dataLayout.getTypeSizeInBits(getMemref().getType().getElementType());

--- a/include/aie/Dialect/AIEX/IR/AIEXDialect.h
+++ b/include/aie/Dialect/AIEX/IR/AIEXDialect.h
@@ -41,14 +41,6 @@ void getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
                              llvm::SmallVector<int64_t, 4> inputStrides,
                              llvm::SmallVector<int64_t, 4> &sizes,
                              llvm::SmallVector<int64_t, 4> &strides);
-mlir::LogicalResult
-verifyStridesWraps(mlir::Operation *forOp,
-                   mlir::BaseMemRefType referencedBufType, int tileCol,
-                   int tileRow, llvm::SmallVector<int64_t, 4> inputSizes,
-                   llvm::SmallVector<int64_t, 4> inputStrides,
-                   llvm::SmallVector<int64_t, 4> hardwareSizes,
-                   llvm::SmallVector<int64_t, 4> hardwareStrides,
-                   bool skipTransformationChecks = false);
 bool isLinearTransfer(llvm::ArrayRef<int64_t> sizes,
                       llvm::ArrayRef<int64_t> strides);
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2215,73 +2215,132 @@ void DMABDOp::print(::mlir::OpAsmPrinter &printer) {
   printer.printOptionalAttrDict((*this)->getAttrs(), elidedAttrs);
 }
 
-// A BDDimLayoutAttr array (outermost-first) describes a contiguous row-major
-// scan when the innermost stride is 1 and each outer stride equals the product
-// of all inner sizes.  Used by both DMABDOp verification and canonicalization.
-mlir::LogicalResult xilinx::AIE::verifyBDSizesStrides(
-    mlir::Operation *forOp, unsigned elemWidthBits,
-    uint32_t addressGranularityBits, llvm::ArrayRef<int64_t> inputSizes,
-    llvm::ArrayRef<int64_t> inputStrides) {
+// Shared verifier for a DMA buffer descriptor's data-layout transform and its
+// explicit iteration. Used by DMABDOp::verify and by the AIEX runtime-sequence
+// lowerings (dma_memcpy_nd, dma_task). See the header comment for the contract.
+//
+// `inputSizes`/`inputStrides` are the pure data-layout dims, innermost-first, in
+// element-width units; all strides are positive (iteration is NOT folded in as a
+// magic stride-0 outer dim). `iterSize`/`iterStride` describe iteration in
+// logical, element-width units (iterSize == 0 means no iteration).
+mlir::LogicalResult xilinx::AIE::verifyBDDataLayoutAndIteration(
+    mlir::Operation *forOp, const AIETargetModel &targetModel,
+    AIETileType tileType, unsigned elemWidthBits,
+    llvm::ArrayRef<int64_t> inputSizes, llvm::ArrayRef<int64_t> inputStrides,
+    int64_t iterSize, int64_t iterStride, bool skipTransformationChecks) {
   assert(inputSizes.size() == inputStrides.size());
   const int n = static_cast<int>(inputSizes.size());
+  const uint32_t granularity = targetModel.getAddressGenGranularity();
+  const uint32_t maxDims = targetModel.getDmaBdMaxDims(tileType);
+  const uint32_t wrapBits = targetModel.getDmaBdWrapBits(tileType);
+  const uint32_t stepBits = targetModel.getDmaBdStepBits(tileType);
+  const uint32_t iterBits = targetModel.getDmaBdIterBits(tileType);
+
+  if (static_cast<uint32_t>(n) > maxDims)
+    return forOp->emitOpError("Cannot give more than ")
+           << maxDims << " dimensions for step sizes and wraps in this tile "
+           << "(got " << n << ").";
+
   if (n == 0)
     return success();
 
   for (int i = 0; i < n; ++i) {
     if (inputSizes[i] <= 0)
       return forOp->emitOpError("Size ") << i << " must be a positive integer.";
+    // A size-1 dimension's stride is never applied (the loop runs once), so any
+    // stride value is allowed for it. For any larger size the stride must be a
+    // positive integer (iteration/repeat is expressed separately, not as a
+    // stride-0 outer dim).
+    if (inputSizes[i] > 1 && inputStrides[i] < 1)
+      return forOp->emitOpError("Stride ")
+             << i << " must be a positive integer.";
   }
 
   // Innermost contiguous run must be a multiple of address granularity --
   // hardware moves whole words; a sub-word innermost run is unrealizable.
-  if (inputSizes[0] * elemWidthBits % addressGranularityBits != 0) {
+  if (inputSizes[0] * elemWidthBits % granularity != 0) {
     std::stringstream msg;
-    msg << "Transfer sizes must be multiples of "
-        << (addressGranularityBits / 8) << " bytes. " << inputSizes[0]
-        << " elements at " << (elemWidthBits / 8) << " bytes each equal "
-        << (inputSizes[0] * elemWidthBits / 8)
-        << " bytes, which is not divisible by " << (addressGranularityBits / 8)
-        << ". ";
+    msg << "Transfer sizes must be multiples of " << (granularity / 8)
+        << " bytes. " << inputSizes[0] << " elements at " << (elemWidthBits / 8)
+        << " bytes each equal " << (inputSizes[0] * elemWidthBits / 8)
+        << " bytes, which is not divisible by " << (granularity / 8) << ". ";
     return forOp->emitOpError(msg.str());
-  }
-
-  // Non-repeat dim strides must be positive when the corresponding size > 1
-  // (the repeat dim, if present as the outermost, may have stride 0).
-  const int repeatDim = n - 1;
-  for (int i = 0; i < n; ++i) {
-    if (inputSizes[i] > 1 && inputStrides[i] < 1) {
-      if (i == repeatDim && inputStrides[i] == 0)
-        continue;
-      return forOp->emitOpError("Stride ")
-             << i << " must be a positive integer.";
-    }
   }
 
   // Stride byte-alignment: innermost stride==1 is always allowed (sub-word
   // packed contiguous run, paired with the granularity check above); any other
   // stride must be a granularity multiple in bytes.
+  auto checkStrideAlignment = [&](int i, int64_t stride,
+                                  const char *what) -> mlir::LogicalResult {
+    if (stride * elemWidthBits % granularity != 0) {
+      std::stringstream msg;
+      msg << what << " " << i << " is " << stride << " elements * "
+          << (elemWidthBits / 8) << " bytes = " << (stride * elemWidthBits / 8)
+          << " bytes, which is not divisible by " << (granularity / 8) << ". ";
+      return forOp->emitOpError(msg.str());
+    }
+    return success();
+  };
   for (int i = 0; i < n; ++i) {
     if (i == 0 && inputStrides[i] == 1)
       continue;
-    if (inputStrides[i] * elemWidthBits % addressGranularityBits != 0) {
-      std::stringstream msg;
-      msg << "Stride " << i << " is " << inputStrides[i] << " elements * "
-          << (elemWidthBits / 8)
-          << " bytes = " << (inputStrides[i] * elemWidthBits / 8)
-          << " bytes, which is not divisible by "
-          << (addressGranularityBits / 8) << ". ";
-      return forOp->emitOpError(msg.str());
-    }
+    if (inputSizes[i] == 1)
+      continue; // stride never applied
+    if (failed(checkStrideAlignment(i, inputStrides[i], "Stride")))
+      return failure();
   }
 
-  // For element widths larger than the granularity (e.g. bfp blocks, i64),
-  // the hardware cannot encode a non-1 innermost stride; getHardwareStrides-
-  // Wraps would silently drop the stride. Force innermost stride == 1.
-  if (elemWidthBits > addressGranularityBits && inputStrides[0] != 1)
+  // For element widths larger than the granularity (e.g. bfp blocks, i64), the
+  // hardware cannot encode a non-1 innermost stride; getHardwareStridesWraps
+  // would silently drop it. Express such accesses with an extra dimension.
+  if (elemWidthBits > granularity && inputStrides[0] != 1)
     return forOp->emitOpError(
                "For element widths larger than the address granularity (")
-           << (addressGranularityBits / 8)
-           << " bytes), innermost dim stride must be 1.";
+           << (granularity / 8)
+           << " bytes), innermost dim stride must be 1; express a strided "
+              "access as an additional dimension instead.";
+
+  // Hardware register-width range checks. The innermost wrap counts whole
+  // granularity words; outer wraps count elements. Strides are encoded as
+  // (stride_in_words - 1), so the field holds up to 2^stepBits.
+  if (!skipTransformationChecks) {
+    int64_t innerWrapWords = inputSizes[0] * elemWidthBits / granularity;
+    if (innerWrapWords > (1L << wrapBits) - 1)
+      return forOp->emitOpError("Size 0 exceeds the [0:")
+             << ((1L << wrapBits) - 1) << "] range.";
+    for (int i = 1; i < n; ++i)
+      if (inputSizes[i] > (1L << wrapBits) - 1)
+        return forOp->emitOpError("Size ")
+               << i << " exceeds the [0:" << ((1L << wrapBits) - 1)
+               << "] range.";
+  }
+  for (int i = 0; i < n; ++i) {
+    if (i == 0 && inputStrides[i] == 1)
+      continue;
+    if (inputSizes[i] == 1)
+      continue; // stride never applied
+    int64_t strideWords = inputStrides[i] * elemWidthBits / granularity;
+    if (strideWords > (1L << stepBits))
+      return forOp->emitOpError("Stride ")
+             << i << " exceeds the [1:" << (1L << stepBits) << "] range.";
+  }
+
+  // Iteration (logical). iterSize == 0/1 means a single pass (no replay).
+  if (iterSize > 1) {
+    if (iterStride <= 0)
+      return forOp->emitOpError(
+          "Iteration stride must be a positive integer when iteration size > "
+          "1.");
+    if (failed(checkStrideAlignment(0, iterStride, "Iteration stride")))
+      return failure();
+    if (iterSize - 1 > (1L << iterBits))
+      return forOp->emitOpError("Iteration size exceeds the [1:")
+             << (1L << iterBits) << "] range.";
+    int64_t iterStrideWords = iterStride * elemWidthBits / granularity;
+    if (iterStrideWords > (1L << stepBits))
+      return forOp->emitOpError("Iteration stride exceeds the [1:")
+             << (1L << stepBits) << "] range.";
+  }
 
   return success();
 }
@@ -2348,16 +2407,6 @@ LogicalResult DMABDOp::verify() {
       nextBdId.has_value() && static_cast<uint32_t>(*nextBdId) >= maxBds)
     return emitOpError("nextBdId attribute exceeds max: ") << maxBds - 1;
   if (auto dims = getDimensions(); dims.has_value()) {
-    size_t maxNDims = 3;
-    if (getOperation()->getParentOfType<MemTileDMAOp>())
-      maxNDims = 4;
-    if (dims->size() > maxNDims)
-      return emitOpError() << "Cannot give more than "
-                           << std::to_string(maxNDims)
-                           << " dimensions for step sizes and wraps in this "
-                              " tile (got "
-                           << std::to_string(dims->size()) << " dimensions).";
-
     auto buffer = llvm::dyn_cast<MemRefType>(getBuffer().getType());
     if (!buffer)
       return emitOpError() << "dimensions attribute cannot be used with "
@@ -2369,36 +2418,27 @@ LogicalResult DMABDOp::verify() {
                            << std::to_string(maxIdx) << " in memref of length "
                            << std::to_string(buffer.getNumElements()) << ".";
 
-    // A contiguous row-major access on a shim tile is lowered to linear mode
-    // by aie-dma-tasks-to-npu / aie-dma-to-npu, using the wide buffer_length
-    // register which is exempt from the 10-bit ND wrap-size limit.
-    // Skip the per-dimension size check when the BD is on a shim tile and the
-    // access is contiguous, so the natural ND form can be written without
-    // triggering a spurious verifier error before lowering.
-    //
-    // Note: the verifier early-exit above means we only reach this code when
-    // the parent op is MemOp, MemTileDMAOp, ShimDMAOp, or DMAOp -- all of
-    // which are TileElements, so parentTile is always non-null here.
-    bool skipSizeCheck =
-        parentTile.isShimTile() && xilinx::AIE::isContiguousBDTransfer(*dims);
-
-    for (BDDimLayoutAttr dim : *dims) {
-      if (0 == dim.getStride())
-        return emitOpError()
-               << "Invalid step size; must be a positive integer.";
+    for (BDDimLayoutAttr dim : *dims)
       if (dim.getStride() > buffer.getNumElements())
         return emitOpError() << "Step size " << std::to_string(dim.getStride())
                              << " exceeds memref size "
                              << std::to_string(buffer.getNumElements());
-      if (!skipSizeCheck && dim.getSize() >= (1UL << 9) + 1)
-        return emitOpError() << "Size may not exceed 1023.";
-      if (dim.getStride() >= (1UL << 19))
-        return emitOpError() << "Stride may not exceed " << (1 << 20);
-    }
 
-    // Granularity / sub-word / stride alignment checks, shared with
-    // AIEX::verifyStridesWraps. dims are stored outermost-first; the helper
-    // expects innermost-first.
+    // A contiguous row-major access on a shim tile is lowered to linear mode
+    // by aie-dma-tasks-to-npu / aie-dma-to-npu, using the wide buffer_length
+    // register which is exempt from the per-dimension wrap-size limit. Skip the
+    // per-dimension range check when the BD is on a shim tile and the access is
+    // contiguous, so the natural ND form can be written without triggering a
+    // spurious verifier error before lowering.
+    //
+    // Note: the verifier early-exit above means we only reach this code when
+    // the parent op is MemOp, MemTileDMAOp, ShimDMAOp, or DMAOp -- all of
+    // which are TileElements, so parentTile is always non-null here.
+    bool skipTransformationChecks =
+        parentTile.isShimTile() && xilinx::AIE::isContiguousBDTransfer(*dims);
+
+    // dims are stored outermost-first; the shared verifier expects
+    // innermost-first.
     SmallVector<int64_t, 4> inputSizes, inputStrides;
     for (auto it = dims->rbegin(); it != dims->rend(); ++it) {
       inputSizes.push_back(static_cast<int64_t>(it->getSize()));
@@ -2407,10 +2447,16 @@ LogicalResult DMABDOp::verify() {
     DataLayout dataLayout = DataLayout::closest(getOperation());
     unsigned elemWidthBits =
         dataLayout.getTypeSizeInBits(buffer.getElementType());
-    if (failed(xilinx::AIE::verifyBDSizesStrides(
-            getOperation(), elemWidthBits,
-            targetModel.getAddressGenGranularity(), inputSizes, inputStrides)))
+    if (failed(xilinx::AIE::verifyBDDataLayoutAndIteration(
+            getOperation(), targetModel, parentTile.getTileType(), elemWidthBits,
+            inputSizes, inputStrides, getIterSize(), getIterStride(),
+            skipTransformationChecks)))
       return failure();
+  } else if (getIterSize() > 1 && !getLen()) {
+    // Iteration with neither data-layout dims nor a length describes nothing to
+    // replay. (A linearized BD legitimately has a length but no dims.)
+    return emitOpError() << "Iteration requires a transfer length or n-d data "
+                            "layouts expressed as wrap(s) and stride(s).";
   }
   if (auto paddims = getPadDimensions(); paddims.has_value()) {
     auto dims = getDimensions();
@@ -2579,15 +2625,18 @@ struct LinearizeContiguousBDTransfer : public mlir::OpRewritePattern<DMABDOp> {
     for (BDDimLayoutAttr dim : *dims)
       product *= dim.getSize();
 
-    // len < product: the outermost dim describes a hardware BD iteration
-    // (preserved downstream as iteration_size/stride). Don't fold it away.
+    // Only the data-layout dims participate here; iteration is carried by the
+    // explicit iter_* attributes and is preserved across this fold. (A
+    // mismatch between len and the data-dim product would be a malformed BD;
+    // leave it for the verifier rather than folding.)
     if (auto lenVal = op.getLen())
       if (static_cast<int64_t>(*lenVal) != product)
         return mlir::failure();
     int32_t len = static_cast<int32_t>(product);
 
     // Drop the dimensions attribute in-place; all other attributes (offset,
-    // len, packet, burst_length, bd_id, etc.) are preserved automatically.
+    // len, packet, burst_length, bd_id, iter_*, etc.) are preserved
+    // automatically.
     rewriter.modifyOpInPlace(op, [&]() {
       op.setLen(len);
       op->removeAttr("dimensions");

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -2218,6 +2218,74 @@ void DMABDOp::print(::mlir::OpAsmPrinter &printer) {
 // A BDDimLayoutAttr array (outermost-first) describes a contiguous row-major
 // scan when the innermost stride is 1 and each outer stride equals the product
 // of all inner sizes.  Used by both DMABDOp verification and canonicalization.
+mlir::LogicalResult xilinx::AIE::verifyBDSizesStrides(
+    mlir::Operation *forOp, unsigned elemWidthBits,
+    uint32_t addressGranularityBits, llvm::ArrayRef<int64_t> inputSizes,
+    llvm::ArrayRef<int64_t> inputStrides) {
+  assert(inputSizes.size() == inputStrides.size());
+  const int n = static_cast<int>(inputSizes.size());
+  if (n == 0)
+    return success();
+
+  for (int i = 0; i < n; ++i) {
+    if (inputSizes[i] <= 0)
+      return forOp->emitOpError("Size ") << i << " must be a positive integer.";
+  }
+
+  // Innermost contiguous run must be a multiple of address granularity --
+  // hardware moves whole words; a sub-word innermost run is unrealizable.
+  if (inputSizes[0] * elemWidthBits % addressGranularityBits != 0) {
+    std::stringstream msg;
+    msg << "Transfer sizes must be multiples of "
+        << (addressGranularityBits / 8) << " bytes. " << inputSizes[0]
+        << " elements at " << (elemWidthBits / 8) << " bytes each equal "
+        << (inputSizes[0] * elemWidthBits / 8)
+        << " bytes, which is not divisible by " << (addressGranularityBits / 8)
+        << ". ";
+    return forOp->emitOpError(msg.str());
+  }
+
+  // Non-repeat dim strides must be positive when the corresponding size > 1
+  // (the repeat dim, if present as the outermost, may have stride 0).
+  const int repeatDim = n - 1;
+  for (int i = 0; i < n; ++i) {
+    if (inputSizes[i] > 1 && inputStrides[i] < 1) {
+      if (i == repeatDim && inputStrides[i] == 0)
+        continue;
+      return forOp->emitOpError("Stride ")
+             << i << " must be a positive integer.";
+    }
+  }
+
+  // Stride byte-alignment: innermost stride==1 is always allowed (sub-word
+  // packed contiguous run, paired with the granularity check above); any other
+  // stride must be a granularity multiple in bytes.
+  for (int i = 0; i < n; ++i) {
+    if (i == 0 && inputStrides[i] == 1)
+      continue;
+    if (inputStrides[i] * elemWidthBits % addressGranularityBits != 0) {
+      std::stringstream msg;
+      msg << "Stride " << i << " is " << inputStrides[i] << " elements * "
+          << (elemWidthBits / 8)
+          << " bytes = " << (inputStrides[i] * elemWidthBits / 8)
+          << " bytes, which is not divisible by "
+          << (addressGranularityBits / 8) << ". ";
+      return forOp->emitOpError(msg.str());
+    }
+  }
+
+  // For element widths larger than the granularity (e.g. bfp blocks, i64),
+  // the hardware cannot encode a non-1 innermost stride; getHardwareStrides-
+  // Wraps would silently drop the stride. Force innermost stride == 1.
+  if (elemWidthBits > addressGranularityBits && inputStrides[0] != 1)
+    return forOp->emitOpError(
+               "For element widths larger than the address granularity (")
+           << (addressGranularityBits / 8)
+           << " bytes), innermost dim stride must be 1.";
+
+  return success();
+}
+
 bool xilinx::AIE::isContiguousBDTransfer(llvm::ArrayRef<BDDimLayoutAttr> dims) {
   if (dims.empty())
     return true; // no ND layout = trivially contiguous
@@ -2328,16 +2396,21 @@ LogicalResult DMABDOp::verify() {
         return emitOpError() << "Stride may not exceed " << (1 << 20);
     }
 
-    // Since streams read 32b words, there's no way to read eg 16b with stride
-    // of 2 (ie lower halfs of each 32b). So force it to be 1 (and then in
-    // CDODirect/XAIEV2 scale the size by 4/getBufferElementTypeWidthInBytes).
-    if (getBufferElementTypeWidthInBytes() < 4 && dims->back().getStride() != 1)
-      return emitOpError(
-          "For <32b width datatypes, inner-most dim stride must be 1");
-
-    if (getBufferElementTypeWidthInBytes() > 4 && dims->back().getStride() != 1)
-      return emitOpError(
-          "For >32b width datatypes, inner-most dim stride must be 1");
+    // Granularity / sub-word / stride alignment checks, shared with
+    // AIEX::verifyStridesWraps. dims are stored outermost-first; the helper
+    // expects innermost-first.
+    SmallVector<int64_t, 4> inputSizes, inputStrides;
+    for (auto it = dims->rbegin(); it != dims->rend(); ++it) {
+      inputSizes.push_back(static_cast<int64_t>(it->getSize()));
+      inputStrides.push_back(static_cast<int64_t>(it->getStride()));
+    }
+    DataLayout dataLayout = DataLayout::closest(getOperation());
+    unsigned elemWidthBits =
+        dataLayout.getTypeSizeInBits(buffer.getElementType());
+    if (failed(xilinx::AIE::verifyBDSizesStrides(
+            getOperation(), elemWidthBits,
+            targetModel.getAddressGenGranularity(), inputSizes, inputStrides)))
+      return failure();
   }
   if (auto paddims = getPadDimensions(); paddims.has_value()) {
     auto dims = getDimensions();

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -793,13 +793,15 @@ struct AIEObjectFifoStatefulTransformPass
       of_elem_index++;
     }
 
+    // repeat_count is the number of EXTRA replays (0 == once), so the number of
+    // times the chain runs is repeat_count + 1.
     int repeatCount = 1;
     int joinDistribFactor = 1;
     if (op.getRepeatCount().has_value())
-      repeatCount = op.getRepeatCount().value();
+      repeatCount = op.getRepeatCount().value() + 1;
     if (linked) {
       if (linkOp->getRepeatCount().has_value())
-        repeatCount = linkOp->getRepeatCount().value();
+        repeatCount = linkOp->getRepeatCount().value() + 1;
       if (linkOp->isDistribute())
         joinDistribFactor *= linkOp->getFifoOuts().size();
       else if (linkOp->isJoin())
@@ -946,10 +948,10 @@ struct AIEObjectFifoStatefulTransformPass
     auto elemType = llvm::cast<MemRefType>(fifo.getElementType());
     int len = elemType.getNumElements();
 
-    // check for repeat count
+    // check for repeat count (number of EXTRA replays; 0 == once)
     int repeatCount = 1;
     if (op.getRepeatCount().has_value())
-      repeatCount = op.getRepeatCount().value();
+      repeatCount = op.getRepeatCount().value() + 1;
 
     // search for the buffers/locks (based on if this objFifo has a link)
     ObjectFifoCreateOp target = op;
@@ -959,8 +961,8 @@ struct AIEObjectFifoStatefulTransformPass
         target = state.objFifoLinks[linkOp.value()];
         if (target == op) {
           if (linkOp->getRepeatCount().has_value()) {
-            acqNum *= linkOp->getRepeatCount().value();
-            relNum *= linkOp->getRepeatCount().value();
+            acqNum *= linkOp->getRepeatCount().value() + 1;
+            relNum *= linkOp->getRepeatCount().value() + 1;
           }
         }
       }
@@ -1125,10 +1127,10 @@ struct AIEObjectFifoStatefulTransformPass
     int acqNum = 1;
     int relNum = 1;
 
-    // check for repeat count
+    // check for repeat count (number of EXTRA replays; 0 == once)
     int repeatCount = 1;
     if (op.getRepeatCount().has_value())
-      repeatCount = op.getRepeatCount().value();
+      repeatCount = op.getRepeatCount().value() + 1;
 
     // check for BD chain repeat count
     auto bdChainIterCount = op.getIterCount();
@@ -1150,8 +1152,8 @@ struct AIEObjectFifoStatefulTransformPass
 
         if (linkOp->getRepeatCount().has_value())
           if (linkOp->getInputObjectFifos()[0] == op) {
-            acqNum *= linkOp->getRepeatCount().value();
-            relNum *= linkOp->getRepeatCount().value();
+            acqNum *= linkOp->getRepeatCount().value() + 1;
+            relNum *= linkOp->getRepeatCount().value() + 1;
           }
 
         if (linkOp->isJoin()) {
@@ -2775,9 +2777,9 @@ struct AIEObjectFifoStatefulTransformPass
 
         // release locks
         int numLocks = releaseOp.relNumber();
-        // account for repetition
+        // account for repetition (repeat_count is EXTRA replays; 0 == once)
         if (op.getRepeatCount().has_value())
-          numLocks *= op.getRepeatCount().value();
+          numLocks *= op.getRepeatCount().value() + 1;
         createUseLocks(builder, op, port, relPerFifo, numLocks,
                        LockAction::Release, state);
 
@@ -2881,9 +2883,9 @@ struct AIEObjectFifoStatefulTransformPass
         else
           numCreate = 0;
 
-        // account for repetition
+        // account for repetition (repeat_count is EXTRA replays; 0 == once)
         if (op.getRepeatCount().has_value())
-          numCreate *= op.getRepeatCount().value();
+          numCreate *= op.getRepeatCount().value() + 1;
 
         auto dev = op->getParentOfType<DeviceOp>();
         if (auto &targetArch = dev.getTargetModel();

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -170,70 +170,6 @@ void AIEX::getHardwareStridesWraps(const AIE::AIETargetModel &targetModel,
   }
 }
 
-mlir::LogicalResult
-AIEX::verifyStridesWraps(mlir::Operation *forOp,
-                         mlir::BaseMemRefType referencedBufType, int tileCol,
-                         int tileRow, llvm::SmallVector<int64_t, 4> inputSizes,
-                         llvm::SmallVector<int64_t, 4> inputStrides,
-                         llvm::SmallVector<int64_t, 4> hardwareSizes,
-                         llvm::SmallVector<int64_t, 4> hardwareStrides,
-                         bool skipTransformationChecks) {
-  const auto &targetModel = AIE::getTargetModel(forOp);
-  auto addressGranularity = targetModel.getAddressGenGranularity();
-  DataLayout dataLayout = DataLayout::closest(forOp);
-  auto elemWidth =
-      dataLayout.getTypeSizeInBits(referencedBufType.getElementType());
-
-  uint32_t wrap_bits = 0;
-  uint32_t step_bits = 0;
-  uint32_t iter_bits = 6;
-  if (targetModel.isShimNOCTile(tileCol, tileRow)) {
-    step_bits = 20; // XAIEMLGBL_NOC_MODULE_DMA_BD0_3_D0_STEPSIZE_WIDTH
-    wrap_bits = 10; // XAIEMLGBL_NOC_MODULE_DMA_BD0_3_D0_WRAP_WIDTH
-  } else if (targetModel.isMemTile(tileCol, tileRow)) {
-    step_bits = 17; // XAIEMLGBL_MEM_TILE_MODULE_DMA_BD0_2_D0_STEPSIZE_WIDTH
-    wrap_bits = 10; // XAIEMLGBL_MEM_TILE_MODULE_DMA_BD0_2_D0_WRAP_WIDTH
-  } else if (targetModel.isCoreTile(tileCol, tileRow)) {
-    step_bits = 13; // XAIEMLGBL_MEMORY_MODULE_DMA_BD0_2_D0_STEPSIZE_WIDTH
-    wrap_bits = 8;  // XAIEMLGBL_MEMORY_MODULE_DMA_BD0_3_D0_WRAP_WIDTH
-  } else {
-    return forOp->emitOpError(
-        "Unsupported tile type at (" + std::to_string(tileCol) + ", " +
-        std::to_string(tileRow) + ") Must be ShimNOC, Mem or Core.");
-  }
-
-  if (failed(AIE::verifyBDSizesStrides(forOp, elemWidth, addressGranularity,
-                                       inputSizes, inputStrides)))
-    return failure();
-
-  if (!skipTransformationChecks && hardwareSizes[0] > (1 << wrap_bits) - 1)
-    return forOp->emitOpError(
-        "Size 0 exceeds the [0:" + std::to_string((1 << wrap_bits) - 1) +
-        "] range.");
-  if (!skipTransformationChecks && hardwareSizes[1] > (1 << wrap_bits) - 1)
-    return forOp->emitOpError(
-        "Size 1 exceeds the [0:" + std::to_string((1 << wrap_bits) - 1) +
-        "] range.");
-  if (hardwareSizes[3] > (1 << iter_bits))
-    return forOp->emitOpError(
-        "Size 3 exceeds the [1:" + std::to_string(1 << iter_bits) + "] range.");
-  if (hardwareStrides[0] > (1 << step_bits))
-    return forOp->emitOpError("Stride 0 exceeds the [1:" +
-                              std::to_string(1 << step_bits) + "] range.");
-  if (hardwareStrides[1] > (1 << step_bits))
-    return forOp->emitOpError("Stride 1 exceeds the [1:" +
-                              std::to_string(1 << step_bits) + "] range.");
-  if (hardwareStrides[2] > (1 << step_bits))
-    return forOp->emitOpError("Stride 2 exceeds the [1:" +
-                              std::to_string(1 << step_bits) + "] range.");
-  // strides[3] exceeding the range is ok iff the sizes[3] is one, which is
-  // checked below
-  if (hardwareStrides[3] > (1 << step_bits) && hardwareSizes[3] > 0)
-    return forOp->emitOpError("Stride 3 exceeds the [1:" +
-                              std::to_string(1 << step_bits) + "] range.");
-
-  return success();
-}
 
 //===----------------------------------------------------------------------===//
 // UseTokenOp
@@ -394,16 +330,17 @@ struct LinearizeContiguousTransfer
       return mlir::failure();
 
     // getMixedSizes/Strides/Offsets return outermost-first; reverse to
-    // innermost-first so index 0 = d0 (innermost) and index 3 = repeat.
-    llvm::SmallVector<int64_t, 4> sizes = llvm::map_to_vector(
+    // innermost-first so index 0 = d0 (innermost). These are the 3 pure
+    // data-layout dims; iteration/repeat live in the iter_*/repeat_count attrs.
+    llvm::SmallVector<int64_t, 3> sizes = llvm::map_to_vector(
         llvm::reverse(op.getMixedSizes()), [](mlir::OpFoldResult s) {
           return mlir::getConstantIntValue(s).value();
         });
-    llvm::SmallVector<int64_t, 4> strides = llvm::map_to_vector(
+    llvm::SmallVector<int64_t, 3> strides = llvm::map_to_vector(
         llvm::reverse(op.getMixedStrides()), [](mlir::OpFoldResult s) {
           return mlir::getConstantIntValue(s).value();
         });
-    llvm::SmallVector<int64_t, 4> offsets = llvm::map_to_vector(
+    llvm::SmallVector<int64_t, 3> offsets = llvm::map_to_vector(
         llvm::reverse(op.getMixedOffsets()), [](mlir::OpFoldResult s) {
           return mlir::getConstantIntValue(s).value();
         });
@@ -412,21 +349,20 @@ struct LinearizeContiguousTransfer
     if (!AIEX::isContiguousTransfer(sizes, strides))
       return mlir::failure();
 
-    // Fold d0/d1/d2 into one linear count; keep the repeat dimension intact.
-    // Build directly in outermost-first order for the replacement op.
+    // Fold the 3 data dims into one linear count. Iteration/repeat are carried
+    // by attributes and are preserved unchanged. Build outermost-first.
     int64_t N = sizes[0] * sizes[1] * sizes[2];
-    llvm::SmallVector<int64_t, 4> newSizesOuter = {sizes[3], 1, 1, N};
-    llvm::SmallVector<int64_t, 4> newStridesOuter = {strides[3], 0, 0, 1};
+    llvm::SmallVector<int64_t, 3> newSizesOuter = {1, 1, N};
+    llvm::SmallVector<int64_t, 3> newStridesOuter = {0, 0, 1};
 
     // getOffsetInBytes() computes: sum(offsets[i] * strides[i] * elemSize).
     // After folding, the intermediate strides become 0, so any non-zero offset
     // in those dimensions would silently contribute 0 bytes.  Preserve the
-    // correct start address by collapsing the innermost three offset/stride
-    // pairs into a single linear element index at d0.
+    // correct start address by collapsing the three offset/stride pairs into a
+    // single linear element index at d0.
     int64_t linearOffset = offsets[0] * strides[0] + offsets[1] * strides[1] +
                            offsets[2] * strides[2];
-    llvm::SmallVector<int64_t, 4> newOffsetsOuter = {offsets[3], 0, 0,
-                                                     linearOffset};
+    llvm::SmallVector<int64_t, 3> newOffsetsOuter = {0, 0, linearOffset};
 
     rewriter.replaceOpWithNewOp<AIEX::NpuDmaMemcpyNdOp>(
         op, op.getMemref(),
@@ -441,7 +377,9 @@ struct LinearizeContiguousTransfer
         op.getD1ZeroBeforeAttr(), op.getD2ZeroBeforeAttr(),
         op.getD0ZeroAfterAttr(), op.getD1ZeroAfterAttr(),
         op.getD2ZeroAfterAttr(), op.getBurstLengthAttr(),
-        op.getOffsetParameterAttr(), op.getOffsetStateTableIdxAttr());
+        op.getOffsetParameterAttr(), op.getOffsetStateTableIdxAttr(),
+        op.getIterSizeAttr(), op.getIterStrideAttr(), op.getIterCurrentAttr(),
+        op.getRepeatCountAttr());
     return mlir::success();
   }
 };
@@ -519,10 +457,6 @@ LogicalResult AIEX::NpuDmaMemcpyNdOp::verify() {
       llvm::map_to_vector(llvm::reverse(getMixedStrides()), [](OpFoldResult s) {
         return getConstantIntValue(s).value();
       });
-  llvm::SmallVector<int64_t, 4> hardwareSizes(4);
-  llvm::SmallVector<int64_t, 4> hardwareStrides(4);
-  getHardwareStridesWraps(targetModel, getOperation(), buffer, inputSizes,
-                          inputStrides, hardwareSizes, hardwareStrides);
   int64_t offset = getOffsetInBytes();
 
   auto errorMessage = checkBurstLength(targetModel, getBurstLength());
@@ -561,9 +495,17 @@ LogicalResult AIEX::NpuDmaMemcpyNdOp::verify() {
         isLinearTransferWithoutTransformation() ||
         (targetModel.isShimNOCTile(col, row) &&
          AIEX::isContiguousTransfer(inputSizes, inputStrides));
-    if (failed(verifyStridesWraps(*this, buffer, col, row, inputSizes,
-                                  inputStrides, hardwareSizes, hardwareStrides,
-                                  skipTransformationChecks))) {
+    // dma_memcpy_nd carries up to three pure data dims (innermost-first);
+    // iteration and repeat are expressed by separate attributes.
+    DataLayout dataLayout = DataLayout::closest(getOperation());
+    unsigned elemWidthBits =
+        dataLayout.getTypeSizeInBits(buffer.getElementType());
+    if (getRepeatCount() != 0 && getIterSize() != 0)
+      return emitOpError("repeat_count and iter_size are mutually exclusive.");
+    if (failed(AIE::verifyBDDataLayoutAndIteration(
+            *this, targetModel, tile.getTileType(), elemWidthBits, inputSizes,
+            inputStrides, getIterSize(), getIterStride(),
+            skipTransformationChecks))) {
       return failure();
     }
   }

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -202,51 +202,9 @@ AIEX::verifyStridesWraps(mlir::Operation *forOp,
         std::to_string(tileRow) + ") Must be ShimNOC, Mem or Core.");
   }
 
-  for (int i = 0; i < 4; i++) {
-    if (inputSizes[i] <= 0) {
-      return forOp->emitOpError("Size ") << i << " must be a positive integer.";
-    }
-  }
-
-  if (inputSizes[0] * elemWidth % addressGranularity != 0) {
-    std::stringstream msg;
-    msg << "Transfer sizes must be multiples of " << (addressGranularity / 8)
-        << " bytes. " << inputSizes[0] << " elements at " << (elemWidth / 8)
-        << " bytes each equal " << (inputSizes[0] * elemWidth / 8)
-        << " bytes, which is not divisible by " << (addressGranularity / 8)
-        << ". ";
-    return forOp->emitOpError(msg.str());
-  }
-
-  for (int i = 0; i < 3; i++) {
-    if (inputSizes[i] > 1 && inputStrides[i] < 1) {
-      // If inputSize[i] == 1, anything is allowable in the stride, since that
-      // stride will never be applied. For any larger size, we must verify that
-      // the stride is positive.
-      return forOp->emitOpError("Stride ")
-             << i << " must be a positive integer.";
-    }
-  }
-  // A value of zero is allowable for the fourth-dimension stride
-  // (this indicates an interation stride for the repeat of 0)
-  if (inputSizes[3] > 1 && inputStrides[3] < 0) {
-    return forOp->emitOpError("Stride 3 must be a non-negative integer.");
-  }
-
-  for (int i = 0; i < 4; i++) {
-    // strides[0] == 1 is ok iff the transfer size is a multiple of
-    // addressGranularity, which is checked below
-    if (i == 0 && inputStrides[i] == 1)
-      continue;
-    if (inputStrides[i] * elemWidth % addressGranularity != 0) {
-      std::stringstream msg;
-      msg << "Stride " << i << " is " << inputStrides[i] << " elements * "
-          << (elemWidth / 8) << " bytes = " << (inputStrides[i] * elemWidth / 8)
-          << " bytes, which is not divisible by " << (addressGranularity / 8)
-          << ". ";
-      return forOp->emitOpError(msg.str());
-    }
-  }
+  if (failed(AIE::verifyBDSizesStrides(forOp, elemWidth, addressGranularity,
+                                       inputSizes, inputStrides)))
+    return failure();
 
   if (!skipTransformationChecks && hardwareSizes[0] > (1 << wrap_bits) - 1)
     return forOp->emitOpError(

--- a/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
@@ -185,10 +185,9 @@ struct AIECtrlPacketToDmaPass
         int col = ctrlPktOp.getColumnFromAddr();
 
         // Emit the batched DMA operation for this (col, row) pair
-        const std::vector<int64_t> staticOffsets = {0, 0, 0,
-                                                    batchIt->startOffset};
-        const std::vector<int64_t> staticSizes = {1, 1, 1, batchIt->totalSize};
-        const std::vector<int64_t> staticStrides = {0, 0, 0, 1};
+        const std::vector<int64_t> staticOffsets = {0, 0, batchIt->startOffset};
+        const std::vector<int64_t> staticSizes = {1, 1, batchIt->totalSize};
+        const std::vector<int64_t> staticStrides = {0, 0, 1};
 
         SymbolRefAttr metadata =
             SymbolRefAttr::get(builder.getContext(), batchIt->shimDmaAllocName);

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -358,9 +358,14 @@ struct AIEDMATasksToNPUPass
           llvm::SmallVector<int64_t, 4>(4, 1);
       llvm::SmallVector<int64_t, 4> input_strides =
           llvm::SmallVector<int64_t, 4>(4, 0);
-      if (dims->size() > 4) {
-        return bd_op->emitOpError("At most four data layout transformation "
-                                  "dimensions may be provided.");
+      // The runtime-sequence BD register file encodes 3 data dims + 1 iteration
+      // dim. (Static BDs lowered via AIERT can use a 4th data dim, but that path
+      // does not reach here.) Iteration is carried by the dma_bd's explicit
+      // iter_* attributes, not by a data dim.
+      if (dims->size() > 3) {
+        return bd_op->emitOpError("At most three data layout transformation "
+                                  "dimensions may be provided for a "
+                                  "runtime-sequence DMA task.");
       }
 
       for (size_t i = 0; i < dims->size(); i++) {
@@ -371,6 +376,9 @@ struct AIEDMATasksToNPUPass
         input_sizes[i] = (*dims)[j].getSize();
         input_strides[i] = (*dims)[j].getStride();
       }
+      // Iteration goes in the index-3 slot expected by getHardwareStridesWraps.
+      input_sizes[3] = bd_op.getIterSize() > 0 ? bd_op.getIterSize() : 1;
+      input_strides[3] = bd_op.getIterStride();
 
       // d3 (repeat) is excluded; a repeated linear transfer is still linear.
       // A contiguous row-major ND access on a shim NOC tile is also lowered
@@ -412,14 +420,19 @@ struct AIEDMATasksToNPUPass
       getHardwareStridesWraps(target_model, bd_op, buffer_type, input_sizes,
                               input_strides, sizes, strides);
 
-      if (failed(verifyStridesWraps(bd_op, buffer_type, tile.getCol(),
-                                    tile.getRow(), input_sizes, input_strides,
-                                    sizes, strides, treatAsLinear))) {
-        return failure();
+      {
+        llvm::ArrayRef<int64_t> verifySizes(input_sizes.data(), 3);
+        llvm::ArrayRef<int64_t> verifyStrides(input_strides.data(), 3);
+        DataLayout dataLayout = DataLayout::closest(bd_op);
+        unsigned elemWidthBits =
+            dataLayout.getTypeSizeInBits(buffer_type.getElementType());
+        if (failed(AIE::verifyBDDataLayoutAndIteration(
+                bd_op, target_model, tile.getTileType(), elemWidthBits,
+                verifySizes, verifyStrides, bd_op.getIterSize(),
+                bd_op.getIterStride(), treatAsLinear))) {
+          return failure();
+        }
       }
-
-      iteration_size = sizes[3];
-      iteration_stride = strides[3];
 
       if (!treatAsLinear) {
         // d0_size, d0_stride
@@ -433,14 +446,6 @@ struct AIEDMATasksToNPUPass
         // d2_stride
         d2stride = strides[2];
         // d2_size set elsewhere
-      }
-      if (input_sizes[3] > 1 && input_strides[3] == 0) {
-        // We allow users to encode the repeat_count as a dimension 3 stride
-        // of 0. This must lower to a iteration wrap of 0, so no stride is
-        // ever added. We then repeat the BD using the repeat_count in
-        // NpuPushQueueOp.
-        iteration_size = 0;
-        iteration_stride = 0;
       }
 
       // Ensure the total transfer length and the length expressed in the lowest
@@ -476,6 +481,21 @@ struct AIEDMATasksToNPUPass
         return bd_op->emitOpError() << "Padding is supported only on MemTiles.";
       }
     }
+
+    // Strided BD iteration from the dma_bd's explicit iter_* attributes. This is
+    // independent of the data-layout dims (a linearized BD has no dims but may
+    // still iterate), so it is computed here rather than inside the dims block.
+    if (bd_op.getIterSize() > 0) {
+      DataLayout dataLayout = DataLayout::closest(bd_op);
+      unsigned elemWidthBits =
+          dataLayout.getTypeSizeInBits(buffer_type.getElementType());
+      // Hardware encoding: wrap is (size - 1); stepsize is in granularity words
+      // and encoded as (words - 1), matching getHardwareStridesWraps' index 3.
+      iteration_size = bd_op.getIterSize() - 1;
+      iteration_stride =
+          bd_op.getIterStride() * elemWidthBits / addr_granularity - 1;
+    }
+
     // find next BD ID, if any
     uint32_t use_next_bd = 0;
     uint32_t next_bd_id = 0;
@@ -546,7 +566,8 @@ struct AIEDMATasksToNPUPass
         /*d0_size=*/d0size, /*d0_stride=*/d0stride,
         /*d1_size=*/d1size, /*d1_stride=*/d1stride,
         /*d2_size=*/d2size, /*d2_stride=*/d2stride,
-        /*iteration_current=*/0, /*iteration_size=*/iteration_size,
+        /*iteration_current=*/(int)bd_op.getIterCurrent(),
+        /*iteration_size=*/iteration_size,
         /*iteration_stride=*/iteration_stride,
         /*next_bd=*/next_bd_id,
         /*row=*/tile.getRow(),

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -266,12 +266,24 @@ public:
 
     auto issue_token = BoolAttr::get(ctx, false);
     auto repeat_count = zero;
-    llvm::SmallVector<int64_t, 4> inputSizes = llvm::map_to_vector(
+    // Up to three pure data-layout dims (innermost-first). Iteration is carried
+    // by the op's explicit iter_* attributes, in the index-3 slot expected by
+    // getHardwareStridesWraps; a pure repeat is carried by repeat_count.
+    llvm::SmallVector<int64_t, 4> dataSizes = llvm::map_to_vector(
         llvm::reverse(op.getMixedSizes()),
         [](OpFoldResult s) { return getConstantIntValue(s).value(); });
-    llvm::SmallVector<int64_t, 4> inputStrides = llvm::map_to_vector(
+    llvm::SmallVector<int64_t, 4> dataStrides = llvm::map_to_vector(
         llvm::reverse(op.getMixedStrides()),
         [](OpFoldResult s) { return getConstantIntValue(s).value(); });
+    llvm::SmallVector<int64_t, 4> inputSizes(dataSizes.begin(),
+                                             dataSizes.end());
+    llvm::SmallVector<int64_t, 4> inputStrides(dataStrides.begin(),
+                                               dataStrides.end());
+    // Pad data dims out to 3, then append the iteration dim at index 3.
+    inputSizes.resize(3, 1);
+    inputStrides.resize(3, 0);
+    inputSizes.push_back(op.getIterSize() > 0 ? op.getIterSize() : 1);
+    inputStrides.push_back(op.getIterStride());
     llvm::SmallVector<int64_t, 4> sizes(4);
     llvm::SmallVector<int64_t, 4> strides(4);
     getHardwareStridesWraps(targetModel, op, bufferType, inputSizes,
@@ -291,9 +303,15 @@ public:
     bool isLinear = op.isLinearTransferWithoutTransformation() ||
                     (targetModel.isShimNOCTile(tileCol, tileRow) &&
                      isContiguousTransfer(inputSizes, inputStrides));
-    if (failed(verifyStridesWraps(op, bufferType, tileCol, tileRow, inputSizes,
-                                  inputStrides, sizes, strides, isLinear))) {
-      return failure();
+    {
+      llvm::ArrayRef<int64_t> verifySizes(inputSizes.data(), 3);
+      llvm::ArrayRef<int64_t> verifyStrides(inputStrides.data(), 3);
+      if (failed(AIE::verifyBDDataLayoutAndIteration(
+              op, targetModel, infoOp.getTileOp().getTileType(),
+              op.getElementTypeBitwidth(), verifySizes, verifyStrides,
+              op.getIterSize(), op.getIterStride(), isLinear))) {
+        return failure();
+      }
     }
 
     // arg_idx and offset for block arguments
@@ -376,21 +394,17 @@ public:
       else
         d2_size = IntegerAttr::get(i32ty, 0);
     }
-    // iteration_current, iteration_size, iteration_stride, repeat_count
-    if (inputSizes[3] > 1) {
-      if (inputStrides[3] > 0) {
-        iteration_size = IntegerAttr::get(i32ty, sizes[3]);
-        iteration_stride = IntegerAttr::get(i32ty, strides[3]);
-      } else {
-        // We allow users to encode the repeat_count as a dimension 3 stride
-        // of 0. This must lower to a iteration wrap of 0, so no stride is
-        // ever added. We then repeat the BD using the repeat_count in
-        // NpuPushQueueOp.
-        iteration_size = zero;
-        iteration_stride = zero;
-      }
+    // iteration_current, iteration_size, iteration_stride: strided BD iteration,
+    // taken from the op's explicit iter_* attributes (index-3 slot).
+    if (op.getIterSize() > 0) {
+      iteration_current = IntegerAttr::get(i32ty, op.getIterCurrent());
+      iteration_size = IntegerAttr::get(i32ty, sizes[3]);
+      iteration_stride = IntegerAttr::get(i32ty, strides[3]);
     }
-    repeat_count = IntegerAttr::get(i32ty, sizes[3]);
+    // repeat_count: a pure replay of the whole BD (no address increment),
+    // pushed via the queue. Both the op attribute and the push-queue hardware
+    // field count EXTRA replays (0 == a single pass), so they map directly.
+    repeat_count = IntegerAttr::get(i32ty, op.getRepeatCount());
 
     // next_bd
 

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -494,6 +494,23 @@ LogicalResult configureBdInBlock(const AIE::AIETargetModel &targetModel,
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetPadding, &dmaTileBd,
                             &dmaPadTensor);
   }
+
+  // Explicit buffer-descriptor iteration (a strided replay of the whole BD).
+  // XAie_DmaSetBdIteration takes LOGICAL (1-based) Wrap and StepSize -- the
+  // driver subtracts 1 when packing the registers -- so pass iter_size/stride
+  // raw. StepSize is in 32b words; iter_stride is in element units.
+  if (uint32_t iterSize = bdOp.getIterSize(); iterSize > 0) {
+    double elementWidthIn32bWords =
+        static_cast<double>(bdOp.getBufferElementTypeWidthInBytes()) / 4.0;
+    uint32_t iterStepSize = static_cast<uint32_t>(
+        static_cast<double>(bdOp.getIterStride()) * elementWidthIn32bWords);
+    // A zero step (no address increment) is encoded as 1 word, matching the
+    // other dimensions' "stride > 0 ? stride : 1" handling above.
+    iterStepSize = iterStepSize > 0 ? iterStepSize : 1;
+    TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetBdIteration, &dmaTileBd,
+                            iterStepSize, static_cast<uint8_t>(iterSize),
+                            static_cast<uint8_t>(bdOp.getIterCurrent()));
+  }
   if (nextBdId) {
     auto enableNextBd = 1;
     TRY_XAIE_API_EMIT_ERROR(bdOp, XAie_DmaSetNextBd, &dmaTileBd,

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -111,9 +111,15 @@ static mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
     int elementWidthInBytes = 0;
     int ndims = 0;
     ArrayRef<BDDimLayoutAttr> dims;
+    uint32_t iterSize = 0;
+    uint32_t iterStride = 0;
+    uint32_t iterCurrent = 0;
     //      StringRef FifoMode = disable; // FIXME: when to enable FIFO mode?
     for (auto op : block->getOps<DMABDOp>()) {
       foundBd = true;
+      iterSize = op.getIterSize();
+      iterStride = op.getIterStride();
+      iterCurrent = op.getIterCurrent();
       if (!targetModel.isShimNOCTile(col, row)) {
         assert(op.getBufferOp().getAddress() &&
                "buffer must have address assigned");
@@ -237,6 +243,21 @@ static mlir::LogicalResult generateDMAConfig(OpType memOp, raw_ostream &output,
         generateXAieDmaSetMultiDimAddr(output, ndims, dims, col, row, bdNum,
                                        BaseAddrA, offsetA, lenA,
                                        elementWidthInBytes, "1");
+
+      // Explicit BD iteration (a strided replay of the whole BD).
+      // XAie_DmaSetBdIteration takes LOGICAL (1-based) Wrap/StepSize; the driver
+      // subtracts 1 when packing the registers. StepSize is in 32b words.
+      if (iterSize > 0) {
+        uint32_t iterStepSizeWords =
+            (uint32_t)((double)iterStride * (double)elementWidthInBytes / 4.0);
+        if (iterStepSizeWords == 0)
+          iterStepSizeWords = 1;
+        output << "__mlir_aie_try(XAie_DmaSetBdIteration("
+               << tileDMAInstRefStr(col, row, bdNum) << ", "
+               << " /* stepsize */ " << iterStepSizeWords << ", "
+               << " /* wrap */ " << iterSize << ", "
+               << " /* iterCurrent */ " << iterCurrent << "));\n";
+      }
 
       if (block->getNumSuccessors() > 0) {
         Block *nextBlock = block->getSuccessors()[0]; // should have only one

--- a/programming_examples/basic/vector_vector_add_BDs_init_values/vector_vector_add.py
+++ b/programming_examples/basic/vector_vector_add_BDs_init_values/vector_vector_add.py
@@ -204,9 +204,9 @@ def vector_vector_add(
     )
 
     def emit_seq(A_data, C_data):
-        in1_task = shim_dma_single_bd_task("of_in1", A_data.op, sizes=[1, 1, 1, N])
+        in1_task = shim_dma_single_bd_task("of_in1", A_data.op, sizes=[1, 1, N])
         out_task = shim_dma_single_bd_task(
-            "of_out", C_data.op, sizes=[1, 1, 1, N], issue_token=True
+            "of_out", C_data.op, sizes=[1, 1, N], issue_token=True
         )
         dma_start_task(in1_task, out_task)
         dma_await_task(out_task)

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -54,6 +54,45 @@ def dma_wait(*args: ObjectFifoCreateOp | str):
         npu_dma_wait(str_name)
 
 
+def _split_tap_iteration(sizes, strides):
+    """Split a TensorAccessPattern's leading dimension into explicit buffer-descriptor
+    iteration/repeat, returning pure data-layout dims.
+
+    A TensorAccessPattern carries up to three data-layout dimensions plus a single
+    leading iteration dimension (this matches the hardware: three data dims, one
+    iteration). This helper translates that leading dimension into the explicit
+    iter_size/iter_stride/repeat_count fields that the op surface now expects, so
+    every op-gen boundary performs the split identically:
+
+    * leading size == 1 (stride irrelevant): no iteration.
+    * leading size > 1 with stride == 0: a pure repeat of the whole descriptor;
+      repeat_count = size - 1 (extra replays).
+    * leading size > 1 with stride > 0: a strided iteration; iter_size = size,
+      iter_stride = stride.
+
+    Returns (data_sizes, data_strides, iter_size, iter_stride, repeat_count).
+    """
+    sizes = list(sizes)
+    strides = list(strides)
+    if len(sizes) != 4 or len(strides) != 4:
+        raise ValueError(
+            "Expected a 4-element TensorAccessPattern (3 data dims + 1 leading "
+            f"iteration dim), but got sizes={sizes}, strides={strides}."
+        )
+    lead_size = sizes[0]
+    lead_stride = strides[0]
+    iter_size = 0
+    iter_stride = 0
+    repeat_count = 0
+    if lead_size > 1:
+        if lead_stride == 0:
+            repeat_count = lead_size - 1
+        else:
+            iter_size = lead_size
+            iter_stride = lead_stride
+    return sizes[1:], strides[1:], iter_size, iter_stride, repeat_count
+
+
 class NpuDmaMemcpyNd(NpuDmaMemcpyNdOp):
     """
     Enables data transfers between the AIE Engine array and external memory.
@@ -63,26 +102,31 @@ class NpuDmaMemcpyNd(NpuDmaMemcpyNdOp):
         bd_id: Identifier integer for the particular Buffer Descriptor control registers used for this memcpy. A buffer descriptor contains all information needed for a DMA transfer described in the parameters below.
         mem: Reference to a host buffer, given as an argument to the sequence function, that this transfer will read from or write to.
         tap (optional): A TensorAccessPattern is an alternative method of specifying offset/sizes/strides for determining an access pattern over the mem buffer.
-        offsets (optional): Start points for data transfer in each dimension. There is a maximum of four offset dimensions.
-        sizes: The extent of data to be transferred across each dimension. There is a maximum of four size dimensions.
+        offsets (optional): Start points for data transfer in each dimension. There are three data-layout offset dimensions.
+        sizes: The extent of data to be transferred across each dimension. There are three data-layout size dimensions.
         strides (optional): Interval steps between data points in each dimension, useful for striding-across and reshaping data.
+        iter_size (optional): Logical (>1) length of a strided replay of the whole buffer descriptor. 0 (default) means no iteration.
+        iter_stride (optional): Address increment (in element units) applied per iteration replay.
+        iter_current (optional): Starting iteration index for the strided replay.
+        repeat_count (optional): Number of EXTRA times to replay the whole buffer descriptor with no address increment (a pure repeat). 0 (default) means a single pass (no repeat).
         burst_length (optional): The configuration of the burst length for the DMA task. If 0, defaults to the highest available value.
 
     Note:
         Contiguous row-major access patterns are automatically folded to canonical linear form
         by the compiler's canonicalization pass. For example, a 2D image access
-        ``sizes=[1, 1, height, width], strides=[0, 0, width, 1]`` is equivalent to
-        ``sizes=[1, 1, 1, height*width], strides=[0, 0, 0, 1]`` and will be canonicalized
+        ``sizes=[1, height, width], strides=[0, width, 1]`` is equivalent to
+        ``sizes=[1, 1, height*width], strides=[0, 0, 1]`` and will be canonicalized
         to the latter. This means the natural multidimensional form can always be used
         without concern for the hardware d0 dimension size limit.
 
     Example:
 
-        npu_dma_memcpy_nd(of_in, 0, input_buffer, sizes=[1, 1, 1, 30])
+        npu_dma_memcpy_nd(of_in, 0, input_buffer, sizes=[1, 1, 30])
 
         The example above describes a linear transfer of 30 data elements, or 120 Bytes, from the input_buffer in host memory into an object FIFO with matching
         metadata labeled "of_in".
-        The size dimensions are expressed right to left where the right is dimension 0 and the left dimension 3. Higher dimensions not used should be set to 1.
+        The size dimensions are expressed right to left where the right is dimension 0 and the left dimension 2. Higher dimensions not used should be set to 1.
+        Buffer-descriptor iteration/repeat are no longer encoded as a leading size dimension; use the iter_*/repeat_count arguments instead.
     """
 
     def __init__(
@@ -98,24 +142,39 @@ class NpuDmaMemcpyNd(NpuDmaMemcpyNdOp):
         burst_length: int = 0,
         packet: tuple[int] | None = None,
         offset_parameter: str | None = None,
+        iter_size: int = 0,
+        iter_stride: int = 0,
+        iter_current: int = 0,
+        repeat_count: int = 0,
     ):
         if tap and not (offsets is None and sizes is None and strides is None):
             raise ValueError(
                 "NpuDmaMemcpyNd can take either a TileAccessPattern OR (sizes and/or strides and/or offsets), but not both."
             )
+        if tap and not (
+            iter_size == 0
+            and iter_stride == 0
+            and iter_current == 0
+            and repeat_count == 0
+        ):
+            raise ValueError(
+                "NpuDmaMemcpyNd derives iter_size/iter_stride/repeat_count from the "
+                "TensorAccessPattern; do not also pass them explicitly when using tap."
+            )
         if tap:
-            sizes = tap.sizes.copy()
-            strides = tap.strides.copy()
+            sizes, strides, iter_size, iter_stride, repeat_count = _split_tap_iteration(
+                tap.sizes, tap.strides
+            )
             # For some reason, the type checking of offsets does not mesh well with offset being a property
             # so here we make sure it is evaluated and properly is seen as an integer.
-            offsets = [0] * 3 + [int(tap.offset)]
+            offsets = [0] * 2 + [int(tap.offset)]
         else:
             if offsets is None:
-                offsets = [0] * 4
+                offsets = [0] * 3
             if sizes is None:
-                sizes = [0] * 4
+                sizes = [0] * 3
             if strides is None:
-                strides = [0] * 3 + [1]
+                strides = [0] * 2 + [1]
         dynamic_offsets, _packed_offsets, static_offsets = _dispatch_mixed_values(
             offsets
         )
@@ -139,6 +198,10 @@ class NpuDmaMemcpyNd(NpuDmaMemcpyNdOp):
             burst_length=burst_length,
             packet=packet,
             offset_parameter=offset_parameter,
+            iter_size=iter_size,
+            iter_stride=iter_stride,
+            iter_current=iter_current,
+            repeat_count=repeat_count,
         )
 
 
@@ -209,6 +272,9 @@ def shim_dma_bd(
     burst_length: int = 0,
     packet: tuple[int] | None = None,
     offset_parameter: str | None = None,
+    iter_size: int = 0,
+    iter_stride: int = 0,
+    iter_current: int = 0,
 ):
     if tap and not (offset is None and sizes is None and strides is None):
         raise ValueError(
@@ -216,8 +282,18 @@ def shim_dma_bd(
         )
 
     if tap:
-        sizes = tap.sizes.copy()
-        strides = tap.strides.copy()
+        # A TensorAccessPattern carries 3 data dims + a leading iteration dim;
+        # the buffer descriptor only carries strided iteration (iter_*). A pure
+        # repeat (repeat_count) belongs on the enclosing task, not the BD.
+        sizes, strides, iter_size, iter_stride, repeat_count = _split_tap_iteration(
+            tap.sizes, tap.strides
+        )
+        if repeat_count != 0:
+            raise ValueError(
+                "shim_dma_bd received a TensorAccessPattern encoding a pure repeat "
+                "(leading size>1, stride==0); a bare buffer descriptor cannot carry a "
+                "repeat. Use shim_dma_single_bd_task, which places repeat_count on the task."
+            )
         # For some reason, the type checking of offsets does not mesh well with offset being a property
         # so here we make sure it is evaluated and properly is seen as an integer.
         offset = int(tap.offset)
@@ -225,9 +301,9 @@ def shim_dma_bd(
     if offset is None:
         offset = 0
     if sizes is None:
-        sizes = [0] * 4
+        sizes = [0] * 3
     if strides is None:
-        strides = [0] * 3 + [1]
+        strides = [0] * 2 + [1]
 
     if transfer_len is None:
         transfer_len = np.prod(sizes[-3:])
@@ -241,6 +317,9 @@ def shim_dma_bd(
         burst_length=burst_length,
         packet=packet,
         offset_parameter=offset_parameter,
+        iter_size=iter_size,
+        iter_stride=iter_stride,
+        iter_current=iter_current,
     )
 
 
@@ -256,6 +335,10 @@ def shim_dma_single_bd_task(
     burst_length: int = 0,
     packet: tuple[int] | None = None,
     offset_parameter: str | None = None,
+    iter_size: int = 0,
+    iter_stride: int = 0,
+    iter_current: int = 0,
+    repeat_count: int = 0,
 ):
     """_summary_
     Enables data transfers between the AIE Engine array and external memory.
@@ -266,34 +349,46 @@ def shim_dma_single_bd_task(
         mem: Reference to a host buffer, given as an argument to the sequence function, that this transfer will read from or write to.
         tap (optional): A TensorAccessPattern is an alternative method of specifying offset/sizes/strides for determining an access pattern over the mem buffer.
         offset (optional): Starting point for the data transfer. Default values is 0.
-        sizes: The extent of data to be transferred across each dimension. There is a maximum of four size dimensions.
+        sizes: The extent of data to be transferred across each dimension. There are three data-layout size dimensions.
         strides (optional): Interval steps between data points in each dimension, useful for striding-across and reshaping data.
         issue_token (optional): If a token is issued, one may call dma_await_task on the returned task. Default is False.
         burst_length (optional): The configuration of the burst length for the DMA task. If 0, defaults to the highest available value.
         packet (optional): The packet header information represented as a (packet_type, packet_id) tuple.
+        iter_size (optional): Logical (>1) length of a strided replay of the whole buffer descriptor. 0 (default) means no iteration.
+        iter_stride (optional): Address increment (in element units) applied per iteration replay.
+        iter_current (optional): Starting iteration index for the strided replay.
+        repeat_count (optional): Number of EXTRA times to replay the whole buffer descriptor with no address increment. 0 (default) means a single pass.
 
     Example:
-        out_task = shim_dma_single_bd_task(of_out, C, sizes=[1, 1, 1, N], issue_token=True)
+        out_task = shim_dma_single_bd_task(of_out, C, sizes=[1, 1, N], issue_token=True)
 
         The example above describes a linear transfer of N data elements from the C buffer in host memory into an object FIFO with matching metadata labeled "of_out".
-        The sizes dimensions are expressed right to left where the right is dimension 0 and the left dimension 3.
+        The sizes dimensions are expressed right to left where the right is dimension 0 and the left dimension 2.
         Higher dimensions not used should be set to 1.
     """
     if tap and not (offset is None and sizes is None and strides is None):
         raise ValueError(
             "shim_dma_single_bd_task can take either a TensorAccessPattern OR (sizes and/or strides and/or offsets), but not both."
         )
+    if tap and not (
+        iter_size == 0 and iter_stride == 0 and iter_current == 0 and repeat_count == 0
+    ):
+        raise ValueError(
+            "shim_dma_single_bd_task derives iter_size/iter_stride/repeat_count from the "
+            "TensorAccessPattern; do not also pass them explicitly when using tap."
+        )
 
     if tap:
-        sizes = tap.sizes.copy()
-        strides = tap.strides.copy()
+        # A TensorAccessPattern carries 3 data dims + a leading iteration dim.
+        # A pure repeat (repeat_count) lives on the task; a strided iteration
+        # (iter_*) lives on the buffer descriptor.
+        sizes, strides, iter_size, iter_stride, repeat_count = _split_tap_iteration(
+            tap.sizes, tap.strides
+        )
         # For some reason, the type checking of offsets does not mesh well with offset being a property
         # so here we make sure it is evaluated and properly is seen as an integer.
         offset = int(tap.offset)
 
-    repeat_count = 0
-    if sizes and sizes[0] > 1:
-        repeat_count = sizes[0] - 1
     task = dma_configure_task_for(
         alloc, repeat_count=repeat_count, issue_token=issue_token
     )
@@ -308,6 +403,9 @@ def shim_dma_single_bd_task(
                 burst_length=burst_length,
                 packet=packet,
                 offset_parameter=offset_parameter,
+                iter_size=iter_size,
+                iter_stride=iter_stride,
+                iter_current=iter_current,
             )
             EndOp()
     return task

--- a/test/Conversion/DmaToNpu/aiert_insts.mlir
+++ b/test/Conversion/DmaToNpu/aiert_insts.mlir
@@ -22,8 +22,8 @@ module {
       %c8 = arith.constant 8 : i64
       %c16 = arith.constant 16 : i64
       %c32 = arith.constant 32 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0, %c1]) { metadata = @of_toMem, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c2,%c0,%c0][%c1,%c2,%c2,%c8][%c0,%c16,%c8, %c1]) { metadata = @of_fromMem, id = 0 : i64, issue_token = false } : memref<4x2x8xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c32][%c0,%c0,%c1]) { metadata = @of_toMem, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c2,%c0,%c0][%c2,%c2,%c8][%c16,%c8,%c1]) { metadata = @of_fromMem, id = 0 : i64, issue_token = false } : memref<4x2x8xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)

--- a/test/Conversion/DmaToNpu/bad_dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/bad_dma_to_npu.mlir
@@ -18,7 +18,7 @@
 module @shimDmaMemcpy{
   aie.device(xcve2302) {
     aie.runtime_sequence(%arg0: memref<1xbf16>, %arg1: memref<1xbf16>, %arg2: memref<1xbf16>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][4, 4, 64, 64][0, 64, 256, 1]) {id = 0 : i64, metadata = @toMem} : memref<1xbf16>
+      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0][4, 64, 64][64, 256, 1]) {id = 0 : i64, metadata = @toMem, repeat_count = 3 : i32} : memref<1xbf16>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     }
     %tile_0_0 = aie.tile(0, 0)

--- a/test/Conversion/DmaToNpu/bad_dma_to_npu_datatype.mlir
+++ b/test/Conversion/DmaToNpu/bad_dma_to_npu_datatype.mlir
@@ -18,7 +18,7 @@
 module @shimDmaMemcpy{
   aie.device(xcve2302) {
     aie.runtime_sequence(%arg0: memref<65536xi64>, %arg1: memref<65536xi64>, %arg2: memref<65536xi64>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][4, 4, 64, 64][0, 64, 256, 1]) {id = 0 : i64, metadata = @toMem} : memref<65536xi64>
+      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0][4, 64, 64][64, 256, 1]) {id = 0 : i64, metadata = @toMem, repeat_count = 3 : i32} : memref<65536xi64>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     }
     %tile_0_0 = aie.tile(0, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu.mlir
@@ -21,8 +21,8 @@
 module  {
   aie.device(npu1) {
     aie.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
-      aiex.npu.dma_memcpy_nd (%arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,64,1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (%arg1[0,0,16][1,16,16][0,64,1]) { metadata = @fromMem, id = 0 : i64 } : memref<16xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @fromMem (%tile_0_0, MM2S, 0)
@@ -47,7 +47,7 @@ module  {
 module  {
   aie.device(npu1) {
     aie.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,64,1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
     }
     %tile_0_0 = aie.tile(0, 0)
@@ -73,7 +73,7 @@ module  {
 module  {
   aie.device(npu1) {
     aie.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,64,1]) { issue_token = true, metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
     }
     %tile_1_0 = aie.tile(1, 0)
@@ -137,7 +137,7 @@ module {
 module {
   aie.device(npu1_1col) {
     aie.runtime_sequence(%arg0: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1], packet = <pkt_id = 2, pkt_type = 3>) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,64,1], packet = <pkt_id = 2, pkt_type = 3>) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @toMem (%tile_0_0, S2MM, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_burst_length.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_burst_length.mlir
@@ -30,10 +30,10 @@ module {
     aie.runtime_sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
         // Note that The burst length encoding is mixed with the stride, so the encoding does not exactly correspond to the burst length.
         // CHECK: memref.global "private" constant {{.*}} = dense<[{{[0-9]*}}, {{[0-9]*}}, {{[0-9]*}}, {{[0-9]*}}, 2097152, {{[0-9]*}}, {{[0-9]*}}, {{[0-9]*}}]>
-        aiex.npu.dma_memcpy_nd (%in[0,2,0,0][1,2,2,8][0,16,1,1]) { metadata = @of_fromMem, id = 0 : i64, burst_length = 64 : i64} : memref<4x2x8xi32>
+        aiex.npu.dma_memcpy_nd (%in[2,0,0][2,2,8][16,1,1]) { metadata = @of_fromMem, id = 0 : i64, burst_length = 64 : i64} : memref<4x2x8xi32>
         // Here the burst length encoding is not mixed with the stride, since the stride is 0. This is 0xC0000000.
         // CHECK: memref.global "private" constant {{.*}} = dense<[{{[0-9]*}}, {{[0-9]*}}, {{[0-9]*}}, {{[0-9]*}}, -1073741824, {{[0-9]*}}, {{[0-9]*}}, {{[0-9]*}}]>
-        aiex.npu.dma_memcpy_nd (%out[0,0,0,0][1,1,1,32][0,0,0,1]) { metadata = @of_toMem, id = 1 : i64, burst_length = 512 : i64} : memref<64xi32>
+        aiex.npu.dma_memcpy_nd (%out[0,0,0][1,1,32][0,0,1]) { metadata = @of_toMem, id = 1 : i64, burst_length = 512 : i64} : memref<64xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_burst_length_invalid.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_burst_length_invalid.mlir
@@ -57,8 +57,8 @@ module {
 module {
   aie.device(npu2) {
     aie.runtime_sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      aiex.npu.dma_memcpy_nd (%in[0,2,0,0][1,2,2,8][0,16,8,1]) { metadata = @of_fromMem, id = 0 : i64, burst_length = 64} : memref<4x2x8xi32>
-      aiex.npu.dma_memcpy_nd (%out[0,0,0,0][1,1,1,32][0,0,0,1]) { metadata = @of_toMem, id = 1 : i64, burst_length = 510 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[2,0,0][2,2,8][16,8,1]) { metadata = @of_fromMem, id = 0 : i64, burst_length = 64} : memref<4x2x8xi32>
+      aiex.npu.dma_memcpy_nd (%out[0,0,0][1,1,32][0,0,1]) { metadata = @of_toMem, id = 1 : i64, burst_length = 510 } : memref<64xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)
@@ -74,8 +74,8 @@ module {
 module {
   aie.device(npu1) {
     aie.runtime_sequence(%in : memref<4x2x8xi32>, %buf : memref<32xi32>, %out : memref<64xi32>) {
-      aiex.npu.dma_memcpy_nd (%in[0,2,0,0][1,2,2,8][0,16,8,1]) { metadata = @of_fromMem, id = 0 : i64, burst_length = 64} : memref<4x2x8xi32>
-      aiex.npu.dma_memcpy_nd (%out[0,0,0,0][1,1,1,32][0,0,0,1]) { metadata = @of_toMem, id = 1 : i64, burst_length = 512 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[2,0,0][2,2,8][16,8,1]) { metadata = @of_fromMem, id = 0 : i64, burst_length = 64} : memref<4x2x8xi32>
+      aiex.npu.dma_memcpy_nd (%out[0,0,0][1,1,32][0,0,1]) { metadata = @of_toMem, id = 1 : i64, burst_length = 512 } : memref<64xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_issue_token.mlir
@@ -24,8 +24,8 @@
 module  {
   aie.device(npu1) {
     aie.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-        aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64, issue_token = true } : memref<16xi32>
-        aiex.npu.dma_memcpy_nd (%arg1[0, 0, 0, 16][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @fromMem, id = 0 : i64, issue_token = false } : memref<16xi32>
+        aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,64,1]) { metadata = @toMem, id = 1 : i64, issue_token = true } : memref<16xi32>
+        aiex.npu.dma_memcpy_nd (%arg1[0,0,16][1,16,16][0,64,1]) { metadata = @fromMem, id = 0 : i64, issue_token = false } : memref<16xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @fromMem (%tile_0_0, MM2S, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_iter_repeat.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_iter_repeat.mlir
@@ -1,0 +1,39 @@
+//===- dma_to_npu_iter_repeat.mlir ------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+// Covers the new explicit iteration/repeat attributes on aiex.npu.dma_memcpy_nd
+// through the aie-dma-to-npu lowering:
+//   - iter_size/iter_stride  -> the BD iteration register (word 6 of the BD)
+//   - repeat_count           -> the push-queue write32 (extra replays)
+//
+// For the iter BD: iter_size=4 -> wrap=3, iter_stride=64 i32 words -> step=63,
+// packed as 0x0030003F = 3145791.
+// For the repeat BD: repeat_count=3 is enqueued via the push-queue command word
+// 0x00030001 = 196609 (repeat in the high half, enqueue bit in the low half).
+
+// RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
+
+// CHECK: memref.global "private" constant @blockwrite_data_0 : memref<8xi32> = dense<[64, 0, 0, 0, -2147483648, 33554432, 3145791, 33554432]>
+// CHECK: memref.global "private" constant @blockwrite_data_1 : memref<8xi32> = dense<[64, 0, 0, 0, -2147483648, 33554432, 0, 33554432]>
+// CHECK: aiex.npu.write32 {address = 119316 : ui32, value = 0 : ui32}
+// CHECK: aiex.npu.write32 {address = 119316 : ui32, value = 196609 : ui32}
+
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<2048xi32>) {
+      // Strided BD iteration via explicit iter_* attributes.
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 64][0, 0, 1]) {id = 0 : i64, metadata = @md, iter_size = 4 : i64, iter_stride = 64 : i64} : memref<2048xi32>
+      // Pure repeat (no address increment) via repeat_count: 3 extra replays.
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 64][0, 0, 1]) {id = 1 : i64, metadata = @md, repeat_count = 3 : i32} : memref<2048xi32>
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @md (%tile_0_0, MM2S, 0)
+  }
+}

--- a/test/Conversion/DmaToNpu/dma_to_npu_subview.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_subview.mlir
@@ -23,7 +23,7 @@ module {
       %subview = memref.subview %arg0[128] [256] [1] : memref<1024xi32> to memref<256xi32, strided<[1], offset: 128>>
       %reinterpret = memref.reinterpret_cast %subview to offset: [0], sizes: [256], strides: [1] : memref<256xi32, strided<[1], offset: 128>> to memref<256xi32>
       // DMA should use the reinterpreted memref, and the pass should trace back to %arg0 with offset
-      aiex.npu.dma_memcpy_nd (%reinterpret[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1]) { metadata = @buffer, id = 0 : i64 } : memref<256xi32>
+      aiex.npu.dma_memcpy_nd (%reinterpret[0,0,0][1,1,256][0,0,1]) { metadata = @buffer, id = 0 : i64 } : memref<256xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @buffer (%tile_0_0, S2MM, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_subview_nd.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_subview_nd.mlir
@@ -28,7 +28,7 @@ module {
         : memref<2x256xi32> to memref<256xi32, strided<[1], offset: 256>>
       %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [256], strides: [1]
         : memref<256xi32, strided<[1], offset: 256>> to memref<256xi32>
-      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1])
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0][1, 1, 256][0, 0, 1])
         { metadata = @buffer_2d_1d, id = 0 : i64 } : memref<256xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
@@ -53,7 +53,7 @@ module {
         : memref<4x8x32xi32> to memref<32xi32, strided<[1], offset: 608>>
       %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [32], strides: [1]
         : memref<32xi32, strided<[1], offset: 608>> to memref<32xi32>
-      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 32][0, 0, 0, 1])
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0][1, 1, 32][0, 0, 1])
         { metadata = @buffer_3d_1d, id = 0 : i64 } : memref<32xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
@@ -79,7 +79,7 @@ module {
         : memref<2x4x8x32xi32> to memref<32xi32, strided<[1], offset: 1632>>
       %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [32], strides: [1]
         : memref<32xi32, strided<[1], offset: 1632>> to memref<32xi32>
-      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 32][0, 0, 0, 1])
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0][1, 1, 32][0, 0, 1])
         { metadata = @buffer_4d_1d, id = 0 : i64 } : memref<32xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
@@ -104,7 +104,7 @@ module {
         : memref<2x512xbf16> to memref<512xbf16, strided<[1], offset: 512>>
       %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [512], strides: [1]
         : memref<512xbf16, strided<[1], offset: 512>> to memref<512xbf16>
-      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 512][0, 0, 0, 1])
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0][1, 1, 512][0, 0, 1])
         { metadata = @buffer_bf16, id = 0 : i64 } : memref<512xbf16>
     }
     %tile_0_0 = aie.tile(0, 0)
@@ -133,7 +133,7 @@ module {
         to memref<256xi32, strided<[1], offset: 1536>>
       %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [256], strides: [1]
         : memref<256xi32, strided<[1], offset: 1536>> to memref<256xi32>
-      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1])
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0][1, 1, 256][0, 0, 1])
         { metadata = @buffer_chain, id = 0 : i64 } : memref<256xi32>
     }
     %tile_0_0 = aie.tile(0, 0)

--- a/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_width_conversion.mlir
@@ -27,7 +27,7 @@
 module @shimDmaMemcpy{
   aie.device(xcve2302) {
     aie.runtime_sequence(%arg0: memref<65536xbf16>, %arg1: memref<65536xbf16>, %arg2: memref<65536xbf16>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][4, 4, 64, 64][0, 64, 256, 1]) {id = 0 : i64, metadata = @toMem} : memref<65536xbf16>
+      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0][4, 64, 64][64, 256, 1]) {id = 0 : i64, metadata = @toMem, repeat_count = 3 : i32} : memref<65536xbf16>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     }
     %tile_2_0 = aie.tile(2, 0)

--- a/test/Passes/materialize-runtime-sequences/inline_symbols.mlir
+++ b/test/Passes/materialize-runtime-sequences/inline_symbols.mlir
@@ -20,7 +20,7 @@ module {
     // CHECK-LABEL: aie.runtime_sequence @main_seq
     aie.runtime_sequence @main_seq(%arg0: memref<64xi32>) {
       // CHECK: aiex.npu.load_pdi {device_ref = @config_with_symbols}
-      // CHECK: aiex.npu.dma_memcpy_nd(%[[ARG0:.*]][0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1])
+      // CHECK: aiex.npu.dma_memcpy_nd(%[[ARG0:.*]][0, 0, 0][1, 1, 64][0, 0, 1])
       // CHECK-SAME: metadata = @buffer_in
       aiex.configure @config_with_symbols {
         aiex.run @seq_with_dma(%arg0) : (memref<64xi32>)
@@ -35,7 +35,7 @@ module {
     aie.shim_dma_allocation @buffer_in(%tile20, S2MM, 0)
     
     aie.runtime_sequence @seq_with_dma(%arg0: memref<64xi32>) {
-      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) { metadata = @buffer_in, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 64][0, 0, 1]) { metadata = @buffer_in, id = 0 : i64 } : memref<64xi32>
     }
   }
 }

--- a/test/Targets/AIETargetCDODirect/dma_bd_iteration.mlir
+++ b/test/Targets/AIETargetCDODirect/dma_bd_iteration.mlir
@@ -1,0 +1,37 @@
+//===- dma_bd_iteration.mlir ------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that a static aie.dma_bd with explicit iter_size/iter_stride lowers
+// through AIERT (XAie_DmaSetBdIteration) into the BD iteration register.
+//
+// The iteration word lives at BD-base + 0x18. The driver packs LOGICAL values:
+//   iter_size  = 4  -> wrap   = 4 - 1 = 3
+//   iter_stride= 64 i32 elems = 64 32b words -> stepsize = 64 - 1 = 63 = 0x3F
+// so the iteration field is 0x0006003F (current = 0).
+
+// RUN: aie-translate --aie-generate-cdo %s --cdo-debug=true | FileCheck %s
+
+// CHECK: (BlockWrite-DMAWriteCmd): Start Address: 0x00000000041A0000  Size: 8
+// CHECK:     Address: 0x00000000041A0018  Data@ {{0x[0-9a-z]+}} is: 0x0006003F
+
+module {
+  aie.device(npu1) {
+    %t = aie.tile(2, 1)
+    %b = aie.buffer(%t) { sym_name = "b", address = 4096 : i32 } : memref<256xi32>
+    %m = aie.memtile_dma(%t) {
+      %s = aie.dma_start("MM2S", 0, ^bd0, ^end)
+    ^bd0:
+      aie.dma_bd(%b : memref<256xi32>, 0, 64, [<size = 8, stride = 8>, <size = 8, stride = 1>]) {iter_size = 4 : i32, iter_stride = 64 : i32, bd_id = 0 : i32}
+      aie.next_bd ^end
+    ^end:
+      aie.end
+    }
+  }
+}

--- a/test/Targets/AIETargetHSA/input_with_addresses.mlir
+++ b/test/Targets/AIETargetHSA/input_with_addresses.mlir
@@ -53,8 +53,8 @@ module {
     aie.shim_dma_allocation @out0 (%tile_6_0, S2MM, 0)
 
     aie.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 0 : i64, metadata = @out0} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 1 : i64, metadata = @in0} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[0,0,0][1,1,64][0,0,1]) {id = 0 : i64, metadata = @out0} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1,64][0,0,1]) {id = 1 : i64, metadata = @in0} : memref<64xi32>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     }
   }

--- a/test/Targets/NPU/npu_dma_memcpy.mlir
+++ b/test/Targets/NPU/npu_dma_memcpy.mlir
@@ -24,7 +24,7 @@ module {
   %tile_0_0 = aie.tile(0, 0)
   aie.shim_dma_allocation @airMemcpyId12 (%tile_0_0, MM2S, 0)
   aie.runtime_sequence (%arg0: memref<2x64x64xi32>, %arg1: memref<2x64x64xi32>, %arg2: memref<2x64x64xi32>) {
-    aiex.npu.dma_memcpy_nd(%arg0[1, 0, 0, 0][1, 2, 32, 32][4096, 2048, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId12} : memref<2x64x64xi32>
+    aiex.npu.dma_memcpy_nd(%arg0[2, 0, 0][2, 32, 32][2048, 64, 1]) {id = 0 : i64, metadata = @airMemcpyId12} : memref<2x64x64xi32>
   }
  }
 }

--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -44,14 +44,14 @@ module {
     aie.shim_dma_allocation @out1 (%tile_0_0, MM2S, 1)
     aie.shim_dma_allocation @out2 (%tile_0_0, MM2S, 2)
     aie.runtime_sequence(%arg0: memref<1024xi32>, %arg1: memref<1024xi32>, %arg2: memref<1024xi32>, %arg3: memref<1024xi32>, %arg4: memref<1024xi32>, %arg5: memref<1024xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 0 : i64, metadata = @in0} : memref<1024xi32>
-      aiex.npu.dma_memcpy_nd (%arg1[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 1 : i64, metadata = @out0} : memref<1024xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1,1024][0,0,1]) {id = 0 : i64, metadata = @in0} : memref<1024xi32>
+      aiex.npu.dma_memcpy_nd (%arg1[0,0,0][1,1,1024][0,0,1]) {id = 1 : i64, metadata = @out0} : memref<1024xi32>
       aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 2 : i64, metadata = @in1} : memref<1024xi32>
-      aiex.npu.dma_memcpy_nd (%arg3[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 3 : i64, metadata = @out1} : memref<1024xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[0,0,0][1,1,1024][0,0,1]) {id = 2 : i64, metadata = @in1} : memref<1024xi32>
+      aiex.npu.dma_memcpy_nd (%arg3[0,0,0][1,1,1024][0,0,1]) {id = 3 : i64, metadata = @out1} : memref<1024xi32>
       aiex.npu.sync {channel = 1 : i32, column = 0 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
-      aiex.npu.dma_memcpy_nd (%arg4[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 2 : i64, metadata = @in2} : memref<1024xi32>
-      aiex.npu.dma_memcpy_nd (%arg5[0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]) {id = 3 : i64, metadata = @out2} : memref<1024xi32>
+      aiex.npu.dma_memcpy_nd (%arg4[0,0,0][1,1,1024][0,0,1]) {id = 2 : i64, metadata = @in2} : memref<1024xi32>
+      aiex.npu.dma_memcpy_nd (%arg5[0,0,0][1,1,1024][0,0,1]) {id = 3 : i64, metadata = @out2} : memref<1024xi32>
       aiex.npu.sync {channel = 0 : i32, column = 2 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     }
   }

--- a/test/aiecc/cpp_aie2p_target.mlir
+++ b/test/aiecc/cpp_aie2p_target.mlir
@@ -56,8 +56,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c32 = arith.constant 32 : i64
-      aiex.npu.dma_memcpy_nd(%arg_out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<32xi32>
-      aiex.npu.dma_memcpy_nd(%arg_in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c32][%c0,%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(%arg_out[%c0,%c0,%c0][%c1,%c1,%c32][%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<32xi32>
+      aiex.npu.dma_memcpy_nd(%arg_in[%c0,%c0,%c0][%c1,%c1,%c32][%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<32xi32>
       aiex.npu.dma_wait {symbol = @out}
     }
   }

--- a/test/aiecc/cpp_aiesim.mlir
+++ b/test/aiecc/cpp_aiesim.mlir
@@ -63,8 +63,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_allocation_schemes.mlir
+++ b/test/aiecc/cpp_allocation_schemes.mlir
@@ -49,7 +49,7 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c128 = arith.constant 128 : i64
-      aiex.npu.dma_memcpy_nd(%buf[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c128][%c0,%c0,%c0,%c1]) {metadata = @fifo, id = 0 : i64, issue_token = true} : memref<128xi32>
+      aiex.npu.dma_memcpy_nd(%buf[%c0,%c0,%c0][%c1,%c1,%c128][%c0,%c0,%c1]) {metadata = @fifo, id = 0 : i64, issue_token = true} : memref<128xi32>
       aiex.npu.dma_wait {symbol = @fifo}
     }
   }

--- a/test/aiecc/cpp_basic.mlir
+++ b/test/aiecc/cpp_basic.mlir
@@ -63,8 +63,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_ctrlpkt.mlir
+++ b/test/aiecc/cpp_ctrlpkt.mlir
@@ -65,8 +65,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_elf_generation.mlir
+++ b/test/aiecc/cpp_elf_generation.mlir
@@ -56,8 +56,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_full_elf_generation.mlir
+++ b/test/aiecc/cpp_full_elf_generation.mlir
@@ -57,8 +57,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_host_compile.mlir
+++ b/test/aiecc/cpp_host_compile.mlir
@@ -74,8 +74,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_link_with.mlir
+++ b/test/aiecc/cpp_link_with.mlir
@@ -49,8 +49,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_link_with_func_level.mlir
+++ b/test/aiecc/cpp_link_with_func_level.mlir
@@ -50,8 +50,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_multi_core.mlir
+++ b/test/aiecc/cpp_multi_core.mlir
@@ -79,8 +79,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @out}
     }
   }

--- a/test/aiecc/cpp_multi_device_sequence.mlir
+++ b/test/aiecc/cpp_multi_device_sequence.mlir
@@ -64,8 +64,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%arg1[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @out1, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @in1, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg1[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @out1, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @in1, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @out1}
     }
 
@@ -73,8 +73,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%arg1[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @out1, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @in1, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg1[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @out1, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @in1, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @out1}
     }
   }
@@ -94,8 +94,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%arg1[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @out2, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @in2, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg1[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @out2, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @in2, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @out2}
     }
   }

--- a/test/aiecc/cpp_multi_link_with.mlir
+++ b/test/aiecc/cpp_multi_link_with.mlir
@@ -54,8 +54,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_no_xchesscc_implies_no_xbridge.mlir
+++ b/test/aiecc/cpp_no_xchesscc_implies_no_xbridge.mlir
@@ -57,8 +57,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_npu_and_xclbin.mlir
+++ b/test/aiecc/cpp_npu_and_xclbin.mlir
@@ -54,7 +54,7 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd(%buf[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1]) {metadata = @data, id = 0 : i64, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%buf[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) {metadata = @data, id = 0 : i64, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @data}
     }
   }

--- a/test/aiecc/cpp_parallel_compilation.mlir
+++ b/test/aiecc/cpp_parallel_compilation.mlir
@@ -81,8 +81,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @out}
     }
   }

--- a/test/aiecc/cpp_partition_npu1.mlir
+++ b/test/aiecc/cpp_partition_npu1.mlir
@@ -31,7 +31,7 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of, id = 0 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of, id = 0 : i64} : memref<16xi32>
     }
   }
 }

--- a/test/aiecc/cpp_partition_npu1_1col.mlir
+++ b/test/aiecc/cpp_partition_npu1_1col.mlir
@@ -31,7 +31,7 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of, id = 0 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of, id = 0 : i64} : memref<16xi32>
     }
   }
 }

--- a/test/aiecc/cpp_partition_npu2.mlir
+++ b/test/aiecc/cpp_partition_npu2.mlir
@@ -31,7 +31,7 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of, id = 0 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of, id = 0 : i64} : memref<16xi32>
     }
   }
 }

--- a/test/aiecc/cpp_transaction.mlir
+++ b/test/aiecc/cpp_transaction.mlir
@@ -53,8 +53,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_unified_compilation.mlir
+++ b/test/aiecc/cpp_unified_compilation.mlir
@@ -85,8 +85,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @out}
     }
   }

--- a/test/aiecc/cpp_xchesscc_basic.mlir
+++ b/test/aiecc/cpp_xchesscc_basic.mlir
@@ -62,8 +62,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_xchesscc_compile_only.mlir
+++ b/test/aiecc/cpp_xchesscc_compile_only.mlir
@@ -58,8 +58,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/cpp_xchesscc_multi_core.mlir
+++ b/test/aiecc/cpp_xchesscc_multi_core.mlir
@@ -84,8 +84,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/aiecc/library_integration.mlir
+++ b/test/aiecc/library_integration.mlir
@@ -61,8 +61,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c16 = arith.constant 16 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<16xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c16][%c0,%c0,%c1]) {metadata = @of_in, id = 0 : i64, issue_token = true} : memref<16xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-2.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-2.mlir
@@ -18,9 +18,9 @@ module {
 
     aie.runtime_sequence(%arg0: memref<32xi8>) {
       %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-          // expected-error@+1 {{At most four data layout transformation dimensions may be provided}}
+          // expected-error@+1 {{At most three data layout transformation dimensions may be provided for a runtime-sequence DMA task.}}
           aie.dma_bd(%arg0 : memref<32xi8>, 4, 32,
-                     [<size=1, stride=4>, <size=1, stride=4>, <size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>]) {bd_id = 0 : i32}
+                     [<size=1, stride=4>, <size=2, stride=4>, <size=2, stride=8>, <size=4, stride=1>]) {bd_id = 0 : i32}
           aie.end
       }
     }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_unranked_memref_repeat.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_unranked_memref_repeat.mlir
@@ -31,7 +31,7 @@ module {
         // The len = 128 covers only the lowest 3 dimensions (8 * 4 * 4)
         // The 4th dimension (size=4, stride=128) is the iteration/repeat
         aie.dma_bd(%arg0 : memref<*xbf16>, 0, 128,
-                   [<size=4, stride=128>, <size=8, stride=64>, <size=4, stride=16>, <size=4, stride=1>]) {bd_id = 0 : i32}
+                   [<size=8, stride=64>, <size=4, stride=16>, <size=4, stride=1>]) {bd_id = 0 : i32, iter_size = 4 : i32, iter_stride = 128 : i32}
         aie.end
       } {issue_token = true}
 

--- a/test/dialect/AIE/bad_dma_bd_iteration.mlir
+++ b/test/dialect/AIE/bad_dma_bd_iteration.mlir
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --verify-diagnostics %s
+
+// Iteration stride must be positive when iteration size > 1.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(2, 1)
+    %b = aie.buffer(%t) { sym_name = "b" } : memref<256xi32>
+    %m = aie.memtile_dma(%t) {
+      %s = aie.dma_start("MM2S", 0, ^bd0, ^end)
+    ^bd0:
+      // expected-error@+1 {{Iteration stride must be a positive integer when iteration size > 1.}}
+      aie.dma_bd(%b : memref<256xi32>, 0, 64, [<size = 8, stride = 8>, <size = 8, stride = 1>]) {iter_size = 4 : i32, iter_stride = 0 : i32}
+      aie.next_bd ^end
+    ^end:
+      aie.end
+    }
+  }
+}
+
+// -----
+
+// A core tile allows at most 3 data-layout dimensions.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(3, 3)
+    %b = aie.buffer(%t) { sym_name = "b" } : memref<256xi32>
+    %m = aie.mem(%t) {
+      %s = aie.dma_start("MM2S", 0, ^bd0, ^end)
+    ^bd0:
+      // expected-error@+1 {{Cannot give more than 3 dimensions for step sizes and wraps in this tile}}
+      aie.dma_bd(%b : memref<256xi32>, 0, 64, [<size = 2, stride = 32>, <size = 2, stride = 16>, <size = 2, stride = 8>, <size = 8, stride = 1>])
+      aie.next_bd ^end
+    ^end:
+      aie.end
+    }
+  }
+}
+
+// -----
+
+// A memtile allows 4 data-layout dimensions (this must verify cleanly).
+module {
+  aie.device(npu1) {
+    %t = aie.tile(2, 1)
+    %b = aie.buffer(%t) { sym_name = "b" } : memref<1024xi32>
+    %m = aie.memtile_dma(%t) {
+      %s = aie.dma_start("MM2S", 0, ^bd0, ^end)
+    ^bd0:
+      aie.dma_bd(%b : memref<1024xi32>, 0, 64, [<size = 2, stride = 256>, <size = 2, stride = 64>, <size = 2, stride = 8>, <size = 8, stride = 1>])
+      aie.next_bd ^end
+    ^end:
+      aie.end
+    }
+  }
+}

--- a/test/dialect/AIE/bad_dma_op.mlir
+++ b/test/dialect/AIE/bad_dma_op.mlir
@@ -53,7 +53,7 @@ module {
 
 // -----
 
-// CHECK: For >32b width datatypes, inner-most dim stride must be 1 
+// CHECK: For element widths larger than the address granularity (4 bytes), innermost dim stride must be 1
 module {
   aie.device(npu1) {
     %tile14 = aie.tile(1, 4)
@@ -63,7 +63,27 @@ module {
       ^bd0:
         aie.dma_bd(%buf14 : memref<128x!aiex.bfp<"v8bfp16ebs8">>, 0, 128, [<size = 8, stride = 16>]) {}
         aie.next_bd ^end
-      ^end: 
+      ^end:
+        aie.end
+    }
+  }
+}
+
+// -----
+
+// Sub-word innermost contiguous run on i8: innermost size=2 elements * 1 byte
+// = 2 bytes, sub-word and unrealizable by 32-bit-granularity DMA.
+// CHECK: 2 elements at 1 bytes each equal 2 bytes, which is not divisible by 4
+module {
+  aie.device(npu1) {
+    %tile14 = aie.tile(1, 4)
+    %buf14 = aie.buffer(%tile14) { sym_name = "buf14" } : memref<128xi8>
+    %mem14 = aie.mem(%tile14) {
+      %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
+      ^bd0:
+        aie.dma_bd(%buf14 : memref<128xi8>, 0, 24, [<size = 3, stride = 4>, <size = 2, stride = 1>])
+        aie.next_bd ^end
+      ^end:
         aie.end
     }
   }

--- a/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
+++ b/test/dialect/AIE/canonicalize_no_linearize_iter_bd.mlir
@@ -16,10 +16,12 @@
 
 // -----
 
-// len < product: outer dim is an iteration dim, must NOT linearize.
+// Explicit iteration: the data dims (product == len) are contiguous and DO
+// linearize, while the explicit iter_* attributes are preserved.
 // CANON-LABEL: @iter_bd_no_linearize
-// CANON:         aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
-// CANON-SAME:        [<size = 32, stride = 4096>, <size = 1, stride = 64>, <size = 64, stride = 64>, <size = 64, stride = 1>]
+// CANON:         aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096)
+// CANON-SAME:      {bd_id = 0 : i32, iter_size = 32 : i32, iter_stride = 4096 : i32}
+// CANON-NOT:         [<
 // LOWER-LABEL: @iter_bd_no_linearize
 // LOWER:         aiex.npu.writebd
 // LOWER-SAME:      buffer_length = 2048
@@ -32,8 +34,9 @@ module {
     aie.runtime_sequence @iter_bd_no_linearize(%arg0 : memref<131072xbf16>) {
       %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
         aie.dma_bd(%arg0 : memref<131072xbf16>, 0, 4096,
-          [<size = 32, stride = 4096>, <size = 1, stride = 64>,
-           <size = 64, stride = 64>, <size = 64, stride = 1>]) {bd_id = 0 : i32}
+          [<size = 1, stride = 64>,
+           <size = 64, stride = 64>, <size = 64, stride = 1>])
+          {bd_id = 0 : i32, iter_size = 32 : i32, iter_stride = 4096 : i32}
         aie.end
       } {issue_token = true}
       aiex.dma_start_task(%t)

--- a/test/dialect/AIE/nd-dma-bad-stride.mlir
+++ b/test/dialect/AIE/nd-dma-bad-stride.mlir
@@ -8,21 +8,43 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --verify-diagnostics %s
+// RUN: aie-opt --split-input-file --verify-diagnostics %s
 
-module @tutorial_2b {
+// i16 (16b) inner stride of 2 elements = 32b = address-granularity multiple.
+// This is realizable in hardware and must pass verification.
+module @stride_word_aligned_ok {
   aie.device(xcve2802) {
     %tile14 = aie.tile(1, 4)
     %tile34 = aie.tile(3, 4)
-
     aie.flow(%tile14, DMA : 0, %tile34, DMA : 0)
     %buf14 = aie.buffer(%tile14) : memref<128xi16>
     %lock14_done = aie.lock(%tile14, 0) { init = 0 : i32 }
     %mem14 = aie.mem(%tile14) {
       %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
       ^bd0:
-        // expected-error@+1 {{'aie.dma_bd' op For <32b width datatypes, inner-most dim stride must be 1}}
         aie.dma_bd(%buf14 : memref<128xi16>, 0, 128, [<size = 32, stride = 2>])
+        aie.next_bd ^end
+      ^end:
+        aie.end
+    }
+  }
+}
+
+// -----
+
+// i16 (16b) inner stride of 3 elements = 48b, not a granularity multiple.
+module @stride_not_word_aligned {
+  aie.device(xcve2802) {
+    %tile14 = aie.tile(1, 4)
+    %tile34 = aie.tile(3, 4)
+    aie.flow(%tile14, DMA : 0, %tile34, DMA : 0)
+    %buf14 = aie.buffer(%tile14) : memref<128xi16>
+    %lock14_done = aie.lock(%tile14, 0) { init = 0 : i32 }
+    %mem14 = aie.mem(%tile14) {
+      %srcDma = aie.dma_start("MM2S", 0, ^bd0, ^end)
+      ^bd0:
+        // expected-error@+1 {{'aie.dma_bd' op Stride 0 is 3 elements * 2 bytes = 6 bytes, which is not divisible by 4}}
+        aie.dma_bd(%buf14 : memref<128xi16>, 0, 128, [<size = 32, stride = 3>])
         aie.next_bd ^end
       ^end:
         aie.end

--- a/test/dialect/AIEX/bad_npu_nd.mlir
+++ b/test/dialect/AIEX/bad_npu_nd.mlir
@@ -23,7 +23,7 @@ module {
       %c1921 = arith.constant 1921 : i64
       %c1080 = arith.constant 1080 : i64
       // expected-error@+1 {{Size 0 exceeds the [0:1023] range}}
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1080,%c1920][%c0,%c0,%c1921,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<1920x1080xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1080,%c1920][%c0,%c1921,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<1920x1080xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)
@@ -43,8 +43,8 @@ module {
       %c16 = arith.constant 16 : i64
       %c32 = arith.constant 32 : i64
       %c128 = arith.constant 128 : i64
-      // expected-error@+1 {{Size 3 exceeds the [1:64] range}}
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c128,%c2,%c2,%c8][%c0,%c16,%c8,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<128x4x2x8xi32>
+      // expected-error@+1 {{Iteration size exceeds the [1:64] range}}
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c2,%c2,%c8][%c16,%c8,%c1]) { metadata = @of_fromMem, id = 0 : i64, iter_size = 128 : i64, iter_stride = 16 : i64 } : memref<128x4x2x8xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)
@@ -61,7 +61,7 @@ module {
       %c2 = arith.constant 2 : i64
       %c2097152 = arith.constant 2097152 : i64
       // expected-error@+1 {{Stride 1 exceeds the [1:1048576] range}}
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2][%c0,%c0,%c2097152,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<8388608xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c2,%c2][%c0,%c2097152,%c1]) { metadata = @of_fromMem, id = 0 : i64 } : memref<8388608xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile_0_0, MM2S, 0)
@@ -80,7 +80,7 @@ module {
       %c2 = arith.constant 2 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Offset must be 4-byte-aligned}}
-      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0,%c1][%c1,%c1,%c1,%c8][%c0,%c0,%c1,%c1]) { metadata = @fifo, id = 0 : i64 } : memref<8xi8>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c1][%c1,%c1,%c8][%c0,%c1,%c1]) { metadata = @fifo, id = 0 : i64 } : memref<8xi8>
     }
   }
 }
@@ -101,7 +101,7 @@ module {
       %c2048 = arith.constant 2048 : i64
       // Although 2048 exceeds the 0:1023 limit for size 0, since the elements are i8s,
       // this should be a size of 512 in address granularity (4 bytes) and hence pass the test.
-      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2048][%c0,%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c2,%c2048][%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -120,7 +120,7 @@ module {
       %c8 = arith.constant 8 : i64
       %c2048 = arith.constant 2048 : i64
       // expected-error@+1 {{Size 0 exceeds the [0:1023] range}}
-      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0,%c0][%c1,%c1,%c2,%c2048][%c0,%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi16>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c2,%c2048][%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi16>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -140,7 +140,7 @@ module {
       %c2 = arith.constant 2 : i64  // Stride of 2 i8s = 2 bytes < 4 byte granularity, should not be possible
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Stride 1 is 2 elements * 1 bytes = 2 bytes, which is not divisible by 4}}
-      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c8][%c0,%c0,%c2,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c2,%c8][%c0,%c2,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -158,7 +158,7 @@ module {
       %c4 = arith.constant 4 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{2 elements at 1 bytes each equal 2 bytes, which is not divisible by 4}}
-      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2][%c0,%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c2][%c0,%c4,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -178,7 +178,7 @@ module {
       %c4 = arith.constant 4 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Stride 0 is 2 elements * 1 bytes = 2 bytes, which is not divisible by 4}}
-      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c8][%c0,%c0,%c0,%c2]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c8][%c0,%c0,%c2]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi8>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -197,7 +197,7 @@ module {
       %c3 = arith.constant 3 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{3 elements at 2 bytes each equal 6 bytes, which is not divisible by 4}}
-      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c3][%c0,%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi16>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c3][%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi16>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -206,7 +206,8 @@ module {
 
 // -----
 
-// first (highest-dimension) stride can go beyond the limit, as long as the corresponding wrap is 1
+// An iteration stride is only range-checked when the iteration size > 1; with
+// iter_size == 1 (a single pass) the stride is never applied, so any value is OK.
 
 module {
   aie.device(npu1) {
@@ -216,10 +217,9 @@ module {
       %c2 = arith.constant 2 : i64
       %c3 = arith.constant 3 : i64
       %c8 = arith.constant 8 : i64
-      %c1572864 = arith.constant 1572864 : i64
-      aiex.npu.dma_memcpy_nd (%a[%c1,%c0,%c0,%c0][%c1,%c1,%c1,%c2][%c1572864,%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi32>
-      // expected-error@+1 {{Stride 3 exceeds the [1:1048576] range.}}
-      aiex.npu.dma_memcpy_nd (%a[%c1,%c0,%c0,%c0][%c2,%c1,%c1,%c2][%c1572864,%c0,%c0,%c1]) { metadata = @objectfifo, id = 1 : i64 } : memref<8xi32>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c2][%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64, iter_size = 1 : i64, iter_stride = 1572864 : i64 } : memref<8xi32>
+      // expected-error@+1 {{Iteration stride exceeds the [1:1048576] range.}}
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c2][%c0,%c0,%c1]) { metadata = @objectfifo, id = 1 : i64, iter_size = 2 : i64, iter_stride = 1572864 : i64 } : memref<8xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -238,9 +238,9 @@ module {
       %c2 = arith.constant 2 : i64
       %c3 = arith.constant 3 : i64
       %c8 = arith.constant 8 : i64
-      aiex.npu.dma_memcpy_nd (%a[%c1,%c0,%c0,%c0][%c1,%c1,%c1,%c2][%c0,%c0,%c0,%c1], packet = <pkt_id = 31, pkt_type = 7>) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi32>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c2][%c0,%c0,%c1], packet = <pkt_id = 31, pkt_type = 7>) { metadata = @objectfifo, id = 0 : i64 } : memref<8xi32>
       // expected-error@+1 {{Packet ID field can only hold 5 bits.}}
-      aiex.npu.dma_memcpy_nd (%a[%c1,%c0,%c0,%c0][%c2,%c1,%c1,%c2][%c0,%c0,%c0,%c1], packet = <pkt_id = 32, pkt_type = 2>) { metadata = @objectfifo, id = 1 : i64 } : memref<8xi32>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c2][%c0,%c0,%c1], packet = <pkt_id = 32, pkt_type = 2>) { metadata = @objectfifo, id = 1 : i64 } : memref<8xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
@@ -260,7 +260,26 @@ module {
       %c3 = arith.constant 3 : i64
       %c8 = arith.constant 8 : i64
       // expected-error@+1 {{Packet type field can only hold 3 bits.}}
-      aiex.npu.dma_memcpy_nd (%a[%c1,%c0,%c0,%c0][%c2,%c1,%c1,%c2][%c0,%c0,%c0,%c1], packet = <pkt_id = 2, pkt_type = 8>) { metadata = @objectfifo, id = 1 : i64 } : memref<8xi32>
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c2][%c0,%c0,%c1], packet = <pkt_id = 2, pkt_type = 8>) { metadata = @objectfifo, id = 1 : i64 } : memref<8xi32>
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)
+  }
+}
+
+// -----
+
+// repeat_count (a pure replay) and iter_size (a strided iteration) describe two
+// different hardware behaviors and cannot both be set on one transfer.
+
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%a : memref<8xi32>) {
+      %c0 = arith.constant 0 : i64
+      %c1 = arith.constant 1 : i64
+      %c2 = arith.constant 2 : i64
+      // expected-error@+1 {{repeat_count and iter_size are mutually exclusive.}}
+      aiex.npu.dma_memcpy_nd (%a[%c0,%c0,%c0][%c1,%c1,%c2][%c0,%c0,%c1]) { metadata = @objectfifo, id = 0 : i64, iter_size = 4 : i64, iter_stride = 2 : i64, repeat_count = 3 : i32 } : memref<8xi32>
     }
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @objectfifo (%tile_0_0, MM2S, 0)

--- a/test/dialect/AIEX/canonicalize_linear.mlir
+++ b/test/dialect/AIEX/canonicalize_linear.mlir
@@ -33,11 +33,11 @@
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_2d
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_2d(%arg0 : memref<2x512xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<2x512xi32>
     }
     %tile = aie.tile(0, 0)
@@ -53,11 +53,11 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_3d
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 60][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 60][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_3d(%arg0 : memref<3x4x5xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 3, 4, 5][0, 20, 5, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][3,4,5][20,5,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<3x4x5xi32>
     }
     %tile = aie.tile(0, 0)
@@ -72,11 +72,11 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @already_linear
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 4096][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 4096][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @already_linear(%arg0 : memref<4096xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1, 4096][0, 0, 0, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1,4096][0,0,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<4096xi32>
     }
     %tile = aie.tile(0, 0)
@@ -91,12 +91,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @no_fold_strided
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 2, 4][0, 0, 3, 1]
+// CHECK-SAME:        [0, 0, 0][1, 2, 4][0, 3, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @no_fold_strided(%arg0 : memref<32xi32>) {
       // stride1=3 != size0=4: genuinely strided rows, cannot fold.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 4][0, 0, 3, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,4][0,3,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<32xi32>
     }
     %tile = aie.tile(0, 0)
@@ -106,18 +106,20 @@ module {
 
 // -----
 
-// Repeat dimension (s3 > 1) is preserved through the fold.
-// sizes=[2,1,2,4] strides=[4096,0,4,1]  ->  sizes=[2,1,1,8] strides=[4096,0,0,1]
+// Strided iteration (iter_size/iter_stride) is preserved through the fold.
+// data sizes=[1,2,4] strides=[0,4,1] (+ iter_size=2, iter_stride=4096)
+//   ->  sizes=[1,1,8] strides=[0,0,1] (iter_* unchanged)
 
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_with_repeat
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][2, 1, 1, 8][4096, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 8][0, 0, 1]
+// CHECK-SAME:        iter_size = 2 : i64, iter_stride = 4096 : i64
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_with_repeat(%arg0 : memref<8192xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][2, 1, 2, 4][4096, 0, 4, 1])
-        { metadata = @of_fromMem, id = 0 : i64 } : memref<8192xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0][1, 2, 4][0, 4, 1])
+        { metadata = @of_fromMem, id = 0 : i64, iter_size = 2 : i64, iter_stride = 4096 : i64 } : memref<8192xi32>
     }
     %tile = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile, MM2S, 0)
@@ -134,11 +136,11 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_bf16
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_bf16(%arg0 : memref<2x512xbf16>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<2x512xbf16>
     }
     %tile = aie.tile(0, 0)
@@ -154,12 +156,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @no_fold_inner_stride
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 2, 4][0, 0, 4, 2]
+// CHECK-SAME:        [0, 0, 0][1, 2, 4][0, 4, 2]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @no_fold_inner_stride(%arg0 : memref<32xi32>) {
       // stride0=2: skips every other element, not a linear scan.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 4][0, 0, 4, 2])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,4][0,4,2])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<32xi32>
     }
     %tile = aie.tile(0, 0)
@@ -175,12 +177,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @no_fold_stride2
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 2, 3, 4][0, 7, 4, 1]
+// CHECK-SAME:        [0, 0, 0][2, 3, 4][7, 4, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @no_fold_stride2(%arg0 : memref<64xi32>) {
       // stride2=7 != size0*size1=4*3=12: non-contiguous outer loop, cannot fold.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 2, 3, 4][0, 7, 4, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][2,3,4][7,4,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<64xi32>
     }
     %tile = aie.tile(0, 0)
@@ -197,12 +199,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_with_offset
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 4][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 4][1, 1, 1024][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_with_offset(%arg0 : memref<2048xi32>) {
       // Offset of 4 elements in d0; sizes/strides fold as normal.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 4][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,4][1,2,512][0,512,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<2048xi32>
     }
     %tile = aie.tile(0, 0)
@@ -228,12 +230,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_d1_offset
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 4096][1, 1, 1, 4096][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 4096][1, 1, 4096][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_d1_offset(%arg0 : memref<128x64xi32>) {
       // Second 64x64 slice: outermost-first offset [0,0,64,0] selects row 64.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 64, 0][1, 1, 64, 64][0, 0, 64, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,64,0][1,64,64][0,64,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<128x64xi32>
     }
     %tile = aie.tile(0, 0)
@@ -257,12 +259,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_d2_offset
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 4096][1, 1, 1, 4096][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 4096][1, 1, 4096][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_d2_offset(%arg0 : memref<4x64x64xi8>) {
       // Second 64x64 tile (index 1 along the batch axis).
-      aiex.npu.dma_memcpy_nd (%arg0[0, 1, 0, 0][1, 1, 64, 64][0, 4096, 64, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[1,0,0][1,64,64][4096,64,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<4x64x64xi8>
     }
     %tile = aie.tile(0, 0)
@@ -277,12 +279,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_packet
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 // CHECK-SAME:        packet = <pkt_type = 0, pkt_id = 5>
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_packet(%arg0 : memref<2x512xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1],
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1],
                                packet = <pkt_id = 5, pkt_type = 0>)
         { metadata = @of_fromMem, id = 0 : i64 } : memref<2x512xi32>
     }
@@ -298,12 +300,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_issue_token
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 // CHECK-SAME:        issue_token = true
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_issue_token(%arg0 : memref<2x512xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1])
         { metadata = @of_fromMem, id = 0 : i64, issue_token = true } : memref<2x512xi32>
     }
     %tile = aie.tile(0, 0)
@@ -323,13 +325,13 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_size1_nonzero_stride1
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 8][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 8][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_size1_nonzero_stride1(%arg0 : memref<32xi32>) {
       // st1=99 (middle stride) with s1=1: the stride is never applied.
       // st2=4==s0=4 is the correct contiguous stride for s2=2.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 2, 1, 4][0, 4, 99, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][2,1,4][4,99,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<32xi32>
     }
     %tile = aie.tile(0, 0)
@@ -348,13 +350,13 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_size2_nonzero_stride2
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 8][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 8][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_size2_nonzero_stride2(%arg0 : memref<32xi32>) {
       // st2=99 (outermost non-repeat stride) with s2=1: the stride is never
       // applied.  st1=4==s0=4 is a valid contiguous stride for s1=2.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 4][0, 99, 4, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,4][99,4,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<32xi32>
     }
     %tile = aie.tile(0, 0)
@@ -371,13 +373,13 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_both_size1_size2_nonzero_strides
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 4][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 4][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_both_size1_size2_nonzero_strides(%arg0 : memref<4xi32>) {
       // st1=99 (middle stride) with s1=1 and st2=7 with s2=1: both strides
       // are never applied; the transfer is a single contiguous run of 4 elems.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1, 4][0, 7, 99, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1,4][7,99,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<4xi32>
     }
     %tile = aie.tile(0, 0)
@@ -387,25 +389,24 @@ module {
 
 // -----
 
-// Non-zero offset in the repeat (d3/outermost) dimension is passed through
-// unchanged to the new op's outermost offset slot.
+// A non-zero iteration position (iter_current) is preserved through the fold,
+// and the data-dim offsets still collapse to d0 as usual.
 //
-// offsets=[5, 0, 0, 0] sizes=[2, 1, 2, 4] strides=[4096, 0, 4, 1]
-// (outermost-first)
-// In innermost-first: offsets=[0,0,0,5], strides=[1,4,0,4096]
-// linearOffset = 0*1 + 0*4 + 0*0 = 0  ->  new offsets [5, 0, 0, 0]
-// sizes -> [2, 1, 1, 8], strides -> [4096, 0, 0, 1]
+// data offsets=[0,0,0] sizes=[1,2,4] strides=[0,4,1]
+//   (+ iter_size=2, iter_stride=4096, iter_current=5)
+// linearOffset = 0  ->  sizes -> [1,1,8], strides -> [0,0,1], iter_* unchanged
 
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_repeat_offset
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [5, 0, 0, 0][2, 1, 1, 8][4096, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 8][0, 0, 1]
+// CHECK-SAME:        iter_current = 5 : i64, iter_size = 2 : i64, iter_stride = 4096 : i64
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_repeat_offset(%arg0 : memref<8192xi32>) {
-      // Outermost offset of 5 repeat-strides; inner dims fold as normal.
-      aiex.npu.dma_memcpy_nd (%arg0[5, 0, 0, 0][2, 1, 2, 4][4096, 0, 4, 1])
-        { metadata = @of_fromMem, id = 0 : i64 } : memref<8192xi32>
+      // Iteration position 5; inner dims fold as normal.
+      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0][1, 2, 4][0, 4, 1])
+        { metadata = @of_fromMem, id = 0 : i64, iter_current = 5 : i64, iter_size = 2 : i64, iter_stride = 4096 : i64 } : memref<8192xi32>
     }
     %tile = aie.tile(0, 0)
     aie.shim_dma_allocation @of_fromMem (%tile, MM2S, 0)
@@ -427,14 +428,14 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_size1_nonzero_offset1
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 297][1, 1, 1, 8][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 297][1, 1, 8][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_size1_nonzero_offset1(%arg0 : memref<512xi32>) {
       // s1=1, so strides[1]=99 is never applied during the transfer, but
       // getOffsetInBytes() uses it to compute the start address.  The fold
       // must preserve offsets[1]*strides[1] = 3*99 = 297 in the d0 slot.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 3, 0][1, 2, 1, 4][0, 4, 99, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,3,0][2,1,4][4,99,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<512xi32>
     }
     %tile = aie.tile(0, 0)
@@ -450,12 +451,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_preserves_metadata
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 // CHECK-SAME:        {id = 7 : i64, metadata = @my_alloc}
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_preserves_metadata(%arg0 : memref<2x512xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1])
         { metadata = @my_alloc, id = 7 : i64 } : memref<2x512xi32>
     }
     %tile = aie.tile(0, 0)
@@ -474,12 +475,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_preserves_burst_length
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 // CHECK-SAME:        burst_length = 64
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_preserves_burst_length(%arg0 : memref<2x512xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1])
         { metadata = @of_fromMem, id = 0 : i64,
           burst_length = 64 : i64 } : memref<2x512xi32>
     }
@@ -498,11 +499,11 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @fold_large_2d_image
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 8294400][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 8294400][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @fold_large_2d_image(%arg0 : memref<8294400xi8>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1080, 7680][0, 0, 7680, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1080,7680][0,7680,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<8294400xi8>
     }
     %tile = aie.tile(0, 0)

--- a/test/dialect/AIEX/canonicalize_linear_dma_task.mlir
+++ b/test/dialect/AIEX/canonicalize_linear_dma_task.mlir
@@ -32,7 +32,7 @@
 // CHECK:         aie.runtime_sequence @mixed_task_and_memcpy_nd
 // -- The dma_memcpy_nd should be folded to linear form.
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 // -- The dma_configure_task op itself must still be present.
 // CHECK:           aiex.dma_configure_task
 // CHECK:           aiex.dma_start_task
@@ -43,7 +43,7 @@ module {
 
     aie.runtime_sequence @mixed_task_and_memcpy_nd(%arg0 : memref<2x512xi32>) {
       // This op is contiguous and should be linearised by --canonicalize.
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<2x512xi32>
 
       // This DMA task op uses a different op (aie.dma_bd) and is not touched
@@ -67,12 +67,12 @@ module {
 // CHECK-LABEL: aie.device(npu1)
 // CHECK:         aie.runtime_sequence @dma_task_style_fold
 // CHECK:           aiex.npu.dma_memcpy_nd
-// CHECK-SAME:        [0, 0, 0, 0][1, 1, 1, 1024][0, 0, 0, 1]
+// CHECK-SAME:        [0, 0, 0][1, 1, 1024][0, 0, 1]
 // CHECK-SAME:        issue_token = true
 module {
   aie.device(npu1) {
     aie.runtime_sequence @dma_task_style_fold(%arg0 : memref<2x512xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 2, 512][0, 0, 512, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,2,512][0,512,1])
         { metadata = @of_fromMem, id = 0 : i64, issue_token = true } : memref<2x512xi32>
     }
     %tile = aie.tile(0, 0)

--- a/test/dialect/AIEX/contiguous_large_dma.mlir
+++ b/test/dialect/AIEX/contiguous_large_dma.mlir
@@ -26,13 +26,13 @@
 // CANON-LABEL: aie.device(npu1)
 // CANON:         aie.runtime_sequence @large_d0_contiguous
 // CANON:           aiex.npu.dma_memcpy_nd
-// CANON-SAME:        [0, 0, 0, 0][1, 1, 1, 2073600][0, 0, 0, 1]
+// CANON-SAME:        [0, 0, 0][1, 1, 2073600][0, 0, 1]
 module {
   aie.device(npu1) {
     // 1080 rows x 1920 i32 words/row = 2073600 elements.
     // d0 = 1920, d1 = 1080: both exceed 1023 but the access is contiguous.
     aie.runtime_sequence @large_d0_contiguous(%arg0 : memref<2073600xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1080, 1920][0, 0, 1920, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1080,1920][0,1920,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<2073600xi32>
     }
     %tile = aie.tile(0, 0)
@@ -48,11 +48,11 @@ module {
 // CANON-LABEL: aie.device(npu1)
 // CANON:         aie.runtime_sequence @large_i8_image
 // CANON:           aiex.npu.dma_memcpy_nd
-// CANON-SAME:        [0, 0, 0, 0][1, 1, 1, 8294400][0, 0, 0, 1]
+// CANON-SAME:        [0, 0, 0][1, 1, 8294400][0, 0, 1]
 module {
   aie.device(npu1) {
     aie.runtime_sequence @large_i8_image(%arg0 : memref<8294400xi8>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1080, 7680][0, 0, 7680, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1080,7680][0,7680,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<8294400xi8>
     }
     %tile = aie.tile(0, 0)
@@ -124,7 +124,7 @@ module {
     // aie-dma-to-npu must lower to linear mode: buffer_length=2073600, all
     // wrap/stride fields zero (d0_size=d1_size=0).
     aie.runtime_sequence @dma_to_npu_large(%arg0 : memref<2073600xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1080, 1920][0, 0, 1920, 1])
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1080,1920][0,1920,1])
         { metadata = @of_fromMem, id = 0 : i64 } : memref<2073600xi32>
     }
     %tile = aie.tile(0, 0)

--- a/test/dialect/AIEX/ctrl_pkt_to_dma.mlir
+++ b/test/dialect/AIEX/ctrl_pkt_to_dma.mlir
@@ -14,7 +14,7 @@
 
 // CHECK-LABEL: aie.device(npu1_1col) {
 // CHECK: aie.runtime_sequence(%[[ARG0:.*]]: memref<?xi32>) {
-// CHECK: aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][1, 1, 1, 3][0, 0, 0, 1]) {id = 0 : i64, issue_token = true, metadata = @ctrlpkt_col0_mm2s_chan0} : memref<?xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0][1, 1, 3][0, 0, 1]) {id = 0 : i64, issue_token = true, metadata = @ctrlpkt_col0_mm2s_chan0} : memref<?xi32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
 
 aie.device(npu1_1col) {
@@ -29,7 +29,7 @@ aie.device(npu1_1col) {
 
 // CHECK-LABEL: aie.device(npu1_1col) {
 // CHECK: aie.runtime_sequence(%[[ARG0:.*]]: memref<?xi32>) {
-// CHECK: aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0, 0][1, 1, 1, 3][0, 0, 0, 1]) {id = 0 : i64, issue_token = true, metadata = @ctrlpkt_col0_mm2s_chan0} : memref<?xi32>
+// CHECK: aiex.npu.dma_memcpy_nd(%[[ARG0]][0, 0, 0][1, 1, 3][0, 0, 1]) {id = 0 : i64, issue_token = true, metadata = @ctrlpkt_col0_mm2s_chan0} : memref<?xi32>
 // CHECK: aiex.npu.sync {channel = 0 : i32, column = 0 : i32, column_num = 1 : i32, direction = 1 : i32, row = 0 : i32, row_num = 1 : i32}
 
 aie.device(npu1_1col) {
@@ -46,11 +46,11 @@ aie.device(npu1_1col) {
 // Check that control packets writes are not combined on npu1
 
 // CHECK-LABEL: aie.device(npu1) {
-// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 3][0, 0, 0, 1])
-// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 3][1, 1, 1, 3][0, 0, 0, 1])
-// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 6][1, 1, 1, 3][0, 0, 0, 1])
-// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 9][1, 1, 1, 3][0, 0, 0, 1])
-// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 12][1, 1, 1, 3][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 3][0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 3][1, 1, 3][0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 6][1, 1, 3][0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 9][1, 1, 3][0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 12][1, 1, 3][0, 0, 1])
 aie.device(npu1) {
   aie.runtime_sequence() {
     aiex.control_packet {address = 0 : ui32, data = array<i32: 100>, opcode = 0 : i32, stream_id = 0 : i32}
@@ -66,7 +66,7 @@ aie.device(npu1) {
 // Check that control packets writes are combined on npu2
 
 // CHECK-LABEL: aie.device(npu2) {
-// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 15][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 15][0, 0, 1])
 aie.device(npu2) {
   aie.runtime_sequence() {
     aiex.control_packet {address = 0 : ui32, data = array<i32: 100>, opcode = 0 : i32, stream_id = 0 : i32}
@@ -82,10 +82,10 @@ aie.device(npu2) {
 // Check that control packets writes are not combined across other operations
 
 // CHECK-LABEL: aie.device(npu2) {
-// CHECK: aiex.npu.dma_memcpy_nd(%{{.*}}[0, 0, 0, 0][1, 1, 1, 6][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%{{.*}}[0, 0, 0][1, 1, 6][0, 0, 1])
 // CHECK: aiex.npu.sync
 // CHECK: aiex.npu.maskwrite32
-// CHECK: aiex.npu.dma_memcpy_nd(%{{.*}}[0, 0, 0, 6][1, 1, 1, 9][0, 0, 0, 1])
+// CHECK: aiex.npu.dma_memcpy_nd(%{{.*}}[0, 0, 6][1, 1, 9][0, 0, 1])
 // CHECK: aiex.npu.sync
 aie.device(npu2) {
   aie.runtime_sequence() {

--- a/test/dialect/AIEX/npu_nd_unranked_memref.mlir
+++ b/test/dialect/AIEX/npu_nd_unranked_memref.mlir
@@ -17,7 +17,7 @@ module {
     %tile_0_0 = aie.tile(0, 0)
     aie.shim_dma_allocation @airMemcpyId9 (%tile_0_0, MM2S, 0)
     aie.runtime_sequence @bare_matmul(%arg0: memref<*xf32>) {
-      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 4, 512][0, 0, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId9} : memref<*xf32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 4, 512][0, 512, 1]) {id = 0 : i64, metadata = @airMemcpyId9} : memref<*xf32>
     }
   }
 }

--- a/test/lower-to-standard/aiex_standard_lowering.mlir
+++ b/test/lower-to-standard/aiex_standard_lowering.mlir
@@ -15,7 +15,7 @@
 module  {
   aie.device(npu1) {
     aie.runtime_sequence(%arg0: memref<16xi32>, %arg1: memref<16xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 64, 1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,64,1]) { metadata = @toMem, id = 1 : i64 } : memref<16xi32>
       aiex.npu.dma_wait {symbol = @toMem}
     }
     %tile_1_0 = aie.tile(1, 0)

--- a/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_12_i8_using_2d_dma_op_with_padding/aie.mlir
@@ -59,8 +59,8 @@ module {
       %c56_i64 = arith.constant 56 : i64
       %c61_i64 = arith.constant 61 : i64
       %c64_i64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c61_i64, %c56_i64][%c0_i64, %c0_i64, %c56_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<61x56xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c61_i64,%c56_i64][%c0_i64,%c56_i64,%c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<61x56xi8>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
 

--- a/test/npu-xrt/add_21_i8_using_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_21_i8_using_dma_op_with_padding/aie.mlir
@@ -66,8 +66,8 @@ module {
       %c1_i64 = arith.constant 1 : i64
       %c32_i64 = arith.constant 32 : i64
       %c64_i64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c32_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c1_i64,%c32_i64][%c0_i64,%c0_i64,%c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi8>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c1_i64,%c64_i64][%c0_i64,%c0_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
 

--- a/test/npu-xrt/add_256_using_dma_op_no_double_buffering/aie.mlir
+++ b/test/npu-xrt/add_256_using_dma_op_no_double_buffering/aie.mlir
@@ -100,8 +100,8 @@ module {
     aie.shim_dma_allocation @data_in (%tile_0_0, MM2S, 0)
     aie.shim_dma_allocation @data_out (%tile_0_0, S2MM, 0)
     aie.runtime_sequence(%arg0: memref<64xi32>, %arg1: memref<32xi32>, %arg2: memref<64xi32>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 0 : i64, metadata = @data_in} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 1, 64][0, 0, 0, 1]) {id = 1 : i64, metadata = @data_out, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,1,64][0,0,1]) {id = 0 : i64, metadata = @data_in} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[0,0,0][1,1,64][0,0,1]) {id = 1 : i64, metadata = @data_out, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @data_out}
     }
   }

--- a/test/npu-xrt/add_314_using_dma_op/aie.mlir
+++ b/test/npu-xrt/add_314_using_dma_op/aie.mlir
@@ -65,8 +65,8 @@ module {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c64_i64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c1_i64,%c64_i64][%c0_i64,%c0_i64,%c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c1_i64,%c64_i64][%c0_i64,%c0_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
 

--- a/test/npu-xrt/add_378_i32_using_dma_op_with_padding/aie.mlir
+++ b/test/npu-xrt/add_378_i32_using_dma_op_with_padding/aie.mlir
@@ -66,8 +66,8 @@ module {
       %c1_i64 = arith.constant 1 : i64
       %c52_i64 = arith.constant 52 : i64
       %c64_i64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c52_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c1_i64, %c64_i64][%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c1_i64,%c52_i64][%c0_i64,%c0_i64,%c1_i64]) {id = 0 : i64, metadata = @objFifo_in0} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c1_i64,%c64_i64][%c0_i64,%c0_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @objFifo_out0}
     }
 

--- a/test/npu-xrt/add_one_cpp_aiecc/aie.mlir
+++ b/test/npu-xrt/add_one_cpp_aiecc/aie.mlir
@@ -50,8 +50,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/add_one_cpp_aiecc_xchesscc/aie.mlir
+++ b/test/npu-xrt/add_one_cpp_aiecc_xchesscc/aie.mlir
@@ -51,8 +51,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/add_one_func_link_with_chess/aie.mlir
+++ b/test/npu-xrt/add_one_func_link_with_chess/aie.mlir
@@ -52,8 +52,8 @@ module {
       %c0  = arith.constant 0 : i64
       %c1  = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/npu-xrt/add_one_func_link_with_peano/aie.mlir
+++ b/test/npu-xrt/add_one_func_link_with_peano/aie.mlir
@@ -54,8 +54,8 @@ module {
       %c1  = arith.constant 1 : i64
       %c8  = arith.constant 8 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/npu-xrt/add_one_objFifo/aie.mlir
+++ b/test/npu-xrt/add_one_objFifo/aie.mlir
@@ -47,8 +47,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/add_one_objFifo_elf/aie.mlir
+++ b/test/npu-xrt/add_one_objFifo_elf/aie.mlir
@@ -47,8 +47,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/add_one_scale_func_link_with_chess/aie.mlir
+++ b/test/npu-xrt/add_one_scale_func_link_with_chess/aie.mlir
@@ -58,8 +58,8 @@ module {
       %c0  = arith.constant 0 : i64
       %c1  = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/npu-xrt/add_one_scale_func_link_with_peano/aie.mlir
+++ b/test/npu-xrt/add_one_scale_func_link_with_peano/aie.mlir
@@ -59,8 +59,8 @@ module {
       %c1  = arith.constant 1 : i64
       %c8  = arith.constant 8 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
-      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) {metadata = @of_out, id = 1 : i64} : memref<64xi32>
+      aiex.npu.dma_memcpy_nd(%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1])  {metadata = @of_in,  id = 0 : i64, issue_token = true} : memref<64xi32>
       aiex.npu.dma_wait {symbol = @of_out}
     }
   }

--- a/test/npu-xrt/add_one_two/aie.mlir
+++ b/test/npu-xrt/add_one_two/aie.mlir
@@ -45,8 +45,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }
@@ -89,8 +89,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/add_one_two_runlist/aie.mlir
+++ b/test/npu-xrt/add_one_two_runlist/aie.mlir
@@ -44,8 +44,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }
@@ -87,8 +87,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/add_one_two_txn/aie.mlir
+++ b/test/npu-xrt/add_one_two_txn/aie.mlir
@@ -47,8 +47,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }
@@ -93,8 +93,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/adjacent_memtile_access/three_memtiles/aie2.py
+++ b/test/npu-xrt/adjacent_memtile_access/three_memtiles/aie2.py
@@ -188,8 +188,8 @@ def my_vector_add():
         # To/from AIE-array data movement
         @runtime_sequence(tensor_ty_c, tensor_ty_c, tensor_ty_c)
         def sequence(A, B, C):
-            npu_dma_memcpy_nd(metadata="in1", bd_id=1, mem=A, sizes=[1, 1, 1, N])
-            npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
+            npu_dma_memcpy_nd(metadata="in1", bd_id=1, mem=A, sizes=[1, 1, N])
+            npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, N])
             npu_dma_wait("out")
 
 

--- a/test/npu-xrt/adjacent_memtile_access/two_memtiles/aie2.py
+++ b/test/npu-xrt/adjacent_memtile_access/two_memtiles/aie2.py
@@ -161,8 +161,8 @@ def my_vector_add():
         # To/from AIE-array data movement
         @runtime_sequence(tensor_ty_c, tensor_ty_c, tensor_ty_c)
         def sequence(A, B, C):
-            npu_dma_memcpy_nd(metadata="in1", bd_id=1, mem=A, sizes=[1, 1, 1, N])
-            npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
+            npu_dma_memcpy_nd(metadata="in1", bd_id=1, mem=A, sizes=[1, 1, N])
+            npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, N])
             npu_dma_wait("out")
 
 

--- a/test/npu-xrt/adjacent_memtile_allocation/onelargefifo_on_2memtile/ext_to_core_L2_placed.py
+++ b/test/npu-xrt/adjacent_memtile_allocation/onelargefifo_on_2memtile/ext_to_core_L2_placed.py
@@ -78,13 +78,13 @@ def external_mem_to_core_L2():
                     metadata=of_in0,
                     bd_id=1,
                     mem=inTensor,
-                    sizes=[1, 1, 1, mem_tile_size],
+                    sizes=[1, 1, mem_tile_size],
                 )
                 npu_dma_memcpy_nd(
                     metadata=of_out0,
                     bd_id=0,
                     mem=outTensor,
-                    sizes=[1, 1, 1, small_size],
+                    sizes=[1, 1, small_size],
                 )
                 # of_out0 will only complete after of_in0 completes, so we just wait on of_out0 instead of both
                 dma_wait(of_out0)

--- a/test/npu-xrt/adjacent_memtile_allocation/onelargefifo_on_3memtile/ext_to_core_L2_placed.py
+++ b/test/npu-xrt/adjacent_memtile_allocation/onelargefifo_on_3memtile/ext_to_core_L2_placed.py
@@ -78,13 +78,13 @@ def external_mem_to_core_L2():
                     metadata=of_in0,
                     bd_id=1,
                     mem=inTensor,
-                    sizes=[1, 1, 1, mem_tile_size],
+                    sizes=[1, 1, mem_tile_size],
                 )
                 npu_dma_memcpy_nd(
                     metadata=of_out0,
                     bd_id=0,
                     mem=outTensor,
-                    sizes=[1, 1, 1, small_size],
+                    sizes=[1, 1, small_size],
                 )
                 # of_out0 will only complete after of_in0 completes, so we just wait on of_out0 instead of both
                 dma_wait(of_out0)

--- a/test/npu-xrt/adjacent_memtile_allocation/twofifo_one_2memtile/ext_to_core_L2_placed.py
+++ b/test/npu-xrt/adjacent_memtile_allocation/twofifo_one_2memtile/ext_to_core_L2_placed.py
@@ -76,13 +76,13 @@ def external_mem_to_core_L2():
                     metadata=of_in0,
                     bd_id=1,
                     mem=inTensor,
-                    sizes=[1, 1, 1, mem_tile_size],
+                    sizes=[1, 1, mem_tile_size],
                 )
                 npu_dma_memcpy_nd(
                     metadata=of_out0,
                     bd_id=0,
                     mem=outTensor,
-                    sizes=[1, 1, 1, mem_tile_size],
+                    sizes=[1, 1, mem_tile_size],
                 )
                 # of_out0 will only complete after of_in0 completes, so we just wait on of_out0 instead of both
                 dma_wait(of_out0)

--- a/test/npu-xrt/bd_chain_repeat_on_memtile/aie2.py
+++ b/test/npu-xrt/bd_chain_repeat_on_memtile/aie2.py
@@ -89,7 +89,7 @@ def my_passthrough_kernel(in1_size, out_size):
                 core_chunk_ty,
                 iter_count=in_num_iterations,
             )
-            split_fifo.set_repeat_count(repeat_counter)
+            split_fifo.set_repeat_count(repeat_counter - 1)
             of_split.append(split_fifo)
 
         split_offsets = [i * elements_per_core_per_chunk for i in range(n_cores)]
@@ -139,11 +139,11 @@ def my_passthrough_kernel(in1_size, out_size):
         def sequence(inTensor, outTensor, notUsed):
             trace_utils.start_trace()
 
-            in_task = shim_dma_single_bd_task(of_in, inTensor, sizes=[1, 1, 1, N])
+            in_task = shim_dma_single_bd_task(of_in, inTensor, sizes=[1, 1, N])
             dma_start_task(in_task)
 
             out_task = shim_dma_single_bd_task(
-                of_out, outTensor, sizes=[1, 1, 1, N_out], issue_token=True
+                of_out, outTensor, sizes=[1, 1, N_out], issue_token=True
             )
             dma_start_task(out_task)
             dma_await_task(out_task)

--- a/test/npu-xrt/cascade_flows/aie.mlir
+++ b/test/npu-xrt/cascade_flows/aie.mlir
@@ -63,8 +63,8 @@ module {
       %c0 = arith.constant 0 : i64
       %c1 = arith.constant 1 : i64
       %c64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/column_specific/aie2.py
+++ b/test/npu-xrt/column_specific/aie2.py
@@ -47,9 +47,9 @@ def my_passthrough():
             @runtime_sequence(vector_ty, vector_ty, vector_ty)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(
-                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N], issue_token=True
+                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N], issue_token=True
                 )
-                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, N])
                 dma_wait(of_in, of_out)
 
     print(ctx.module)

--- a/test/npu-xrt/ctrl_packet_reconfig/aie.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig/aie.mlir
@@ -76,8 +76,8 @@ module {
       %c61_i64 = arith.constant 61 : i64
       %c64_i64 = arith.constant 64 : i64
       aiex.configure @main {
-        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
         aiex.npu.dma_wait { symbol = @objFifo_out0 }
       }
     }

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/aie.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/aie.mlir
@@ -296,8 +296,8 @@ module {
       %c4096_i64 = arith.constant 4096 : i64
       %c64_i64 = arith.constant 64 : i64
       aiex.configure @main {
-        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c4_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 0, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<4x64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c4_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c4_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64], packet = <pkt_id = 0, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64,%c0_i64,%c0_i64][%c4_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<4x64x64xi8>
         aiex.npu.dma_wait { symbol = @objFifo_out0 }
       }
     }

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/aie.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/aie.mlir
@@ -261,15 +261,15 @@ module {
       %c4096_i64 = arith.constant 4096 : i64
       %c64_i64 = arith.constant 64 : i64
       aiex.configure @main {
-        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 0 : i64, metadata = @shim_in_0} : memref<4x64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c1_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 1 : i64, metadata = @shim_in_1} : memref<4x64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c2_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 2 : i64, metadata = @shim_in_2} : memref<4x64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c3_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 3 : i64, metadata = @shim_in_3} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 0 : i64, metadata = @shim_in_0} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg0[%c1_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 1 : i64, metadata = @shim_in_1} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg0[%c2_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 2 : i64, metadata = @shim_in_2} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg0[%c3_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 3 : i64, metadata = @shim_in_3} : memref<4x64x64xi8>
 
-        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 4 : i64, metadata = @shim_out_0, issue_token = true} : memref<4x64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c1_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 5 : i64, metadata = @shim_out_1, issue_token = true} : memref<4x64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c2_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 6 : i64, metadata = @shim_out_2, issue_token = true} : memref<4x64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c3_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 7 : i64, metadata = @shim_out_3, issue_token = true} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64]) {id = 4 : i64, metadata = @shim_out_0, issue_token = true} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg1[%c1_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64]) {id = 5 : i64, metadata = @shim_out_1, issue_token = true} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg1[%c2_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64]) {id = 6 : i64, metadata = @shim_out_2, issue_token = true} : memref<4x64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg1[%c3_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c4096_i64,%c64_i64,%c1_i64]) {id = 7 : i64, metadata = @shim_out_3, issue_token = true} : memref<4x64x64xi8>
         aiex.npu.dma_wait { symbol = @shim_out_0 }
         aiex.npu.dma_wait { symbol = @shim_out_1 }
         aiex.npu.dma_wait { symbol = @shim_out_2 }

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/aie.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/aie.mlir
@@ -73,8 +73,8 @@ module {
       %c61_i64 = arith.constant 61 : i64
       %c64_i64 = arith.constant 64 : i64
       aiex.configure @main {
-        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
-        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
+        aiex.npu.dma_memcpy_nd (%arg1[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
         aiex.npu.dma_wait { symbol = @objFifo_out0 }
       }
     }

--- a/test/npu-xrt/device_width/aie2.py
+++ b/test/npu-xrt/device_width/aie2.py
@@ -46,9 +46,9 @@ def my_passthrough():
             @runtime_sequence(vector_ty, vector_ty, vector_ty)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(
-                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N], issue_token=True
+                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N], issue_token=True
                 )
-                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, N])
                 dma_wait(of_in, of_out)
 
     print(ctx.module)

--- a/test/npu-xrt/dma_complex_dims/aie2.py
+++ b/test/npu-xrt/dma_complex_dims/aie2.py
@@ -128,11 +128,11 @@ def my_passthrough(m, k, K, r, s):
                     metadata=of_in_shim_to_mem,
                     bd_id=1,
                     mem=A,
-                    sizes=[1, 1, 1, m * K],
+                    sizes=[1, 1, m * K],
                 )
 
                 npu_dma_memcpy_nd(
-                    metadata=of_out_mem_to_shim, bd_id=0, mem=C, sizes=[1, 1, 1, m * K]
+                    metadata=of_out_mem_to_shim, bd_id=0, mem=C, sizes=[1, 1, m * K]
                 )
                 # wait only on output since input will have completed before output
                 dma_wait(of_out_mem_to_shim)

--- a/test/npu-xrt/dma_task_large_linear/aie2.py
+++ b/test/npu-xrt/dma_task_large_linear/aie2.py
@@ -57,13 +57,13 @@ def design():
                 in_act_task = dma_configure_task_for(of_in, issue_token=True)
                 with bds(in_act_task) as bd:
                     with bd[0]:
-                        shim_dma_bd(A, sizes=[1, 1, 1, BUFFER_LEN])
+                        shim_dma_bd(A, sizes=[1, 1, BUFFER_LEN])
                         EndOp()
 
                 out_task = dma_configure_task_for(of_out, issue_token=True)
                 with bds(out_task) as bd:
                     with bd[0]:
-                        shim_dma_bd(B, sizes=[1, 1, 1, BUFFER_LEN])
+                        shim_dma_bd(B, sizes=[1, 1, BUFFER_LEN])
                         EndOp()
 
                 dma_start_task(in_act_task, out_task)

--- a/test/npu-xrt/dmabd_task_queue/aie.mlir
+++ b/test/npu-xrt/dmabd_task_queue/aie.mlir
@@ -181,10 +181,10 @@ module {
     aie.shim_dma_allocation @airMemcpyId4 (%tile_0_0, MM2S, 0)
     aie.shim_dma_allocation @airMemcpyId5 (%tile_1_0, MM2S, 0)
     aie.runtime_sequence @six(%arg0: memref<5xi32>, %arg1: memref<96xi32>, %arg2: memref<96xi32>, %arg3: memref<9xi32>) {
-      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 5][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<5xi32>
-      aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0, 0][1, 1, 1, 96][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<96xi32>
-      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 1, 96][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId5} : memref<96xi32>
-      aiex.npu.dma_memcpy_nd(%arg3[0, 0, 0, 0][1, 1, 1, 9][0, 0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId12} : memref<9xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 5][0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<5xi32>
+      aiex.npu.dma_memcpy_nd(%arg1[0, 0, 0][1, 1, 96][0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<96xi32>
+      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0][1, 1, 96][0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId5} : memref<96xi32>
+      aiex.npu.dma_memcpy_nd(%arg3[0, 0, 0][1, 1, 9][0, 0, 1]) {id = 0 : i64, metadata = @airMemcpyId12} : memref<9xi32>
       aiex.npu.sync {channel = 0 : i32, column = 2 : i32, column_num = 1 : i32, direction = 0 : i32, row = 0 : i32, row_num = 1 : i32}
     }
   }

--- a/test/npu-xrt/dynamic_object_fifo/nested_loops/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/nested_loops/aie2.py
@@ -64,9 +64,9 @@ def nested_loops():
             @runtime_sequence(tensor_ty, tensor_ty)
             def sequence(A, C):
                 npu_dma_memcpy_nd(
-                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N], issue_token=True
+                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N], issue_token=True
                 )
-                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, O])
+                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, O])
                 dma_wait(of_in, of_out)
 
     print(ctx.module)

--- a/test/npu-xrt/dynamic_object_fifo/ping_pong/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/ping_pong/aie2.py
@@ -60,8 +60,8 @@ def ping_pong():
             # To/from AIE-array data movement
             @runtime_sequence(tensor_ty, tensor_ty)
             def sequence(A, C):
-                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N])
-                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, N])
                 dma_wait(of_out)
 
     print(ctx.module)

--- a/test/npu-xrt/dynamic_object_fifo/reduction/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/reduction/aie2.py
@@ -64,9 +64,9 @@ def reduction():
             @runtime_sequence(tensor_in_ty, tensor_out_ty)
             def sequence(A, C):
                 npu_dma_memcpy_nd(
-                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N], issue_token=True
+                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N], issue_token=True
                 )
-                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, O])
+                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, O])
                 dma_wait(of_in, of_out)
 
     print(ctx.module)

--- a/test/npu-xrt/dynamic_object_fifo/sliding_window/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/sliding_window/aie2.py
@@ -73,8 +73,8 @@ def sliding_window():
 
             @runtime_sequence(tensor_ty, tensor_ty)
             def sequence(A, C):
-                npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
-                npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, N])
+                npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, N])
                 npu_sync(column=0, row=0, direction=0, channel=0)
 
     print(ctx.module)

--- a/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/sliding_window_conditional/aie2.py
@@ -72,8 +72,8 @@ def sliding_window():
 
             @runtime_sequence(tensor_ty, tensor_ty)
             def sequence(A, C):
-                npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, 1, N])
-                npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata="in", bd_id=1, mem=A, sizes=[1, 1, N])
+                npu_dma_memcpy_nd(metadata="out", bd_id=0, mem=C, sizes=[1, 1, N])
                 dma_wait(of_out)
 
     print(ctx.module)

--- a/test/npu-xrt/dynamic_object_fifo/two_core_sliding_window/aie2.py
+++ b/test/npu-xrt/dynamic_object_fifo/two_core_sliding_window/aie2.py
@@ -91,8 +91,8 @@ def two_core_sliding_window():
 
             @runtime_sequence(tensor_ty, tensor_ty)
             def sequence(A, C):
-                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N])
-                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, N])
                 dma_wait(of_out)
 
     print(ctx.module)

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_bufferx4.mlir
@@ -635,9 +635,9 @@ module {
       memref.assume_alignment %arg0, 64 : memref<16x16xi32>
       memref.assume_alignment %arg1, 64 : memref<16x16xi32>
       memref.assume_alignment %arg2, 64 : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,16,1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg1[0,0,0][1,16,16][0,16,1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[0,0,0][1,16,16][0,16,1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait {symbol = @airMemcpyId12}
     }
   } {sym_name = "segment_0"}

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_cascadex4.mlir
@@ -483,9 +483,9 @@ module {
       memref.assume_alignment %arg0, 64 : memref<16x16xi32>
       memref.assume_alignment %arg1, 64 : memref<16x16xi32>
       memref.assume_alignment %arg2, 64 : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,16,1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg1[0,0,0][1,16,16][0,16,1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[0,0,0][1,16,16][0,16,1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait {symbol = @airMemcpyId12}
     }
   } {sym_name = "segment_0"}

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx1.mlir
@@ -188,9 +188,9 @@ module {
       memref.assume_alignment %arg0, 64 : memref<16x16xi32>
       memref.assume_alignment %arg1, 64 : memref<16x16xi32>
       memref.assume_alignment %arg2, 64 : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,16,1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg1[0,0,0][1,16,16][0,16,1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[0,0,0][1,16,16][0,16,1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait { symbol = @airMemcpyId12}
     }
   } {sym_name = "segment_0"}

--- a/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
+++ b/test/npu-xrt/matrix_multiplication_using_cascade/aie_plainx4.mlir
@@ -519,9 +519,9 @@ module {
       memref.assume_alignment %arg0, 64 : memref<16x16xi32>
       memref.assume_alignment %arg1, 64 : memref<16x16xi32>
       memref.assume_alignment %arg2, 64 : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg1[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 16, 16][0, 0, 16, 1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg0[0,0,0][1,16,16][0,16,1]) {id = 0 : i64, metadata = @airMemcpyId4} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg1[0,0,0][1,16,16][0,16,1]) {id = 1 : i64, metadata = @airMemcpyId5} : memref<16x16xi32>
+      aiex.npu.dma_memcpy_nd (%arg2[0,0,0][1,16,16][0,16,1]) {id = 2 : i64, metadata = @airMemcpyId12, issue_token = true} : memref<16x16xi32>
       aiex.npu.dma_wait {symbol = @airMemcpyId12}
     }
   } {sym_name = "segment_0"}

--- a/test/npu-xrt/nd_memcpy_linear_repeat/aie2.py
+++ b/test/npu-xrt/nd_memcpy_linear_repeat/aie2.py
@@ -58,15 +58,16 @@ def design():
                     metadata=fifo_a,
                     bd_id=1,
                     mem=A,
-                    sizes=[repeat_count, 1, 1, a_len],
-                    strides=[0, 0, 0, 1],
+                    sizes=[1, 1, a_len],
+                    strides=[0, 0, 1],
+                    repeat_count=repeat_count - 1,
                 )
                 npu_dma_memcpy_nd(
                     metadata=fifo_c,
                     bd_id=0,
                     mem=C,
-                    sizes=[1, 1, 1, c_len],
-                    strides=[0, 0, 0, 1],
+                    sizes=[1, 1, c_len],
+                    strides=[0, 0, 1],
                 )
                 dma_wait(fifo_c)
 

--- a/test/npu-xrt/nd_memcpy_transforms/aie2.py
+++ b/test/npu-xrt/nd_memcpy_transforms/aie2.py
@@ -78,25 +78,25 @@ def design():
                     metadata=fifo_a,
                     bd_id=1,
                     mem=A,
-                    offsets=[0, 0, 0, 0],
-                    sizes=[1, a_len // 4, 2, 2],
-                    strides=[0, 2, a_len // 2, 1],
+                    offsets=[0, 0, 0],
+                    sizes=[a_len // 4, 2, 2],
+                    strides=[2, a_len // 2, 1],
                 )
                 npu_dma_memcpy_nd(
                     metadata=fifo_b,
                     bd_id=1,
                     mem=B,
-                    offsets=[0, 0, 0, 0],
-                    sizes=[1, 2, b_len // 4, 2],
-                    strides=[0, 2, 4, 1],
+                    offsets=[0, 0, 0],
+                    sizes=[2, b_len // 4, 2],
+                    strides=[2, 4, 1],
                 )
                 npu_dma_memcpy_nd(
                     metadata=fifo_c,
                     bd_id=0,
                     mem=C,
-                    offsets=[0, 0, 0, c_offset],
-                    sizes=[1, 1, 1, c_len],
-                    strides=[0, 0, 0, 1],
+                    offsets=[0, 0, c_offset],
+                    sizes=[1, 1, c_len],
+                    strides=[0, 0, 1],
                 )
                 dma_wait(fifo_c)
 

--- a/test/npu-xrt/neighbor_tile_memory_access/aie2.py
+++ b/test/npu-xrt/neighbor_tile_memory_access/aie2.py
@@ -67,11 +67,11 @@ def my_vector_bias_add():
                 metadata=of_in0,
                 bd_id=1,
                 mem=inTensor,
-                sizes=[1, 1, 1, PROBLEM_SIZE],
+                sizes=[1, 1, PROBLEM_SIZE],
                 issue_token=True,
             )
             npu_dma_memcpy_nd(
-                metadata=of_out0, bd_id=0, mem=outTensor, sizes=[1, 1, 1, PROBLEM_SIZE]
+                metadata=of_out0, bd_id=0, mem=outTensor, sizes=[1, 1, PROBLEM_SIZE]
             )
             dma_wait(of_in0, of_out0)
 

--- a/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/compute_repeat/aie2.py
@@ -56,7 +56,7 @@ def compute_repeat():
             # AIE-array data movement with object fifos
             of_in = object_fifo("in", ShimTile, ComputeTile, 1, tensor_ty)
             of_out = object_fifo("out", ComputeTile, ShimTile, 1, tensor_ty)
-            of_out.set_repeat_count(repeat_count)
+            of_out.set_repeat_count(repeat_count - 1)
 
             # Compute tile
             @core(ComputeTile)
@@ -72,12 +72,12 @@ def compute_repeat():
             # To/from AIE-array data movement
             @runtime_sequence(tensor_ty, tensor_ty, tensor_out_ty)
             def sequence(A, B, C):
-                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N])
                 npu_dma_memcpy_nd(
                     metadata=of_out,
                     bd_id=0,
                     mem=C,
-                    sizes=[1, 1, 1, data_out_size],
+                    sizes=[1, 1, data_out_size],
                 )
                 # of_out will only complete after of_in completes, so we just wait on of_out instead of both
                 dma_wait(of_out)

--- a/test/npu-xrt/objectfifo_repeat/distribute_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/distribute_repeat/aie2.py
@@ -64,8 +64,8 @@ def distribute_repeat():
             of_in = object_fifo("in", ShimTile, MemTile, 1, in_ty)
             of_in2 = object_fifo("in2", MemTile, ComputeTile2, 2, half_ty)
             of_in3 = object_fifo("in3", MemTile, ComputeTile3, 2, half_ty)
-            of_in2.set_repeat_count(repeat_counter)
-            of_in3.set_repeat_count(repeat_counter)
+            of_in2.set_repeat_count(repeat_counter - 1)
+            of_in3.set_repeat_count(repeat_counter - 1)
             object_fifo_link(of_in, [of_in2, of_in3], [], [0, N // 2])
 
             of_out2 = object_fifo("out2", ComputeTile2, MemTile, 2, half_ty)
@@ -100,9 +100,9 @@ def distribute_repeat():
             # To/from AIE-array data movement
             @runtime_sequence(in_ty, in_ty, out_ty)
             def sequence(A, B, C):
-                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N])
                 npu_dma_memcpy_nd(
-                    metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, out_size]
+                    metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, out_size]
                 )
                 # of_out will only complete after of_in completes, so we just wait on of_out instead of both
                 dma_wait(of_out)

--- a/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/init_values_repeat/aie2.py
@@ -65,7 +65,7 @@ def init_values_repeat():
                     np.arange(1, N + 1, dtype=np.int32),
                 ],
             )
-            of_in.set_repeat_count(memtile_repeat_count)
+            of_in.set_repeat_count(memtile_repeat_count - 1)
             of_out = object_fifo("out", ComputeTile, ShimTile, 1, tensor_ty)
 
             # Compute tile
@@ -87,7 +87,7 @@ def init_values_repeat():
                     metadata=of_out,
                     bd_id=0,
                     mem=C,
-                    sizes=[1, 1, 1, data_out_size],
+                    sizes=[1, 1, data_out_size],
                 )
                 # of_out will only complete after of_in completes, so we just wait on of_out instead of both
                 dma_wait(of_out)

--- a/test/npu-xrt/objectfifo_repeat/simple_repeat/aie2.py
+++ b/test/npu-xrt/objectfifo_repeat/simple_repeat/aie2.py
@@ -55,18 +55,18 @@ def simple_repeat():
             # AIE-array data movement with object fifos
             of_in = object_fifo("in", ShimTile, MemTile, 1, tensor_ty)
             of_out = object_fifo("out", MemTile, ShimTile, 1, tensor_ty)
-            of_out.set_repeat_count(memtile_repeat_count)
+            of_out.set_repeat_count(memtile_repeat_count - 1)
             object_fifo_link(of_in, of_out)
 
             # To/from AIE-array data movement
             @runtime_sequence(tensor_ty, tensor_ty, tensor_out_ty)
             def sequence(A, B, C):
-                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N])
                 npu_dma_memcpy_nd(
                     metadata=of_out,
                     bd_id=0,
                     mem=C,
-                    sizes=[1, 1, 1, data_out_size],
+                    sizes=[1, 1, data_out_size],
                 )
                 # of_out will only complete after of_in completes, so we just wait on of_out instead of both
                 dma_wait(of_out)

--- a/test/npu-xrt/packet_flow/aie.mlir
+++ b/test/npu-xrt/packet_flow/aie.mlir
@@ -71,8 +71,8 @@ module {
       %c56_i64 = arith.constant 56 : i64
       %c61_i64 = arith.constant 61 : i64
       %c64_i64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
 

--- a/test/npu-xrt/packet_flow_fanin/aie.mlir
+++ b/test/npu-xrt/packet_flow_fanin/aie.mlir
@@ -93,9 +93,9 @@ module {
       %c1_i64 = arith.constant 1 : i64
       %c64_i64 = arith.constant 64 : i64
       %c128_i64 = arith.constant 128 : i64
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<128x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c64_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 0>) {id = 1 : i64, metadata = @objFifo_in1} : memref<128x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c128_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 2 : i64, metadata = @objFifo_out0, issue_token = true} : memref<128x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<128x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c64_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64], packet = <pkt_id = 7, pkt_type = 0>) {id = 1 : i64, metadata = @objFifo_in1} : memref<128x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c128_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64]) {id = 2 : i64, metadata = @objFifo_out0, issue_token = true} : memref<128x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
 

--- a/test/npu-xrt/packet_flow_fanout/aie.mlir
+++ b/test/npu-xrt/packet_flow_fanout/aie.mlir
@@ -119,10 +119,10 @@ module {
       %c1_i64 = arith.constant 1 : i64
       %c64_i64 = arith.constant 64 : i64
       // Packet-flow fanout happening at shim dma channel @objFifo_in0, where packet id 3 and 7 go to tile_0_1's S2MM DMA channel 0 and 2, respectively
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<128x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c64_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 7, pkt_type = 0>) {id = 1 : i64, metadata = @objFifo_in0} : memref<128x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 2 : i64, metadata = @objFifo_out0, issue_token = true} : memref<128x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c64_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 3 : i64, metadata = @objFifo_out1, issue_token = true} : memref<128x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<128x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64,%c64_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64], packet = <pkt_id = 7, pkt_type = 0>) {id = 1 : i64, metadata = @objFifo_in0} : memref<128x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c0_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64]) {id = 2 : i64, metadata = @objFifo_out0, issue_token = true} : memref<128x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64,%c64_i64,%c0_i64][%c1_i64,%c64_i64,%c64_i64][%c0_i64,%c64_i64,%c1_i64]) {id = 3 : i64, metadata = @objFifo_out1, issue_token = true} : memref<128x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
       aiex.npu.dma_wait { symbol = @objFifo_out1 }
     }

--- a/test/npu-xrt/runtime_cumsum/aie.mlir
+++ b/test/npu-xrt/runtime_cumsum/aie.mlir
@@ -92,8 +92,8 @@ module {
         aie.runtime_sequence @sequence(%xy: memref<128xi32>) {
             aiex.npu.rtp_write(@rtp2, 0, 1)
             // read first row and write to second row
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 0][1, 1, 1, 16][0, 0, 0, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 16][1, 1, 1, 16][0, 0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0][1, 1, 16][0, 0, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 16][1, 1, 16][0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
             aiex.npu.dma_wait {symbol = @mem_out}
             //┌───────────────────────────────┐
             //│Output:                        │
@@ -107,8 +107,8 @@ module {
 
             // read first two rows and write to the third row
             aiex.npu.rtp_write(@rtp2, 1, 2)
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 0][1, 1, 2, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 32][1, 1, 1, 16][0, 0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0][1, 2, 16][0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 32][1, 1, 16][0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
             aiex.npu.dma_wait {symbol = @mem_out}
             //┌───────────────────────────────┐
             //│Output:                        │
@@ -124,24 +124,24 @@ module {
 
             // read first three rows and write to the 4th row
             aiex.npu.rtp_write(@rtp2, 2, 3)
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 0][1, 1, 3, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 48][1, 1, 1, 16][0, 0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0][1, 3, 16][0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 48][1, 1, 16][0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
             aiex.npu.dma_wait {symbol = @mem_out}
             aiex.npu.rtp_write(@rtp2, 3, 4)
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 0][1, 1, 4, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 64][1, 1, 1, 16][0, 0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0][1, 4, 16][0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 64][1, 1, 16][0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
             aiex.npu.dma_wait {symbol = @mem_out}
             aiex.npu.rtp_write(@rtp2, 4, 5)
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 0][1, 1, 5, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 80][1, 1, 1, 16][0, 0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0][1, 5, 16][0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 80][1, 1, 16][0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
             aiex.npu.dma_wait {symbol = @mem_out}
             aiex.npu.rtp_write(@rtp2, 5, 6)
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 0][1, 1, 6, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 96][1, 1, 1, 16][0, 0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0][1, 6, 16][0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 96][1, 1, 16][0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
             aiex.npu.dma_wait {symbol = @mem_out}
             aiex.npu.rtp_write(@rtp2, 6, 7)
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 0][1, 1, 7, 16][0, 0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
-            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0, 112][1, 1, 1, 16][0, 0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 0][1, 7, 16][0, 16, 1]) {id = 0 : i64, metadata = @mem_In} : memref<128xi32>
+            aiex.npu.dma_memcpy_nd(%xy[0, 0, 112][1, 1, 16][0, 0, 1]) {id = 2 : i64, metadata = @mem_out} : memref<128xi32>
             aiex.npu.dma_wait {symbol = @mem_out}
         }
     }

--- a/test/npu-xrt/static_L1_init/aie.mlir
+++ b/test/npu-xrt/static_L1_init/aie.mlir
@@ -141,8 +141,8 @@ module {
     }
     aie.shim_dma_allocation @in1 (%tile_0_0, MM2S, 0)
     aie.runtime_sequence(%arg0: memref<256xi32>, %arg1: memref<256xi32>, %arg2: memref<256xi32>) {
-      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1]) {id = 1 : i64, metadata = @in1} : memref<256xi32>
-      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1]) {id = 0 : i64, metadata = @out} : memref<256xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 256][0, 0, 1]) {id = 1 : i64, metadata = @in1} : memref<256xi32>
+      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0][1, 1, 256][0, 0, 1]) {id = 0 : i64, metadata = @out} : memref<256xi32>
       aiex.npu.dma_wait {symbol = @out}
     }
     %mem_0_2 = aie.mem(%tile_0_2) {

--- a/test/npu-xrt/sync_task_complete_token/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token/aie2.py
@@ -71,9 +71,9 @@ def design():
                             metadata=fifo_input,
                             bd_id=j,
                             mem=input,
-                            offsets=[0, 0, 0, i * 16 + j],
-                            sizes=[1, 1, 1, 1],
-                            strides=[0, 0, 0, 1],
+                            offsets=[0, 0, i * 16 + j],
+                            sizes=[1, 1, 1],
+                            strides=[0, 0, 1],
                             issue_token=True,
                         )
                         dma_wait(fifo_input)
@@ -83,9 +83,9 @@ def design():
                         metadata=fifo_output,
                         bd_id=0,
                         mem=output,
-                        offsets=[0, 0, 0, i],
-                        sizes=[1, 1, 1, 1],
-                        strides=[0, 0, 0, 1],
+                        offsets=[0, 0, i],
+                        sizes=[1, 1, 1],
+                        strides=[0, 0, 1],
                     )
                     dma_wait(fifo_output)
 

--- a/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
+++ b/test/npu-xrt/sync_task_complete_token_bd_chaining/aie2.py
@@ -134,9 +134,9 @@ def design():
                         metadata=fifo_output,
                         bd_id=0,
                         mem=output,
-                        offsets=[0, 0, 0, i],
-                        sizes=[1, 1, 1, 1],
-                        strides=[0, 0, 0, 1],
+                        offsets=[0, 0, i],
+                        sizes=[1, 1, 1],
+                        strides=[0, 0, 1],
                     )
                     dma_wait(fifo_output)
 

--- a/test/npu-xrt/tile_mapped_read/aie.mlir
+++ b/test/npu-xrt/tile_mapped_read/aie.mlir
@@ -59,8 +59,8 @@ module {
       %c64 = arith.constant 64 : i64
       // Set Core_Processor_Bus register Enable = 1. Without this the core will hang on access to the processor bus
       aiex.npu.maskwrite32 {address = 0x32038 : ui32, row = 2 : i32, column = 0 : i32, value = 0x1 : ui32, mask = 0x1 : ui32}
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c64][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<64xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c64][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<64xi32>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/two_col/aie.mlir
+++ b/test/npu-xrt/two_col/aie.mlir
@@ -140,8 +140,8 @@ module {
       aiex.npu.rtp_write(@rtp1, 1, 0)
       aiex.npu.rtp_write(@rtp2, 1, 0)
       aiex.npu.rtp_write(@rtp3, 1, 0)
-      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2048][%c0,%c0,%c0, %c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<2048xi32>
-      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c2048][%c0,%c0,%c0, %c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<2048xi32>
+      aiex.npu.dma_memcpy_nd (%out[%c0,%c0,%c0][%c1,%c1,%c2048][%c0,%c0,%c1]) { metadata = @objFifo_out0, id = 1 : i64, issue_token = true } : memref<2048xi32>
+      aiex.npu.dma_memcpy_nd (%in[%c0,%c0,%c0][%c1,%c1,%c2048][%c0,%c0,%c1]) { metadata = @objFifo_in0, id = 0 : i64 } : memref<2048xi32>
       aiex.npu.dma_wait {symbol = @objFifo_out0}
     }
   }

--- a/test/npu-xrt/vec_vec_add_memtile_init/aie.mlir
+++ b/test/npu-xrt/vec_vec_add_memtile_init/aie.mlir
@@ -152,8 +152,8 @@ module {
     }
     aie.shim_dma_allocation @in1 (%tile_0_0, MM2S, 0)
     aie.runtime_sequence(%arg0: memref<256xi32>, %arg1: memref<256xi32>, %arg2: memref<256xi32>) {
-      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1]) {id = 1 : i64, metadata = @in1} : memref<256xi32>
-      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1]) {id = 0 : i64, metadata = @out} : memref<256xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 256][0, 0, 1]) {id = 1 : i64, metadata = @in1} : memref<256xi32>
+      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0][1, 1, 256][0, 0, 1]) {id = 0 : i64, metadata = @out} : memref<256xi32>
       aiex.npu.dma_wait {symbol = @out}
     }
     %mem_0_2 = aie.mem(%tile_0_2) {

--- a/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
+++ b/test/npu-xrt/vec_vec_add_objfifo_init/aie2.py
@@ -85,8 +85,8 @@ def my_vector_add():
         # To/from AIE-array data movement
         @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
         def sequence(A, B, C):
-            npu_dma_memcpy_nd(metadata=of_in2, bd_id=2, mem=B, sizes=[1, 1, 1, N])
-            npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+            npu_dma_memcpy_nd(metadata=of_in2, bd_id=2, mem=B, sizes=[1, 1, N])
+            npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, N])
             # of_out will only complete after of_in completes, so we just wait on of_out instead of both
             dma_wait(of_out)
 

--- a/test/npu-xrt/vec_vec_add_tile_init/aie.mlir
+++ b/test/npu-xrt/vec_vec_add_tile_init/aie.mlir
@@ -137,8 +137,8 @@ module {
     }
     aie.shim_dma_allocation @in1 (%tile_0_0, MM2S, 0)
     aie.runtime_sequence(%arg0: memref<256xi32>, %arg1: memref<256xi32>, %arg2: memref<256xi32>) {
-      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1]) {id = 1 : i64, metadata = @in1} : memref<256xi32>
-      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1]) {id = 0 : i64, metadata = @out} : memref<256xi32>
+      aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 256][0, 0, 1]) {id = 1 : i64, metadata = @in1} : memref<256xi32>
+      aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0][1, 1, 256][0, 0, 1]) {id = 0 : i64, metadata = @out} : memref<256xi32>
       aiex.npu.dma_wait {symbol = @out}
     }
     %mem_0_2 = aie.mem(%tile_0_2) {

--- a/test/objectFifo-stateful-transform/bd_chain_on_memtile/bd_chain_with_repeat_count.mlir
+++ b/test/objectFifo-stateful-transform/bd_chain_on_memtile/bd_chain_with_repeat_count.mlir
@@ -62,6 +62,6 @@ module {
     %tile11 = aie.tile(1, 1)
     %tile13 = aie.tile(1, 3)
 
-    aie.objectfifo @of1 (%tile11, {%tile13}, 1 : i32) {repeat_count = 3 : i32, iter_count = 5 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile11, {%tile13}, 1 : i32) {repeat_count = 2 : i32, iter_count = 5 : i32} : !aie.objectfifo<memref<16xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/dma_transformations/memtile_padding_test.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/memtile_padding_test.mlir
@@ -12,10 +12,6 @@
     // CHECK: %{{.*}}tile_0_0 = aie.tile(0, 0)
     // CHECK: %{{.*}}tile_0_1 = aie.tile(0, 1)
     // CHECK: %{{.*}}tile_0_2 = aie.tile(0, 2)
-    // CHECK: %[[VAL_2:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_0"} : memref<64x64xi8>
-    // CHECK: %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_1"} : memref<64x64xi8>
-    // CHECK: %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock_0"}
-    // CHECK: %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock_0"}
     // CHECK: %[[VAL_6:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_out1_buff_0"} : memref<64x64xi8>
     // CHECK: %[[VAL_7:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_out1_buff_1"} : memref<64x64xi8>
     // CHECK: %[[VAL_8:.*]] = aie.lock(%{{.*}}tile_0_2, 2) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock_0"}
@@ -24,6 +20,10 @@
     // CHECK: %[[VAL_11:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_in1_cons_buff_1"} : memref<64x64xi8>
     // CHECK: %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_0_2, 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock_0"}
     // CHECK: %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_0_2, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock_0"}
+    // CHECK: %[[VAL_2:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_0"} : memref<64x64xi8>
+    // CHECK: %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_1"} : memref<64x64xi8>
+    // CHECK: %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock_0"}
+    // CHECK: %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock_0"}
     // CHECK: %[[VAL_14:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_in1_buff_0"} : memref<64x64xi8>
     // CHECK: %[[VAL_15:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_in1_buff_1"} : memref<64x64xi8>
     // CHECK: %[[VAL_16:.*]] = aie.lock(%{{.*}}tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in1_prod_lock_0"}

--- a/test/objectFifo-stateful-transform/dma_transformations/memtile_padding_test.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/memtile_padding_test.mlir
@@ -9,136 +9,132 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: aie-opt --aie-objectFifo-stateful-transform %s | FileCheck %s
-    // CHECK:       %[[SHIM_TILE:.*]] = aie.tile(0, 0)
-    // CHECK:       %[[MEM_TILE:.*]] = aie.tile(0, 1)
-    // CHECK:       %[[COMP_TILE:.*]] = aie.tile(0, 2)
-    // CHECK-DAG:   %[[OUT1_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_out1_cons_buff_0"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[OUT1_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_out1_cons_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[OUT1_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 2) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock_0"}
-    // CHECK-DAG:   %[[OUT1_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock_0"}
-    // CHECK-DAG:   %[[OUT1_BUFF_0:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_out1_buff_0"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[OUT1_BUFF_1:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_out1_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[OUT1_PROD_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 2) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock_0"}
-    // CHECK-DAG:   %[[OUT1_CONS_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_lock_0"}
-    // CHECK-DAG:   %[[IN1_CONS_BUFF_0:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_in1_cons_buff_0"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[IN1_CONS_BUFF_1:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_in1_cons_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[IN1_CONS_PROD_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock_0"}
-    // CHECK-DAG:   %[[IN1_CONS_CONS_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock_0"}
-    // CHECK-DAG:   %[[IN1_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_in1_buff_0"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[IN1_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_in1_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[IN1_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 0) {init = 2 : i32, sym_name = "objFifo_in1_prod_lock_0"}
-    // CHECK-DAG:   %[[IN1_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_lock_0"}
-    // CHECK-DAG:   %[[OUT0_CONS_PROD_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 2)
-    // CHECK-DAG:   %[[OUT0_CONS_CONS_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 3)
-    // CHECK-DAG:   %[[IN0_PROD_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 0)
-    // CHECK-DAG:   %[[IN0_CONS_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 1)
-    // CHECK-DAG:   aie.flow(%[[SHIM_TILE]], DMA : 0, %[[MEM_TILE]], DMA : 0)
-    // CHECK-DAG:   aie.flow(%[[MEM_TILE]], DMA : 0, %[[COMP_TILE]], DMA : 0)
-    // CHECK-DAG:   aie.flow(%[[COMP_TILE]], DMA : 0, %[[MEM_TILE]], DMA : 1)
-    // CHECK-DAG:   aie.flow(%[[MEM_TILE]], DMA : 1, %[[SHIM_TILE]], DMA : 0)
-    // CHECK:       %core_0_2 = aie.core(%[[COMP_TILE]]) {
-    // CHECK:         aie.use_lock(%[[IN1_CONS_CONS_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.use_lock(%[[OUT1_PROD_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         %c0 = arith.constant 0 : index
-    // CHECK:         %c1 = arith.constant 1 : index
-    // CHECK:         %c64 = arith.constant 64 : index
-    // CHECK:         %c12_i8 = arith.constant 12 : i8
-    // CHECK:         scf.for %arg0 = %c0 to %c64 step %c1 {
-    // CHECK:           scf.for %arg1 = %c0 to %c64 step %c1 {
-    // CHECK:             %0 = memref.load %[[IN1_CONS_BUFF_0]][%arg0, %arg1] : memref<64x64xi8>
-    // CHECK:             %1 = arith.addi %0, %c12_i8 : i8
-    // CHECK:             memref.store %1, %[[IN1_CONS_BUFF_0]][%arg0, %arg1] : memref<64x64xi8>
-    // CHECK:           }
-    // CHECK:         }
-    // CHECK:         aie.use_lock(%[[IN1_CONS_PROD_LOCK]], Release, 1)
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_LOCK]], Release, 1)
-    // CHECK:         aie.end
-    // CHECK:       }
-    // CHECK:       aie.runtime_sequence(%arg0: memref<61x56xi8>, %arg1: memref<32xi8>, %arg2: memref<64x64xi8>) {
-    // CHECK:         aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 61, 56][0, 0, 56, 1]) {id = 0 : i64, metadata = @objFifo_in0_shim_alloc} : memref<61x56xi8>
-    // CHECK:         aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0, 0][1, 1, 64, 64][0, 0, 64, 1]) {id = 1 : i64, issue_token = true, metadata = @objFifo_out0_shim_alloc} : memref<64x64xi8>
-    // CHECK:         aiex.npu.dma_wait {symbol = @objFifo_out0_shim_alloc}
-    // CHECK:       }
-    // CHECK:       aie.shim_dma_allocation @objFifo_in0_shim_alloc(%shim_noc_tile_0_0, MM2S, 0)
-    // CHECK:       %memtile_dma_0_1 = aie.memtile_dma(%[[MEM_TILE]]) {
-    // CHECK:         %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
-    // CHECK:       ^bb1:
-    // CHECK:         aie.use_lock(%[[IN1_PROD_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[IN1_BUFF_0]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[IN1_CONS_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb2
-    // CHECK:       ^bb2:
-    // CHECK:         aie.use_lock(%[[IN1_PROD_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[IN1_BUFF_1]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[IN1_CONS_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb1
-    // CHECK:       ^bb3:
-    // CHECK:         %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
-    // CHECK:       ^bb4:
-    // CHECK:         aie.use_lock(%[[IN1_CONS_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[IN1_BUFF_0]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[IN1_PROD_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb5
-    // CHECK:       ^bb5:
-    // CHECK:         aie.use_lock(%[[IN1_CONS_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[IN1_BUFF_1]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[IN1_PROD_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb4
-    // CHECK:       ^bb6:
-    // CHECK:         %2 = aie.dma_start(S2MM, 1, ^bb7, ^bb9)
-    // CHECK:       ^bb7:
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[OUT1_CONS_BUFF_0]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_CONS_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb8
-    // CHECK:       ^bb8:
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[OUT1_CONS_BUFF_1]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_CONS_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb7
-    // CHECK:       ^bb9:
-    // CHECK:         %3 = aie.dma_start(MM2S, 1, ^bb10, ^bb12)
-    // CHECK:       ^bb10:
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_CONS_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[OUT1_CONS_BUFF_0]] : memref<64x64xi8>, 0, 4096, [<size = 61, stride = 56>, <size = 56, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>, <const_pad_before = 4, const_pad_after = 4>])
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_PROD_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb11
-    // CHECK:       ^bb11:
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_CONS_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[OUT1_CONS_BUFF_1]] : memref<64x64xi8>, 0, 4096, [<size = 61, stride = 56>, <size = 56, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>, <const_pad_before = 4, const_pad_after = 4>])
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_PROD_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb10
-    // CHECK:       ^bb12:
-    // CHECK:         aie.end
-    // CHECK:       }
-    // CHECK:       %mem_0_2 = aie.mem(%[[COMP_TILE]]) {
-    // CHECK:         %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
-    // CHECK:       ^bb1:
-    // CHECK:         aie.use_lock(%[[IN1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[IN1_CONS_BUFF_0]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[IN1_CONS_CONS_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb2
-    // CHECK:       ^bb2:
-    // CHECK:         aie.use_lock(%[[IN1_CONS_PROD_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[IN1_CONS_BUFF_1]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[IN1_CONS_CONS_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb1
-    // CHECK:       ^bb3:
-    // CHECK:         %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
-    // CHECK:       ^bb4:
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[OUT1_BUFF_0]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[OUT1_PROD_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb5
-    // CHECK:       ^bb5:
-    // CHECK:         aie.use_lock(%[[OUT1_CONS_LOCK]], AcquireGreaterEqual, 1)
-    // CHECK:         aie.dma_bd(%[[OUT1_BUFF_1]] : memref<64x64xi8>, 0, 4096)
-    // CHECK:         aie.use_lock(%[[OUT1_PROD_LOCK]], Release, 1)
-    // CHECK:         aie.next_bd ^bb4
-    // CHECK:       ^bb6:
-    // CHECK:         aie.end
-    // CHECK:       }
-    // CHECK:       aie.shim_dma_allocation @objFifo_out0_shim_alloc(%shim_noc_tile_0_0, S2MM, 0)
+    // CHECK: %{{.*}}tile_0_0 = aie.tile(0, 0)
+    // CHECK: %{{.*}}tile_0_1 = aie.tile(0, 1)
+    // CHECK: %{{.*}}tile_0_2 = aie.tile(0, 2)
+    // CHECK: %[[VAL_2:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_0"} : memref<64x64xi8>
+    // CHECK: %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_out1_cons_buff_1"} : memref<64x64xi8>
+    // CHECK: %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_0_1, 2) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock_0"}
+    // CHECK: %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_0_1, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock_0"}
+    // CHECK: %[[VAL_6:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_out1_buff_0"} : memref<64x64xi8>
+    // CHECK: %[[VAL_7:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_out1_buff_1"} : memref<64x64xi8>
+    // CHECK: %[[VAL_8:.*]] = aie.lock(%{{.*}}tile_0_2, 2) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock_0"}
+    // CHECK: %[[VAL_9:.*]] = aie.lock(%{{.*}}tile_0_2, 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_lock_0"}
+    // CHECK: %[[VAL_10:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_in1_cons_buff_0"} : memref<64x64xi8>
+    // CHECK: %[[VAL_11:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "objFifo_in1_cons_buff_1"} : memref<64x64xi8>
+    // CHECK: %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_0_2, 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock_0"}
+    // CHECK: %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_0_2, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock_0"}
+    // CHECK: %[[VAL_14:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_in1_buff_0"} : memref<64x64xi8>
+    // CHECK: %[[VAL_15:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "objFifo_in1_buff_1"} : memref<64x64xi8>
+    // CHECK: %[[VAL_16:.*]] = aie.lock(%{{.*}}tile_0_1, 0) {init = 2 : i32, sym_name = "objFifo_in1_prod_lock_0"}
+    // CHECK: %[[VAL_17:.*]] = aie.lock(%{{.*}}tile_0_1, 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_lock_0"}
+    // CHECK: aie.flow(%{{.*}}tile_0_0, DMA : 0, %{{.*}}tile_0_1, DMA : 0)
+    // CHECK: aie.flow(%{{.*}}tile_0_1, DMA : 0, %{{.*}}tile_0_2, DMA : 0)
+    // CHECK: aie.flow(%{{.*}}tile_0_2, DMA : 0, %{{.*}}tile_0_1, DMA : 1)
+    // CHECK: aie.flow(%{{.*}}tile_0_1, DMA : 1, %{{.*}}tile_0_0, DMA : 0)
+    // CHECK: %core_0_2 = aie.core(%{{.*}}tile_0_2) {
+    // CHECK:   aie.use_lock(%[[VAL_13]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.use_lock(%[[VAL_8]], AcquireGreaterEqual, 1)
+    // CHECK:   %c0 = arith.constant 0 : index
+    // CHECK:   %c1 = arith.constant 1 : index
+    // CHECK:   %c64 = arith.constant 64 : index
+    // CHECK:   %c12_i8 = arith.constant 12 : i8
+    // CHECK:   scf.for %arg0 = %c0 to %c64 step %c1 {
+    // CHECK:     scf.for %arg1 = %c0 to %c64 step %c1 {
+    // CHECK:       %0 = memref.load %[[VAL_10]][%arg0, %arg1] : memref<64x64xi8>
+    // CHECK:       %1 = arith.addi %0, %c12_i8 : i8
+    // CHECK:       memref.store %1, %[[VAL_10]][%arg0, %arg1] : memref<64x64xi8>
+    // CHECK:     }
+    // CHECK:   }
+    // CHECK:   aie.use_lock(%[[VAL_12]], Release, 1)
+    // CHECK:   aie.use_lock(%[[VAL_9]], Release, 1)
+    // CHECK:   aie.end
+    // CHECK: }
+    // CHECK: aie.runtime_sequence(%arg0: memref<61x56xi8>, %arg1: memref<32xi8>, %arg2: memref<64x64xi8>) {
+    // CHECK:   aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 61, 56][0, 56, 1]) {id = 0 : i64, metadata = @objFifo_in0_shim_alloc} : memref<61x56xi8>
+    // CHECK:   aiex.npu.dma_memcpy_nd(%arg2[0, 0, 0][1, 64, 64][0, 64, 1]) {id = 1 : i64, issue_token = true, metadata = @objFifo_out0_shim_alloc} : memref<64x64xi8>
+    // CHECK:   aiex.npu.dma_wait {symbol = @objFifo_out0_shim_alloc}
+    // CHECK: }
+    // CHECK: aie.shim_dma_allocation @objFifo_in0_shim_alloc(%shim_noc_tile_0_0, MM2S, 0)
+    // CHECK: %memtile_dma_0_1 = aie.memtile_dma(%{{.*}}tile_0_1) {
+    // CHECK:   %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+    // CHECK: ^bb1:
+    // CHECK:   aie.use_lock(%[[VAL_16]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_14]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_17]], Release, 1)
+    // CHECK:   aie.next_bd ^bb2
+    // CHECK: ^bb2:
+    // CHECK:   aie.use_lock(%[[VAL_16]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_15]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_17]], Release, 1)
+    // CHECK:   aie.next_bd ^bb1
+    // CHECK: ^bb3:
+    // CHECK:   %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
+    // CHECK: ^bb4:
+    // CHECK:   aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_14]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_16]], Release, 1)
+    // CHECK:   aie.next_bd ^bb5
+    // CHECK: ^bb5:
+    // CHECK:   aie.use_lock(%[[VAL_17]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_15]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_16]], Release, 1)
+    // CHECK:   aie.next_bd ^bb4
+    // CHECK: ^bb6:
+    // CHECK:   %2 = aie.dma_start(S2MM, 1, ^bb7, ^bb9)
+    // CHECK: ^bb7:
+    // CHECK:   aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_2]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_5]], Release, 1)
+    // CHECK:   aie.next_bd ^bb8
+    // CHECK: ^bb8:
+    // CHECK:   aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_3]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_5]], Release, 1)
+    // CHECK:   aie.next_bd ^bb7
+    // CHECK: ^bb9:
+    // CHECK:   %3 = aie.dma_start(MM2S, 1, ^bb10, ^bb12)
+    // CHECK: ^bb10:
+    // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_2]] : memref<64x64xi8>, 0, 4096, [<size = 61, stride = 56>, <size = 56, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>, <const_pad_before = 4, const_pad_after = 4>])
+    // CHECK:   aie.use_lock(%[[VAL_4]], Release, 1)
+    // CHECK:   aie.next_bd ^bb11
+    // CHECK: ^bb11:
+    // CHECK:   aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_3]] : memref<64x64xi8>, 0, 4096, [<size = 61, stride = 56>, <size = 56, stride = 1>], [<const_pad_before = 2, const_pad_after = 1>, <const_pad_before = 4, const_pad_after = 4>])
+    // CHECK:   aie.use_lock(%[[VAL_4]], Release, 1)
+    // CHECK:   aie.next_bd ^bb10
+    // CHECK: ^bb12:
+    // CHECK:   aie.end
+    // CHECK: }
+    // CHECK: %mem_0_2 = aie.mem(%{{.*}}tile_0_2) {
+    // CHECK:   %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)
+    // CHECK: ^bb1:
+    // CHECK:   aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_10]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_13]], Release, 1)
+    // CHECK:   aie.next_bd ^bb2
+    // CHECK: ^bb2:
+    // CHECK:   aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_11]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_13]], Release, 1)
+    // CHECK:   aie.next_bd ^bb1
+    // CHECK: ^bb3:
+    // CHECK:   %1 = aie.dma_start(MM2S, 0, ^bb4, ^bb6)
+    // CHECK: ^bb4:
+    // CHECK:   aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_6]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_8]], Release, 1)
+    // CHECK:   aie.next_bd ^bb5
+    // CHECK: ^bb5:
+    // CHECK:   aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
+    // CHECK:   aie.dma_bd(%[[VAL_7]] : memref<64x64xi8>, 0, 4096)
+    // CHECK:   aie.use_lock(%[[VAL_8]], Release, 1)
+    // CHECK:   aie.next_bd ^bb4
+    // CHECK: ^bb6:
+    // CHECK:   aie.end
+    // CHECK:   }
+    // CHECK: aie.shim_dma_allocation @objFifo_out0_shim_alloc(%shim_noc_tile_0_0, S2MM, 0)
 
 module {
   aie.device(npu1_1col) {
@@ -174,8 +170,8 @@ module {
     }
 
     aie.runtime_sequence(%arg0: memref<61x56xi8>, %arg1: memref<32xi8>, %arg2: memref<64x64xi8>) {
-      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0, 0][1, 1, 61, 56][0, 0, 56, 1]) {id = 0 : i64, metadata = @objFifo_in0} : memref<61x56xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0, 0][1, 1, 64, 64][0, 0, 64, 1]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[0, 0, 0][1, 61, 56][0, 56, 1]) {id = 0 : i64, metadata = @objFifo_in0} : memref<61x56xi8>
+      aiex.npu.dma_memcpy_nd (%arg2[0, 0, 0][1, 64, 64][0, 64, 1]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/objectFifo-stateful-transform/init_values/init_values_repeat_test.mlir
+++ b/test/objectFifo-stateful-transform/init_values/init_values_repeat_test.mlir
@@ -81,7 +81,7 @@ module @init_repeat {
     %tile12 = aie.tile(1, 2)
     %tile13 = aie.tile(1, 3)
 
-    aie.objectfifo @of0 (%tile12, {%tile13}, 2 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<2x2xi32>> = [dense<[[0, 1], [2, 3]]> : memref<2x2xi32>, 
+    aie.objectfifo @of0 (%tile12, {%tile13}, 2 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<2x2xi32>> = [dense<[[0, 1], [2, 3]]> : memref<2x2xi32>, 
                                                                                                                      dense<[[4, 5], [6, 7]]> : memref<2x2xi32>]
  }
 }

--- a/test/objectFifo-stateful-transform/repeat_count/hw_repeat_optimization_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/hw_repeat_optimization_test.mlir
@@ -14,10 +14,10 @@
 // When numBlocks == 1 and repeat_count > 1, the stateful transform generates
 // 1 BD with dma_start repeat_count instead of N identical BDs.
 
-// MemTile with repeat_count=3, depth=1: 1 BD + repeat_count=2
+// MemTile with repeat_count=3, depth=1: 1 BD + repeat_count=3
 // CHECK-LABEL: @memtile_hw_repeat
 // CHECK:       %memtile_dma
-// CHECK:         aie.dma_start(MM2S, 0, ^[[BD:.*]], ^{{.*}}, repeat_count = 2)
+// CHECK:         aie.dma_start(MM2S, 0, ^[[BD:.*]], ^{{.*}}, repeat_count = 3)
 // CHECK:       ^[[BD]]:
 // CHECK:         aie.dma_bd(
 // CHECK:         aie.next_bd ^[[BD]]
@@ -32,10 +32,10 @@ module @memtile_hw_repeat {
 
 // -----
 
-// Core tile with repeat_count=4, depth=1: 1 BD + repeat_count=3
+// Core tile with repeat_count=4, depth=1: 1 BD + repeat_count=4
 // CHECK-LABEL: @core_hw_repeat
 // CHECK:       %mem_0_2 = aie.mem
-// CHECK:         aie.dma_start(MM2S, 0, ^[[BD:.*]], ^{{.*}}, repeat_count = 3)
+// CHECK:         aie.dma_start(MM2S, 0, ^[[BD:.*]], ^{{.*}}, repeat_count = 4)
 // CHECK:       ^[[BD]]:
 // CHECK:         aie.dma_bd(
 // CHECK:         aie.next_bd ^[[BD]]

--- a/test/objectFifo-stateful-transform/repeat_count/link_distribute_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_distribute_repeat_count_test.mlir
@@ -164,8 +164,8 @@ module @memtileRepeat {
     %tile33 = aie.tile(3, 3)
 
     aie.objectfifo @of0 (%tile10, {%tile11}, 2 : i32) : !aie.objectfifo<memref<32xi32>>
-    aie.objectfifo @of1 (%tile11, {%tile12}, 2 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
-    aie.objectfifo @of2 (%tile11, {%tile33}, 2 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile11, {%tile12}, 2 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of2 (%tile11, {%tile33}, 2 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
     aie.objectfifo.link [@of0] -> [@of1, @of2] ([] [0, 16])
  }
 }

--- a/test/objectFifo-stateful-transform/repeat_count/link_join_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_join_repeat_count_test.mlir
@@ -90,8 +90,8 @@ module @memtileRepeat {
     %tile12 = aie.tile(1, 2)
     %tile33 = aie.tile(3, 3)
 
-    aie.objectfifo @of0 (%tile12, {%tile11}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
-    aie.objectfifo @of1 (%tile33, {%tile11}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of0 (%tile12, {%tile11}, 1 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile33, {%tile11}, 1 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
     aie.objectfifo @of2 (%tile11, {%tile10}, 1 : i32) : !aie.objectfifo<memref<32xi32>>
     aie.objectfifo.link [@of0, @of1] -> [@of2] ([0, 16] [])
  }

--- a/test/objectFifo-stateful-transform/repeat_count/link_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_repeat_count_test.mlir
@@ -91,10 +91,10 @@ module @memtileRepeat {
     %tile33 = aie.tile(3, 3)
 
     aie.objectfifo @of0 (%tile10, {%tile11}, 1 : i32) : !aie.objectfifo<memref<32xi32>>
-    aie.objectfifo @of1 (%tile11, {%tile12}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile11, {%tile12}, 1 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
     aie.objectfifo.link [@of0] -> [@of1] ([] [])
 
-    aie.objectfifo @of2 (%tile33, {%tile21}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<32xi32>>
+    aie.objectfifo @of2 (%tile33, {%tile21}, 1 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<32xi32>>
     aie.objectfifo @of3 (%tile21, {%tile10}, 1 : i32) : !aie.objectfifo<memref<16xi32>>
     aie.objectfifo.link [@of2] -> [@of3] ([] [])
  }

--- a/test/objectFifo-stateful-transform/repeat_count/memtile_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/memtile_repeat_count_test.mlir
@@ -49,6 +49,6 @@ module @repeatCount {
     %tile11 = aie.tile(1, 1)
     %tile13 = aie.tile(1, 3)
 
-    aie.objectfifo @of1 (%tile11, {%tile13}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile11, {%tile13}, 1 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
  }
 }

--- a/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
@@ -63,7 +63,7 @@ module @repeatCount {
     %tile12 = aie.tile(1, 2)
     %tile13 = aie.tile(1, 3)
 
-    aie.objectfifo @of1 (%tile12, {%tile13}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile12, {%tile13}, 1 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
 
     func.func @some_work(%lineOut : memref<16xi32>) -> () {
        return

--- a/test/objectFifo-stateful-transform/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count_test.mlir
@@ -88,7 +88,7 @@ module @repeatCount {
     %tile13 = aie.tile(1, 3)
 
     aie.objectfifo @of0 (%tile11, {%tile12}, 1 : i32) : !aie.objectfifo<memref<16xi32>>
-    aie.objectfifo @of1 (%tile12, {%tile13}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of1 (%tile12, {%tile13}, 1 : i32) {repeat_count = 2 : i32} : !aie.objectfifo<memref<16xi32>>
 
     %core33 = aie.core(%tile12) {
       %c0 = arith.constant 0 : index

--- a/test/python/aiex_ops.py
+++ b/test/python/aiex_ops.py
@@ -43,14 +43,14 @@ def NpuDmaMemcpyNdOp():
     def device_body():
         @runtime_sequence(np.ndarray[(100,), np.dtype[np.int8]])
         def sequence(B):
-            # CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0, 0][1, 1, 1, 100][0, 0, 0, 1], packet = <pkt_type = 1, pkt_id = 4>) {id = 1 : i64, issue_token = true, metadata = @objFifo_out0} : memref<100xi8>
+            # CHECK: aiex.npu.dma_memcpy_nd(%arg0[0, 0, 0][1, 1, 100][0, 0, 1], packet = <pkt_type = 1, pkt_id = 4>) {id = 1 : i64, issue_token = true, metadata = @objFifo_out0} : memref<100xi8>
             npu_dma_memcpy_nd(
                 metadata="objFifo_out0",
                 bd_id=1,
                 mem=B,
-                offsets=[0, 0, 0, 0],
-                sizes=[1, 1, 1, 100],
-                strides=[0, 0, 0, 1],
+                offsets=[0, 0, 0],
+                sizes=[1, 1, 100],
+                strides=[0, 0, 1],
                 packet=(1, 4),
                 issue_token=True,
             )

--- a/test/python/dma_op.py
+++ b/test/python/dma_op.py
@@ -36,7 +36,7 @@ from util import construct_and_print_module
 #    %memtile_dma_0_1 = aie.memtile_dma(%tile_0_1) {
 #      %0 = aie.dma(MM2S, 0) [{
 #        aie.use_lock(%lock_0_1_0, AcquireGreaterEqual)
-#        aie.dma_bd(%mem_A : memref<2x1xi16>, 0, 2, [<size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>, <size = 1, stride = 1>])
+#        aie.dma_bd(%mem_A : memref<2x1xi16>, 0, 2, [<size = 2, stride = 1>])
 #        aie.use_lock(%lock_0_1, Release)
 #      }]
 #      aie.end
@@ -71,10 +71,7 @@ def objFifo_example():
                     buff_mem_A,
                     len=2,
                     dimensions=[
-                        (1, 1),
-                        (1, 1),
-                        (1, 1),
-                        (1, 1),
+                        (2, 1),
                     ],
                 )
                 use_lock(prod_lock_mem_A, LockAction.Release)

--- a/test/python/npu-xrt/test_jit_placed_style.py
+++ b/test/python/npu-xrt/test_jit_placed_style.py
@@ -59,9 +59,9 @@ def passthrough(
 
         @runtime_sequence(tensor_ty, tensor_ty)
         def sequence(A, B):
-            in_task = shim_dma_single_bd_task(of_in, A, sizes=[1, 1, 1, num_elements])
+            in_task = shim_dma_single_bd_task(of_in, A, sizes=[1, 1, num_elements])
             out_task = shim_dma_single_bd_task(
-                of_out, B, sizes=[1, 1, 1, num_elements], issue_token=True
+                of_out, B, sizes=[1, 1, num_elements], issue_token=True
             )
             dma_start_task(in_task, out_task)
             dma_await_task(out_task)

--- a/test/python/npu.py
+++ b/test/python/npu.py
@@ -70,8 +70,8 @@ def my_vector_scalar(module):
 
         @runtime_sequence(N_ty, N_ty, N_ty)
         def sequence(A, B, C):
-            npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N])
-            npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+            npu_dma_memcpy_nd(metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N])
+            npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, N])
             dma_wait(of_out)
 
     assert module.operation.verify()
@@ -184,24 +184,29 @@ def my_matmul(module):
                         metadata=of_inA,
                         bd_id=2 * tile_row + 1,
                         mem=A,
-                        offsets=[0, 0, 0, A_row_offset_in_i32s],
-                        sizes=[N_div_n, K_div_k, m, k_in_i32s],
-                        strides=[0, k_in_i32s, K_in_i32s, 1],
+                        offsets=[0, 0, A_row_offset_in_i32s],
+                        sizes=[K_div_k, m, k_in_i32s],
+                        strides=[k_in_i32s, K_in_i32s, 1],
+                        repeat_count=N_div_n - 1,
                     )
                     npu_dma_memcpy_nd(
                         metadata=of_inB,
                         bd_id=2 * tile_row + 2,
                         mem=B,
-                        sizes=[N_div_n, K_div_k, k, n_in_i32s],
-                        strides=[n_in_i32s, k_x_N_in_i32s, N_in_i32s, 1],
+                        sizes=[K_div_k, k, n_in_i32s],
+                        strides=[k_x_N_in_i32s, N_in_i32s, 1],
+                        iter_size=N_div_n,
+                        iter_stride=n_in_i32s,
                     )
                 npu_dma_memcpy_nd(
                     metadata=of_outC,
                     bd_id=0,
                     mem=C,
-                    offsets=[0, 0, 0, C_row_offset_in_i32s],
-                    sizes=[num_tile_rows, N_div_n, m, n_in_i32s_out],
-                    strides=[m_x_N_in_i32s_out, n_in_i32s_out, N_in_i32s_out, 1],
+                    offsets=[0, 0, C_row_offset_in_i32s],
+                    sizes=[N_div_n, m, n_in_i32s_out],
+                    strides=[n_in_i32s_out, N_in_i32s_out, 1],
+                    iter_size=num_tile_rows,
+                    iter_stride=m_x_N_in_i32s_out,
                 )
                 dma_wait(of_outC)
 
@@ -395,15 +400,15 @@ def edge_detect(module):
                 metadata=inOF_L3L2,
                 bd_id=1,
                 mem=I,
-                sizes=[1, 1, 36, 64],
-                strides=[0, 0, 64, 1],
+                sizes=[1, 36, 64],
+                strides=[0, 64, 1],
             )
             npu_dma_memcpy_nd(
                 metadata=outOF_L2L3,
                 bd_id=0,
                 mem=O,
-                sizes=[1, 1, 36, 64],
-                strides=[0, 0, 64, 1],
+                sizes=[1, 36, 64],
+                strides=[0, 64, 1],
             )
             dma_wait(outOF_L2L3)
 
@@ -447,11 +452,9 @@ def my_add_one_objFifo(module):
             np.ndarray[(64,), np.dtype[np.int32]],
         )
         def sequence(inTensor, notUsed, outTensor):
+            npu_dma_memcpy_nd(metadata=of_in0, bd_id=1, mem=inTensor, sizes=[1, 1, 64])
             npu_dma_memcpy_nd(
-                metadata=of_in0, bd_id=1, mem=inTensor, sizes=[1, 1, 1, 64]
-            )
-            npu_dma_memcpy_nd(
-                metadata=of_out0, bd_id=0, mem=outTensor, sizes=[1, 1, 1, 64]
+                metadata=of_out0, bd_id=0, mem=outTensor, sizes=[1, 1, 64]
             )
             dma_wait(of_out0)
 

--- a/test/python/objFifo.py
+++ b/test/python/objFifo.py
@@ -23,7 +23,7 @@ from util import construct_and_print_module
 # CHECK:      %{{.*}}tile_1_2 = aie.tile(1, 2)
 # CHECK:      %{{.*}}tile_1_3 = aie.tile(1, 3)
 # CHECK:      aie.objectfifo @of0(%{{.*}}tile_0_0, {%{{.*}}tile_1_2}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
-# CHECK:      aie.objectfifo @of1(%{{.*}}tile_0_1, {%{{.*}}tile_1_2}, 2 : i32) {repeat_count = 4 : i32} : !aie.objectfifo<memref<256xi32>>
+# CHECK:      aie.objectfifo @of1(%{{.*}}tile_0_1, {%{{.*}}tile_1_2}, 2 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<256xi32>>
 # CHECK:      aie.objectfifo @of2(%{{.*}}tile_1_2, {%{{.*}}tile_1_3}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
 # CHECK:      aie.objectfifo.allocate @of2(%{{.*}}tile_1_3)
 # CHECK:      aie.objectfifo @of3(%{{.*}}tile_0_0, {%{{.*}}tile_1_3}, 2 : i32) {aie_stream = 1 : i32, aie_stream_port = 1 : i32} : !aie.objectfifo<memref<256xi32>>
@@ -52,7 +52,7 @@ def objFifo_example():
 
         of0 = object_fifo("of0", S, T_, 2, np.ndarray[(256,), np.dtype[np.int32]])
         of1 = object_fifo("of1", M, T_, 2, np.ndarray[(256,), np.dtype[np.int32]])
-        of1.set_repeat_count(4)
+        of1.set_repeat_count(3)
         of2 = object_fifo("of2", T_, C_, 2, np.ndarray[(256,), np.dtype[np.int32]])
         of2.allocate(C_)
 

--- a/test/python/trace_utils.py
+++ b/test/python/trace_utils.py
@@ -132,13 +132,13 @@ def passthroughKernel():
                     metadata=of_in,
                     bd_id=0,
                     mem=inTensor,
-                    sizes=[1, 1, 1, tensorSizeInInt32s],
+                    sizes=[1, 1, tensorSizeInInt32s],
                 )
                 npu_dma_memcpy_nd(
                     metadata=of_out,
                     bd_id=1,
                     mem=outTensor,
-                    sizes=[1, 1, 1, tensorSizeInInt32s],
+                    sizes=[1, 1, tensorSizeInInt32s],
                 )
                 dma_wait(of_out)
 

--- a/test/python/zero_pad.py
+++ b/test/python/zero_pad.py
@@ -60,9 +60,9 @@ def my_passthrough():
             @runtime_sequence(tensor_ty, tensor_ty, tensor_ty)
             def sequence(A, B, C):
                 npu_dma_memcpy_nd(
-                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, 1, N], issue_token=True
+                    metadata=of_in, bd_id=1, mem=A, sizes=[1, 1, N], issue_token=True
                 )
-                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, 1, N])
+                npu_dma_memcpy_nd(metadata=of_out, bd_id=0, mem=C, sizes=[1, 1, N])
                 dma_wait(of_in, of_out)
 
     print(ctx.module)


### PR DESCRIPTION
Closes #2566.                                             

`AIEX::verifyStridesWraps` already had a careful granularity-based check for BD sizes and strides — this PR pulls the size/stride/granularity portion into a shared helper `AIE::verifyBDSizesStrides` so `aie.dma_bd`'s verifier can use the same logic. Two follow-on behavior changes fall out:
- **`aie.dma_bd` now accepts inner-dim strides > 1 on sub-32b types** when `stride × elemWidth` is a multiple of the address granularity (e.g. `memref<128xi16>, [<size=32, stride=2>]` — 2 × 16b = 32b, perfectly word-aligned). The previous blanket check rejected these even though hardware can encode them.
- **`aie.dma_bd` now rejects sub-word innermost contiguous runs** (e.g. `memref<128xi8>, [<size=3, stride=4>, <size=2, stride=1>]` — innermost run = 2 bytes). The AIEX path already caught these; the AIE path didn't.                                                                                                                                                                                                            
   
The `elemWidth > granularity` constraint added in #2435 (innermost stride must be 1 for bfp / wide types) is preserved in the shared helper, matching the silent `strides[0] = 0` behavior in `getHardwareStridesWraps`.