### PR TITLE
[chore] Bump scripts to pull latest-wheels-4

### DIFF
--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -43,7 +43,7 @@ fi
 
 # If force install or an install dir isn't passed
 if [[ $FORCE_INSTALL -eq 1 || ( "$#" -lt 1 && -z "$(pip show mlir_aie | grep '^Location:')" ) ]]; then
-  python3 -m pip install -I mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3
+  python3 -m pip install -I mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4
   export MLIR_AIE_INSTALL_DIR="$(pip show mlir_aie | grep '^Location:' | awk '{print $2}')/mlir_aie"
 fi
 

--- a/utils/iron_setup.py
+++ b/utils/iron_setup.py
@@ -504,11 +504,11 @@ def install_plan(
                 print(f"[setup] WARNING: post-step for {flag} failed (continuing)")
 
     # mlir_aie wheels (IRON)
-    # Modes: auto | skip | latest-wheels-3 | wheelhouse[:<path>]
+    # Modes: auto | skip | latest-wheels-4 | wheelhouse[:<path>]
     # Auto mode exists until wheels are available for Windows.
     mlir_raw = str(getattr(args, "mlir_aie", "auto") or "auto").strip().lower()
     mlir_mode, allow_missing_mlir_aie = (
-        ("latest-wheels-3", IS_WINDOWS) if mlir_raw == "auto" else (mlir_raw, False)
+        ("latest-wheels-4", IS_WINDOWS) if mlir_raw == "auto" else (mlir_raw, False)
     )
     if mlir_mode != "skip":
         try:
@@ -527,7 +527,7 @@ def install_plan(
                 for pkg in ("mlir_aie", "aie_python_bindings"):
                     pip_pkg(pkg, wheelhouse=wheelhouse_dir, no_deps=True, no_index=True)
             else:
-                mlir_find_links = "https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3/"
+                mlir_find_links = "https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/"
                 print(f"[setup] Installing mlir_aie from {mlir_find_links}")
                 pip_pkg("mlir_aie", find_links=mlir_find_links)
         except CommandError:
@@ -824,7 +824,7 @@ def _add_install_args(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--mlir-aie",
         default="auto",
-        help="mlir_aie wheel source: auto | skip | latest-wheels-3 | wheelhouse[:<path>]",
+        help="mlir_aie wheel source: auto | skip | latest-wheels-4 | wheelhouse[:<path>]",
     )
     p.add_argument(
         "--llvm-aie",

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -8,7 +8,7 @@
 ##===----------------------------------------------------------------------===##
 #
 # This script is the quickest path to running the Ryzen AI reference designs.
-# Please have the Vitis tools and XRT environment setup before sourcing the 
+# Please have the Vitis tools and XRT environment setup before sourcing the
 # script.
 #
 # Usage: source ./utils/quick_setup.sh
@@ -18,7 +18,7 @@
 echo "Setting up RyzenAI developement tools..."
 if [ -z "${WSL_DISTRO_NAME-}" ]; then
   XRTSMI=`which xrt-smi`
-  if ! test -f "$XRTSMI"; then 
+  if ! test -f "$XRTSMI"; then
     echo "xrt-smi not found. Is XRT installed?"
     return 1
   fi
@@ -56,7 +56,7 @@ $my_python -m venv ironenv
 source ironenv/bin/activate
 python3 -m pip install --upgrade pip
 
-python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-3/ 
+python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
 export MLIR_AIE_INSTALL_DIR="$(pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 
 # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1053). Revert once fixed upstream.


### PR DESCRIPTION
I think maybe this was one of those "kick the can down the lane" sort of things but, regardless, we forgot to have user scripts start pulling the actual latest wheels, even though we have been publishing them for almost a month.