### PR TITLE
ci: run RyzenAI SW lit tests serially (-j2 -> -j1)

### DIFF
--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -141,7 +141,7 @@ jobs:
 
             ninja install
             # filter out slow tests (e.g. create-flows/vecmul_4x4_slow_test.mlir) due to timeout.
-            export LIT_OPTS="-j2 -sv --timeout 600 --filter-out slow_test"
+            export LIT_OPTS="-j1 -sv --timeout 600 --filter-out slow_test"
             ninja check-aie
 
             popd


### PR DESCRIPTION
## Summary
- The **Build and Test with Ryzen AI Software** job (`buildAndTestRyzenAISw.yml`) runs on GitHub-hosted `ubuntu-latest` (4 vCPU / 16 GB RAM). With the Ryzen AI SW stack installed, the lit suite includes `xchesscc` tests that each peak at several GB RSS.
- Even at `-j2` these overlap and starve the runner for memory, producing the recurring **"The hosted runner lost communication with the server"** failures on `main`. The runner is OOM-killed before it can upload logs (the log blob comes back `404 BlobNotFound`).
- This drops the lit parallelism to `-j1` so `xchesscc` invocations never overlap, trading wall-clock time for reliability on the memory-constrained hosted runner.

## Diagnosis
Recent red runs on `main` for this workflow show the runner-lost-communication annotation, and the ubuntu22/ubuntu24 matrix legs fail on *alternating* runs — a signature of host resource exhaustion rather than a source regression. The build and compilation steps always succeed; only the test execution phase dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)