### PR TITLE
ci: sync nanobind across wheel/test locks and guard against drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,12 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 6 8,22 * *"
+    # nanobind is held at 2.12.0: 2.13.0 rejects passing an OpResult where a
+    # Value is declared, breaking eudsl-python-extras' ArithValue path. Bumping
+    # requires a compatible eudsl/mlir-distro rebuild, so let dependabot skip it
+    # until that lands (revisit alongside the eudsl/llvm bump).
+    ignore:
+      - dependency-name: "nanobind"
     groups:
       pip-minor-patch:
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,37 +14,29 @@ updates:
       github-actions-major:
         update-types: ["major"]
 
+  # All pip manifests share a build toolchain (nanobind, pybind11, cmake,
+  # setuptools, numpy, ...). They live in one entry using the plural
+  # `directories` key so a bump to a shared dependency lands as a SINGLE
+  # cross-directory PR instead of independent per-directory PRs. Previously
+  # these were three separate entries; a per-directory bump moved one manifest
+  # and left the others behind, drifting nanobind out of ABI lockstep and
+  # breaking wheels at import time. One entry makes that divergence impossible
+  # by construction (the check_shared_dep_versions.py CI guard is the backstop
+  # for hand edits).
   - package-ecosystem: "pip"
-    directory: "/python"
+    directories:
+      - "/python"
+      - "/utils/mlir_wheels"
+      - "/utils/mlir_aie_wheels"
     schedule:
       interval: "cron"
       cronjob: "0 6 8,22 * *"
     groups:
-      python-minor-patch:
+      pip-minor-patch:
+        patterns: ["*"]
         update-types: ["minor", "patch"]
-      python-major:
-        update-types: ["major"]
-
-  - package-ecosystem: "pip"
-    directory: "/utils/mlir_aie_wheels"
-    schedule:
-      interval: "cron"
-      cronjob: "0 6 8,22 * *"
-    groups:
-      mlir-aie-wheels-minor-patch:
-        update-types: ["minor", "patch"]
-      mlir-aie-wheels-major:
-        update-types: ["major"]
-
-  - package-ecosystem: "pip"
-    directory: "/utils/mlir_wheels"
-    schedule:
-      interval: "cron"
-      cronjob: "0 6 8,22 * *"
-    groups:
-      mlir-wheels-minor-patch:
-        update-types: ["minor", "patch"]
-      mlir-wheels-major:
+      pip-major:
+        patterns: ["*"]
         update-types: ["major"]
 
   - package-ecosystem: "pre-commit"

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -65,6 +65,14 @@ jobs:
           level: error
           fail_level: any
 
+      # Cross-lock check: the regen above proves each lock matches its own
+      # source, but not that shared ABI-coupled deps (nanobind, pybind11, ...)
+      # resolve to the SAME version across locks. A per-directory Dependabot
+      # bump that moves one manifest and not another passes regen but breaks
+      # the wheel at import time; this guard turns that into a fast failure.
+      - name: Check shared dependency versions agree
+        run: python3 utils/check_shared_dep_versions.py
+
   clang-tidy-pylint:
 
     name: Python and C/C++ Lint
@@ -414,11 +422,11 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-path: /home/runner/work/mlir-aie/mlir-aie/build_release/report/index.html
           edit-mode: replace
-  
+
   license-compliance:
     name: License Compliance Check
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -440,4 +448,3 @@ jobs:
 
       - name: Check copyright notice format
         run: python utils/check_copyright_format.py
-  

--- a/python/requirements_dev.lock
+++ b/python/requirements_dev.lock
@@ -568,9 +568,9 @@ mypy-extensions==1.1.0 \
     --hash=sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505 \
     --hash=sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558
     # via black
