### PR TITLE
Resolve JIT compiler tools portably

### DIFF
--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -126,12 +126,7 @@ def compile_mlir_module(
     # If no work_dir is provided, fall back to aiecc.run() which writes to a
     # temporary file internally.
     if work_dir:
-        aiecc_bin = shutil.which("aiecc")
-        if not aiecc_bin:
-            raise RuntimeError(
-                "Could not find 'aiecc' binary. Ensure mlir-aie is installed "
-                "and its bin directory is in PATH."
-            )
+        aiecc_bin = config.aiecc_path()
         mlir_file = os.path.join(work_dir, "aie.mlir")
         with open(mlir_file, "w") as f:
             f.write(str(mlir_module))

--- a/python/utils/config.py
+++ b/python/utils/config.py
@@ -7,7 +7,12 @@
 # (c) Copyright 2025 Advanced Micro Devices, Inc.
 
 import os
+import shutil
 import aie.compiler.aiecc.configure as config
+
+
+def _executable_name(name):
+    return f"{name}.exe" if os.name == "nt" else name
 
 
 def peano_install_dir():
@@ -22,7 +27,7 @@ def peano_install_dir():
 def peano_cxx_path():
     """Returns the path to the Peano C++ compiler."""
     install_dir = peano_install_dir()
-    peano_cxx = os.path.join(install_dir, "bin", "clang++")
+    peano_cxx = os.path.join(install_dir, "bin", _executable_name("clang++"))
     if not os.path.isfile(peano_cxx):
         raise RuntimeError(f"Peano compiler not found in {peano_cxx}")
     return peano_cxx
@@ -31,7 +36,7 @@ def peano_cxx_path():
 def peano_linker_path():
     """Returns the path to the Peano linker."""
     install_dir = peano_install_dir()
-    peano_ld = os.path.join(install_dir, "bin", "ld.lld")
+    peano_ld = os.path.join(install_dir, "bin", _executable_name("ld.lld"))
     if not os.path.isfile(peano_ld):
         raise RuntimeError(f"Peano linker not found in {peano_ld}")
     return peano_ld
@@ -43,6 +48,22 @@ def root_path():
     if not os.path.isdir(root_dir):
         raise RuntimeError(f"Invalid MLIR-AIE root directory: {root_dir}")
     return root_dir
+
+
+def aiecc_path():
+    """Returns the aiecc executable used by JIT compilation."""
+    bundled_aiecc = os.path.join(root_path(), "bin", _executable_name("aiecc"))
+    if os.path.isfile(bundled_aiecc):
+        return bundled_aiecc
+
+    path_aiecc = shutil.which(_executable_name("aiecc"))
+    if path_aiecc:
+        return path_aiecc
+
+    raise RuntimeError(
+        "Could not find aiecc. Expected it under the MLIR-AIE bin directory "
+        "or on PATH."
+    )
 
 
 def cxx_header_path():


### PR DESCRIPTION
The Python JIT path currently looks up `aiecc` directly from `PATH`, which is flaky on native Windows.

This tiny patch routes `aiecc` lookup through `python/utils/config.py` and makes the configured compiler-tool names use `.exe` on Windows.