### PR TITLE
[aiecc] Downgrade LLVM 23 f0x float literals for Peano compatibility

### DIFF
--- a/test/aiecc/peano_compat_f0x_float.mlir
+++ b/test/aiecc/peano_compat_f0x_float.mlir
@@ -1,0 +1,58 @@
+//===- peano_compat_f0x_float.mlir - downgradeIRForPeano f0x float --------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Regression test: downgradeIRForPeano must rewrite 'f0x<8hex>' typed float
+// literals (introduced in LLVM 23) to the double-widened '0x<16hex>' form
+// that Peano's LLVM 21 opt can parse.
+//
+// Without the fix, aiecc fails with:
+//   opt: ...peano-compat.ll:N:M: error: expected value token
+//     %r = fadd float %x, f0x3727C5AC
+//
+// The constant 9.99999974E-6 (float32 bits 0x3727C5AC, the layernorm epsilon)
+// is a concrete trigger: LLVM 23's IR printer emits it as 'f0x3727C5AC'
+// because it cannot be represented exactly as a short decimal literal.
+// After downgrade the peano-compat.ll must use the equivalent double-widened
+// form '0x3EE4F8B580000000' which Peano's LLVM 21 can parse.
+
+// REQUIRES: peano
+
+// RUN: aiecc --no-xchesscc --no-xbridge --tmpdir %t %s
+// RUN: FileCheck %s --input-file %t/main_core_0_2.peano-compat.ll \
+// RUN:   --implicit-check-not="f0x"
+// RUN: FileCheck %s --input-file %t/main_core_0_2.peano-compat.ll \
+// RUN:   --check-prefix=CHECK-HEX
+
+// CHECK: define void @core_0_2()
+// CHECK-HEX: 0x3EE4F8B580000000
+
+module {
+  aie.device(npu2) {
+    %tile_0_2 = aie.tile(0, 2)
+    %buf_in  = aie.buffer(%tile_0_2) {sym_name = "in"}  : memref<256xf32>
+    %buf_out = aie.buffer(%tile_0_2) {sym_name = "out"} : memref<256xf32>
+
+    %core_0_2 = aie.core(%tile_0_2) {
+      %c0   = arith.constant 0 : index
+      %c256 = arith.constant 256 : index
+      %c1   = arith.constant 1 : index
+      // This f32 constant (the closest float32 to 1e-5, used as layernorm
+      // epsilon) has bit pattern 0x3727C5AC. LLVM 23 emits it as
+      // 'f0x3727C5AC'; the downgrade must rewrite it to '0x3EE4F8B580000000'.
+      %eps  = arith.constant 9.99999974E-6 : f32
+      scf.for %i = %c0 to %c256 step %c1 {
+        %val = memref.load %buf_in[%i] : memref<256xf32>
+        %out = arith.addf %val, %eps : f32
+        memref.store %out, %buf_out[%i] : memref<256xf32>
+      }
+      aie.end
+    }
+  }
+}

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -2111,9 +2111,8 @@ static std::string downgradeIRForPeano(StringRef ir) {
     while ((pos = result.find(f0xPfx, pos)) != std::string::npos) {
       // Require a non-identifier, non-sigil character before 'f' to avoid
       // matching inside LLVM IR value names like '%f0xDEAD' or '@f0xBEEF'.
-      if (pos > 0 &&
-          (isIdentChar(result[pos - 1]) || result[pos - 1] == '%' ||
-           result[pos - 1] == '@')) {
+      if (pos > 0 && (isIdentChar(result[pos - 1]) || result[pos - 1] == '%' ||
+                      result[pos - 1] == '@')) {
         pos += f0xPfx.size();
         continue;
       }
@@ -2123,8 +2122,9 @@ static std::string downgradeIRForPeano(StringRef ir) {
              std::isxdigit(static_cast<unsigned char>(result[hexEnd])))
         ++hexEnd;
       // Require exactly 8 hex digits followed by a non-hex-digit boundary.
-      bool trailingOk = hexEnd >= result.size() ||
-                        !std::isxdigit(static_cast<unsigned char>(result[hexEnd]));
+      bool trailingOk =
+          hexEnd >= result.size() ||
+          !std::isxdigit(static_cast<unsigned char>(result[hexEnd]));
       if (hexEnd - hexStart == 8 && trailingOk) {
         // Decode the 32-bit float bit pattern and re-encode as a double so
         // that Peano's LLVM 21 opt can parse the resulting hex literal.

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -50,7 +50,6 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <cstring>
 #include <random>
 
 #include "aie/Conversion/Passes.h"
@@ -2102,16 +2101,31 @@ static std::string downgradeIRForPeano(StringRef ir) {
   // prefix encodes the type and the 8 hex digits encode the IEEE-754 bits
   // directly). Older LLVM (including Peano's LLVM 21) only accepts float
   // constants as their value widened to double, written as 0x<16 hex digits>.
+  // Only match at token boundaries: the character before 'f' must not be an
+  // identifier character (to avoid matching inside %f0xDEAD or similar), and
+  // the character after the 8 hex digits must not be a hex digit (to avoid
+  // partial matches against longer hex strings).
   {
     const std::string f0xPfx = "f0x";
     pos = 0;
     while ((pos = result.find(f0xPfx, pos)) != std::string::npos) {
+      // Require a non-identifier, non-sigil character before 'f' to avoid
+      // matching inside LLVM IR value names like '%f0xDEAD' or '@f0xBEEF'.
+      if (pos > 0 &&
+          (isIdentChar(result[pos - 1]) || result[pos - 1] == '%' ||
+           result[pos - 1] == '@')) {
+        pos += f0xPfx.size();
+        continue;
+      }
       size_t hexStart = pos + f0xPfx.size();
       size_t hexEnd = hexStart;
       while (hexEnd < result.size() && hexEnd < hexStart + 8 &&
              std::isxdigit(static_cast<unsigned char>(result[hexEnd])))
         ++hexEnd;
-      if (hexEnd - hexStart == 8) {
+      // Require exactly 8 hex digits followed by a non-hex-digit boundary.
+      bool trailingOk = hexEnd >= result.size() ||
+                        !std::isxdigit(static_cast<unsigned char>(result[hexEnd]));
+      if (hexEnd - hexStart == 8 && trailingOk) {
         // Decode the 32-bit float bit pattern and re-encode as a double so
         // that Peano's LLVM 21 opt can parse the resulting hex literal.
         uint32_t fbits = static_cast<uint32_t>(

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -50,6 +50,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstring>
 #include <random>
 
 #include "aie/Conversion/Passes.h"
@@ -2094,6 +2095,42 @@ static std::string downgradeIRForPeano(StringRef ir) {
       result.erase(pos, end - pos);
     else
       pos = end;
+  }
+  // Rewrite LLVM 23+ 'f0x<8hex>' typed float literals to the double-widened
+  // '0x<16hex>' form that Peano's LLVM 21 opt can parse.
+  // LLVM 23 introduced a compact syntax for 32-bit float constants (the 'f'
+  // prefix encodes the type and the 8 hex digits encode the IEEE-754 bits
+  // directly). Older LLVM (including Peano's LLVM 21) only accepts float
+  // constants as their value widened to double, written as 0x<16 hex digits>.
+  {
+    const std::string f0xPfx = "f0x";
+    pos = 0;
+    while ((pos = result.find(f0xPfx, pos)) != std::string::npos) {
+      size_t hexStart = pos + f0xPfx.size();
+      size_t hexEnd = hexStart;
+      while (hexEnd < result.size() && hexEnd < hexStart + 8 &&
+             std::isxdigit(static_cast<unsigned char>(result[hexEnd])))
+        ++hexEnd;
+      if (hexEnd - hexStart == 8) {
+        // Decode the 32-bit float bit pattern and re-encode as a double so
+        // that Peano's LLVM 21 opt can parse the resulting hex literal.
+        uint32_t fbits = static_cast<uint32_t>(
+            std::stoul(result.substr(hexStart, 8), nullptr, 16));
+        float fval;
+        std::memcpy(&fval, &fbits, sizeof(fval));
+        double dval = static_cast<double>(fval);
+        uint64_t dbits;
+        std::memcpy(&dbits, &dval, sizeof(dval));
+        // Format as "0x" followed by 16 uppercase hex digits.
+        std::string replacement = "0x";
+        for (int shift = 60; shift >= 0; shift -= 4)
+          replacement += "0123456789ABCDEF"[(dbits >> shift) & 0xFu];
+        result.replace(pos, hexEnd - pos, replacement);
+        pos += replacement.size();
+      } else {
+        pos = hexEnd;
+      }
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Summary

LLVM 23 introduced a compact `f0x<8hex>` syntax for float32 constants in textual LLVM IR, where the 8 hex digits directly encode the IEEE-754 bit pattern. Peano's LLVM 21 `opt` cannot parse this format, causing aiecc to fail with:

```
opt: ...peano-compat.ll: error: expected value token
  %r = fadd float %x, f0x3727C5AC
```

This broke softmax and layernorm tests in [mlir-air#1693](https://github.com/Xilinx/mlir-air/pull/1693) when bumping mlir-aie to v1.3.3 (which uses a newer mlir-distro / LLVM 23 build that emits `f0x`).

## Fix

Extend `downgradeIRForPeano` in `tools/aiecc/aiecc.cpp` to rewrite each `f0x<8hex>` literal to the double-widened `0x<16hex>` form that LLVM 21 accepts:

- Scan the IR string for the `f0x` prefix followed by exactly 8 hex digits
- Decode the 32-bit bit pattern as IEEE-754 float32
- Widen to double and emit as `0x<16 uppercase hex digits>`

Example: `f0x3727C5AC` → `0x3EE4F8B580000000` (the float32 value 9.99999974E-6 widened to double).

## Test

`test/aiecc/peano_compat_f0x_float.mlir` — a minimal AIE core that uses `arith.constant 9.99999974E-6 : f32` (bits 0x3727C5AC, the layernorm epsilon), which LLVM 23 emits as `f0x3727C5AC`. The test checks:
- `--implicit-check-not="f0x"` — no `f0x` literals remain in the peano-compat.ll
- `CHECK-HEX: 0x3EE4F8B580000000` — the double-widened replacement is present

## Test plan

- [ ] `test/aiecc/peano_compat_f0x_float.mlir` passes (REQUIRES: peano)
- [ ] `test/xrt/43_triton_layernorm` passes after bumping mlir-air to include this fix
- [ ] `test/xrt/42_triton_softmax_bf16` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)