### PR TITLE
Add custom DMA programming example via IRON Resolvable

### DIFF
--- a/programming_examples/basic/custom_dma/Makefile
+++ b/programming_examples/basic/custom_dma/Makefile
@@ -1,0 +1,41 @@
+##===- Makefile -----------------------------------------------------------===##
+#
+# This file licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+#
+##===----------------------------------------------------------------------===##
+
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+include ${srcdir}/../../makefile-common
+VPATH := ${srcdir}/../../../aie_kernels/generic
+
+devicename ?= npu2
+targetname = custom_dma
+
+.PHONY: all clean
+
+all: build/final.xclbin
+
+build/%.cc.o: %.cc
+	mkdir -p ${@D}
+	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -DBIT_WIDTH=8 -c $< -o ${@F}
+
+build/aie.mlir: ${srcdir}/${targetname}.py
+	mkdir -p ${@D}
+	python3 $< -d ${devicename} > $@
+
+build/final.xclbin: build/aie.mlir build/passThrough.cc.o
+	mkdir -p ${@D}
+	cd ${@D} && aiecc --aie-generate-xclbin --aie-generate-npu-insts \
+		--no-xchesscc --no-xbridge \
+		--xclbin-name=${@F} --npu-insts-name=insts.bin $(<:%=../%)
+
+run_py: build/final.xclbin
+	${powershell} python3 ${srcdir}/test.py -x build/final.xclbin -i build/insts.bin -k MLIR_AIE
+
+clean:
+	rm -rf build _build

--- a/programming_examples/basic/custom_dma/Makefile
+++ b/programming_examples/basic/custom_dma/Makefile
@@ -11,7 +11,6 @@
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 include ${srcdir}/../../makefile-common
-VPATH := ${srcdir}/../../../aie_kernels/generic
 
 devicename ?= npu2
 targetname = custom_dma
@@ -20,15 +19,11 @@ targetname = custom_dma
 
 all: build/final.xclbin
 
-build/%.cc.o: %.cc
-	mkdir -p ${@D}
-	cd ${@D} && ${PEANO_INSTALL_DIR}/bin/clang++ ${PEANOWRAP2P_FLAGS} -DBIT_WIDTH=8 -c $< -o ${@F}
-
 build/aie.mlir: ${srcdir}/${targetname}.py
 	mkdir -p ${@D}
 	python3 $< -d ${devicename} > $@
 
-build/final.xclbin: build/aie.mlir build/passThrough.cc.o
+build/final.xclbin: build/aie.mlir
 	mkdir -p ${@D}
 	cd ${@D} && aiecc --aie-generate-xclbin --aie-generate-npu-insts \
 		--no-xchesscc --no-xbridge \

--- a/programming_examples/basic/custom_dma/README.md
+++ b/programming_examples/basic/custom_dma/README.md
@@ -1,0 +1,55 @@
+<!---//===- README.md -----------------------------------------*- Markdown -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//-->
+
+# Custom DMA
+
+This IRON design demonstrates how to program arbitrary DMA patterns from the high-level IRON API by writing a `Resolvable` subclass. The example reads two non-contiguous rows from a matrix stored on a MemTile, skipping an intermediate row — a scatter-read pattern that ObjectFifo cannot express because ObjectFifo elements are uniform and always read from sequential positions.
+
+## Source Files Overview
+
+1. `custom_dma.py`: A Python script that defines the IRON design. It contains a `ScatterReadDMA` class (a `Resolvable` subclass) that emits custom locks, DMA buffer descriptors, and flows alongside standard IRON components (ObjectFifo, Worker, Runtime).
+
+1. `test.py`: Host program to run the design on the NPU and verify the output against expected values.
+
+## Design Overview
+
+A 3×16 matrix of `int32` values is pre-loaded on a MemTile via `initial_value`. A two-BD DMA chain reads row 0 and row 2 using per-BD offsets (`offset=0` and `offset=32`), skipping row 1. Each BD transfers 16 elements to a compute tile, which copies them to an output ObjectFifo that drains to the host.
+
+```
+MemTile buffer (48 x i32):
+  row 0 [0..15]  = [100, 101, ..., 115]  ← BD1 reads here
+  row 1 [16..31] = [300, 301, ..., 315]  (skipped)
+  row 2 [32..47] = [200, 201, ..., 215]  ← BD2 reads here
+```
+
+The `ScatterReadDMA` class integrates with IRON through the `Resolvable` interface:
+- `tiles()` declares tile dependencies so `Program.resolve_program()` resolves them before `resolve()` runs.
+- `resolve()` emits the MemTile buffer, locks, flow, and DMA schedule as raw MLIR ops.
+- `acquire()` / `release()` provide lock-based synchronization that the Worker's core function calls at kernel time.
+
+The MemTile DMA is triggered from the runtime sequence via `set_lock_value`, which ensures the shim drain is configured before data starts flowing.
+
+## Usage
+
+### Compilation
+
+To compile the design:
+
+```shell
+make
+```
+
+### Python Testbench
+
+To run the design:
+
+```shell
+make run_py
+```

