### PR TITLE
Revert "Update nanobind requirement from >=2.12.0 to >=2.13.0 in /utils/mlir_wheels"

### DIFF
--- a/utils/mlir_wheels/requirements.in
+++ b/utils/mlir_wheels/requirements.in
@@ -16,4 +16,4 @@ numpy>=2.4.6
 # mlir-native-tools is intentionally NOT hash-pinned here: it lives on an
 # internal index reached via PIP_FIND_LINKS at build time, not on PyPI, so
 # pip-compile can't resolve it. mlirDistro.yml installs it separately.
-nanobind>=2.13.0
+nanobind>=2.12.0


### PR DESCRIPTION
Reverts Xilinx/mlir-aie#3202

Use nanobind <= 2.12 for compatibility with eudsl for now.