### PR TITLE
aiecc: emit the real host BO count in kernels.json instead of hardcoding 5

### DIFF
--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -30,7 +30,7 @@
 // The runtime_sequence below has 6 host buffer arguments; bo5 must be emitted.
 // A previously hardcoded 5-arg loop dropped it, under-declaring the kernel ABI.
 // CHECK: "name": "bo5"
-// CHECK: "offset": "0x3c"
+// CHECK: "offset": "0x3C"
 // CHECK: "dpu_kernel_id": "0x901"
 // CHECK: "name": "MLIRAIE"
 // CHECK: "name": "MLIR_AIE"

--- a/test/aiecc/buffers_xclbin.mlir
+++ b/test/aiecc/buffers_xclbin.mlir
@@ -27,6 +27,10 @@
 // CHECK: "name": "bo2"
 // CHECK: "name": "bo3"
 // CHECK: "name": "bo4"
+// The runtime_sequence below has 6 host buffer arguments; bo5 must be emitted.
+// A previously hardcoded 5-arg loop dropped it, under-declaring the kernel ABI.
+// CHECK: "name": "bo5"
+// CHECK: "offset": "0x3c"
 // CHECK: "dpu_kernel_id": "0x901"
 // CHECK: "name": "MLIRAIE"
 // CHECK: "name": "MLIR_AIE"

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -3510,8 +3510,8 @@ static LogicalResult generateMemTopologyJson(StringRef jsonPath) {
   return writeJsonToFile(jsonPath, llvm::json::Value(std::move(memData)));
 }
 
-static LogicalResult generateKernelsJson(StringRef jsonPath,
-                                         StringRef devName) {
+static LogicalResult generateKernelsJson(StringRef jsonPath, StringRef devName,
+                                         int numHostBOs) {
   llvm::json::Array arguments;
   arguments.push_back(llvm::json::Object{{"name", "opcode"},
                                          {"address-qualifier", "SCALAR"},
@@ -3528,7 +3528,7 @@ static LogicalResult generateKernelsJson(StringRef jsonPath,
                                          {"offset", "0x10"}});
 
   int offset = 0x14;
-  for (int i = 0; i < 5; i++) {
+  for (int i = 0; i < numHostBOs; i++) {
     std::string offsetHex = llvm::formatv("0x{0}", llvm::utohexstr(offset));
     arguments.push_back(llvm::json::Object{{"name", ("bo" + Twine(i)).str()},
                                            {"memory-connection", "HOST"},
@@ -4845,7 +4845,26 @@ static LogicalResult generateCdoArtifacts(ModuleOp moduleOp,
 
     SmallString<128> kernelsPath(tmpDirName);
     sys::path::append(kernelsPath, devName.str() + "_kernels.json");
-    if (failed(generateKernelsJson(kernelsPath, devName)))
+    // The host buffer (boN) count in kernels.json must match the kernel: a
+    // kernel with more than 5 host BOs otherwise gets an under-declared ABI.
+    // Raise the count to the real runtime-sequence argument count (as the
+    // full-ELF paths below do), keeping 5 as a floor so kernels with <=5 host
+    // BOs produce byte-identical kernels.json.
+    constexpr int kMinHostBOs = 5;
+    int numHostBOs = kMinHostBOs;
+    for (auto devOp : moduleOp.getOps<xilinx::AIE::DeviceOp>()) {
+      if (devOp.getSymName() != devName)
+        continue;
+      for (auto seqOp : devOp.getOps<xilinx::AIE::RuntimeSequenceOp>()) {
+        if (!seqOp.getBody().empty()) {
+          int n = seqOp.getBody().front().getNumArguments();
+          if (n > numHostBOs)
+            numHostBOs = n;
+        }
+      }
+      break;
+    }
+    if (failed(generateKernelsJson(kernelsPath, devName, numHostBOs)))
       return failure();
 
     // Generate partition JSON (with placeholder PDI path in dry-run)


### PR DESCRIPTION
## Problem

`aiecc`'s `generateKernelsJson` writes the `<device>_kernels.json` ABI manifest that XRT uses to launch a DPU kernel. It emitted the host-buffer (`boN`) argument list with a loop hardcoded to exactly 5:

```cpp
for (int i = 0; i < 5; i++) { ... "bo" + Twine(i) ... }
```

The 5 is unrelated to the kernel; it never looks at how many host buffers the kernel actually takes. A kernel whose runtime sequence takes more than 5 host buffers gets a `kernels.json` that under-declares its arguments: every `boN` past index 4 is dropped, so the generated DPU kernel metadata no longer matches the kernel.

Minimal repro: a `runtime_sequence` with 6 or more host buffer arguments produces a `kernels.json` that stops at `bo4`.

## Fix

Pass the host-buffer count into `generateKernelsJson` and loop to it. The count is the runtime-sequence argument count, computed at the call site in `generateCdoArtifacts` with the same `getNumArguments()` idiom this file already uses for the full-ELF artifact paths.

`5` is kept as a floor, so kernels with `<=5` host BOs produce byte-identical `kernels.json` (no change for existing kernels; only the previously-broken `>5` case changes). I used the floor rather than an exact count specifically to avoid changing the output of every existing small kernel. Happy to switch `generateKernelsJson` to the exact runtime-sequence count (matching the full-ELF paths exactly) instead, if you prefer that consistency.

## Test

`test/aiecc/buffers_xclbin.mlir` already drives a 6-host-buffer `runtime_sequence` through the xclbin path, but only checked `bo0..bo4` (which is why the truncation went unnoticed). I extended it to also check that `bo5` is emitted at its expected offset. Without this fix the 6th host buffer is silently dropped and the new check fails; with it, it passes. The test runs in the `test/aiecc` lit suite.

I have not run a full local toolchain build (the multi-hour LLVM build); the change is verified by inspection against the three existing `getNumArguments()` call sites in this file and by the strengthened lit test, which CI builds and runs.

## Note

`python/compiler/aiecc/main.py` is now a thin wrapper that delegates to this C++ binary, so the Python `aiecc.py` xclbin path is covered by the same fix and the same test.
