### PR TITLE
[VectorToAIEVec][AIE2P] Lower v8bf16 arith.addf/subf via v16bf16 zero-pad

### DIFF
--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -1876,6 +1876,41 @@ struct LowerVectorAddOrSubOpToAIEVecAddElemOrSubElemOp
     }
     // Float types
     else {
+      // v8bf16: pad to v16bf16 via concat with zero, run the standard
+      // 16-wide UPS+AddElem+SRS path, extract the lower 8. Same building
+      // blocks as the int widen-by-zero-pad helper at L377-389.
+      if (laneSize == 8 && resultElWidth == 16) {
+        auto loc = srcOp.getLoc();
+        VectorType v16Ty = createVectorType(16, scalarType);
+        VectorType v8Ty = resultType;
+        auto zeroCst = arith::ConstantOp::create(
+            rewriter, loc, scalarType, rewriter.getZeroAttr(scalarType));
+        auto v16Zero = aievec::BroadcastScalarOp::create(rewriter, loc, v16Ty,
+                                                         zeroCst->getResult(0));
+        auto v8Zero = aievec::ExtOp::create(rewriter, loc, v8Ty,
+                                            v16Zero->getResult(0), 0);
+        auto lhs16 = aievec::ConcatOp::create(
+            rewriter, loc, v16Ty,
+            SmallVector<Value>{lhs, v8Zero->getResult(0)});
+        auto rhs16 = aievec::ConcatOp::create(
+            rewriter, loc, v16Ty,
+            SmallVector<Value>{rhs, v8Zero->getResult(0)});
+        Type accType = getVectorOpDestType(v16Ty, /*AIE2 =*/true);
+        auto lUpsOp =
+            aievec::UPSOp::create(rewriter, loc, accType, lhs16->getResult(0));
+        auto rUpsOp =
+            aievec::UPSOp::create(rewriter, loc, accType, rhs16->getResult(0));
+        auto elemOp =
+            DstOpTy::create(rewriter, loc, lUpsOp->getResult(0).getType(),
+                            lUpsOp->getResult(0), rUpsOp->getResult(0));
+        auto shiftParamOp = arith::ConstantOp::create(
+            rewriter, loc, rewriter.getI32IntegerAttr(0));
+        auto srsOp = aievec::SRSOp::create(
+            rewriter, loc, v16Ty, elemOp.getResult(), shiftParamOp.getResult());
+        rewriter.replaceOpWithNewOp<aievec::ExtOp>(srcOp, v8Ty,
+                                                   srsOp.getResult(), 0);
+        return success();
+      }
       if (laneSize != 16 && laneSize != 32)
         return failure();
 
@@ -5483,7 +5518,7 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
   });
 
   // AIE2P-specific legalization: Override AddFOp to support laneSize==32 for
-  // float types
+  // float types. Also route v8bf16 through aievec (padded to v16bf16).
   target.addDynamicallyLegalOp<arith::AddFOp>([](arith::AddFOp op) {
     auto resultType = dyn_cast<VectorType>(op.getType());
     if (!resultType)
@@ -5492,7 +5527,11 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
     Type scalarType = resultType.getElementType();
     unsigned laneSize = getVectorLaneSize(resultType);
 
-    // For float types, support both laneSize==16 and laneSize==32
+    // For bf16, support laneSize 8 (via pad-to-16), 16, and 32
+    if (isa<FloatType>(scalarType) && scalarType.getIntOrFloatBitWidth() == 16)
+      return laneSize != 8 && laneSize != 16 && laneSize != 32;
+
+    // For other float types, support both laneSize==16 and laneSize==32
     if (isa<FloatType>(scalarType))
       return laneSize != 16 && laneSize != 32;
 
@@ -5501,7 +5540,7 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
   });
 
   // AIE2P-specific legalization: Override SubFOp to support laneSize==32 for