--- a/programming_examples/basic/custom_dma/README.md
+++ b/programming_examples/basic/custom_dma/README.md
@@ -10,30 +10,25 @@
 
 # Custom DMA
 
-This IRON design demonstrates how to program arbitrary DMA patterns from the high-level IRON API by writing a `Resolvable` subclass. The example reads two non-contiguous rows from a matrix stored on a MemTile, skipping an intermediate row — a scatter-read pattern that ObjectFifo cannot express because ObjectFifo elements are uniform and always read from sequential positions.
+This IRON design demonstrates how to program custom DMA patterns that integrate with the IRON API by using a `Resolvable` subclass. `ScatterReadDMA` is automatically discovered in the Worker's `fn_args` by `Program`, which calls `resolve()` to emit the DMA configuration.
 
 ## Source Files Overview
 
-1. `custom_dma.py`: A Python script that defines the IRON design. It contains a `ScatterReadDMA` class (a `Resolvable` subclass) that emits custom locks, DMA buffer descriptors, and flows alongside standard IRON components (ObjectFifo, Worker, Runtime).
+1. `custom_dma.py`: A Python script that defines the IRON design. It contains a `ScatterReadDMA` class (a `Resolvable` subclass) that emits custom locks, DMA buffer descriptors, and flows alongside standard IRON components.
 
 1. `test.py`: Host program to run the design on the NPU and verify the output against expected values.
 
 ## Design Overview
 
-A 3×16 matrix of `int32` values is pre-loaded on a MemTile via `initial_value`. A two-BD DMA chain reads row 0 and row 2 using per-BD offsets (`offset=0` and `offset=32`), skipping row 1. Each BD transfers 16 elements to a compute tile, which copies them to an output ObjectFifo that drains to the host.
+A 4×16 matrix of `int32` values is pre-loaded on a MemTile via `initial_value`. A custom three-BD DMA chain reads rows 0, 1, and 3 (skipping row 2) using per-BD offsets with non-uniform spacing. Each BD transfers 16 elements to a compute tile, which copies them to an output ObjectFifo that drains to the host.
 
 ```
-MemTile buffer (48 x i32):
+MemTile buffer (64 x i32):
   row 0 [0..15]  = [100, 101, ..., 115]  ← BD1 reads here
-  row 1 [16..31] = [300, 301, ..., 315]  (skipped)
-  row 2 [32..47] = [200, 201, ..., 215]  ← BD2 reads here
+  row 1 [16..31] = [200, 201, ..., 215]  ← BD2 reads here
+  row 2 [32..47] = [300, 301, ..., 315]  (skipped)
+  row 3 [48..63] = [400, 401, ..., 415]  ← BD3 reads here
 ```
