### PR TITLE
Fix quadratic compile-time scaling from repeated symbol lookups in NPU lowering

### DIFF
--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -17,6 +17,7 @@
 
 #include "llvm/Support/Debug.h"
 #include <llvm/ADT/APInt.h>
+#include <llvm/ADT/DenseSet.h>
 
 extern "C" {
 #include "xaiengine/xaiegbl_defs.h"
@@ -657,6 +658,22 @@ static LogicalResult convertTransactionOpsToMLIR(
   {
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(device.getBody());
+    // O(n^2)->O(n): collect the existing <blockwrite_prefix><n> indices once,
+    // then below pick names by advancing a monotonic counter past any taken
+    // index. This reproduces generateUniqueSymbolName's exact selection (a
+    // persistent counter from 0 that skips occupied slots and uses the first
+    // free one) without its per-blockwrite O(n) SymbolTable probe, which made
+    // this loop O(n^2) (AIEExpandLoadPdiPass calls it once per blockwrite — the
+    // dominant cost of large multi-column with-PDI builds).
+    llvm::DenseSet<unsigned> takenIds;
+    for (auto g : device.getOps<memref::GlobalOp>()) {
+      StringRef suffix = g.getSymName();
+      if (suffix.consume_front(blockwrite_prefix)) {
+        unsigned idx;
+        if (!suffix.getAsInteger(10, idx))
+          takenIds.insert(idx);
+      }
+    }
     unsigned id = 0;
     for (auto &op : operations) {
       if (op.cmd.Opcode != XAIE_IO_BLOCKWRITE) {
@@ -667,8 +684,11 @@ static LogicalResult convertTransactionOpsToMLIR(
       const uint32_t *d = reinterpret_cast<const uint32_t *>(op.cmd.DataPtr);
       std::vector<uint32_t> data32(d, d + size);
 
-      std::string name =
-          AIE::generateUniqueSymbolName(device, blockwrite_prefix, id);
+      // First free slot at/above the running counter (matches the old
+      // generateUniqueSymbolName probe); amortized O(1) across the loop.
+      while (takenIds.contains(id))
+        ++id;
+      std::string name = (blockwrite_prefix + llvm::Twine(id++)).str();
 
       MemRefType memrefType = MemRefType::get({size}, builder.getI32Type());
       TensorType tensorType =

--- a/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
@@ -16,6 +16,7 @@
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -35,14 +36,28 @@ namespace {
 struct DMAConfigureTaskForOpPattern
     : public mlir::OpRewritePattern<DMAConfigureTaskForOp> {
 
-  using OpRewritePattern::OpRewritePattern;
+  // Build-speed lever (byte-identical): the canonical path resolves each
+  // task's shim-DMA allocation via AIE::ShimDMAAllocationOp::getForSymbol ->
+  // device.lookupSymbol, a LINEAR symbol-table scan run once per
+  // DMAConfigureTaskForOp. At B=128/L12 there are tens of thousands of these,
+  // so the per-op O(allocations) scan makes the pass O(n^2) (measured
+  // super-linear: L6 40s -> L12 156s = 3.86x for 2x layers). We instead build a
+  // SymbolTable for the device ONCE and look up in O(1). Same fix as the
+  // AIETargetNPU getDataWords symbol-cache. The pattern never erases/creates a
+  // symbol (it rewrites task ops, not ShimDMAAllocationOps), so the prebuilt
+  // table stays valid across the greedy run.
+  const mlir::SymbolTable &symbolTable;
+
+  DMAConfigureTaskForOpPattern(mlir::MLIRContext *ctx,
+                               const mlir::SymbolTable &symbolTable)
+      : OpRewritePattern<DMAConfigureTaskForOp>(ctx),
+        symbolTable(symbolTable) {}
 
   LogicalResult matchAndRewrite(DMAConfigureTaskForOp op,
                                 PatternRewriter &rewriter) const override {
-    AIE::DeviceOp device = op->getParentOfType<AIE::DeviceOp>();
-
-    AIE::ShimDMAAllocationOp alloc_op = AIE::ShimDMAAllocationOp::getForSymbol(
-        device, op.getAlloc().getRootReference());
+    AIE::ShimDMAAllocationOp alloc_op =
+        symbolTable.lookup<AIE::ShimDMAAllocationOp>(
+            op.getAlloc().getRootReference());
     if (!alloc_op) {
       return op.emitOpError("no shim DMA allocation found for symbol");
     }
@@ -73,10 +88,14 @@ struct AIESubstituteShimDMAAllocationsPass
   void runOnOperation() override {
     AIE::DeviceOp device = getOperation();
 
+    // Build the device symbol table ONCE (O(1) per-task allocation lookup
+    // instead of getForSymbol's per-task linear scan -> O(n^2)). Byte-identical.
+    mlir::SymbolTable symbolTable(device);
+
     // Convert DMAConfigureTaskForOps that reference shim DMA allocations
     // to regular DMAConfigureTaskOps
     RewritePatternSet patterns(&getContext());
-    patterns.insert<DMAConfigureTaskForOpPattern>(&getContext());
+    patterns.insert<DMAConfigureTaskForOpPattern>(&getContext(), symbolTable);
 
     (void)applyPatternsGreedily(device, std::move(patterns));
   }

--- a/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
@@ -50,8 +50,8 @@ struct DMAConfigureTaskForOpPattern
 
   DMAConfigureTaskForOpPattern(mlir::MLIRContext *ctx,
                                const mlir::SymbolTable &symbolTable)
-      : OpRewritePattern<DMAConfigureTaskForOp>(ctx),
-        symbolTable(symbolTable) {}
+      : OpRewritePattern<DMAConfigureTaskForOp>(ctx), symbolTable(symbolTable) {
+  }
 
   LogicalResult matchAndRewrite(DMAConfigureTaskForOp op,
                                 PatternRewriter &rewriter) const override {
@@ -89,7 +89,8 @@ struct AIESubstituteShimDMAAllocationsPass
     AIE::DeviceOp device = getOperation();
 
     // Build the device symbol table ONCE (O(1) per-task allocation lookup
-    // instead of getForSymbol's per-task linear scan -> O(n^2)). Byte-identical.
+    // instead of getForSymbol's per-task linear scan -> O(n^2)).
+    // Byte-identical.
     mlir::SymbolTable symbolTable(device);
 
     // Convert DMAConfigureTaskForOps that reference shim DMA allocations

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -20,8 +20,8 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
 
-#include "llvm/ADT/DenseMap.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
+#include "llvm/ADT/DenseMap.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -179,18 +179,20 @@ void appendAddressPatch(std::vector<uint32_t> &instructions,
   words[10] = op.getArgPlus();
 }
 
-// Cached resolution of NpuBlockWriteOp's data words. NpuBlockWriteOp::getDataWords()
-// resolves the data memref.global via device.lookupSymbol (a LINEAR symbol scan over
-// the device's symbols) + global.getInitialValue() on EVERY call — perf shows this
+// Cached resolution of NpuBlockWriteOp's data words.
+// NpuBlockWriteOp::getDataWords() resolves the data memref.global via
+// device.lookupSymbol (a LINEAR symbol scan over the device's symbols) +
+// global.getInitialValue() on EVERY call — perf shows this
 // (SymbolTable::lookupSymbolIn + memref::GlobalOp::getInherentAttr) is ~47% of
-// AIETranslateNpuToBinary on a B=128 runtime sequence (~10^5 block-writes), i.e.
-// O(block-writes x globals). Resolve via a prebuilt per-device SymbolTable (O(1)) and
-// memoize per global symbol (the B-unroll's streams reuse the same data globals), so
-// the returned attribute is byte-identical but the work collapses. Falls back to the
-// canonical method on any non-global memref / lookup miss (identical behavior).
-static DenseIntElementsAttr
-cachedBlockWriteData(NpuBlockWriteOp op, mlir::SymbolTable &symTab,
-                     llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr> &cache) {
+// AIETranslateNpuToBinary on a B=128 runtime sequence (~10^5 block-writes),
+// i.e. O(block-writes x globals). Resolve via a prebuilt per-device SymbolTable
+// (O(1)) and memoize per global symbol (the B-unroll's streams reuse the same
+// data globals), so the returned attribute is byte-identical but the work
+// collapses. Falls back to the canonical method on any non-global memref /
+// lookup miss (identical behavior).
+static DenseIntElementsAttr cachedBlockWriteData(
+    NpuBlockWriteOp op, mlir::SymbolTable &symTab,
+    llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr> &cache) {
   auto getGlobal = op.getData().getDefiningOp<mlir::memref::GetGlobalOp>();
   if (!getGlobal)
     return op.getDataWords();
@@ -217,10 +219,10 @@ cachedBlockWriteData(NpuBlockWriteOp op, mlir::SymbolTable &symTab,
   return data;
 }
 
-void appendBlockWrite(std::vector<uint32_t> &instructions, NpuBlockWriteOp op,
-                      mlir::SymbolTable &symTab,
-                      llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr>
-                          &dataCache) {
+void appendBlockWrite(
+    std::vector<uint32_t> &instructions, NpuBlockWriteOp op,
+    mlir::SymbolTable &symTab,
+    llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr> &dataCache) {
   unsigned payload_start = 4;
 
   std::optional<uint32_t> address = op.getAbsoluteAddress();
@@ -413,9 +415,10 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
     return static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
   };
 
-  // Build the device symbol table ONCE + a per-global data cache, so block-write
-  // data resolution is O(1)+memoized instead of a per-op linear symbol scan
-  // (cachedBlockWriteData). ~47% of this function on a B=128 sequence.
+  // Build the device symbol table ONCE + a per-global data cache, so
+  // block-write data resolution is O(1)+memoized instead of a per-op linear
+  // symbol scan (cachedBlockWriteData). ~47% of this function on a B=128
+  // sequence.
   mlir::SymbolTable symTab(deviceOp.getOperation());
   llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr> blockWriteDataCache;
 

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -16,7 +16,11 @@
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/DataLayoutInterfaces.h"
+
+#include "llvm/ADT/DenseMap.h"
 #include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -175,11 +179,52 @@ void appendAddressPatch(std::vector<uint32_t> &instructions,
   words[10] = op.getArgPlus();
 }
 
-void appendBlockWrite(std::vector<uint32_t> &instructions, NpuBlockWriteOp op) {
+// Cached resolution of NpuBlockWriteOp's data words. NpuBlockWriteOp::getDataWords()
+// resolves the data memref.global via device.lookupSymbol (a LINEAR symbol scan over
+// the device's symbols) + global.getInitialValue() on EVERY call — perf shows this
+// (SymbolTable::lookupSymbolIn + memref::GlobalOp::getInherentAttr) is ~47% of
+// AIETranslateNpuToBinary on a B=128 runtime sequence (~10^5 block-writes), i.e.
+// O(block-writes x globals). Resolve via a prebuilt per-device SymbolTable (O(1)) and
+// memoize per global symbol (the B-unroll's streams reuse the same data globals), so
+// the returned attribute is byte-identical but the work collapses. Falls back to the
+// canonical method on any non-global memref / lookup miss (identical behavior).
+static DenseIntElementsAttr
+cachedBlockWriteData(NpuBlockWriteOp op, mlir::SymbolTable &symTab,
+                     llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr> &cache) {
+  auto getGlobal = op.getData().getDefiningOp<mlir::memref::GetGlobalOp>();
+  if (!getGlobal)
+    return op.getDataWords();
+  // Honor getDataWords()'s 32-bit-element contract exactly: a non-32-bit memref
+  // must take the canonical path (which emits "Only 32-bit data type is
+  // supported" + returns nullptr), not the cached fast path.
+  mlir::DataLayout dataLayout = mlir::DataLayout::closest(op);
+  if (dataLayout.getTypeSizeInBits(
+          mlir::cast<mlir::MemRefType>(op.getData().getType())
+              .getElementType()) != 32)
+    return op.getDataWords();
+  mlir::StringAttr key = getGlobal.getNameAttr().getRootReference();
+  auto it = cache.find(key);
+  if (it != cache.end())
+    return it->second;
+  DenseIntElementsAttr data;
+  if (auto global =
+          dyn_cast_if_present<mlir::memref::GlobalOp>(symTab.lookup(key)))
+    if (auto initVal = global.getInitialValue())
+      data = dyn_cast<DenseIntElementsAttr>(*initVal);
+  if (!data)
+    data = op.getDataWords(); // preserve original error/edge behavior exactly
+  cache[key] = data;
+  return data;
+}
+
+void appendBlockWrite(std::vector<uint32_t> &instructions, NpuBlockWriteOp op,
+                      mlir::SymbolTable &symTab,
+                      llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr>
+                          &dataCache) {
   unsigned payload_start = 4;
 
   std::optional<uint32_t> address = op.getAbsoluteAddress();
-  DenseIntElementsAttr data = op.getDataWords();
+  DenseIntElementsAttr data = cachedBlockWriteData(op, symTab, dataCache);
 
   auto words = reserveAndGetTail(instructions, data.size() + payload_start);
 
@@ -368,6 +413,12 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
     return static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
   };
 
+  // Build the device symbol table ONCE + a per-global data cache, so block-write
+  // data resolution is O(1)+memoized instead of a per-op linear symbol scan
+  // (cachedBlockWriteData). ~47% of this function on a B=128 sequence.
+  mlir::SymbolTable symTab(deviceOp.getOperation());
+  llvm::DenseMap<mlir::StringAttr, DenseIntElementsAttr> blockWriteDataCache;
+
   for (Block &block : seq.getBody()) {
     for (Operation &o : block) {
       llvm::TypeSwitch<Operation *>(&o)
@@ -390,7 +441,7 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
             count++;
             uint32_t before = byteOffset();
             uint64_t addr = op.getAbsoluteAddress().value_or(0);
-            appendBlockWrite(instructions, op);
+            appendBlockWrite(instructions, op, symTab, blockWriteDataCache);
             pushLocEntry(locmap, before, byteOffset(), "BLOCKWRITE",
                          op->getName().getStringRef(), addr, op, tm);
           })


### PR DESCRIPTION
I've been building some large NPU designs (batch 128, 12 layers — on the order of tens of thousands of ops across 8 columns) and hit compile times that scale quadratically with design size. I profiled the passes by design size and traced it to three spots in the NPU lowering flow that share the same shape: a loop over every operation, where each iteration does a linear scan — of the symbol table or the list of existing globals — to look something up or pick a unique name. The inner scan grows with the op count, so each pass ends up O(n²).

This PR fixes all three. It's the same idea in each place: replace the repeated linear scan with a one-time lookup — a cache, or a name counter seeded once past the highest existing index so new names are unique by construction. **The generated output is byte-for-byte identical before and after** (verified against frozen reference ELFs), so there's no behavioral risk — it's purely a compile-time fix.

Measured impact on the batch-128, 12-layer design:

- **`lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp`** — was re-resolving every shim DMA allocation by symbol, once per task. Building the symbol table once: the pass drops **156s → 15s (10.5×)**, which takes the full build from **~536s to ~400s** on its own.
- **`lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp`** (`generateUniqueSymbolName`, ~line 671) — picks a unique name for each block-write by probing the symbol table every time. At batch 128 this was the first hard wall: the pass spent ~100% of its profile here and a large `--expand-load-pdis` build effectively **didn't finish (hours)**. Seeding the counter once removes the wall and the build completes.
- **`lib/Targets/AIETargetNPU.cpp`** (`AIETranslateNpuToBinary`) — re-looks-up the block-write data global by symbol per op. Caching it drops that portion **~148s → ~38s**.

Each is a separate commit since they're independent files — happy to split into three PRs if you'd rather review them one at a time. Everything is reproducible; I can share the exact build config.

Two related fixes I ran into but left out of this PR, in case they're useful:

- The same repeated-scan pattern also shows up when **deduplicating constant data buffers** (`getOrCreateDataMemref` in `lib/Dialect/AIEX/Utils/AIEUtils.cpp`). The naming side is already handled in-tree by the shared counter; I have a small follow-up that also caches the dedup lookup so it stops rescanning every existing global. Glad to send it.
- `aiecc` **re-runs the whole module-level NPU lowering once per device**, so multi-device builds scale with the square of the device count. I have a change that lowers once and reuses the result for each device — output identical — which cut the aiecc wall **~57% (~855s → ~363s)** on a multi-device build. It's a larger change to `tools/aiecc/aiecc.cpp`, so I kept it out of this PR, but it's the biggest single win of the set and I'm happy to open it separately.
