### PR TITLE
[ci][bugfix] Test examples against the same-commit wheel, not a mutable tag 

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -9,6 +9,9 @@ on:
       - main
       - test-ryzen-ai
   pull_request:
+    # Default activity types plus labeled/unlabeled so toggling the
+    # "test-wheels" label re-evaluates the gated wheel-example jobs.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   merge_group:
   schedule:
     # Runs at midnight (00:00) every day
@@ -163,8 +166,27 @@ jobs:
           rm -rf $NPU_CACHE_HOME
           rm -rf $PIP_CACHE_DIR
 
+  # Build the single wheel the examples run against, FROM THIS RUN's commit, so
+  # the example test never installs a stale published wheel. Expensive
+  # (~19 min), so gated: runs in the merge queue (authoritative, on the
+  # post-merge commit) or on demand when a PR carries the "test-wheels" label.
+  build-examples-wheel:
+    name: Build examples wheel (py3.12, RTTI ON)
+    if: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'test-wheels') }}
+    uses: ./.github/workflows/buildRyzenWheels.yml
+    with:
+      python_version: "3.12"
+      enable_rtti: ON
+      reusable_call: true
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+
   build-quick-setup:
     name: Run Examples on Ryzen AI
+    needs: build-examples-wheel
+    if: ${{ github.event_name == 'merge_group' || contains(github.event.pull_request.labels.*.name, 'test-wheels') }}
     runs-on: ${{ matrix.runner_type }}
     strategy:
       fail-fast: false
@@ -178,6 +200,14 @@ jobs:
         with:
           submodules: "true"
 
+      # Pull the wheel built from this same run (build-examples-wheel) so the
+      # examples test exactly this commit's mlir_aie, not a published tag.
+      - name: Download same-commit mlir_aie wheel
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: mlir_aie_rtti_ON-3.12
+          path: ${{ github.workspace }}/examples-wheel
+
       # Launch an ssh session via a proxy server if there is a need
       # for debug. This seems to live for 35 min max
       # https://github.com/mxschmitt/action-tmate
@@ -187,7 +217,7 @@ jobs:
         # click on "launch_tmate_terminal_for_debug"
         if: github.event_name == 'workflow_dispatch'
                 && inputs.launch_tmate_terminal_for_debug
-      
+
       - name: Print hostname
         run: hostname
 
@@ -198,6 +228,9 @@ jobs:
           # only when present so the job works on both old and new XRT.
           [ -f /opt/xilinx/xrt/setup.sh ] && source /opt/xilinx/xrt/setup.sh
           export PATH=$VITIS/bin:$VITIS/aietools/bin:$PATH
+          # Install the same-commit wheel downloaded above instead of the
+          # published rolling tag.
+          export MLIR_AIE_WHEEL_DIR="${{ github.workspace }}/examples-wheel"
           source utils/quick_setup.sh
           # quick_setup changes directory to programming_examples, so we need to return to mlir-aie
           cd ..
@@ -255,6 +288,23 @@ jobs:
             LIT_FILTER="gemm_asymmetric_tile_buffering" \
             ninja check-reference-designs
           popd
+
+      - name: Explain failure
+        if: failure()
+        run: |
+          cat >&2 <<'EOF'
+          ::error::Wheel example validation failed.
+          This job installs the mlir_aie wheel built from THIS commit (job
+          build-examples-wheel) and runs the examples against it. A failure here
+          usually means either:
+            * the wheel build failed, or
+            * an example imports an mlir_aie symbol the built wheel does not
+              expose (source/wheel skew) — e.g. a new symbol added in this PR.
+
+          To reproduce on your PR without waiting for the merge queue, add the
+          "test-wheels" label to the PR (remove and re-add it to re-run). That
+          runs this exact build + example test on your branch.
+          EOF
 
       - name: Cleanup NPU_CACHE_HOME
         if: always()

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -178,9 +178,13 @@ jobs:
       python_version: "3.12"
       enable_rtti: "ON"
       reusable_call: true
+    # Must grant at least what the called workflow's build-repo job declares
+    # (contents: write + packages: read for attestation and the ghcr base
+    # image), or reusable-workflow validation fails at startup.
     permissions:
       id-token: write
-      contents: read
+      contents: write
+      packages: read
       attestations: write
 
   build-quick-setup:

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -176,7 +176,7 @@ jobs:
     uses: ./.github/workflows/buildRyzenWheels.yml
     with:
       python_version: "3.12"
