### PR TITLE
ci: hash-pin cibuildwheel in distro builds to fix Windows wheel repair

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -83,7 +83,7 @@ runs:
 
     - name: pip install standard tools
       shell: bash
-      run: pip install cibuildwheel wheel
+      run: pip install --require-hashes -r python/requirements_dev.lock
 
     - name: install rename
       if: ${{ inputs.MATRIX_OS == 'ubuntu-22.04' || inputs.MATRIX_OS == 'macos-12' || inputs.MATRIX_OS == 'macos-14' }}

--- a/.github/workflows/mlirAIEDistro.yml
+++ b/.github/workflows/mlirAIEDistro.yml
@@ -167,8 +167,14 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
         # checkout just the actions in order to pick and choose
-        # where the actual repo is checked out manually (see actions/setup_base)
-        sparse-checkout: .github/actions
+        # where the actual repo is checked out manually (see actions/setup_base).
+        # requirements_dev.lock is pulled too so setup_base can hash-pin its
+        # build tooling (cibuildwheel/wheel) before the full tree is cloned.
+        # Single-file paths require non-cone mode.
+        sparse-checkout: |
+          .github/actions
+          python/requirements_dev.lock
+        sparse-checkout-cone-mode: false
 
     - uses: ./.github/actions/setup_base
       id: setup_base

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -177,8 +177,14 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
         # checkout just the actions in order to pick and choose
-        # where the actual repo is checked out manually (see actions/setup_base)
-        sparse-checkout: .github/actions
+        # where the actual repo is checked out manually (see actions/setup_base).
+        # requirements_dev.lock is pulled too so setup_base can hash-pin its
+        # build tooling (cibuildwheel/wheel) before the full tree is cloned.
+        # Single-file paths require non-cone mode.
+        sparse-checkout: |
+          .github/actions
+          python/requirements_dev.lock
+        sparse-checkout-cone-mode: false
 
     - uses: ./.github/actions/setup_base
       id: setup_base


### PR DESCRIPTION
## Summary
- Windows distro wheel builds broke when cibuildwheel silently floated 3.4.1 → 4.0.0 via an unpinned `pip install` in `setup_base` (the one spot that opted out of the repo's hash-locked tooling). cibw 4 enables Windows delvewheel repair by default, which ran without `--add-path`/`--analyze-existing-exes` and couldn't locate the bundled `nanobind-mlir.dll`. 
- Install build tooling from the existing hash-pinned `python/requirements_dev.lock` (`cibuildwheel==3.4.1`) instead. Extend the pre-`setup_base` sparse-checkout to also fetch that lock (non-cone mode for the single-file path), since `setup_base` runs before the full tree is cloned.
- Makes cibuildwheel upgrades deliberate: dependabot already tracks `requirements_dev.lock`, so a future major bump surfaces as a reviewable PR instead of silently breaking main.
  
## Context
Affects both `mlirAIEDistro.yml` and `mlirDistro.yml`. The Windows job is non-blocking, so this was red on `main` while overall CI showed green; this also unblocks #3156 once it rebases.
  
## Test plan
- [ ] Trigger **MLIR Distro** and the AIE distro workflow via `workflow_dispatch` on this branch (the `paths:` filter won't auto-run on a `setup_base`-only change) and confirm the Windows `rtti=ON`/`rtti=OFF` wheel jobs go green.