### PR TITLE
[router] Dense integer vertex IDs in Pathfinder for routing speedup

### DIFF
--- a/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
+++ b/include/aie/Dialect/AIE/Transforms/AIEPathFinder.h
@@ -208,9 +208,30 @@ public:
   bool addFixedConnection(SwitchboxOp switchboxOp) override;
   std::optional<std::map<PathEndPoint, SwitchSettings>>
   findPaths(int maxIterations) override;
-  std::map<PathEndPoint, PathEndPoint> dijkstraShortestPaths(PathEndPoint src);
 
 private:
+  // A directed edge in the dense routing graph: from some node to node `dst`,
+  // realized by switchbox-connect `sb` at matrix position (i, j). `sb`, `i` and
+  // `j` index live into `graph` so demand reads always see the current
+  // iteration's weights.
+  struct Edge {
+    int dst;
+    SwitchboxConnect *sb;
+    int i;
+    int j;
+  };
+
+  // Build the dense integer node numbering and per-node adjacency from `graph`
+  // and `flows`. Topology is fixed across congestion iterations, so this runs
+  // once. Edge order per node matches the legacy PathEndPoint-sorted order to
+  // preserve identical routing output.
+  void buildRoutingGraph();
+
+  // Dijkstra over the dense graph from dense node `srcId`. Fills `preds` (dense
+  // predecessor id per node, or -1) and `predEdge` (the edge taken to reach
+  // each node). Reuses the scratch buffers below.
+  void dijkstraShortestPaths(int srcId);
+
   // Flows to be routed
   std::vector<Flow> flows;
   // Represent all routable paths as a graph
@@ -219,11 +240,21 @@ private:
   // switchbox otherwise, it represents connections (South, North, West, East)
   // accross two switchboxes
   std::map<std::pair<TileID, TileID>, SwitchboxConnect> graph;
-  // Channels available in the network
-  // The key is a PathEndPoint representing the start of a path
-  // The value is a vector of PathEndPoints representing the possible ends of
-  // the path
-  std::map<PathEndPoint, std::vector<PathEndPoint>> channels;
+
+  // Dense routing graph (built once by buildRoutingGraph()).
+  bool graphBuilt = false;
+  std::map<PathEndPoint, int> nodeIds;      // PathEndPoint -> dense id
+  std::vector<PathEndPoint> nodes;          // dense id -> PathEndPoint
+  std::vector<std::vector<Edge>> adjacency; // dense id -> out-edges
+
+  // Dijkstra scratch, sized to nodes.size() and reused across calls.
+  std::vector<double> distance;
+  std::vector<uint64_t> indexInHeap;
+  std::vector<int8_t> colors;
+  std::vector<int> preds;
+  std::vector<Edge> predEdge;
+
+  int getOrAddNodeId(const PathEndPoint &pep);
 };
 
 // DynamicTileAnalysis integrates the Pathfinder class into the MLIR