-  // float types
+  // float types. Also route v8bf16 through aievec (padded to v16bf16).
   target.addDynamicallyLegalOp<arith::SubFOp>([](arith::SubFOp op) {
     auto resultType = dyn_cast<VectorType>(op.getType());
     if (!resultType)
@@ -5510,7 +5549,11 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
     Type scalarType = resultType.getElementType();
     unsigned laneSize = getVectorLaneSize(resultType);
 
-    // For float types, support both laneSize==16 and laneSize==32
+    // For bf16, support laneSize 8 (via pad-to-16), 16, and 32
+    if (isa<FloatType>(scalarType) && scalarType.getIntOrFloatBitWidth() == 16)
+      return laneSize != 8 && laneSize != 16 && laneSize != 32;
+
+    // For other float types, support both laneSize==16 and laneSize==32
     if (isa<FloatType>(scalarType))
       return laneSize != 16 && laneSize != 32;
 

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -1877,9 +1877,9 @@ struct LowerVectorAddOrSubOpToAIEVecAddElemOrSubElemOp
     // Float types
     else {
       // v8bf16: pad to v16bf16 via concat with zero, run the standard
-      // 16-wide UPS+AddElem+SRS path, extract the lower 8. Same building
-      // blocks as the int widen-by-zero-pad helper at L377-389.
-      if (laneSize == 8 && resultElWidth == 16) {
+      // 16-wide UPS+AddElem+SRS path, extract the lower 8. Uses the same
+      // building blocks as the integer widen-by-zero-pad helper.
+      if (laneSize == 8 && scalarType.isBF16()) {
         auto loc = srcOp.getLoc();
         VectorType v16Ty = createVectorType(16, scalarType);
         VectorType v8Ty = resultType;
@@ -5527,8 +5527,10 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
     Type scalarType = resultType.getElementType();
     unsigned laneSize = getVectorLaneSize(resultType);
 
-    // For bf16, support laneSize 8 (via pad-to-16), 16, and 32
-    if (isa<FloatType>(scalarType) && scalarType.getIntOrFloatBitWidth() == 16)
+    // For bf16, support laneSize 8 (via pad-to-16), 16, and 32. Other
+    // 16-bit floats (e.g. f16) are not handled by the aievec lowering
+    // and must fall through to the default float predicate below.
+    if (scalarType.isBF16())
       return laneSize != 8 && laneSize != 16 && laneSize != 32;
 
     // For other float types, support both laneSize==16 and laneSize==32
@@ -5549,8 +5551,10 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
     Type scalarType = resultType.getElementType();
     unsigned laneSize = getVectorLaneSize(resultType);
 
-    // For bf16, support laneSize 8 (via pad-to-16), 16, and 32
-    if (isa<FloatType>(scalarType) && scalarType.getIntOrFloatBitWidth() == 16)
+    // For bf16, support laneSize 8 (via pad-to-16), 16, and 32. Other
+    // 16-bit floats (e.g. f16) are not handled by the aievec lowering
+    // and must fall through to the default float predicate below.
+    if (scalarType.isBF16())
       return laneSize != 8 && laneSize != 16 && laneSize != 32;
 
     // For other float types, support both laneSize==16 and laneSize==32

--- a/test/Conversion/VectorToAIEVec/test-add-aie2p.mlir
+++ b/test/Conversion/VectorToAIEVec/test-add-aie2p.mlir
@@ -1,0 +1,61 @@
+//===- test-add-aie2p.mlir -------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-vector-to-aievec="aie-target=aie2p" -cse | FileCheck %s
+
+// CHECK-LABEL: func @vecaddf_f32(
+// CHECK-SAME: %[[LHS:.*]]: vector<16xf32>,
+// CHECK-SAME: %[[RHS:.*]]: vector<16xf32>)
+func.func @vecaddf_f32(%arg0: vector<16xf32>, %arg1: vector<16xf32>) -> vector<16xf32> {
+  // CHECK:  %[[LCAST:.*]] = aievec.cast %[[LHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+  // CHECK:  %[[RCAST:.*]] = aievec.cast %[[RHS]] {isResAcc = true} : vector<16xf32>, vector<16xf32>
+  // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LCAST]], %[[RCAST]] : vector<16xf32>
+  // CHECK:  %[[CAST:.*]] = aievec.cast %[[ADD]] {isResAcc = false} : vector<16xf32>, vector<16xf32>
+  %0 = arith.addf %arg0, %arg1 : vector<16xf32>
+  // CHECK: return %[[CAST]] : vector<16xf32>
+  return %0 : vector<16xf32>
+}
+
+// CHECK-LABEL: func @vecaddf_bf16(
+// CHECK-SAME: %[[LHS:.*]]: vector<16xbf16>,
+// CHECK-SAME: %[[RHS:.*]]: vector<16xbf16>)
+func.func @vecaddf_bf16(%arg0: vector<16xbf16>, %arg1: vector<16xbf16>) -> vector<16xbf16> {
+  // CHECK:  %[[C0:.*]] = arith.constant 0 : i32
+  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+  // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<16xf32>
+  // CHECK:  %[[SRS:.*]] = aievec.srs %[[ADD]], %[[C0]] : vector<16xf32>, i32, vector<16xbf16>
+  %0 = arith.addf %arg0, %arg1 : vector<16xbf16>
+  // CHECK: return %[[SRS]] : vector<16xbf16>
+  return %0 : vector<16xbf16>
+}
+
+// 8-wide bf16 add is below the AIE2P native lane width (16). The pattern
+// pads each operand to v16bf16 by concatenating with a zero half, runs the
+// standard UPS+AddElem+SRS bf16 path, then extracts the lower 8 lanes.
+// CHECK-LABEL: func @vecaddf_bf16_v8(
+// CHECK-SAME: %[[LHS:.*]]: vector<8xbf16>,
+// CHECK-SAME: %[[RHS:.*]]: vector<8xbf16>)
+func.func @vecaddf_bf16_v8(%arg0: vector<8xbf16>, %arg1: vector<8xbf16>) -> vector<8xbf16> {
+  // CHECK:  %[[C0_I32:.*]] = arith.constant 0 : i32
+  // CHECK:  %[[C0_BF16:.*]] = arith.constant 0.000000e+00 : bf16
+  // CHECK:  %[[V16Z:.*]] = aievec.broadcast_scalar %[[C0_BF16]] : bf16, vector<16xbf16>
+  // CHECK:  %[[V8Z:.*]] = aievec.ext %[[V16Z]] {index = 0 : i8} : vector<16xbf16>, vector<8xbf16>
+  // CHECK:  %[[LHS16:.*]] = aievec.concat %[[LHS]], %[[V8Z]] : vector<8xbf16>, vector<16xbf16>
+  // CHECK:  %[[RHS16:.*]] = aievec.concat %[[RHS]], %[[V8Z]] : vector<8xbf16>, vector<16xbf16>
+  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS16]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS16]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+  // CHECK:  %[[ADD:.*]] = aievec.add_elem %[[LUPS]], %[[RUPS]] : vector<16xf32>
+  // CHECK:  %[[SRS:.*]] = aievec.srs %[[ADD]], %[[C0_I32]] : vector<16xf32>, i32, vector<16xbf16>
+  // CHECK:  %[[EXTLO:.*]] = aievec.ext %[[SRS]] {index = 0 : i8} : vector<16xbf16>, vector<8xbf16>
+  %0 = arith.addf %arg0, %arg1 : vector<8xbf16>
+  // CHECK: return %[[EXTLO]] : vector<8xbf16>
+  return %0 : vector<8xbf16>
+}

--- a/test/Conversion/VectorToAIEVec/test-sub-aie2p.mlir
+++ b/test/Conversion/VectorToAIEVec/test-sub-aie2p.mlir
@@ -65,3 +65,26 @@ func.func @vecsubf_bf16_f32_mixed(%arg0: vector<16xbf16>, %arg1: vector<16xf32>)
   // CHECK: return %[[CAST]] : vector<16xf32>
   return %2 : vector<16xf32>
 }
+
+// 8-wide bf16 sub is below the AIE2P native lane width (16). The pattern
+// pads each operand to v16bf16 by concatenating with a zero half, runs the
+// standard UPS+SubElem+SRS bf16 path, then extracts the lower 8 lanes.
+// CHECK-LABEL: func @vecsubf_bf16_v8(
+// CHECK-SAME: %[[LHS:.*]]: vector<8xbf16>,
+// CHECK-SAME: %[[RHS:.*]]: vector<8xbf16>)
+func.func @vecsubf_bf16_v8(%arg0: vector<8xbf16>, %arg1: vector<8xbf16>) -> vector<8xbf16> {
+  // CHECK:  %[[C0_I32:.*]] = arith.constant 0 : i32
+  // CHECK:  %[[C0_BF16:.*]] = arith.constant 0.000000e+00 : bf16
+  // CHECK:  %[[V16Z:.*]] = aievec.broadcast_scalar %[[C0_BF16]] : bf16, vector<16xbf16>
+  // CHECK:  %[[V8Z:.*]] = aievec.ext %[[V16Z]] {index = 0 : i8} : vector<16xbf16>, vector<8xbf16>
+  // CHECK:  %[[LHS16:.*]] = aievec.concat %[[LHS]], %[[V8Z]] : vector<8xbf16>, vector<16xbf16>
+  // CHECK:  %[[RHS16:.*]] = aievec.concat %[[RHS]], %[[V8Z]] : vector<8xbf16>, vector<16xbf16>
+  // CHECK:  %[[LUPS:.*]] = aievec.ups %[[LHS16]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+  // CHECK:  %[[RUPS:.*]] = aievec.ups %[[RHS16]] {shift = 0 : i8} : vector<16xbf16>, vector<16xf32>
+  // CHECK:  %[[SUB:.*]] = aievec.sub_elem %[[LUPS]], %[[RUPS]] : vector<16xf32>
+  // CHECK:  %[[SRS:.*]] = aievec.srs %[[SUB]], %[[C0_I32]] : vector<16xf32>, i32, vector<16xbf16>
+  // CHECK:  %[[EXTLO:.*]] = aievec.ext %[[SRS]] {index = 0 : i8} : vector<16xbf16>, vector<8xbf16>
+  %0 = arith.subf %arg0, %arg1 : vector<8xbf16>
+  // CHECK: return %[[EXTLO]] : vector<8xbf16>
+  return %0 : vector<8xbf16>
+}


### PR DESCRIPTION
## Summary

- Teach the float branch of `LowerVectorAddOrSubOpToAIEVecAddElemOrSubElemOp` to handle 8-wide bf16 by padding to v16bf16 via `aievec.concat` + `aievec.broadcast_scalar`/`ext`, running the standard UPS+AddElem/SubElem+SRS path, then extracting the lower 8 lanes with `aievec.ext`.
- Flip the AIE2P legality predicates for `arith.AddFOp` and `arith.SubFOp` so 8-wide bf16 is marked illegal and routed through this new pattern.
- Add `test-add-aie2p.mlir` (with `vecaddf_f32`, `vecaddf_bf16`, `vecaddf_bf16_v8`); extend `test-sub-aie2p.mlir` with `vecsubf_bf16_v8`.

## Why

Today `arith.addf vector<8xbf16>` (and `subf`) survives the conversion pass unchanged on AIE2P and only fails at Peano `llc` (`unable to legalize G_FADD <8 x s16>`). That blocks any frontend that emits a sub-native-width bf16 vector add — e.g. inlining around a kernel ABI like int4 matvec `DIM_M=8`, where the L1 accumulator is naturally 8 elements wide.

After this patch the op lowers to one native 256-bit vector add plus subreg-only pad/extract, so the cost is essentially equivalent to a hand-written 16-wide add that discards the upper 8.

## Test plan

- [x] `lit -sv test/Conversion/VectorToAIEVec` — all 40 tests PASS (including the 2 new ones)
- [x] `programming_examples/primitives/vector_examples/vector_add` at `VECTOR_SIZE=8` on NPU2 hardware — PASS
- [x] No regression in existing v16/v32 bf16 and f32 add/sub patterns (lit goldens unchanged)