### PR TITLE
docs: add uuid-dev to build prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ xrt-smi examine
     ```bash
     # Python versions 3.11, 3.12, 3.13, and 3.14 are currently supported by our wheels
     sudo apt install \
-    build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip
+    build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip uuid-dev
     ```
 
     > **Note:** CMake **3.30 or newer** is required. If your distribution provides an older

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -103,7 +103,7 @@ xrt-smi examine
     ```bash
     # Python versions 3.11, 3.12, 3.13, and 3.14 are currently supported by our wheels
     sudo apt install \
-    build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip
+    build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip uuid-dev
     ```
 
 ## Build and Install mlir-aie and IRON

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ Turn off SecureBoot (Allows for unsigned drivers to be installed):
     ```bash
     # Python versions 3.11, 3.12, 3.13, and 3.14 are currently supported by our wheels
     sudo apt install \
-    build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip
+    build-essential clang clang-14 lld lld-14 cmake ninja-build python3-venv python3-pip uuid-dev
     ```
 
     > **Note:** CMake **3.30 or newer** is required. If your distribution provides an older


### PR DESCRIPTION
uuid-dev is required when building on a fresh Ubuntu image; add it to the apt install lists alongside the other prerequisite packages.