### PR TITLE
Propagate NPU2=1 into lit subprocesses on Strix     

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -62,6 +62,7 @@ xrt_config = LitConfigHelper.detect_xrt(
     config.xrt_include_dir,
     config.xrt_bin_dir,
     config.aie_src_root,
+    llvm_config,
     config.vitis_components,
 )
 

--- a/programming_guide/lit.cfg.py
+++ b/programming_guide/lit.cfg.py
@@ -44,6 +44,7 @@ xrt_config = LitConfigHelper.detect_xrt(
     config.xrt_include_dir,
     config.xrt_bin_dir,
     config.aie_src_root,
+    llvm_config,
     config.vitis_components,
 )
 

--- a/python/aie_lit_utils/lit_config_helpers.py
+++ b/python/aie_lit_utils/lit_config_helpers.py
@@ -256,6 +256,7 @@ class LitConfigHelper:
         xrt_include_dir: str,
         xrt_bin_dir: str,
         aie_src_root: str,
+        llvm_config,
         vitis_components: Optional[List[str]] = None,
     ) -> HardwareConfig:
         """
@@ -409,6 +410,7 @@ class LitConfigHelper:
                         )
                         config.features.extend(["ryzen_ai", "ryzen_ai_npu2"])
                         config.substitutions["%run_on_npu2%"] = run_on_npu2
+                        llvm_config.with_environment("NPU2", "1")
                         logger.info(
                             "Running tests on NPU2 with command line: %s", run_on_npu2
                         )

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -70,6 +70,7 @@ xrt_config = LitConfigHelper.detect_xrt(
     config.xrt_include_dir,
     config.xrt_bin_dir,
     config.aie_src_root,
+    llvm_config,
     config.vitis_components,
 )
 

--- a/test/npu-xrt/verify_npu2_env/run.lit
+++ b/test/npu-xrt/verify_npu2_env/run.lit
@@ -1,0 +1,11 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Regression: NPU2=1 must propagate from lit into test subprocesses on Strix
+// so Makefile-driven examples whose devicename defaults to
+// `$(if $(filter 1,$(NPU2)),npu2,npu)` pick the AIE2P target.
+//
+// REQUIRES: ryzen_ai_npu2
+//
+// RUN: %python -c "import os; print('NPU2=' + os.environ.get('NPU2','<unset>'))" | FileCheck %s
+// CHECK: NPU2=1


### PR DESCRIPTION
  ## Summary

  - On `ryzen_ai_npu2` detection, `detect_xrt` now exports `NPU2=1` into the lit environment so Makefile examples with `devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)` pick `npu2` without each lit having to pass
   `devicename=npu2` on every `make` line.           
  - `detect_xrt` gains a `llvm_config` parameter (matches `detect_chess`/`detect_peano`); three `lit.cfg.py` callers updated.                                                                                        
  - Adds `test/npu-xrt/verify_npu2_env/run.lit` as a regression.                                          

  ## Why                                             

Without this, a Strix lit that omitted `devicename=npu2` compiled kernels for `aie2` (Phoenix) while aiecc lowered the design for `aie.device(npu2)`. The wrong-arch `.o` stitched into the xclbin and dispatch hung with `ERT_CMD_STATE_TIMEOUT`. Standalone runs were fine because `utils/env_setup.sh` already sets `NPU2=1` in the shell. `REQUIRES: ryzen_ai_npu2` gates hardware, not arch propagation.                      
                                                                                                                                                                                               
  ## Test plan                                       
                                                             
  Verified on Strix:
                    
  - [x] Regression lit FAILs (`NPU2=<unset>`) without the fix, PASSes (`NPU2=1`) with it.
  - [x] End-to-end: a stripped `eltwise_mul` lit picks `--target=aie2p` with the fix and `--target=aie2` without it.                                                                                                 
  - [x] `black --check` and pre-commit hooks pass. 