### PR TITLE
Fix ccache-action Windows TLS failure

### DIFF
--- a/.github/actions/setup_ccache/action.yml
+++ b/.github/actions/setup_ccache/action.yml
@@ -25,7 +25,8 @@ runs:
   using: "composite"
   steps:
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.12
+      uses: hendrikmuhs/ccache-action@v1.2.23
+      continue-on-error: true
       with:
         key: ${{ inputs.MATRIX_OS }}-${{ inputs.MATRIX_ARCH }}-${{ inputs.EXTRA_KEY }}
         max-size: "1G"

--- a/.github/actions/setup_ccache/action.yml
+++ b/.github/actions/setup_ccache/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       continue-on-error: true
       with:
         key: ${{ inputs.MATRIX_OS }}-${{ inputs.MATRIX_ARCH }}-${{ inputs.EXTRA_KEY }}


### PR DESCRIPTION
## Summary

- Bumps `hendrikmuhs/ccache-action` from `v1.2.12` → `v1.2.23`, which includes fixes for the TLS/SSL error (`exit code 35`) seen when restoring cache on Windows runners via Git's `sh.exe`
- Adds `continue-on-error: true` to the ccache step so future transient cache failures don't fail the entire job (ccache is an optimization, not a hard requirement)

## Test plan

- [ ] Verify the `windows-2022 AMD64 rtti=OFF` and `windows-2022 AMD64 rtti=ON` jobs pass in CI on this PR
- [ ] Confirm ccache restore succeeds (or gracefully skips) on Windows without failing the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)