-
-The `ScatterReadDMA` class integrates with IRON through the `Resolvable` interface:
-- `tiles()` declares tile dependencies so `Program.resolve_program()` resolves them before `resolve()` runs.
-- `resolve()` emits the MemTile buffer, locks, flow, and DMA schedule as raw MLIR ops.
-- `acquire()` / `release()` provide lock-based synchronization that the Worker's core function calls at kernel time.
-
 The MemTile DMA is triggered from the runtime sequence via `set_lock_value`, which ensures the shim drain is configured before data starts flowing.
 
 ## Usage

--- a/programming_examples/basic/custom_dma/README.md
+++ b/programming_examples/basic/custom_dma/README.md
@@ -16,7 +16,7 @@ This IRON design demonstrates how to program custom DMA patterns that integrate 
 
 1. `custom_dma.py`: A Python script that defines the IRON design. It contains a `ScatterReadDMA` class (a `Resolvable` subclass) that emits custom locks, DMA buffer descriptors, and flows alongside standard IRON components.
 
-1. `test.py`: Host program to run the design on the NPU and verify the output against expected values.
+2. `test.py`: Host program to run the design on the NPU and verify the output against expected values.
 
 ## Design Overview
 

--- a/programming_examples/basic/custom_dma/custom_dma.py
+++ b/programming_examples/basic/custom_dma/custom_dma.py
@@ -18,11 +18,10 @@ from aie.dialects.aiex import set_lock_value
 
 
 class ScatterReadDMA(Resolvable):
-    """Read two equal-sized sections at different offsets from a MemTile buffer.
+    """Read three equal-sized sections at non-uniform offsets from a MemTile buffer.
 
-    A two-BD chain reads ``transfer_len`` elements from ``offset_a``, then
-    ``transfer_len`` elements from ``offset_b``, cycling.  Both sections
-    share a single recv buffer on the compute tile.
+    A custom three-BD chain pattern reads ``transfer_len`` elements from ``offset_a``,
+    ``offset_b``, and ``offset_c``, cycling.
 
     Usage: pass an instance as a Worker ``fn_arg``.  Inside the worker
     function, call ``acquire(1)`` / ``release(1)`` to synchronize with
@@ -38,6 +37,7 @@ class ScatterReadDMA(Resolvable):
         transfer_len: int,
         offset_a: int,
         offset_b: int,
+        offset_c: int,
         memtile_placement=None,
         compute_placement=None,
     ):
@@ -48,6 +48,7 @@ class ScatterReadDMA(Resolvable):
         self._transfer_len = transfer_len
         self._offset_a = offset_a
         self._offset_b = offset_b
+        self._offset_c = offset_c
         self._memtile = memtile_placement
         self._compute = compute_placement
 
@@ -122,21 +123,26 @@ class ScatterReadDMA(Resolvable):
         # --- DMA flow: MemTile MM2S → compute S2MM ---
         flow(memtile_op, WireBundle.DMA, 0, compute_op, WireBundle.DMA, 0)
 
-        # --- MemTile DMA: two-BD chain with different offsets ---
+        # --- MemTile DMA: three-BD chain with non-uniform offsets ---
         @memtile_dma(memtile_op)
         def _mtdma(block):
-            dma_start(DMAChannelDir.MM2S, 0, dest=block[1], chain=block[3])
-            with block[1]:  # BD1: section A
+            dma_start(DMAChannelDir.MM2S, 0, dest=block[1], chain=block[4])
+            with block[1]:  # BD1: row at offset_a
                 use_lock(mem_cons_lock, LockAction.AcquireGreaterEqual)
                 dma_bd(src_buf, offset=self._offset_a, len=self._transfer_len)
                 use_lock(mem_prod_lock, LockAction.Release)
                 next_bd(block[2])
