### PR TITLE
[AIE2P] Inline int4 -> bf16 dequant lowerings

### DIFF
--- a/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
+++ b/include/aie/Dialect/XLLVM/IR/XLLVMAIE2IntrOps.td
@@ -877,4 +877,20 @@ def VectorSel32AIE2pIntrOp :
         [TypeIs<"res", VectorOfLengthAndType<[16], [I32]>>]>,
     AIE2I32SelElem;
 
+// AIE2P int4-unpack intrinsics: take a 32xi8 (= 64 packed nibbles) and
+// produce 64xi8 (one full int8 per nibble). The i32 `sign` argument
+// selects unsigned (0) vs signed (1) interpretation of the nibbles.
+// Maps to llvm.aie2p.unpack.I512.I8.I4 / llvm.aie2p.unpack.I1024.I8.I4.
+def UnpackI512I8I4AIE2pIntrOp :
+    AIEVec2p_IntrOp<"unpack.I512.I8.I4",
+        [TypeIs<"res", VectorOfLengthAndType<[64], [I8]>>]>,
+    Arguments<(ins VectorOfLengthAndType<[32], [I8]>:$src,
+                   I32:$sign)>;
+
+def UnpackI1024I8I4AIE2pIntrOp :
+    AIEVec2p_IntrOp<"unpack.I1024.I8.I4",
+        [TypeIs<"res", VectorOfLengthAndType<[128], [I8]>>]>,
+    Arguments<(ins VectorOfLengthAndType<[64], [I8]>:$src,
+                   I32:$sign)>;
+
 #endif // AIE_DIALECT_XLLVM_IR_XLLVMAIE2INTROPS_TD

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -2942,6 +2942,54 @@ public:
   }
 };
 
