### PR TITLE
[wheels] Keep lib/objects-Release so find_package(AIE) import check passes

### DIFF
--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -339,8 +339,9 @@ class CMakeBuild(build_ext):
             # install prefix; none belong in a shipped wheel.
             #
             # NOTE: lib/objects-Release is intentionally kept. It holds the
-            # per-object .o files for AIE's ENABLE_AGGREGATION libraries
-            # (obj.AIERT/obj.AIETargets/obj.AIECAPI, ~2 MB) which the exported
+            # per-object object files (.o on Linux/macOS, .obj on Windows) for
+            # AIE's ENABLE_AGGREGATION libraries (obj.AIERT/obj.AIETargets/
+            # obj.AIECAPI, ~2 MB) which the exported
             # lib/cmake/aie/MLIRTargets-release.cmake references via
             # IMPORTED_OBJECTS. Pruning it leaves dangling references and makes
             # downstream find_package(AIE) fail its import check.

--- a/utils/mlir_aie_wheels/setup.py
+++ b/utils/mlir_aie_wheels/setup.py
@@ -335,12 +335,17 @@ class CMakeBuild(build_ext):
                 elif p.exists():
                     p.unlink()
 
-            # CMake leaks staging directories, intermediate .o files, and
-            # __pycache__ caches into the install prefix; none belong in a
-            # shipped wheel.
+            # CMake leaks staging directories and __pycache__ caches into the
+            # install prefix; none belong in a shipped wheel.
+            #
+            # NOTE: lib/objects-Release is intentionally kept. It holds the
+            # per-object .o files for AIE's ENABLE_AGGREGATION libraries
+            # (obj.AIERT/obj.AIETargets/obj.AIECAPI, ~2 MB) which the exported
+            # lib/cmake/aie/MLIRTargets-release.cmake references via
+            # IMPORTED_OBJECTS. Pruning it leaves dangling references and makes
+            # downstream find_package(AIE) fail its import check.
             for leaked in [
                 Path(install_dir) / "src",
-                Path(install_dir) / "lib" / "objects-Release",
             ]:
                 if leaked.exists():
                     shutil.rmtree(leaked)


### PR DESCRIPTION
## Summary
The `mlir_aie` wheel build prunes `lib/objects-Release/` as a "CMake leak"
(`utils/mlir_aie_wheels/setup.py`), but it is not a leak: the exported
`lib/cmake/aie/MLIRTargets-release.cmake` references those `.o` files via
`IMPORTED_OBJECTS` on AIE's `ENABLE_AGGREGATION` targets (`obj.AIERT`,
`obj.AIETargets`, `obj.AIECAPI`). Pruning it leaves dangling references, so any
downstream `find_package(AIE)` aborts during its import check:

```
CMake Error ... MLIRTargets.cmake:
  The imported target "obj.AIERT" references the file
    ".../lib/objects-Release/obj.AIERT/AIERT.cpp.o"
  but this file does not exist.
```

This breaks building e.g. mlir-air from source against the prebuilt wheel
(the `objects-Release` prune was introduced alongside the wheel-slimming in #3072).

## Fix
Keep `lib/objects-Release/` in the wheel. It is ~2 MB (only AIE's three
aggregated libraries; the MLIR distro's objects ship in the `mlir` wheel) — a
negligible size cost that keeps the exported CMake config self-consistent.

Suppressing the `obj.*` export instead is **not** viable:
`MLIR_INSTALL_AGGREGATE_OBJECTS` is force-set to `1` by `MLIRConfig.cmake` (so a
`-D` override on the AIE build has no effect), and forcing it off breaks the
in-tree `libAIEAggregateCAPI.so` aggregate build (`AddMLIR.cmake` `SEND_ERROR`:
"Cannot build aggregate from imported targets which were not installed via
MLIR_INSTALL_AGGREGATE_OBJECTS").

## Verification
With `objects-Release/` retained, a standalone `find_package(AIE REQUIRED CONFIG)`
pointing `AIE_DIR` at the wheel's `lib/cmake/aie` configures cleanly. Building
mlir-air from source against the wheel no longer needs placeholder `.o` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)