### PR TITLE
ci: scope pre-push license hooks to the pushed files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,28 +81,27 @@ repos:
       files: ^(python/requirements_dev\.txt|utils/mlir_(aie_)?wheels/(requirements|ci-tools)\.(in|txt))$
 
     # REUSE compliance: every file must have a license/copyright notice (either
-    # inline or declared in REUSE.toml). Scans the whole repo, so it does not
-    # take filenames. Runs before check-copyright-format, which then validates
-    # the notice wording.
+    # inline or declared in REUSE.toml). Scoped to the files being pushed via
+    # `reuse lint-file` so an unrelated dirty working tree doesn't block a push;
+    # the authoritative whole-repo `reuse lint` still runs in CI. Runs before
+    # check-copyright-format, which then validates the notice wording.
     - id: reuse-lint
       name: Check REUSE compliance
       language: python
-      entry: reuse lint
+      entry: reuse lint-file
       additional_dependencies: ['reuse[charset-normalizer]==6.2.0']
-      pass_filenames: false
-      always_run: true
+      pass_filenames: true
       stages: [pre-push]
 
     # Format gate on top of REUSE: every copyright notice must match an approved
     # canonical form (see utils/check_copyright_format.py). REUSE only checks that
     # a notice exists, not how it is written, so this catches stray commas, the
-    # "AMD Inc." shorthand, "(c) Copyright" ordering, etc. Scans the whole repo
-    # via `reuse lint`, so it does not take filenames.
+    # "AMD Inc." shorthand, "(c) Copyright" ordering, etc. Scoped to the pushed
+    # files here; the script scans the whole repo when invoked with no args (CI).
     - id: check-copyright-format
       name: Check copyright notice format
       language: python
       entry: python utils/check_copyright_format.py
       additional_dependencies: ['reuse[charset-normalizer]==6.2.0']
-      pass_filenames: false
-      always_run: true
+      pass_filenames: true
       stages: [pre-push]

--- a/utils/check_copyright_format.py
+++ b/utils/check_copyright_format.py
@@ -16,6 +16,7 @@ preserved verbatim.
 Usage:
 
     python utils/check_copyright_format.py            # check the whole repo
+    python utils/check_copyright_format.py FILE...     # check only the given files
     python utils/check_copyright_format.py --list     # also print every notice
 
 Note: the trigger tokens below are assembled from fragments on purpose, so that
@@ -154,18 +155,40 @@ def tracked_files() -> list[str]:
     return [rec.get("path", "").lstrip("./") for rec in data.get("files", [])]
 
 
-def collect_notices() -> dict[str, list[str]]:
-    """Return {raw notice line: [sources]} from inline headers + REUSE.toml."""
+def _to_repo_relative(paths: list[str]) -> list[str]:
+    """Normalize caller-supplied paths to repo-relative POSIX strings."""
+    rels = []
+    for p in paths:
+        try:
+            rels.append(str(Path(p).resolve().relative_to(REPO_ROOT)))
+        except ValueError:
+            # Outside the repo: keep as-is; the header read will simply skip it.
+            rels.append(p)
+    return rels
+
+
+def collect_notices(files: list[str] | None = None) -> dict[str, list[str]]:
+    """Return {raw notice line: [sources]} from inline headers + REUSE.toml.
+
+    When ``files`` is given, only those files are scanned (used by the file-scoped
+    pre-push hook). When it is empty/None, the whole repo is scanned via
+    ``tracked_files()`` (used by CI and ``--list``). REUSE.toml-declared notices
+    are only folded in for the whole-repo scan, since they are not attributable to
+    any single pushed file.
+    """
     overrides, declared = load_reuse_toml()
     notices: dict[str, list[str]] = defaultdict(list)
 
