### PR TITLE
aiecc: build per-core compile slices from a stripped base module

### DIFF
--- a/test/aiecc/Inputs/per_core_slice_lowering_equivalence.divergent.mlir
+++ b/test/aiecc/Inputs/per_core_slice_lowering_equivalence.divergent.mlir
@@ -1,0 +1,33 @@
+//===- per_core_slice_lowering_equivalence.divergent.mlir -----*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Negative fixture for per_core_slice_lowering_equivalence.mlir. Same as the
+// stripped slice, except the target core stores a different value (123 instead
+// of 7), so its lowering diverges. A "not FileCheck" RUN asserts this does NOT
+// match the golden, which proves the golden actually pins the target core's
+// computation (guards the equivalence check against silently going vacuous).
+module @slice_divergent {
+ aie.device(npu1_2col) @device1 {
+  %t02 = aie.tile(0, 2)
+  %t12 = aie.tile(1, 2)
+  %l02 = aie.lock(%t02, 0)
+  %b02 = aie.buffer(%t02) { sym_name = "a02" } : memref<16xi32>
+  %l12 = aie.lock(%t12, 0)
+  %b12 = aie.buffer(%t12) { sym_name = "a12" } : memref<16xi32>
+  %c02 = aie.core(%t02) {
+    aie.use_lock(%l02, Acquire, 0)
+    %v = arith.constant 123 : i32
+    %i = arith.constant 3 : index
+    memref.store %v, %b02[%i] : memref<16xi32>
+    aie.use_lock(%l02, Release, 1)
+    aie.end
+  }
+ }
+}

--- a/test/aiecc/Inputs/per_core_slice_lowering_equivalence.slice.mlir
+++ b/test/aiecc/Inputs/per_core_slice_lowering_equivalence.slice.mlir
@@ -1,0 +1,33 @@
+//===- per_core_slice_lowering_equivalence.slice.mlir ---------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Stripped slice for core (0, 2), produced the way compileCores produces it:
+// @device1 only (@device2 removed), the runtime sequence removed, and the other
+// core's aie.core op removed. The other core's tile, buffer, and lock are kept,
+// because compileCores erases only the aie.core ops. Driven by the RUN lines in
+// per_core_slice_lowering_equivalence.mlir.
+module @slice {
+ aie.device(npu1_2col) @device1 {
+  %t02 = aie.tile(0, 2)
+  %t12 = aie.tile(1, 2)
+  %l02 = aie.lock(%t02, 0)
+  %b02 = aie.buffer(%t02) { sym_name = "a02" } : memref<16xi32>
+  %l12 = aie.lock(%t12, 0)
+  %b12 = aie.buffer(%t12) { sym_name = "a12" } : memref<16xi32>
+  %c02 = aie.core(%t02) {
+    aie.use_lock(%l02, Acquire, 0)
+    %v = arith.constant 7 : i32
+    %i = arith.constant 3 : index
+    memref.store %v, %b02[%i] : memref<16xi32>
+    aie.use_lock(%l02, Release, 1)
+    aie.end
+  }
+ }
+}

--- a/test/aiecc/Inputs/per_core_slice_lowering_equivalence.wrongcore.mlir
+++ b/test/aiecc/Inputs/per_core_slice_lowering_equivalence.wrongcore.mlir
@@ -1,0 +1,30 @@
+//===- per_core_slice_lowering_equivalence.wrongcore.mlir -----*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Negative fixture for per_core_slice_lowering_equivalence.mlir. The slice keeps
+// the wrong core: the other core (1, 2) instead of the target (0, 2). Lowering
+// for tilecol=0 tilerow=2 then yields no @core_0_2, so a "not FileCheck" RUN
+// asserts it does NOT match the golden, proving the golden pins which core is
+// lowered.
+module @slice_wrongcore {
+ aie.device(npu1_2col) @device1 {
+  %t12 = aie.tile(1, 2)
+  %l12 = aie.lock(%t12, 0)
+  %b12 = aie.buffer(%t12) { sym_name = "a12" } : memref<16xi32>
+  %c12 = aie.core(%t12) {
+    aie.use_lock(%l12, Acquire, 0)
+    %v = arith.constant 99 : i32
+    %i = arith.constant 5 : index
+    memref.store %v, %b12[%i] : memref<16xi32>
+    aie.use_lock(%l12, Release, 1)
+    aie.end
+  }
+ }
+}

