### PR TITLE
[aie_api] Drop jgmelber fork; track stock Xilinx/aie_api

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 	branch = c-api-support
 [submodule "third_party/aie_api"]
 	path = third_party/aie_api
-	url = https://github.com/jgmelber/aie_api
+	url = https://github.com/Xilinx/aie_api

--- a/programming_examples/makefile-common
+++ b/programming_examples/makefile-common
@@ -13,6 +13,13 @@ devicename ?= $(if $(filter 1,$(NPU2)),npu2,npu)
 
 WARNING_FLAGS = -Wno-parentheses -Wno-attributes -Wno-macro-redefined -Wno-empty-body -Wno-missing-template-arg-list-after-template-kw
 
+# Pre-trip aie_api's aie_adf.hpp include guard so stock upstream aie_api never
+# pulls in <adf.h> (a Vitis-only header absent from Peano).  No mlir-aie kernel
+# uses adf:: symbols, so this only suppresses dead code and lets us track
+# unforked Xilinx/aie_api.  (The chess path gets the same define centrally in
+# tools/chess-clang/xchesscc_wrapper.)
+NO_ADF_FLAGS = -D__AIE_API_AIE_ADF_HPP__
+
 CHESSCC1_FLAGS = -f -p me -P ${AIE_INCLUDE_DIR} -I ${AIETOOLS_DIR}/include
 CHESSCC2_FLAGS = -f -p me -P ${AIE2_INCLUDE_DIR} -I ${AIETOOLS_DIR}/include
 CHESS_FLAGS = -P ${AIE_INCLUDE_DIR}
@@ -20,8 +27,8 @@ CHESS_FLAGS = -P ${AIE_INCLUDE_DIR}
 CHESSCCWRAP1_FLAGS = aie -I ${AIETOOLS_DIR}/include
 CHESSCCWRAP2_FLAGS = aie2 -I ${AIETOOLS_DIR}/include
 CHESSCCWRAP2P_FLAGS = aie2p -I ${AIETOOLS_DIR}/include
-PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_DIR}/include
-PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_DIR}/include
+PEANOWRAP2_FLAGS = -O2 -std=c++20 --target=aie2-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_DIR}/include ${NO_ADF_FLAGS}
+PEANOWRAP2P_FLAGS = -O2 -std=c++20 --target=aie2p-none-unknown-elf ${WARNING_FLAGS} -DNDEBUG -I ${MLIR_AIE_DIR}/include ${NO_ADF_FLAGS}
 
 TEST_POWERSHELL := $(shell command -v powershell.exe >/dev/null 2>&1 && echo yes || echo no)
 ifeq ($(TEST_POWERSHELL),yes)

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -112,6 +112,12 @@ def compile_cxx_core_function(
             "-Wno-empty-body",
             "-O2",
             "-DNDEBUG",
+            # Pre-trip aie_api's aie_adf.hpp include guard so stock upstream
+            # aie_api never pulls in <adf.h> (Vitis-only, absent from Peano).
+            # No mlir-aie kernel uses adf:: symbols, so this only elides dead
+            # code.  (The chess path gets the same define centrally in
+            # tools/chess-clang/xchesscc_wrapper.)
+            "-D__AIE_API_AIE_ADF_HPP__",
             f"--target={target_arch}-none-unknown-elf",
         ]
 

--- a/tools/chess-clang/xchesscc_wrapper
+++ b/tools/chess-clang/xchesscc_wrapper
@@ -50,4 +50,7 @@ LIBDIR=${AIETOOLS}/data/${AIETARGET}/lib
 INCDIR=${AIETOOLS}/include
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-xchesscc --aiearch ${AIEARCH} -p me -C Release_LLVM -D__AIENGINE__ $EXTRA_DEFS -I $INCDIR -P $LIBDIR -d -f $@
+# Pre-trip aie_api's aie_adf.hpp include guard so stock upstream aie_api never
+# pulls in <adf.h>.  No mlir-aie kernel uses adf:: symbols, so this only elides
+# dead code and lets us track unforked Xilinx/aie_api.
+xchesscc --aiearch ${AIEARCH} -p me -C Release_LLVM -D__AIENGINE__ -D__AIE_API_AIE_ADF_HPP__ $EXTRA_DEFS -I $INCDIR -P $LIBDIR -d -f $@

--- a/tools/chess-clang/xchesscc_wrapper
+++ b/tools/chess-clang/xchesscc_wrapper
@@ -28,17 +28,14 @@ if [ $TARGET != "AIE" -a $TARGET != "AIE2" -a $TARGET != "AIE2P" ]
 fi
 if [ $TARGET == "AIE" ]
   then
-    EXTRA_DEFS="-D__AIE_ARCH__=10 -D__AIEARCH__=10"
     AIEARCH=versal_prod
     AIETARGET=versal_prod
 elif [ $TARGET == "AIE2" ]
   then
-    EXTRA_DEFS="-D__AIE_ARCH__=20 -D__AIEARCH__=20"
     AIEARCH=aie2
     AIETARGET=aie_ml
 elif [ $TARGET == "AIE2P" ]
   then
