### PR TITLE
[Utils] Generalize traceSubviewToBlockArgument to N-D rank-reducing subviews

### DIFF
--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -60,41 +60,27 @@ AIEX::traceSubviewToBlockArgument(Value value) {
       continue;
     }
 
-    // Handle memref.subview (accumulate base byte offset and pass through).
-    //
-    // Supports any source rank, including rank-reducing subviews. The byte
-    // offset delta is read directly off the strided layouts: the subview
-    // verifier already bakes Sum(offset[d] * sourceStride[d]) into the
-    // result type offset, so (resultOffset - sourceOffset) is the delta in
-    // elements.
-    //
-    // Result-slice contiguity is intentionally not enforced here. The caller
-    // is responsible for supplying DMA size/stride descriptors that correctly
-    // describe the access pattern on the root buffer; the aie/aiex dialect
-    // verifiers (DMABDOp, NpuDmaMemcpyNdOp) enforce hardware legality of
-    // those descriptors independently.
+    // Handle memref.subview. Accepts any source rank; byte-offset delta is
+    // (resultOffset - sourceOffset) from the strided layouts.
     if (auto subviewOp = dyn_cast<memref::SubViewOp>(defOp)) {
       auto sourceType = subviewOp.getSourceType();
       auto resultType = subviewOp.getType();
 
-      // All slicing parameters must be static.
       if (llvm::any_of(subviewOp.getStaticOffsets(), ShapedType::isDynamic) ||
           llvm::any_of(subviewOp.getStaticSizes(), ShapedType::isDynamic) ||
           llvm::any_of(subviewOp.getStaticStrides(), ShapedType::isDynamic))
         return std::nullopt;
 
-      // Slicing strides must be 1 (no skipping in source).
+      // No skipping in source.
       if (llvm::any_of(subviewOp.getStaticStrides(),
                        [](int64_t s) { return s != 1; }))
         return std::nullopt;
 
-      // Element size must be byte-addressable.
       unsigned elemSizeInBits =
           sourceType.getElementType().getIntOrFloatBitWidth();
       if (elemSizeInBits % 8 != 0)
         return std::nullopt;
 
-      // Read the byte-offset delta off the strided layouts.
       llvm::SmallVector<int64_t> srcStrides, resStrides;
       int64_t srcOff, resOff;
       if (failed(sourceType.getStridesAndOffset(srcStrides, srcOff)) ||

--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -60,44 +60,66 @@ AIEX::traceSubviewToBlockArgument(Value value) {
       continue;
     }
 
-    // Handle memref.subview (accumulate offset and validate)
+    // Handle memref.subview (accumulate offset and validate).
+    //
+    // Supports N-D sources, including rank-reducing subviews. Byte offset is
+    // accumulated as Σ (offset[d] × sourceStride[d]) × elemSizeBytes, where
+    // sourceStride comes from the source memref's layout. All subview offsets,
+    // sizes and strides must be static, and all subview strides must equal 1
+    // (no skipping). The source's innermost stride must be 1 so the result
+    // remains contiguous.
     if (auto subviewOp = dyn_cast<memref::SubViewOp>(defOp)) {
-      // Verify static offsets, sizes, strides
-      if (!subviewOp.getStaticOffsets().empty() &&
-          subviewOp.getStaticOffsets()[0] == ShapedType::kDynamic) {
-        return std::nullopt;
-      }
-      if (!subviewOp.getStaticSizes().empty() &&
-          subviewOp.getStaticSizes()[0] == ShapedType::kDynamic) {
-        return std::nullopt;
-      }
-      if (!subviewOp.getStaticStrides().empty() &&
-          subviewOp.getStaticStrides()[0] == ShapedType::kDynamic) {
-        return std::nullopt;
-      }
-
-      // Only support rank-1 subviews
-      if (subviewOp.getSourceType().getRank() != 1 ||
-          subviewOp.getType().getRank() != 1) {
-        return std::nullopt;
-      }
-
-      // Only support stride of 1 (contiguous)
-      if (!subviewOp.getStaticStrides().empty() &&
-          subviewOp.getStaticStrides()[0] != 1) {
-        return std::nullopt;
-      }
-
-      // Calculate and accumulate offset in bytes
       auto sourceType = subviewOp.getSourceType();
+
+      // All offsets/sizes/strides must be static.
+      auto staticOffsets = subviewOp.getStaticOffsets();
+      auto staticSizes = subviewOp.getStaticSizes();
+      auto staticStrides = subviewOp.getStaticStrides();
+      for (int64_t v : staticOffsets) {
+        if (v == ShapedType::kDynamic)
+          return std::nullopt;
+      }
+      for (int64_t v : staticSizes) {
+        if (v == ShapedType::kDynamic)
+          return std::nullopt;
+      }
+      for (int64_t v : staticStrides) {
+        if (v == ShapedType::kDynamic)
+          return std::nullopt;
+      }
+
+      // All subview strides must be 1 (no skipping in source).
+      for (int64_t s : staticStrides) {
+        if (s != 1)
+          return std::nullopt;
+      }
+
+      // Element size must be byte-addressable.
       unsigned elemSizeInBits =
           sourceType.getElementType().getIntOrFloatBitWidth();
-      if (elemSizeInBits % 8 != 0) {
+      if (elemSizeInBits % 8 != 0)
         return std::nullopt;
-      }
       unsigned elemSizeInBytes = elemSizeInBits / 8;
-      int64_t offsetInElements = subviewOp.getStaticOffsets()[0];
-      offsetInBytes += offsetInElements * elemSizeInBytes;
+
+      // Get source strides + offset. Required for byte-offset arithmetic.
+      llvm::SmallVector<int64_t> sourceStrides;
+      int64_t sourceBaseOffset;
+      if (failed(
+              sourceType.getStridesAndOffset(sourceStrides, sourceBaseOffset)))
+        return std::nullopt;
+      if (sourceBaseOffset == ShapedType::kDynamic)
+        return std::nullopt;
+      // Innermost source stride must be 1 (otherwise the slice is not
+      // contiguous in memory and a single linear DMA can't describe it).
+      if (sourceStrides.empty() || sourceStrides.back() != 1)
+        return std::nullopt;
+
+      // Accumulate byte offset: Σ (offset[d] × sourceStride[d]) × elemSize.
+      int64_t totalElemOffset = sourceBaseOffset;
+      for (size_t d = 0; d < staticOffsets.size(); ++d) {
+        totalElemOffset += staticOffsets[d] * sourceStrides[d];
+      }
+      offsetInBytes += totalElemOffset * elemSizeInBytes;
 
       current = subviewOp.getSource();
       continue;

--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -60,66 +60,50 @@ AIEX::traceSubviewToBlockArgument(Value value) {
       continue;
     }
 
-    // Handle memref.subview (accumulate offset and validate).
+    // Handle memref.subview (accumulate base byte offset and pass through).
     //
-    // Supports N-D sources, including rank-reducing subviews. Byte offset is
-    // accumulated as Σ (offset[d] × sourceStride[d]) × elemSizeBytes, where
-    // sourceStride comes from the source memref's layout. All subview offsets,
-    // sizes and strides must be static, and all subview strides must equal 1
-    // (no skipping). The source's innermost stride must be 1 so the result
-    // remains contiguous.
+    // Supports any source rank, including rank-reducing subviews. The byte
+    // offset delta is read directly off the strided layouts: the subview
+    // verifier already bakes Sum(offset[d] * sourceStride[d]) into the
+    // result type offset, so (resultOffset - sourceOffset) is the delta in
+    // elements.
+    //
+    // Result-slice contiguity is intentionally not enforced here. The caller
+    // is responsible for supplying DMA size/stride descriptors that correctly
+    // describe the access pattern on the root buffer; the aie/aiex dialect
+    // verifiers (DMABDOp, NpuDmaMemcpyNdOp) enforce hardware legality of
+    // those descriptors independently.
     if (auto subviewOp = dyn_cast<memref::SubViewOp>(defOp)) {
       auto sourceType = subviewOp.getSourceType();
+      auto resultType = subviewOp.getType();
 
-      // All offsets/sizes/strides must be static.
-      auto staticOffsets = subviewOp.getStaticOffsets();
-      auto staticSizes = subviewOp.getStaticSizes();
-      auto staticStrides = subviewOp.getStaticStrides();
-      for (int64_t v : staticOffsets) {
-        if (v == ShapedType::kDynamic)
-          return std::nullopt;
-      }
-      for (int64_t v : staticSizes) {
-        if (v == ShapedType::kDynamic)
-          return std::nullopt;
-      }
-      for (int64_t v : staticStrides) {
-        if (v == ShapedType::kDynamic)
-          return std::nullopt;
-      }
+      // All slicing parameters must be static.
+      if (llvm::any_of(subviewOp.getStaticOffsets(), ShapedType::isDynamic) ||
+          llvm::any_of(subviewOp.getStaticSizes(), ShapedType::isDynamic) ||
+          llvm::any_of(subviewOp.getStaticStrides(), ShapedType::isDynamic))
+        return std::nullopt;
 
-      // All subview strides must be 1 (no skipping in source).
-      for (int64_t s : staticStrides) {
-        if (s != 1)
-          return std::nullopt;
-      }
+      // Slicing strides must be 1 (no skipping in source).
+      if (llvm::any_of(subviewOp.getStaticStrides(),
+                       [](int64_t s) { return s != 1; }))
+        return std::nullopt;
 
       // Element size must be byte-addressable.
       unsigned elemSizeInBits =
           sourceType.getElementType().getIntOrFloatBitWidth();
       if (elemSizeInBits % 8 != 0)
         return std::nullopt;
-      unsigned elemSizeInBytes = elemSizeInBits / 8;
 
-      // Get source strides + offset. Required for byte-offset arithmetic.
-      llvm::SmallVector<int64_t> sourceStrides;
-      int64_t sourceBaseOffset;
-      if (failed(
-              sourceType.getStridesAndOffset(sourceStrides, sourceBaseOffset)))
+      // Read the byte-offset delta off the strided layouts.
+      llvm::SmallVector<int64_t> srcStrides, resStrides;
+      int64_t srcOff, resOff;
+      if (failed(sourceType.getStridesAndOffset(srcStrides, srcOff)) ||
+          failed(resultType.getStridesAndOffset(resStrides, resOff)))
         return std::nullopt;
-      if (sourceBaseOffset == ShapedType::kDynamic)
-        return std::nullopt;
-      // Innermost source stride must be 1 (otherwise the slice is not
-      // contiguous in memory and a single linear DMA can't describe it).
-      if (sourceStrides.empty() || sourceStrides.back() != 1)
+      if (srcOff == ShapedType::kDynamic || resOff == ShapedType::kDynamic)
         return std::nullopt;
 
-      // Accumulate byte offset: Σ (offset[d] × sourceStride[d]) × elemSize.
-      int64_t totalElemOffset = sourceBaseOffset;
-      for (size_t d = 0; d < staticOffsets.size(); ++d) {
-        totalElemOffset += staticOffsets[d] * sourceStrides[d];
-      }
-      offsetInBytes += totalElemOffset * elemSizeInBytes;
+      offsetInBytes += (resOff - srcOff) * (elemSizeInBits / 8);
 
       current = subviewOp.getSource();
       continue;

--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -61,7 +61,9 @@ AIEX::traceSubviewToBlockArgument(Value value) {
     }
 
     // Handle memref.subview. Accepts any source rank; byte-offset delta is
-    // (resultOffset - sourceOffset) from the strided layouts.
+    // (resultOffset - sourceOffset) from the strided layouts. The result
+    // slice must remain row-major contiguous so callers can treat it as
+    // linear from the returned base offset.
     if (auto subviewOp = dyn_cast<memref::SubViewOp>(defOp)) {
       auto sourceType = subviewOp.getSourceType();
       auto resultType = subviewOp.getType();
@@ -88,6 +90,24 @@ AIEX::traceSubviewToBlockArgument(Value value) {
         return std::nullopt;
       if (srcOff == ShapedType::kDynamic || resOff == ShapedType::kDynamic)
         return std::nullopt;
+
+      // Result must be row-major contiguous: innermost stride == 1, and each
+      // outer stride equals the product of all inner sizes. (Size-1 dims are
+      // free: their stride is never stepped.) Without this, e.g. a column
+      // slice of a 2D row-major memref would be accepted and patched as if
+      // linear.
+      ArrayRef<int64_t> resShape = resultType.getShape();
+      if (!resShape.empty()) {
+        if (resStrides.back() != 1)
+          return std::nullopt;
+        uint64_t product = 1;
+        for (int d = static_cast<int>(resShape.size()) - 1; d > 0; --d) {
+          product *= static_cast<uint64_t>(resShape[d]);
+          if (resShape[d - 1] > 1 &&
+              static_cast<uint64_t>(resStrides[d - 1]) != product)
+            return std::nullopt;
+        }
+      }
 
       offsetInBytes += (resOff - srcOff) * (elemSizeInBits / 8);
 

--- a/test/Conversion/DmaToNpu/dma_to_npu_subview_nd.mlir
+++ b/test/Conversion/DmaToNpu/dma_to_npu_subview_nd.mlir
@@ -1,0 +1,142 @@
+//===- dma_to_npu_subview_nd.mlir -------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-dma-to-npu %s | FileCheck %s
+
+// Exercises traceSubviewToBlockArgument on multi-dimensional, including
+// rank-reducing, memref.subview chains feeding aiex.npu.dma_memcpy_nd.
+
+// 2D -> 1D rank-reducing subview: row 1 of a memref<2x256xi32>.
+// Byte offset = 1 * 256 * 4 = 1024.
+
+// CHECK-LABEL: aie.runtime_sequence
+// CHECK-SAME: memref<2x256xi32>
+// CHECK: aiex.npu.address_patch
+// CHECK-SAME: arg_idx = 0 : i32
+// CHECK-SAME: arg_plus = 1024 : i32
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<2x256xi32>) {
+      %row = memref.subview %arg0[1, 0] [1, 256] [1, 1]
+        : memref<2x256xi32> to memref<256xi32, strided<[1], offset: 256>>
+      %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [256], strides: [1]
+        : memref<256xi32, strided<[1], offset: 256>> to memref<256xi32>
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1])
+        { metadata = @buffer_2d_1d, id = 0 : i64 } : memref<256xi32>
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @buffer_2d_1d (%tile_0_0, S2MM, 0)
+  }
+}
+
+// -----
+
+// 3D -> 1D rank-reducing subview: pick (slice 2, row 3, all cols) of a
+// memref<4x8x32xi32>. Byte offset = (2 * 8 * 32 + 3 * 32) * 4 = 2432.
+
+// CHECK-LABEL: aie.runtime_sequence
+// CHECK-SAME: memref<4x8x32xi32>
+// CHECK: aiex.npu.address_patch
+// CHECK-SAME: arg_idx = 0 : i32
+// CHECK-SAME: arg_plus = 2432 : i32
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<4x8x32xi32>) {
+      %row = memref.subview %arg0[2, 3, 0] [1, 1, 32] [1, 1, 1]
+        : memref<4x8x32xi32> to memref<32xi32, strided<[1], offset: 608>>
+      %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [32], strides: [1]
+        : memref<32xi32, strided<[1], offset: 608>> to memref<32xi32>
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 32][0, 0, 0, 1])
+        { metadata = @buffer_3d_1d, id = 0 : i64 } : memref<32xi32>
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @buffer_3d_1d (%tile_0_0, S2MM, 0)
+  }
+}
+
+// -----
+
+// 4D -> 1D rank-reducing subview through three dropped dims.
+// memref<2x4x8x32xi32>, slice [1, 2, 3, 0] of size [1, 1, 1, 32].
+// Byte offset = (1*4*8*32 + 2*8*32 + 3*32) * 4 = 1632 * 4 = 6528.
+
+// CHECK-LABEL: aie.runtime_sequence
+// CHECK-SAME: memref<2x4x8x32xi32>
+// CHECK: aiex.npu.address_patch
+// CHECK-SAME: arg_idx = 0 : i32
+// CHECK-SAME: arg_plus = 6528 : i32
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<2x4x8x32xi32>) {
+      %row = memref.subview %arg0[1, 2, 3, 0] [1, 1, 1, 32] [1, 1, 1, 1]
+        : memref<2x4x8x32xi32> to memref<32xi32, strided<[1], offset: 1632>>
+      %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [32], strides: [1]
+        : memref<32xi32, strided<[1], offset: 1632>> to memref<32xi32>
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 32][0, 0, 0, 1])
+        { metadata = @buffer_4d_1d, id = 0 : i64 } : memref<32xi32>
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @buffer_4d_1d (%tile_0_0, S2MM, 0)
+  }
+}
+
+// -----
+
+// 2D -> 1D rank-reducing subview with bf16 element type.
+// memref<2x512xbf16>, row 1. Byte offset = 1 * 512 * 2 = 1024.
+
+// CHECK-LABEL: aie.runtime_sequence
+// CHECK-SAME: memref<2x512xbf16>
+// CHECK: aiex.npu.address_patch
+// CHECK-SAME: arg_idx = 0 : i32
+// CHECK-SAME: arg_plus = 1024 : i32
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<2x512xbf16>) {
+      %row = memref.subview %arg0[1, 0] [1, 512] [1, 1]
+        : memref<2x512xbf16> to memref<512xbf16, strided<[1], offset: 512>>
+      %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [512], strides: [1]
+        : memref<512xbf16, strided<[1], offset: 512>> to memref<512xbf16>
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 512][0, 0, 0, 1])
+        { metadata = @buffer_bf16, id = 0 : i64 } : memref<512xbf16>
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @buffer_bf16 (%tile_0_0, S2MM, 0)
+  }
+}
+
+// -----
+
+// Chained 3D -> 2D rank-reducing subview, then 2D -> 1D rank-reducing subview.
+// memref<2x4x256xi32> arg, take outer index 1 (offset 4*256*4=4096),
+// then take row 2 (offset 2*256*4=2048). Total = 6144 bytes.
+
+// CHECK-LABEL: aie.runtime_sequence
+// CHECK-SAME: memref<2x4x256xi32>
+// CHECK: aiex.npu.address_patch
+// CHECK-SAME: arg_idx = 0 : i32
+// CHECK-SAME: arg_plus = 6144 : i32
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence(%arg0: memref<2x4x256xi32>) {
+      %plane = memref.subview %arg0[1, 0, 0] [1, 4, 256] [1, 1, 1]
+        : memref<2x4x256xi32> to memref<4x256xi32, strided<[256, 1], offset: 1024>>
+      %row = memref.subview %plane[2, 0] [1, 256] [1, 1]
+        : memref<4x256xi32, strided<[256, 1], offset: 1024>>
+        to memref<256xi32, strided<[1], offset: 1536>>
+      %row_cast = memref.reinterpret_cast %row to offset: [0], sizes: [256], strides: [1]
+        : memref<256xi32, strided<[1], offset: 1536>> to memref<256xi32>
+      aiex.npu.dma_memcpy_nd (%row_cast[0, 0, 0, 0][1, 1, 1, 256][0, 0, 0, 1])
+        { metadata = @buffer_chain, id = 0 : i64 } : memref<256xi32>
+    }
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @buffer_chain (%tile_0_0, S2MM, 0)
+  }
+}


