### PR TITLE
[ci] Pin llvm-aie to last-good nightly (2026062301) to unblock CI

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -101,7 +101,8 @@ jobs:
           python -m pip install --require-hashes -r python/requirements_dev.lock
 
           # Install llvm-aie (Peano) which is needed for unittests requiring compiling NPU code
-          pip install -I llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+          # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1053). Revert once fixed upstream.
+          pip install -I "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
           export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 
           sed -i.bak 's/OUTPUT_TIMEOUT = 10/OUTPUT_TIMEOUT = 100/g' \

--- a/.github/workflows/buildAndTestVitis.yml
+++ b/.github/workflows/buildAndTestVitis.yml
@@ -96,7 +96,8 @@ jobs:
           python -m pip install --require-hashes -r python/requirements_dev.lock
 
           # Install llvm-aie (Peano) which is needed for unittests requiring compiling NPU code
-          pip install -I llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+          # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1053). Revert once fixed upstream.
+          pip install -I "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
           export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
           
           sed -i.bak 's/OUTPUT_TIMEOUT = 10/OUTPUT_TIMEOUT = 100/g' \

--- a/utils/build-mlir-aie-from-wheels.sh
+++ b/utils/build-mlir-aie-from-wheels.sh
@@ -49,7 +49,8 @@ if [ "$#" -ge 4 ]; then
   echo "PEANO_INSTALL_DIR DIR: $PEANO_INSTALL_DIR"
   export PEANO_INSTALL_DIR=${PEANO_INSTALL_DIR}
 else
-  python3 -m pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+  # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1053). Revert once fixed upstream.
+  python3 -m pip install "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
   export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
   echo "PEANO_INSTALL_DIR DIR: $PEANO_INSTALL_DIR"
   export PEANO_INSTALL_DIR=${PEANO_INSTALL_DIR}

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -49,7 +49,8 @@ fi
 
 # If force install or an install dir isn't passed
 if [[ $FORCE_INSTALL -eq 1 || ( "$#" -lt 2 && -z "$(pip show llvm-aie | grep '^Location:')" ) ]]; then
-  python3 -m pip install -I llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
+  # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1053). Revert once fixed upstream.
+  python3 -m pip install -I "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly
   export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep '^Location:' | awk '{print $2}')/llvm-aie"
 fi
 

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -59,7 +59,8 @@ python3 -m pip install --upgrade pip
 python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3/ 
 export MLIR_AIE_INSTALL_DIR="$(pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 
-python3 -m pip install llvm-aie -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly/
+# Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1053). Revert once fixed upstream.
+python3 -m pip install "llvm-aie==21.0.0.2026062301+cb664e8c" -f https://github.com/Xilinx/llvm-aie/releases/expanded_assets/nightly/
 export PEANO_INSTALL_DIR="$(pip show llvm-aie | grep ^Location: | awk '{print $2}')/llvm-aie"
 
 pip install pre-commit


### PR DESCRIPTION
## Problem

The scheduled "Build and Test with AIE tools on Ryzen AI" workflow has been red since 2026-06-25. CI installs llvm-aie (Peano) from the unpinned `nightly` channel, and the 2026-06-24 nightly miscompiles `int -> float -> int` at `-O2`: the argument-defining load is scheduled into the soft-float call's delay slots, so on AIE2 (in-order, no interlocks, ~7-cycle load latency vs 5 delay slots) the callee reads a stale argument register. The result is a silent wrong answer, which the on-hardware tests catch as failures (e.g. `test_algorithms.py::test_transform_different_datatypes_extern[int32-int]`).

Root cause, a hardware-free reproducer, the bisect (a single inter-block scheduler commit), and on-device confirmation (good PASS, bad FAIL, `-O0` PASS) are in Xilinx/llvm-aie#1053.

## Fix

Pin llvm-aie to the last-good nightly `21.0.0.2026062301+cb664e8c` at every install site (the Ryzen AI and Vitis workflows plus the three `utils` setup scripts), so CI goes green again. This is a temporary stopgap to be reverted once the upstream codegen fix lands.

Verified the pinned wheel resolves from the nightly find-links index.
