### PR TITLE
[ci] Reduce Dependabot PR churn via grouping and biweekly off-LLVM scheduling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,38 +3,54 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "cron"
+      cronjob: "0 6 8,22 * *"
     groups:
-      actions-minor-patch:
+      github-actions-minor-patch:
         update-types: ["minor", "patch"]
+      github-actions-major:
+        update-types: ["major"]
 
   - package-ecosystem: "pip"
     directory: "/python"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
+      interval: "cron"
+      cronjob: "0 6 8,22 * *"
     groups:
       python-minor-patch:
         update-types: ["minor", "patch"]
+      python-major:
+        update-types: ["major"]
 
   - package-ecosystem: "pip"
     directory: "/utils/mlir_aie_wheels"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
+      interval: "cron"
+      cronjob: "0 6 8,22 * *"
+    groups:
+      mlir-aie-wheels-minor-patch:
+        update-types: ["minor", "patch"]
+      mlir-aie-wheels-major:
+        update-types: ["major"]
 
   - package-ecosystem: "pip"
     directory: "/utils/mlir_wheels"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
+      interval: "cron"
+      cronjob: "0 6 8,22 * *"
+    groups:
+      mlir-wheels-minor-patch:
+        update-types: ["minor", "patch"]
+      mlir-wheels-major:
+        update-types: ["major"]
 
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
+      interval: "cron"
+      cronjob: "0 6 8,22 * *"
     groups:
       pre-commit-minor-patch:
         update-types: ["minor", "patch"]
+      pre-commit-major:
+        update-types: ["major"]


### PR DESCRIPTION
Reduces the volume of Dependabot PRs while keeping dependencies current. Three changes to `.github/dependabot.yml`: 
  
- **Biweekly cadence (8th & 22nd of each month)** via cron `0 6 8,22 * *`, replacing the weekly schedule. The dates are chosen to interleave with the `update-llvm.yml` workflow, which runs on the 1st and 15th — so Dependabot PRs land on the weeks the LLVM bump is quiet. 
- **Grouping for all five ecosystems** (github-actions, two pip wheel dirs, python, pre-commit). Each ecosystem now batches updates into a `*-minor-patch` group and a separate `*-major` group, so routine bumps arrive as a single PR and breaking majors split out on their own.
- **Dropped `open-pull-requests-limit`**, now redundant under grouping (per-ecosystem PR count is at most 2).
    
Net effect: from up to ~19 PRs/week down to at most ~10 grouped PRs twice a month (typically ~5, since majors are rare). Security PRs are unaffected and still fire immediately.