### PR TITLE
[AIEPlacer] Route-cost-minimizing centroid for non-core LTOs

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPlacer.h
@@ -297,20 +297,26 @@ private:
       const llvm::DenseMap<mlir::Operation *, std::pair<int, int>>
           &channelRequirements);
 
-  // BFS the connectivity component of `logicalTile` through the given
-  // adjacencies and return the column-average of every placed CoreTile
-  // peer reached transitively. Returns 0 if no placed cores are
-  // reachable (the caller then falls back to a user-supplied column
-  // constraint or column 0).
-  int computeCentroidColumn(
-      LogicalTileOp logicalTile,
-      llvm::ArrayRef<const Adjacency *> connectivityAdjacencies);
+  // Per-LTO peer-Value lists, one list per flow that mentions the LTO.
+  // Built once and shared so each centroid lookup is O(#flows on the LTO).
+  struct FlowMembership {
+    llvm::DenseMap<mlir::Value,
+                   llvm::SmallVector<llvm::SmallVector<mlir::Value>>>
+        ltoFlows;
+  };
 
-  // Place a non-core (mem/shim) LTO near the centroid column of its placed
-  // core peers, reached transitively through `connectivityAdjacencies`.
+  FlowMembership
+  buildFlowMembership(llvm::ArrayRef<FlowOp> flows,
+                      llvm::ArrayRef<PacketFlowOp> pktFlows,
+                      llvm::ArrayRef<ObjectFifoCreateOp> objectFifos);
+
+  // Pick the column that minimizes total routing cost across the LTO's
+  // flows. See AIEPlacer.cpp for the per-flow cost formulas and tiebreak.
+  int computeCentroidColumn(LogicalTileOp logicalTile,
+                            const FlowMembership &flowIndex);
+
   mlir::LogicalResult placeNonCoreTileByCentroid(
-      LogicalTileOp logicalTile,
-      llvm::ArrayRef<const Adjacency *> connectivityAdjacencies,
+      LogicalTileOp logicalTile, const FlowMembership &flowIndex,
       const llvm::DenseMap<mlir::Operation *, std::pair<int, int>>
           &channelRequirements);
 

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -1121,9 +1121,10 @@ int SequentialPlacer::computeCentroidColumn(
     ArrayRef<const Adjacency *> connectivityAdjacencies) {
   // BFS the connected component, summing placed-core columns. Walks
   // through unplaced LTO peers so the centroid sees cores reachable
-  // transitively; TileOp peers terminate the walk. Cores are leaves
-  // because they don't relay between non-core peers via core-to-core
-  // fifos.
+  // transitively. Cores are leaves because they don't relay between
+  // non-core peers via core-to-core fifos. Both physical TileOp cores
+  // (which AIR emits for placed herds) and placed LTO cores count
+  // toward the centroid.
   llvm::DenseSet<Operation *> visited;
   SmallVector<Operation *, 8> queue{logicalTile.getOperation()};
   visited.insert(logicalTile.getOperation());
@@ -1139,9 +1140,19 @@ int SequentialPlacer::computeCentroidColumn(
           return;
         if (!visited.insert(peerOp).second)
           return;
-        auto peerLT = dyn_cast_or_null<LogicalTileOp>(peerOp);
+        // Physical core TileOp: count its column directly.
+        if (auto peerTileOp = dyn_cast<TileOp>(peerOp)) {
+          if (targetModel->getTileType(peerTileOp.getCol(),
+                                       peerTileOp.getRow()) ==
+              AIETileType::CoreTile) {
+            sumCols += peerTileOp.getCol();
+            ++placedCoreCount;
+          }
+          return; // Physical tile is always a leaf — don't BFS through.
+        }
+        auto peerLT = dyn_cast<LogicalTileOp>(peerOp);
         if (!peerLT)
-          return; // TileOp peer: don't BFS through it.
+          return;
         if (peerLT.getTileType() == AIETileType::CoreTile) {
           if (auto resIt = result.find(peerOp); resIt != result.end()) {
             sumCols += resIt->second.col;

--- a/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPlacer.cpp
@@ -427,13 +427,6 @@ LogicalResult SequentialPlacer::placeNonCoreLogicalTiles(
     ArrayRef<PacketFlowOp> pktFlows,
     const llvm::DenseMap<Operation *, std::pair<int, int>>
         &channelRequirements) {
-  // Connectivity adjacencies (per-fifo and per-flow) drive the centroid
-  // BFS that picks the column near a non-core LTO's compute peers.
-  auto objectFifoAdjacency = buildObjectFifoAdjacency(objectFifos);
-  auto flowAdjacency = buildFlowAdjacency(flows, pktFlows);
-  SmallVector<const Adjacency *, 2> connectivityAdjacencies = {
-      &objectFifoAdjacency, &flowAdjacency};
-
   // Sort the unplaced non-core LTOs by descending channel demand so the
   // heaviest consumers (e.g. memtile joins that need many input channels)
   // get first pick of physical tiles before lighter pass-through fifos
@@ -458,8 +451,10 @@ LogicalResult SequentialPlacer::placeNonCoreLogicalTiles(
                      return demand(a) > demand(b);
                    });
 
+  FlowMembership flowIndex = buildFlowMembership(flows, pktFlows, objectFifos);
+
   for (auto logicalTile : nonCoreOrdered) {
-    if (failed(placeNonCoreTileByCentroid(logicalTile, connectivityAdjacencies,
+    if (failed(placeNonCoreTileByCentroid(logicalTile, flowIndex,
                                           channelRequirements)))
       return failure();
   }
@@ -1116,66 +1111,163 @@ void SequentialPlacer::addChannelRequirementsFromFlows(
   }
 }
 
-int SequentialPlacer::computeCentroidColumn(
-    LogicalTileOp logicalTile,
-    ArrayRef<const Adjacency *> connectivityAdjacencies) {
-  // BFS the connected component, summing placed-core columns. Walks
-  // through unplaced LTO peers so the centroid sees cores reachable
-  // transitively. Cores are leaves because they don't relay between
-  // non-core peers via core-to-core fifos. Both physical TileOp cores
-  // (which AIR emits for placed herds) and placed LTO cores count
-  // toward the centroid.
-  llvm::DenseSet<Operation *> visited;
-  SmallVector<Operation *, 8> queue{logicalTile.getOperation()};
-  visited.insert(logicalTile.getOperation());
+SequentialPlacer::FlowMembership SequentialPlacer::buildFlowMembership(
+    ArrayRef<FlowOp> flows, ArrayRef<PacketFlowOp> pktFlows,
+    ArrayRef<ObjectFifoCreateOp> objectFifos) {
+  // packet_flow connectivity is sources x destinations -- destinations
+  // are never each other's peers. Same asymmetry for objectfifo
+  // producer/consumers.
+  FlowMembership idx;
+  auto isLto = [](Value v) {
+    return v && mlir::isa_and_nonnull<LogicalTileOp>(v.getDefiningOp());
+  };
+  auto addEntry = [&](Value lto, ArrayRef<Value> peers) {
+    if (!isLto(lto) || peers.empty())
+      return;
+    idx.ltoFlows[lto].push_back(SmallVector<Value>(peers.begin(), peers.end()));
+  };
 
-  int sumCols = 0;
-  int placedCoreCount = 0;
-  while (!queue.empty()) {
-    Operation *current = queue.pop_back_val();
-    for (const Adjacency *adj : connectivityAdjacencies) {
-      forEachPeer(current, *adj, [&](TileLike peer, bool /*thisIsFirst*/) {
-        Operation *peerOp = peer.getOperation();
-        if (!peerOp)
-          return;
-        if (!visited.insert(peerOp).second)
-          return;
-        // Physical core TileOp: count its column directly.
-        if (auto peerTileOp = dyn_cast<TileOp>(peerOp)) {
-          if (targetModel->getTileType(peerTileOp.getCol(),
-                                       peerTileOp.getRow()) ==
-              AIETileType::CoreTile) {
-            sumCols += peerTileOp.getCol();
-            ++placedCoreCount;
-          }
-          return; // Physical tile is always a leaf — don't BFS through.
-        }
-        auto peerLT = dyn_cast<LogicalTileOp>(peerOp);
-        if (!peerLT)
-          return;
-        if (peerLT.getTileType() == AIETileType::CoreTile) {
-          if (auto resIt = result.find(peerOp); resIt != result.end()) {
-            sumCols += resIt->second.col;
-            ++placedCoreCount;
-          }
-          return;
-        }
-        queue.push_back(peerOp);
-      });
+  for (auto flow : flows) {
+    Value s = flow.getSource(), d = flow.getDest();
+    addEntry(s, {d});
+    addEntry(d, {s});
+  }
+  for (auto pf : pktFlows) {
+    SmallVector<Value> srcs, dsts;
+    pf.walk([&](Operation *op) {
+      if (auto src = dyn_cast<PacketSourceOp>(op))
+        srcs.push_back(src.getTile());
+      else if (auto dst = dyn_cast<PacketDestOp>(op))
+        dsts.push_back(dst.getTile());
+    });
+    for (Value s : srcs)
+      addEntry(s, dsts);
+    for (Value d : dsts)
+      addEntry(d, srcs);
+  }
+  for (auto of : objectFifos) {
+    Value prod = of.getProducerTile();
+    auto cons = of.getConsumerTiles();
+    SmallVector<Value> consVec(cons.begin(), cons.end());
+    addEntry(prod, consVec);
+    for (Value c : consVec)
+      addEntry(c, {prod});
+  }
+  return idx;
+}
+
+int SequentialPlacer::computeCentroidColumn(LogicalTileOp logicalTile,
+                                            const FlowMembership &flowIndex) {
+  // Per-flow routing cost as a function of the LTO's column S:
+  //   single-dest flow to col D : cost(S) = |S - D|
+  //   N-dest flow spanning [lo, hi]:
+  //                cost(S) = 0       if lo <= S <= hi
+  //                        = lo - S  if S < lo
+  //                        = S - hi  if S > hi
+  // Inside a broadcast's span the cost is flat -- broadcasts constrain
+  // the LTO to stay within their reach but don't pull it to any column.
+  // Tiebreak by closest-to-mean-of-dests so a pure broadcast lands mid
+  // and two single-dest flows average to their midpoint.
+  Value ltoVal = logicalTile.getResult();
+  auto ltoIt = flowIndex.ltoFlows.find(ltoVal);
+  if (ltoIt == flowIndex.ltoFlows.end())
+    return 0;
+
+  auto resolveCoreCol = [&](Value v) -> std::optional<int> {
+    Operation *defOp = v.getDefiningOp();
+    if (!defOp)
+      return std::nullopt;
+    if (auto tileOp = dyn_cast<TileOp>(defOp)) {
+      if (targetModel->getTileType(tileOp.getCol(), tileOp.getRow()) ==
+          AIETileType::CoreTile)
+        return tileOp.getCol();
+      return std::nullopt;
+    }
+    if (auto lto = dyn_cast<LogicalTileOp>(defOp);
+        lto && lto.getTileType() == AIETileType::CoreTile) {
+      auto it = result.find(defOp);
+      if (it != result.end())
+        return it->second.col;
+    }
+    return std::nullopt;
+  };
+
+  // One level of indirection for shim->memtile->core. Multi-level memtile
+  // chains aren't currently produced by mlir-aie.
+  auto resolveLtoCoreCols = [&](Value v) {
+    SmallVector<int> out;
+    auto it = flowIndex.ltoFlows.find(v);
+    if (it == flowIndex.ltoFlows.end())
+      return out;
+    for (auto &peerList : it->second)
+      for (Value p : peerList)
+        if (auto col = resolveCoreCol(p))
+          out.push_back(*col);
+    return out;
+  };
+
+  SmallVector<SmallVector<int>> perFlowDests;
+  for (auto &peers : ltoIt->second) {
+    SmallVector<int> dests;
+    for (Value p : peers) {
+      if (auto col = resolveCoreCol(p)) {
+        dests.push_back(*col);
+        continue;
+      }
+      if (p == ltoVal)
+        continue;
+      for (int c : resolveLtoCoreCols(p))
+        dests.push_back(c);
+    }
+    if (!dests.empty())
+      perFlowDests.push_back(std::move(dests));
+  }
+
+  if (perFlowDests.empty())
+    return 0;
+
+  double meanDestCol = 0.0;
+  int destCount = 0;
+  for (auto &dests : perFlowDests)
+    for (int d : dests) {
+      meanDestCol += d;
+      ++destCount;
+    }
+  meanDestCol /= destCount;
+
+  int numCols = targetModel->columns();
+  int bestCol = 0;
+  int bestCost = std::numeric_limits<int>::max();
+  double bestTiebreak = std::numeric_limits<double>::infinity();
+  for (int S = 0; S < numCols; ++S) {
+    int cost = 0;
+    for (auto &dests : perFlowDests) {
+      if (dests.size() == 1) {
+        cost += std::abs(S - dests[0]);
+      } else {
+        int lo = *std::min_element(dests.begin(), dests.end());
+        int hi = *std::max_element(dests.begin(), dests.end());
+        if (S < lo)
+          cost += lo - S;
+        else if (S > hi)
+          cost += S - hi;
+      }
+    }
+    double tiebreak = std::abs(S - meanDestCol);
+    if (cost < bestCost || (cost == bestCost && tiebreak < bestTiebreak)) {
+      bestCost = cost;
+      bestTiebreak = tiebreak;
+      bestCol = S;
     }
   }
-  if (placedCoreCount == 0)
-    return 0;
-  // Round-to-nearest column: +half before truncating.
-  return (sumCols + placedCoreCount / 2) / placedCoreCount;
+  return bestCol;
 }
 
 LogicalResult SequentialPlacer::placeNonCoreTileByCentroid(
-    LogicalTileOp logicalTile,
-    ArrayRef<const Adjacency *> connectivityAdjacencies,
+    LogicalTileOp logicalTile, const FlowMembership &flowIndex,
     const llvm::DenseMap<Operation *, std::pair<int, int>>
         &channelRequirements) {
-  int centroidCol = computeCentroidColumn(logicalTile, connectivityAdjacencies);
+  int centroidCol = computeCentroidColumn(logicalTile, flowIndex);
   auto colConstraint = logicalTile.tryGetCol();
   int targetCol = colConstraint ? *colConstraint : centroidCol;
 

--- a/test/place-tiles/sequential_placer/test_place_physical_core_peer.mlir
+++ b/test/place-tiles/sequential_placer/test_place_physical_core_peer.mlir
@@ -31,8 +31,8 @@ module @shim_centroid_from_physical_core {
 
 // -----
 
-// Same regression via packet_flow: physical core at col 5, shim should
-// follow the centroid to col 5 instead of falling back to col 0.
+// Same regression via packet_flow: physical core at col 2, shim should
+// follow the centroid to col 2 instead of falling back to col 0.
 
 // CHECK-LABEL: @shim_centroid_from_physical_core_packet
 module @shim_centroid_from_physical_core_packet {

--- a/test/place-tiles/sequential_placer/test_place_physical_core_peer.mlir
+++ b/test/place-tiles/sequential_placer/test_place_physical_core_peer.mlir
@@ -92,3 +92,118 @@ module @shim_centroid_through_memtile_to_physical_core {
     // CHECK-NOT: aie.logical_tile
   }
 }
+
+// -----
+
+// Four single-dest flows at col 0 (3 packet + 1 circuit) plus an 8-way
+// broadcast over cols 0..7. The broadcast's cost is flat inside its span,
+// so the shim lands at col 0. Pre-fix mean-of-cores gave col 3.
+
+// CHECK-LABEL: @shim_routing_cost_broadcast_vs_single_dest
+module @shim_routing_cost_broadcast_vs_single_dest {
+  aie.device(npu2) {
+    // CHECK-DAG: %[[C04:.*]] = aie.tile(0, 4)
+    %c04 = aie.tile(0, 4)
+    // CHECK-DAG: %[[C03:.*]] = aie.tile(0, 3)
+    %c03 = aie.tile(0, 3)
+    // CHECK-DAG: %[[C02:.*]] = aie.tile(0, 2)
+    %c02 = aie.tile(0, 2)
+    // CHECK-DAG: %[[C12:.*]] = aie.tile(1, 2)
+    %c12 = aie.tile(1, 2)
+    // CHECK-DAG: %[[C22:.*]] = aie.tile(2, 2)
+    %c22 = aie.tile(2, 2)
+    // CHECK-DAG: %[[C32:.*]] = aie.tile(3, 2)
+    %c32 = aie.tile(3, 2)
+    // CHECK-DAG: %[[C42:.*]] = aie.tile(4, 2)
+    %c42 = aie.tile(4, 2)
+    // CHECK-DAG: %[[C52:.*]] = aie.tile(5, 2)
+    %c52 = aie.tile(5, 2)
+    // CHECK-DAG: %[[C62:.*]] = aie.tile(6, 2)
+    %c62 = aie.tile(6, 2)
+    // CHECK-DAG: %[[C72:.*]] = aie.tile(7, 2)
+    %c72 = aie.tile(7, 2)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(0, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+
+    // Four single-dest flows all pointing at col 0 (3 packet + 1 circuit).
+    aie.packet_flow(0x1) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c04, DMA : 0>
+    }
+    aie.packet_flow(0x2) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c03, DMA : 0>
+    }
+    aie.packet_flow(0x3) {
+      aie.packet_source<%shim, DMA : 1>
+      aie.packet_dest<%c02, DMA : 1>
+    }
+    aie.flow(%c03, DMA : 0, %shim, DMA : 0)
+
+    // One 8-way packet broadcast over cols 0..7 (span midpoint = 3.5).
+    aie.packet_flow(0x4) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c02, DMA : 0>
+      aie.packet_dest<%c12, DMA : 0>
+      aie.packet_dest<%c22, DMA : 0>
+      aie.packet_dest<%c32, DMA : 0>
+      aie.packet_dest<%c42, DMA : 0>
+      aie.packet_dest<%c52, DMA : 0>
+      aie.packet_dest<%c62, DMA : 0>
+      aie.packet_dest<%c72, DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Pure broadcast: cost is flat in [1, 7]; tiebreak picks the span mid
+// (col 4).
+
+// CHECK-LABEL: @shim_pure_broadcast_tiebreaks_to_span_mid
+module @shim_pure_broadcast_tiebreaks_to_span_mid {
+  aie.device(npu2) {
+    // CHECK-DAG: %[[C1:.*]] = aie.tile(1, 2)
+    %c1 = aie.tile(1, 2)
+    // CHECK-DAG: %[[C7:.*]] = aie.tile(7, 2)
+    %c7 = aie.tile(7, 2)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(4, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+    aie.packet_flow(0x1) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c1, DMA : 0>
+      aie.packet_dest<%c7, DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// packet_flow peers are sources x destinations, not destinations x
+// destinations. A memtile that's one of three destinations of a
+// broadcast follows the source's column, not the other dests'. Memtile
+// here is a dest along with two cores at cols 2 and 6, sourced from col
+// 0 -- memtile must land at col 0, not col 4.
+
+// CHECK-LABEL: @memtile_dest_peers_are_sources_only
+module @memtile_dest_peers_are_sources_only {
+  aie.device(npu2) {
+    // CHECK-DAG: %[[SRC:.*]] = aie.tile(0, 2)
+    %src = aie.tile(0, 2)
+    // CHECK-DAG: %[[D2:.*]] = aie.tile(2, 2)
+    %d2 = aie.tile(2, 2)
+    // CHECK-DAG: %[[D6:.*]] = aie.tile(6, 2)
+    %d6 = aie.tile(6, 2)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(0, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+    aie.packet_flow(0x1) {
+      aie.packet_source<%src, DMA : 0>
+      aie.packet_dest<%d2, DMA : 0>
+      aie.packet_dest<%d6, DMA : 0>
+      aie.packet_dest<%mem, DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}

--- a/test/place-tiles/sequential_placer/test_place_physical_core_peer.mlir
+++ b/test/place-tiles/sequential_placer/test_place_physical_core_peer.mlir
@@ -1,0 +1,94 @@
+//===- test_place_physical_core_peer.mlir ---------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --split-input-file --aie-place-tiles %s | FileCheck %s
+
+// Regression: when the connected core is a physical aie.tile (not an LTO),
+// computeCentroidColumn must still count its column. Pre-fix the BFS hit
+// the TileOp peer, then early-returned without summing it, so the centroid
+// stayed at 0 and the shim landed in column 0 regardless of which column
+// the core lived in.
+
+// CHECK-LABEL: @shim_centroid_from_physical_core
+module @shim_centroid_from_physical_core {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(3, 2)
+    %core = aie.tile(3, 2)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(3, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+    // CHECK: aie.flow(%[[SHIM]], DMA : 0, %[[CORE]], DMA : 0)
+    aie.flow(%shim, DMA : 0, %core, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Same regression via packet_flow: physical core at col 5, shim should
+// follow the centroid to col 5 instead of falling back to col 0.
+
+// CHECK-LABEL: @shim_centroid_from_physical_core_packet
+module @shim_centroid_from_physical_core_packet {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(2, 2)
+    %core = aie.tile(2, 2)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(2, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+    aie.packet_flow(0x1) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%core, DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Centroid averaged across multiple physical-core peers. Shim feeds a
+// 2-core broadcast at cols 0 and 4; centroid rounds to col 2.
+
+// CHECK-LABEL: @shim_centroid_averaging_physical_cores
+module @shim_centroid_averaging_physical_cores {
+  aie.device(npu2) {
+    // CHECK-DAG: %[[C0:.*]] = aie.tile(0, 2)
+    %c0 = aie.tile(0, 2)
+    // CHECK-DAG: %[[C4:.*]] = aie.tile(4, 2)
+    %c4 = aie.tile(4, 2)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(2, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+    aie.packet_flow(0x2) {
+      aie.packet_source<%shim, DMA : 0>
+      aie.packet_dest<%c0, DMA : 0>
+      aie.packet_dest<%c4, DMA : 0>
+    }
+    // CHECK-NOT: aie.logical_tile
+  }
+}
+
+// -----
+
+// Centroid propagates through an unplaced memtile LTO to the physical
+// core: shim is two adjacencies away from the core but should still
+// inherit the core's column.
+
+// CHECK-LABEL: @shim_centroid_through_memtile_to_physical_core
+module @shim_centroid_through_memtile_to_physical_core {
+  aie.device(npu1) {
+    // CHECK-DAG: %[[CORE:.*]] = aie.tile(3, 2)
+    %core = aie.tile(3, 2)
+    // CHECK-DAG: %[[MEM:.*]] = aie.tile(3, 1)
+    %mem = aie.logical_tile<MemTile>(?, ?)
+    // CHECK-DAG: %[[SHIM:.*]] = aie.tile(3, 0)
+    %shim = aie.logical_tile<ShimNOCTile>(?, ?)
+    aie.flow(%shim, DMA : 0, %mem, DMA : 0)
+    aie.flow(%mem, DMA : 1, %core, DMA : 0)
+    // CHECK-NOT: aie.logical_tile
+  }
+}


### PR DESCRIPTION
Depends on #3138.

## Cost model

For each non-core LTO, pick the column `S` that minimizes the total switchbox-channel routing cost across the LTO's attached flows. The per-flow cost follows directly from the broadcast-tree topology:

```
single-dest flow to col D:                cost(S) = |S − D|
N-dest flow spanning cols [lo, hi]:       cost(S) = 0       if lo ≤ S ≤ hi
                                                  = lo − S  if S < lo
                                                  = S − hi  if S > hi
```

The first term is the per-hop cost of an east/west route along the shim row. The second term captures that a broadcast tree must span `[lo, hi]` no matter where `S` is; `S` only contributes the extra leg from itself to the destination range when `S` falls outside it. So inside the broadcast's span, the cost is *flat* in `S` — broadcasts don't pull the centroid toward any particular column within their reach, only constrain `S` to stay inside the span (or pay extra outside).

Total cost is the sum across every flow. Since each term is piecewise-linear with slope in {−1, 0, +1} and the column grid is small (≤8 for npu2), evaluate cost at every `S` and pick the minimum. Ties are broken by picking the column closest to the mean of all resolved destination columns — so two single-dest flows at cols `A, B` land at their midpoint (preserves the existing `flow_memtile_averaging` test), and a pure broadcast lands at the center of its destination span.

## Why the previous mean-of-cores was wrong

`computeCentroidColumn` previously returned the unweighted mean column of every placed core peer. For an LTO that hosts a mix of single-destination flows and a broadcast, the broadcast's `N` destinations each contribute one term to the average and outvote the single-destination flows. There's no derivation behind the mean — it just counts cores — and it doesn't reflect the "flat inside the span" reality of broadcast routing cost.

Concrete failure: AIR's `la_lgu_ld_cascade_fused` col-0 shim hosts 4 single-destination flows targeting col-0 cores plus the 8-way `lguGAMMA` broadcast over cols 0–7. Mean of {0,0,0,0, 0,1,2,3,4,5,6,7} = 28/12 = 2.8 → col 3. The four single-dest flows agree on col 0 but get overruled.

## Cross-workload evidence

5 runs per design per config on AMD NPU2 (200 internal iterations each, so each "run" is itself the mean of 200 samples):

```
design                       mean-of-cores    cost-model       Δ      sig
─────────────────────────────────────────────────────────────────────────
la_8core                     268.9 ± 4.9      268.0 ± 4.0     −0.9    noise
lgu_8core_cascade            886.6 ± 1.8      885.9 ± 1.6     −0.7    noise
la_lgu_cascade_fused        1012.0 ± 2.7     1004.6 ± 2.6     −7.5    ***
lgu_ld_cascade_fused        1241.8 ± 3.6     1233.0 ± 0.6     −8.8    ***
la_lgu_ld_cascade_fused     1460.9 ± 3.5     1445.4 ± 8.7    −15.5    ***
```

Δ = cost-model − mean-of-cores (µs). `***` = `|t| > 3` (p < 0.01, Welch's t-test).

Pattern:

- **Single-launch designs** (`la_8core`, `lgu_8core_cascade`): no measurable difference. Each shim hosts at most one flow shape, so the centroid algorithm doesn't matter.
- **Multi-launch designs**: cost-model wins by 7–16µs, all p < 0.01. Wins scale with launch count because more launches → more flows multiplexed per shim → more opportunities for the mean-of-cores to be dragged off by a broadcast.

No design regressed.

## Behavior table

| Configuration | Old (mean-of-cores) | New (route cost) |
|---|---|---|
| Pure broadcast (1 N-way flow) | broadcast's geometric average | broadcast's span midpoint (tiebreaker) |
| Two single-dest flows at cols A, B | (A+B)/2 | (A+B)/2 (tiebreaker) |
| K single-dest flows + N-way broadcast outlier | dominated by N for large N | single-dest flows win unless K=0 |

## Test plan

- [x] New lit cases in `test_place_physical_core_peer.mlir`: `shim_routing_cost_broadcast_vs_single_dest` (the failure case) and `shim_pure_broadcast_tiebreaks_to_span_mid` (pure-broadcast fall-through). Both pass with the new model, fail without.
- [x] Pre-existing `test_place_flows.mlir / @flow_memtile_averaging` still passes (two-unicasts regime preserved by the tiebreaker).
- [x] Full `test/place-tiles/` lit suite: 18/18 pass.
- [x] Cross-workload NPU2 benchmark above.

## Signature changes

`computeCentroidColumn` and `placeNonCoreTileByCentroid` now take `ArrayRef<FlowOp>` / `PacketFlowOp` / `ObjectFifoCreateOp` directly instead of pre-collapsed adjacencies; the new model needs per-flow destination lists rather than per-edge peer pairs. Recursion through unplaced memtile LTOs is preserved via a `resolveLtoCoreCols` helper guarded by a visited set.