-            with block[2]:  # BD2: section B (different offset, same length)
+            with block[2]:  # BD2: row at offset_b
                 use_lock(mem_cons_lock, LockAction.AcquireGreaterEqual)
                 dma_bd(src_buf, offset=self._offset_b, len=self._transfer_len)
                 use_lock(mem_prod_lock, LockAction.Release)
+                next_bd(block[3])
+            with block[3]:  # BD3: row at offset_c
+                use_lock(mem_cons_lock, LockAction.AcquireGreaterEqual)
+                dma_bd(src_buf, offset=self._offset_c, len=self._transfer_len)
+                use_lock(mem_prod_lock, LockAction.Release)
                 next_bd(block[1])
-            with block[3]:
+            with block[4]:
                 EndOp()
 
         # --- Compute tile DMA: S2MM, loops forever ---
@@ -153,21 +159,23 @@ class ScatterReadDMA(Resolvable):
 
 
 def custom_dma_design(dev):
-    # Buffer layout on MemTile: 3 rows × 16 columns (48 x i32).
-    # BD1 reads row 0, BD2 reads row 2, skipping row 1.
+    # Buffer layout on MemTile: 4 rows × 16 columns (64 x i32).
+    # Three BDs read rows 0, 1, and 3 — gaps of 1 and 2 rows (non-uniform).
     cols = 16
+    total_elems = 4 * cols
     transfer_len = cols
     offset_a = 0 * cols  # row 0
-    offset_b = 2 * cols  # row 2
-    total_elems = 3 * cols  # 48
+    offset_b = 1 * cols  # row 1
+    offset_c = 3 * cols  # row 3 (skips row 2)
 
     buf_type = np.ndarray[(total_elems,), np.dtype[np.int32]]
     transfer_type = np.ndarray[(transfer_len,), np.dtype[np.int32]]
 
     init_data = np.zeros(total_elems, dtype=np.int32)
-    init_data[offset_a : offset_a + cols] = np.arange(100, 100 + cols, dtype=np.int32)
-    init_data[1 * cols : 2 * cols] = np.arange(300, 300 + cols, dtype=np.int32)
-    init_data[offset_b : offset_b + cols] = np.arange(200, 200 + cols, dtype=np.int32)
+    for r in range(4):
+        init_data[r * cols : (r + 1) * cols] = np.arange(
+            (r + 1) * 100, (r + 1) * 100 + cols, dtype=np.int32
+        )
 
     # Request one MemTile and one compute tile; the placer assigns coordinates.
     memtile = AnyMemTile.copy()
@@ -181,6 +189,7 @@ def custom_dma_design(dev):
         transfer_len=transfer_len,
         offset_a=offset_a,
         offset_b=offset_b,
+        offset_c=offset_c,
         memtile_placement=memtile,
         compute_placement=compute,
     )
@@ -188,14 +197,21 @@ def custom_dma_design(dev):
     of_out = ObjectFifo(transfer_type, depth=1, name="out")
 
     def core_fn(scatter_h, of_out, n):
-        # Section A
+        # Row 0
         chunk = scatter_h.acquire(1)
         elem_out = of_out.acquire(1)
         for i in range_(n):
             elem_out[i] = chunk[i]
         scatter_h.release(1)
         of_out.release(1)
-        # Section B
+        # Row 1
+        chunk = scatter_h.acquire(1)
+        elem_out = of_out.acquire(1)
+        for i in range_(n):
+            elem_out[i] = chunk[i]
+        scatter_h.release(1)
+        of_out.release(1)
+        # Row 3
         chunk = scatter_h.acquire(1)
         elem_out = of_out.acquire(1)
         for i in range_(n):
@@ -210,11 +226,10 @@ def custom_dma_design(dev):
         while_true=True,
     )
 
-    # Output: two transfers (section A + section B)
-    out_type = np.ndarray[(transfer_len * 2,), np.dtype[np.int32]]
+    out_type = np.ndarray[(transfer_len * 3,), np.dtype[np.int32]]
 
     def rt_start_memtile_dma(scatter_obj):
