### PR TITLE
requirements_ml: exact-pin torch to +cpu wheel (fixes dependabot)

### DIFF
--- a/python/requirements_ml.txt
+++ b/python/requirements_ml.txt
@@ -1,2 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.12.0
+# Exact pin: PEP 440 forbids the +cpu local label with range operators (>=).
+torch==2.12.0+cpu


### PR DESCRIPTION
## Summary
- Switches `python/requirements_ml.txt` from `torch>=2.12.0` to `torch==2.12.0+cpu`.
- The CPU extra-index-url labels every release with the `+cpu` PEP 440 local version label, which is illegal with range operators (`>=`). That's why dependabot's #3155 produced the invalid `torch>=2.12.0+cpu` and every wheel/Ryzen-AI job failed on `pip install`.
- An exact pin keeps the label legal and lets dependabot keep proposing valid version bumps (`==X+cpu`). 
    
  Supersedes/closes #3155.