### PR TITLE
[wheels] Restore C++ dev artifacts needed by mlir-air

### DIFF
--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -321,22 +321,13 @@ class CMakeBuild(build_ext):
                 check=True,
             )
 
-            # C++-developer-only content: anyone pip installing this wheel
-            # reaches the toolchain through Python, never through native
-            # linking. aie_api/ and aie_kernels/ headers stay — user AIE
-            # kernels #include those at compile time. *.lib on Windows is
-            # the MSVC equivalent of Linux *.a — static linker artifacts
-            # produced by the LLVM/MLIR install rules that nothing in the
-            # runtime path links against (verified: aiecc.exe / aie-opt.exe
-            # / AIEAggregateCAPI.dll are self-contained).
+            # C API headers and CDO static driver headers are not needed by
+            # downstream C++ consumers (e.g. mlir-air) that build against the
+            # AIE dialect directly.
             dev_paths = [
-                Path(install_dir) / "include" / "aie",
                 Path(install_dir) / "include" / "aie-c",
                 Path(install_dir) / "include" / "bootgen_c_api.h",
                 Path(install_dir) / "include" / "xaienginecdo_static",
-                Path(install_dir) / "lib" / "cmake",
-                *(Path(install_dir) / "lib").glob("*.a"),
-                *(Path(install_dir) / "lib").glob("*.lib"),
             ]
             for p in dev_paths:
                 if p.is_dir():


### PR DESCRIPTION
@erwei-xilinx flagged in #3072 that mlir-air builds against the mlir-aie wheel's C++ artifacts — specifically the AIE dialect headers (`include/aie/`), CMake config (`lib/cmake/`) for find_package(`AIE`), and static libraries (`*.a`) for `AIE`, `AIETransforms`, and `AIEX`.

This restores those three while keeping the removal of `include/aie-c/`, `include/bootgen_c_api.h`, and `include/xaienginecdo_static/` — confirmed absent from mlir-air's source tree.

Closes #3072 (comment): https://github.com/Xilinx/mlir-aie/pull/3072#issuecomment-4760813630