-        set_lock_value(scatter_obj._mem_cons_lock, 2)
+        set_lock_value(scatter_obj._mem_cons_lock, 3)
 
     rt = Runtime()
     with rt.sequence(out_type, out_type, out_type) as (_, b_out, _):

--- a/programming_examples/basic/custom_dma/custom_dma.py
+++ b/programming_examples/basic/custom_dma/custom_dma.py
@@ -1,0 +1,239 @@
+# custom_dma/custom_dma.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
+import numpy as np
+import argparse
+import sys
+
+from aie.iron import ObjectFifo, Program, Runtime, Worker
+from aie.iron.controlflow import range_
+from aie.iron.device import NPU2, AnyComputeTile, AnyMemTile
+from aie.iron.resolvable import Resolvable
+from aie.dialects.aiex import set_lock_value
+
+
+class ScatterReadDMA(Resolvable):
+    """Read two equal-sized sections at different offsets from a MemTile buffer.
+
+    A two-BD chain reads ``transfer_len`` elements from ``offset_a``, then
+    ``transfer_len`` elements from ``offset_b``, cycling.  Both sections
+    share a single recv buffer on the compute tile.
+
+    Usage: pass an instance as a Worker ``fn_arg``.  Inside the worker
+    function, call ``acquire(1)`` / ``release(1)`` to synchronize with
+    each BD completion.
+    """
+
+    def __init__(
+        self,
+        buf_type,
+        initial_value: np.ndarray,
+        recv_type,
+        name: str,
+        transfer_len: int,
+        offset_a: int,
+        offset_b: int,
+        memtile_placement=None,
+        compute_placement=None,
+    ):
+        self._buf_type = buf_type
+        self._initial_value = np.asarray(initial_value, dtype=np.int32)
+        self._recv_type = recv_type
+        self._name = name
+        self._transfer_len = transfer_len
+        self._offset_a = offset_a
+        self._offset_b = offset_b
+        self._memtile = memtile_placement
+        self._compute = compute_placement
+
+        # Set by resolve(); used by acquire/release at kernel time.
+        self._comp_cons_lock = None
+        self._comp_prod_lock = None
+        self._recv_buf = None
+
+    def tiles(self) -> list:
+        ts = []
+        if self._memtile is not None:
+            ts.append(self._memtile)
+        if self._compute is not None:
+            ts.append(self._compute)
+        return ts
+
+    def acquire(self, n: int = 1):
+        from aie.dialects.aie import use_lock, LockAction
+
+        use_lock(self._comp_cons_lock, LockAction.AcquireGreaterEqual)
+        return self._recv_buf
+
+    def release(self, n: int = 1):
+        from aie.dialects.aie import use_lock, LockAction
+
+        use_lock(self._comp_prod_lock, LockAction.Release)
+
+    def resolve(self, loc=None, ip=None) -> None:
+        from aie.dialects.aie import (
+            buffer,
+            lock,
+            flow,
+            memtile_dma,
+            mem,
+            dma_start,
+            dma_bd,
+            next_bd,
+            use_lock,
+            DMAChannelDir,
+            LockAction,
+            WireBundle,
+            EndOp,
+        )
+
+        memtile_op = self._memtile.op
+        compute_op = self._compute.op
+
+        # --- MemTile side ---
+        # cons_lock starts at 0 so the DMA is blocked until the runtime
+        # sequence triggers it via set_lock_value.
+        mem_prod_lock = lock(memtile_op, init=0)
+        mem_cons_lock = lock(memtile_op, init=0)
+        self._mem_cons_lock = mem_cons_lock
+
+        src_buf = buffer(
+            memtile_op,
+            self._buf_type,
+            self._name,
+            initial_value=self._initial_value,
+        )
+
+        # --- Compute tile side ---
+        comp_prod_lock = lock(compute_op, init=1)
+        comp_cons_lock = lock(compute_op, init=0)
+
+        recv_buf = buffer(compute_op, self._recv_type, f"{self._name}_recv")
+
+        self._comp_cons_lock = comp_cons_lock
+        self._comp_prod_lock = comp_prod_lock
+        self._recv_buf = recv_buf
+
+        # --- DMA flow: MemTile MM2S → compute S2MM ---
+        flow(memtile_op, WireBundle.DMA, 0, compute_op, WireBundle.DMA, 0)
+
+        # --- MemTile DMA: two-BD chain with different offsets ---
+        @memtile_dma(memtile_op)
+        def _mtdma(block):
+            dma_start(DMAChannelDir.MM2S, 0, dest=block[1], chain=block[3])
+            with block[1]:  # BD1: section A
+                use_lock(mem_cons_lock, LockAction.AcquireGreaterEqual)
+                dma_bd(src_buf, offset=self._offset_a, len=self._transfer_len)
+                use_lock(mem_prod_lock, LockAction.Release)
+                next_bd(block[2])
+            with block[2]:  # BD2: section B (different offset, same length)
+                use_lock(mem_cons_lock, LockAction.AcquireGreaterEqual)
+                dma_bd(src_buf, offset=self._offset_b, len=self._transfer_len)
+                use_lock(mem_prod_lock, LockAction.Release)
+                next_bd(block[1])
+            with block[3]:
+                EndOp()
+
+        # --- Compute tile DMA: S2MM, loops forever ---
+        @mem(compute_op)
+        def _cdma(block):
+            dma_start(DMAChannelDir.S2MM, 0, dest=block[1], chain=block[2])
+            with block[1]:
+                use_lock(comp_prod_lock, LockAction.AcquireGreaterEqual)
+                dma_bd(recv_buf)
+                use_lock(comp_cons_lock, LockAction.Release)
+                next_bd(block[1])
+            with block[2]:
+                EndOp()
+
+
+def custom_dma_design(dev):
+    # Buffer layout on MemTile: 3 rows × 16 columns (48 x i32).
+    # BD1 reads row 0, BD2 reads row 2, skipping row 1.
+    cols = 16
+    transfer_len = cols
+    offset_a = 0 * cols  # row 0
+    offset_b = 2 * cols  # row 2
+    total_elems = 3 * cols  # 48
+
+    buf_type = np.ndarray[(total_elems,), np.dtype[np.int32]]
+    transfer_type = np.ndarray[(transfer_len,), np.dtype[np.int32]]
+
+    init_data = np.zeros(total_elems, dtype=np.int32)
+    init_data[offset_a : offset_a + cols] = np.arange(100, 100 + cols, dtype=np.int32)
+    init_data[1 * cols : 2 * cols] = np.arange(300, 300 + cols, dtype=np.int32)
+    init_data[offset_b : offset_b + cols] = np.arange(200, 200 + cols, dtype=np.int32)
+
+    # Request one MemTile and one compute tile; the placer assigns coordinates.
+    memtile = AnyMemTile.copy()
+    compute = AnyComputeTile.copy()
+
+    scatter = ScatterReadDMA(
+        buf_type=buf_type,
+        initial_value=init_data,
+        recv_type=transfer_type,
+        name="scatter_buf",
+        transfer_len=transfer_len,
+        offset_a=offset_a,
+        offset_b=offset_b,
+        memtile_placement=memtile,
+        compute_placement=compute,
+    )
+
+    of_out = ObjectFifo(transfer_type, depth=1, name="out")
+
+    def core_fn(scatter_h, of_out, n):
+        # Section A
+        chunk = scatter_h.acquire(1)
+        elem_out = of_out.acquire(1)
+        for i in range_(n):
+            elem_out[i] = chunk[i]
+        scatter_h.release(1)
+        of_out.release(1)
+        # Section B
+        chunk = scatter_h.acquire(1)
+        elem_out = of_out.acquire(1)
+        for i in range_(n):
+            elem_out[i] = chunk[i]
+        scatter_h.release(1)
+        of_out.release(1)
+
+    worker = Worker(
+        core_fn,
+        [scatter, of_out.prod(), transfer_len],
+        tile=compute,
+        while_true=True,
+    )
+
+    # Output: two transfers (section A + section B)
+    out_type = np.ndarray[(transfer_len * 2,), np.dtype[np.int32]]
+
+    def rt_start_memtile_dma(scatter_obj):
+        set_lock_value(scatter_obj._mem_cons_lock, 2)
+
+    rt = Runtime()
+    with rt.sequence(out_type, out_type, out_type) as (_, b_out, _):
+        rt.start(worker)
+        tg = rt.task_group()
+        rt.drain(of_out.cons(), b_out, wait=True, task_group=tg)
+        rt.inline_ops(rt_start_memtile_dma, [scatter])
+        rt.finish_task_group(tg)
+
+    return Program(dev, rt).resolve_program()
+
+
+p = argparse.ArgumentParser()
+p.add_argument("-d", "--dev", required=True, dest="device", help="AIE Device")
+opts = p.parse_args(sys.argv[1:])
+
+if opts.device == "npu2":
+    dev = NPU2()
+else:
+    raise ValueError(f"[ERROR] Device name {opts.device} is unknown")
+
+print(custom_dma_design(dev))