-nanobind==2.12.0 \
-    --hash=sha256:0ae77c1a88f27153fa57045ee00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee \
-    --hash=sha256:a10d3d88e691dcdf22696f9acd893fda3c5a05635763aea238829d274fcad480
+nanobind==2.13.0 \
+    --hash=sha256:9268d7201eaf5519ae61b7a83175f2af77088cb4b99dd3ce5b00550f697da7b7 \
+    --hash=sha256:c7b04d6a6a4cd57985571e605539399b51331ae455d7fce576a5e2fcb89b1dcf
     # via -r requirements_dev.txt
 ninja==1.11.1.4 \
     --hash=sha256:055f386fb550c2c9d6157e45e20a84d29c47968876b9c5794ae2aec46f952306 \

--- a/python/requirements_dev.lock
+++ b/python/requirements_dev.lock
@@ -568,9 +568,9 @@ mypy-extensions==1.1.0 \
     --hash=sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505 \
     --hash=sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558
     # via black
-nanobind==2.13.0 \
-    --hash=sha256:9268d7201eaf5519ae61b7a83175f2af77088cb4b99dd3ce5b00550f697da7b7 \
-    --hash=sha256:c7b04d6a6a4cd57985571e605539399b51331ae455d7fce576a5e2fcb89b1dcf
+nanobind==2.12.0 \
+    --hash=sha256:0ae77c1a88f27153fa57045ee00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee \
+    --hash=sha256:a10d3d88e691dcdf22696f9acd893fda3c5a05635763aea238829d274fcad480
     # via -r requirements_dev.txt
 ninja==1.11.1.4 \
     --hash=sha256:055f386fb550c2c9d6157e45e20a84d29c47968876b9c5794ae2aec46f952306 \

--- a/python/requirements_dev.txt
+++ b/python/requirements_dev.txt
@@ -14,10 +14,13 @@ patchelf; platform_system == "Linux"
 pre-commit>=4.6.0,<5.0
 black[jupyter]
 pyright
-# nanobind ABI-couples to the prebuilt mlir distro wheel (built against this
-# same version); a mismatch breaks Value-subclass recognition at runtime. Pin
-# exact and bump only alongside a distro rebuild.
-nanobind==2.12.0
+# nanobind ABI-couples to the prebuilt mlir distro wheel (built against the
+# same version); a mismatch breaks Value-subclass recognition at runtime. Keep
+# this constraint identical to utils/mlir_wheels/requirements.in and
+# utils/mlir_aie_wheels/requirements.txt — the abi-deps CI guard
+# (utils/check_shared_dep_versions.py) fails the build if the resolved versions
+# diverge across those locks.
+nanobind>=2.13.0
 lit
 matplotlib
 psutil

--- a/python/requirements_dev.txt
+++ b/python/requirements_dev.txt
@@ -19,8 +19,10 @@ pyright
 # this constraint identical to utils/mlir_wheels/requirements.in and
 # utils/mlir_aie_wheels/requirements.txt — the abi-deps CI guard
 # (utils/check_shared_dep_versions.py) fails the build if the resolved versions
-# diverge across those locks.
-nanobind>=2.13.0
+# diverge across those locks. Pinned at 2.12.0: 2.13.0 rejects passing an
+# OpResult where a Value is declared, breaking eudsl-python-extras' ArithValue
+# path. Bump only alongside a compatible eudsl/distro rebuild.
+nanobind==2.12.0
 lit
 matplotlib
 psutil