-      enable_rtti: ON
+      enable_rtti: "ON"
       reusable_call: true
     permissions:
       id-token: write

--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -178,14 +178,15 @@ jobs:
       python_version: "3.12"
       enable_rtti: "ON"
       reusable_call: true
-    # Must grant at least what the called workflow's build-repo job declares
-    # (contents: write + packages: read for attestation and the ghcr base
-    # image), or reusable-workflow validation fails at startup.
+    # Must grant the union of what ALL of the called workflow's jobs declare
+    # (build-repo, build-windows, publish) — GitHub validates every nested
+    # job's permissions at startup even when gated off via if:.
     permissions:
       id-token: write
       contents: write
       packages: read
       attestations: write
+      actions: read
 
   build-quick-setup:
     name: Run Examples on Ryzen AI

--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -13,6 +13,23 @@ on:
         type: string
         required: false
         default: ''
+  workflow_call:
+    inputs:
+      python_version:
+        description: 'Single Python version to build (narrows the matrix when set)'
+        type: string
+        required: false
+        default: ''
+      enable_rtti:
+        description: 'Single RTTI setting to build, ON or OFF (narrows the matrix when set)'
+        type: string
+        required: false
+        default: ''
+      reusable_call:
+        description: 'True when invoked as a reusable workflow; suppresses publishing and Windows builds'
+        type: boolean
+        required: false
+        default: false
   push:
     tags:
       - 'v*.*.*'
@@ -42,8 +59,27 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 jobs:
+  setup:
+    name: Compute wheel build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        shell: bash
+        # When invoked as a reusable workflow with a single python_version +
+        # enable_rtti, build just that one config; otherwise build the full
+        # published matrix.
+        run: |
+          if [ -n "${{ inputs.python_version }}" ] && [ -n "${{ inputs.enable_rtti }}" ]; then
+            echo 'matrix={"include":[{"python_version":"${{ inputs.python_version }}","ENABLE_RTTI":"${{ inputs.enable_rtti }}"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"python_version":"3.11","ENABLE_RTTI":"ON"},{"python_version":"3.11","ENABLE_RTTI":"OFF"},{"python_version":"3.12","ENABLE_RTTI":"ON"},{"python_version":"3.12","ENABLE_RTTI":"OFF"},{"python_version":"3.13","ENABLE_RTTI":"ON"},{"python_version":"3.13","ENABLE_RTTI":"OFF"},{"python_version":"3.14","ENABLE_RTTI":"ON"},{"python_version":"3.14","ENABLE_RTTI":"OFF"}]}' >> "$GITHUB_OUTPUT"
+          fi
+
   build-repo:
     name: Build and upload mlir_aie wheels
+    needs: setup
 
     runs-on: ubuntu-latest
 
@@ -55,31 +91,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - python_version: "3.11"
-            ENABLE_RTTI: ON
-
-          - python_version: "3.11"
-            ENABLE_RTTI: OFF
-
-          - python_version: "3.12"
-            ENABLE_RTTI: ON
-
-          - python_version: "3.12"
-            ENABLE_RTTI: OFF
-
-          - python_version: "3.13"
-            ENABLE_RTTI: ON
-
-          - python_version: "3.13"
-            ENABLE_RTTI: OFF
-
-          - python_version: "3.14"
-            ENABLE_RTTI: ON
-
-          - python_version: "3.14"
-            ENABLE_RTTI: OFF
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Free disk space
@@ -249,10 +261,17 @@ jobs:
         with:
           path: wheelhouse/repaired_wheel/mlir_aie*whl
           name: mlir_aie_rtti_${{ matrix.ENABLE_RTTI }}-${{ matrix.python_version }}
+          # Reusable-call wheels are only needed for same-run handoff to the
+          # examples job; keep them a week so they don't accumulate. Other
+          # triggers keep the repo-default retention (0 = use default).
+          retention-days: ${{ inputs.reusable_call && 7 || 0 }}
 
 
   build-windows:
     name: Build and upload mlir_aie wheels (Windows)
+    # A reusable call only needs the single narrowed Linux wheel; never build
+    # Windows for it.
+    if: ${{ !inputs.reusable_call }}
 
     runs-on: windows-2022
 
@@ -496,9 +515,10 @@ jobs:
   publish:
     name: Publish wheels
     if: |
