### PR TITLE
[iron] Expose multi-dim DMA strides (Bd.dimensions) and cross-core L1 buffer sharing

### DIFF
--- a/python/iron/buffer.py
+++ b/python/iron/buffer.py
@@ -62,6 +62,12 @@ class Buffer(Resolvable):
             self._name = f"buf_{next(Buffer._gbuf_index)}"
         self._use_write_rtp = use_write_rtp
         self._tile = tile
+        # Whether the user pinned this Buffer to an explicit tile at
+        # construction.  A Worker may auto-pin ``_tile`` later as a
+        # convenience, so ``_tile is not None`` is not a reliable signal of
+        # user intent; this flag is.  Only explicitly-placed Buffers may be
+        # shared (read) across Workers — see :class:`Worker`.
+        self._explicit_tile = tile is not None
         self._owner_worker = None
 
     @property

--- a/python/iron/dataflow/tile_dma.py
+++ b/python/iron/dataflow/tile_dma.py
@@ -97,6 +97,12 @@ class Bd:
     # ``(pkt_type, pkt_id)``.  Pairs with a :class:`PacketFlow` that uses
     # the same ``pkt_id`` so the routing fabric dispatches correctly.
     packet: tuple[int, int] | None = None
+    # Multi-dimensional (strided) access pattern, as a list of
+    # ``(size, stride)`` tuples, innermost dimension last — the same form
+    # the ``aie.dma_bd`` dialect op's ``dimensions`` attribute accepts (lowered
+    # via the registered ``BDDimLayoutArrayAttr`` builder).  ``None`` (default)
+    # emits a plain contiguous transfer.
+    dimensions: list[tuple[int, int]] | None = None
 
 
 @dataclass
@@ -248,6 +254,8 @@ class TileDma(Resolvable):
                             bd_kwargs["len"] = bd.length
                         if bd.packet is not None:
                             bd_kwargs["packet"] = bd.packet
+                        if bd.dimensions is not None:
+                            bd_kwargs["dimensions"] = bd.dimensions
                         dma_bd(bd.buffer.op, **bd_kwargs)
                         for rel in bd.releases:
                             rel.emit()

--- a/python/iron/worker.py
+++ b/python/iron/worker.py
@@ -108,20 +108,35 @@ class Worker(ObjectFifoEndpoint):
                 arg.endpoint = self
                 self._fifos.append(arg)
             elif isinstance(arg, Buffer):
+                # A Buffer pinned to an EXPLICIT tile may legitimately be shared
+                # across Workers: AIE compute tiles can read a neighbor tile's L1
+                # directly, so a producer core's output buffer can be an input to a
+                # consumer core on an adjacent tile. In that case the FIRST worker that
+                # references it "owns"/places it and later workers are non-owning
+                # readers. We only forbid sharing for AUTO-PLACED buffers (no explicit
+                # tile), where two owners would race to pin it to different tiles.
+                # Note: ``_tile`` alone is not a reliable signal — the owning Worker
+                # auto-pins ``_tile`` to its own tile below — so we key off
+                # ``_explicit_tile``, which records the user's construction-time intent.
                 if arg._owner_worker is not None and arg._owner_worker is not self:
