### PR TITLE
Move to generic labels for self-hosted runners

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner_type: [ amd_ryzenai5pro_340, amd_ryzen7_8845hs ]
+        runner_type: [ aie2-4col, aie2p-8col ]
     env:
       NPU_CACHE_HOME: ${{ github.workspace }}/iron-cache-${{ matrix.runner_type }}-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}/.pip-cache-${{ matrix.runner_type }}-${{ github.run_id }}
@@ -83,6 +83,9 @@ jobs:
         # click on "launch_tmate_terminal_for_debug"
         if: github.event_name == 'workflow_dispatch'
                 && inputs.launch_tmate_terminal_for_debug
+
+      - name: Print hostname
+        run: hostname
 
       - name: Run commands
         run: |
@@ -166,7 +169,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner_type: [ amd7940hs, amdhx370 ]
+        runner_type: [ aie2-4col, aie2p-8col ]
     env:
       NPU_CACHE_HOME: ${{ github.workspace }}/iron-cache-${{ matrix.runner_type }}-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}/.pip-cache-${{ matrix.runner_type }}-${{ github.run_id }}
@@ -184,6 +187,9 @@ jobs:
         # click on "launch_tmate_terminal_for_debug"
         if: github.event_name == 'workflow_dispatch'
                 && inputs.launch_tmate_terminal_for_debug
+      
+      - name: Print hostname
+        run: hostname
 
       - name: Run commands
         run: |
@@ -229,7 +235,7 @@ jobs:
           mkdir $NPU_CACHE_HOME
 
           # TEMP(#3059): dump NPU stack versions to diagnose mobilenet/run_e2e.lit
-          # bn1 NPU timeout that reproduces on amdhx370 CI but not on the same
+          # bn1 NPU timeout that reproduces on aie2p-8col CI but not on the same
           # HX 370 chip locally. Revert once the divergence is understood.
           echo "===== NPU STACK VERSIONS (${{ matrix.runner_type }}) ====="
           uname -a || true

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner_type: [ amd7940hs, amdhx370 ]
+        runner_type: [ amdryzenai5pro340 ]
     env:
       NPU_CACHE_HOME: ${{ github.workspace }}/iron-cache-${{ matrix.runner_type }}-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}/.pip-cache-${{ matrix.runner_type }}-${{ github.run_id }}

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner_type: [ amdryzenai5pro340 ]
+        runner_type: [ amd_ryzenai5pro_340, amd_ryzen7_8845hs ]
     env:
       NPU_CACHE_HOME: ${{ github.workspace }}/iron-cache-${{ matrix.runner_type }}-${{ github.run_id }}
       PIP_CACHE_DIR: ${{ github.workspace }}/.pip-cache-${{ matrix.runner_type }}-${{ github.run_id }}


### PR DESCRIPTION
The new runners aren't 7940HS/HX370s. But the jobs only care about aie2 vs aie2p and 4col vs 8col. New labeling scheme: aie2-4col vs aie2p-8col generic labels, along with a label of the specific processor of a runner (if future need arises).

Also print the hostname of the runner that picked up a job to help isolate if a particular runner is causing issues.