--- a/programming_examples/basic/custom_dma/run_strix_makefile.lit
+++ b/programming_examples/basic/custom_dma/run_strix_makefile.lit
@@ -1,0 +1,10 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: mkdir -p test_stx
+// RUN: cd test_stx
+// RUN: make -f %S/Makefile clean
+// RUN: make -f %S/Makefile devicename=npu2
+// RUN: %run_on_npu2% make -f %S/Makefile run_py devicename=npu2

--- a/programming_examples/basic/custom_dma/test.py
+++ b/programming_examples/basic/custom_dma/test.py
@@ -1,0 +1,52 @@
+# test.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
+"""Test for the custom_dma scatter-read example.
+
+Expected output (32 x i32):
+  [0..15]  = row 0: [100, 101, ..., 115]
+  [16..31] = row 2: [200, 201, ..., 215]
+"""
+
+import numpy as np
+import sys
+import aie.utils.test as test_utils
+import aie.iron as iron
+from aie.utils import DefaultNPURuntime
+
+
+def main(opts):
+    out_dtype = np.int32
+    cols = 16
+    out_volume = cols * 2  # two row transfers
+
+    row0 = np.arange(100, 100 + cols, dtype=out_dtype)
+    row2 = np.arange(200, 200 + cols, dtype=out_dtype)
+    ref = np.concatenate([row0, row2])
+
+    out = iron.zeros([out_volume], dtype=out_dtype)
+    dummy = iron.zeros([out_volume], dtype=out_dtype)
+
+    print("Running...\n")
+    npu_opts = test_utils.create_npu_kernel(opts)
+    res = DefaultNPURuntime.run_test(
+        npu_opts.npu_kernel,
+        [dummy, out],
+        {1: ref},
+        verify=npu_opts.verify,
+        verbosity=npu_opts.verbosity,
+    )
+    if res == 0:
+        print("\nPASS!\n")
+    sys.exit(res)
+
+
+if __name__ == "__main__":
+    p = test_utils.create_default_argparser()
+    opts = p.parse_args(sys.argv[1:])
+    main(opts)

