### PR TITLE
Use DMA hardware repeat for single-buffer ObjectFifos with repeat_count

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -980,9 +980,14 @@ struct AIEObjectFifoStatefulTransformPass
     Block *bdBlock = builder.createBlock(endBlock);
 
     // create DMA channel
+    // With a single buffer, the DMA hardware repeat_count avoids
+    // duplicating identical BDs.
+    bool useHwRepeat = (repeatCount > 1 && numBlocks == 1);
+    int dmaRepeatCount = useHwRepeat ? repeatCount - 1 : 0;
+    int bdRepeatCount = useHwRepeat ? 1 : repeatCount;
     builder.setInsertionPointToStart(dmaBlock);
     DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
-                       channelIndex, /*repeatCout*/ 0, bdBlock, endBlock);
+                       channelIndex, dmaRepeatCount, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
       lastDmaBlock->getTerminator()->setSuccessor(dmaBlock, 1);
 
@@ -994,8 +999,8 @@ struct AIEObjectFifoStatefulTransformPass
     for (size_t i = 0; i < numBlocks; i++) {
       if (elemIndex >= state.buffersPerFifo[target].size())
         break;
-      for (int r = 0; r < repeatCount; r++) {
-        if (totalBlocks == numBlocks * repeatCount - 1)
+      for (int r = 0; r < bdRepeatCount; r++) {
+        if (totalBlocks == numBlocks * bdRepeatCount - 1)
           succ = bdBlock;
         else
           succ = builder.createBlock(endBlock);
@@ -1221,13 +1226,19 @@ struct AIEObjectFifoStatefulTransformPass
     // create DMA channel
     builder.setInsertionPointToStart(dmaBlock);
 
-    // Use iter_count if available, otherwise default to 0
     int taskCount = 0;
     bool isBdChainMode = false;
     if (bdChainIterCount.has_value()) {
       taskCount = bdChainIterCount.value() - 1;
       isBdChainMode = true;
     }
+    // With a single buffer and no join/distribute, the DMA hardware
+    // repeat_count avoids duplicating identical BDs.
+    bool useHwRepeat = (repeatCount > 1 && numBlocks == 1 &&
+                        joinDistribFactor == 1 && !isBdChainMode);
+    if (useHwRepeat)
+      taskCount = repeatCount - 1;
+    int bdRepeatFactor = useHwRepeat ? 1 : repeatCount;
     DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
                        channelIndex, taskCount, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
@@ -1244,8 +1255,8 @@ struct AIEObjectFifoStatefulTransformPass
     for (size_t i = 0; i < numBlocks; i++) {
       if (elemIndex >= state.buffersPerFifo[target].size())
         break;
-      for (int r = 0; r < repeatCount * joinDistribFactor; r++) {
-        if (totalBlocks == numBlocks * repeatCount * joinDistribFactor - 1) {
+      for (int r = 0; r < bdRepeatFactor * joinDistribFactor; r++) {
+        if (totalBlocks == numBlocks * bdRepeatFactor * joinDistribFactor - 1) {
           // If iter_count attribute is set (BD chain mode), create a
           // dedicated terminating block
           if (isBdChainMode) {

--- a/test/objectFifo-stateful-transform/repeat_count/hw_repeat_optimization_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/hw_repeat_optimization_test.mlir
@@ -1,0 +1,108 @@
+//===- hw_repeat_optimization_test.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform --split-input-file %s | FileCheck %s
+
+// Test: Hardware repeat optimization for repeat_count with single buffer (depth=1).
+// When numBlocks == 1 and repeat_count > 1, the stateful transform generates
+// 1 BD with dma_start repeat_count instead of N identical BDs.
+
+// MemTile with repeat_count=3, depth=1: 1 BD + repeat_count=2
+// CHECK-LABEL: @memtile_hw_repeat
+// CHECK:       %memtile_dma
+// CHECK:         aie.dma_start(MM2S, 0, ^[[BD:.*]], ^{{.*}}, repeat_count = 2)
+// CHECK:       ^[[BD]]:
+// CHECK:         aie.dma_bd(
+// CHECK:         aie.next_bd ^[[BD]]
+module @memtile_hw_repeat {
+  aie.device(npu2) {
+    %tile11 = aie.tile(1, 1)
+    %tile12 = aie.tile(1, 2)
+
+    aie.objectfifo @of1(%tile11, {%tile12}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<16xi32>>
+  }
+}
+
+// -----
+
+// Core tile with repeat_count=4, depth=1: 1 BD + repeat_count=3
+// CHECK-LABEL: @core_hw_repeat
+// CHECK:       %mem_0_2 = aie.mem
+// CHECK:         aie.dma_start(MM2S, 0, ^[[BD:.*]], ^{{.*}}, repeat_count = 3)
+// CHECK:       ^[[BD]]:
+// CHECK:         aie.dma_bd(
+// CHECK:         aie.next_bd ^[[BD]]
+module @core_hw_repeat {
+  aie.device(npu2) {
+    %tile02 = aie.tile(0, 2)
+    %tile03 = aie.tile(0, 3)
+
+    aie.objectfifo @of1(%tile02, {%tile03}, 1 : i32) {repeat_count = 4 : i32} : !aie.objectfifo<memref<64xi32>>
+  }
+}
+
+// -----
+
+// depth=2 with repeat_count=3: should NOT use hardware repeat (multiple buffers)
+// CHECK-LABEL: @no_hw_repeat_depth2
+// CHECK:       %mem_0_2 = aie.mem
+// CHECK:         aie.dma_start(MM2S, 0, ^{{.*}}, ^{{.*}})
+// CHECK-NOT:     repeat_count
+module @no_hw_repeat_depth2 {
+  aie.device(npu2) {
+    %tile02 = aie.tile(0, 2)
+    %tile03 = aie.tile(0, 3)
+
+    aie.objectfifo @of1(%tile02, {%tile03}, 2 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<64xi32>>
+  }
+}
+
+// -----
+
+// depth=1 with repeat_count=1: no repeat_count in output (trivial case)
+// CHECK-LABEL: @no_hw_repeat_count1
+// CHECK:       %memtile_dma
+// CHECK:         aie.dma_start(MM2S, 0, ^[[BD:.*]], ^{{.*}})
+// CHECK-NOT:     repeat_count
+// CHECK:       ^[[BD]]:
+// CHECK:         aie.dma_bd(
+// CHECK:         aie.next_bd ^[[BD]]
+module @no_hw_repeat_count1 {
+  aie.device(npu2) {
+    %tile11 = aie.tile(1, 1)
+    %tile12 = aie.tile(1, 2)
+
+    aie.objectfifo @of1(%tile11, {%tile12}, 1 : i32) {repeat_count = 1 : i32} : !aie.objectfifo<memref<16xi32>>
+  }
+}
+
+// -----
+
+// depth=1, repeat_count=3 with distribute: should NOT use hardware repeat
+// (joinDistribFactor > 1 means BDs interleave across sub-buffers)
+// CHECK-LABEL: @no_hw_repeat_distribute
+// CHECK:       %memtile_dma
+// The S2MM (receive) side of the linked objectfifo on the MemTile
+// should NOT have repeat_count because distribute interleaves BDs.
+// CHECK:         aie.dma_start(S2MM, 0, ^{{.*}}, ^{{.*}})
+// CHECK-NOT:     repeat_count
+module @no_hw_repeat_distribute {
+  aie.device(npu2) {
+    %tile11 = aie.tile(1, 1)
+    %tile12 = aie.tile(1, 2)
+    %tile13 = aie.tile(1, 3)
+    %tile21 = aie.tile(2, 1)
+
+    aie.objectfifo @of_in(%tile21, {%tile11}, 1 : i32) {repeat_count = 3 : i32} : !aie.objectfifo<memref<32xi32>>
+    aie.objectfifo @of_out1(%tile11, {%tile12}, 1 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of_out2(%tile11, {%tile13}, 1 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo.link [@of_in] -> [@of_out1, @of_out2]([] [0, 16])
+  }
+}

--- a/test/objectFifo-stateful-transform/repeat_count/link_join_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_join_repeat_count_test.mlir
@@ -16,87 +16,67 @@
 // CHECK:     %{{.*}}tile_1_1 = aie.tile(1, 1)
 // CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
 // CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
-// CHECK:     %[[VAL_2:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of2_buff_0"} : memref<32xi32> 
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 1 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_1, 2) {init = 1 : i32, sym_name = "of2_prod_lock_1"}
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_1, 3) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
-// CHECK:     %[[VAL_7:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of1_buff_0"} : memref<16xi32> 
-// CHECK:     %[[VAL_8:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_9:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
-// CHECK:     %[[VAL_10:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_0"} : memref<16xi32> 
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 3 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK-DAG: %[[OF2_BUF:.*]] = aie.buffer({{.*}}) {sym_name = "of2_buff_0"} : memref<32xi32>
+// CHECK-DAG: %[[OF2_PROD0:.*]] = aie.lock({{.*}}, 0) {init = 1 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK-DAG: %[[OF2_CONS0:.*]] = aie.lock({{.*}}, 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK-DAG: %[[OF2_PROD1:.*]] = aie.lock({{.*}}, 2) {init = 1 : i32, sym_name = "of2_prod_lock_1"}
+// CHECK-DAG: %[[OF2_CONS1:.*]] = aie.lock({{.*}}, 3) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
+// CHECK-DAG: %[[OF1_BUF:.*]] = aie.buffer({{.*}}) {sym_name = "of1_buff_0"} : memref<16xi32>
+// CHECK-DAG: %[[OF1_PROD:.*]] = aie.lock({{.*}}, 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK-DAG: %[[OF1_CONS:.*]] = aie.lock({{.*}}, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK-DAG: %[[OF0_BUF:.*]] = aie.buffer({{.*}}) {sym_name = "of0_buff_0"} : memref<16xi32>
+// CHECK-DAG: %[[OF0_PROD:.*]] = aie.lock({{.*}}, 0) {init = 3 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK-DAG: %[[OF0_CONS:.*]] = aie.lock({{.*}}, 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_1, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_3_3, DMA : 0, %{{.*}}tile_1_1, DMA : 1)
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_0, DMA : 0)
 // CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
-// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb4)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
-// CHECK:       aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_11]], Release, 1)
-// CHECK:       aie.next_bd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_11]], Release, 1)
-// CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb3:  // pred: ^bb2
-// CHECK:       aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_10]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_11]], Release, 1)
+// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 2)
+// CHECK:     ^bb1:
+// CHECK:       aie.use_lock(%[[OF0_CONS]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF0_BUF]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.use_lock(%[[OF0_PROD]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb4:  // pred: ^bb0
+// CHECK:     ^bb2:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
-// CHECK:       aie.use_lock(%[[VAL_3]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_2]] : memref<32xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
+// CHECK:     ^bb1:
+// CHECK:       aie.use_lock(%[[OF2_PROD0]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF2_BUF]] : memref<32xi32>, 0, 16)
+// CHECK:       aie.use_lock(%[[OF2_CONS0]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:     ^bb2:
 // CHECK:       %1 = aie.dma_start(S2MM, 1, ^bb3, ^bb4)
-// CHECK:     ^bb3:  // 2 preds: ^bb2, ^bb3
-// CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_2]] : memref<32xi32>, 16, 16)
-// CHECK:       aie.use_lock(%[[VAL_6]], Release, 1)
+// CHECK:     ^bb3:
+// CHECK:       aie.use_lock(%[[OF2_PROD1]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF2_BUF]] : memref<32xi32>, 16, 16)
+// CHECK:       aie.use_lock(%[[OF2_CONS1]], Release, 1)
 // CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb4:  // pred: ^bb2
+// CHECK:     ^bb4:
 // CHECK:       %2 = aie.dma_start(MM2S, 0, ^bb5, ^bb7)
-// CHECK:     ^bb5:  // 2 preds: ^bb4, ^bb6
-// CHECK:       aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_2]] : memref<32xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_3]], Release, 1)
+// CHECK:     ^bb5:
+// CHECK:       aie.use_lock(%[[OF2_CONS0]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF2_BUF]] : memref<32xi32>, 0, 16)
+// CHECK:       aie.use_lock(%[[OF2_PROD0]], Release, 1)
 // CHECK:       aie.next_bd ^bb6
-// CHECK:     ^bb6:  // pred: ^bb5
-// CHECK:       aie.use_lock(%[[VAL_6]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_2]] : memref<32xi32>, 16, 16)
-// CHECK:       aie.use_lock(%[[VAL_5]], Release, 1)
+// CHECK:     ^bb6:
+// CHECK:       aie.use_lock(%[[OF2_CONS1]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF2_BUF]] : memref<32xi32>, 16, 16)
+// CHECK:       aie.use_lock(%[[OF2_PROD1]], Release, 1)
 // CHECK:       aie.next_bd ^bb5
-// CHECK:     ^bb7:  // pred: ^bb4
+// CHECK:     ^bb7:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %mem_3_3 = aie.mem(%{{.*}}tile_3_3) {
-// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb4)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
-// CHECK:       aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_8]], Release, 1)
-// CHECK:       aie.next_bd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_8]], Release, 1)
-// CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb3:  // pred: ^bb2
-// CHECK:       aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_7]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_8]], Release, 1)
+// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 2)
+// CHECK:     ^bb1:
+// CHECK:       aie.use_lock(%[[OF1_CONS]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF1_BUF]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.use_lock(%[[OF1_PROD]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb4:  // pred: ^bb0
+// CHECK:     ^bb2:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     aie.shim_dma_allocation @of2_shim_alloc(%shim_noc_tile_1_0, S2MM, 0)

--- a/test/objectFifo-stateful-transform/repeat_count/link_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_repeat_count_test.mlir
@@ -12,100 +12,70 @@
 
 // CHECK: module @memtileRepeat {
 // CHECK:   aie.device(npu1) {
-// CHECK:     %{{.*}}tile_1_0 = aie.tile(1, 0)
-// CHECK:     %{{.*}}tile_1_1 = aie.tile(1, 1)
-// CHECK:     %{{.*}}tile_2_1 = aie.tile(2, 1)
-// CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
-// CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
-// CHECK:     %[[VAL_2:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "of2_cons_buff_0"} : memref<32xi32> 
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_1, 0) {init = 1 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of2_buff_0"} : memref<32xi32> 
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 3 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
-// CHECK:     %[[VAL_8:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32> 
-// CHECK:     %[[VAL_9:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<32xi32> 
-// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 3 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
-// CHECK:     aie.flow(%{{.*}}tile_1_0, DMA : 0, %{{.*}}tile_1_1, DMA : 0)
-// CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
-// CHECK:     aie.flow(%{{.*}}tile_3_3, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
-// CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 0, %{{.*}}tile_1_0, DMA : 0)
-// CHECK:     aie.shim_dma_allocation @of0_shim_alloc(%shim_noc_tile_1_0, MM2S, 0)
+// CHECK-DAG: %[[OF2_BUF:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of2_buff_0"} : memref<32xi32>
+// CHECK-DAG: %[[OF2_PROD:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 3 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK-DAG: %[[OF2_CONS:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK-DAG: %[[OF1C_BUF:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
+// CHECK-DAG: %[[OF1C_PROD:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK-DAG: %[[OF1C_CONS:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK-DAG: %[[OF2C_BUF:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "of2_cons_buff_0"} : memref<32xi32>
+// CHECK-DAG: %[[OF2C_PROD:.*]] = aie.lock(%{{.*}}tile_2_1, 0) {init = 1 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK-DAG: %[[OF2C_CONS:.*]] = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK-DAG: %[[OF0C_BUF:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<32xi32>
+// CHECK-DAG: %[[OF0C_PROD:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 3 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK-DAG: %[[OF0C_CONS:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
 // CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
-// CHECK:       aie.use_lock(%[[VAL_12]], AcquireGreaterEqual, 3)
-// CHECK:       aie.dma_bd(%[[VAL_11]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_13]], Release, 3)
+// CHECK:     ^bb1:
+// CHECK:       aie.use_lock(%[[OF0C_PROD]], AcquireGreaterEqual, 3)
+// CHECK:       aie.dma_bd(%[[OF0C_BUF]] : memref<32xi32>, 0, 32)
+// CHECK:       aie.use_lock(%[[OF0C_CONS]], Release, 3)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb2:  // pred: ^bb0
-// CHECK:       %1 = aie.dma_start(MM2S, 0, ^bb3, ^bb6)
-// CHECK:     ^bb3:  // 2 preds: ^bb2, ^bb5
-// CHECK:       aie.use_lock(%[[VAL_13]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_11]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_12]], Release, 1)
-// CHECK:       aie.next_bd ^bb4
-// CHECK:     ^bb4:  // pred: ^bb3
-// CHECK:       aie.use_lock(%[[VAL_13]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_11]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_12]], Release, 1)
-// CHECK:       aie.next_bd ^bb5
-// CHECK:     ^bb5:  // pred: ^bb4
-// CHECK:       aie.use_lock(%[[VAL_13]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_11]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_12]], Release, 1)
+// CHECK:     ^bb2:
+// CHECK:       %1 = aie.dma_start(MM2S, 0, ^bb3, ^bb4, repeat_count = 2)
+// CHECK:     ^bb3:
+// CHECK:       aie.use_lock(%[[OF0C_CONS]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF0C_BUF]] : memref<32xi32>, 0, 32)
+// CHECK:       aie.use_lock(%[[OF0C_PROD]], Release, 1)
 // CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb6:  // pred: ^bb2
+// CHECK:     ^bb4:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
-// CHECK:       aie.use_lock(%[[VAL_9]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_8]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_10]], Release, 1)
+// CHECK:     ^bb1:
+// CHECK:       aie.use_lock(%[[OF1C_PROD]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF1C_BUF]] : memref<16xi32>, 0, 16)
+// CHECK:       aie.use_lock(%[[OF1C_CONS]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:     ^bb2:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %mem_3_3 = aie.mem(%{{.*}}tile_3_3) {
-// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb4)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
-// CHECK:       aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_5]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_6]], Release, 1)
-// CHECK:       aie.next_bd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_5]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_6]], Release, 1)
-// CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb3:  // pred: ^bb2
-// CHECK:       aie.use_lock(%[[VAL_7]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_5]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_6]], Release, 1)
+// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 2)
+// CHECK:     ^bb1:
+// CHECK:       aie.use_lock(%[[OF2_CONS]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF2_BUF]] : memref<32xi32>, 0, 32)
+// CHECK:       aie.use_lock(%[[OF2_PROD]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb4:  // pred: ^bb0
+// CHECK:     ^bb2:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %memtile_dma_2_1 = aie.memtile_dma(%{{.*}}tile_2_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
-// CHECK:       aie.use_lock(%[[VAL_3]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_2]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
+// CHECK:     ^bb1:
+// CHECK:       aie.use_lock(%[[OF2C_PROD]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF2C_BUF]] : memref<32xi32>, 0, 32)
+// CHECK:       aie.use_lock(%[[OF2C_CONS]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb2:  // pred: ^bb0
+// CHECK:     ^bb2:
 // CHECK:       %1 = aie.dma_start(MM2S, 0, ^bb3, ^bb4)
-// CHECK:     ^bb3:  // 2 preds: ^bb2, ^bb3
-// CHECK:       aie.use_lock(%[[VAL_4]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_2]] : memref<32xi32>, 0, 32)
-// CHECK:       aie.use_lock(%[[VAL_3]], Release, 1)
+// CHECK:     ^bb3:
+// CHECK:       aie.use_lock(%[[OF2C_CONS]], AcquireGreaterEqual, 1)
+// CHECK:       aie.dma_bd(%[[OF2C_BUF]] : memref<32xi32>, 0, 32)
+// CHECK:       aie.use_lock(%[[OF2C_PROD]], Release, 1)
 // CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb4:  // pred: ^bb2
+// CHECK:     ^bb4:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     aie.shim_dma_allocation @of3_shim_alloc(%shim_noc_tile_1_0, S2MM, 0)

--- a/test/objectFifo-stateful-transform/repeat_count/memtile_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/memtile_repeat_count_test.mlir
@@ -22,23 +22,13 @@
 // CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
 // CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
-// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb4)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
-// CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
-// CHECK:       aie.next_bd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
-// CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb4:  // pred: ^bb0
+// CHECK:     ^bb2:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %mem_1_3 = aie.mem(%{{.*}}tile_1_3) {

--- a/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
@@ -36,23 +36,13 @@
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
-// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb4)
-// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb3
-// CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
-// CHECK:       aie.next_bd ^bb2
-// CHECK:     ^bb2:  // pred: ^bb1
-// CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
-// CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb3:  // pred: ^bb2
+// CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 2)
+// CHECK:     ^bb1:  // 2 preds: ^bb0, ^bb1
 // CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
-// CHECK:     ^bb4:  // pred: ^bb0
+// CHECK:     ^bb2:  // pred: ^bb0
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %mem_1_3 = aie.mem(%{{.*}}tile_1_3) {

--- a/test/objectFifo-stateful-transform/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count_test.mlir
@@ -59,23 +59,13 @@
 // CHECK:       aie.use_lock(%[[VAL_8]], Release, 1)
 // CHECK:       aie.next_bd ^bb1
 // CHECK:     ^bb2:  // pred: ^bb0
-// CHECK:       %1 = aie.dma_start(MM2S, 0, ^bb3, ^bb6)
-// CHECK:     ^bb3:  // 2 preds: ^bb2, ^bb5
-// CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
-// CHECK:       aie.next_bd ^bb4
-// CHECK:     ^bb4:  // pred: ^bb3
-// CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
-// CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
-// CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
-// CHECK:       aie.next_bd ^bb5
-// CHECK:     ^bb5:  // pred: ^bb4
+// CHECK:       %1 = aie.dma_start(MM2S, 0, ^bb3, ^bb4, repeat_count = 2)
+// CHECK:     ^bb3:
 // CHECK:       aie.use_lock(%[[VAL_5]], AcquireGreaterEqual, 1)
 // CHECK:       aie.dma_bd(%[[VAL_3]] : memref<16xi32>, 0, 16)
 // CHECK:       aie.use_lock(%[[VAL_4]], Release, 1)
 // CHECK:       aie.next_bd ^bb3
-// CHECK:     ^bb6:  // pred: ^bb2
+// CHECK:     ^bb4:
 // CHECK:       aie.end
 // CHECK:     }
 // CHECK:     %mem_1_3 = aie.mem(%{{.*}}tile_1_3) {


### PR DESCRIPTION
## Summary
When an ObjectFifo has depth=1 and repeat_count > 1, emit a single BD with the DMA hardware repeat_count parameter instead of unrolling N identical BDs. This saves BD slots, which is particularly valuable on MemTiles where BDs are partitioned across channel parity pools.

## Changes
  - `AIEObjectFifoStatefulTransform.cpp`: Core path emits
    `dma_start(..., repeat_count = N-1)` with a single BD when
    numBlocks == 1. MemTile path does the same when joinDistribFactor
    == 1 and iter_count is not set.
  - `hw_repeat_optimization_test.mlir` (new): Tests hw repeat on
    MemTile, core tile, negative cases for depth > 1, repeat_count = 1,
    and distribute linkage.
  - Updated CHECK patterns in 5 existing repeat_count tests to match
    the new single-BD output.