### PR TITLE
Fix unsafe JIT artifact-cache cleanup in dma_compression

### DIFF
--- a/programming_examples/basic/dma_compression/test_dma_compression.py
+++ b/programming_examples/basic/dma_compression/test_dma_compression.py
@@ -8,14 +8,13 @@ python3 test_dma_compression.py --skip both,core_both
 
 import argparse
 import hashlib
-import shutil
 import sys
 import time
-from pathlib import Path
 
 import numpy as np
 
 import aie.iron as iron
+from aie.utils import cleanup_npu_runtime
 
 from dma_compression import dma_compression, CONFIGS, RATIOED_N
 
@@ -29,27 +28,9 @@ def _detect_arch() -> str:
     return rt.npu_str
 
 
-def _isolate_for_next_config():
-    # Drop stale xclbin + hw_context so the next dispatch's registration
-    # doesn't fail with ENODEV from DRM_IOCTL_AMDXDNA_CREATE_HWCTX.
-    cache = Path.home() / ".npu" / "cache"
-    if cache.exists():
-        for entry in cache.iterdir():
-            shutil.rmtree(entry, ignore_errors=True)
-    try:
-        from aie.utils.jit import _compiled_kernels
-
-        _compiled_kernels.clear()
-    except Exception:
-        pass
-    try:
-        from aie.utils import _get_default_npu_runtime
-
-        rt = _get_default_npu_runtime()
-        if rt is not None:
-            rt.cleanup()
-    except Exception:
-        pass
+def _reset_runtime_for_next_config():
+    """Release cached XRT contexts before the next DMA configuration."""
+    cleanup_npu_runtime()
 
 
 N = 4096
@@ -293,7 +274,7 @@ def main() -> int:
     needs_compressed_input = any(c.endswith("both") and c not in skip for c in configs)
     compressed_input_np = None
     if needs_compressed_input:
-        _isolate_for_next_config()
+        _reset_runtime_for_next_config()
         print("[ pre-compute cmp_only ] capturing compressed-arange for *both configs")
         in_t = iron.arange(N, dtype=np.uint32, device="npu")
         out_t = iron.full(N, SENTINEL, dtype=np.uint32, device="npu")
@@ -306,12 +287,12 @@ def main() -> int:
         if cfg in skip:
             print(f"[{cfg:>23}] SKIP")
             continue
-        _isolate_for_next_config()
+        _reset_runtime_for_next_config()
         cfg_input = compressed_input_np if cfg.endswith("both") else None
         all_ok &= run_one(cfg, verbose=args.verbose, input_np=cfg_input)
 
     if not args.config and "roundtrip" not in skip:
-        _isolate_for_next_config()
+        _reset_runtime_for_next_config()
         all_ok &= run_roundtrip(verbose=args.verbose)
 
     print()

--- a/python/utils/__init__.py
+++ b/python/utils/__init__.py
@@ -220,6 +220,13 @@ def _get_default_npu_runtime():
     return _DefaultNPURuntime
 
 
+def cleanup_npu_runtime() -> None:
+    """Release cached XRT resources without initializing the default runtime."""
+    runtime = globals().get("DefaultNPURuntime", _DefaultNPURuntime)
+    if runtime is not None:
+        runtime.cleanup()
+
+
 def __getattr__(name):
     if name == "DefaultNPURuntime":
         return _get_default_npu_runtime()

--- a/python/utils/callabledesign.py
+++ b/python/utils/callabledesign.py
@@ -337,9 +337,14 @@ class CallableDesign:
             extra_key=compilable._generation_cache_key(),
         )
 
