### PR TITLE
[aiecc] Default -j to 0 (auto-detect CPU count)

### DIFF
--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -138,7 +138,7 @@ jobs:
 
             ninja install
             # filter out slow tests (e.g. create-flows/vecmul_4x4_slow_test.mlir) due to timeout.
-            export LIT_OPTS="-sv --timeout 600 --filter-out slow_test"
+            export LIT_OPTS="-j2 -sv --timeout 600 --filter-out slow_test"
             ninja check-aie
 
             popd

--- a/test/aiecc/cpp_multi_core.mlir
+++ b/test/aiecc/cpp_multi_core.mlir
@@ -17,8 +17,8 @@
 // CHECK: Successfully parsed input file
 // CHECK: Device 'main' with 2 core(s)
 // CHECK: Compiling 2 core(s)
-// CHECK: Compiling core (0, 2)
-// CHECK: Compiling core (1, 2)
+// CHECK-DAG: Compiling core (0, 2)
+// CHECK-DAG: Compiling core (1, 2)
 // CHECK: Compilation completed successfully
 
 module {

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -407,8 +407,8 @@ static cl::opt<bool> keepLoc(
 static cl::opt<unsigned> numThreads(
     "j", cl::Prefix,
     cl::desc("Number of parallel threads for core compilation (0 = auto-detect "
-             "based on CPU count, default: 1 for sequential)"),
-    cl::init(1), cl::cat(aieCompilerOptions));
+             "based on CPU count, default: 4)"),
+    cl::init(4), cl::cat(aieCompilerOptions));
 
 static cl::alias numThreadsLong("nthreads", cl::desc("Alias for -j"),
                                 cl::aliasopt(numThreads),
@@ -2538,8 +2538,7 @@ static LogicalResult compileCore(MLIRContext &context, ModuleOp moduleOp,
     SmallString<128> chessHackPath(tmpDirName);
     sys::path::append(chessHackPath,
                       deviceName.str() + "_core_" + std::to_string(core.col) +
-                          "_" + std::to_string(core.col) + "_" +
-                          std::to_string(core.row) + ".chesshack.ll");
+                          "_" + std::to_string(core.row) + ".chesshack.ll");
     {
       std::error_code ec;
       raw_fd_ostream chessHackFile(chessHackPath, ec);

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -407,8 +407,8 @@ static cl::opt<bool> keepLoc(
 static cl::opt<unsigned> numThreads(
     "j", cl::Prefix,
     cl::desc("Number of parallel threads for core compilation (0 = auto-detect "
-             "based on CPU count, default: 4)"),
-    cl::init(4), cl::cat(aieCompilerOptions));
+             "based on CPU count, default: 0)"),
+    cl::init(0), cl::cat(aieCompilerOptions));
 
 static cl::alias numThreadsLong("nthreads", cl::desc("Alias for -j"),
                                 cl::aliasopt(numThreads),


### PR DESCRIPTION
## Summary

Default `aiecc`'s `-j` to **0** (auto-detect by CPU count, capped at the number of cores to compile), was `1`. The previous default meant core compilation ran fully sequentially for the common path, since IRON does not pass `-j`. `-j0` engages the existing parallel `compileCores` path and scales it to the host; `-j1` remains available for memory-constrained hosts, and any explicit `-jN` still wins.

This supersedes the earlier `-j4` proposal: a fixed 4 OOM-killed the "Build and Test with Ryzen AI Software" CI runner (2 cores / ~7 GB). Under `ninja check-aie`, lit's own worker pool multiplied by 4 per-core compiles per `aiecc` invocation starved the runner ("hosted runner lost communication"). Auto-detect keeps per-invocation parallelism proportional to the actual machine.

## Changes

1. **Default `-j` to 0** in `tools/aiecc/aiecc.cpp` (auto-detect via `hardware_concurrency()`, capped at core count).
2. **Fix a latent chesshack temp-filename collision** in `compileCore()`. The `.chesshack.ll` name was built from `col + "_" + col + "_" + row` (column twice, no distinct row slot), so two cores in the same column but different rows produced the same path and could clobber each other under concurrent compilation. Corrected to `col_row`, matching every other per-core artifact.
3. **`cpp_multi_core.mlir`**: the two per-core "Compiling core" lines now run in parallel and appear in non-deterministic order. Switched to `CHECK-DAG`.

## Test plan

- [x] Builds clean on the from-wheels toolchain
- [x] `-j0` verified to auto-detect and run parallel (`Compiling 2 core(s) in parallel (2 threads)`)
- [x] `test/aiecc/` lit suite passes locally (only unrelated `cpp_npu_and_xclbin` fails — needs `xclbinutil`, absent locally; passes in CI)
- [x] CI regression suite (incl. Ryzen AI Software runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)