### PR TITLE
AIEX: make getOrCreateDataMemref dedup O(1) via optional cache

### DIFF
--- a/include/aie/Dialect/AIEX/AIEUtils.h
+++ b/include/aie/Dialect/AIEX/AIEUtils.h
@@ -11,15 +11,30 @@
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
 
 using namespace mlir;
 
 namespace xilinx {
 namespace AIEX {
 
-memref::GlobalOp getOrCreateDataMemref(OpBuilder &builder, AIE::DeviceOp dev,
-                                       mlir::Location loc,
-                                       ArrayRef<uint32_t> words);
+// Find (or create) a private constant `memref.global` in `dev` holding `words`.
+//
+// `dedupCache`/`nextId`, when provided, make repeated calls O(1): without them,
+// each call rescans every existing global for dedup and probes the symbol table
+// for a free name, which is O(n) per call. Callers lowering many BDs (e.g. NPU
+// DMA lowering of a large multi-column program) should pass both, seeded once
+// from the device's existing globals. `dedupCache` maps each initial-value to
+// its global; `*nextId` is the next free "blockwrite_data_<n>" index (one past
+// the max already present), which the helper post-increments per created
+// global. Seeding past the max guarantees unique names by construction (no
+// symbol-table probe). Both are scoped to one device's lowering and hold raw op
+// handles; discard them afterward.
+memref::GlobalOp getOrCreateDataMemref(
+    OpBuilder &builder, AIE::DeviceOp dev, mlir::Location loc,
+    ArrayRef<uint32_t> words,
+    llvm::DenseMap<mlir::Attribute, memref::GlobalOp> *dedupCache = nullptr,
+    unsigned *nextId = nullptr);
 
 // Result of tracing through subview/cast operations to a block argument for
 // traceSubviewToBlockArgument function.

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -526,8 +526,17 @@ struct WriteBdToBlockWritePattern : OpConversionPattern<NpuWriteBdOp> {
   using OpConversionPattern::OpConversionPattern;
 
 public:
-  WriteBdToBlockWritePattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpConversionPattern(context, benefit) {}
+  WriteBdToBlockWritePattern(
+      MLIRContext *context,
+      llvm::DenseMap<Attribute, memref::GlobalOp> *dedupCache, unsigned *nextId,
+      PatternBenefit benefit = 1)
+      : OpConversionPattern(context, benefit), dedupCache(dedupCache),
+        nextId(nextId) {}
+
+  // Per-pass-run memo + next free name index for blockwrite data globals (see
+  // getOrCreateDataMemref). Owned by the pass; live only during the conversion.
+  llvm::DenseMap<Attribute, memref::GlobalOp> *dedupCache;
+  unsigned *nextId;
 
   LogicalResult
   matchAndRewrite(NpuWriteBdOp op, OpAdaptor adaptor,
@@ -705,7 +714,8 @@ public:
     {
       OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPoint(op->getParentOfType<AIE::RuntimeSequenceOp>());
-      global = getOrCreateDataMemref(rewriter, dev, op.getLoc(), words);
+      global = getOrCreateDataMemref(rewriter, dev, op.getLoc(), words,
+                                     dedupCache, nextId);
     }
     auto memref = memref::GetGlobalOp::create(
         rewriter, op.getLoc(), global.getType(), global.getName());
@@ -746,6 +756,25 @@ struct AIEDmaToNpuPass : xilinx::AIEX::impl::AIEDmaToNpuBase<AIEDmaToNpuPass> {
     target.addDynamicallyLegalOp<NpuMaskWrite32Op>(
         [&](NpuMaskWrite32Op op) { return !op.getBuffer(); });
 
+    // Seed, from the device's existing globals, a dedup cache (initial-value ->
+    // global) and the next free "blockwrite_data_<n>" name index (one past the
+    // current max). WriteBdToBlockWritePattern keeps both in sync as it creates
+    // globals, giving O(1) dedup and name-uniquing per BD; seeding the index
+    // past the max keeps names unique by construction. Both are locals holding
+    // raw op handles and must not outlive this conversion.
+    llvm::DenseMap<Attribute, memref::GlobalOp> dataMemrefCache;
+    unsigned nextBlockwriteId = 0;
+    for (auto g : device.getOps<memref::GlobalOp>()) {
+      if (auto initVal = g.getInitialValue())
+        dataMemrefCache.try_emplace(*initVal, g);
+      StringRef suffix = g.getSymName();
+      if (suffix.consume_front("blockwrite_data_")) {
+        unsigned idx;
+        if (!suffix.getAsInteger(10, idx) && idx >= nextBlockwriteId)
+          nextBlockwriteId = idx + 1;
+      }
+    }
+
     RewritePatternSet patterns(&getContext());
     patterns.insert<BlockWriteSymToAddr>(&getContext());
     patterns.insert<DmaToNpuPattern>(&getContext());
@@ -754,7 +783,8 @@ struct AIEDmaToNpuPass : xilinx::AIEX::impl::AIEDmaToNpuBase<AIEDmaToNpuPass> {
     patterns.insert<PushQueuetoWrite32Pattern>(&getContext());
     patterns.insert<RtpToWrite32Pattern>(&getContext());
     patterns.insert<Write32SymToAddr>(&getContext());
-    patterns.insert<WriteBdToBlockWritePattern>(&getContext());
+    patterns.insert<WriteBdToBlockWritePattern>(&getContext(), &dataMemrefCache,
+                                                &nextBlockwriteId);
 
     if (failed(applyPartialConversion(device, target, std::move(patterns))))
       signalPassFailure();

--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -144,7 +144,8 @@ memref::GlobalOp AIEX::getOrCreateDataMemref(
     // globals and kept in sync below as we create new ones.
     auto it = dedupCache->find(initVal);
     if (it != dedupCache->end()) {
-      // initVal encodes element data + shape, but not memref layout/memory space.
+      // initVal encodes element data + shape, but not memref layout/memory
+      // space.
       if (it->second && it->second.getType() == memrefType)
         return it->second;
       dedupCache->erase(it);

--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -14,8 +14,8 @@
 using namespace mlir;
 using namespace xilinx;
 
-// Counter shared across calls to getOrCreateDataMemref so that uniquing scans
-// can skip past previously used indices efficiently.
+// Counter used to name private blockwrite data globals when no caller-supplied
+// next-index is available; the symbol-table probe below keeps names unique.
 static unsigned blockwriteDataCounter = 0;
 
 std::optional<AIEX::SubviewTraceResult>
@@ -125,37 +125,58 @@ AIEX::traceSubviewToBlockArgument(Value value) {
   return std::nullopt;
 }
 
-memref::GlobalOp AIEX::getOrCreateDataMemref(OpBuilder &builder,
-                                             AIE::DeviceOp dev,
-                                             mlir::Location loc,
-                                             ArrayRef<uint32_t> words) {
+memref::GlobalOp AIEX::getOrCreateDataMemref(
+    OpBuilder &builder, AIE::DeviceOp dev, mlir::Location loc,
+    ArrayRef<uint32_t> words,
+    llvm::DenseMap<mlir::Attribute, memref::GlobalOp> *dedupCache,
+    unsigned *nextId) {
   uint32_t num_words = words.size();
   MemRefType memrefType = MemRefType::get({num_words}, builder.getI32Type());
   TensorType tensorType =
       RankedTensorType::get({num_words}, builder.getI32Type());
-  memref::GlobalOp global = nullptr;
   auto initVal = DenseElementsAttr::get<uint32_t>(tensorType, words);
-  auto otherGlobals = dev.getOps<memref::GlobalOp>();
-  for (auto g : otherGlobals) {
-    if (g.getType() != memrefType)
-      continue;
-    auto otherValue = g.getInitialValue();
-    if (!otherValue)
-      continue;
-    if (*otherValue != initVal)
-      continue;
-    global = g;
-    break;
+
+  // Dedup. The initial-value attribute is uniqued and encodes both the element
+  // data and the (shaped) type, so it is a sufficient key on its own.
+  memref::GlobalOp global = nullptr;
+  if (dedupCache) {
+    // O(1): the cache is seeded by the caller from the device's existing
+    // globals and kept in sync below as we create new ones.
+    auto it = dedupCache->find(initVal);
+    if (it != dedupCache->end())
+      return it->second;
+  } else {
+    // No cache supplied: scan existing globals for a match. Callers that create
+    // many globals should pass a cache (see header).
+    for (auto g : dev.getOps<memref::GlobalOp>()) {
+      if (g.getType() != memrefType)
+        continue;
+      auto otherValue = g.getInitialValue();
+      if (!otherValue)
+        continue;
+      if (*otherValue != initVal)
+        continue;
+      return g;
+    }
   }
-  if (!global) {
-    std::string name = "blockwrite_data_";
+
+  // With a caller-supplied `nextId` (one past the largest existing
+  // blockwrite_data_<n>) the name is unique by construction; otherwise probe
+  // the symbol table for a free index.
+  std::string name;
+  if (nextId) {
+    name = "blockwrite_data_" + std::to_string((*nextId)++);
+  } else {
+    name = "blockwrite_data_";
     while (dev.lookupSymbol(name + std::to_string(blockwriteDataCounter)))
       blockwriteDataCounter++;
-    name += std::to_string(blockwriteDataCounter);
-    global = memref::GlobalOp::create(builder, loc, name,
-                                      builder.getStringAttr("private"),
-                                      memrefType, initVal, true, nullptr);
+    name += std::to_string(blockwriteDataCounter++);
   }
+  global = memref::GlobalOp::create(builder, loc, name,
+                                    builder.getStringAttr("private"),
+                                    memrefType, initVal, true, nullptr);
+  if (dedupCache)
+    (*dedupCache)[initVal] = global;
   return global;
 }
 

--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -143,8 +143,12 @@ memref::GlobalOp AIEX::getOrCreateDataMemref(
     // O(1): the cache is seeded by the caller from the device's existing
     // globals and kept in sync below as we create new ones.
     auto it = dedupCache->find(initVal);
-    if (it != dedupCache->end())
-      return it->second;
+    if (it != dedupCache->end()) {
+      // initVal encodes element data + shape, but not memref layout/memory space.
+      if (it->second && it->second.getType() == memrefType)
+        return it->second;
+      dedupCache->erase(it);
+    }
   } else {
     // No cache supplied: scan existing globals for a match. Callers that create
     // many globals should pass a cache (see header).


### PR DESCRIPTION
## What
`getOrCreateDataMemref` deduplicates blockwrite data globals by linearly
scanning every existing `memref.global` in the device, and finds a free
`blockwrite_data_<n>` name by probing the symbol table, both O(n) per call, so
lowering a runtime sequence with n block-writes is O(n^2).

This adds an optional caller-supplied dedup cache (`initial-value -> global`)
plus a seeded next-index counter. `AIEDmaToNpu` seeds both once per device from
the existing globals and keeps them in sync, turning per-BD dedup + naming into
O(1), i.e. **O(n^2) -> O(n)** over the whole sequence. When the cache/index are
not supplied, the function falls back to the existing linear scan + symbol-table
probe, so other callers are unaffected.

## Why
Large multi-column NPU programs create many distinct blockwrite data globals; the
per-call linear dedup scan plus symbol-table name probe make the dma-to-npu
lowering scale O(n^2) in the number of block-writes. The cache makes both O(1)
per call.

## Behavior
Single-device lowering is byte-identical (names start at `blockwrite_data_0` as
before). For multi-device modules lowered in one process, the data globals are
numbered per-device rather than via a process-global counter that continues
across devices, but this naming difference does not affect the emitted output:
the global name is an internal symbol consumed during lowering and does not enter
the NPU binary. Verified by renaming/renumbering the `blockwrite_data_*` globals
and confirming `aie-translate --aie-npu-to-binary` produces a bit-identical
binary. Existing lit tests pass unchanged.

## Testing
- CI.
- Binary-equivalence check under global renaming/renumbering (per above).

Follow-up to #3178 (same compile-scaling pattern). Complements the shared
`blockwriteDataCounter` from #3105, which addressed the naming probe but not the
dedup scan.