--- a/utils/check_shared_dep_versions.py
+++ b/utils/check_shared_dep_versions.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Assert that ABI-coupled build dependencies resolve to the SAME version across
+every lockfile that feeds a wheel build or its runtime/test environment.
+
+The lockfiles guard (utils/regenerate_lockfiles.sh + the lintAndFormat
+"Lockfiles match inputs" job) only proves each .lock is internally consistent
+with its own source manifest. It does NOT catch the case where two manifests
+pin the same package with different constraints so their locks resolve to
+different versions -- e.g. requirements_dev.txt at nanobind==2.12.0 while the
+wheel is built against nanobind>=2.13.0. That mismatch breaks nanobind's
+Value-subclass recognition at import time and only surfaces on a hardware smoke
+test. This checker makes that divergence a fast, obvious CI failure instead.
+
+Packages listed in SHARED_PACKAGES must resolve identically in ALL locks in
+which they appear. A package absent from a given lock is fine (not every env
+needs every build tool); the constraint is only that where it IS present, the
+version agrees.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Lockfiles that must agree on the shared build/ABI dependencies below. These
+# are the hash-pinned outputs of utils/regenerate_lockfiles.sh that install
+# into either a wheel build (mlir_wheels, mlir_aie_wheels) or the runtime/test
+# environment that loads the resulting extension modules (requirements_dev).
+LOCKFILES = [
+    "python/requirements_dev.lock",
+    "utils/mlir_wheels/requirements.lock",
+    "utils/mlir_aie_wheels/requirements.lock",
+]
+
+# Packages whose version must match across every lock they appear in. nanobind
+# and pybind11 compile C-extension ABI into the wheel and must match the
+# environment that imports it; the rest are the shared build toolchain, kept in
+# lockstep so a Dependabot bump can't move one lock and leave another behind.
+SHARED_PACKAGES = [
+    "nanobind",
+    "pybind11",
+    "cmake",
+    "setuptools",
+    "numpy",
+]
+
+# Matches a top-of-entry pin line in a uv/pip-compile lock, e.g.
+#   nanobind==2.13.0 \
+#   ninja==1.11.1.4 ; sys_platform == 'win32' \
+# Captures the package name and the exact version. Continuation/hash lines are
+# indented, so anchoring at column 0 avoids matching "# via nanobind" comments.
+_PIN_RE = re.compile(r"^(?P<name>[A-Za-z0-9._-]+)==(?P<version>[^\s;\\]+)")
+
+
+def _normalize(name):
+    # PEP 503 name normalization so "pybind11[global]" / underscores / case all
+    # compare equal.
+    name = name.split("[", 1)[0]
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def parse_lock(path):
+    """Return {normalized_name: version} for the pinned entries in a lockfile."""
+    versions = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        m = _PIN_RE.match(line)
+        if m:
+            versions[_normalize(m.group("name"))] = m.group("version")
+    return versions
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent
+
+    parsed = {}
+    missing = []
+    for rel in LOCKFILES:
+        path = repo_root / rel
+        if not path.is_file():
+            missing.append(rel)
+            continue
+        parsed[rel] = parse_lock(path)
+
+    if missing:
+        print("error: lockfile(s) not found:", file=sys.stderr)
+        for rel in missing:
+            print(f"  {rel}", file=sys.stderr)
+        return 1
+
+    failures = []
+    for pkg in SHARED_PACKAGES:
+        key = _normalize(pkg)
+        # {version: [locks that resolved to it]}
+        seen = {}
+        for rel, versions in parsed.items():
+            if key in versions:
+                seen.setdefault(versions[key], []).append(rel)
+        if len(seen) > 1:
+            failures.append((pkg, seen))
+
+    if failures:
+        print(
+            "error: ABI-coupled dependencies diverge across lockfiles.\n"
+            "These packages must resolve to the same version in every lock; a\n"
+            "mismatch means a wheel is built against one version but imported\n"
+            "under another. Align the constraints in the source manifests and\n"
+            "rerun utils/regenerate_lockfiles.sh.\n",
+            file=sys.stderr,
+        )
+        for pkg, seen in failures:
+            print(f"  {pkg}:", file=sys.stderr)
+            for version, locks in sorted(seen.items()):
+                for rel in locks:
+                    print(f"    {version:<16} {rel}", file=sys.stderr)
+        return 1
+
+    checked = ", ".join(SHARED_PACKAGES)
+    print(f"shared dependency versions agree across all lockfiles ({checked})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/mlir_aie_wheels/requirements.lock
+++ b/utils/mlir_aie_wheels/requirements.lock
@@ -33,9 +33,9 @@ mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via markdown-it-py
-nanobind==2.13.0 \
-    --hash=sha256:9268d7201eaf5519ae61b7a83175f2af77088cb4b99dd3ce5b00550f697da7b7 \
-    --hash=sha256:c7b04d6a6a4cd57985571e605539399b51331ae455d7fce576a5e2fcb89b1dcf
+nanobind==2.12.0 \
+    --hash=sha256:0ae77c1a88f27153fa57045ee00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee \
+    --hash=sha256:a10d3d88e691dcdf22696f9acd893fda3c5a05635763aea238829d274fcad480
     # via -r requirements.txt
 ninja==1.11.1.4 ; sys_platform == 'win32' \
     --hash=sha256:055f386fb550c2c9d6157e45e20a84d29c47968876b9c5794ae2aec46f952306 \

--- a/utils/mlir_aie_wheels/requirements.txt
+++ b/utils/mlir_aie_wheels/requirements.txt
@@ -1,7 +1,7 @@
 # Source for utils/mlir_aie_wheels/requirements.lock (hash-pinned, installed by
 # cibuildwheel before-build). After editing this file, regenerate the .lock with:
 #   utils/regenerate_lockfiles.sh
-cmake>=4.3.4
+cmake>=4.3.4, <5.0
 importlib-metadata
 ninja!=1.13.0; platform_system=="Windows"
 numpy>=2.4.6

--- a/utils/mlir_aie_wheels/requirements.txt
+++ b/utils/mlir_aie_wheels/requirements.txt
@@ -10,4 +10,4 @@ pybind11[global]>=3.0.4
 rich
 setuptools>=82.0.1
 wheel
-nanobind>=2.13.0
+nanobind==2.12.0

--- a/utils/mlir_wheels/requirements.in
+++ b/utils/mlir_wheels/requirements.in
@@ -16,4 +16,4 @@ numpy>=2.4.6
 # mlir-native-tools is intentionally NOT hash-pinned here: it lives on an
 # internal index reached via PIP_FIND_LINKS at build time, not on PyPI, so
 # pip-compile can't resolve it. mlirDistro.yml installs it separately.
-nanobind>=2.13.0
+nanobind==2.12.0

--- a/utils/mlir_wheels/requirements.lock
+++ b/utils/mlir_wheels/requirements.lock
@@ -21,9 +21,9 @@ cmake==4.3.4 \
     --hash=sha256:ec21974344e7073dea495a961645316dc51bc7d38a8d8f29b0e19e4930d11f65 \
     --hash=sha256:fd2a9894a9aa798674a273d1e230b5ba9d1ab855d437ad86bf52f1cef29271b7
     # via -r requirements.in
-nanobind==2.13.0 \
-    --hash=sha256:9268d7201eaf5519ae61b7a83175f2af77088cb4b99dd3ce5b00550f697da7b7 \
-    --hash=sha256:c7b04d6a6a4cd57985571e605539399b51331ae455d7fce576a5e2fcb89b1dcf
+nanobind==2.12.0 \
+    --hash=sha256:0ae77c1a88f27153fa57045ee00f7b0a7b06b1cd3df942e95a34b38c5d0a5bee \
+    --hash=sha256:a10d3d88e691dcdf22696f9acd893fda3c5a05635763aea238829d274fcad480
     # via -r requirements.in
 ninja==1.11.1.4 \
     --hash=sha256:055f386fb550c2c9d6157e45e20a84d29c47968876b9c5794ae2aec46f952306 \


### PR DESCRIPTION
Pin nanobind to 2.12, as 2.13 doesn't seem compatible with the eudsl version we are using currently.

To guard against further version drift:
- Collapse the three pip Dependabot entries into one multi-directory entry so a shared-dependency bump lands as a single cross-directory PR and can't drift.
- Add utils/check_shared_dep_versions.py (wired into the lockfiles CI job) to assert ABI-coupled deps resolve to the same version across all locks.
- Align mlir_aie_wheels cmake upper bound with the dev manifest.