### PR TITLE
hostruntime: accept narrower-column overrides on wider runtime devices

### DIFF
--- a/python/utils/hostruntime/hostruntime.py
+++ b/python/utils/hostruntime/hostruntime.py
@@ -100,18 +100,28 @@ class HostRuntime(ABC):
 
     def check_device_consistency(self):
         """
-        Check if the overridden device matches the runtime device.
+        Check if the overridden device is loadable on the runtime device.
+
+        A 1- or N-column variant of a generation (e.g. NPU1Col1) is loadable
+        on a wider device of the same generation (e.g. a 4-column NPU1), so we
+        accept any override whose arch matches and whose column count is <=
+        the runtime device's column count.
         """
         mod = sys.modules[__package__]
         override = getattr(mod, "_CURRENT_DEVICE", None)
-        if override:
-            runtime_device = self.device()
-            if getattr(override, "_device", None) != getattr(
-                runtime_device, "_device", None
-            ):
-                raise RuntimeError(
-                    f"Overridden device {override} does not match runtime device {runtime_device}"
-                )
+        if override is None:
+            return
+        runtime_device = self.device()
+        try:
+            same_arch = override.arch == runtime_device.arch
+            fits = override.cols <= runtime_device.cols
+        except AttributeError:
+            same_arch = fits = False
+        if not (same_arch and fits):
+            raise RuntimeError(
+                f"Overridden device {override} is not loadable on runtime "
+                f"device {runtime_device}"
+            )
 
     @abstractmethod
     def load(self, npu_kernel: NPUKernel, **kwargs) -> KernelHandle:

--- a/test/python/npu-xrt/test_device_override.py
+++ b/test/python/npu-xrt/test_device_override.py
@@ -8,7 +8,7 @@
 # RUN: %run_on_npu2% %pytest %s
 
 import pytest
-from aie.iron.device import NPU1, NPU2
+from aie.iron.device import NPU1, NPU1Col1, NPU2, NPU2Col1
 import aie.utils as utils
 
 
@@ -57,9 +57,18 @@ def test_device_consistency():
     # Should not raise
     runtime.check_device_consistency()
 
-    # Set incompatible override
+    # A 1-column variant of the same generation is loadable on the full device.
+    utils.set_current_device(NPU1Col1())
+    runtime.check_device_consistency()
+
+    # Set incompatible override (wrong generation)
     utils.set_current_device(NPU2())
-    with pytest.raises(RuntimeError, match="does not match runtime device"):
+    with pytest.raises(RuntimeError, match="not loadable on runtime device"):
+        runtime.check_device_consistency()
+
+    # Wrong generation, narrower variant — still incompatible.
+    utils.set_current_device(NPU2Col1())
+    with pytest.raises(RuntimeError, match="not loadable on runtime device"):
         runtime.check_device_consistency()
 
     # Reset


### PR DESCRIPTION
## Summary
  - `HostRuntime.check_device_consistency` compared the override and runtime `_device` enums for exact equality, which rejected `set_current_device(NPU1Col1())` on a 4-column NPU1 runtime device even though a 1-column xclbin is loadable on any wider device of the same generation.
- The check now requires matching `arch` and `override.cols <= runtime.cols`.
- Surfaced while reproducing #2301: the literal pytest snippet there uses `set_current_device(NPU1Col1())` on a Phoenix box and, post-#2737, fails at xclbin load even though the compiled design runs correctly. With this fix the snippet runs unmodified.

## Test plan
- [x] `pytest test/python/npu-xrt/test_device_override.py` on NPU1 — `test_device_consistency` extended to cover the narrower-variant accept case (`NPU1Col1` override on `NPU1` runtime) and a wrong-generation reject case (`NPU2Col1` override on `NPU1` runtime); both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)