### PR DESCRIPTION
## What
Generalizes `AIEX::traceSubviewToBlockArgument()` in [`lib/Dialect/AIEX/Utils/AIEUtils.cpp`](lib/Dialect/AIEX/Utils/AIEUtils.cpp) from rank-1-only to any source rank, including rank-reducing subviews.

## Why
The helper is shared by `AIEDMATasksToNPU.cpp`, `AIEDmaToNpu.cpp`, and `AIEMaterializeRuntimeSequences.cpp`. Today it rejects any chain that walks back through a multi-dimensional source — for example:

```mlir
%row0 = memref.subview %arg[0, 0] [1, N] [1, 1]
    : memref<MxNxbf16> to memref<Nxbf16, strided<[1]>>
%row0_cast = memref.cast %row0 : memref<Nxbf16, strided<[1]>> to memref<Nxbf16>
// ...
aie.dma_bd(%row0_cast : memref<Nxbf16>, ...)
```

The chain trace returns `nullopt` at the rank-1-only guard, and the caller falls through to the misleading diagnostic:

> `'aie.dma_bd' op Buffer argument must be a constant aie.buffer, a runtime sequence input argument, or a (chain of) subview(s) or cast(s) of a block argument with constant offsets and strides equal to one.`

…even though the chain *does* have constant offsets and unit strides.

