### PR TITLE
Switch from `latest-wheels-3` to `latest-wheels-4`

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -500,8 +500,8 @@ jobs:
         with:
           artifacts: wheels_on_flat/mlir_aie*whl
           token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: latest-wheels-3
-          name: latest-wheels-3
+          tag: latest-wheels-4
+          name: latest-wheels-4
           allowUpdates: true
           replacesArtifacts: false
           omitBodyDuringUpdate: true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ![GitHub Downloads](https://img.shields.io/github/downloads/Xilinx/mlir-aie/latest-wheels/total?color=blue&cacheSeconds=86400)
 ![GitHub Downloads 2](https://img.shields.io/github/downloads/Xilinx/mlir-aie/latest-wheels-2/total?color=blue&cacheSeconds=86400)
 ![GitHub Downloads 3](https://img.shields.io/github/downloads/Xilinx/mlir-aie/latest-wheels-3/total?color=blue&cacheSeconds=86400)
+![GitHub Downloads 4](https://img.shields.io/github/downloads/Xilinx/mlir-aie/latest-wheels-4/total?color=blue&cacheSeconds=86400)
 ![GitHub Contributors](https://img.shields.io/github/contributors/Xilinx/mlir-aie?cacheSeconds=86400)
 
 _Note: Badge values are cached for up to 24 hours (`cacheSeconds=86400`) to reduce load on Shields.io and GitHub, so counts may lag behind real-time activity._
@@ -147,7 +148,7 @@ xrt-smi examine
    1. **Latest:** For the latest wheels (not necessarily a release):
       ```bash
       # Install IRON library and mlir-aie from the latest wheel
-      python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+      python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4
       ```
 
    1. **Latest Release:** Alternatively, you can install the latest released version of `mlir-aie`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
    1. **Latest:** For the latest wheels (not necessarily a release):
       ```bash
       # Install IRON library and mlir-aie from the latest wheel
-      python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+      python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4
       ```
 
    1. **Latest Release:** Alternatively, you can install the latest released version of `mlir-aie`.


### PR DESCRIPTION
Mirrors #2856 (\`latest-wheels-2\` → \`latest-wheels-3\`). The \`latest-wheels-3\` release has hit GitHub's 1000-asset-per-release hard cap and \`buildRyzenWheels.yml\`'s \`Publish wheels\` job now silently drops most ABI variants as warnings (job still reports success):

\`\`\`
##[warning]Failed to upload artifact mlir_aie-1.3.2.dev109+gb48afd6-cp312-cp312-manylinux_2_35_x86_64.whl.
Validation Failed: ... "file_count limited to 1000 assets per release"
\`\`\`

For \`dev109+gb48afd6\` (built from \`b48afd6\`) only the cp314 wheels squeezed in; cp311/cp312/cp313 × {linux, windows} all got dropped. This is currently blocking any consumer pinned to cp312 (e.g. mlir-air pin bumps) from picking up new mlir-aie.

Once this PR lands, the next \`buildRyzenWheels\` run will publish to the empty \`latest-wheels-4\` release and all ABI variants will fit.

A small follow-up PR (mirroring #2857) will flip the consumer-side scripts (\`utils/env_setup.sh\`, \`utils/quick_setup.sh\`, \`utils/iron_setup.py\`) once \`latest-wheels-4\` has at least one wheel published.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>