-                    raise ValueError(
-                        f"Buffer '{arg._name}' is already placed on another "
-                        f"Worker; a Buffer cannot be shared across Workers."
-                    )
-                arg._owner_worker = self
-                self._buffers.append(arg)
-                # If the Buffer has no tile, pin it to the Worker's tile as a
-                # convenience.  If the user pinned it explicitly to a neighbor
-                # tile (AIE compute tiles can read N/S/E/W neighbors' L1
-                # directly), honor that placement — Program.resolve discovers
-                # the neighbor tile via Buffer.tiles().
-                if arg._tile is None:
-                    arg._tile = self._tile
+                    if not arg._explicit_tile:
+                        raise ValueError(
+                            f"Buffer '{arg._name}' has no explicit tile and is shared "
+                            f"across Workers; pin it to a tile (Buffer(tile=...)) so "
+                            f"placement is unambiguous."
+                        )
+                    # shared reader: keep original owner, just record the reference.
+                    self._buffers.append(arg)
+                else:
+                    arg._owner_worker = self
+                    self._buffers.append(arg)
+                    # If the Buffer has no tile, pin it to the Worker's tile as a
+                    # convenience.  If the user pinned it explicitly to a neighbor
+                    # tile (AIE compute tiles can read N/S/E/W neighbors' L1
+                    # directly), honor that placement — Program.resolve discovers
+                    # the neighbor tile via Buffer.tiles().
+                    if arg._tile is None:
+                        arg._tile = self._tile
             elif isinstance(arg, ScratchpadParameter):
                 pass  # ScratchpadParameters are device-level symbols; no tile placement needed
             elif isinstance(arg, ObjectFifo):

