### PR TITLE
Harden CI workflow against head_ref injection + fix test_lib format string

### DIFF
--- a/.github/workflows/buildAndTestAieTools.yml
+++ b/.github/workflows/buildAndTestAieTools.yml
@@ -68,6 +68,8 @@ jobs:
           githubToken: ${{ github.token }}
           dockerRunArgs: |
             --mac-address ${{ secrets.XILINX_MAC }}
+          env: |
+            HEAD_REF: ${{ github.head_ref }}
           run: |
             ls -l /opt/Xilinx/Vitis/2023.2/
 
@@ -79,7 +81,7 @@ jobs:
             git clone https://github.com/Xilinx/mlir-aie.git
             cd /mlir-aie
 
-            git checkout ${{ github.head_ref }}
+            git checkout "$HEAD_REF"
             if [ x"${{ inputs.AIE_COMMIT }}" != x"" ]; then
               git reset --hard ${{ inputs.AIE_COMMIT }}
             fi

--- a/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
+++ b/.github/workflows/buildAndTestAieToolsHsaBuildOnly.yml
@@ -68,6 +68,8 @@ jobs:
           githubToken: ${{ github.token }}
           dockerRunArgs: |
             --mac-address ${{ secrets.XILINX_MAC }}
+          env: |
+            HEAD_REF: ${{ github.head_ref }}
           run: |
             ls -l /opt/Xilinx/Vitis/2023.2/
 
@@ -95,7 +97,7 @@ jobs:
             git clone https://github.com/Xilinx/mlir-aie.git
             cd /mlir-aie
 
-            git checkout ${{ github.head_ref }}
+            git checkout "$HEAD_REF"
             if [ x"${{ inputs.AIE_COMMIT }}" != x"" ]; then
               git reset --hard ${{ inputs.AIE_COMMIT }}
             fi

--- a/runtime_lib/test_lib/memory_allocator_ion.cpp
+++ b/runtime_lib/test_lib/memory_allocator_ion.cpp
@@ -99,7 +99,7 @@ int *mlir_aie_mem_alloc(struct aie_libxaie_ctx_t *ctx, ext_mem_model_t &handle,
 
   Ret = ioctl(Fd, ION_IOC_ALLOC, &AllocArgs);
   if (Ret != 0) {
-    XAIE_ERROR("Failed to allocate memory of %lu bytes\n");
+    XAIE_ERROR("Failed to allocate memory of %d bytes\n", size);
     goto error_ion;
   }
 


### PR DESCRIPTION
## Summary
Two small hardening/correctness fixes surfaced while triaging the repo's security & quality alerts (OSSF Scorecard + a local CodeQL run).
  
- **CI:** Route `github.head_ref` through the `run-on-arch-action` `env:` input and reference the quoted `"$HEAD_REF"` instead of interpolating it directly into the `run:` script, in `buildAndTestAieTools.yml` and `buildAndTestAieToolsHsaBuildOnly.yml`. Prevents shell injection via a crafted branch name.
- **test_lib:** Fix `XAIE_ERROR("...%lu bytes\n")` in the ION allocator error path — it passed no argument (garbage vararg). Now passes `size` and matches the conversion to its `int` type (`%d`).
  
## Notes
- The CodeQL sweep (Python + C++) and Scorecard otherwise came back clean; these were the only actionable findings.