### PR TITLE
[aie_api] keep jgmelber fork, bump to 2026.1 + No ADF patch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 	branch = c-api-support
 [submodule "third_party/aie_api"]
 	path = third_party/aie_api
-	url = https://github.com/Xilinx/aie_api
+	url = https://github.com/jgmelber/aie_api


### PR DESCRIPTION
Stacked on top of #3169.

#3169 as opened drops the `jgmelber/aie_api` fork and moves the submodule to `Xilinx/aie_api` @ 2026.1 (`bec000f`), abandoning the local "No ADF headers" carry as dead code.

This PR instead **keeps the fork** and updates it:

- `jgmelber/aie_api` `main` force-updated to upstream 2026.1 (`bec000f`) + the "No ADF headers" patch reapplied → `2b7eedf`.
- `.gitmodules` url reverted to `https://github.com/jgmelber/aie_api`.
- submodule pointer bumped `bec000f` → `2b7eedf`.

The patch is still live against 2026.1: upstream `aie.hpp` still `#include`s `aie_adf.hpp` under `#ifdef __AIENGINE__`; the carry comments it out (single-line diff).