### PR TITLE
wheel: hygiene + Linux size flags (follow-on to #3072)

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,4 @@
 aiofiles
-# dataclasses is deprecated above Python 3.6
-dataclasses>=0.6,<=0.8; python_version < "3.7"
 numpy>=1.26,<2.3; python_version < "3.11"
 numpy>=2.4.6,<3.0; python_version >= "3.11"
 rich

--- a/utils/mlir_aie_wheels/requirements.lock
+++ b/utils/mlir_aie_wheels/requirements.lock
@@ -21,10 +21,6 @@ cmake==4.3.2 \
     --hash=sha256:ea95db137fd27f420d5e149c41e1f7621e786869afa3ca0fe18301df9e066607 \
     --hash=sha256:f8f570813753ed4564928cf45c4c13c31e46b3e66b1a07fe695cb9f7b7af185e
     # via -r requirements.txt
-dataclasses==0.6 \
-    --hash=sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f \
-    --hash=sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84
-    # via -r requirements.txt
 importlib-metadata==9.0.0 \
     --hash=sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7 \
     --hash=sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc

--- a/utils/mlir_aie_wheels/requirements.txt
+++ b/utils/mlir_aie_wheels/requirements.txt
@@ -2,7 +2,6 @@
 # cibuildwheel before-build). After editing this file, regenerate the .lock with:
 #   utils/regenerate_lockfiles.sh
 cmake>=4.3.2
-dataclasses
 importlib-metadata
 ninja!=1.13.0; platform_system=="Windows"
 numpy>=2.3

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -13,6 +13,7 @@ from importlib_metadata import files
 from setuptools import Extension, setup, find_packages
 from setuptools.command.build_ext import build_ext
 from setuptools.command.develop import develop
+from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
 sys.path.append(os.path.dirname(__file__))
@@ -236,6 +237,26 @@ class CMakeBuild(build_ext):
                 "-DLLVM_USE_CRT_MINSIZEREL=MT",
                 "-DLLVM_USE_CRT_RELEASE=MT",
             ]
+        elif platform.system() == "Linux":
+            # Equivalent of MSVC's default /OPT:REF + /OPT:ICF in Release.
+            # Per-function/data sections let --gc-sections prune unused
+            # code at link time; lld's --icf=safe folds byte-identical
+            # functions (common with heavy templates in MLIR/LLVM) without
+            # breaking address-taken semantics. ICF is restricted to
+            # native x86_64 because the aarch64 cross-build drives the
+            # link through aarch64-linux-gnu-gcc, which defaults to the
+            # system ld and won't pick up lld via this flag.
+            size_compile = "-ffunction-sections -fdata-sections"
+            size_link = "-Wl,--gc-sections"
+            if os.getenv("CIBW_ARCHS") in {"x86_64", "AMD64", None}:
+                cmake_args.append("-DLLVM_USE_LINKER=lld")
+                size_link += " -Wl,--icf=safe"
+            cmake_args += [
+                f"-DCMAKE_C_FLAGS_RELEASE=-O3 -DNDEBUG {size_compile}",
+                f"-DCMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG {size_compile}",
+                f"-DCMAKE_EXE_LINKER_FLAGS={size_link}",
+                f"-DCMAKE_SHARED_LINKER_FLAGS={size_link}",
+            ]
 
         cmake_args_dict = get_cross_cmake_args()
         cmake_args += [f"-D{k}={v}" for k, v in cmake_args_dict.items()]
@@ -308,7 +329,9 @@ class CMakeBuild(build_ext):
             # C++-developer-only content: anyone pip installing this wheel
             # reaches the toolchain through Python, never through native
             # linking. aie_api/ and aie_kernels/ headers stay — user AIE
-            # kernels #include those at compile time.
+            # kernels #include those at compile time. Static archives under
+            # runtime_lib/ (xaiengine.lib, test_utils.lib) stay — those are
+            # the documented link surface for host test executables.
             dev_paths = [
                 Path(install_dir) / "include" / "aie",
                 Path(install_dir) / "include" / "aie-c",
@@ -316,7 +339,23 @@ class CMakeBuild(build_ext):
                 Path(install_dir) / "include" / "xaienginecdo_static",
                 Path(install_dir) / "lib" / "cmake",
                 *(Path(install_dir) / "lib").glob("*.a"),
+                *(Path(install_dir) / "lib").glob("*.lib"),
             ]