+// AIE2P unpack int4-packed: source is vector<N/2 x i8> carrying N packed
+// nibbles, result is vector<N x i8> (one byte per nibble). Maps directly
+// to llvm.aie2p.unpack.I512.I8.I4 (N=64) or .I1024.I8.I4 (N=128).
+// AWQ packed weights are unsigned; the signed offset is folded into the
+// per-group zero point so the intrinsic is invoked with sign=0.
+class UnpackI4OpAIE2pConversion
+    : public mlir::ConvertOpToLLVMPattern<aievec::UnpackOp> {
+public:
+  using ConvertOpToLLVMPattern<aievec::UnpackOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(aievec::UnpackOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto srcTy = cast<VectorType>(op.getSource().getType());
+    auto dstTy = cast<VectorType>(op.getResult().getType());
+    if (!srcTy.getElementType().isInteger(8) ||
+        !dstTy.getElementType().isInteger(8))
+      return failure();
+
+    unsigned srcLanes = getVectorLaneSize(srcTy);
+    unsigned dstLanes = getVectorLaneSize(dstTy);
+    if (dstLanes != 2 * srcLanes)
+      return failure();
+    if (dstLanes != 64 && dstLanes != 128)
+      return failure();
+
+    auto signCst = LLVM::ConstantOp::create(
+        rewriter, loc, rewriter.getI32Type(), rewriter.getI32IntegerAttr(0));
+
+    Value unpacked;
+    if (dstLanes == 64) {
+      unpacked = xllvm::UnpackI512I8I4AIE2pIntrOp::create(
+                     rewriter, loc, VectorType::get({64}, rewriter.getI8Type()),
+                     adaptor.getSource(), signCst)
+                     ->getResult(0);
+    } else {
+      unpacked =
+          xllvm::UnpackI1024I8I4AIE2pIntrOp::create(
+              rewriter, loc, VectorType::get({128}, rewriter.getI8Type()),
+              adaptor.getSource(), signCst)
+              ->getResult(0);
+    }
+    rewriter.replaceOp(op, unpacked);
+    return success();
+  }
+};
+
 class BroadcastOpConversion
     : public mlir::ConvertOpToLLVMPattern<aievec::BroadcastOp> {
 public:
@@ -5651,6 +5699,9 @@ void populateAIEVecToLLVMAIE2pConversionPatterns(
   patterns.add<ExtOpAIE2pConversion>(converter);
   patterns.add<ExtractElemOpAIE2pConversion>(converter);
   patterns.add<ConcatOpAIE2pConversion>(converter);
+  // Higher benefit so it matches before the generic stub UnpackOpConversion
+  // returns failure for i4->i8 inputs.
+  patterns.add<UnpackI4OpAIE2pConversion>(converter, /*benefit=*/2);
   patterns.add<ExpOpAIE2pConversion>(converter);
   patterns.add<TanhOpAIE2pConversion>(converter);
   patterns.add<InvOpAIE2pConversion>(converter);

--- a/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
+++ b/lib/Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp
@@ -5103,7 +5103,13 @@ class FoldAIECastOps : public mlir::ConvertOpToLLVMPattern<aievec::CastOp> {
   }
 };
 
-// AIE2p version of FoldAIECastOps
+// AIE2p version of FoldAIECastOps.
+// On AIE2P the int/float accumulators share the same physical register, so
+// aievec.cast between e.g. v32i32 (acc32) and v32f32 (accfloat) is a no-op
+// at hardware level. LLVM IR still needs a typed value, so emit an
+// llvm.bitcast when the source/destination LLVM types differ but have the
+// same bitwidth. Replace with the source value directly when types already
+// match (the cast becomes a pure type alias).
 class FoldAIECastOpsAIE2p
     : public mlir::ConvertOpToLLVMPattern<aievec::CastOp> {
   using ConvertOpToLLVMPattern<aievec::CastOp>::ConvertOpToLLVMPattern;
@@ -5111,8 +5117,14 @@ class FoldAIECastOpsAIE2p
   LogicalResult
   matchAndRewrite(aievec::CastOp castOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // Fold the cast.
-    rewriter.replaceOp(castOp, adaptor.getSource());
+    Value src = adaptor.getSource();
+    Type srcTy = src.getType();
+    Type dstTy = getTypeConverter()->convertType(castOp.getResult().getType());
+    if (srcTy == dstTy) {
+      rewriter.replaceOp(castOp, src);
+      return success();
+    }
+    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(castOp, dstTy, src);
     return success();
   }
 };

--- a/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
@@ -1025,12 +1025,8 @@ LogicalResult verifyPackUnpackOp(T op) {
   if (!sourceType || !resultType)
     return op.emitError("requires vector type");
 
-  // The number of lanes must match
   unsigned sourceLanes = getVectorLaneSize(sourceType);
   unsigned resultLanes = getVectorLaneSize(resultType);
-  if (sourceLanes != resultLanes)
-    return op.emitError("The number of lanes in input and "
-                        "output vector must match");
 
   Type stype = sourceType.getElementType();
   unsigned stypeWidth = stype.getIntOrFloatBitWidth();
@@ -1038,16 +1034,30 @@ LogicalResult verifyPackUnpackOp(T op) {
   unsigned rtypeWidth = rtype.getIntOrFloatBitWidth();
 
   if (isa<PackOp>(op)) {
-    // The datatype of source must be i16, and datatype of result must be i8
-    if (stypeWidth != 16)
-      return op.emitError("input must be an int16 vector");
-    if (rtypeWidth != 8)
-      return op.emitError("output must be an int8 vector");
+    // Pack: i16 -> i8 with matching lane count (existing AIE2 path) OR
+    // i8 -> i8 with input lanes = 2 * output lanes (AIE2P int4 path; the
+    // result carries 2 packed nibbles per byte).
+    bool legalI16I8 =
+        stypeWidth == 16 && rtypeWidth == 8 && sourceLanes == resultLanes;
+    bool legalI8I4Packed =
+        stypeWidth == 8 && rtypeWidth == 8 && sourceLanes == 2 * resultLanes;
+    if (!legalI16I8 && !legalI8I4Packed)
+      return op.emitError(
+          "pack must narrow i16->i8 (same lanes) or i8->i8 (input lanes = "
+          "2 * output lanes, int4-packed)");
   } else {
-    if (stypeWidth != 8)
-      return op.emitError("input must be an int8 vector");
-    if (rtypeWidth != 16)
-      return op.emitError("output must be an int16 vector");
+    // Unpack: i8 -> i16 with matching lane count (existing AIE2 path) OR
+    // i8 -> i8 with output lanes = 2 * input lanes (AIE2P int4 path; the
+    // input carries 2 packed nibbles per byte and the output expands each
+    // nibble into a full byte).
+    bool legalI8I16 =
+        stypeWidth == 8 && rtypeWidth == 16 && sourceLanes == resultLanes;
+    bool legalI4PackedI8 =
+        stypeWidth == 8 && rtypeWidth == 8 && resultLanes == 2 * sourceLanes;
+    if (!legalI8I16 && !legalI4PackedI8)
+      return op.emitError(
+          "unpack must widen i8->i16 (same lanes) or i8->i8 (output lanes = "
+          "2 * input lanes, int4-packed)");
   }
 
   return success();

--- a/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
+++ b/lib/Dialect/AIEVec/IR/AIEVecOps.cpp
@@ -1029,8 +1029,12 @@ LogicalResult verifyPackUnpackOp(T op) {
   unsigned resultLanes = getVectorLaneSize(resultType);
 
   Type stype = sourceType.getElementType();
-  unsigned stypeWidth = stype.getIntOrFloatBitWidth();
   Type rtype = resultType.getElementType();
+  // Pack/unpack are integer packing ops; reject non-integer element types
+  // (e.g. f16/bf16) even though they share bitwidths with the legal forms.
+  if (!isa<IntegerType>(stype) || !isa<IntegerType>(rtype))
+    return op.emitError("requires integer element types");
+  unsigned stypeWidth = stype.getIntOrFloatBitWidth();
   unsigned rtypeWidth = rtype.getIntOrFloatBitWidth();
 
   if (isa<PackOp>(op)) {

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3540,8 +3540,7 @@ struct LowerVectorSIToFPI16BF16AIE2pPattern
       return failure();
     if (!srcTy.getElementType().isInteger(16))
       return failure();
-    auto dstEl = dyn_cast<FloatType>(dstTy.getElementType());
-    if (!dstEl || dstEl.getWidth() != 16)
+    if (!dstTy.getElementType().isBF16())
       return failure();
     unsigned lanes = srcTy.getNumElements();
     if (lanes != 16 && lanes != 32 && lanes != 64)

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3477,6 +3477,108 @@ struct LowerExtOpPattern : OpConversionPattern<SrcOpTy> {
 using LowerExtFOpPattern = LowerExtOpPattern<arith::ExtFOp>;
 using LowerExtSIOpPattern = LowerExtOpPattern<arith::ExtSIOp>;
 
+// Vector arith.sitofp i16 -> bf16 on AIE2P via the classic "magic number"
+// trick that aie_api uses in detail/aie2p/elementary.hpp:
+//
+//   1. UPS the int16 input to acc32 (32-bit integer accumulator lanes).
+//   2. Add a per-lane "magic_l" constant to the acc32 vector. The constant
+//      is the bit pattern of bf16(0x4b01) (= 2^23 + 128) broadcast over the
+//      lanes and reinterpreted as i32 -- chosen so that the resulting acc32
+//      vector, when bit-reinterpreted as f32 and subtracted from the same
+//      magic constant in accfloat space, yields the float representation of
+//      the original signed int16 input.
+//   3. aievec.cast acc32 -> accfloat is a register bit-alias on AIE2P
+//      (the same physical accumulator register).
+//   4. accfloat subtract of the magic constant.
+//   5. SRS accfloat -> bf16.
+//
+// Lane width 16 or 32 maps directly to the native AIE2P 256/1024-bit
+// accumulator. 64 splits into two 32-wide halves and concats the results.
+struct LowerVectorSIToFPI16BF16AIE2pPattern
+    : OpConversionPattern<arith::SIToFPOp> {
+  using OpConversionPattern<arith::SIToFPOp>::OpConversionPattern;
+
+  static Value emitMagicSiToFp(ConversionPatternRewriter &rewriter,
+                               Location loc, Value srcI16, unsigned lanes) {
+    Type i16Ty = rewriter.getI16Type();
+    Type i32Ty = rewriter.getI32Type();
+    Type bf16Ty = rewriter.getBF16Type();
+    Type f32Ty = rewriter.getF32Type();
+    VectorType vecI16 = VectorType::get({lanes}, i16Ty);
+    VectorType vecI32 = VectorType::get({lanes}, i32Ty);
+    VectorType vecBF16 = VectorType::get({lanes}, bf16Ty);
+    VectorType vecF32 = VectorType::get({lanes}, f32Ty);
+
+    DenseElementsAttr magicI16Attr = DenseElementsAttr::get(
+        vecI16, rewriter.getI16IntegerAttr(static_cast<int16_t>(0x4b01)));
+    Value magicI16Vec =
+        arith::ConstantOp::create(rewriter, loc, vecI16, magicI16Attr);
+    Value magicBF16Vec =
+        vector::BitCastOp::create(rewriter, loc, vecBF16, magicI16Vec);
+    Value magicAccF =
+        aievec::UPSOp::create(rewriter, loc, vecF32, magicBF16Vec);
+    Value magicAccI = aievec::CastOp::create(rewriter, loc, vecI32, magicAccF,
+                                             /*isResAcc=*/true);
+    Value vAccI = aievec::UPSOp::create(rewriter, loc, vecI32, srcI16);
+    Value vSumI = arith::AddIOp::create(rewriter, loc, vAccI, magicAccI);
+    Value vSumAccF = aievec::CastOp::create(rewriter, loc, vecF32, vSumI,
+                                            /*isResAcc=*/true);
+    Value vDiffAccF =
+        aievec::SubElemOp::create(rewriter, loc, vecF32, vSumAccF, magicAccF);
+    Value shiftCst =
+        arith::ConstantOp::create(rewriter, loc, rewriter.getI32IntegerAttr(0));
+    return aievec::SRSOp::create(rewriter, loc, vecBF16, vDiffAccF, shiftCst)
+        .getResult();
+  }
+
+  LogicalResult
+  matchAndRewrite(arith::SIToFPOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<VectorType>(adaptor.getIn().getType());
+    auto dstTy = dyn_cast<VectorType>(op.getType());
+    if (!srcTy || !dstTy || srcTy.getRank() != 1 || dstTy.getRank() != 1)
+      return failure();
+    if (!srcTy.getElementType().isInteger(16))
+      return failure();
+    auto dstEl = dyn_cast<FloatType>(dstTy.getElementType());
+    if (!dstEl || dstEl.getWidth() != 16)
+      return failure();
+    unsigned lanes = srcTy.getNumElements();
+    if (lanes != 16 && lanes != 32 && lanes != 64)
+      return failure();
+
+    Location loc = op.getLoc();
+    if (lanes == 16 || lanes == 32) {
+      Value out = emitMagicSiToFp(rewriter, loc, adaptor.getIn(), lanes);
+      rewriter.replaceOp(op, out);
+      return success();
+    }
+
+    // 64-wide: split into two 32-wide halves via vector.shuffle
+    // (vector.extract_strided_slice is illegal in this conversion target).
+    SmallVector<int64_t> loMask, hiMask, catMask;
+    for (int64_t i = 0; i < 32; ++i)
+      loMask.push_back(i);
+    for (int64_t i = 32; i < 64; ++i)
+      hiMask.push_back(i);
+    for (int64_t i = 0; i < 64; ++i)
+      catMask.push_back(i);
+    Value lo = vector::ShuffleOp::create(rewriter, loc, adaptor.getIn(),
+                                         adaptor.getIn(), loMask)
+                   .getResult();
+    Value hi = vector::ShuffleOp::create(rewriter, loc, adaptor.getIn(),
+                                         adaptor.getIn(), hiMask)
+                   .getResult();
+    Value loBF16 = emitMagicSiToFp(rewriter, loc, lo, 32);
+    Value hiBF16 = emitMagicSiToFp(rewriter, loc, hi, 32);
+    Value cat =
+        vector::ShuffleOp::create(rewriter, loc, loBF16, hiBF16, catMask)
+            .getResult();
+    rewriter.replaceOp(op, cat);
+    return success();
+  }
+};
+
 // Match `arith.extui (vector.bitcast %x : vector<Mxi8> to vector<2Mxi4>)
 // to vector<2Mxi8>` and replace with `aievec.unpack %x` directly on the
 // byte-packed source. The vector<...xi4> intermediate never reaches Peano
@@ -4750,6 +4852,12 @@ static void populateAIEVecCommonConversionPatterns(RewritePatternSet &patterns,
   // but only triggers for the i4-packed shape, so it is benign for AIE2.
   patterns.add<LowerExtUIOfBitcastI4ToUnpackPattern>(patterns.getContext(),
                                                      /*benefit=*/2);
+  // AIE2P magic-number lowering for arith.sitofp v16i16/v32i16 -> v16/v32
+  // bf16. Higher benefit than the generic per-lane scalarise pattern; runs
+  // on AIE2 too but only fires when the legality predicate marks the op
+  // illegal (currently AIE2P only).
+  patterns.add<LowerVectorSIToFPI16BF16AIE2pPattern>(patterns.getContext(),
+                                                     /*benefit=*/3);
   // clang-format on
 }
 
@@ -5600,6 +5708,14 @@ static void configureAIEVecV2PLegalizations(ConversionTarget &target,
     // For other types, only laneSize==16 (same as AIE2)
     return laneSize != 16;
   });
+
+  // LowerVectorSIToFPI16BF16AIE2pPattern uses vector.shuffle to split
+  // 64-wide inputs into two 32-wide halves; mark shuffle legal so the
+  // pattern's replacement IR survives partial conversion. Rank-1
+  // arith.sitofp is already marked illegal by the common legality config
+  // (LLVMIR backend), so LowerVectorSIToFPI16BF16AIE2pPattern is tried
+  // ahead of the per-lane scalarize fallback by pattern benefit.
+  target.addLegalOp<vector::ShuffleOp>();
 }
 
 static void configureAIEVecV2Legalizations(ConversionTarget &target,

--- a/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
+++ b/lib/Dialect/AIEVec/Transforms/VectorToAIEVecConversions.cpp
@@ -3477,6 +3477,53 @@ struct LowerExtOpPattern : OpConversionPattern<SrcOpTy> {
 using LowerExtFOpPattern = LowerExtOpPattern<arith::ExtFOp>;
 using LowerExtSIOpPattern = LowerExtOpPattern<arith::ExtSIOp>;
 
+// Match `arith.extui (vector.bitcast %x : vector<Mxi8> to vector<2Mxi4>)
+// to vector<2Mxi8>` and replace with `aievec.unpack %x` directly on the
+// byte-packed source. The vector<...xi4> intermediate never reaches Peano
+// llc, which cannot legalize llvm.bitcast on i4 vectors.
+//
+// This recognises the canonical standard-MLIR encoding of an AWQ int4
+// unpack: byte load of packed nibbles -> bitcast to i4 vector -> extui to
+// i8 vector. The aievec.unpack op then lowers to the AIE2P intrinsic
+// llvm.aie2p.unpack.I512.I8.I4 (or the I1024 variant) directly.
+struct LowerExtUIOfBitcastI4ToUnpackPattern
+    : OpConversionPattern<arith::ExtUIOp> {
+  using OpConversionPattern<arith::ExtUIOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(arith::ExtUIOp extOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<VectorType>(adaptor.getIn().getType());
+    auto dstTy = dyn_cast<VectorType>(extOp.getType());
+    if (!srcTy || !dstTy)
+      return failure();
+    if (srcTy.getRank() != 1 || dstTy.getRank() != 1)
+      return failure();
+    if (!srcTy.getElementType().isInteger(4) ||
+        !dstTy.getElementType().isInteger(8))
+      return failure();
+    unsigned lanes = srcTy.getNumElements();
+    if (lanes != dstTy.getNumElements())
+      return failure();
+    if (lanes != 64 && lanes != 128)
+      return failure();
+
+    auto bitcastOp = adaptor.getIn().getDefiningOp<vector::BitCastOp>();
+    if (!bitcastOp)
+      return failure();
+    auto bitcastSrcTy = dyn_cast<VectorType>(bitcastOp.getSource().getType());
+    if (!bitcastSrcTy || bitcastSrcTy.getRank() != 1 ||
+        !bitcastSrcTy.getElementType().isInteger(8))
+      return failure();
+    if (bitcastSrcTy.getNumElements() * 2 != lanes)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<aievec::UnpackOp>(extOp, dstTy,
+                                                  bitcastOp.getSource());
+    return success();
+  }
+};
+
 // Scalarize a vector arith int<->fp conversion (sitofp / uitofp / fptosi /
 // fptoui). The AIE2/AIE2P GISel legalizers only handle the scalar form of
 // these conversions (libcalls); there is no vector int<->fp instruction.
@@ -4698,6 +4745,11 @@ static void populateAIEVecCommonConversionPatterns(RewritePatternSet &patterns,
                LowerExtSIOpPattern,
                LowerTruncFOpPattern,
                LowerTruncIOpPattern>(patterns.getContext());
+  // Match canonical int4 unpack (vector.bitcast + arith.extui) ahead of the
+  // generic ExtUI/ExtSI handling; runs on both AIE2 and AIE2P call sites
+  // but only triggers for the i4-packed shape, so it is benign for AIE2.
+  patterns.add<LowerExtUIOfBitcastI4ToUnpackPattern>(patterns.getContext(),
+                                                     /*benefit=*/2);
   // clang-format on
 }
 
@@ -4988,6 +5040,37 @@ static void configureAIEVecCommonLegalizations(ConversionTarget &target,
     unsigned dstElWidth = dstScalarType.getIntOrFloatBitWidth();
     return srcLaneSize != 32 || (dstElWidth <= srcElWidth) ||
            (dstLaneSize != srcLaneSize);
+  });
+
+  // Mark `arith.extui vector<Nxi4> to vector<Nxi8>` illegal precisely when
+  // the producer is a `vector.bitcast vector<N/2xi8> to vector<Nxi4>` of a
+  // supported lane count (64 or 128 nibbles). That is the only shape
+  // LowerExtUIOfBitcastI4ToUnpackPattern can rewrite; stray ExtUI ops
+  // (including i4 ones not fed by a bitcast) stay legal and pass through
+  // to the standard arith-to-llvm path.
+  target.addDynamicallyLegalOp<arith::ExtUIOp>([](arith::ExtUIOp extuiOp) {
+    auto srcType = dyn_cast<VectorType>(extuiOp.getIn().getType());
+    auto dstType = dyn_cast<VectorType>(extuiOp.getOut().getType());
+    if (!srcType || !dstType)
+      return true;
+    if (srcType.getRank() != 1 || dstType.getRank() != 1)
+      return true;
+    Type srcScalarType = srcType.getElementType();
+    Type dstScalarType = dstType.getElementType();
+    if (!srcScalarType.isInteger(4) || !dstScalarType.isInteger(8))
+      return true;
+    unsigned lanes = srcType.getNumElements();
+    if (lanes != 64 && lanes != 128)
+      return true;
+    auto bitcastOp = extuiOp.getIn().getDefiningOp<vector::BitCastOp>();
+    if (!bitcastOp)
+      return true;
+    auto bitcastSrcType = dyn_cast<VectorType>(bitcastOp.getSource().getType());
+    if (!bitcastSrcType || bitcastSrcType.getRank() != 1 ||
+        !bitcastSrcType.getElementType().isInteger(8) ||
+        bitcastSrcType.getNumElements() * 2 != lanes)
+      return true;
+    return false;
   });
 
   target.addDynamicallyLegalOp<arith::TruncFOp>([](arith::TruncFOp truncfOp) {

--- a/test/Conversion/AIEVecToLLVM/test-cast.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-cast.mlir
@@ -52,3 +52,24 @@ func.func @test_cast_non_acc() -> vector<16xf32> {
   %0 = aievec.cast %cst {isResAcc = false} : vector<16xf32>, vector<16xf32>
   return %0 : vector<16xf32>
 }
+
+// aievec.cast between v32i32 (acc32) and v32f32 (accfloat) is a no-op at
+// AIE2P hardware level (shared accumulator register). Lowering must emit
+// llvm.bitcast so the value survives translation to LLVM IR rather than
+// dropping to a stranded unrealized_conversion_cast.
+// CHECK-AIE2P-LABEL: @test_cast_acc32_to_accfloat_aie2p
+func.func @test_cast_acc32_to_accfloat_aie2p(%arg0: vector<32xi32>) -> vector<32xf32> {
+  // CHECK-AIE2P: %[[BC:.*]] = llvm.bitcast %arg0 : vector<32xi32> to vector<32xf32>
+  // CHECK-AIE2P: return %[[BC]] : vector<32xf32>
+  %0 = aievec.cast %arg0 {isResAcc = true} : vector<32xi32>, vector<32xf32>
+  return %0 : vector<32xf32>
+}
+
+// And the reverse direction (accfloat -> acc32) symmetric.
+// CHECK-AIE2P-LABEL: @test_cast_accfloat_to_acc32_aie2p
+func.func @test_cast_accfloat_to_acc32_aie2p(%arg0: vector<32xf32>) -> vector<32xi32> {
+  // CHECK-AIE2P: %[[BC:.*]] = llvm.bitcast %arg0 : vector<32xf32> to vector<32xi32>
+  // CHECK-AIE2P: return %[[BC]] : vector<32xi32>
+  %0 = aievec.cast %arg0 {isResAcc = true} : vector<32xf32>, vector<32xi32>
+  return %0 : vector<32xi32>
+}

--- a/test/Conversion/AIEVecToLLVM/test-unpack-int4-aie2p.mlir
+++ b/test/Conversion/AIEVecToLLVM/test-unpack-int4-aie2p.mlir
@@ -1,0 +1,35 @@
+//===- test-unpack-int4-aie2p.mlir ------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-aievec-to-llvm='aie-target=aie2p' | FileCheck %s
+
+// AIE2P int4-packed unpack: input is byte-packed (2 nibbles per byte). The
+// op result widens lane count by 2x while keeping i8 element type. Maps to
+// the I512/I1024 unpack intrinsic with unsigned-mode (sign=0) because AWQ
+// packed weights are unsigned and the signed offset is folded into the
+// per-group zero point.
+
+// CHECK-LABEL: @test_unpack_i4_v64
+func.func @test_unpack_i4_v64(%arg0: vector<32xi8>) -> vector<64xi8> {
+  // CHECK:  %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK:  %[[OUT:.*]] = "xllvm.intr.aie2p.unpack.I512.I8.I4"(%arg0, %[[C0]]) : (vector<32xi8>, i32) -> vector<64xi8>
+  %0 = aievec.unpack %arg0 : vector<32xi8>, vector<64xi8>
+  // CHECK: return %[[OUT]] : vector<64xi8>
+  return %0 : vector<64xi8>
+}
+
+// CHECK-LABEL: @test_unpack_i4_v128
+func.func @test_unpack_i4_v128(%arg0: vector<64xi8>) -> vector<128xi8> {
+  // CHECK:  %[[C0:.*]] = llvm.mlir.constant(0 : i32) : i32
+  // CHECK:  %[[OUT:.*]] = "xllvm.intr.aie2p.unpack.I1024.I8.I4"(%arg0, %[[C0]]) : (vector<64xi8>, i32) -> vector<128xi8>
+  %0 = aievec.unpack %arg0 : vector<64xi8>, vector<128xi8>
+  // CHECK: return %[[OUT]] : vector<128xi8>
+  return %0 : vector<128xi8>
+}

--- a/test/Conversion/VectorToAIEVec/test-extui-i4-unpack-aie2p.mlir
+++ b/test/Conversion/VectorToAIEVec/test-extui-i4-unpack-aie2p.mlir
@@ -1,0 +1,48 @@
+//===- test-extui-i4-unpack-aie2p.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-vector-to-aievec='aie-target=aie2p target-backend=llvmir' -cse | FileCheck %s
+
+// Canonical standard-MLIR for AWQ int4 unpack on AIE2P:
+//   1. byte load (vector<N/2 x i8>)
+//   2. vector.bitcast to vector<N x i4> (logical nibble view)
+//   3. arith.extui to vector<N x i8>
+// Lowers to aievec.unpack on the byte-packed source. The bitcast and extui
+// are folded away; vector<N x i4> never reaches Peano (which cannot
+// legalize llvm.bitcast on i4 vector types).
+
+// CHECK-LABEL: @extui_i4_to_i8_v64(
+// CHECK-SAME:  %[[ARG:.*]]: vector<32xi8>
+func.func @extui_i4_to_i8_v64(%pk_i8: vector<32xi8>) -> vector<64xi8> {
+  // CHECK:  %[[OUT:.*]] = aievec.unpack %[[ARG]] : vector<32xi8>, vector<64xi8>
+  %pk_i4 = vector.bitcast %pk_i8 : vector<32xi8> to vector<64xi4>
+  %w_i8 = arith.extui %pk_i4 : vector<64xi4> to vector<64xi8>
+  // CHECK: return %[[OUT]] : vector<64xi8>
+  return %w_i8 : vector<64xi8>
+}
+
+// CHECK-LABEL: @extui_i4_to_i8_v128(
+// CHECK-SAME:  %[[ARG:.*]]: vector<64xi8>
+func.func @extui_i4_to_i8_v128(%pk_i8: vector<64xi8>) -> vector<128xi8> {
+  // CHECK:  %[[OUT:.*]] = aievec.unpack %[[ARG]] : vector<64xi8>, vector<128xi8>
+  %pk_i4 = vector.bitcast %pk_i8 : vector<64xi8> to vector<128xi4>
+  %w_i8 = arith.extui %pk_i4 : vector<128xi4> to vector<128xi8>
+  return %w_i8 : vector<128xi8>
+}
+
+// Negative: a stray extui i4->i8 NOT fed by a bitcast must remain legal
+// (no aievec.unpack synthesised).
+// CHECK-LABEL: @extui_i4_to_i8_no_bitcast
+func.func @extui_i4_to_i8_no_bitcast(%pk_i4: vector<64xi4>) -> vector<64xi8> {
+  // CHECK-NOT: aievec.unpack
+  // CHECK: arith.extui
+  %w_i8 = arith.extui %pk_i4 : vector<64xi4> to vector<64xi8>
+  return %w_i8 : vector<64xi8>
+}

--- a/test/Conversion/VectorToAIEVec/test-sitofp-i16-bf16-aie2p.mlir
+++ b/test/Conversion/VectorToAIEVec/test-sitofp-i16-bf16-aie2p.mlir
@@ -1,0 +1,66 @@
+//===- test-sitofp-i16-bf16-aie2p.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// Verify the magic-number lowering for `arith.sitofp vector<Nxi16> to
+// vector<Nxbf16>` on AIE2P. AIE2P has no vector int->fp instruction; the
+// pattern emits the classic "magic constant" sequence used by aie_api
+// (see detail/aie2p/elementary.hpp) on top of existing aievec ops:
+//
+//   UPS(int16 -> acc32) -> add(magic.as_acc32) -> cast(acc32 -> accfloat)
+//   -> sub(magic.as_accfloat) -> SRS(accfloat -> bf16)
+//
+// 64-wide inputs are split into two 32-wide halves via vector.shuffle.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt %s --convert-vector-to-aievec='aie-target=aie2p target-backend=llvmir' -cse | FileCheck %s
+
+// CHECK-LABEL: @sitofp_v32_i16_bf16(
+// CHECK-SAME:  %[[A:.*]]: vector<32xi16>
+func.func @sitofp_v32_i16_bf16(%v: vector<32xi16>) -> vector<32xbf16> {
+  // CHECK:  %[[CST:.*]] = arith.constant dense<19201> : vector<32xi16>
+  // CHECK:  %[[BC:.*]] = vector.bitcast %[[CST]] : vector<32xi16> to vector<32xbf16>
+  // CHECK:  %[[MAGIC_F:.*]] = aievec.ups %[[BC]] {{.*}} : vector<32xbf16>, vector<32xf32>
+  // CHECK:  %[[MAGIC_I:.*]] = aievec.cast %[[MAGIC_F]] {isResAcc = true} : vector<32xf32>, vector<32xi32>
+  // CHECK:  %[[V_I:.*]] = aievec.ups %[[A]] {{.*}} : vector<32xi16>, vector<32xi32>
+  // CHECK:  %[[SUM_I:.*]] = arith.addi %[[V_I]], %[[MAGIC_I]] : vector<32xi32>
+  // CHECK:  %[[SUM_F:.*]] = aievec.cast %[[SUM_I]] {isResAcc = true} : vector<32xi32>, vector<32xf32>
+  // CHECK:  %[[DIFF:.*]] = aievec.sub_elem %[[SUM_F]], %[[MAGIC_F]] : vector<32xf32>
+  // CHECK:  %[[BF:.*]] = aievec.srs %[[DIFF]], {{.*}} : vector<32xf32>, i32, vector<32xbf16>
+  %r = arith.sitofp %v : vector<32xi16> to vector<32xbf16>
+  // CHECK: return %[[BF]] : vector<32xbf16>
+  return %r : vector<32xbf16>
+}
+
+// 16-wide: same pattern, narrower vector type.
+// CHECK-LABEL: @sitofp_v16_i16_bf16
+func.func @sitofp_v16_i16_bf16(%v: vector<16xi16>) -> vector<16xbf16> {
+  // CHECK:  aievec.ups %{{.*}} : vector<16xi16>, vector<16xi32>
+  // CHECK:  arith.addi %{{.*}}, %{{.*}} : vector<16xi32>
+  // CHECK:  aievec.cast %{{.*}} {isResAcc = true} : vector<16xi32>, vector<16xf32>
+  // CHECK:  aievec.sub_elem %{{.*}}, %{{.*}} : vector<16xf32>
+  // CHECK:  aievec.srs %{{.*}} : vector<16xf32>, i32, vector<16xbf16>
+  %r = arith.sitofp %v : vector<16xi16> to vector<16xbf16>
+  return %r : vector<16xbf16>
+}
+
+// 64-wide: split into two 32-wide halves via vector.shuffle, run the magic
+// sequence on each, then concat the bf16 results with vector.shuffle.
+// CHECK-LABEL: @sitofp_v64_i16_bf16(
+// CHECK-SAME:  %[[A:.*]]: vector<64xi16>
+func.func @sitofp_v64_i16_bf16(%v: vector<64xi16>) -> vector<64xbf16> {
+  // CHECK:  %[[LO:.*]] = vector.shuffle %[[A]], %[[A]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] : vector<64xi16>, vector<64xi16>
+  // CHECK:  %[[HI:.*]] = vector.shuffle %[[A]], %[[A]] [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63] : vector<64xi16>, vector<64xi16>
+  // CHECK:  aievec.ups %[[LO]] {{.*}} : vector<32xi16>, vector<32xi32>
+  // CHECK:  aievec.ups %[[HI]] {{.*}} : vector<32xi16>, vector<32xi32>
+  // CHECK:  vector.shuffle %{{.*}}, %{{.*}} [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63] : vector<32xbf16>, vector<32xbf16>
+  %r = arith.sitofp %v : vector<64xi16> to vector<64xbf16>
+  return %r : vector<64xbf16>
+}

--- a/test/Conversion/VectorToAIEVec/test-sitofp-i16-bf16-aie2p.mlir
+++ b/test/Conversion/VectorToAIEVec/test-sitofp-i16-bf16-aie2p.mlir
@@ -56,8 +56,11 @@ func.func @sitofp_v16_i16_bf16(%v: vector<16xi16>) -> vector<16xbf16> {
 // CHECK-LABEL: @sitofp_v64_i16_bf16(
 // CHECK-SAME:  %[[A:.*]]: vector<64xi16>
 func.func @sitofp_v64_i16_bf16(%v: vector<64xi16>) -> vector<64xbf16> {
-  // CHECK:  %[[LO:.*]] = vector.shuffle %[[A]], %[[A]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] : vector<64xi16>, vector<64xi16>
-  // CHECK:  %[[HI:.*]] = vector.shuffle %[[A]], %[[A]] [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63] : vector<64xi16>, vector<64xi16>
+  // The second operand of each split shuffle is unused; the canonicalizer
+  // (run by -convert-vector-to-aievec) rewrites it to ub.poison.
+  // CHECK:  %[[POISON:.*]] = ub.poison : vector<64xi16>
+  // CHECK:  %[[LO:.*]] = vector.shuffle %[[A]], %[[POISON]] [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31] : vector<64xi16>, vector<64xi16>
+  // CHECK:  %[[HI:.*]] = vector.shuffle %[[A]], %[[POISON]] [32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63] : vector<64xi16>, vector<64xi16>
   // CHECK:  aievec.ups %[[LO]] {{.*}} : vector<32xi16>, vector<32xi32>
   // CHECK:  aievec.ups %[[HI]] {{.*}} : vector<32xi16>, vector<32xi32>
   // CHECK:  vector.shuffle %{{.*}}, %{{.*}} [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63] : vector<32xbf16>, vector<32xbf16>


### PR DESCRIPTION
Adds the four AIE2P lowerings needed to author the AWQ-style int4 → bf16
dequant body in standard MLIR (vector + arith + aievec) and lower it
cleanly through `convert-vector-to-aievec` → `convert-aievec-to-llvm`
→ LLVM dialect → Peano llc, without falling back to per-lane scalar
libcalls or hitting type-mismatched `unrealized_conversion_cast`s.

Each commit is one self-contained lowering with a focused lit test under
`test/Conversion/`; the four together unblock the inline matvec /
inline-dequant designs in mlir-air's `programming_examples/`. The
commits are independent but two pairs have a runtime dependency:

- `[AIEVecToLLVM] aievec.cast` (1/4) is consumed by
  `[VectorToAIEVec] magic sitofp` (4/4) at runtime
- `[AIEVec] aievec.unpack i4 → i8` (2/4) is consumed by
  `[VectorToAIEVec] extui+bitcast rewriter` (3/4) at runtime

Each lit test FileChecks at its own pass boundary, so all four tests
pass independently in isolation.

## Commits

1. **[AIEVecToLLVM][AIE2P] Emit llvm.bitcast for aievec.cast across acc bank**
   Acc bank is shared between int and float on AIE2P; previous
   FoldAIECastOpsAIE2p dropped the cast outright, leaving a type
   mismatch that translation surfaced as
   `builtin.unrealized_conversion_cast`. Emit `llvm.bitcast` when the
   source/result LLVM types differ but share bitwidth; keep the
   pure-fold behaviour for matching types.
   Test: extends `test-cast.mlir` with `test_cast_acc32_to_accfloat_aie2p`
   plus the reverse direction.

2. **[AIEVec][AIE2P] Wire aievec.unpack for byte-packed int4 → int8**
   Adds the AIE2P-specific lowering for the byte-packed lane-doubling
   shape (input `vector<N/2xi8>`, output `vector<Nxi8>` for N ∈ {64,
   128}). New TableGen intrinsic bindings
   `UnpackI512I8I4AIE2pIntrOp` / `UnpackI1024I8I4AIE2pIntrOp`,
   verifier in `AIEVecOps.cpp::verifyPackUnpackOp` extended to accept
   the new shape, and a new `UnpackI4OpAIE2pConversion` registered
   with higher benefit so it pre-empts the stub `UnpackOpConversion`.
   Unsigned mode (sign=0) since AWQ packed weights are unsigned and
   the signed offset is folded into the per-group zero point.
   Test: new `test-unpack-int4-aie2p.mlir` covers both 64-lane and
   128-lane forms.

3. **[VectorToAIEVec][AIE2P] Lower extui(bitcast i8→i4) to aievec.unpack**
   Standard MLIR users author int4 unpack as
   `vector.bitcast %i8 to vector<Nxi4>` followed by `arith.extui` to
   `vector<Nxi8>`. Peano can't legalize `llvm.bitcast` on
   `vector<Nxi4>`, so the chain has to be rewritten pre-LLVM.
   New `LowerExtUIOfBitcastI4ToUnpackPattern` matches the pair (lane
   counts 64 or 128) and replaces it with `aievec.unpack` on the
   original byte-packed source; the intermediate `vector<Nxi4>` value
   never appears in the post-pass IR. Legality predicate is tightened
   to mark `arith.extui` illegal only when its operand is genuinely a
   matching `vector.bitcast`, so bare `extui` on i4 vectors (which
   the rewriter can't handle) remains legal and falls through to the
   standard arith-to-llvm lowering.
   Test: new `test-extui-i4-unpack-aie2p.mlir` covers 64/128-lane plus
   a negative case (bare extui without bitcast predecessor) that
   locks the legality predicate.

4. **[VectorToAIEVec][AIE2P] Magic-number sitofp i16 → bf16 (v16/v32/v64)**
   Vector `arith.sitofp i16 → bf16` has no AIE2P backend
   instruction; the existing `ScalarizeVectorSIToFPOpPattern` unrolls
   to N scalar libcalls per lane (N=64 dominates the AWQ dequant
   inner-loop runtime). New `LowerVectorSIToFPI16BF16AIE2pPattern`
   emits the magic-constant Fix2Float sequence used by aie_api's
   `detail/aie2p/elementary.hpp` (UPS magic bf16 → magic accfloat;
   aievec.cast acc32 alias; UPS i16 → acc32; integer add of the
   two acc32 values; cast back to accfloat; sub_elem the magic
   accfloat; SRS to bf16). Lane widths 16 and 32 emit one sequence
   each; 64 splits via `vector.shuffle` into two 32-wide halves and
   concats the bf16 results. Pattern benefit is 3 so it pre-empts
   the per-lane scalarize fallback (benefit 1).
   The common-config legality predicate marks all rank-1 vector
   sitofp illegal; this patch deliberately does NOT add an
   AIE2P-specific predicate (an earlier draft did and silently
   neutered scalarize for all unsupported shapes — now fixed).
   Test: new `test-sitofp-i16-bf16-aie2p.mlir` covers v16/v32/v64.
   `test-scalarize-int-fp-conv.mlir` continues to lock other
   sitofp/uitofp/fptosi/fptoui shapes scalarising as before.

## Verification

- `ninja check-aie` — 770 passed, 20 pre-existing failures all under
  `python/*.py` (environment-related, unrelated to this change).
- All 4 lit tests pass individually via `aie-opt` direct invocation.
- End-to-end NPU2 perf measured on the `dequant_awq_inline` design
  (per commit 4's message): 57.2 µs avg with magic sitofp vs 96.7
  µs with scalarize fallback vs 54.5 µs for the hand-written
  kernel-call baseline. ~5% gap from the magic-number split overhead.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>