--- a/test/aiecc/cpp_parallel_compilation.mlir
+++ b/test/aiecc/cpp_parallel_compilation.mlir
@@ -23,6 +23,14 @@
 // CHECK: Generated ELF
 // CHECK: Compilation completed successfully
 
+// Parallel per-core slicing must emit the same object as serial compilation.
+// Compile the same design both ways into separate tmpdirs and diff the per-core
+// objects: byte-identical objects pin the slicing equivalence claim.
+// RUN: aiecc --no-xchesscc --no-xbridge --tmpdir=%t.ser %s
+// RUN: aiecc --no-xchesscc --no-xbridge -j 2 --tmpdir=%t.par %s
+// RUN: diff %t.ser/main_core_0_2.o %t.par/main_core_0_2.o
+// RUN: diff %t.ser/main_core_1_2.o %t.par/main_core_1_2.o
+
 module {
   aie.device(npu2_4col) {
     %tile_0_0 = aie.tile(0, 0)

--- a/test/aiecc/per_core_slice_lowering_equivalence.mlir
+++ b/test/aiecc/per_core_slice_lowering_equivalence.mlir
@@ -1,0 +1,89 @@
+//===- per_core_slice_lowering_equivalence.mlir ---------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Per-core compile slicing must not change what a core lowers to. compileCores
+// builds each per-core compile input by stripping the runtime sequences, the
+// sibling devices, and the other cores, on the premise that the per-core
+// lowering (aie-standard-lowering with device + tilecol/tilerow) already
+// extracts only the target core and discards the rest. This test pins that
+// premise: lowering core (0, 2) of @device1 must yield the same function from
+// the full multi-device module (this file: two devices, two cores in @device1,
+// a runtime sequence) and from the stripped slice (Inputs/...slice.mlir:
+// @device1 with the other core's aie.core op, the sequence, and @device2
+// removed, exactly the way compileCores strips, keeping the other core's tile,
+// buffer, and lock). Both inputs are checked against the same expected lowering,
+// so if a future change makes per-core lowering depend on the stripped content
+// the two diverge and this fails. Pure aie-opt, no hardware.
+
+// The full module and the stripped slice must lower the target core the same:
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering="device=device1 tilecol=0 tilerow=2" %s | FileCheck %s
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering="device=device1 tilecol=0 tilerow=2" %S/Inputs/per_core_slice_lowering_equivalence.slice.mlir | FileCheck %s
+
+// Negative guards: the equivalence check has teeth. A slice that diverges in the
+// target core, or that keeps the wrong core, must NOT match the same golden.
+// These keep the positive checks above from silently going vacuous.
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering="device=device1 tilecol=0 tilerow=2" %S/Inputs/per_core_slice_lowering_equivalence.divergent.mlir | not FileCheck %s
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering="device=device1 tilecol=0 tilerow=2" %S/Inputs/per_core_slice_lowering_equivalence.wrongcore.mlir | not FileCheck %s
+
+// CHECK-DAG: memref.global "public" @a12 : memref<16xi32>
+// CHECK-DAG: memref.global "public" @a02 : memref<16xi32>
+// CHECK: func.func @core_0_2() {
+// CHECK: call @llvm.aie2.acquire
+// CHECK: %[[VAL:.*]] = arith.constant 7 : i32
+// CHECK: %[[BUF:.*]] = memref.get_global @a02 : memref<16xi32>
+// CHECK: memref.store %[[VAL]], %[[BUF]][%{{.*}}] : memref<16xi32>
+// CHECK: call @llvm.aie2.release
+// CHECK: return
+
+module @full {
+ aie.device(npu1_2col) @device1 {
+  %t02 = aie.tile(0, 2)
+  %t12 = aie.tile(1, 2)
+  %l02 = aie.lock(%t02, 0)
+  %b02 = aie.buffer(%t02) { sym_name = "a02" } : memref<16xi32>
+  %l12 = aie.lock(%t12, 0)
+  %b12 = aie.buffer(%t12) { sym_name = "a12" } : memref<16xi32>
+  %c02 = aie.core(%t02) {
+    aie.use_lock(%l02, Acquire, 0)
+    %v = arith.constant 7 : i32
+    %i = arith.constant 3 : index
+    memref.store %v, %b02[%i] : memref<16xi32>
+    aie.use_lock(%l02, Release, 1)
+    aie.end
+  }
+  %c12 = aie.core(%t12) {
+    aie.use_lock(%l12, Acquire, 0)
+    %v = arith.constant 99 : i32
+    %i = arith.constant 5 : index
+    memref.store %v, %b12[%i] : memref<16xi32>
+    aie.use_lock(%l12, Release, 1)
+    aie.end
+  }
+  aie.runtime_sequence @seq(%arg0 : memref<16xi32>) {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c16 = arith.constant 16 : i64
+    aiex.npu.dma_memcpy_nd(%arg0[%c0,%c0,%c0,%c0][%c1,%c1,%c1,%c16][%c0,%c0,%c0,%c1]) {metadata = @fifo, id = 0 : i64} : memref<16xi32>
+  }
+ }
+ aie.device(npu1_2col) @device2 {
+  %t12 = aie.tile(1, 2)
+  %l12 = aie.lock(%t12, 0)
+  %b22 = aie.buffer(%t12) { sym_name = "a22" } : memref<16xi32>
+  %c12 = aie.core(%t12) {
+    aie.use_lock(%l12, Acquire, 0)
+    %v = arith.constant 42 : i32
+    %i = arith.constant 1 : index
+    memref.store %v, %b22[%i] : memref<16xi32>
+    aie.use_lock(%l12, Release, 1)
+    aie.end
+  }
+ }
+}

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -2784,11 +2784,63 @@ compileCores(MLIRContext &context, ModuleOp moduleOp, Operation *deviceOp,
   // We need to serialize the module to string and deserialize in each thread
   // because MLIRContext is not thread-safe for multi-threaded mutation.
 
-  // First, serialize the module to string for parallel workers
-  std::string moduleStr;
+  // Each parallel worker re-parses the module in its own MLIRContext and the
+  // per-core lowering then keeps only its own core, discarding everything else.
+  // Serializing the whole multi-core, multi-device module once and handing that
+  // same string to every worker is O(N) memory per worker for an N-core device,
+  // and the string also carries the runtime sequences, which the per-core
+  // lowering never touches but which dominate the module text once the host DMA
+  // program is unrolled (tens of thousands of dma_bd ops). For large designs
+  // the peak memory and the repeated full-module clones become the dominant
+  // cost.
+  //
+  // Instead, build a stripped base module once, then derive a small per-core
+  // slice from it. The stripped base drops (a) the runtime sequences (host-side
+  // DMA orchestration, unused by per-core lowering) and (b) every other device
+  // (a core only references its own device's tiles/buffers/locks/objectfifos).
+  // Each per-core slice clones that small base and erases the other cores.
+  // Cloning the stripped base instead of the full module makes the per-core
+  // clones cheap, and the resulting slice strings are byte-identical to the old
+  // path, so the emitted object/ELF is unchanged. Slicing runs here (serial,
+  // one clone live at a time, so peak memory stays bounded) before the parallel
+  // fan-out.
+  OwningOpRef<ModuleOp> strippedBase = moduleOp.clone();
   {
-    llvm::raw_string_ostream os(moduleStr);
-    moduleOp->print(os);
+    // Strip the runtime sequences (host-side, unused by per-core lowering)...
+    SmallVector<xilinx::AIE::RuntimeSequenceOp> seqs;
+    strippedBase->walk(
+        [&](xilinx::AIE::RuntimeSequenceOp s) { seqs.push_back(s); });
+    for (auto s : seqs)
+      s.erase();
+    // ...and every other device. compileCores is per-device and a per-core
+    // object only references its own device's tiles/buffers/locks/objectfifos,
+    // never a sibling device, so dropping the other device shells shrinks each
+    // per-core slice further without changing the emitted object/ELF.
+    SmallVector<xilinx::AIE::DeviceOp> otherDevices;
+    strippedBase->walk([&](xilinx::AIE::DeviceOp d) {
+      if (d.getSymName() != deviceName)
+        otherDevices.push_back(d);
+    });
+    for (auto d : otherDevices)
+      d.erase();
+  }
+  std::map<std::pair<int, int>, std::string> coreModuleStrs;
+  for (const auto &core : cores) {
+    OwningOpRef<ModuleOp> slice = strippedBase->clone();
+    SmallVector<xilinx::AIE::CoreOp> otherCores;
+    slice->walk([&](xilinx::AIE::CoreOp c) {
+      auto t = dyn_cast<xilinx::AIE::TileOp>(c.getTile().getDefiningOp());
+      if (!t || t.getCol() != core.col || t.getRow() != core.row)
+        otherCores.push_back(c);
+    });
+    for (auto c : otherCores)
+      c.erase();
+    std::string s;
+    {
+      llvm::raw_string_ostream os(s);
+      slice->print(os);
+    }
+    coreModuleStrs[{core.col, core.row}] = std::move(s);
   }
 
   // Get the dialect registry to use for parallel contexts
@@ -2824,7 +2876,7 @@ compileCores(MLIRContext &context, ModuleOp moduleOp, Operation *deviceOp,
     // Create task for this core
     futures.push_back(std::async(
         std::launch::async,
-        [&registry, &moduleStr, deviceName = deviceName.str(),
+        [&registry, &coreModuleStrs, deviceName = deviceName.str(),
          tmpDirName = tmpDirName.str(), aieTarget = aieTarget.str(), core,
          &resultsMutex, &elfPaths, &hasFailure, &activeThreads]() {
           // Each thread creates its own MLIRContext
@@ -2839,8 +2891,8 @@ compileCores(MLIRContext &context, ModuleOp moduleOp, Operation *deviceOp,
 
           // Parse the module in this thread's context
           ParserConfig parseConfig(&threadContext);
-          OwningOpRef<ModuleOp> threadModule =
-              parseSourceString<ModuleOp>(moduleStr, parseConfig);
+          OwningOpRef<ModuleOp> threadModule = parseSourceString<ModuleOp>(
+              coreModuleStrs.at({core.col, core.row}), parseConfig);
 
           if (!threadModule) {
             {


### PR DESCRIPTION
# aiecc: build per-core compile slices from a stripped base module

## What

`compileCores` fans out per-core compilation across worker threads. Each worker
re-parses the module text in its own `MLIRContext` and the per-core lowering
keeps only its own core, discarding the rest. The previous code serialized the
whole multi-core, multi-device module once and handed that same string to every
worker, so peak memory grew with (workers x full module) and every worker
re-parsed the runtime sequences, which the per-core lowering never uses but which
dominate the module text once the host DMA program is unrolled.

This builds a stripped base module once (drop the runtime sequences and every
other device), then derives each per-core slice by cloning that small base and
erasing the other cores. The per-core slice strings are byte-identical to the old
path, so the emitted object/ELF is unchanged; only the parse and clone cost
changes.

## Why it matters

Measured against upstream `main` at `1a5eed4` on a large multi-device design
(a batch-128 decode design: ~212 cores across ~21 devices), cold `aiecc`, `-j16`,
on an AMD Ryzen AI 9 465 (10 cores / 20 threads) with 32 GB RAM (Linux). The ELF
is byte-identical across all three rows (sha256 `370686d...`).

| aiecc configuration | aiecc wall (cold) | peak RSS |
|---|---|---|
| current upstream | did not finish within 30 min | ~18.7 GB |
| upstream + #3211 + #3212 | 139 s | 18.7 GB |
| upstream + #3211 + #3212 + this PR | 67 s | 1.7 GB |

On current upstream this design did not finish compiling within 30 minutes on
our hardware (it was still in the per-core phase, ~56 of ~212 cores after 27
minutes), which is why the companion compile-scaling fixes (#3211 lower-once,
#3212 getOrCreateDataMemref dedup) are needed to make it tractable at all. Its
peak RSS is the same ~18.7 GB as the second row, because the per-core memory
blowup this PR addresses is independent of those two fixes.

This PR's specific contribution is the last row: on top of #3211 + #3212 it
**halves the total aiecc wall (139 s -> 67 s)** and **cuts peak RSS ~11x (18.7 GB
-> 1.7 GB)**. The memory drop is the important part: without slicing, peak RSS
scales with worker-count x full-module-size, so it grows with both the design
size and the build parallelism.

## Correctness

The per-core slice is the lowering of that core's body plus its device-level
tiles/buffers/locks/objectfifos; it never references the runtime sequence
(host-side DMA orchestration) or any other device. The emitted per-core
object/ELF is therefore unchanged: the final whole-array ELF is byte-identical
(sha256 unchanged) before and after this change on the design above.
