### PR TITLE
[dyn-seq P1.4] Static-vs-dynamic TXN equivalence harness

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -340,6 +340,14 @@ struct AIEDMATasksToNPUPass
 
     uint32_t bd_id = bd_op.getBdId().value();
     int64_t offset = bd_op.getOffsetInBytes();
+    // A runtime len operand would be silently baked to the buffer's element
+    // count by getLenInBytes(); reject it on the static path (as sizes/strides
+    // are below) rather than encode a wrong length.
+    if (bd_op.getLen() && !bd_op.getConstantLen())
+      return bd_op->emitOpError(
+          "runtime-valued BD len is not supported on the static NPU "
+          "lowering path; use a compile-time constant or the dynamic EmitC "
+          "path (--aie-npu-to-cpp)");
     uint64_t len = bd_op.getLenInBytes();
     uint64_t len_addr_granularity = len * 8 / addr_granularity;
 

--- a/test/Targets/NPU/static_vs_dynamic/Inputs/compare_main.cpp
+++ b/test/Targets/NPU/static_vs_dynamic/Inputs/compare_main.cpp
@@ -64,10 +64,9 @@ bool equal(const char *aName, const std::vector<uint32_t> &a, const char *bName,
   size_t lim = a.size() < b.size() ? a.size() : b.size();
   for (size_t i = 0; i < lim; ++i) {
     if (a[i] != b[i]) {
-      std::fprintf(stderr,
-                   "%s vs %s differ at word %zu: 0x%08llx vs 0x%08llx\n",
-                   aName, bName, i, (unsigned long long)a[i],
-                   (unsigned long long)b[i]);
+      std::fprintf(
+          stderr, "%s vs %s differ at word %zu: 0x%08llx vs 0x%08llx\n", aName,
+          bName, i, (unsigned long long)a[i], (unsigned long long)b[i]);
       return false;
     }
   }

--- a/test/Targets/NPU/static_vs_dynamic/Inputs/compare_main.cpp
+++ b/test/Targets/NPU/static_vs_dynamic/Inputs/compare_main.cpp
@@ -1,0 +1,102 @@
+//===- compare_main.cpp ----------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Three-way TXN equivalence harness for the static-vs-dynamic tests.
+//
+// It proves the milestone #3222 correctness spine for one runtime sequence:
+//
+//   1. golden   = the production binary emitter (aie-translate --aie-npu-to-
+//                 binary), read from the hex file passed as argv[1].
+//   2. STATIC_FN = the C++ TXN builder generated from the *static* sequence
+//                 (all-constant fields).
+//   3. DYN_FN(ARGVAL) = the C++ TXN builder generated from the *dynamic*
+//                 sequence, invoked with the same constant the static side
+//                 bakes in.
+//
+// All three word streams must be byte-identical. Splitting the check three
+// ways localizes a regression: golden-vs-STATIC isolates the EmitC codegen
+// against the binary emitter; STATIC-vs-DYN isolates runtime-argument
+// substitution.
+//
+// The generated header (which defines STATIC_FN and DYN_FN) is #included via
+// -DGEN_HDR; STATIC_FN / DYN_FN / ARGVAL come from -D so this one file serves
+// both DMA paths and any future size.
+//
+//===----------------------------------------------------------------------===//
+
+#include GEN_HDR
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Read a hex-per-line word stream (the "%08X\n" format emitted by
+// aie-translate --aie-npu-to-binary -aie-output-binary=false).
+std::vector<uint32_t> readHex(const char *path) {
+  std::ifstream in(path);
+  if (!in) {
+    std::fprintf(stderr, "cannot open golden hex file '%s'\n", path);
+    std::exit(2);
+  }
+  std::vector<uint32_t> words;
+  std::string line;
+  while (std::getline(in, line)) {
+    if (line.empty())
+      continue;
+    words.push_back(
+        static_cast<uint32_t>(std::strtoul(line.c_str(), nullptr, 16)));
+  }
+  return words;
+}
+
+// Report the first divergence (or a length mismatch) and return false.
+bool equal(const char *aName, const std::vector<uint32_t> &a, const char *bName,
+           const std::vector<uint32_t> &b) {
+  size_t lim = a.size() < b.size() ? a.size() : b.size();
+  for (size_t i = 0; i < lim; ++i) {
+    if (a[i] != b[i]) {
+      std::fprintf(stderr, "%s vs %s differ at word %zu: 0x%08x vs 0x%08x\n",
+                   aName, bName, i, a[i], b[i]);
+      return false;
+    }
+  }
+  if (a.size() != b.size()) {
+    std::fprintf(stderr,
+                 "%s (%zu words) and %s (%zu words) have equal prefix "
+                 "but different length\n",
+                 aName, a.size(), bName, b.size());
+    return false;
+  }
+  return true;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: %s <golden.hex>\n", argv[0]);
+    return 2;
+  }
+
+  std::vector<uint32_t> golden = readHex(argv[1]);
+  std::vector<uint32_t> stat = STATIC_FN();
+  std::vector<uint32_t> dyn = DYN_FN(ARGVAL);
+
+  bool ok = equal("golden", golden, "static-C++", stat) &&
+            equal("static-C++", stat, "dynamic-C++", dyn);
+
+  if (!ok)
+    return 1;
+
+  std::printf("equivalent: %zu words (arg=%d)\n", golden.size(), (int)(ARGVAL));
+  return 0;
+}

--- a/test/Targets/NPU/static_vs_dynamic/Inputs/compare_main.cpp
+++ b/test/Targets/NPU/static_vs_dynamic/Inputs/compare_main.cpp
@@ -64,8 +64,10 @@ bool equal(const char *aName, const std::vector<uint32_t> &a, const char *bName,
   size_t lim = a.size() < b.size() ? a.size() : b.size();
   for (size_t i = 0; i < lim; ++i) {
     if (a[i] != b[i]) {
-      std::fprintf(stderr, "%s vs %s differ at word %zu: 0x%08x vs 0x%08x\n",
-                   aName, bName, i, a[i], b[i]);
+      std::fprintf(stderr,
+                   "%s vs %s differ at word %zu: 0x%08llx vs 0x%08llx\n",
+                   aName, bName, i, (unsigned long long)a[i],
+                   (unsigned long long)b[i]);
       return false;
     }
   }

--- a/test/Targets/NPU/static_vs_dynamic/README.md
+++ b/test/Targets/NPU/static_vs_dynamic/README.md
@@ -1,0 +1,71 @@
+<!--
+Copyright (C) 2026 Advanced Micro Devices, Inc.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+-->
+
+# Static-vs-dynamic TXN equivalence harness
+
+These tests prove milestone #3222's correctness spine: a compiled-once
+`aie.runtime_sequence` produces the *same* TXN word stream whether its scalar
+fields are baked-in constants or supplied as runtime arguments.
+
+Each test lowers two sequences — one static (all constants), one dynamic (takes
+an `i32` argument) — to terminal npu ops, then compares three word streams that
+must be byte-identical:
+
+1. **golden** — the production binary emitter,
+   `aie-translate --aie-npu-to-binary -aie-output-binary=false` on the static
+   sequence.
+2. **`generate_txn_<static>()`** — the C++ TXN builder from
+   `aie-translate --aie-npu-to-cpp`, same constants. Catches EmitC-codegen drift
+   against the binary emitter.
+3. **`generate_txn_<dynamic>(N)`** — the C++ builder from the dynamic sequence,
+   invoked with the constant the static side bakes in. Catches runtime-argument
+   substitution drift.
+
+`Inputs/compare_main.cpp` reads the golden hex file and calls the two generated
+functions (selected via `-DSTATIC_FN` / `-DDYN_FN`, argument via `-DARGVAL`,
+header via `-DGEN_HDR`), reporting the first divergent word on mismatch.
+
+Two DMA lowering paths are covered because they converge on the same terminal
+ops but reach them differently:
+
+- `memcpy_nd.mlir` — the `aiex.npu.dma_memcpy_nd` path (`--aie-dma-to-npu`).
+- `dma_task.mlir` — the DMA-task path
+  (`dma_configure_task_for` / `dma_start_task` / `dma_await_task`, carrying the
+  SSA `bd_id`), which needs `--aie-substitute-shim-dma-allocations
+  --aie-assign-runtime-sequence-bd-ids --aie-dma-tasks-to-npu` before the shared
+  `--aie-dma-to-npu` step, and is the only path that exercises the `sync` op.
+
+Both paths are covered on both device generations: `memcpy_nd.mlir` /
+`dma_task.mlir` target npu2, and `memcpy_nd_npu1.mlir` / `dma_task_npu1.mlir`
+target npu1. Device info is baked into the TXN header words, so equivalence is
+checked per generation.
+
+Between them the tests exercise every op the C++ TXN target supports: `write32`,
+`maskwrite32`, `blockwrite`, `address_patch`, and `sync`.
+
+Only `rtp_write` carries the runtime value: it is the most a runtime argument
+can drive without pushing the BD onto the per-register `write32` path, which
+would make the static and dynamic streams differ structurally rather than in
+value. Genuinely runtime-valued DMA sizes/strides arrive with the Phase-2
+dynamic BD-word encoder, which will extend this harness.
+
+## Adding a new size
+
+Add a static sequence that bakes the new value (e.g. `@memcpy_static_8192`, as
+in `memcpy_nd.mlir`), then add two RUN lines: one that emits its golden with
+`-aie-sequence-name=<that sequence>`, and one that compiles the comparator with
+`-DSTATIC_FN=<that sequence>` and `-DDYN_FN` still the shared dynamic sequence,
+passing the new value as `-DARGVAL=`. The dynamic sequence is reused unchanged.
+No C++ changes are needed — `compare_main.cpp` is fully parameterized by `-D`
+macros. (The static side needs its own sequence because the golden is the binary
+emitter run on all-constant fields.)
+
+## Adding a new DMA pattern
+
+Add another `aiex.npu.dma_memcpy_nd` (or another BD in a `dma_configure_task_for`)
+to *both* the static and dynamic sequences, keeping them structurally identical
+apart from the runtime argument. Remember the `aie.dma_bd` length is the product
+of the lowest three dimension sizes — the highest dimension is the BD repeat
+count, not part of the transfer length.

--- a/test/Targets/NPU/static_vs_dynamic/dma_task.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/dma_task.mlir
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Static-vs-dynamic TXN equivalence for the DMA-task path
+// (dma_configure_task_for / dma_start_task / dma_await_task, carrying the SSA
+// bd_id introduced in #3225).
+//
+// This path lowers differently from dma_memcpy_nd: dma-tasks-to-npu first
+// produces npu.push_queue / npu.write_bd (and an npu.sync per awaited token),
+// which dma-to-npu then lowers to the same terminal write32 / blockwrite /
+// sync / address_patch ops. This test proves that convergence end to end -
+// nothing else in the tree exercises a DMA-task sequence all the way to a TXN
+// stream - and that the C++ builder is byte-identical to the binary emitter
+// on it, for both a static and a runtime-arg sequence.
+//
+// The await steps mean issue_token=true is required on the configures, so this
+// is also the path that exercises the sync op in the EmitC target. Two BD
+// shapes (repeat count in the highest dim; length is the product of the lower
+// three) cover more than one BD encoding.
+//
+// To add another size, see README.md in this directory.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t.d && mkdir -p %t.d
+
+// Lower the DMA-task ops to terminal npu ops. Unlike the dma_memcpy_nd path
+// this needs the shim substitution + BD-id assignment + dma-tasks-to-npu
+// stages before the shared dma-to-npu step.
+// RUN: aie-opt --aie-substitute-shim-dma-allocations \
+// RUN:   --aie-assign-runtime-sequence-bd-ids --aie-dma-tasks-to-npu \
+// RUN:   --aie-dma-to-npu %s -o %t.d/lowered.mlir
+
+// Golden word stream from the production binary emitter.
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false \
+// RUN:   -aie-sequence-name=task_static %t.d/lowered.mlir > %t.d/golden.hex
+
+// One generated header holds both generate_txn_main_task_static/_dynamic.
+// RUN: aie-translate --aie-npu-to-cpp %t.d/lowered.mlir > %t.d/gen.h
+
+// Host-compile and run the three-way comparator.
+// RUN: %host_clang -std=c++17 -I%S/../../../../include \
+// RUN:   -DGEN_HDR='"%t.d/gen.h"' \
+// RUN:   -DSTATIC_FN=generate_txn_main_task_static \
+// RUN:   -DDYN_FN=generate_txn_main_task_dynamic -DARGVAL=4096 \
+// RUN:   %S/Inputs/compare_main.cpp %host_link_flags -o %t.d/cmp.exe
+// RUN: %t.d/cmp.exe %t.d/golden.hex
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %rtp = aie.buffer(%tile_0_2) {sym_name = "rtp", address = 49152 : i32} : memref<16xi32>
+    aie.shim_dma_allocation @of_in  (%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @of_out (%tile_0_0, S2MM, 0)
+
+    aie.runtime_sequence @task_static(%in: memref<8192xi32>, %out: memref<8192xi32>) {
+      %c4096 = arith.constant 4096 : i32
+      %c4097 = arith.constant 4097 : i32
+      aiex.npu.rtp_write(@rtp, 0, %c4096) : i32
+      aiex.npu.rtp_write(@rtp, 4, %c4097) : i32
+      %tout = aiex.dma_configure_task_for @of_out {
+        aie.dma_bd(%out : memref<8192xi32> offset = 0 len = 2048 sizes = [2, 4, 8, 64] strides = [2048, 512, 64, 1]) {bd_id = 0 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tout)
+      %tin = aiex.dma_configure_task_for @of_in {
+        aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 4096 sizes = [1, 8, 16, 32] strides = [4096, 512, 32, 1]) {bd_id = 1 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tin)
+      aiex.dma_await_task(%tout)
+      aiex.dma_await_task(%tin)
+    }
+
+    aie.runtime_sequence @task_dynamic(%in: memref<8192xi32>, %out: memref<8192xi32>, %n: i32) {
+      %c1 = arith.constant 1 : i32
+      %np1 = arith.addi %n, %c1 : i32
+      aiex.npu.rtp_write(@rtp, 0, %n) : i32
+      aiex.npu.rtp_write(@rtp, 4, %np1) : i32
+      %tout = aiex.dma_configure_task_for @of_out {
+        aie.dma_bd(%out : memref<8192xi32> offset = 0 len = 2048 sizes = [2, 4, 8, 64] strides = [2048, 512, 64, 1]) {bd_id = 0 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tout)
+      %tin = aiex.dma_configure_task_for @of_in {
+        aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 4096 sizes = [1, 8, 16, 32] strides = [4096, 512, 32, 1]) {bd_id = 1 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tin)
+      aiex.dma_await_task(%tout)
+      aiex.dma_await_task(%tin)
+    }
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/dma_task_npu1.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/dma_task_npu1.mlir
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// npu1 counterpart of dma_task.mlir (the DMA-task path). Device info is baked
+// into the TXN header words, so the static ≡ dynamic equivalence is checked
+// per device generation; this file covers npu1 while dma_task.mlir covers
+// npu2. See that file and README.md for details.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: aie-opt --aie-substitute-shim-dma-allocations \
+// RUN:   --aie-assign-runtime-sequence-bd-ids --aie-dma-tasks-to-npu \
+// RUN:   --aie-dma-to-npu %s -o %t.d/lowered.mlir
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false \
+// RUN:   -aie-sequence-name=task_static %t.d/lowered.mlir > %t.d/golden.hex
+// RUN: aie-translate --aie-npu-to-cpp %t.d/lowered.mlir > %t.d/gen.h
+// RUN: %host_clang -std=c++17 -I%S/../../../../include \
+// RUN:   -DGEN_HDR='"%t.d/gen.h"' \
+// RUN:   -DSTATIC_FN=generate_txn_main_task_static \
+// RUN:   -DDYN_FN=generate_txn_main_task_dynamic -DARGVAL=4096 \
+// RUN:   %S/Inputs/compare_main.cpp %host_link_flags -o %t.d/cmp.exe
+// RUN: %t.d/cmp.exe %t.d/golden.hex
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %rtp = aie.buffer(%tile_0_2) {sym_name = "rtp", address = 49152 : i32} : memref<16xi32>
+    aie.shim_dma_allocation @of_in  (%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @of_out (%tile_0_0, S2MM, 0)
+
+    aie.runtime_sequence @task_static(%in: memref<8192xi32>, %out: memref<8192xi32>) {
+      %c4096 = arith.constant 4096 : i32
+      %c4097 = arith.constant 4097 : i32
+      aiex.npu.rtp_write(@rtp, 0, %c4096) : i32
+      aiex.npu.rtp_write(@rtp, 4, %c4097) : i32
+      %tout = aiex.dma_configure_task_for @of_out {
+        aie.dma_bd(%out : memref<8192xi32> offset = 0 len = 2048 sizes = [2, 4, 8, 64] strides = [2048, 512, 64, 1]) {bd_id = 0 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tout)
+      %tin = aiex.dma_configure_task_for @of_in {
+        aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 4096 sizes = [1, 8, 16, 32] strides = [4096, 512, 32, 1]) {bd_id = 1 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tin)
+      aiex.dma_await_task(%tout)
+      aiex.dma_await_task(%tin)
+    }
+
+    aie.runtime_sequence @task_dynamic(%in: memref<8192xi32>, %out: memref<8192xi32>, %n: i32) {
+      %c1 = arith.constant 1 : i32
+      %np1 = arith.addi %n, %c1 : i32
+      aiex.npu.rtp_write(@rtp, 0, %n) : i32
+      aiex.npu.rtp_write(@rtp, 4, %np1) : i32
+      %tout = aiex.dma_configure_task_for @of_out {
+        aie.dma_bd(%out : memref<8192xi32> offset = 0 len = 2048 sizes = [2, 4, 8, 64] strides = [2048, 512, 64, 1]) {bd_id = 0 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tout)
+      %tin = aiex.dma_configure_task_for @of_in {
+        aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 4096 sizes = [1, 8, 16, 32] strides = [4096, 512, 32, 1]) {bd_id = 1 : i32}
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%tin)
+      aiex.dma_await_task(%tout)
+      aiex.dma_await_task(%tin)
+    }
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/memcpy_nd.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/memcpy_nd.mlir
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Static-vs-dynamic TXN equivalence for the aiex.npu.dma_memcpy_nd path.
+//
+// Two runtime sequences describe the same transfer: @memcpy_static bakes the
+// rtp value in as a constant; @memcpy_dynamic takes it as a runtime %n arg.
+// The harness proves three word streams are byte-identical:
+//   - the production binary emitter on @memcpy_static (the golden),
+//   - generate_txn_main_memcpy_static() (EmitC path, same constants),
+//   - generate_txn_main_memcpy_dynamic(4096) (runtime arg == the baked constant).
+//
+// Each sequence carries two distinct 4-D DMA patterns so more than one BD
+// blockwrite / address_patch encoding is exercised. rtp_write is the only
+// runtime-driven field: it is the most a runtime argument can affect without
+// forcing the BD onto the per-register write32 path, which would make the
+// static and dynamic streams differ structurally rather than in value.
+//
+// To add another size, see README.md in this directory.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t.d && mkdir -p %t.d
+
+// Lower the dma_memcpy_nd ops to terminal npu ops.
+// RUN: aie-opt --aie-dma-to-npu %s -o %t.d/lowered.mlir
+
+// Golden word stream from the production binary emitter.
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false \
+// RUN:   -aie-sequence-name=memcpy_static %t.d/lowered.mlir > %t.d/golden.hex
+
+// One generated header holds both generate_txn_main_memcpy_static/_dynamic.
+// RUN: aie-translate --aie-npu-to-cpp %t.d/lowered.mlir > %t.d/gen.h
+
+// Host-compile and run the three-way comparator.
+// RUN: %host_clang -std=c++17 -I%S/../../../../include \
+// RUN:   -DGEN_HDR='"%t.d/gen.h"' \
+// RUN:   -DSTATIC_FN=generate_txn_main_memcpy_static \
+// RUN:   -DDYN_FN=generate_txn_main_memcpy_dynamic -DARGVAL=4096 \
+// RUN:   %S/Inputs/compare_main.cpp %host_link_flags -o %t.d/cmp.exe
+// RUN: %t.d/cmp.exe %t.d/golden.hex
+
+// Second size: a distinct static sequence bakes N=8192, and the same dynamic
+// sequence is invoked with 8192. This exercises the add-a-size recipe and
+// guards the runtime-argument path at more than one value.
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false \
+// RUN:   -aie-sequence-name=memcpy_static_8192 %t.d/lowered.mlir > %t.d/golden_8192.hex
+// RUN: %host_clang -std=c++17 -I%S/../../../../include \
+// RUN:   -DGEN_HDR='"%t.d/gen.h"' \
+// RUN:   -DSTATIC_FN=generate_txn_main_memcpy_static_8192 \
+// RUN:   -DDYN_FN=generate_txn_main_memcpy_dynamic -DARGVAL=8192 \
+// RUN:   %S/Inputs/compare_main.cpp %host_link_flags -o %t.d/cmp_8192.exe
+// RUN: %t.d/cmp_8192.exe %t.d/golden_8192.hex
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %rtp = aie.buffer(%tile_0_2) {sym_name = "rtp", address = 49152 : i32} : memref<16xi32>
+    aie.shim_dma_allocation @of_in  (%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @of_out (%tile_0_0, S2MM, 0)
+
+    aie.runtime_sequence @memcpy_static(%in: memref<8192xi32>, %out: memref<8192xi32>) {
+      %c4096 = arith.constant 4096 : i32
+      %c4097 = arith.constant 4097 : i32
+      %mwaddr = arith.constant 196612 : i32
+      %mwmask = arith.constant 255 : i32
+      aiex.npu.rtp_write(@rtp, 0, %c4096) : i32
+      aiex.npu.rtp_write(@rtp, 4, %c4097) : i32
+      aiex.npu.maskwrite32(%mwaddr, %c4096, %mwmask) : i32, i32, i32
+      aiex.npu.dma_memcpy_nd(%out[0, 0, 0, 0][2, 4, 8, 64][2048, 512, 64, 1]) {id = 1 : i64, metadata = @of_out} : memref<8192xi32>
+      aiex.npu.dma_memcpy_nd(%in [0, 0, 0, 0][1, 8, 16, 32][4096, 512, 32, 1]) {id = 0 : i64, metadata = @of_in} : memref<8192xi32>
+    }
+
+    aie.runtime_sequence @memcpy_dynamic(%in: memref<8192xi32>, %out: memref<8192xi32>, %n: i32) {
+      %c1 = arith.constant 1 : i32
+      %np1 = arith.addi %n, %c1 : i32
+      %mwaddr = arith.constant 196612 : i32
+      %mwmask = arith.constant 255 : i32
+      aiex.npu.rtp_write(@rtp, 0, %n) : i32
+      aiex.npu.rtp_write(@rtp, 4, %np1) : i32
+      aiex.npu.maskwrite32(%mwaddr, %n, %mwmask) : i32, i32, i32
+      aiex.npu.dma_memcpy_nd(%out[0, 0, 0, 0][2, 4, 8, 64][2048, 512, 64, 1]) {id = 1 : i64, metadata = @of_out} : memref<8192xi32>
+      aiex.npu.dma_memcpy_nd(%in [0, 0, 0, 0][1, 8, 16, 32][4096, 512, 32, 1]) {id = 0 : i64, metadata = @of_in} : memref<8192xi32>
+    }
+
+    // Second size for the add-a-size recipe: identical body to @memcpy_static
+    // but bakes N=8192. The dynamic sequence above is invoked with 8192 to
+    // match it.
+    aie.runtime_sequence @memcpy_static_8192(%in: memref<8192xi32>, %out: memref<8192xi32>) {
+      %c8192 = arith.constant 8192 : i32
+      %c8193 = arith.constant 8193 : i32
+      %mwaddr = arith.constant 196612 : i32
+      %mwmask = arith.constant 255 : i32
+      aiex.npu.rtp_write(@rtp, 0, %c8192) : i32
+      aiex.npu.rtp_write(@rtp, 4, %c8193) : i32
+      aiex.npu.maskwrite32(%mwaddr, %c8192, %mwmask) : i32, i32, i32
+      aiex.npu.dma_memcpy_nd(%out[0, 0, 0, 0][2, 4, 8, 64][2048, 512, 64, 1]) {id = 1 : i64, metadata = @of_out} : memref<8192xi32>
+      aiex.npu.dma_memcpy_nd(%in [0, 0, 0, 0][1, 8, 16, 32][4096, 512, 32, 1]) {id = 0 : i64, metadata = @of_in} : memref<8192xi32>
+    }
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/memcpy_nd_npu1.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/memcpy_nd_npu1.mlir
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// npu1 counterpart of memcpy_nd.mlir. Device info is baked into the TXN header
+// words, so the static ≡ dynamic equivalence is checked per device generation;
+// this file covers npu1 while memcpy_nd.mlir covers npu2. See that file and
+// README.md for how the three-way comparison works.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t.d && mkdir -p %t.d
+// RUN: aie-opt --aie-dma-to-npu %s -o %t.d/lowered.mlir
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false \
+// RUN:   -aie-sequence-name=memcpy_static %t.d/lowered.mlir > %t.d/golden.hex
+// RUN: aie-translate --aie-npu-to-cpp %t.d/lowered.mlir > %t.d/gen.h
+// RUN: %host_clang -std=c++17 -I%S/../../../../include \
+// RUN:   -DGEN_HDR='"%t.d/gen.h"' \
+// RUN:   -DSTATIC_FN=generate_txn_main_memcpy_static \
+// RUN:   -DDYN_FN=generate_txn_main_memcpy_dynamic -DARGVAL=4096 \
+// RUN:   %S/Inputs/compare_main.cpp %host_link_flags -o %t.d/cmp.exe
+// RUN: %t.d/cmp.exe %t.d/golden.hex
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %rtp = aie.buffer(%tile_0_2) {sym_name = "rtp", address = 49152 : i32} : memref<16xi32>
+    aie.shim_dma_allocation @of_in  (%tile_0_0, MM2S, 0)
+    aie.shim_dma_allocation @of_out (%tile_0_0, S2MM, 0)
+
+    aie.runtime_sequence @memcpy_static(%in: memref<8192xi32>, %out: memref<8192xi32>) {
+      %c4096 = arith.constant 4096 : i32
+      %c4097 = arith.constant 4097 : i32
+      %mwaddr = arith.constant 196612 : i32
+      %mwmask = arith.constant 255 : i32
+      aiex.npu.rtp_write(@rtp, 0, %c4096) : i32
+      aiex.npu.rtp_write(@rtp, 4, %c4097) : i32
+      aiex.npu.maskwrite32(%mwaddr, %c4096, %mwmask) : i32, i32, i32
+      aiex.npu.dma_memcpy_nd(%out[0, 0, 0, 0][2, 4, 8, 64][2048, 512, 64, 1]) {id = 1 : i64, metadata = @of_out} : memref<8192xi32>
+      aiex.npu.dma_memcpy_nd(%in [0, 0, 0, 0][1, 8, 16, 32][4096, 512, 32, 1]) {id = 0 : i64, metadata = @of_in} : memref<8192xi32>
+    }
+
+    aie.runtime_sequence @memcpy_dynamic(%in: memref<8192xi32>, %out: memref<8192xi32>, %n: i32) {
+      %c1 = arith.constant 1 : i32
+      %np1 = arith.addi %n, %c1 : i32
+      %mwaddr = arith.constant 196612 : i32
+      %mwmask = arith.constant 255 : i32
+      aiex.npu.rtp_write(@rtp, 0, %n) : i32
+      aiex.npu.rtp_write(@rtp, 4, %np1) : i32
+      aiex.npu.maskwrite32(%mwaddr, %n, %mwmask) : i32, i32, i32
+      aiex.npu.dma_memcpy_nd(%out[0, 0, 0, 0][2, 4, 8, 64][2048, 512, 64, 1]) {id = 1 : i64, metadata = @of_out} : memref<8192xi32>
+      aiex.npu.dma_memcpy_nd(%in [0, 0, 0, 0][1, 8, 16, 32][4096, 512, 32, 1]) {id = 0 : i64, metadata = @of_in} : memref<8192xi32>
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-runtime-len.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-runtime-len.mlir
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: aie-opt --verify-diagnostics --aie-dma-tasks-to-npu %s
+
+// A runtime-valued dma_bd len would be silently baked to the buffer's element
+// count by getLenInBytes() on the static NPU lowering path. Reject it with a
+// clear diagnostic (mirroring the runtime-valued size/stride guard), rather
+// than encode a wrong length. Genuinely runtime-valued len arrives with the
+// dynamic BD-word encoder (--aie-npu-to-cpp).
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+
+    aie.runtime_sequence(%arg0: memref<4096xi32>, %len: i32) {
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+          // expected-error@+1 {{runtime-valued BD len is not supported on the static NPU lowering path}}
+          aie.dma_bd(%arg0 : memref<4096xi32> offset = 0 len = %len sizes = [1, 8, 16, 32] strides = [4096, 512, 32, 1]) {bd_id = 0 : i32}
+          aie.end
+      }
+    }
+  }
+}


### PR DESCRIPTION
Phase 1 finale of #3222. Adds a lit harness proving the milestone's "static ≡ dynamic" criterion: a runtime_sequence produces an identical TXN stream whether its scalar fields are baked-in constants or runtime arguments.

Each test lowers a static and a dynamic sequence to npu ops, then asserts three identical word streams: the binary-emitter golden, `generate_txn_<static>()`, and `generate_txn_<dynamic>(N)`. The split localizes drift to EmitC codegen vs. runtime-arg substitution. `Inputs/compare_main.cpp` reports the first divergent word and is `-D` parameterized to serve every path/device/size.

## Coverage

  |                             | npu2 | npu1 |
  | --------------------------- | :--: | :--: |
  | `dma_memcpy_nd` (2 sizes)   |  ✓   |  ✓   |
  | DMA-task path (`sync`)      |  ✓   |  ✓   |

Both DMA paths (the DMA-task path — SSA `bd_id` from #3225 — is the only one exercised end-to-end to a TXN stream and the only one reaching `sync`), both device generations, and every supported op (`write32`, `maskwrite32`, `blockwrite`, `address_patch`, `sync`).

Stacked on #3256.