### PR TITLE
[aiecc] Make scf->cf lowering runtime-sequence-aware

### DIFF
--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -33,6 +33,8 @@ std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIEDmaToNpuPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIENpuToCertPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIECertPagesPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>> createAIEXToStandardPass();
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+createAIESCFToControlFlowPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIEMaterializeBDChainsPass();
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -31,6 +31,36 @@ def AIEXToStandard : Pass<"aiex-standard-lowering", "mlir::ModuleOp"> {
   ];
 }
 
+def AIESCFToControlFlow : Pass<"aie-scf-to-control-flow", "mlir::ModuleOp"> {
+  let summary = "Lower scf to cf everywhere except inside runtime sequences";
+  let description = [{
+    Converts structured control flow (`scf`) to unstructured control flow
+    (`cf`) throughout the module, with one exception: `scf` operations nested
+    inside an `aie.runtime_sequence` are left untouched.
+
+    A runtime sequence is `NoTerminator` and is lowered to a flat NPU
+    instruction stream that has no notion of branches; its loops are instead
+    resolved by the dedicated runtime-sequence lowering path (loop unrolling
+    for compile-time-constant trip counts, or the dynamic EmitC path
+    otherwise). Running the generic `convert-scf-to-cf` over a runtime
+    sequence would both violate its `NoTerminator` block invariant (the ops
+    following a lowered loop end up in a terminator-less block) and feed the
+    flat NPU emitter control-flow ops it silently drops -- a miscompile.
+
+    This pass is therefore a drop-in replacement for `convert-scf-to-cf` in
+    pipelines that contain runtime sequences: core/host `scf` is lowered to
+    `cf` as usual (e.g. before `aie-standard-lowering`), while runtime-sequence
+    control flow is preserved for its own lowering.
+  }];
+
+  let constructor = "xilinx::AIEX::createAIESCFToControlFlowPass()";
+  let dependentDialects = [
+    "mlir::cf::ControlFlowDialect",
+    "xilinx::AIE::AIEDialect",
+    "xilinx::AIEX::AIEXDialect",
+  ];
+}
+
 def AIECreateCores : Pass<"aie-create-cores", "AIE::DeviceOp"> {
   let summary = "Create CoreOp, MemOp, and FlowOp of AIE dialect";
   let description = [{

--- a/lib/Dialect/AIEX/Transforms/AIESCFToControlFlow.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESCFToControlFlow.cpp
@@ -1,0 +1,78 @@
+//===- AIESCFToControlFlow.cpp ----------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+//
+// Lower scf to cf everywhere in the module EXCEPT inside aie.runtime_sequence
+// bodies.
+//
+// A runtime sequence is NoTerminator and is translated to a flat NPU
+// instruction stream with no concept of branches. Its loops are lowered by the
+// dedicated runtime-sequence path (unrolling for compile-time-constant trip
+// counts; the dynamic EmitC path otherwise), not by generic scf->cf. Applying
+// convert-scf-to-cf to a runtime sequence would (1) break the NoTerminator
+// block invariant -- the ops after a lowered loop land in a terminator-less
+// block -- and (2) emit cf.br / cf.cond_br that the flat NPU emitter silently
+// drops, a miscompile. So we mark scf inside a runtime sequence as legal
+// (leave it alone) and convert everything else.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace xilinx::AIEX {
+#define GEN_PASS_DEF_AIESCFTOCONTROLFLOW
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+} // namespace xilinx::AIEX
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIEX;
+
+namespace {
+
+struct AIESCFToControlFlowPass
+    : xilinx::AIEX::impl::AIESCFToControlFlowBase<AIESCFToControlFlowPass> {
+
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+
+    ConversionTarget target(getContext());
+    // Everything is legal by default; only scf outside a runtime sequence is
+    // illegal. (Matching upstream convert-scf-to-cf, which marks every other
+    // op legal so the structural block-splitting can relocate them freely.)
+    target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+    target.addLegalDialect<cf::ControlFlowDialect>();
+    // scf is illegal (must be converted) UNLESS it lives inside a runtime
+    // sequence, whose control flow has its own lowering path.
+    target.addDynamicallyLegalDialect<scf::SCFDialect>([](Operation *op) {
+      return op->getParentOfType<AIE::RuntimeSequenceOp>() != nullptr;
+    });
+
+    RewritePatternSet patterns(&getContext());
+    populateSCFToControlFlowConversionPatterns(patterns);
+
+    if (failed(applyPartialConversion(module, target, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
+xilinx::AIEX::createAIESCFToControlFlowPass() {
+  return std::make_unique<AIESCFToControlFlowPass>();
+}

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 add_mlir_dialect_library(AIEXTransforms
   AIEXToStandard.cpp
+  AIESCFToControlFlow.cpp
   AIECreateCores.cpp
   AIECreateLocks.cpp
   AIEHerdRouting.cpp
@@ -43,6 +44,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIEXUtils
   MLIRIR
   MLIRPass
+  MLIRSCFToControlFlow
   MLIRSupport
   MLIRTransformUtils
   )

--- a/test/Passes/scf-to-control-flow/scf_to_control_flow.mlir
+++ b/test/Passes/scf-to-control-flow/scf_to_control_flow.mlir
@@ -1,0 +1,79 @@
+//===- scf_to_control_flow.mlir --------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-scf-to-control-flow --split-input-file %s | FileCheck %s
+
+// scf in a core body is lowered to cf, exactly like the generic
+// convert-scf-to-cf.
+
+// CHECK-LABEL: aie.core
+// CHECK-NOT:   scf.for
+// CHECK:       cf.br
+// CHECK:       cf.cond_br
+aie.device(npu1) {
+  %t = aie.tile(0, 2)
+  %core = aie.core(%t) {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c8 step %c1 {
+    }
+    aie.end
+  }
+}
+
+// -----
+
+// scf inside a runtime sequence is left untouched: the runtime sequence is
+// NoTerminator and its loops are lowered by the dedicated runtime-sequence
+// path, not by scf->cf.
+
+// CHECK-LABEL: aie.runtime_sequence @runtime_seq_scf_preserved
+// CHECK:       scf.for
+// CHECK-NOT:   cf.br
+aie.device(npu1) {
+  %t = aie.tile(0, 0)
+  aie.runtime_sequence @runtime_seq_scf_preserved(%arg0: memref<8xi32>) {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c8 step %c1 {
+    }
+  }
+}
+
+// -----
+
+// Both in one device: the core loop is lowered to cf while the runtime-sequence
+// loop is preserved.
+
+// CHECK-LABEL: aie.core
+// CHECK:         cf.cond_br
+// CHECK:       aie.runtime_sequence @mixed
+// CHECK:         scf.for
+aie.device(npu1) {
+  %t02 = aie.tile(0, 2)
+  %t00 = aie.tile(0, 0)
+  %core = aie.core(%t02) {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c8 step %c1 {
+    }
+    aie.end
+  }
+  aie.runtime_sequence @mixed(%arg0: memref<8xi32>) {
+    %c0 = arith.constant 0 : index
+    %c8 = arith.constant 8 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c8 step %c1 {
+    }
+  }
+}

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -1557,8 +1557,12 @@ static LogicalResult runResourceAllocationPipeline(ModuleOp moduleOp,
 
   devicePm2.addPass(xilinx::AIE::createAIEVectorTransferLoweringPass());
 
-  // Step 5: Convert SCF to CF (module-level pass)
-  pm.addPass(createSCFToControlFlowPass());
+  // Step 5: Convert SCF to CF (module-level pass).
+  // Uses the runtime-sequence-aware lowering rather than the generic
+  // convert-scf-to-cf: scf inside an aie.runtime_sequence is left intact (it
+  // is NoTerminator and lowered to a flat NPU instruction stream by its own
+  // path), while core/host scf is lowered to cf as usual.
+  pm.addPass(xilinx::AIEX::createAIESCFToControlFlowPass());
 
   if (verbose) {
     llvm::outs() << "Running resource allocation pipeline in-memory "


### PR DESCRIPTION
## Summary

`aie.runtime_sequence` is `NoTerminator` and lowers to a flat NPU instruction stream that has no branches — the emitter just drops any `cf.br` / `cf.cond_br`. But the resource-allocation pipeline ran the generic `convert-scf-to-cf`, which also descends into runtime sequences. So lowering a runtime-sequence loop either crashes (`block with no terminator`) or silently miscompiles.
  
This never bit anyone because no existing IR put `scf` inside a runtime sequence — it surfaces the moment one contains a loop.
  
## Fix

New `aie-scf-to-control-flow` pass: lowers `scf` everywhere **except** inside a runtime sequence, used in place of `convert-scf-to-cf`. Runtime-sequence loops are left for their own lowering path.
  
For designs without runtime-sequence loops, the emitted NPU instructions are **byte-identical** to before (verified on `add_one_objFifo`) — it only differs where the old pass was wrong.
  
## Test plan
  
- [x] New unit test: core `scf`→`cf`, runtime-sequence `scf` preserved
- [x] `add_one_objFifo` compiles; NPU insts byte-identical to baseline
- [x] `lit test/Passes` + `lit test/aiecc` pass