--- a/programming_examples/basic/custom_dma/test.py
+++ b/programming_examples/basic/custom_dma/test.py
@@ -8,9 +8,10 @@
 
 """Test for the custom_dma scatter-read example.
 
-Expected output (32 x i32):
+Expected output (48 x i32):
   [0..15]  = row 0: [100, 101, ..., 115]
-  [16..31] = row 2: [200, 201, ..., 215]
+  [16..31] = row 1: [200, 201, ..., 215]
+  [32..47] = row 3: [400, 401, ..., 415]
 """
 
 import numpy as np
@@ -23,11 +24,12 @@ from aie.utils import DefaultNPURuntime
 def main(opts):
     out_dtype = np.int32
     cols = 16
-    out_volume = cols * 2  # two row transfers
+    out_volume = cols * 3  # three row transfers
 
     row0 = np.arange(100, 100 + cols, dtype=out_dtype)
-    row2 = np.arange(200, 200 + cols, dtype=out_dtype)
-    ref = np.concatenate([row0, row2])
+    row1 = np.arange(200, 200 + cols, dtype=out_dtype)
+    row3 = np.arange(400, 400 + cols, dtype=out_dtype)
+    ref = np.concatenate([row0, row1, row3])
 
     out = iron.zeros([out_volume], dtype=out_dtype)
     dummy = iron.zeros([out_volume], dtype=out_dtype)