-      github.event_name == 'workflow_dispatch' ||
+      !inputs.reusable_call &&
+      (github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')))
     runs-on: ubuntu-latest
     needs: [build-repo, build-windows]
     permissions:
@@ -577,7 +597,11 @@ jobs:
           makeLatest: ${{ !(contains(github.ref_name, 'rc') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
       - name: Release latest wheels (RTTI ON)
-        if: github.event_name != 'push'
+        # Only publish from events that represent main (merge queue) or an
+        # intentional refresh. Excludes pull_request so PRs no longer overwrite
+        # the shared rolling tag with unmerged branch content; excludes reusable
+        # calls so the test workflow never republishes.
+        if: ${{ !inputs.reusable_call && contains(fromJSON('["merge_group","schedule","workflow_dispatch"]'), github.event_name) }}
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           artifacts: wheels_on_flat/mlir_aie*whl
@@ -590,7 +614,7 @@ jobs:
           makeLatest: false
 
       - name: Release latest wheels (RTTI OFF)
-        if: github.event_name != 'push'
+        if: ${{ !inputs.reusable_call && contains(fromJSON('["merge_group","schedule","workflow_dispatch"]'), github.event_name) }}
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           artifacts: wheels_off_flat/mlir_aie*whl

--- a/utils/quick_setup.sh
+++ b/utils/quick_setup.sh
@@ -56,7 +56,14 @@ $my_python -m venv ironenv
 source ironenv/bin/activate
 python3 -m pip install --upgrade pip
 
-python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+# Prefer a locally-provided wheel (e.g. a CI artifact built from this same
+# commit) when MLIR_AIE_WHEEL_DIR is set; otherwise fall back to the published
+# rolling tag for local-dev convenience.
+if [ -n "${MLIR_AIE_WHEEL_DIR:-}" ]; then
+  python3 -m pip install mlir_aie -f "$MLIR_AIE_WHEEL_DIR"
+else
+  python3 -m pip install mlir_aie -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/latest-wheels-4/
+fi
 export MLIR_AIE_INSTALL_DIR="$(pip show mlir_aie | grep ^Location: | awk '{print $2}')/mlir_aie"
 
 # Temp pin: latest llvm-aie nightly miscompiles int->float->int at -O2 (Xilinx/llvm-aie#1053). Revert once fixed upstream.


### PR DESCRIPTION
A combination of more CI runners (higher concurrency) + https://github.com/Xilinx/mlir-aie/pull/3234 + https://github.com/Xilinx/mlir-aie/pull/3235 revealed some fragility in how we test wheels. These PRs are correct; the errors are pre-existing.

"Run Examples on Ryzen AI" installed `mlir_aie` from the **mutable** `latest-wheels-4` tag (via `utils/quick_setup.sh`), so it tested the last-published wheel rather than the commit under test. When source added a symbol the wheel lacked (e.g. `cleanup_npu_runtime` from #3235), the example failed with `ImportError` — and since every PR overwrites the tag, failures were nondeterministic.                                             
                                       
Now the example installs the wheel built from the **same workflow run**, so it always tests this commit's `mlir_aie`.
                                       
- **Same-run handoff:** new `build-examples-wheel` job builds the one needed wheel (py3.12, RTTI ON) via `workflow_call`; `build-quick-setup` pulls it with `needs:` + `download-artifact` and installs it through a new `MLIR_AIE_WHEEL_DIR` seam in `quick_setup.sh` (falls back to `latest-wheels-4` locally).                                                                  
- **Cost-gated:** the ~19 min build runs only in the **merge queue** or on-demand via the `test-wheels` label; ordinary PR pushes keep the cheap source/lit/unit tier.                                                      
- **Publish hygiene:** PRs no longer overwrite `latest-wheels-4` (publish gated to `merge_group`/`schedule`/`workflow_dispatch`); reusable calls never republish or build Windows.          
- **Guided failure:** `if: failure()` explains the likely skew cause and points to the `test-wheels` label.
                                       
Requires the `test-wheels` label (already created). Follow-ups: build-once-test-publish-if-green pipeline (kills the duplicate py3.12 build + gates publish on the test); ccache persistence to speed the cold build.          
                                       
## Test plan                         
                                                                             
- [ ] Merge queue: `build-examples-wheel` uploads `mlir_aie_rtti_ON-3.12`; `build-quick-setup` installs it and passes
  `basic/dma_compression/run_jit.lit`.                                       
- [ ] `test-wheels`-labeled PR: same path runs on the branch.
- [ ] Unlabeled PR push: wheel jobs skipped, cheap tier still runs.        
- [ ] No publish to `latest-wheels-4` on `pull_request` or reusable calls. 