-        if compilable.use_cache and cache_key in self._kernel_cache:
-            kernel = self._kernel_cache[cache_key]
-        else:
+        kernel = self._kernel_cache.get(cache_key) if compilable.use_cache else None
+        if kernel is not None and (
+            not Path(kernel.xclbin_path).is_file()
+            or not Path(kernel.insts_path).is_file()
+        ):
+            self._kernel_cache.pop(cache_key, None)
+            kernel = None
+        if kernel is None:
             kernel = self._compile_and_build_kernel(compilable, cache_key, trace_config)
 
         tensor_args, remaining_scalars = compilable.split_runtime_args(

--- a/test/python/test_callable_design_unit.py
+++ b/test/python/test_callable_design_unit.py
@@ -468,6 +468,49 @@ def test_call_binds_runtime_device_before_in_process_cache(monkeypatch):
     assert "__iron_device__" not in seen_keys[0][1]
 
 
+@pytest.mark.parametrize("artifact_name", ["xclbin_path", "insts_path"])
+def test_call_rebuilds_removed_cached_artifacts(
+    monkeypatch, tmp_path, npu2_device, artifact_name
+):
+    """A memory-cache entry is invalid after either artifact is removed."""
+
+    def gen():
+        pass
+
+    class FakeKernel:
+        def __init__(self, xclbin_path, insts_path, result):
+            self.xclbin_path = xclbin_path
+            self.insts_path = insts_path
+            self.result = result
+
+        def __call__(self, *args, **kwargs):
+            return self.result
+
+    cd = CallableDesign(gen)
+    builds = []
+
+    def fake_compile_and_build(self, compilable, cache_key, trace_config):
+        index = len(builds)
+        xclbin_path = tmp_path / f"{index}.xclbin"
+        insts_path = tmp_path / f"{index}.bin"
+        xclbin_path.touch()
+        insts_path.touch()
+        kernel = FakeKernel(xclbin_path, insts_path, index)
+        self._kernel_cache[cache_key] = kernel
+        builds.append(kernel)
+        return kernel
+
+    monkeypatch.setattr(
+        CallableDesign, "_compile_and_build_kernel", fake_compile_and_build
+    )
+
+    assert cd() == 0
+    getattr(builds[0], artifact_name).unlink()
+
+    assert cd() == 1
+    assert len(builds) == 2
+
+
 def test_function_cache_key_keeps_internal_identity_out_of_compile_kwargs():
     """User compile keys cannot collide with internal cache dimensions."""
     from aie.utils.compile.cache.utils import _create_function_cache_key

--- a/test/python/test_device_binding_cache_unit.py
+++ b/test/python/test_device_binding_cache_unit.py
@@ -269,3 +269,38 @@ def test_iron_reexports_set_current_device():
     import aie.iron as iron
 
     assert iron.set_current_device is set_current_device
+
+
+def test_cleanup_npu_runtime_releases_cached_default_runtime(monkeypatch):
+    """Runtime cleanup releases resources from an existing cached default runtime."""
+    import aie.utils as utils
+
+    class FakeRuntime:
+        def __init__(self):
+            self.cleanup_calls = 0
+
+        def cleanup(self):
+            self.cleanup_calls += 1
+
+    runtime = FakeRuntime()
+    monkeypatch.setattr(utils, "_DefaultNPURuntime", runtime)
+    monkeypatch.delitem(utils.__dict__, "DefaultNPURuntime", raising=False)
+
+    utils.cleanup_npu_runtime()
+
+    assert runtime.cleanup_calls == 1
+
+
+def test_cleanup_npu_runtime_does_not_initialize_default_runtime(monkeypatch):
+    """Runtime cleanup is a no-op until a default runtime already exists."""
+    import aie.utils as utils
+
+    monkeypatch.setattr(utils, "_DefaultNPURuntime", None)
+    monkeypatch.delitem(utils.__dict__, "DefaultNPURuntime", raising=False)
+    monkeypatch.setattr(
+        utils,
+        "_get_default_npu_runtime",
+        lambda: pytest.fail("runtime cleanup must not initialize XRT"),
+    )
+
+    utils.cleanup_npu_runtime()


### PR DESCRIPTION
There was some pathological cache behavior going on with this example/test. In short, when run locally, it was nuking *its own* `xclbin` while it was still running. The problem is that the paths were still in memory, causing `CallableDesign` to try to reuse a cached kernel whose backing no longer existed, so... crash.

This wasn't showing up during CI because the hard-coded nuke target did not match the cache root in the runner environment. So, I started by removing the hard-coded cleanup and having `CallableDesign` attempt to recompile missing artifacts if needed. But then, while testing with parallel workers, it turned out the nuke actually had MIRVs, and recursively destroyed *every* JIT artifact directory under the cache root. Just the whole thing, regardless of hash or `.lock` (!!!).

Again, that did not show up in CI because the thing was mostly pointed at the wrong cache tree. Anyway, I think I have it fixed up now. The recursion is removed, I neutered the thing's ability to meddle in cache management that should be handled by the compiler, and I replaced it with runtime cleanup that should not wake XRT and, I think, fulfills the needs of the example better than nukes. I also added a few tests around the new behavior.