### PR TITLE
Bind IRON target device before JIT generation and caching

### DIFF
--- a/programming_examples/basic/packet_switch/packet_switch.py
+++ b/programming_examples/basic/packet_switch/packet_switch.py
@@ -27,7 +27,7 @@ packet ID, so use ``rt.inline_ops`` as the escape hatch there.
 Two invocation modes:
 
   * compile-only: ``... --op add --xclbin-path=PATH --insts-path=PATH``
-  * emit-MLIR:    ``... --op add --emit-mlir``
+  * emit-MLIR:    ``... --op add --dev npu --emit-mlir``
 """
 
 import argparse

--- a/programming_examples/basic/vector_vector_modulo/README.md
+++ b/programming_examples/basic/vector_vector_modulo/README.md
@@ -14,7 +14,7 @@ A simple binary operator: a single AIE core computes `c = a % b` element-wise on
 
 ## Source Files Overview
 
-1. `vector_vector_modulo.py`: An `@iron.jit`-decorated design that delegates its dataflow body to `aie.iron.algorithms.transform_binary`. Supports three invocation modes — standalone (jit + run + verify), compile-only (`--xclbin-path` / `--insts-path`, used by the NPU `Makefile`), and emit-MLIR (`--emit-mlir`, used by the aiecc-based vck5000 path).
+1. `vector_vector_modulo.py`: An `@iron.jit`-decorated design that delegates its dataflow body to `aie.iron.algorithms.transform_binary`. Supports three invocation modes — standalone (jit + run + verify), compile-only (`--xclbin-path` / `--insts-path`, used by the NPU `Makefile`), and emit-MLIR (`-d xcvc1902 --emit-mlir`, used by the aiecc-based vck5000 path).
 
 1. `test.cpp`: C++ testbench targeting Ryzen™ AI. Loads the compiled XCLBIN, configures the AIE module, supplies input data, executes on the NPU, and verifies the results.
 

--- a/programming_guide/README.md
+++ b/programming_guide/README.md
@@ -61,7 +61,7 @@ b = iron.zeros(1024,  dtype=np.int32, device="npu")
 my_design(a, b)              # compile + run + sync back
 ```
 
-`my_design.as_mlir(a, b)` or `python3 my_design.py --emit-mlir` prints the lowered MLIR without touching the NPU.
+`my_design.as_mlir(a, b)` prints MLIR for the active target, binding an attached runtime target when one is available. `python3 my_design.py --dev npu --emit-mlir` emits an offline target without touching the NPU.
 
 ## Where to go next
 

--- a/programming_guide/iron_configuration.md
+++ b/programming_guide/iron_configuration.md
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2025-2026, Advanced Micro Devices, Inc.
-// 
+//
 //===----------------------------------------------------------------------===//-->
 
 # IRON Python Configurations

--- a/programming_guide/iron_configuration.md
+++ b/programming_guide/iron_configuration.md
@@ -32,11 +32,10 @@ CPUOnlyTensor
 
 ## Default IRON Device
 
-If the IRON device is not set, many designs will fetch it on demand from the [`DefaultNPURuntime`](../python/utils/__init__.py) (a `CachedXRTRuntime` instance), which queries XRT for the attached NPU. You can override this by calling [`iron.set_current_device()`](../python/utils/hostruntime/__init__.py), which takes the new device and returns the previous one:
+If the IRON device is not set, many designs fetch it on demand from the [`DefaultNPURuntime`](../python/utils/__init__.py) (a `CachedXRTRuntime` instance), which queries XRT for the attached NPU. Select an explicit target with `iron.set_current_device()`:
 ```python
 >>> import aie.iron as iron
 >>> iron.set_current_device(iron.device.NPU1())
-<abc.NPU2 object at 0x722a659826c0>
 >>> iron.get_current_device()
 <abc.NPU1 object at 0x722a65903a10>
 ```
@@ -52,12 +51,12 @@ cache subdirectory, no collision with the binary for whatever NPU is
 physically attached:
 
 ```python
+import aie.iron as iron
 from aie.iron.device import NPU1Col1, NPU2Col1
-from aie.utils.hostruntime import set_current_device
 
 # Same generator, two arches → two distinct cache dirs.
 for dev_cls in (NPU1Col1, NPU2Col1):
-    set_current_device(dev_cls())
+    iron.set_current_device(dev_cls())
     my_design.specialize(N=4096).compile()
 ```
 
@@ -75,11 +74,17 @@ can drive their DMA-layout transforms from the kernel itself instead
 of hardcoding for one arch:
 
 ```python
+import aie.iron as iron
+from aie.iron.device import NPU2Col1
+
+iron.set_current_device(NPU2Col1())
 mm = kernels.mm(dim_m=64, dim_k=64, dim_n=64,
                 input_dtype=np.int16, output_dtype=np.int16)
 r, s, t = mm.mac_dims
-# r/s/t now reflect whichever arch is active per get_current_device().
 ```
+
+Set the target before constructing an arch-sensitive factory. The factory
+selects its source and MMUL geometry when it is created.
 
 The full per-arch table lives in
 [`python/iron/kernels/linalg.py`](../python/iron/kernels/linalg.py)
@@ -148,7 +153,7 @@ has a docstring; `help(obj)` or `print(obj.__doc__)` shows it.
 
 | Helper | What it does |
 |--------|--------------|
-| `aie.utils.hostruntime.argparse.device_from_args(args)` | Resolve a parsed argparse `Namespace` to a `Device` — collapses `from_name(args.dev, n_cols=...)` boilerplate.  `n_cols="auto"` reads `args.n_cols` if present, otherwise defaults to 1.  Lives next to the `add_*_args` family that produces the `Namespace` it consumes. |
+| `aie.utils.hostruntime.argparse.device_from_args(args)` | Resolve an explicit parsed `args.dev` to a `Device` — collapses `from_name(args.dev, n_cols=...)` boilerplate. Returns `None` when target selection is automatic, so `run_design_cli()` can bind the attached runtime family. `n_cols="auto"` reads `args.n_cols` if present, otherwise defaults to 1. |
 | `aie.utils.DefaultNPURuntime` | Module-level `CachedXRTRuntime` instance; auto-detects NPU1 / NPU2 via XRT.  Used by `iron.tensor(..., device="npu")` and `@iron.jit` runtime binding. |
 | `aie.utils.hostruntime.argparse.{add_compile_args, add_runtime_args}` | Add the standard `--xclbin-path`/`--insts-path` and `--xclbin`/`--instr`/`-k`/`--trace_size` flags to a parser. |
 | `aie.utils.test.create_npu_kernel(opts)` | Build an `NPUKernel` (plus optional `TraceConfig`) from a parsed `argparse.Namespace`.  See `programming_examples/basic/vector_scalar_mul/test.py` for the canonical use pattern. |

--- a/programming_guide/section-1/Makefile
+++ b/programming_guide/section-1/Makefile
@@ -19,11 +19,11 @@ include ${srcdir}/../../programming_examples/makefile-common
 all: run
 
 run:
-	${powershell} python3 ${srcdir}/aie2.py
+	${powershell} python3 ${srcdir}/aie2.py --dev ${devicename}
 
 emit-mlir:
 	mkdir -p build
-	${powershell} python3 ${srcdir}/aie2.py --emit-mlir > build/aie.mlir
+	${powershell} python3 ${srcdir}/aie2.py --dev ${devicename} --emit-mlir > build/aie.mlir
 
 clean:
 	rm -rf build

--- a/programming_guide/section-1/README.md
+++ b/programming_guide/section-1/README.md
@@ -14,7 +14,7 @@ When we program the AIE-array, we need to declare and configure its structural b
 
 ## <ins>Walkthrough of Python source file (aie2.py)</ins>
 
-Let's look at a minimal IRON design in [aie2.py](./aie2.py). The whole design is one function decorated with `@iron.jit`: the first time you call it, IRON JIT-compiles the design and runs it on the attached NPU; `--emit-mlir` prints the lowered MLIR instead.
+Let's look at a minimal IRON design in [aie2.py](./aie2.py). The whole design is one function decorated with `@iron.jit`: the first time you call it, IRON JIT-compiles the design and runs it on the attached NPU; `--dev <target> --emit-mlir` prints the lowered MLIR instead.
 
 ```python
 import aie.iron as iron
@@ -97,10 +97,10 @@ ComputeTile4 = Tile(0, 5)
 
 ## <ins>Inspecting the generated MLIR</ins>
 
-`@iron.jit` lowers your design through the AIE dialect on its way to a binary. To see the MLIR without running anything, pass `--emit-mlir`:
+`@iron.jit` lowers your design through the AIE dialect on its way to a binary. To see the MLIR without running anything, pass `--dev <target> --emit-mlir`:
 
 ```shell
-python3 aie2.py --emit-mlir
+python3 aie2.py --dev npu --emit-mlir
 ```
 
 The Makefile also exposes `make emit-mlir` which redirects the output to `build/aie.mlir`.

--- a/programming_guide/section-1/aie2.py
+++ b/programming_guide/section-1/aie2.py
@@ -12,8 +12,8 @@ A single ``Worker`` placed on tile (0, 2) writes zeros into a local
 facing output) and starts the worker.
 
 The whole design is just a function decorated with ``@iron.jit``: the
-first call JIT-compiles + runs on the attached NPU; ``--emit-mlir``
-prints the lowered MLIR without touching the hardware.
+first call JIT-compiles + runs on the attached NPU; ``--dev npu
+--emit-mlir`` prints the lowered MLIR without touching the hardware.
 """
 
 import argparse

--- a/programming_guide/section-1/run_makefile.lit
+++ b/programming_guide/section-1/run_makefile.lit
@@ -6,6 +6,7 @@
 // RUN: mkdir -p test_run_makefile
 // RUN: cd test_run_makefile
 // RUN: make -f %S/Makefile clean
-// RUN: make -f %S/Makefile emit-mlir
-// RUN: %run_on_npu1% make -f %S/Makefile run
-// RUN: %run_on_npu2% make -f %S/Makefile run
+// RUN: %run_on_npu1% make -f %S/Makefile devicename=npu emit-mlir
+// RUN: %run_on_npu1% make -f %S/Makefile devicename=npu run
+// RUN: %run_on_npu2% make -f %S/Makefile devicename=npu2 emit-mlir
+// RUN: %run_on_npu2% make -f %S/Makefile devicename=npu2 run

--- a/programming_guide/section-2/section-2e/README.md
+++ b/programming_guide/section-2/section-2e/README.md
@@ -23,7 +23,7 @@
 
 This section walks through scaling a single-Worker IRON design out to multiple Workers. We will start with the code in [aie2.py](./aie2.py) which contains a simple design running on a single Worker, and progressively turn it into the code in [aie2_multi.py](./aie2_multi.py) which contains the same design distributed across three Workers.
 
