### PR TITLE
ci: close three CI gaps that let breakage reach main

### DIFF
--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -116,13 +116,23 @@ jobs:
         run: |
 
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
-          if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF"]; then
+          if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF" ]; then
             WHEEL=mlir_no_rtti
           else
             WHEEL=mlir
           fi
-          pip -q download $WHEEL==$VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
+          for attempt in 1 2 3; do
+            rm -f mlir-*.whl
+            if pip -q download $WHEEL==$VERSION \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to download MLIR wheel after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
           unzip -q mlir-*.whl
 
       # Build the repo test target in release mode to build and test.

--- a/.github/workflows/buildAndTestMulti.yml
+++ b/.github/workflows/buildAndTestMulti.yml
@@ -122,7 +122,7 @@ jobs:
             WHEEL=mlir
           fi
           for attempt in 1 2 3; do
-            rm -f mlir-*.whl
+            rm -f "$WHEEL"-*.whl
             if pip -q download $WHEEL==$VERSION \
               -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro; then
               break
@@ -133,11 +133,17 @@ jobs:
             fi
             sleep $((attempt * 5))
           done
-          unzip -q mlir-*.whl
+          unzip -q "$WHEEL"-*.whl
 
       # Build the repo test target in release mode to build and test.
       - name: Build and test
         run: |
+
+          if [ x"${{ matrix.ENABLE_RTTI }}" == x"OFF" ]; then
+            WHEEL=mlir_no_rtti
+          else
+            WHEEL=mlir
+          fi
 
           mkdir -p build_release/install
           cd build_release
@@ -164,8 +170,8 @@ jobs:
             -DLLVM_ENABLE_ASSERTIONS=${{ matrix.ENABLE_ASSERTIONS }} \
             -DLLVM_ENABLE_RTTI=${{ matrix.ENABLE_RTTI }} \
             -DCMAKE_MODULE_PATH=$PWD/../cmake/modulesXilinx \
-            -DMLIR_DIR=$PWD/../mlir/lib/cmake/mlir \
-            -DLLVM_DIR=$PWD/../mlir/lib/cmake/llvm \
+            -DMLIR_DIR=$PWD/../$WHEEL/lib/cmake/mlir \
+            -DLLVM_DIR=$PWD/../$WHEEL/lib/cmake/llvm \
             -DLLVM_EXTERNAL_LIT="$LLVM_EXTERNAL_LIT"
 
           ninja

--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -77,8 +77,18 @@ jobs:
         id: mlir-wheels
         run: |
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
-          pip -q download mlir==$VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
+          for attempt in 1 2 3; do
+            rm -f mlir-*.whl
+            if pip -q download mlir==$VERSION \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to download MLIR wheel after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
           unzip -q mlir-*.whl
 
       - name: Ccache for C++ compilation

--- a/.github/workflows/buildAndTestRyzenAISw.yml
+++ b/.github/workflows/buildAndTestRyzenAISw.yml
@@ -113,8 +113,18 @@ jobs:
             VERSION=$(utils/clone-llvm.sh --get-wheel-version)
 
             cd /workspace
-            pip -q download mlir==$VERSION \
-              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
+            for attempt in 1 2 3; do
+              rm -f mlir-*.whl
+              if pip -q download mlir==$VERSION \
+                -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "Failed to download MLIR wheel after ${attempt} attempts" >&2
+                exit 1
+              fi
+              sleep $((attempt * 5))
+            done
             unzip -q mlir-*.whl
 
             mkdir -p /workspace/install

--- a/.github/workflows/buildAndTestVitis.yml
+++ b/.github/workflows/buildAndTestVitis.yml
@@ -94,8 +94,18 @@ jobs:
             $(python -c 'import site; print(site.getsitepackages()[0])')/jupyter_client/runapp.py
 
           VERSION=$(utils/clone-llvm.sh --get-wheel-version)
-          pip -q download mlir==$VERSION \
-            -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro
+          for attempt in 1 2 3; do
+            rm -f mlir-*.whl
+            if pip -q download mlir==$VERSION \
+              -f https://github.com/Xilinx/mlir-aie/releases/expanded_assets/mlir-distro; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Failed to download MLIR wheel after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 5))
+          done
           unzip -q mlir-*.whl
           # I have no clue why but the system clock on GHA containers is like 12 hours ahead.
           # That means wheels have file with time stamps in the future which makes ninja loop

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -56,9 +56,20 @@ jobs:
       - name: Regenerate lockfiles
         run: utils/regenerate_lockfiles.sh
 
