### PR TITLE
Update `xdna-driver` tag

### DIFF
--- a/utils/build_drivers.sh
+++ b/utils/build_drivers.sh
@@ -93,8 +93,8 @@ fi
 
 echo "Setting up XDNA driver repository..."
 # Clone or update the XDNA driver repository and initialize submodules
-XDNA_TAG=beb9e450fe123ecdf395453971576179cedcf1dd
-# (1.7 tag as of 2026/02/17) 
+XDNA_TAG=944ca35a395b7dfa37ac3f437f1da48feca7bffc
+# (1.7 tag as of 2026/05/27) 
 if [ -d "xdna-driver" ]; then
     echo "xdna-driver directory already exists. Removing and re-cloning to ensure clean state..."
     rm -rf xdna-driver


### PR DESCRIPTION
The latest tag on the `1.7` branch; contains the scratchpad memory Python bindings in PyXRT that will be required for #3061