## How
The walk now accepts any source rank. The byte-offset delta is read directly off the strided layouts of the subview's source and result types:

```cpp
offsetInBytes += (resultOffset - sourceOffset) * elemSizeInBytes;
```

The subview verifier already bakes `Sum(subviewOffset[d] * sourceStride[d])` into the result type's strided-layout offset, so no manual loop is needed.

Preserved safety properties:
- All subview offsets, sizes, and strides must be static
- All subview strides must equal 1 (no skipping in source)
- Element size must be byte-addressable
- Source and result strided-layout offsets must be static
- **Result must be row-major contiguous**: innermost stride equals 1, and each outer stride equals the suffix-product of inner sizes (size-1 dims are stride-free). This rejects e.g. a column slice of a row-major 2D memref (`memref<8x1xi32, strided<[16, 1]>>`) so it can't be silently patched as if linear. The check applies to the *result* type rather than the source's innermost stride (the original PR's framing), which is the property callers actually need.

## Use case
Unblocks routing the output of one `air.launch` (or one `aiex.run`) into a row of a packed 2D buffer that a subsequent launch reads as input, without a host-side copy or an extra intermediate launch. Concretely: stitching three sub-launches into one ELF where launch A writes its output to row 0 of a shared `memref<2xNxbf16>` via a 2D→1D subview, launch B reads it as part of a packed 2-row input, launch C reads it as a residual via the same subview.

## Testing
- Added [`test/Conversion/DmaToNpu/dma_to_npu_subview_nd.mlir`](test/Conversion/DmaToNpu/dma_to_npu_subview_nd.mlir) covering five cases: 2D→1D, 3D→1D, 4D→1D rank-reducing chains; bf16 element type; chained 3D→2D→1D subviews. Each case checks the expected `aiex.npu.address_patch arg_plus = <bytes>`.
- Existing [`test/Conversion/DmaToNpu/dma_to_npu_subview.mlir`](test/Conversion/DmaToNpu/dma_to_npu_subview.mlir) still passes (rank-1 regression).
- Manually verified the contiguity guard: a `memref<8x1xi32, strided<[16, 1]>>` column slice now produces the standard `aie.dma_bd` diagnostic instead of being silently patched.
- Built locally with `clang-format-17`. End-to-end verified: a stitched 2-launch test with the previously-rejected 2D→1D subview chain now compiles cleanly and produces NPU output with correlation > 0.99 against a CPU reference.

## Known follow-ups (out of scope)
The `memref.reinterpret_cast` branch a few lines above in the same function has two pre-existing limitations this PR doesn't touch:
- It doesn't accumulate the cast's own offset operand.
- Its stride check rejects any non-trivial strided layout, including standard row-major `[N, 1]`.

These would be a separate cleanup.