-    EXTRA_DEFS="-D__AIE_ARCH__=21 -D__AIEARCH__=21"
     AIEARCH=aie2p
     AIETARGET=aie2p
 else
@@ -50,7 +47,11 @@ LIBDIR=${AIETOOLS}/data/${AIETARGET}/lib
 INCDIR=${AIETOOLS}/include
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-# Pre-trip aie_api's aie_adf.hpp include guard so stock upstream aie_api never
-# pulls in <adf.h>.  No mlir-aie kernel uses adf:: symbols, so this only elides
-# dead code and lets us track unforked Xilinx/aie_api.
-xchesscc --aiearch "${AIEARCH}" -p me -C Release_LLVM -D__AIENGINE__ -D__AIE_API_AIE_ADF_HPP__ $EXTRA_DEFS -I "${INCDIR}" -P "${LIBDIR}" -d -f "$@"
+# __AIENGINE__ selects the real (non-graph) aie_api implementation and is
+# required by upstream aie.hpp.  __AIE_ARCH__ (the arch selector aie_api reads)
+# is set intrinsically by `--aiearch`; the legacy explicit __AIEARCH__/__AIE_ARCH__
+# defines are unused and dropped.
+# -D__AIE_API_AIE_ADF_HPP__ pre-trips aie_api's aie_adf.hpp include guard so
+# stock upstream aie_api never pulls in <adf.h> (no mlir-aie kernel uses adf::
+# symbols); this lets us track unforked Xilinx/aie_api.
+xchesscc --aiearch "${AIEARCH}" -p me -C Release_LLVM -D__AIENGINE__ -D__AIE_API_AIE_ADF_HPP__ -I "${INCDIR}" -P "${LIBDIR}" -d -f "$@"

--- a/tools/chess-clang/xchesscc_wrapper
+++ b/tools/chess-clang/xchesscc_wrapper
@@ -53,4 +53,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Pre-trip aie_api's aie_adf.hpp include guard so stock upstream aie_api never
 # pulls in <adf.h>.  No mlir-aie kernel uses adf:: symbols, so this only elides
 # dead code and lets us track unforked Xilinx/aie_api.
-xchesscc --aiearch ${AIEARCH} -p me -C Release_LLVM -D__AIENGINE__ -D__AIE_API_AIE_ADF_HPP__ $EXTRA_DEFS -I $INCDIR -P $LIBDIR -d -f $@
+xchesscc --aiearch "${AIEARCH}" -p me -C Release_LLVM -D__AIENGINE__ -D__AIE_API_AIE_ADF_HPP__ $EXTRA_DEFS -I "${INCDIR}" -P "${LIBDIR}" -d -f "$@"


### PR DESCRIPTION
## Summary

Removes the need for the `jgmelber/aie_api` fork and moves the submodule to stock `Xilinx/aie_api` @ `bec000f` (2026.1).

**Root cause the fork worked around:** upstream `aie_api/aie.hpp` includes `aie_adf.hpp` — and thus the Vitis-only `<adf.h>` — under `#ifdef __AIENGINE__`. Peano's clang *unconditionally* defines `__AIENGINE__` (`Xilinx/llvm-aie` `clang/lib/Basic/Targets/AIE.cpp`), so compiling stock-upstream aie_api with Peano fails: `'adf.h' file not found`. The fork existed only to comment out that single include.

**Fix (no fork, no upstream/Peano edits):** pre-trip `aie_adf.hpp`'s own include guard by defining `-D__AIE_API_AIE_ADF_HPP__` on the kernel compile line, so the `#include "aie_adf.hpp"` becomes a no-op. Safe because **zero** mlir-aie kernels reference any `adf::` symbol — this only elides dead code.

Why not the obvious alternatives:
- `-U__AIENGINE__` breaks Peano's own base headers (`aiebase_typedefs.h` guards `cint16` on `__AIENGINE__`).
- Patching upstream `aie.hpp` or Peano was out of scope (keep the fix inside mlir-aie).

Applied at every kernel-compile site:
- `programming_examples/makefile-common` — `NO_ADF_FLAGS` on `PEANOWRAP2_FLAGS`/`PEANOWRAP2P_FLAGS`
- `python/utils/compile/utils.py` — Peano branch of the IRON JIT compile
- `tools/chess-clang/xchesscc_wrapper` — central chokepoint covering all chess builds (incl. test RUN lines)

This obsoletes #3260 (there's no fork left to bump).

## Test plan

- [x] Peano (`use_chess=0`): `passthrough_kernel` builds + runs **PASS!** on NPU2 (Strix) with stock upstream `bec000f` headers
- [x] Chess (`use_chess=1`): `passthrough_kernel` builds + runs **PASS!** on NPU2
- [x] Control: without the define, Peano fails with exactly `'adf.h' file not found`
- [x] Verified the guard macro `__AIE_API_AIE_ADF_HPP__` and the `#ifdef __AIENGINE__` include site both exist in `xilinx/main`'s (restructured) `aie.hpp`
- [x] CI regression suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)