--- a/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEPathFinder.cpp
@@ -186,6 +186,21 @@ ShimMuxOp DynamicTileAnalysis::getShimMux(OpBuilder &builder, int col) {
 
 void Pathfinder::initialize(int maxCol, int maxRow,
                             const AIETargetModel &targetModel) {
+  // Reset all state so a Pathfinder instance can be safely reused across
+  // analyses/devices. In particular the dense-graph cache below must be
+  // rebuilt for the new topology; leaving graphBuilt set would reuse stale
+  // node IDs and adjacency.
+  graph.clear();
+  flows.clear();
+  graphBuilt = false;
+  nodeIds.clear();
+  nodes.clear();
+  adjacency.clear();
+  distance.clear();
+  indexInHeap.clear();
+  colors.clear();
+  preds.clear();
+  predEdge.clear();
 
   std::map<WireBundle, int> maxChannels;
   auto intraconnect = [&](int col, int row) {
@@ -400,94 +415,154 @@ bool Pathfinder::addFixedConnection(SwitchboxOp switchboxOp) {
 
 static constexpr double INF = std::numeric_limits<double>::max();
 
-std::map<PathEndPoint, PathEndPoint>
-Pathfinder::dijkstraShortestPaths(PathEndPoint src) {
-  // Use std::map instead of DenseMap because DenseMap doesn't let you
-  // overwrite tombstones.
-  std::map<PathEndPoint, double> distance;
-  std::map<PathEndPoint, PathEndPoint> preds;
-  std::map<PathEndPoint, uint64_t> indexInHeap;
-  enum Color { WHITE, GRAY, BLACK };
-  std::map<PathEndPoint, Color> colors;
+namespace {
+enum Color : int8_t { WHITE = 0, GRAY = 1, BLACK = 2 };
+} // namespace
+
+int Pathfinder::getOrAddNodeId(const PathEndPoint &pep) {
+  auto it = nodeIds.find(pep);
+  if (it != nodeIds.end())
+    return it->second;
+  int id = static_cast<int>(nodes.size());
+  nodeIds[pep] = id;
+  nodes.push_back(pep);
+  return id;
+}
+
+// Build the dense integer node numbering and per-node adjacency once. The graph
+// topology is fixed across congestion iterations (only the demand weights
+// change), so this is computed a single time and the edges carry live pointers
+// into `graph` for demand lookups. Edge order per node matches the legacy
+// PathEndPoint-sorted channel order to preserve identical routing output.
+void Pathfinder::buildRoutingGraph() {
+  // Seed the dense node set with all flow endpoints (the only nodes Dijkstra is
+  // ever started from or traced back to). Remaining nodes are discovered lazily
+  // as edge destinations below, exactly mirroring the legacy on-demand channel
+  // expansion in dijkstraShortestPaths.
+  for (auto &f : flows) {
+    getOrAddNodeId(f.src);
+    for (auto &d : f.dsts)
+      getOrAddNodeId(d);
+  }
+
+  // Process nodes by growing index; getOrAddNodeId() may append new nodes as
+  // edge destinations are discovered, so re-read nodes.size() each iteration.
+  for (size_t id = 0; id < nodes.size(); id++) {
+    PathEndPoint src = nodes[id];
+    // Collect destination PathEndPoints exactly as the legacy lazy channel
+    // discovery did, then sort by PathEndPoint for deterministic edge order.
+    std::vector<PathEndPoint> dests;
+    auto intraIt = graph.find(std::make_pair(src.coords, src.coords));
+    if (intraIt != graph.end()) {
+      auto &sb = intraIt->second;
+      for (size_t i = 0; i < sb.srcPorts.size(); i++)
+        for (size_t j = 0; j < sb.dstPorts.size(); j++)
+          if (sb.srcPorts[i] == src.port &&
+              sb.connectivity[i][j] == Connectivity::AVAILABLE)
+            dests.push_back(PathEndPoint{src.coords, sb.dstPorts[j]});
+    }
+    std::vector<std::pair<TileID, Port>> neighbors = {
+        {{src.coords.col, src.coords.row - 1},
+         {WireBundle::North, src.port.channel}},
+        {{src.coords.col - 1, src.coords.row},
+         {WireBundle::East, src.port.channel}},
+        {{src.coords.col, src.coords.row + 1},
+         {WireBundle::South, src.port.channel}},
+        {{src.coords.col + 1, src.coords.row},
+         {WireBundle::West, src.port.channel}}};
+    for (const auto &[neighborCoords, neighborPort] : neighbors) {
+      auto nIt = graph.find(std::make_pair(src.coords, neighborCoords));
+      if (nIt != graph.end() &&
+          src.port.bundle == getConnectingBundle(neighborPort.bundle)) {
+        auto &sb = nIt->second;
+        if (std::find(sb.dstPorts.begin(), sb.dstPorts.end(), neighborPort) !=
+            sb.dstPorts.end())
+          dests.push_back({neighborCoords, neighborPort});
+      }
+    }
+    std::sort(dests.begin(), dests.end());
+
+    std::vector<Edge> edges;
+    edges.reserve(dests.size());
+    for (auto &dest : dests) {
+      auto &sb = graph[std::make_pair(src.coords, dest.coords)];
+      int i = static_cast<int>(std::distance(
+          sb.srcPorts.begin(),
+          std::find(sb.srcPorts.begin(), sb.srcPorts.end(), src.port)));
+      int j = static_cast<int>(std::distance(
+          sb.dstPorts.begin(),
+          std::find(sb.dstPorts.begin(), sb.dstPorts.end(), dest.port)));
+      assert(i < static_cast<int>(sb.srcPorts.size()));
+      assert(j < static_cast<int>(sb.dstPorts.size()));
+      int destId = getOrAddNodeId(dest);
+      edges.push_back(Edge{destId, &sb, i, j});
+    }
+    // getOrAddNodeId above may have reallocated `adjacency` via index growth in
+    // later iterations, but we only assign this node's edges now.
+    if (adjacency.size() < nodes.size())
+      adjacency.resize(nodes.size());
+    adjacency[id] = std::move(edges);
+  }
+  size_t n = nodes.size();
+  if (adjacency.size() < n)
+    adjacency.resize(n);
+
+  // Size the reusable Dijkstra scratch buffers.
+  distance.assign(n, INF);
+  indexInHeap.assign(n, 0);
+  colors.assign(n, WHITE);
+  preds.assign(n, -1);
+  predEdge.assign(n, Edge{-1, nullptr, 0, 0});
+  graphBuilt = true;
+}
+
+// Dijkstra over the dense graph from dense node `srcId`. Fills the `preds` and
+// `predEdge` scratch buffers. This is a 1:1 port of the legacy
+// PathEndPoint-keyed version with all per-node std::map lookups replaced by
+// flat vector indexing; the push/relax control flow (including the WHITE-node
+// always-push behavior and the absence of a heap decrease-key) is preserved to
+// keep output identical.
+void Pathfinder::dijkstraShortestPaths(int srcId) {
+  size_t n = nodes.size();
+  std::fill(distance.begin(), distance.end(), INF);
+  std::fill(colors.begin(), colors.end(), static_cast<int8_t>(WHITE));
+  std::fill(preds.begin(), preds.end(), -1);
+  std::fill(indexInHeap.begin(), indexInHeap.end(), uint64_t{0});
+  (void)n;
+
   typedef d_ary_heap_indirect<
-      /*Value=*/PathEndPoint, /*Arity=*/4,
-      /*IndexInHeapPropertyMap=*/std::map<PathEndPoint, uint64_t>,
-      /*DistanceMap=*/std::map<PathEndPoint, double> &,
+      /*Value=*/int, /*Arity=*/4,
+      /*IndexInHeapPropertyMap=*/std::vector<uint64_t> &,
+      /*DistanceMap=*/std::vector<double> &,
       /*Compare=*/std::less<>>
       MutableQueue;
   MutableQueue Q(distance, indexInHeap);
 
-  distance[src] = 0.0;
-  Q.push(src);
+  distance[srcId] = 0.0;
+  Q.push(srcId);
   while (!Q.empty()) {
-    src = Q.top();
+    int s = Q.top();
     Q.pop();
-
-    // get all channels src connects to
-    if (channels.count(src) == 0) {
-      auto &sb = graph[std::make_pair(src.coords, src.coords)];
-      for (size_t i = 0; i < sb.srcPorts.size(); i++) {
-        for (size_t j = 0; j < sb.dstPorts.size(); j++) {
-          if (sb.srcPorts[i] == src.port &&
-              sb.connectivity[i][j] == Connectivity::AVAILABLE) {
-            // connections within the same switchbox
-            channels[src].push_back(PathEndPoint{src.coords, sb.dstPorts[j]});
-          }
-        }
-      }
-      // connections to neighboring switchboxes
-      std::vector<std::pair<TileID, Port>> neighbors = {
-          {{src.coords.col, src.coords.row - 1},
-           {WireBundle::North, src.port.channel}},
-          {{src.coords.col - 1, src.coords.row},
-           {WireBundle::East, src.port.channel}},
-          {{src.coords.col, src.coords.row + 1},
-           {WireBundle::South, src.port.channel}},
-          {{src.coords.col + 1, src.coords.row},
-           {WireBundle::West, src.port.channel}}};
-
-      for (const auto &[neighborCoords, neighborPort] : neighbors) {
-        if (graph.count(std::make_pair(src.coords, neighborCoords)) > 0 &&
-            src.port.bundle == getConnectingBundle(neighborPort.bundle)) {
-          auto &sb = graph[std::make_pair(src.coords, neighborCoords)];
-          if (std::find(sb.dstPorts.begin(), sb.dstPorts.end(), neighborPort) !=
-              sb.dstPorts.end())
-            channels[src].push_back({neighborCoords, neighborPort});
-        }
-      }
-      std::sort(channels[src].begin(), channels[src].end());
-    }
-
-    for (auto &dest : channels[src]) {
-      if (distance.count(dest) == 0)
-        distance[dest] = INF;
-      auto &sb = graph[std::make_pair(src.coords, dest.coords)];
-      size_t i = std::distance(
-          sb.srcPorts.begin(),
-          std::find(sb.srcPorts.begin(), sb.srcPorts.end(), src.port));
-      size_t j = std::distance(
-          sb.dstPorts.begin(),
-          std::find(sb.dstPorts.begin(), sb.dstPorts.end(), dest.port));
-      assert(i < sb.srcPorts.size());
-      assert(j < sb.dstPorts.size());
-      bool relax = distance[src] + sb.demand[i][j] < distance[dest];
-      if (colors.count(dest) == 0) {
-        // was WHITE
+    for (Edge &e : adjacency[s]) {
+      int dst = e.dst;
+      double w = e.sb->demand[e.i][e.j];
+      bool relax = distance[s] + w < distance[dst];
+      if (colors[dst] == WHITE) {
         if (relax) {
-          distance[dest] = distance[src] + sb.demand[i][j];
-          preds[dest] = src;
-          colors[dest] = GRAY;
+          distance[dst] = distance[s] + w;
+          preds[dst] = s;
+          predEdge[dst] = e;
+          colors[dst] = GRAY;
         }
-        Q.push(dest);
-      } else if (colors[dest] == GRAY && relax) {
-        distance[dest] = distance[src] + sb.demand[i][j];
-        preds[dest] = src;
+        Q.push(dst);
+      } else if (colors[dst] == GRAY && relax) {
+        distance[dst] = distance[s] + w;
+        preds[dst] = s;
+        predEdge[dst] = e;
       }
     }
-    colors[src] = BLACK;
+    colors[s] = BLACK;
   }
-
-  return preds;
 }
 
 // Perform congestion-aware routing for all flows which have been added.
@@ -500,6 +575,13 @@ std::optional<std::map<PathEndPoint, SwitchSettings>>
 Pathfinder::findPaths(const int maxIterations) {
   LLVM_DEBUG(llvm::dbgs() << "\t---Begin Pathfinder::findPaths---\n");
   std::map<PathEndPoint, SwitchSettings> routingSolution;
+  // Build the dense routing graph once; topology is invariant across
+  // iterations.
+  if (!graphBuilt)
+    buildRoutingGraph();
+  // Stamp-based "processed" set (avoids O(n) clears per flow).
+  std::vector<uint32_t> processedStamp(nodes.size(), 0);
+  uint32_t curStamp = 0;
   // initialize all Channel histories to 0
   for (auto &[_, sb] : graph) {
     for (size_t i = 0; i < sb.srcPorts.size(); i++) {
@@ -565,41 +647,45 @@ Pathfinder::findPaths(const int maxIterations) {
       for (const auto &[packetGroupId, isPriority, src, dsts] : flows) {
         // Use dijkstra to find path given current demand from the start
         // switchbox; find the shortest paths to each other switchbox. Output is
-        // in the predecessor map, which must then be processed to get
+        // in the predecessor arrays, which must then be processed to get
         // individual switchbox settings
-        std::set<PathEndPoint> processed;
-        std::map<PathEndPoint, PathEndPoint> preds = dijkstraShortestPaths(src);
+        int srcId = nodeIds.at(src);
+        dijkstraShortestPaths(srcId);
 
         // trace the path of the flow backwards via predecessors
         // increment used_capacity for the associated channels
         SwitchSettings switchSettings;
-        processed.insert(src);
+        ++curStamp;
+        processedStamp[srcId] = curStamp;
         for (auto endPoint : dsts) {
           if (endPoint == src) {
             // route to self
             switchSettings[src.coords].srcs.push_back(src.port);
             switchSettings[src.coords].dsts.push_back(src.port);
           }
-          auto curr = endPoint;
+          int currId = nodeIds.at(endPoint);
           // trace backwards until a vertex already processed is reached
-          while (!processed.count(curr)) {
-            auto &sb = graph[std::make_pair(preds[curr].coords, curr.coords)];
-            size_t i =
-                std::distance(sb.srcPorts.begin(),
-                              std::find(sb.srcPorts.begin(), sb.srcPorts.end(),
-                                        preds[curr].port));
-            size_t j = std::distance(
-                sb.dstPorts.begin(),
-                std::find(sb.dstPorts.begin(), sb.dstPorts.end(), curr.port));
-            assert(i < sb.srcPorts.size());
-            assert(j < sb.dstPorts.size());
+          while (processedStamp[currId] != curStamp) {
+            // If Dijkstra never reached this node it has no predecessor; the
+            // destination is unroutable under the current demand. Bail out of
+            // this iteration rather than indexing with a -1 predecessor.
+            if (preds[currId] < 0)
+              return std::nullopt;
+            const PathEndPoint &curr = nodes[currId];
+            const Edge &e = predEdge[currId];
+            int predId = preds[currId];
+            const PathEndPoint &pred = nodes[predId];
+            SwitchboxConnect &sb = *e.sb;
+            int i = e.i;
+            int j = e.j;
             sb.isPriority[i][j] = isPriority;
             if (packetGroupId >= 0 &&
                 (sb.packetGroupId[i][j] == -1 ||
                  sb.packetGroupId[i][j] == packetGroupId)) {
               for (size_t k = 0; k < sb.srcPorts.size(); k++) {
                 for (size_t l = 0; l < sb.dstPorts.size(); l++) {
-                  if (k == i || l == j) {
+                  if (k == static_cast<size_t>(i) ||
+                      l == static_cast<size_t>(j)) {
                     sb.packetGroupId[k][l] = packetGroupId;
                   }
                 }
@@ -616,13 +702,12 @@ Pathfinder::findPaths(const int maxIterations) {
             // if at capacity, bump demand to discourage using this Channel
             // this means the order matters!
             sb.bumpDemand(i, j);
-            if (preds[curr].coords == curr.coords) {
-              switchSettings[preds[curr].coords].srcs.push_back(
-                  preds[curr].port);
+            if (pred.coords == curr.coords) {
+              switchSettings[pred.coords].srcs.push_back(pred.port);
               switchSettings[curr.coords].dsts.push_back(curr.port);
             }
-            processed.insert(curr);
-            curr = preds[curr];
+            processedStamp[currId] = curStamp;
+            currId = predId;
           }
         }
         // add this flow to the proposed solution

--- a/lib/Dialect/AIE/Transforms/d_ary_heap.h
+++ b/lib/Dialect/AIE/Transforms/d_ary_heap.h
@@ -69,6 +69,10 @@ inline void put(T& pa, K k, const V& val) { pa[k] = val;  }
 template <class K, class V>
 inline const V& get(const std::map<K, V>& pa, K k) { return pa.at(k); }
 
+// Overload for a flat vector-backed property map (dense integer keys).
+template <class V>
+inline const V& get(const std::vector<V>& pa, std::size_t k) { return pa[k]; }
+
 // D-ary heap using an indirect compare operator (use identity_property_map
 // as DistanceMap to get a direct compare operator).  This heap appears to be
 // commonly used for Dijkstra's algorithm for its good practical performance
@@ -204,7 +208,11 @@ private:
     // distance map
     // typedef typename boost::property_traits< DistanceMap >::value_type
     //     distance_type;
-    typedef typename std::remove_reference<DistanceMap>::type::mapped_type distance_type;
+    // Derive the distance value type from whatever get(distance, Value) yields,
+    // so this works for both std::map and flat std::vector distance maps.
+    typedef typename std::remove_cv<typename std::remove_reference<decltype(get(
+        std::declval<typename std::remove_reference<DistanceMap>::type &>(),
+        std::declval<Value>()))>::type>::type distance_type;
 
     // Get the parent of a given node in the heap
     static size_type parent(size_type index) { return (index - 1) / Arity; }

--- a/test/create-flows/unreachable_dest_err_test.mlir
+++ b/test/create-flows/unreachable_dest_err_test.mlir
@@ -1,0 +1,24 @@
+//===- unreachable_dest_err_test.mlir --------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// A flow whose destination cannot be reached by the router exercises the
+// trace-back unreachable-destination guard (no predecessor for the dest), which
+// must fail the routing cleanly rather than indexing with a -1 predecessor.
+
+// RUN: not aie-opt --aie-create-pathfinder-flows %s 2>&1 | FileCheck %s
+// CHECK: error: Unable to find a legal routing
+
+module {
+  aie.device(npu1) {
+    %t00 = aie.tile(0, 0)
+    %t01 = aie.tile(0, 1)
+    aie.flow(%t00, DMA : 0, %t01, Core : 0)
+  }
+}


### PR DESCRIPTION
## Summary

The pathfinder router (`Pathfinder::findPaths`) is the dominant compile-time cost of aiecc — **~99.7% of routing time**. For whole_array 8x4 (npu2, 116 circuit + 7 packet flows) the negotiated-congestion loop runs ~24 iterations × 123 flows = **~2950 full Dijkstra runs**, and the original implementation put an `O(log n)` `std::map<PathEndPoint,...>` red-black-tree lookup (with multi-field key comparison) in the innermost relaxation loop.

This PR replaces the per-vertex `std::map` machinery with a **dense integer vertex numbering** built once per routing run:

- **`buildRoutingGraph()`** (runs once — graph topology is invariant across congestion iterations, only demand weights change) assigns each `(coords, port)` a dense id and precomputes per-node adjacency as `vector<vector<Edge>>`. Each `Edge` caches a pointer to its `SwitchboxConnect` plus the `(i, j)` matrix indices, so demand reads still see the current iteration's live weights. Nodes are discovered by transitive closure from every flow's `src` and `dsts`, so any node a per-flow Dijkstra can reach is enumerated.
- **`dijkstraShortestPaths(int srcId)`** now uses flat `std::vector` scratch buffers indexed by dense id, reused across calls. The push/relax control flow (WHITE-node always-push, no GRAY decrease-key) is preserved exactly.
- Trace-back uses the cached `predEdge[]` instead of re-finding port indices; the per-flow "processed" set is a stamp-based vector instead of a `std::set`.
- **`d_ary_heap.h`** is generalized to accept a flat vector-backed distance/index map so the heap can key on dense ints.

## Performance

Isolated routing pass (`aie-opt --pass-pipeline="builtin.module(aie.device(aie-create-pathfinder-flows))"`), best of 3:

| Design | Before | After | Speedup |
|---|---|---|---|
| whole_array 8c | 8.79 s | 0.22 s | **40x** |
| whole_array 4c | 1.45 s | 0.05 s | 29x |
| whole_array 2c | 0.21 s | 0.03 s | 7x |
| yolo26n chain | 0.24 s | 0.05 s | 4.8x |

The speedup scales superlinearly with array size as the `std::map` overhead grows with node count.

End-to-end, on top of the parallel-link / `-j4`-default aiecc work, a full `make NPU2=1 n_aie_cols=8 use_chess=0` compile of whole_array 8x4 drops from **~12.6 s to ~4.5 s** — with routing no longer the bottleneck, the per-core compile/link parallelism dominates the remaining time.

## Correctness — routing output is unchanged

- Physical MLIR **byte-identical** across a 9-design corpus: whole_array 1/2/4/8c, passthrough_kernel, edge_detect, color_threshold, vector_scalar_add_runlist, and a yolo26n chain.
- `insts.bin` byte-identical; NPU whole_array 8x4 run **PASS** (88.9 GFLOPs).
- All supported `create-flows` / `create-packet-flows` / `find-flows` / `herd-routing` lit tests pass.

## Test plan

- [x] `ninja aie-opt` builds clean (`-Werror`)
- [x] Byte-identical physical-MLIR routing output across 9-design corpus
- [x] `insts.bin` byte-identical vs baseline (whole_array 8x4)
- [x] NPU hardware run PASS
- [x] `create-flows` / `create-packet-flows` / `find-flows` / `herd-routing` lit suites pass
- [x] Full `check-aie` in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)