### PR TITLE
requirements_dev: pin nanobind==2.12.0 (ABI-coupled to mlir distro)

### DIFF
--- a/python/requirements_dev.txt
+++ b/python/requirements_dev.txt
@@ -13,7 +13,10 @@ cibuildwheel
 patchelf; platform_system == "Linux"
 pre-commit>=4.6.0,<5.0
 black[jupyter]
-nanobind>=2.12.0
+# nanobind ABI-couples to the prebuilt mlir distro wheel (built against this
+# same version); a mismatch breaks Value-subclass recognition at runtime. Pin
+# exact and bump only alongside a distro rebuild.
+nanobind==2.12.0
 lit
 matplotlib
 psutil


### PR DESCRIPTION
The Ryzen AI Software workflow installs the loose requirements_dev.txt (cp310-only SDK can't use the py>=3.11 lock), so nanobind>=2.12.0 auto-floated to 2.13.0 when it published, mismatching the prebuilt mlir distro wheel's nanobind ABI and breaking Value-subclass recognition (TypeError in arith.py at runtime across all Python tests). Pin exact so the source matches the lock and only moves alongside a distro rebuild.