+
+            # Upstream MLIR install ships Python bindings for every dialect
+            # it knows about. Drop the ones nothing in the AIE Python tree
+            # imports (verified via grep). pdl/irdl/nvgpu stay — used by
+            # extras/dialects and dialects/ext.py.
+            unused_dialects = (
+                "spirv", "omp", "smt", "shard", "sparse_tensor",
+                "x86", "amdgpu", "shape", "emitc", "async",
+            )
+            dialects_dir = Path(install_dir) / "python" / "aie" / "dialects"
+            for d in unused_dialects:
+                dev_paths.extend(dialects_dir.glob(f"{d}.py"))
+                dev_paths.extend(dialects_dir.glob(f"{d}"))
+                dev_paths.extend(dialects_dir.glob(f"_{d}_*.py"))
+                dev_paths.extend(dialects_dir.glob(f"{d}_*"))
             for p in dev_paths:
                 if p.is_dir():
                     shutil.rmtree(p)
@@ -373,6 +412,21 @@ class CMakeBuild(build_ext):
         finally:
             if cleanup_build_temp and build_succeeded:
                 _remove_tree(build_temp)
+
+
+class EggInfoCorrectTopLevel(egg_info):
+    """The CMakeExtension is named "_mlir_aie" (a placeholder for the CMake
+    build), but the wheel actually installs the `mlir_aie` package tree (and
+    `mlir_aie.libs` from auditwheel). setuptools writes the extension name
+    into top_level.txt, which then misreports the install for `pip
+    uninstall`, RECORD audits, and any tool that scans top_level. Overwrite
+    it with the real top-level packages after egg_info runs."""
+
+    def run(self):
+        super().run()
+        top_level = Path(self.egg_info) / "top_level.txt"
+        if top_level.exists():
+            top_level.write_text("mlir_aie\n", encoding="utf-8")
 
 
 class DevelopWithPth(develop):
@@ -453,7 +507,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Software Development :: Compilers",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
@@ -479,6 +532,7 @@ setup(
     cmdclass={
         "build_ext": CMakeBuild,
         "develop": DevelopWithPth,
+        "egg_info": EggInfoCorrectTopLevel,
         "install": InstallWithPth,
     },
     zip_safe=False,


### PR DESCRIPTION
Cleans up several wheel-packaging issues spotted while reviewing the rehearsal output from #3072.

Windows wheel
- Strip ``mlir_aie/lib/*.lib`` from the install tree. These are static linker artifacts produced as a side effect of the LLVM/MLIR CMake install rules; nothing in the runtime path links against them (``aiecc.exe`` / ``aie-opt.exe`` / ``AIEAggregateCAPI.dll`` are fully self-contained, verified via ``objdump -p``). Linux already strips the equivalent ``*.a`` files, so this just closes the asymmetry.

Unused dialect bindings (both OSes)
- Upstream MLIR install ships Python bindings for every dialect it knows about. Prune the ones nothing in the AIE Python tree imports (verified via grep across the install): spirv, omp, smt, shard, sparse_tensor, x86, amdgpu, shape, emitc, async. Keep pdl, irdl, nvgpu, which are pulled in transitively by extras/dialects and dialects/ext.py. ~2.5 MB win plus a clearer 'what's in this wheel' story.

Metadata correctness
- ``top_level.txt`` was reporting ``_mlir_aie`` (the CMakeExtension placeholder name) but the wheel actually installs the ``mlir_aie`` package tree. Override ``egg_info`` to write the correct value so ``pip uninstall`` and other top-level scanners see reality.
- Drop the ``Programming Language :: Python :: 3.10`` classifier -- ``python_requires`` is already ``>=3.11``, so the classifier was contradicting the requirement.
- Drop the dead ``dataclasses>=0.6,<=0.8; python_version < "3.7"`` requirement from ``python/requirements.txt`` and the unconditional ``dataclasses`` build dep from ``utils/mlir_aie_wheels/``. Project is 3.11+, dataclasses has been in stdlib since 3.7. Regenerate the affected lockfiles.

Linux size flags
- Add ``-ffunction-sections -fdata-sections`` (compile) and ``-Wl,--gc-sections -Wl,--icf=safe`` (link, lld) to the Linux wheel build. This is the equivalent of MSVC's default ``/OPT:REF`` + ``/OPT:ICF`` behavior in Release and accounts for a measurable chunk of the Linux-vs-Windows wheel-size gap. ICF and ``LLVM_USE_LINKER=lld`` are gated to native x86_64; aarch64 cross-compile keeps using the ``aarch64-linux-gnu-gcc`` driver's default linker. Expected ~10-15% reduction on Linux.