--- a/python/iron/worker.py
+++ b/python/iron/worker.py
@@ -65,7 +65,8 @@ class Worker(ObjectFifoEndpoint):
         Raises:
             ValueError: Parameters are validated.
         """
-        tile = tile.copy()
+        if tile is AnyComputeTile:
+            tile = tile.copy()
         if tile.tile_type is not None and tile.tile_type != AIETileType.CoreTile:
             raise ValueError(
                 f"Worker requires a compute tile, but got tile_type={tile.tile_type}"

--- a/test/python/worker_tile_sharing.py
+++ b/test/python/worker_tile_sharing.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s
+
+"""Test that Worker shares tile identity when an explicit tile is passed,
+but copies the tile when using the default AnyComputeTile singleton."""
+
+from aie.iron import Worker
+from aie.iron.device import AnyComputeTile, Tile
+
+
+def test_default_tile_is_copied():
+    """Two Workers using the default tile should get separate tile objects."""
+    w1 = Worker(None)
+    w2 = Worker(None)
+    assert w1.tile is not w2.tile, "Default tiles should be distinct copies"
+
+
+def test_explicit_tile_is_shared():
+    """An explicitly-passed tile should be shared, not copied."""
+    t = AnyComputeTile.copy()
+    w = Worker(None, tile=t)
+    assert w.tile is t, "Explicit tile should be shared with the Worker"
+
+
+def test_default_instance_is_not_mutated():
+    """Passing AnyComputeTile directly should copy it to avoid mutation."""
+    w = Worker(None, tile=AnyComputeTile)
+    assert w.tile is not AnyComputeTile, "Shared default should be copied"
+
+
+def test_placed_tile_is_shared():
+    """A placed Tile with coordinates should be shared."""
+    t = Tile(0, 2)
+    w = Worker(None, tile=t)
+    assert w.tile is t, "Placed tile should be shared with the Worker"
+
+
+test_default_tile_is_copied()
+test_explicit_tile_is_shared()
+test_default_instance_is_not_mutated()
+test_placed_tile_is_shared()
+print("All tests passed")


### PR DESCRIPTION
## Summary

#3059 introduced a `Resolvable` subclass (`StaticWeightStream`) inside programming_examples/ml/mobilenet to program custom DMA patterns from the high-level IRON API. This PR extracts that pattern into a standalone example.

This example creates a `ScatterReadDMA` Resolvable to read rows 0, 1, and 3 (skipping row 2) using per-BD offsets with non-uniform spacing from a 4x16 matrix initialized on a MemTile, to the same compute tile buffer.

## Changes
- **`programming_examples/basic/custom_dma/`**: New example to demonstrate how custom DMA programming integrates with the high-level IRON API in the same design by using `Resolvable` subclass.
- **`python/iron/worker.py`**: Worker only copies the tile when using the default `AnyComputeTile` singleton. Explicitly-passed tiles are no longer copied, allowing components to share the same tile with a Worker via the standard `tile=` argument.