### PR TITLE
wheels: detect rc/alpha/beta tags as prereleases on tag-release

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -573,7 +573,8 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           omitBodyDuringUpdate: true
-          makeLatest: true
+          prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') }}
+          makeLatest: ${{ !(contains(github.ref_name, 'rc') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
       - name: Release latest wheels (RTTI ON)
         if: github.event_name != 'push'


### PR DESCRIPTION
## Summary
- Today's tag-Release step always sets `makeLatest: true`, so any rc/alpha/beta tag would clobber the repo's "Latest release" pointer.
- Switch `makeLatest` and `prerelease` to mirror the tag name: tags containing `rc`/`alpha`/`beta` are pre-releases and don't take the "latest" slot.
- Behavior for v1.3.2 (no suffix) is unchanged.
  
## Motivation
About to do a `v1.3.2-rc0` dry-run release to exercise the tag-release path before the real v1.3.2 cut. Without this change, rc0 would briefly be marked as Latest on the releases page.
   
## Test plan
 - [ ] CI green
 - [ ] After merge: tag `v1.3.2-rc0` from main and confirm the resulting release is marked Pre-release and not Latest
 - [ ] Then tag `v1.3.2` from main and confirm it takes the Latest slot