--- a/test/python/bd_dimensions.py
+++ b/test/python/bd_dimensions.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s | FileCheck %s
+
+"""Test that Bd.dimensions forwards a multi-dimensional (strided) access
+pattern to the underlying aie.dma_bd op, emitting <size = .., stride = ..>
+dims in the lowered MLIR."""
+
+import numpy as np
+
+from aie.iron import Bd, Buffer, DmaChannel, Program, Runtime, TileDma
+from aie.iron.device import NPU2Col1, Tile
+from aie.dialects._aie_enum_gen import AIETileType, DMAChannelDir
+
+
+def emit_strided_bd():
+    n = 256
+    vector_ty = np.ndarray[(n,), np.dtype[np.int32]]
+
+    compute_tile = Tile(col=0, row=2, tile_type=AIETileType.CoreTile)
+    buf = Buffer(tile=compute_tile, type=vector_ty, name="strided_buf")
+
+    # A 2-D strided access pattern: outer 16x(stride 16), inner 16x(stride 1).
+    tile_dma = TileDma(
+        tile=compute_tile,
+        channels=[
+            DmaChannel(
+                direction=DMAChannelDir.MM2S,
+                channel=0,
+                bds=[
+                    Bd(
+                        buffer=buf,
+                        offset=0,
+                        length=n,
+                        dimensions=[(16, 16), (16, 1)],
+                        next="self",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    rt = Runtime()
+    rt.add_tile_dma(tile_dma)
+    with rt.sequence(vector_ty) as _:
+        pass
+
+    return Program(NPU2Col1(), rt).resolve_program()
+
+
+# CHECK: aie.dma_bd({{.*}} : memref<256xi32>, 0, 256, [<size = 16, stride = 16>, <size = 16, stride = 1>])
+print(emit_strided_bd())

--- a/test/python/npu-xrt/test_objectfifo.py
+++ b/test/python/npu-xrt/test_objectfifo.py
@@ -215,14 +215,17 @@ def test_workers_cannot_share_tile_by_coordinates():
 
 
 def test_buffer_cannot_be_shared_across_workers():
-    """A Buffer passed to two Workers must error on the second assignment."""
+    """An auto-placed Buffer (no explicit tile) passed to two Workers must
+    error on the second assignment, since its placement would be ambiguous.
+    (A Buffer pinned to an explicit tile may be shared — see
+    test/python/worker_buffer_sharing.py.)"""
     n_ty = np.ndarray[(1024,), np.dtype[np.int32]]
     buf_ty = np.ndarray[(16,), np.dtype[np.int32]]
     buf = Buffer(type=buf_ty, name="shared_buf")
     of1 = ObjectFifo(n_ty, name="buf_of1")
     _ = Worker(None, [of1.cons(), buf])
     of2 = ObjectFifo(n_ty, name="buf_of2")
-    with pytest.raises(ValueError, match="already placed on"):
+    with pytest.raises(ValueError, match="no explicit tile"):
         Worker(None, [of2.cons(), buf])
 
 

--- a/test/python/worker_buffer_sharing.py
+++ b/test/python/worker_buffer_sharing.py
@@ -1,0 +1,143 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s | FileCheck %s
+
+"""Test that a Buffer pinned to an explicit tile may be referenced by a
+second Worker (valid cross-core neighbor-L1 read): the first referencing
+Worker owns/places it, later ones are non-owning readers. Auto-placed
+(no-tile) buffers are still forbidden from being shared across Workers."""
+
+import numpy as np
+
+from aie.iron import Buffer, ObjectFifo, Program, Runtime, Worker
+from aie.iron.device import NPU2Col1, Tile
+from aie.dialects._aie_enum_gen import AIETileType
+from aie.passmanager import PassManager
+
+buf_ty = np.ndarray[(64,), np.dtype[np.int32]]
+
+
+def test_explicit_tile_buffer_shared_across_workers():
+    """A Buffer pinned to an explicit tile can be passed to two Workers."""
+    tile = Tile(col=0, row=2, tile_type=AIETileType.CoreTile)
+    shared = Buffer(tile=tile, type=buf_ty, name="shared_buf")
+
+    producer = Worker(None, [shared], tile=tile)
+    consumer_tile = Tile(col=0, row=3, tile_type=AIETileType.CoreTile)
+    consumer = Worker(None, [shared], tile=consumer_tile)
+
+    # First worker owns/places it; the second is a non-owning reader.
+    assert shared._owner_worker is producer, "First worker should own the buffer"
+    assert shared in producer._buffers
+    assert shared in consumer._buffers
+    assert shared._tile is tile, "Explicit tile placement must be honored"
+
+
+def test_auto_placed_buffer_sharing_still_raises():
+    """A Buffer with no explicit tile shared across Workers is ambiguous."""
+    shared = Buffer(type=buf_ty, name="auto_buf")
+
+    w1 = Worker(None, [shared])
+    raised = False
+    try:
+        Worker(None, [shared])
+    except ValueError as e:
+        raised = True
+        assert "no explicit tile" in str(e)
+    assert raised, "Sharing an auto-placed Buffer across Workers must raise"
+
+
+def test_shared_buffer_resolves_to_cross_core_access():
+    """End-to-end: a Buffer pinned to a producer tile and read by a consumer
+    Worker on a neighbor tile must resolve to a single aie.buffer declared on
+    the producer tile, written by the producer core and read by the consumer
+    core (the cross-core neighbor-L1 access this change enables)."""
+    prod_tile = Tile(col=0, row=2, tile_type=AIETileType.CoreTile)
+    cons_tile = Tile(col=0, row=3, tile_type=AIETileType.CoreTile)
+
+    # Pinned to the producer tile; the consumer reads it from the neighbor tile.
+    shared = Buffer(buf_ty, name="shared_l1", tile=prod_tile)
+    of_out = ObjectFifo(buf_ty, name="out")
+
+    def prod_fn(buf):
+        buf[0] = 1
+
+    def cons_fn(buf, of_out):
+        elem = of_out.acquire(1)
+        x = buf[0]
+        of_out.release(1)
+
+    producer = Worker(prod_fn, [shared], tile=prod_tile)
+    consumer = Worker(cons_fn, [shared, of_out.prod()], tile=cons_tile)
+
+    rt = Runtime()
+    with rt.sequence(buf_ty) as out:
+        rt.start(producer, consumer)
+        rt.drain(of_out.cons(), out, wait=True)
+
+    print(Program(NPU2Col1(), rt).resolve_program())
+
+
+def test_unpinned_consumer_is_steered_to_owner_neighbor():
+    """End-to-end through --aie-place-tiles: when the owner is pinned but the
+    consumer Worker is left unpinned, the SequentialPlacer's buffer-adjacency
+    constraint (buildBufferAdjacency + isLegalMemAffinity) must steer the
+    consumer onto a tile whose L1 is shared with the owner. Owner pinned at
+    (0, 2); the consumer must land on its N neighbor (0, 3)."""
+    prod_tile = Tile(col=0, row=2, tile_type=AIETileType.CoreTile)
+
+    shared = Buffer(buf_ty, name="shared_l1", tile=prod_tile)
+    of_out = ObjectFifo(buf_ty, name="out")
+
+    def prod_fn(buf):
+        buf[0] = 1
+
+    def cons_fn(buf, of_out):
+        elem = of_out.acquire(1)
+        x = buf[0]
+        of_out.release(1)
+
+    producer = Worker(prod_fn, [shared], tile=prod_tile)  # owner pinned (0, 2)
+    consumer = Worker(cons_fn, [shared, of_out.prod()])  # unpinned
+
+    rt = Runtime()
+    with rt.sequence(buf_ty) as out:
+        rt.start(producer, consumer)
+        rt.drain(of_out.cons(), out, wait=True)
+
+    module = Program(NPU2Col1(), rt).resolve_program()
+    pm = PassManager.parse(
+        "builtin.module(aie.device(aie-place-tiles))", context=module.context
+    )
+    pm.run(module.operation)
+    print(module)
+
+
+test_explicit_tile_buffer_shared_across_workers()
+test_auto_placed_buffer_sharing_still_raises()
+
+# A single buffer, declared once on the producer tile (0, 2)...
+# CHECK: %[[PTILE:.+]] = aie.logical_tile<CoreTile>(0, 2)
+# CHECK: %[[CTILE:.+]] = aie.logical_tile<CoreTile>(0, 3)
+# CHECK: %[[BUF:.+]] = aie.buffer(%[[PTILE]]) {sym_name = "shared_l1"}
+# ...written by the producer core...
+# CHECK: aie.core(%[[PTILE]])
+# CHECK: memref.store {{.*}}, %[[BUF]]
+# ...and read by the consumer core on the neighbor tile.
+# CHECK: aie.core(%[[CTILE]])
+# CHECK: memref.load %[[BUF]]
+test_shared_buffer_resolves_to_cross_core_access()
+
+# After --aie-place-tiles, the pinned owner is at (0, 2) and the unpinned
+# consumer is steered onto its memory-affinity neighbor (0, 3); the shared
+# buffer and both cores reference the placed physical tiles. (Tiles are
+# emitted in placement order, which lands (0, 3) before (0, 2).)
+# CHECK: %[[CT:.+]] = aie.tile(0, 3)
+# CHECK: %[[PT:.+]] = aie.tile(0, 2)
+# CHECK: %[[PBUF:.+]] = aie.buffer(%[[PT]]) {sym_name = "shared_l1"}
+# CHECK: aie.core(%[[PT]])
+# CHECK: aie.core(%[[CT]])
+# CHECK: memref.load %[[PBUF]]
+# CHECK-NOT: aie.logical_tile
+test_unpinned_consumer_is_steered_to_owner_neighbor()


### PR DESCRIPTION
Two small, independent fixes to IRON. Both expose capabilities the `aie.*` dialect already supports but that IRON silently dropped or rejected.

**1. `Bd.dimensions` — multi-dim (strided) DMA access patterns.** `aie.dma_bd` accepts a `dimensions` attribute (list of `(size, stride)` tuples), but `Bd` had no field for it and `TileDma.resolve` never forwarded one, so IRON could only express contiguous transfers. Adds the field; `None` (default) keeps the existing behavior.

**2. Worker — allow an explicitly-tiled Buffer to be shared (read) across Workers.** AIE cores can read a neighbor tile's L1 directly, so a producer core's buffer can be a read-only input to a consumer on an adjacent tile — and the SequentialPlacer already models this (`buildBufferAdjacency` + `isLegalMemAffinity`). IRON's Worker guard rejected it anyway. Now a Buffer pinned to an explicit tile may be referenced by later Workers (first owns/places it, rest are non-owning readers); auto-placed buffers are still rejected to avoid ambiguous placement. Adds `Buffer._explicit_tile` to track user intent, since the owner auto-pins `_tile` and so `_tile` alone can't signal it.