-Both files are wrapped in `@iron.jit`, so calling each design from `_run_and_verify` JIT-compiles and runs end-to-end on the attached NPU; `--emit-mlir` prints the lowered MLIR for inspection.
+Both files are wrapped in `@iron.jit`, so calling each design from `_run_and_verify` JIT-compiles and runs end-to-end on the attached NPU; `--dev <target> --emit-mlir` prints the lowered MLIR for inspection.
 
 In the first part of our design we set up the data movement using Object FIFOs. The simple design has a total of four Object FIFOs, two of which are created by forwarding data for an implicit copy. The Object FIFOs move objects of datatype `<48xi32>`. `of_in` brings data from external memory and is linked, through a Mem tile, to `of_in0` which brings data from the Mem tile to the Worker. For the output side, `of_out0` brings data from the Worker to the Mem tile where it is linked to `of_out` to bring the data out to external memory. The corresponding code is shown below:
 ```python

--- a/programming_guide/section-2/section-2e/README.md
+++ b/programming_guide/section-2/section-2e/README.md
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // Copyright (C) 2024, Advanced Micro Devices, Inc.
-// 
+//
 //===----------------------------------------------------------------------===//-->
 
 # <ins>Section 2e - Programming for multiple cores</ins>

--- a/programming_guide/section-3/vector_scalar_mul.py
+++ b/programming_guide/section-3/vector_scalar_mul.py
@@ -16,8 +16,8 @@ Three modes:
 
 * ``python3 vector_scalar_mul.py`` — JIT-compile + run + verify on the
   attached NPU.
-* ``python3 vector_scalar_mul.py --emit-mlir`` — print the lowered MLIR
-  (no NPU access).
+* ``python3 vector_scalar_mul.py --dev npu --emit-mlir`` — print the
+  lowered MLIR (no NPU access).
 * ``python3 vector_scalar_mul.py --xclbin-path X --insts-path Y`` —
   compile-only, drop the xclbin/insts pair for the explicit-XRT
   walkthrough (used by ``test.cpp`` and ``test.py``).

--- a/programming_guide/section-4/section-4a/vector_scalar_mul.py
+++ b/programming_guide/section-4/section-4a/vector_scalar_mul.py
@@ -18,7 +18,8 @@ Three modes (same as section-3):
 
 * ``python3 vector_scalar_mul.py [--iters N --warmup K]`` — JIT-compile
   + run + verify + benchmark on the attached NPU.
-* ``python3 vector_scalar_mul.py --emit-mlir`` — print the lowered MLIR.
+* ``python3 vector_scalar_mul.py --dev npu --emit-mlir`` — print the
+  lowered MLIR.
 * ``python3 vector_scalar_mul.py --xclbin-path X --insts-path Y`` —
   compile-only.
 """

--- a/programming_guide/section-4/section-4b/vector_scalar_mul.py
+++ b/programming_guide/section-4/section-4b/vector_scalar_mul.py
@@ -19,7 +19,8 @@ Three modes (same as section-3/4a):
 
 * ``python3 vector_scalar_mul.py [-t N]`` — JIT-compile + run on the
   attached NPU; with ``-t N`` (bytes) trace is enabled.
-* ``python3 vector_scalar_mul.py --emit-mlir`` — print the lowered MLIR.
+* ``python3 vector_scalar_mul.py --dev npu --emit-mlir`` — print the
+  lowered MLIR.
 * ``python3 vector_scalar_mul.py --xclbin-path X --insts-path Y`` —
   compile-only, drop the xclbin/insts pair for the explicit-XRT
   walkthrough.

--- a/python/iron/__init__.py
+++ b/python/iron/__init__.py
@@ -80,6 +80,7 @@ from aie.utils import (
     zeros_like,
     ceildiv,
     set_tensor_class,
+    set_current_device,
     get_current_device,
     ensure_current_device,
 )
@@ -130,6 +131,7 @@ __all__ = [
     "zeros_like",
     "ceildiv",
     "set_tensor_class",
+    "set_current_device",
     "get_current_device",
     "ensure_current_device",
     # dtype helpers

--- a/python/iron/__init__.py
+++ b/python/iron/__init__.py
@@ -81,6 +81,7 @@ from aie.utils import (
     ceildiv,
     set_tensor_class,
     get_current_device,
+    ensure_current_device,
 )
 
 __all__ = [
@@ -130,6 +131,7 @@ __all__ = [
     "ceildiv",
     "set_tensor_class",
     "get_current_device",
+    "ensure_current_device",
     # dtype helpers
     "str_to_dtype",
     "dtype_to_str",

--- a/python/iron/kernels/_common.py
+++ b/python/iron/kernels/_common.py
@@ -27,7 +27,7 @@ def _detect_arch() -> str:
         import aie.iron as _iron
         from aie.utils.compile.utils import resolve_target_arch
 
-        device = _iron.get_current_device()
+        device = _iron.get_current_device(probe_runtime=False)
         return resolve_target_arch(device)
     except (ImportError, RuntimeError, AttributeError, ValueError):
         # ImportError: iron not built; RuntimeError: no active device set;

--- a/python/iron/kernels/_common.py
+++ b/python/iron/kernels/_common.py
@@ -24,10 +24,10 @@ def _detect_arch() -> str:
     Falls back to ``'aie2'`` if no device is currently set.
     """
     try:
-        import aie.iron as _iron
+        from aie.utils import get_current_device
         from aie.utils.compile.utils import resolve_target_arch
 
-        device = _iron.get_current_device(probe_runtime=False)
+        device = get_current_device(probe_runtime=False)
         return resolve_target_arch(device)
     except (ImportError, RuntimeError, AttributeError, ValueError):
         # ImportError: iron not built; RuntimeError: no active device set;

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -226,9 +226,13 @@ def __getattr__(name):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def get_current_device():
-    """
-    Get the current NPU device.
+def get_current_device(*, probe_runtime: bool = True):
+    """Get the current NPU device.
+
+    Args:
+        probe_runtime: When True, infer the device from the default runtime if
+            no explicit device has been bound.  Use False for offline inspection
+            paths that must not initialize the runtime.
 
     Returns:
         Device | None: The current device if available, else None.
@@ -236,8 +240,33 @@ def get_current_device():
     if hostruntime._CURRENT_DEVICE:
         return hostruntime._CURRENT_DEVICE
 
+    if not probe_runtime:
+        return None
+
     runtime = _get_default_npu_runtime()
     if runtime:
         return runtime.device()
     else:
         return None
+
+
+def ensure_current_device(*, probe_runtime: bool = True):
+    """Bind and return the device observed by IRON.
+
+    ``get_current_device()`` can infer a device from the runtime without making
+    that device explicit. Architecture-sensitive generators need a single
+    process-wide device selection so kernel factories, cache hashing, MLIR
+    generation, and external-kernel compilation all see the same target.
+
+    Args:
+        probe_runtime: Forwarded to ``get_current_device``. Use False for
+            offline inspection paths that must not initialize the runtime.
+
+    Returns:
+        Device | None: The device that was bound, or ``None`` if no device
+        was available and nothing was bound.
+    """
+    device = get_current_device(probe_runtime=probe_runtime)
+    if device is not None:
+        set_current_device(device)
+    return device

--- a/python/utils/callabledesign.py
+++ b/python/utils/callabledesign.py
@@ -313,10 +313,16 @@ class CallableDesign:
             k: v for k, v in effective_compile_kwargs.items() if k != "trace_config"
         }
 
-        compilable = self._build_compilable(call_compile_kwargs)
+        from aie.utils import ensure_current_device
 
-        # In-process key includes runtime_args (tensor shapes); on-disk key in
-        # _compute_cache_hash does not. Divergence is intentional: if a generator
+        ensure_current_device()
+
+        compilable = self._build_compilable(call_compile_kwargs)
+        cache_compile_kwargs["__iron_device__"] = compilable._generation_cache_key()
+
+        # In-process key includes runtime_args (tensor shapes) and the active
+        # device; on-disk key in _compute_cache_hash does not include tensor
+        # shapes. Divergence is intentional: if a generator
         # omits CompileTime[T] for shape, the disk artifact reuses but the in-process
         # slot changes, so validate_tensor_args() surfaces the mismatch.
         generator = compilable.mlir_generator

--- a/python/utils/callabledesign.py
+++ b/python/utils/callabledesign.py
@@ -318,7 +318,6 @@ class CallableDesign:
         ensure_current_device()
 
         compilable = self._build_compilable(call_compile_kwargs)
-        cache_compile_kwargs["__iron_device__"] = compilable._generation_cache_key()
 
         # In-process key includes runtime_args (tensor shapes) and the active
         # device; on-disk key in _compute_cache_hash does not include tensor
@@ -335,6 +334,7 @@ class CallableDesign:
             cache_fn,
             runtime_args,
             cache_compile_kwargs,
+            extra_key=compilable._generation_cache_key(),
         )
 
         if compilable.use_cache and cache_key in self._kernel_cache:

--- a/python/utils/compile/cache/utils.py
+++ b/python/utils/compile/cache/utils.py
@@ -110,8 +110,13 @@ def _release_lock(lock_file) -> None:
             pass
 
 
-def _create_function_cache_key(function, args, kwargs):
-    """Create a cache key for a function call based on function name and argument types/shapes."""
+def _create_function_cache_key(function, args, kwargs, *, extra_key=()):
+    """Create a cache key for a function call based on call inputs.
+
+    ``extra_key`` is an optional immutable discriminator owned by the caller.
+    It is kept outside ``kwargs`` so internal cache dimensions cannot collide
+    with user-facing compile-time parameter names.
+    """
     func_name = function.__name__
 
     # Create signature from argument types and shapes
@@ -192,7 +197,8 @@ def _create_function_cache_key(function, args, kwargs):
             signature_parts.append(f"{key}_{type(value).__name__}_{val_hash}")
 
     signature = "_".join(signature_parts)
-    return (func_name, signature)
+    key = (func_name, signature)
+    return (*key, extra_key) if extra_key else key
 
 
 @contextlib.contextmanager

--- a/python/utils/compile/jit/_hash.py
+++ b/python/utils/compile/jit/_hash.py
@@ -12,7 +12,7 @@ Two halves so callers can distinguish "recipe changed" from "rebuild needed":
 * :func:`_compute_recipe_hash`   — generator bytecode + compile_kwargs +
   aiecc/compile flags.  Pure function of the design specification.
 * :func:`_compute_artifact_hash` — source / object mtimes + tool mtimes +
-  target arch.  Captures things that change the *output* of compilation
+  target device.  Captures things that change the *output* of compilation
   without changing the *recipe*.
 
 :func:`_compute_hash` composes both into the 24-hex cache-key
@@ -31,6 +31,18 @@ from pathlib import Path
 from typing import Any, Callable, Mapping
 
 logger = logging.getLogger(__name__)
+
+
+def _device_identity_key(device) -> tuple[str, str, str, str]:
+    """Return the cache-relevant identity of an IRON device."""
+    if device is None:
+        return ("none", "", "", "")
+    return (
+        f"{type(device).__module__}.{type(device).__qualname__}",
+        str(getattr(device, "arch", "")),
+        str(getattr(device, "cols", "")),
+        str(getattr(device, "rows", "")),
+    )
 
 
 def _compute_recipe_hash(
@@ -98,7 +110,7 @@ def _compute_artifact_hash(
     source_files: list[Path] | tuple[Path, ...],
     object_files: list[Path] | tuple[Path, ...],
 ) -> str:
-    """Hash of the "artifacts": source/object mtimes + tool mtimes + target arch.
+    """Hash of the "artifacts": source/object mtimes + tool mtimes + target device.
 
     Captures everything that can change the *output* of compilation without
     changing the *recipe*: edited C++ kernels, swapped object files, upgraded
@@ -120,9 +132,9 @@ def _compute_artifact_hash(
         except (FileNotFoundError, OSError):
             pass
 
-    # Static .mlir is arch-agnostic; compiled kernels need a target identifier.
-    # Missing components collapse to a constant + WARNING log so cross-arch cache
-    # collisions surface instead of silently aliasing.
+    # Static .mlir is target-agnostic; compiled kernels need a device identifier.
+    # Missing components collapse to a constant + WARNING log so cross-target
+    # cache collisions surface instead of silently aliasing.
     if not isinstance(generator, Path):
         try:
             import aie.iron as _iron
@@ -138,12 +150,14 @@ def _compute_artifact_hash(
                     else None
                 )
             target_arch = resolve_target_arch(device)
+            target_device = _device_identity_key(device)
         except (ImportError, AttributeError, RuntimeError, ValueError) as exc:
             logger.warning(
                 "_compute_artifact_hash: target_arch unresolved (%s); using 'unknown'",
                 exc,
             )
             target_arch = "unknown"
+            target_device = ("unknown", "", "", "")
 
         try:
             from aie.utils import config as _config
@@ -182,7 +196,8 @@ def _compute_artifact_hash(
             aiecc_mtime = "absent"
 
         h.update(
-            f"target_arch={target_arch}|peano_mtime={peano_mtime}|aiecc_mtime={aiecc_mtime}".encode()
+            f"target_arch={target_arch}|target_device={target_device!r}|"
+            f"peano_mtime={peano_mtime}|aiecc_mtime={aiecc_mtime}".encode()
         )
 
     return h.hexdigest()

--- a/python/utils/compile/jit/_hash.py
+++ b/python/utils/compile/jit/_hash.py
@@ -9,8 +9,8 @@
 
 Two halves so callers can distinguish "recipe changed" from "rebuild needed":
 
-* :func:`_compute_recipe_hash`   — generator bytecode + compile_kwargs +
-  aiecc/compile flags.  Pure function of the design specification.
+* :func:`_compute_recipe_hash`   — generator identity + compile_kwargs +
+  aiecc/compile flags. Target-independent design identity.
 * :func:`_compute_artifact_hash` — source / object mtimes + tool mtimes +
   target device.  Captures things that change the *output* of compilation
   without changing the *recipe*.
@@ -53,9 +53,9 @@ def _compute_recipe_hash(
 ) -> str:
     """Hash of the "recipe": generator bytecode + CompileTime[T] kwargs + flags.
 
-    Pure function of the design specification; does not touch the filesystem
-    or environment.  Two CompilableDesigns with the same recipe_hash will
-    produce identical MLIR (modulo nondeterminism in the generator body).
+    Captures the target-independent generator and compile configuration. It
+    omits device identity, so equal recipe hashes can produce different
+    target-specialized MLIR.
     """
     h = hashlib.sha256()
 
@@ -137,18 +137,10 @@ def _compute_artifact_hash(
     # cache collisions surface instead of silently aliasing.
     if not isinstance(generator, Path):
         try:
-            import aie.iron as _iron
-            from aie.utils import DefaultNPURuntime
+            from aie.utils import get_current_device
             from aie.utils.compile.utils import resolve_target_arch
 
-            try:
-                device = _iron.get_current_device()
-            except (RuntimeError, AttributeError):
-                device = (
-                    DefaultNPURuntime.device()
-                    if DefaultNPURuntime is not None
-                    else None
-                )
+            device = get_current_device(probe_runtime=False)
             target_arch = resolve_target_arch(device)
             target_device = _device_identity_key(device)
         except (ImportError, AttributeError, RuntimeError, ValueError) as exc:

--- a/python/utils/compile/jit/compilabledesign.py
+++ b/python/utils/compile/jit/compilabledesign.py
@@ -15,23 +15,21 @@ Hashing is split into two halves so callers can distinguish "recipe changed"
 from "rebuild needed":
 
 * ``recipe_hash``   — generator bytecode + compile_kwargs + aiecc/compile flags
-* ``artifact_hash`` — source / object mtimes + tool mtimes + target arch
+* ``artifact_hash`` — source / object mtimes + tool mtimes + target device
 
 ``hash(design)`` composes both into a 24-hex cache key; no MLIR generation
 needed for a cache lookup.
 
-Generation is memoized at the instance level via :attr:`CompilableDesign._generated`
-(a ``functools.cached_property`` returning the MLIR text + collected
-``ExternalFunction`` instances). Caching the *text* — not the Module — is what
-makes this safe across MLIR Contexts: every consumer call re-parses into a
-fresh ``mlir_mod_ctx()`` and gets a Module bound to its own Context. Safe
-because all constructor inputs are frozen, so the generated MLIR is a pure
-function of the instance.
+Generation is memoized per active IRON device via :attr:`CompilableDesign._generated`.
+Caching the *text* — not the Module — is what makes this safe across MLIR
+Contexts: every consumer call re-parses into a fresh ``mlir_mod_ctx()`` and gets
+a Module bound to its own Context. The active device is part of the generation
+key because kernel factories and ``Program(...)`` creation can specialize on the
+current target.
 """
 
 from __future__ import annotations
 
-import functools
 import inspect
 import json
 import logging
@@ -52,7 +50,12 @@ from aie.extras.context import mlir_mod_ctx  # pyright: ignore[reportMissingImpo
 from aie.ir import Module as _Module  # pyright: ignore[reportAttributeAccessIssue]
 
 from ._dma_size_parser import parse_dma_sizes
-from ._hash import _compute_artifact_hash, _compute_hash, _compute_recipe_hash
+from ._hash import (
+    _compute_artifact_hash,
+    _compute_hash,
+    _compute_recipe_hash,
+    _device_identity_key,
+)
 from ._introspect import (
     _introspect_generator,
     _is_compile_param,
@@ -125,6 +128,7 @@ class CompilableDesign:
         self._inst_path: Path | None = None
         self._kernel_dir: Path | None = None
         self._expected_tensor_sizes: list[int] | None = None
+        self._generated_cache: dict[tuple, tuple[str, list]] = {}
 
         # Introspect generator signature to split param categories.  Cache
         # hints+sig on self so split_runtime_args / _generate_mlir reuse the
@@ -209,6 +213,10 @@ class CompilableDesign:
                 "(the JIT cache does not track ELF artifacts)."
             )
 
+        from aie.utils import ensure_current_device
+
+        ensure_current_device()
+
         if explicit_paths:
             assert xclbin_path is not None and inst_path is not None
             # Absolutize so compile_external_kernel's `cwd=kernel_dir` doesn't
@@ -278,7 +286,7 @@ class CompilableDesign:
                 # in an env without pyxrt silently builds .o files for aie2 instead
                 # of aie2p — link succeeds, runtime times out (ERT_CMD_STATE_TIMEOUT).
                 try:
-                    device = _iron.get_current_device()
+                    device = _iron.get_current_device(probe_runtime=False)
                 except (RuntimeError, AttributeError):
                     device = (
                         DefaultNPURuntime.device()
@@ -568,10 +576,10 @@ class CompilableDesign:
 
     @property
     def artifact_hash(self) -> str:
-        """Hash of the build environment: source/object mtimes + tool mtimes + arch.
+        """Hash of the build environment: source/object mtimes + tool mtimes + device.
 
         Changes whenever a kernel ``.cc``, an ``.o``, Peano, aiecc, or the
-        target arch changes; identifies the *with what* of compilation.
+        target device changes; identifies the *with what* of compilation.
         """
         return _compute_artifact_hash(
             self.mlir_generator,
@@ -589,25 +597,36 @@ class CompilableDesign:
             self.compile_flags,
         )
 
-    @functools.cached_property
-    def _generated(self) -> tuple[str, list]:
-        """Run the generator once and cache ``(mlir_text, external_kernels)``.
+    def _generation_cache_key(self) -> tuple:
+        """Return the identity that affects cached MLIR generation.
 
-        Generation (executing the user's MLIR builder) is the dominant
-        in-process cost on a cold-disk cache path. Caching the *text* — not
-        the Module — is safe across MLIR Contexts: the Module is bound to the
-        Context that built it, but the text is not, so each ``_generate_mlir``
-        call can re-parse into the live Context and return a fresh Module.
-
-        ExternalFunction instances are Python objects with no Context
-        affinity; cached directly. Their ``_compiled`` flag survives reuse,
-        so a second ``compile()`` correctly skips already-built kernels.
-
-        Safe to memoize because :class:`CompilableDesign` inputs are frozen
-        at ``__init__`` (``compile_kwargs`` is a ``MappingProxyType``; the
-        list fields are tuples), so the generated MLIR is a pure function
-        of ``self``.
+        Static ``.mlir`` files key on their path. Python generators key on the
+        explicitly bound device, without probing the runtime.
         """
+        if isinstance(self.mlir_generator, Path):
+            return ("path", str(self.mlir_generator))
+
+        try:
+            import aie.iron as _iron
+
+            device = _iron.get_current_device(probe_runtime=False)
+        except (ImportError, RuntimeError, AttributeError, ValueError, TypeError):
+            device = None
+
+        return ("device",) + _device_identity_key(device)
+
+    @property
+    def _generated(self) -> tuple[str, list]:
+        """Return cached ``(mlir_text, external_kernels)`` for the active device."""
+        key = self._generation_cache_key()
+        generated = self._generated_cache.get(key)
+        if generated is None:
+            generated = self._generate_uncached()
+            self._generated_cache[key] = generated
+        return generated
+
+    def _generate_uncached(self) -> tuple[str, list]:
+        """Run the generator and collect generated MLIR text and external kernels."""
         from aie.iron.kernel import ExternalFunction
 
         if isinstance(self.mlir_generator, Path):
@@ -699,6 +718,8 @@ class CompilableDesign:
             return _Module.parse(mlir_text)
 
     def __hash__(self) -> int:
+        # The cache hash includes the active target device. Do not use a
+        # CompilableDesign as a stable key while retargeting devices.
         # Fold the 96-bit cache hash down to a signed 64-bit Python hash.
         h = int(self._compute_cache_hash(), 16)
         # Wrap to the range [-(2^63), 2^63-1] by taking modulo and adjusting.

--- a/python/utils/compile/jit/compilabledesign.py
+++ b/python/utils/compile/jit/compilabledesign.py
@@ -14,7 +14,7 @@ pair via ``compile()``.
 Hashing is split into two halves so callers can distinguish "recipe changed"
 from "rebuild needed":
 
-* ``recipe_hash``   — generator bytecode + compile_kwargs + aiecc/compile flags
+* ``recipe_hash``   — generator identity + compile_kwargs + aiecc/compile flags
 * ``artifact_hash`` — source / object mtimes + tool mtimes + target device
 
 ``hash(design)`` composes both into a 24-hex cache key; no MLIR generation
@@ -195,7 +195,6 @@ class CompilableDesign:
         too — the cache path doesn't track ELF artifacts.
         """
         from aie.iron.kernel import ExternalFunction
-        from aie.utils import DefaultNPURuntime
 
         if (xclbin_path is None) != (inst_path is None):
             raise ValueError(
@@ -213,9 +212,8 @@ class CompilableDesign:
                 "(the JIT cache does not track ELF artifacts)."
             )
 
-        from aie.utils import ensure_current_device
-
-        ensure_current_device()
+        if not isinstance(self.mlir_generator, Path):
+            self._bind_generation_device()
 
         if explicit_paths:
             assert xclbin_path is not None and inst_path is not None
@@ -250,10 +248,9 @@ class CompilableDesign:
                 self._xclbin_path = xclbin_path
                 self._inst_path = inst_path
                 self._kernel_dir = kernel_dir
-                # Populate on cache hit too, else validate_tensor_args no-ops
-                # and callers see kernel garbage instead of a shape error.
-                if self._expected_tensor_sizes is None:
-                    self._expected_tensor_sizes = parse_dma_sizes(kernel_dir)
+                # The active artifact may have changed since the previous
+                # compile(), so refresh its validation metadata on every hit.
+                self._expected_tensor_sizes = parse_dma_sizes(kernel_dir)
                 return xclbin_path, inst_path
 
             if explicit_paths:
@@ -270,29 +267,12 @@ class CompilableDesign:
                 )
 
             try:
-                # _EXTERN_CACHE ops bind to a prior MLIR Context; reuse across
-                # contexts segfaults in func.function_type. Clear per compile.
-                from aie.iron.kernels._common import _EXTERN_CACHE
-
-                _EXTERN_CACHE.clear()
                 mlir_module = self._generate_mlir(ExternalFunction)
 
+                from aie.utils import get_current_device
                 from aie.utils.compile import resolve_target_arch
-                import aie.iron as _iron
 
-                # Prefer iron's current device (matches `iron.get_current_device()`
-                # inside the generator); fall back to XRT-detected only when unset.
-                # Without this, a Strix-targeted design (iron set to NPU2) running
-                # in an env without pyxrt silently builds .o files for aie2 instead
-                # of aie2p — link succeeds, runtime times out (ERT_CMD_STATE_TIMEOUT).
-                try:
-                    device = _iron.get_current_device(probe_runtime=False)
-                except (RuntimeError, AttributeError):
-                    device = (
-                        DefaultNPURuntime.device()
-                        if DefaultNPURuntime is not None
-                        else None
-                    )
+                device = get_current_device(probe_runtime=False)
                 target_arch = resolve_target_arch(device)
 
                 external_kernels = list(ExternalFunction._instances)
@@ -434,7 +414,8 @@ class CompilableDesign:
         """Generate and return the MLIR module without compiling to xclbin.
 
         Useful for inspecting generated MLIR, debugging, or offline analysis.
-        Does not require an NPU or XRT to be present.
+        Binds an available runtime-detected device before generation so
+        target-sensitive builders and the generation cache see the same device.
 
         Returns:
             The generated ``mlir.ir.Module``.
@@ -564,8 +545,8 @@ class CompilableDesign:
     def recipe_hash(self) -> str:
         """Hash of the design recipe: generator + CompileTime[T] kwargs + flags.
 
-        Stable across rebuilds; identifies the *what* of compilation. Two
-        designs with equal ``recipe_hash`` produce identical MLIR.
+        Identifies the target-independent design recipe. Device-specialized
+        MLIR also depends on the bound device.
         """
         return _compute_recipe_hash(
             self.mlir_generator,
@@ -597,6 +578,18 @@ class CompilableDesign:
             self.compile_flags,
         )
 
+    def _bind_generation_device(self):
+        """Bind an available runtime device before target-sensitive work."""
+        if isinstance(self.mlir_generator, Path):
+            return None
+
+        try:
+            from aie.utils import ensure_current_device
+
+            return ensure_current_device()
+        except (ImportError, RuntimeError, AttributeError, ValueError, TypeError):
+            return None
+
     def _generation_cache_key(self) -> tuple:
         """Return the identity that affects cached MLIR generation.
 
@@ -607,9 +600,9 @@ class CompilableDesign:
             return ("path", str(self.mlir_generator))
 
         try:
-            import aie.iron as _iron
+            from aie.utils import get_current_device
 
-            device = _iron.get_current_device(probe_runtime=False)
+            device = get_current_device(probe_runtime=False)
         except (ImportError, RuntimeError, AttributeError, ValueError, TypeError):
             device = None
 
@@ -618,6 +611,7 @@ class CompilableDesign:
     @property
     def _generated(self) -> tuple[str, list]:
         """Return cached ``(mlir_text, external_kernels)`` for the active device."""
+        self._bind_generation_device()
         key = self._generation_cache_key()
         generated = self._generated_cache.get(key)
         if generated is None:
@@ -678,7 +672,13 @@ class CompilableDesign:
                 f"compile_kwargs do not match CompileTime[T] parameters — {exc}"
             ) from exc
 
+        # Kernel factories cache ExternalFunction instances. Those instances
+        # retain MLIR operations after resolution, so every fresh generation
+        # must begin with a context-local factory cache.
+        from aie.iron.kernels._common import _EXTERN_CACHE
+
         ExternalFunction._instances.clear()
+        _EXTERN_CACHE.clear()
 
         _tensor_placeholders = {
             name: _TensorPlaceholder(name) for name in self.tensor_params

--- a/python/utils/hostruntime/argparse.py
+++ b/python/utils/hostruntime/argparse.py
@@ -29,7 +29,7 @@ def add_compile_args(
     *,
     with_dev: bool = True,
     dev_choices: tuple[str, ...] = DEFAULT_DEV_CHOICES,
-    default_dev: str = "npu",
+    default_dev: str | None = None,
     short_dev: str | None = "-d",
     with_elf: bool = False,
     with_emit_mlir: bool = False,
@@ -43,7 +43,10 @@ def add_compile_args(
         dev_choices: Allowed device-name strings (default
             ``("npu", "npu2")``).  Pass e.g. ``("npu", "npu2", "xcvc1902")``
             for designs that also accept the VCK5000 target.
-        default_dev: Default value for ``--dev``.
+        default_dev: Fixed target used when ``--dev`` is omitted. ``None``
+            (the default) selects the attached runtime device for run and
+            local compile-only modes. ``--emit-mlir`` requires an explicit
+            target.
         short_dev: Short-option for ``--dev``.  ``None`` to skip the short
             opt (matmul designs use ``--dev`` only because ``-d`` is
             already taken by something else).
@@ -56,18 +59,25 @@ def add_compile_args(
     """
     if with_dev:
         names = ("--dev",) if short_dev is None else (short_dev, "--dev")
+        if default_dev is None:
+            dev_help = (
+                "target device family (auto-detected for run and local "
+                "compilation; required for --emit-mlir)"
+            )
+        else:
+            dev_help = "target device family (default: %(default)s)"
         parser.add_argument(
             *names,
             type=str,
             choices=list(dev_choices),
             default=default_dev,
-            help="target device family (default: %(default)s)",
+            help=dev_help,
         )
     if with_emit_mlir:
         parser.add_argument(
             "--emit-mlir",
             action="store_true",
-            help="print the resolved MLIR module to stdout (aiecc / vck5000 path)",
+            help="print the resolved MLIR module to stdout (requires --dev)",
         )
     parser.add_argument(
         "--xclbin-path",
@@ -271,13 +281,17 @@ def device_from_args(
             ``n_cols="auto"``.
 
     Returns:
-        Device instance.
+        Device | None: The selected device, or ``None`` when the CLI leaves
+        device selection to the runtime.
     """
+    dev = getattr(args, dev_attr)
+    if dev is None:
+        return None
+
     # Lazy import: argparse.py is otherwise pure-stdlib and avoids the
     # aie.iron import edge until a caller actually needs to resolve a Device.
     from aie.iron.device import from_name
 
-    dev = getattr(args, dev_attr)
     resolved_cols: int | None
     if n_cols == "auto":
         resolved_cols = getattr(args, "n_cols", None)

--- a/python/utils/hostruntime/cli.py
+++ b/python/utils/hostruntime/cli.py
@@ -20,8 +20,8 @@ Almost every basic/ design's ``main()`` is the same skeleton:
         _run_and_verify(opts)
 
 …where ``_compile_only`` always does the same ``--insts-path`` check +
-``set_current_device(from_name(opts.dev))`` + ``design.specialize(**kw)
-.compile(xclbin_path=opts.xclbin_path, inst_path=opts.insts_path
+device binding + ``design.specialize(**kw).compile(
+xclbin_path=opts.xclbin_path, inst_path=opts.insts_path
 [, elf_path=opts.elf_path])``.
 
 This module wraps that skeleton so each design just declares the two
@@ -56,8 +56,9 @@ def run_design_cli(
 
     The standard branch tree (in order):
 
-      1. If ``validate`` is given, call ``validate(opts)`` first.
-      2. If ``opts.emit_mlir`` is True, set the current device, then:
+      1. Resolve and bind the current device.
+      2. If ``validate`` is given, call ``validate(opts)``.
+      3. If ``opts.emit_mlir`` is True, then:
 
          * If an ``emit_mlir`` callback was supplied, call ``emit_mlir(opts)``.
          * Otherwise print ``design.specialize(**compile_kwargs).as_mlir()``
@@ -66,16 +67,15 @@ def run_design_cli(
 
          Then return.
 
-      3. If ``opts.xclbin_path`` is set:
+      4. If ``opts.xclbin_path`` is set:
 
          * Refuse if ``opts.insts_path`` is unset (``sys.exit`` with the
            standard message).
-         * Set the current device.
          * Call ``design.specialize(**compile_kwargs).compile(
            xclbin_path=opts.xclbin_path, inst_path=opts.insts_path,
            [elf_path=opts.elf_path])``.
 
-      4. Otherwise, call ``run_and_verify(opts)``.
+      5. Otherwise, call ``run_and_verify(opts)``.
 
     Args:
         design: The ``@iron.jit``-decorated design (a ``CallableDesign``).
@@ -118,9 +118,6 @@ def run_design_cli(
     from aie.iron.device import from_name
     from aie.utils.hostruntime import set_current_device
 
-    if validate is not None:
-        validate(opts)
-
     if device is None:
         # Default: read opts.dev and pass through from_name.
         if not hasattr(opts, "dev"):
@@ -135,8 +132,13 @@ def run_design_cli(
 
         device = _default_device
 
+    resolved_device = _resolve(device, opts)
+    set_current_device(resolved_device)
+
+    if validate is not None:
+        validate(opts)
+
     if getattr(opts, "emit_mlir", False):
-        set_current_device(_resolve(device, opts))
         if emit_mlir is not None:
             emit_mlir(opts)
         else:
@@ -147,7 +149,6 @@ def run_design_cli(
     if getattr(opts, "xclbin_path", None):
         if not getattr(opts, "insts_path", None):
             sys.exit("--xclbin-path requires --insts-path (must be set together)")
-        set_current_device(_resolve(device, opts))
         kwargs = _resolve(compile_kwargs, opts)
         spec = design.specialize(**kwargs)
         compile_opts = dict(xclbin_path=opts.xclbin_path, inst_path=opts.insts_path)

--- a/python/utils/hostruntime/cli.py
+++ b/python/utils/hostruntime/cli.py
@@ -42,6 +42,39 @@ def _resolve(value: Any, opts) -> Any:
     return value(opts) if callable(value) else value
 
 
+def _runtime_device_name(device: Any) -> str:
+    """Return the standard CLI name for a detected NPU device."""
+    from aie.utils.compile import resolve_target_arch
+
+    target_arch = resolve_target_arch(device)
+    if target_arch == "aie2":
+        return "npu"
+    if target_arch == "aie2p":
+        return "npu2"
+    raise RuntimeError(f"Unsupported runtime target architecture: {target_arch}")
+
+
+def _detect_runtime_target(opts, *, mode: str):
+    """Resolve the active NPU family for an automatic CLI target."""
+    from aie.utils import get_current_device
+
+    runtime_device = get_current_device()
+    if runtime_device is None:
+        if mode == "compile":
+            sys.exit(
+                "run_design_cli: compile-only mode requires --dev when no NPU "
+                "runtime device is available."
+            )
+        sys.exit(
+            "run_design_cli: no NPU runtime device is available for an "
+            "automatic target selection."
+        )
+
+    if hasattr(opts, "dev"):
+        opts.dev = _runtime_device_name(runtime_device)
+    return runtime_device
+
+
 def run_design_cli(
     design,
     opts,
@@ -56,7 +89,9 @@ def run_design_cli(
 
     The standard branch tree (in order):
 
-      1. Resolve and bind the current device.
+      1. Bind an explicit ``--dev`` target or concrete ``device`` argument,
+         or detect the attached runtime device for run and local compile-only
+         modes.
       2. If ``validate`` is given, call ``validate(opts)``.
       3. If ``opts.emit_mlir`` is True, then:
 
@@ -81,8 +116,9 @@ def run_design_cli(
         design: The ``@iron.jit``-decorated design (a ``CallableDesign``).
         opts: Parsed ``argparse.Namespace`` — must expose at minimum
             ``xclbin_path`` / ``insts_path`` (the standard
-            ``add_compile_args`` flags).  ``emit_mlir`` and ``elf_path``
-            are read if present.
+            ``add_compile_args`` flags). ``dev`` may be ``None`` to request
+            automatic runtime selection. ``emit_mlir`` and ``elf_path`` are
+            read if present.
         compile_kwargs: Either a dict OR a callable that takes ``opts``
             and returns the kwargs dict to pass to
             ``design.specialize()``.  Callable form is convenient for
@@ -95,11 +131,12 @@ def run_design_cli(
             harness omit this; reaching the run branch without it exits
             with a clear "no python run path" message.
         device: Optional iron ``Device`` instance OR callable
-            ``opts -> Device``.  If omitted, defaults to
-            ``from_name(opts.dev)`` (using whatever device choices the
-            argparse setup allowed).  Pass a callable when the device
-            depends on more than just ``opts.dev`` — e.g. matmul's
-            ``(opts.dev, opts.n_aie_cols)`` mapping.
+            ``opts -> Device``. An explicit ``opts.dev`` is resolved through
+            this value, or through ``from_name(opts.dev)`` when omitted. When
+            ``opts.dev`` is ``None``, the dispatcher detects the attached NPU
+            family, updates ``opts.dev``, and then invokes a callable selector
+            so it can retain its declared column profile. Pass a ``Device``
+            instance to pin a target independently of the CLI.
         emit_mlir: Optional callable for the ``--emit-mlir`` branch.
             If ``opts.emit_mlir`` is True but this is None, the dispatcher
             falls back to printing
@@ -109,36 +146,60 @@ def run_design_cli(
             passed-in tensor).  Pass an explicit callable when the
             generator needs real ``iron.tensor`` instances at MLIR-gen
             time.
-        validate: Optional callable invoked before any branch — e.g. for
-            shape / arg consistency checks that should fire in all modes.
+        validate: Optional callable invoked after target selection — e.g.
+            for shape / arg consistency checks that should fire in all modes.
     """
-    # Late imports so this module is cheap to import even when no
-    # design ever calls it (and to dodge circular-import issues with
-    # aie.iron.device).
-    from aie.iron.device import from_name
+    # Late imports keep this module cheap to import and avoid circular imports
+    # until a design actually enters the dispatcher.
     from aie.utils.hostruntime import set_current_device
 
-    if device is None:
-        # Default: read opts.dev and pass through from_name.
-        if not hasattr(opts, "dev"):
+    emit_mlir_requested = getattr(opts, "emit_mlir", False)
+    compile_only_requested = getattr(opts, "xclbin_path", None) is not None
+    requested_dev = getattr(opts, "dev", None)
+
+    if compile_only_requested and not getattr(opts, "insts_path", None):
+        sys.exit("--xclbin-path requires --insts-path (must be set together)")
+
+    if requested_dev is None:
+        has_concrete_device = device is not None and not callable(device)
+        if emit_mlir_requested and not has_concrete_device:
+            sys.exit(
+                "run_design_cli: --emit-mlir requires an explicit target; "
+                "pass --dev."
+            )
+
+        if device is None and not hasattr(opts, "dev"):
             raise ValueError(
                 "run_design_cli: device=None requires opts to expose a "
                 "'dev' attribute (the standard add_compile_args flag). "
                 "Pass device=<Device or callable> explicitly otherwise."
             )
 
-        def _default_device(opts):
-            return from_name(opts.dev)
+        if has_concrete_device:
+            resolved_device = device
+        else:
+            mode = "compile" if compile_only_requested else "run"
+            _detect_runtime_target(opts, mode=mode)
+            if device is None:
+                from aie.iron.device import from_name
 
-        device = _default_device
+                resolved_device = from_name(opts.dev)
+            else:
+                resolved_device = _resolve(device, opts)
+        set_current_device(resolved_device)
+    else:
+        if device is None:
+            from aie.iron.device import from_name
 
-    resolved_device = _resolve(device, opts)
-    set_current_device(resolved_device)
+            resolved_device = from_name(requested_dev)
+        else:
+            resolved_device = _resolve(device, opts)
+        set_current_device(resolved_device)
 
     if validate is not None:
         validate(opts)
 
-    if getattr(opts, "emit_mlir", False):
+    if emit_mlir_requested:
         if emit_mlir is not None:
             emit_mlir(opts)
         else:
@@ -146,9 +207,7 @@ def run_design_cli(
             print(design.specialize(**kwargs).as_mlir())
         return
 
-    if getattr(opts, "xclbin_path", None):
-        if not getattr(opts, "insts_path", None):
-            sys.exit("--xclbin-path requires --insts-path (must be set together)")
+    if compile_only_requested:
         kwargs = _resolve(compile_kwargs, opts)
         spec = design.specialize(**kwargs)
         compile_opts = dict(xclbin_path=opts.xclbin_path, inst_path=opts.insts_path)

--- a/python/utils/hostruntime/cli.py
+++ b/python/utils/hostruntime/cli.py
@@ -34,12 +34,25 @@ real ``iron.tensor`` instances at MLIR-gen time.
 from __future__ import annotations
 
 import sys
-from typing import Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping, TypeAlias
+
+if TYPE_CHECKING:
+    from aie.iron.device import Device
+
+_DeviceArg: TypeAlias = "Device | Callable[[Any], Device | None]"
 
 
 def _resolve(value: Any, opts) -> Any:
     """Resolve ``value`` to a concrete value: call it if callable, else pass through."""
     return value(opts) if callable(value) else value
+
+
+def _resolve_device(value: _DeviceArg, opts) -> "Device":
+    """Resolve a CLI device selector to a concrete Device."""
+    resolved = value(opts) if callable(value) else value
+    if resolved is None:
+        raise ValueError("run_design_cli: device selector returned None")
+    return resolved
 
 
 def _runtime_device_name(device: Any) -> str:
@@ -81,7 +94,7 @@ def run_design_cli(
     *,
     compile_kwargs: Mapping[str, Any] | Callable[[Any], Mapping[str, Any]],
     run_and_verify: Callable[[Any], None] | None = None,
-    device: Any | Callable[[Any], Any] | None = None,
+    device: _DeviceArg | None = None,
     emit_mlir: Callable[[Any], None] | None = None,
     validate: Callable[[Any], None] | None = None,
 ) -> None:
@@ -175,7 +188,7 @@ def run_design_cli(
                 "Pass device=<Device or callable> explicitly otherwise."
             )
 
-        if has_concrete_device:
+        if device is not None and not callable(device):
             resolved_device = device
         else:
             mode = "compile" if compile_only_requested else "run"
@@ -185,7 +198,7 @@ def run_design_cli(
 
                 resolved_device = from_name(opts.dev)
             else:
-                resolved_device = _resolve(device, opts)
+                resolved_device = _resolve_device(device, opts)
         set_current_device(resolved_device)
     else:
         if device is None:
@@ -193,7 +206,7 @@ def run_design_cli(
 
             resolved_device = from_name(requested_dev)
         else:
-            resolved_device = _resolve(device, opts)
+            resolved_device = _resolve_device(device, opts)
         set_current_device(resolved_device)
 
     if validate is not None:

--- a/test/python/test_algorithms_api.py
+++ b/test/python/test_algorithms_api.py
@@ -1,0 +1,30 @@
+# test_algorithms_api.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# RUN: %pytest %s
+"""Unit tests for public IRON algorithm package exports."""
+
+import numpy as np
+
+from aie.iron.device import NPU1Col1
+from aie.utils.hostruntime import set_current_device
+
+
+def test_transform_export_is_callable_and_returns_module():
+    from aie.iron.algorithms import transform
+
+    assert callable(transform)
+
+    set_current_device(NPU1Col1())
+    try:
+        tensor_ty = np.ndarray[(1024,), np.dtype[np.int32]]
+        module = transform(lambda x: x + 1, tensor_ty, tile_size=16)
+        assert module is not None
+        assert hasattr(module, "operation")
+    finally:
+        set_current_device(None)

--- a/test/python/test_callable_design_unit.py
+++ b/test/python/test_callable_design_unit.py
@@ -428,3 +428,59 @@ def test_as_mlir_no_warning_when_no_conflict():
     assert (
         not conflict_warnings
     ), "as_mlir() must not warn when call-time and pre-bound values match"
+
+
+def test_call_binds_runtime_device_before_in_process_cache(monkeypatch):
+    """Direct @iron.jit calls bind the runtime device before cache lookup."""
+    import aie.utils as utils
+    from aie.iron.device import NPU2
+    from aie.utils.hostruntime import set_current_device
+
+    class FakeRuntime:
+        def device(self):
+            return NPU2()
+
+    def gen():
+        pass
+
+    set_current_device(None)
+    monkeypatch.setattr(utils, "_get_default_npu_runtime", lambda: FakeRuntime())
+
+    cd = CallableDesign(gen)
+    seen_keys = []
+
+    def fake_compile_and_build(self, compilable, cache_key, trace_config):
+        seen_keys.append(cache_key)
+        assert type(utils.get_current_device(probe_runtime=False)).__name__ == "NPU2"
+        return lambda *args, **kwargs: "ran"
+
+    monkeypatch.setattr(
+        CallableDesign, "_compile_and_build_kernel", fake_compile_and_build
+    )
+
+    try:
+        assert cd() == "ran"
+    finally:
+        set_current_device(None)
+
+    assert seen_keys
+    assert "__iron_device__" in seen_keys[0][1]
+
+
+def test_call_argument_errors_do_not_probe_runtime(monkeypatch):
+    """Cheap call-shape errors are reported before runtime device probing."""
+    import aie.utils as utils
+    from aie.utils.hostruntime import set_current_device
+
+    def gen(a: In):
+        pass
+
+    def fail_runtime_probe():
+        raise AssertionError("runtime should not be probed before argument validation")
+
+    set_current_device(None)
+    monkeypatch.setattr(utils, "_get_default_npu_runtime", fail_runtime_probe)
+
+    cd = CallableDesign(gen)
+    with pytest.raises(TypeError, match="at most 1 positional"):
+        cd(object(), object())

--- a/test/python/test_callable_design_unit.py
+++ b/test/python/test_callable_design_unit.py
@@ -132,7 +132,10 @@ class TestJitDecorator:
         def gen(a: In):
             pass
 
-        assert any("/opt/inc" in str(p) for p in gen.compilable.include_paths)
+        assert any(
+            "opt/inc" in str(p).replace("\\", "/")
+            for p in gen.compilable.include_paths
+        )
 
     def test_object_files_forwarded(self):
         @jit(object_files=["add.o"])
@@ -464,7 +467,26 @@ def test_call_binds_runtime_device_before_in_process_cache(monkeypatch):
         set_current_device(None)
 
     assert seen_keys
-    assert "__iron_device__" in seen_keys[0][1]
+    assert seen_keys[0][-1][0] == "device"
+    assert "__iron_device__" not in seen_keys[0][1]
+
+
+def test_function_cache_key_keeps_internal_identity_out_of_compile_kwargs():
+    """User compile keys cannot collide with internal cache dimensions."""
+    from aie.utils.compile.cache.utils import _create_function_cache_key
+
+    def gen():
+        pass
+
+    key = _create_function_cache_key(
+        gen,
+        (),
+        {"__iron_device__": "user-value"},
+        extra_key=("device", "NPU2Col1"),
+    )
+
+    assert "__iron_device__" in key[1]
+    assert key[2] == ("device", "NPU2Col1")
 
 
 def test_call_argument_errors_do_not_probe_runtime(monkeypatch):
@@ -484,3 +506,44 @@ def test_call_argument_errors_do_not_probe_runtime(monkeypatch):
     cd = CallableDesign(gen)
     with pytest.raises(TypeError, match="at most 1 positional"):
         cd(object(), object())
+
+
+def test_as_mlir_binds_runtime_device_before_generation(monkeypatch):
+    """Inspection follows the same device binding invariant as __call__."""
+    import aie.utils as utils
+    from aie.iron.device import NPU2Col1
+    from aie.utils.hostruntime import set_current_device
+
+    class FakeRuntime:
+        def device(self):
+            return NPU2Col1()
+
+    def gen():
+        pass
+
+    set_current_device(None)
+    monkeypatch.setattr(utils, "_get_default_npu_runtime", lambda: FakeRuntime())
+
+    cd = CallableDesign(gen)
+
+    def fake_generate_uncached(self):
+        assert (
+            type(utils.get_current_device(probe_runtime=False)).__name__
+            == "NPU2Col1"
+        )
+        return ("module {}", [])
+
+    def fake_generate_mlir(self, _ExternalFunction):
+        return self._generated[0]
+
+    monkeypatch.setattr(CompilableDesign, "_generate_uncached", fake_generate_uncached)
+    monkeypatch.setattr(CompilableDesign, "_generate_mlir", fake_generate_mlir)
+
+    try:
+        assert cd.as_mlir() == "module {}"
+    finally:
+        set_current_device(None)
+
+    keys = list(cd.compilable._generated_cache)
+    assert len(keys) == 1
+    assert "NPU2Col1" in keys[0][1]

--- a/test/python/test_callable_design_unit.py
+++ b/test/python/test_callable_design_unit.py
@@ -133,8 +133,7 @@ class TestJitDecorator:
             pass
 
         assert any(
-            "opt/inc" in str(p).replace("\\", "/")
-            for p in gen.compilable.include_paths
+            "opt/inc" in str(p).replace("\\", "/") for p in gen.compilable.include_paths
         )
 
     def test_object_files_forwarded(self):
@@ -528,8 +527,7 @@ def test_as_mlir_binds_runtime_device_before_generation(monkeypatch):
 
     def fake_generate_uncached(self):
         assert (
-            type(utils.get_current_device(probe_runtime=False)).__name__
-            == "NPU2Col1"
+            type(utils.get_current_device(probe_runtime=False)).__name__ == "NPU2Col1"
         )
         return ("module {}", [])
 

--- a/test/python/test_compilabledesign.py
+++ b/test/python/test_compilabledesign.py
@@ -898,8 +898,6 @@ def test_kernels_mm_mac_dims_per_arch():
     ), f"AIE2P i16/i16 mac_dims expected (4, 4, 8), got {mm_aie2p.mac_dims}"
 
 
-
-
 def test_compile_mixed_explicit_paths_raises():
     """Passing only one of (xclbin_path, inst_path) is rejected up front."""
     import pytest

--- a/test/python/test_compilabledesign.py
+++ b/test/python/test_compilabledesign.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pytest
 
 from aie.extras.context import mlir_mod_ctx
-from aie.iron.device import NPU1Col1, NPU2Col1, NPU2Col2
+from aie.iron.device import NPU1Col1, NPU2Col1
 from aie.iron.kernel import ExternalFunction, Kernel
 from aie.utils.compile.jit._dma_size_parser import parse_dma_sizes
 from aie.utils.compile.jit.compilabledesign import CompilableDesign, _compute_hash
@@ -451,7 +451,7 @@ def test_to_json_contains_all_fields():
     assert data["aiecc_flags"] == ["--verbose"]
     assert data["compile_flags"] == ["-O3"]
     assert "kernel.cc" in data["source_files"][0]
-    assert "/opt/inc" in data["include_paths"][0]
+    assert "opt/inc" in data["include_paths"][0].replace("\\", "/")
     assert "add.o" in data["object_files"][0]
     assert "generator_name" in data
     assert "cache_hash" in data
@@ -497,7 +497,7 @@ def test_from_json_restores_source_and_include_paths():
     d = CompilableDesign(gen, source_files=["k.cc"], include_paths=["/opt"])
     d2 = CompilableDesign.from_json(d.to_json(), generator=gen)
     assert any("k.cc" in str(sf) for sf in d2.source_files)
-    assert any("/opt" in str(p) for p in d2.include_paths)
+    assert any("opt" in str(p).replace("\\", "/") for p in d2.include_paths)
 
 
 def test_from_json_with_object_files():
@@ -898,66 +898,6 @@ def test_kernels_mm_mac_dims_per_arch():
     ), f"AIE2P i16/i16 mac_dims expected (4, 4, 8), got {mm_aie2p.mac_dims}"
 
 
-def test_generated_cache_tracks_active_device(monkeypatch):
-    """MLIR generation cache entries are keyed by the active IRON device."""
-
-    def gen():
-        pass
-
-    cd = CompilableDesign(gen)
-    calls = []
-
-    def fake_generate_uncached(self):
-        calls.append(self._generation_cache_key())
-        return (f"mlir-{len(calls)}", [])
-
-    monkeypatch.setattr(CompilableDesign, "_generate_uncached", fake_generate_uncached)
-
-    set_current_device(NPU1Col1())
-    first_aie2 = cd._generated
-    second_aie2 = cd._generated
-
-    set_current_device(NPU2Col1())
-    first_aie2p = cd._generated
-    second_aie2p = cd._generated
-
-    set_current_device(None)
-
-    assert first_aie2 == second_aie2
-    assert first_aie2p == second_aie2p
-    assert first_aie2 != first_aie2p
-    assert len(calls) == 2
-
-
-def test_compute_hash_changes_when_active_device_width_changes():
-    """The filesystem cache key includes the active device identity, not just arch."""
-    gen = _gemm_gen()
-    cd = CompilableDesign(gen, compile_kwargs={"M": 64, "K": 64, "N": 64})
-
-    set_current_device(NPU2Col1())
-    h_one_col = cd._compute_cache_hash()
-
-    set_current_device(NPU2Col2())
-    h_two_col = cd._compute_cache_hash()
-
-    set_current_device(None)
-
-    assert h_one_col != h_two_col
-
-
-def test_transform_returns_module():
-    import numpy as np
-    from aie.iron.algorithms import transform
-
-    set_current_device(NPU1Col1())
-    try:
-        tensor_ty = np.ndarray[(1024,), np.dtype[np.int32]]
-        # This should not raise and should return an MLIR module
-        module = transform(lambda x: x + 1, tensor_ty, tile_size=16)
-        assert module is not None
-        assert hasattr(module, "operation")
-    finally:
-        set_current_device(None)
 
 
 def test_compile_mixed_explicit_paths_raises():

--- a/test/python/test_compilabledesign.py
+++ b/test/python/test_compilabledesign.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pytest
 
 from aie.extras.context import mlir_mod_ctx
-from aie.iron.device import NPU1Col1, NPU2Col1
+from aie.iron.device import NPU1Col1, NPU2Col1, NPU2Col2
 from aie.iron.kernel import ExternalFunction, Kernel
 from aie.utils.compile.jit._dma_size_parser import parse_dma_sizes
 from aie.utils.compile.jit.compilabledesign import CompilableDesign, _compute_hash
@@ -897,6 +897,53 @@ def test_kernels_mm_mac_dims_per_arch():
         8,
     ), f"AIE2P i16/i16 mac_dims expected (4, 4, 8), got {mm_aie2p.mac_dims}"
 
+
+
+def test_generated_cache_tracks_active_device(monkeypatch):
+    """MLIR generation cache entries are keyed by the active IRON device."""
+
+    def gen():
+        pass
+
+    cd = CompilableDesign(gen)
+    calls = []
+
+    def fake_generate_uncached(self):
+        calls.append(self._generation_cache_key())
+        return (f"mlir-{len(calls)}", [])
+
+    monkeypatch.setattr(CompilableDesign, "_generate_uncached", fake_generate_uncached)
+
+    set_current_device(NPU1Col1())
+    first_aie2 = cd._generated
+    second_aie2 = cd._generated
+
+    set_current_device(NPU2Col1())
+    first_aie2p = cd._generated
+    second_aie2p = cd._generated
+
+    set_current_device(None)
+
+    assert first_aie2 == second_aie2
+    assert first_aie2p == second_aie2p
+    assert first_aie2 != first_aie2p
+    assert len(calls) == 2
+
+
+def test_compute_hash_changes_when_active_device_width_changes():
+    """The filesystem cache key includes the active device identity, not just arch."""
+    gen = _gemm_gen()
+    cd = CompilableDesign(gen, compile_kwargs={"M": 64, "K": 64, "N": 64})
+
+    set_current_device(NPU2Col1())
+    h_one_col = cd._compute_cache_hash()
+
+    set_current_device(NPU2Col2())
+    h_two_col = cd._compute_cache_hash()
+
+    set_current_device(None)
+
+    assert h_one_col != h_two_col
 
 def test_transform_returns_module():
     import numpy as np

--- a/test/python/test_compilabledesign.py
+++ b/test/python/test_compilabledesign.py
@@ -898,7 +898,6 @@ def test_kernels_mm_mac_dims_per_arch():
     ), f"AIE2P i16/i16 mac_dims expected (4, 4, 8), got {mm_aie2p.mac_dims}"
 
 
-
 def test_generated_cache_tracks_active_device(monkeypatch):
     """MLIR generation cache entries are keyed by the active IRON device."""
 
@@ -944,6 +943,7 @@ def test_compute_hash_changes_when_active_device_width_changes():
     set_current_device(None)
 
     assert h_one_col != h_two_col
+
 
 def test_transform_returns_module():
     import numpy as np

--- a/test/python/test_device_binding_cache_unit.py
+++ b/test/python/test_device_binding_cache_unit.py
@@ -96,8 +96,7 @@ def test_generated_root_binds_runtime_device_before_cache_key(monkeypatch):
 
     def fake_generate_uncached(self):
         assert (
-            type(utils.get_current_device(probe_runtime=False)).__name__
-            == "NPU2Col1"
+            type(utils.get_current_device(probe_runtime=False)).__name__ == "NPU2Col1"
         )
         return ("mlir", [])
 
@@ -113,7 +112,9 @@ def test_generated_root_binds_runtime_device_before_cache_key(monkeypatch):
     assert "NPU2Col1" in keys[0][1]
 
 
-def test_cache_hit_refreshes_tensor_metadata_for_the_selected_artifact(monkeypatch, tmp_path):
+def test_cache_hit_refreshes_tensor_metadata_for_the_selected_artifact(
+    monkeypatch, tmp_path
+):
     """Returning to a cached target restores that artifact's validation metadata."""
     import aie.utils as utils
     import aie.utils.compile.jit.compilabledesign as compilabledesign_module

--- a/test/python/test_device_binding_cache_unit.py
+++ b/test/python/test_device_binding_cache_unit.py
@@ -1,0 +1,270 @@
+# test_device_binding_cache_unit.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# RUN: %pytest %s
+"""Unit tests for target-device-sensitive generation and cache identity."""
+
+from pathlib import Path
+
+import pytest
+
+from aie.iron.device import NPU1Col1, NPU2Col1, NPU2Col2
+from aie.utils import set_current_device
+from aie.utils.compile.jit import CompileTime, In, Out
+from aie.utils.compile.jit.compilabledesign import CompilableDesign
+
+
+def _gemm_gen():
+    def gemm(
+        a: In,
+        b: In,
+        c: Out,
+        *,
+        M: CompileTime[int],
+        K: CompileTime[int],
+        N: CompileTime[int],
+    ):
+        pass
+
+    return gemm
+
+
+def test_generated_cache_tracks_active_device(monkeypatch):
+    """MLIR generation cache entries are keyed by the active IRON device."""
+
+    def gen():
+        pass
+
+    cd = CompilableDesign(gen)
+    calls = []
+
+    def fake_generate_uncached(self):
+        calls.append(self._generation_cache_key())
+        return (f"mlir-{len(calls)}", [])
+
+    monkeypatch.setattr(CompilableDesign, "_generate_uncached", fake_generate_uncached)
+
+    set_current_device(NPU1Col1())
+    first_aie2 = cd._generated
+    second_aie2 = cd._generated
+
+    set_current_device(NPU2Col1())
+    first_aie2p = cd._generated
+    second_aie2p = cd._generated
+
+    set_current_device(None)
+
+    assert first_aie2 == second_aie2
+    assert first_aie2p == second_aie2p
+    assert first_aie2 != first_aie2p
+    assert len(calls) == 2
+
+
+def test_uncached_generation_clears_context_bound_external_functions():
+    """Fresh MLIR generation never reuses factory objects from another context."""
+    from aie.iron.kernels import _common as kernel_common
+
+    def gen():
+        pass
+
+    kernel_common._EXTERN_CACHE["stale"] = object()
+    CompilableDesign(gen)._generate_uncached()
+
+    assert not kernel_common._EXTERN_CACHE
+
+
+def test_generated_root_binds_runtime_device_before_cache_key(monkeypatch):
+    """Direct MLIR generation binds the runtime device before cache lookup."""
+    import aie.utils as utils
+
+    class FakeRuntime:
+        def device(self):
+            return NPU2Col1()
+
+    def gen():
+        pass
+
+    set_current_device(None)
+    monkeypatch.setattr(utils, "_get_default_npu_runtime", lambda: FakeRuntime())
+
+    cd = CompilableDesign(gen)
+
+    def fake_generate_uncached(self):
+        assert (
+            type(utils.get_current_device(probe_runtime=False)).__name__
+            == "NPU2Col1"
+        )
+        return ("mlir", [])
+
+    monkeypatch.setattr(CompilableDesign, "_generate_uncached", fake_generate_uncached)
+
+    try:
+        assert cd._generated == ("mlir", [])
+    finally:
+        set_current_device(None)
+
+    keys = list(cd._generated_cache)
+    assert len(keys) == 1
+    assert "NPU2Col1" in keys[0][1]
+
+
+def test_cache_hit_refreshes_tensor_metadata_for_the_selected_artifact(monkeypatch, tmp_path):
+    """Returning to a cached target restores that artifact's validation metadata."""
+    import aie.utils as utils
+    import aie.utils.compile.jit.compilabledesign as compilabledesign_module
+
+    def gen():
+        pass
+
+    artifacts = {
+        "npu1": [16],
+        "npu2": [32],
+    }
+    for name in artifacts:
+        kernel_dir = tmp_path / name
+        kernel_dir.mkdir()
+        (kernel_dir / "final.xclbin").touch()
+        (kernel_dir / "insts.bin").touch()
+
+    cd = CompilableDesign(gen)
+    hashes = iter(("npu1", "npu2", "npu1"))
+    monkeypatch.setattr(cd, "_compute_cache_hash", lambda: next(hashes))
+    monkeypatch.setattr(compilabledesign_module, "NPU_CACHE_HOME", tmp_path)
+    monkeypatch.setattr(
+        compilabledesign_module,
+        "parse_dma_sizes",
+        lambda kernel_dir: artifacts[kernel_dir.name],
+    )
+    monkeypatch.setattr(utils, "ensure_current_device", lambda: None)
+
+    cd.compile()
+    assert cd._expected_tensor_sizes == [16]
+
+    cd.compile()
+    assert cd._expected_tensor_sizes == [32]
+
+    cd.compile()
+    assert cd._expected_tensor_sizes == [16]
+
+
+def test_compute_hash_changes_when_active_device_width_changes():
+    """The filesystem cache key includes the active device identity, not just arch."""
+    gen = _gemm_gen()
+    cd = CompilableDesign(gen, compile_kwargs={"M": 64, "K": 64, "N": 64})
+
+    set_current_device(NPU2Col1())
+    h_one_col = cd._compute_cache_hash()
+
+    set_current_device(NPU2Col2())
+    h_two_col = cd._compute_cache_hash()
+
+    set_current_device(None)
+
+    assert h_one_col != h_two_col
+
+
+def test_python_compile_binds_before_cache_lookup(monkeypatch, tmp_path):
+    """Generated designs bind the target before selecting a cache entry."""
+    import aie.utils as utils
+    import aie.utils.compile.jit.compilabledesign as compilabledesign_module
+
+    def gen():
+        pass
+
+    cd = CompilableDesign(gen)
+    calls = []
+
+    def fake_ensure_current_device():
+        calls.append("bind")
+        return NPU2Col1()
+
+    def fake_cache_hash():
+        assert calls == ["bind"]
+        calls.append("hash")
+        return "target"
+
+    cache_dir = tmp_path / "target"
+    cache_dir.mkdir()
+    (cache_dir / "final.xclbin").touch()
+    (cache_dir / "insts.bin").touch()
+
+    monkeypatch.setattr(utils, "ensure_current_device", fake_ensure_current_device)
+    monkeypatch.setattr(cd, "_compute_cache_hash", fake_cache_hash)
+    monkeypatch.setattr(compilabledesign_module, "NPU_CACHE_HOME", tmp_path)
+    monkeypatch.setattr(compilabledesign_module, "parse_dma_sizes", lambda _dir: None)
+
+    cd.compile()
+    assert calls == ["bind", "hash"]
+
+
+def test_static_mlir_compile_does_not_bind_runtime(monkeypatch, tmp_path):
+    """Static MLIR compilation does not initialize or bind the runtime."""
+    import aie.utils as utils
+    import aie.utils.compile as compile_utils
+    import aie.utils.compile.jit.compilabledesign as compilabledesign_module
+
+    mlir_path = tmp_path / "design.mlir"
+    mlir_path.write_text("module {}")
+    cd = CompilableDesign(mlir_path, use_cache=False)
+    set_current_device(None)
+
+    monkeypatch.setattr(
+        utils,
+        "ensure_current_device",
+        lambda: pytest.fail("static MLIR compilation must not bind the runtime"),
+    )
+    monkeypatch.setattr(
+        utils,
+        "_get_default_npu_runtime",
+        lambda: pytest.fail("static MLIR compilation must not initialize XRT"),
+    )
+    monkeypatch.setattr(cd, "_generate_mlir", lambda _external_function: object())
+    monkeypatch.setattr(compile_utils, "resolve_target_arch", lambda _device: "aie2")
+
+    def fake_compile_mlir_module(**kwargs):
+        Path(kwargs["xclbin_path"]).touch()
+        Path(kwargs["insts_path"]).touch()
+
+    monkeypatch.setattr(
+        compilabledesign_module, "compile_mlir_module", fake_compile_mlir_module
+    )
+
+    xclbin_path = tmp_path / "out.xclbin"
+    inst_path = tmp_path / "out.insts"
+    try:
+        assert cd.compile(xclbin_path=xclbin_path, inst_path=inst_path) == (
+            xclbin_path.resolve(),
+            inst_path.resolve(),
+        )
+    finally:
+        set_current_device(None)
+
+
+def test_cache_hash_does_not_probe_runtime(monkeypatch):
+    """Inspecting an unbound design cache key never initializes XRT."""
+    import aie.utils as utils
+
+    cd = CompilableDesign(_gemm_gen(), compile_kwargs={"M": 64, "K": 64, "N": 64})
+    set_current_device(None)
+    monkeypatch.setattr(
+        utils,
+        "_get_default_npu_runtime",
+        lambda: pytest.fail("cache-key inspection must not initialize XRT"),
+    )
+
+    try:
+        assert cd._compute_cache_hash()
+    finally:
+        set_current_device(None)
+
+
+def test_iron_reexports_set_current_device():
+    """The documented IRON device-selection entry point is public."""
+    import aie.iron as iron
+
+    assert iron.set_current_device is set_current_device

--- a/test/python/test_hostruntime_cli.py
+++ b/test/python/test_hostruntime_cli.py
@@ -7,35 +7,222 @@
 # (c) Copyright 2026 Advanced Micro Devices, Inc.
 
 # RUN: %pytest %s
-"""Unit tests for the shared IRON example CLI dispatcher."""
 
-from argparse import Namespace
+from __future__ import annotations
 
-from aie.utils import get_current_device
-from aie.utils.hostruntime import set_current_device
-from aie.utils.hostruntime.cli import run_design_cli
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from aie.utils.hostruntime.argparse import add_compile_args, device_from_args
+from aie.utils.hostruntime import cli
 
 
-def test_run_design_cli_binds_device_before_validate_and_run():
-    """The selected CLI device is current before any user callback runs."""
-    opts = Namespace(dev="npu2", emit_mlir=False, xclbin_path=None, insts_path=None)
-    seen = []
+class _Design:
+    def __init__(self):
+        self.compile_kwargs = None
+        self.compile_options = None
 
-    def validate(_opts):
-        seen.append(type(get_current_device(probe_runtime=False)).__name__)
+    def specialize(self, **kwargs):
+        self.compile_kwargs = kwargs
+        return self
 
-    def run_and_verify(_opts):
-        seen.append(type(get_current_device(probe_runtime=False)).__name__)
+    def compile(self, **kwargs):
+        self.compile_options = kwargs
 
-    try:
-        run_design_cli(
-            object(),
-            opts,
-            compile_kwargs={},
-            run_and_verify=run_and_verify,
-            validate=validate,
-        )
-    finally:
-        set_current_device(None)
 
-    assert seen == ["NPU2Col1", "NPU2Col1"]
+def _automatic_options(*, emit_mlir=False, xclbin_path=None, insts_path=None):
+    return SimpleNamespace(
+        dev=None,
+        emit_mlir=emit_mlir,
+        xclbin_path=xclbin_path,
+        insts_path=insts_path,
+    )
+
+
+def _mock_runtime_target(monkeypatch):
+    import aie.utils as utils
+    import aie.utils.hostruntime as hostruntime
+
+    runtime_device = object()
+    set_calls = []
+    monkeypatch.setattr(utils, "get_current_device", lambda: runtime_device)
+    monkeypatch.setattr(
+        utils,
+        "ensure_current_device",
+        lambda: pytest.fail(
+            "automatic CLI selection must not bind the runtime device"
+        ),
+    )
+    monkeypatch.setattr(hostruntime, "set_current_device", set_calls.append)
+    monkeypatch.setattr(cli, "_runtime_device_name", lambda device: "npu2")
+    return runtime_device, set_calls
+
+
+def test_compile_args_leave_target_automatic_by_default():
+    parser = argparse.ArgumentParser()
+    add_compile_args(parser, with_emit_mlir=True)
+
+    assert parser.parse_args([]).dev is None
+    assert parser.parse_args(["--dev", "npu2"]).dev == "npu2"
+
+    fixed_parser = argparse.ArgumentParser()
+    add_compile_args(fixed_parser, default_dev="npu2")
+    assert fixed_parser.parse_args([]).dev == "npu2"
+
+
+def test_device_from_args_defers_an_omitted_target():
+    assert device_from_args(SimpleNamespace(dev=None)) is None
+
+
+def test_run_design_cli_uses_runtime_family_with_the_declared_profile(monkeypatch):
+    _runtime_device, set_calls = _mock_runtime_target(monkeypatch)
+    profile_device = object()
+    opts = _automatic_options()
+    observed = []
+
+    cli.run_design_cli(
+        _Design(),
+        opts,
+        compile_kwargs={},
+        run_and_verify=lambda resolved_opts: observed.append(resolved_opts.dev),
+        device=lambda resolved_opts: (
+            observed.append(f"selector:{resolved_opts.dev}") or profile_device
+        ),
+    )
+
+    assert set_calls == [profile_device]
+    assert opts.dev == "npu2"
+    assert observed == ["selector:npu2", "npu2"]
+
+
+def test_run_design_cli_uses_the_default_profile_for_an_automatic_family(monkeypatch):
+    _runtime_device, set_calls = _mock_runtime_target(monkeypatch)
+    import aie.iron.device as iron_device
+
+    profile_device = object()
+    selected_names = []
+    monkeypatch.setattr(
+        iron_device,
+        "from_name",
+        lambda name: selected_names.append(name) or profile_device,
+    )
+    opts = _automatic_options()
+
+    cli.run_design_cli(
+        _Design(),
+        opts,
+        compile_kwargs={},
+        run_and_verify=lambda _: None,
+    )
+
+    assert selected_names == ["npu2"]
+    assert set_calls == [profile_device]
+
+
+def test_run_design_cli_respects_an_explicit_target(monkeypatch):
+    import aie.utils as utils
+    import aie.utils.hostruntime as hostruntime
+
+    target_device = object()
+    set_calls = []
+    monkeypatch.setattr(
+        utils,
+        "get_current_device",
+        lambda: pytest.fail("explicit targets must not probe the runtime"),
+    )
+    monkeypatch.setattr(
+        utils,
+        "ensure_current_device",
+        lambda: pytest.fail("explicit targets must not bind the runtime device"),
+    )
+    monkeypatch.setattr(hostruntime, "set_current_device", set_calls.append)
+    opts = SimpleNamespace(
+        dev="npu2", emit_mlir=False, xclbin_path=None, insts_path=None
+    )
+
+    cli.run_design_cli(
+        _Design(),
+        opts,
+        compile_kwargs={},
+        run_and_verify=lambda _: None,
+        device=lambda _: target_device,
+    )
+
+    assert set_calls == [target_device]
+
+
+def test_run_design_cli_uses_runtime_target_for_local_compile_only(monkeypatch):
+    _runtime_device, set_calls = _mock_runtime_target(monkeypatch)
+    profile_device = object()
+    opts = _automatic_options(xclbin_path="out.xclbin", insts_path="out.insts")
+    design = _Design()
+
+    cli.run_design_cli(
+        design,
+        opts,
+        compile_kwargs={},
+        device=lambda resolved_opts: (
+            profile_device
+            if resolved_opts.dev == "npu2"
+            else pytest.fail("wrong target")
+        ),
+    )
+
+    assert set_calls == [profile_device]
+    assert opts.dev == "npu2"
+    assert design.compile_options == {
+        "xclbin_path": "out.xclbin",
+        "inst_path": "out.insts",
+    }
+
+
+def test_emit_mlir_requires_an_explicit_target():
+    opts = _automatic_options(emit_mlir=True)
+
+    with pytest.raises(SystemExit, match=r"--emit-mlir requires an explicit target"):
+        cli.run_design_cli(_Design(), opts, compile_kwargs={})
+
+
+def test_emit_mlir_accepts_a_concrete_device_without_dev(monkeypatch):
+    """A programmatic fixed target is sufficient for offline MLIR emission."""
+    import aie.utils as utils
+    import aie.utils.hostruntime as hostruntime
+
+    target_device = object()
+    set_calls = []
+    emitted = []
+    monkeypatch.setattr(
+        utils,
+        "get_current_device",
+        lambda: pytest.fail("a concrete target must not probe the runtime"),
+    )
+    monkeypatch.setattr(
+        utils,
+        "ensure_current_device",
+        lambda: pytest.fail("a concrete target must not bind the runtime device"),
+    )
+    monkeypatch.setattr(hostruntime, "set_current_device", set_calls.append)
+    opts = _automatic_options(emit_mlir=True)
+
+    cli.run_design_cli(
+        _Design(),
+        opts,
+        compile_kwargs={},
+        device=target_device,
+        emit_mlir=lambda resolved_opts: emitted.append(resolved_opts),
+    )
+
+    assert set_calls == [target_device]
+    assert emitted == [opts]
+
+
+def test_compile_only_without_runtime_requires_an_explicit_target(monkeypatch):
+    import aie.utils as utils
+
+    monkeypatch.setattr(utils, "get_current_device", lambda: None)
+    opts = _automatic_options(xclbin_path="out.xclbin", insts_path="out.insts")
+
+    with pytest.raises(SystemExit, match=r"compile-only mode requires --dev"):
+        cli.run_design_cli(_Design(), opts, compile_kwargs={})

--- a/test/python/test_hostruntime_cli.py
+++ b/test/python/test_hostruntime_cli.py
@@ -51,9 +51,7 @@ def _mock_runtime_target(monkeypatch):
     monkeypatch.setattr(
         utils,
         "ensure_current_device",
-        lambda: pytest.fail(
-            "automatic CLI selection must not bind the runtime device"
-        ),
+        lambda: pytest.fail("automatic CLI selection must not bind the runtime device"),
     )
     monkeypatch.setattr(hostruntime, "set_current_device", set_calls.append)
     monkeypatch.setattr(cli, "_runtime_device_name", lambda device: "npu2")

--- a/test/python/test_hostruntime_cli.py
+++ b/test/python/test_hostruntime_cli.py
@@ -1,0 +1,41 @@
+# test_hostruntime_cli.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# RUN: %pytest %s
+"""Unit tests for the shared IRON example CLI dispatcher."""
+
+from argparse import Namespace
+
+from aie.utils import get_current_device
+from aie.utils.hostruntime import set_current_device
+from aie.utils.hostruntime.cli import run_design_cli
+
+
+def test_run_design_cli_binds_device_before_validate_and_run():
+    """The selected CLI device is current before any user callback runs."""
+    opts = Namespace(dev="npu2", emit_mlir=False, xclbin_path=None, insts_path=None)
+    seen = []
+
+    def validate(_opts):
+        seen.append(type(get_current_device(probe_runtime=False)).__name__)
+
+    def run_and_verify(_opts):
+        seen.append(type(get_current_device(probe_runtime=False)).__name__)
+
+    try:
+        run_design_cli(
+            object(),
+            opts,
+            compile_kwargs={},
+            run_and_verify=run_and_verify,
+            validate=validate,
+        )
+    finally:
+        set_current_device(None)
+
+    assert seen == ["NPU2Col1", "NPU2Col1"]


### PR DESCRIPTION
This fixes a target-device ordering issue in the centralized IRON JIT path that was discovered while testing #3075.

IRON generators and external-kernel helpers choose different code paths depending on the active target device. The JIT path could discover the runtime device, but not bind it early enough for generation and cache lookup to see the **same** device that compilation and execution would later use. On NPU2 systems, that could leave part of the pipeline specializing for AIE2 while the rest targeted AIE2P.

This patch makes the ordering explicit:

* Resolve and bind the CLI-selected device before `run_design_cli()` callbacks.
* Bind the runtime-observed device in direct `@iron.jit` calls after argument validation, but before cache lookup, generation, and compilation.
* Cache generated MLIR per active device.
* Include the full IRON device identity in JIT cache keys.

With this change, architecture-sensitive generation, external-kernel selection, cache lookup, compilation, and execution all now agree on the same target device, and tests have been added to enforce that rule.