-    # Notices declared inside REUSE.toml (binary files, third-party, proprietary).
-    for value in declared:
-        notices[value].append("REUSE.toml")
+    scoped = bool(files)
+    if not scoped:
+        # Notices declared inside REUSE.toml (binary files, third-party, proprietary).
+        for value in declared:
+            notices[value].append("REUSE.toml")
 
     self_rel = str(Path(__file__).resolve().relative_to(REPO_ROOT))
     skip_exact = {"REUSE.toml", self_rel}
-    for rel in tracked_files():
+    candidates = _to_repo_relative(files) if scoped else tracked_files()
+    for rel in candidates:
         if rel in skip_exact or rel.startswith("LICENSES/"):
             continue
         if any(rx.match(rel) for rx in overrides):
@@ -190,7 +213,8 @@ def collect_notices() -> dict[str, list[str]]:
 
 def main(argv: list[str]) -> int:
     show_all = "--list" in argv
-    notices = collect_notices()
+    files = [a for a in argv if not a.startswith("-")]
+    notices = collect_notices(files)
 
     first_party = {n: f for n, f in notices.items() if is_first_party(n)}
     violations = {n: f for n, f in first_party.items() if not is_approved(n)}

--- a/utils/check_copyright_format.py
+++ b/utils/check_copyright_format.py
@@ -156,14 +156,19 @@ def tracked_files() -> list[str]:
 
 
 def _to_repo_relative(paths: list[str]) -> list[str]:
-    """Normalize caller-supplied paths to repo-relative POSIX strings."""
+    """Return the in-repo paths as repo-relative POSIX strings.
+
+    Paths outside the repository are dropped, so file-scoped scanning can never
+    open arbitrary files off disk (e.g. when invoked with an absolute path);
+    only files under REPO_ROOT are ever scanned. ``as_posix()`` keeps the
+    separators consistent with ``tracked_files()`` on every platform.
+    """
     rels = []
     for p in paths:
         try:
-            rels.append(str(Path(p).resolve().relative_to(REPO_ROOT)))
+            rels.append(Path(p).resolve().relative_to(REPO_ROOT).as_posix())
         except ValueError:
-            # Outside the repo: keep as-is; the header read will simply skip it.
-            rels.append(p)
+            continue  # outside the repo: never scan
     return rels
 
 


### PR DESCRIPTION
## Summary
The `reuse-lint` and `check-copyright-format` **pre-push** hooks scanned the entire working tree (`reuse lint`, `pass_filenames: false`, `always_run: true`). Any unrelated untracked file or dirty submodule in a developer's tree therefore blocked an otherwise-clean push with license violations the commit never touched (this happened on #3284, forcing a throwaway-worktree workaround).

This scopes both pre-push hooks to the files actually being pushed:
- `reuse-lint` now runs `reuse lint-file` with `pass_filenames: true` (the pinned `reuse==6.2.0` supports `lint-file`).
- `utils/check_copyright_format.py` accepts optional positional file paths and scans only those; **with no args it still scans the whole repo**, so the authoritative CI check (`lintAndFormat.yml`, which calls `reuse lint` and `check_copyright_format.py` with no args) is unchanged and `main` stays fully protected.

`REUSE.toml`-declared notices are only folded in for the whole-repo scan, since they aren't attributable to any single pushed file.

## Why not just exclude `.codex/` etc.
An `exclude:` allowlist only patches today's stray dirs; the next tool's dot-dir re-breaks it. File-scoping fixes the whole class of "unrelated dirty tree blocks my push" problem while keeping the fast local pre-flight.

## Test plan
- [x] `check_copyright_format.py FILE` (compliant) → passes; `check_copyright_format.py` (no args) → still scans whole repo (CI parity).
- [x] `check_copyright_format.py <non-compliant file>` → fails, catches `AMD` shorthand.
- [x] `pre-commit run reuse-lint --hook-stage pre-push --files <compliant>` → Passed, ignores stray untracked files in the tree.
- [x] `pre-commit run reuse-lint --hook-stage pre-push --files <non-compliant>` → Failed (in-scope violations still caught).
- [x] Real `git push` with the pre-push hooks active passed against only the pushed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)