-      # Leaves any drift in the working tree so the suggester below can turn it
-      # into review suggestions. fail_level: any makes the job red on drift.
+      # Fail on any drift, regardless of which files the PR touched.
+      # action-suggester uses filter_mode: diff_context and silently passes
+      # when drift is in files not already in the PR diff (e.g. a Dependabot
+      # bump that updates requirements.txt but not the compiled .lock).
+      - name: Fail on lockfile drift
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Lockfiles are out of date. Run utils/regenerate_lockfiles.sh and commit the result."
+            exit 1
+          fi
+
+      # Post the fix as inline PR suggestions (best-effort; does not gate merge).
       - name: Suggest lockfile updates
+        if: failure()
         uses: reviewdog/action-suggester@2558ba17e65a9039e73764a73009fc05fef28a46  # v1.24
         with:
           tool_name: regenerate-lockfiles

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoLiveness.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoLiveness.cpp
@@ -1,10 +1,7 @@
 //===- AIEObjectFifoLiveness.cpp --------------------------------*- C++ -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //

--- a/test/Passes/objectfifo-liveness/acyclic.mlir
+++ b/test/Passes/objectfifo-liveness/acyclic.mlir
@@ -1,10 +1,7 @@
 //===- acyclic.mlir --------------------------------------*- MLIR -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/Passes/objectfifo-liveness/pointpoint_cycle.mlir
+++ b/test/Passes/objectfifo-liveness/pointpoint_cycle.mlir
@@ -1,10 +1,7 @@
 //===- pointpoint_cycle.mlir -----------------------------*- MLIR -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/Passes/objectfifo-liveness/single_trip_wide_broadcast.mlir
+++ b/test/Passes/objectfifo-liveness/single_trip_wide_broadcast.mlir
@@ -1,10 +1,7 @@
 //===- single_trip_wide_broadcast.mlir -------------------*- MLIR -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/Passes/objectfifo-liveness/sufficient.mlir
+++ b/test/Passes/objectfifo-liveness/sufficient.mlir
@@ -1,10 +1,7 @@
 //===- sufficient.mlir -----------------------------------*- MLIR -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/Passes/objectfifo-liveness/under_buffered.mlir
+++ b/test/Passes/objectfifo-liveness/under_buffered.mlir
@@ -1,10 +1,7 @@
 //===- under_buffered.mlir -------------------------------*- MLIR -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 

--- a/test/Passes/objectfifo-liveness/unrelated_cycles_no_crosstalk.mlir
+++ b/test/Passes/objectfifo-liveness/unrelated_cycles_no_crosstalk.mlir
@@ -1,10 +1,7 @@
 //===- unrelated_cycles_no_crosstalk.mlir ---------------------*- MLIR -*-===//
 //
-// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
## Summary
  
Three independent CI-hygiene fixes, all in the "a check that should have caught something didn't" family:
  
### 1. Lockfile drift check (original)
- `reviewdog/action-suggester` uses `filter_mode: diff_context`, so it only flags drift in lines already in the PR diff. A Dependabot bump that edits `requirements.txt` but not the compiled `.lock` passes silently — how PR #3302 slipped through with `setuptools==82.0.1` still in the lock.
- Adds an explicit `git diff --exit-code` step that fails on any drift in any file; keeps the reviewdog suggester as best-effort inline annotation.
    
### 2. MLIR distro wheel download has no retry
- The four build-and-test workflows fetch the 1.1 GB MLIR distro wheel with a single un-retried `pip download`. A transient GitHub release-assets hiccup makes pip fall back to the dead PyPI `mlir` 0.0.1 package (`No matching distribution found for mlir==...`) and fails the whole job.
- Wraps the download in the same 3-attempt retry loop already used in `buildRyzenWheels.yml`.
    
### 3. Silent `[: missing ']'` in buildAndTestMulti.yml
- `[ x"..." == x"OFF"]` (missing space before `]`) has errored since #868 (Dec 2023). It fell through to `else`, silently downloading the RTTI-on wheel for `ENABLE_RTTI=OFF` matrix entries — never a hard failure, so it went unnoticed for 2.5 years. Adds the space.
    
### Also: unbreak main
- Migrates the 7 objectfifo-liveness files from #3257 to the canonical copyright-then-SPDX header. Their old LLVM-style boilerplate was banned by #3296's forbidden-strings list; #3257 was approved before #3296 landed and merged without rebasing, so the header check only failed once both were on main.