### PR TITLE
ci: drop merge_group trigger from Ryzen AI wheel builds

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -40,7 +40,6 @@ on:
   push:
     tags:
       - 'v*.*.*'
-  merge_group:
   schedule:
     # At 04:00. (see https://crontab.guru)
     - cron: '0 4 * * *'
@@ -50,9 +49,9 @@ defaults:
     shell: bash
 
 concurrency:
-  # A PR number if a pull request and otherwise the commit hash. This cancels
-  # queued and in-progress runs for the same PR (presubmit) or commit
-  # (postsubmit).
+  # A PR number if a pull request and otherwise the commit hash (tag pushes,
+  # schedule, manual dispatch). This cancels queued and in-progress runs for
+  # the same PR or ref.
   group: ci-build-test-ryzenai-experimental-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
@@ -614,11 +613,11 @@ jobs:
           makeLatest: ${{ !(contains(github.ref_name, 'rc') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta')) }}
 
       - name: Release latest wheels (RTTI ON)
-        # Only publish from events that represent main (merge queue) or an
-        # intentional refresh. Excludes pull_request so PRs no longer overwrite
-        # the shared rolling tag with unmerged branch content; excludes reusable
-        # calls so the test workflow never republishes.
-        if: ${{ !inputs.reusable_call && contains(fromJSON('["merge_group","schedule","workflow_dispatch"]'), github.event_name) }}
+        # Only publish from the nightly schedule or an intentional manual
+        # refresh. Excludes pull_request so PRs no longer overwrite the shared
+        # rolling tag with unmerged branch content; excludes reusable calls so
+        # the test workflow never republishes.
+        if: ${{ !inputs.reusable_call && contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) }}
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           artifacts: wheels_on_flat/mlir_aie*whl
@@ -631,7 +630,7 @@ jobs:
           makeLatest: false
 
       - name: Release latest wheels (RTTI OFF)
-        if: ${{ !inputs.reusable_call && contains(fromJSON('["merge_group","schedule","workflow_dispatch"]'), github.event_name) }}
+        if: ${{ !inputs.reusable_call && contains(fromJSON('["schedule","workflow_dispatch"]'), github.event_name) }}
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd  # v1.21.0
         with:
           artifacts: wheels_off_flat/mlir_aie*whl


### PR DESCRIPTION
## Summary

`main` shows a red ✗ even though all tests and required checks pass. The cause is the **`Build wheels for Ryzen AI`** workflow (`.github/workflows/buildRyzenWheels.yml`):

- It triggers on `merge_group` with `concurrency: cancel-in-progress: true`.
- When a merge-queue run is superseded, its in-flight wheel jobs are **cancelled** mid-build.
- GitHub attaches those `cancelled` check-runs to the `main` HEAD sha and treats `cancelled` as non-success, so the commit renders with a ✗.

On the current `main` HEAD (`04a172cc4dd4`), 57 checks are `success` and the only non-green results are **11 `cancelled`** wheel jobs — all from this workflow, none of them test failures. None of the wheel jobs are required status checks (verified against branch protection), so dropping the `merge_group` trigger does not affect the merge queue.

## Changes

- Remove the `merge_group:` trigger from `buildRyzenWheels.yml`. Wheels still build on `pull_request`, tag pushes (`v*.*.*`), the nightly `schedule`, and `workflow_dispatch`.
- Update the two "Release latest wheels" publish steps: they previously used `merge_group` as the "represents main" signal for refreshing the rolling `latest-wheels-*` tags. That refresh now happens via the nightly `schedule` (and manual dispatch), so the `merge_group` entry is removed from their `if:` conditions.
- Refresh the now-stale concurrency and publish-step comments.

## Test plan

- [ ] Confirm the wheel workflow no longer runs on `merge_group` (no cancelled wheel check-runs land on `main` after merge).
- [ ] Confirm the nightly scheduled run still builds and publishes the `latest-wheels-*` rolling tags.
- [ ] Confirm PR-triggered wheel builds still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)