### PR TITLE
AIEMaterializeBDChains: resolve shim DMA allocations via a prebuilt SymbolTable

### DIFF
--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeBDChains.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeBDChains.cpp
@@ -29,15 +29,7 @@ using namespace xilinx::AIEX;
 
 struct DMAStartBdChainForOpPattern : RewritePattern {
 
-  // Build-speed lever (byte-identical): the canonical path resolves each
-  // dma_start_bd_chain_for op's shim-DMA allocation via
-  // AIE::ShimDMAAllocationOp::getForSymbol -> device.lookupSymbol, a LINEAR
-  // symbol-table scan run once per DMAStartBdChainForOp. In large designs there
-  // are many of these, so the per-op O(allocations) scan makes the pass O(n^2).
-  // We instead build a SymbolTable for the device ONCE and look up in O(1). Same
-  // fix as AIESubstituteShimDMAAllocations. The pattern never erases/creates a
-  // symbol (it rewrites task ops, not ShimDMAAllocationOps), so the prebuilt
-  // table stays valid across the greedy run.
+  // Symbol-lookup cache used for speedier `ShimDMAAllocationOp` lookups
   const mlir::SymbolTable &symbolTable;
 
   DMAStartBdChainForOpPattern(MLIRContext *ctx,

--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeBDChains.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeBDChains.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Analysis/CallGraph.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -28,9 +29,22 @@ using namespace xilinx::AIEX;
 
 struct DMAStartBdChainForOpPattern : RewritePattern {
 
-  DMAStartBdChainForOpPattern(MLIRContext *ctx)
+  // Build-speed lever (byte-identical): the canonical path resolves each
+  // dma_start_bd_chain_for op's shim-DMA allocation via
+  // AIE::ShimDMAAllocationOp::getForSymbol -> device.lookupSymbol, a LINEAR
+  // symbol-table scan run once per DMAStartBdChainForOp. In large designs there
+  // are many of these, so the per-op O(allocations) scan makes the pass O(n^2).
+  // We instead build a SymbolTable for the device ONCE and look up in O(1). Same
+  // fix as AIESubstituteShimDMAAllocations. The pattern never erases/creates a
+  // symbol (it rewrites task ops, not ShimDMAAllocationOps), so the prebuilt
+  // table stays valid across the greedy run.
+  const mlir::SymbolTable &symbolTable;
+
+  DMAStartBdChainForOpPattern(MLIRContext *ctx,
+                              const mlir::SymbolTable &symbolTable)
       : RewritePattern(DMAStartBdChainForOp::getOperationName(),
-                       PatternBenefit(1), ctx) {}
+                       PatternBenefit(1), ctx),
+        symbolTable(symbolTable) {}
 
   LogicalResult matchAndRewrite(Operation *op_any,
                                 PatternRewriter &rewriter) const override {
@@ -38,10 +52,9 @@ struct DMAStartBdChainForOpPattern : RewritePattern {
     if (!op) {
       return failure();
     }
-    AIE::DeviceOp device = op->getParentOfType<AIE::DeviceOp>();
 
     AIE::ShimDMAAllocationOp alloc_op =
-        AIE::ShimDMAAllocationOp::getForSymbol(device, op.getAlloc());
+        symbolTable.lookup<AIE::ShimDMAAllocationOp>(op.getAlloc());
     if (!alloc_op) {
       return op.emitOpError("no shim DMA allocation found for symbol");
     }
@@ -126,8 +139,12 @@ struct AIEMaterializeBDChainsPass
     rewriter_config.setRegionSimplificationLevel(
         GreedySimplifyRegionLevel::Disabled);
 
+    // Build the device symbol table ONCE (O(1) per-op allocation lookup instead
+    // of getForSymbol's per-op linear scan -> O(n^2)). Byte-identical.
+    mlir::SymbolTable symbolTable(device);
+
     RewritePatternSet patterns_0(ctx);
-    patterns_0.insert<DMAStartBdChainForOpPattern>(ctx);
+    patterns_0.insert<DMAStartBdChainForOpPattern>(ctx, symbolTable);
     DMAConfigureTaskOp::getCanonicalizationPatterns(patterns_0, ctx);
     if (failed(applyPatternsGreedily(device, std::move(patterns_0),
                                      rewriter_config))) {

--- a/lib/Dialect/AIEX/Transforms/AIEMaterializeBDChains.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEMaterializeBDChains.cpp
@@ -139,8 +139,6 @@ struct AIEMaterializeBDChainsPass
     rewriter_config.setRegionSimplificationLevel(
         GreedySimplifyRegionLevel::Disabled);
 
-    // Build the device symbol table ONCE (O(1) per-op allocation lookup instead
-    // of getForSymbol's per-op linear scan -> O(n^2)). Byte-identical.
     mlir::SymbolTable symbolTable(device);
 
     RewritePatternSet patterns_0(ctx);


### PR DESCRIPTION
## Summary

`AIEMaterializeBDChains` resolves each `aiex.dma_start_bd_chain_for` op's shim
DMA allocation with `AIE::ShimDMAAllocationOp::getForSymbol(device, ...)`, which
calls `device.lookupSymbol` -- a linear scan of the device symbol table -- once
per op. On designs with many `dma_start_bd_chain_for` ops the per-op scan makes
this lookup component O(n^2).

This mirrors the fix already merged for `AIESubstituteShimDMAAllocations`
(#3178): build the device `SymbolTable` once in `runOnOperation` and look up in
O(1). The rewrite pattern never creates or erases a symbol (it rewrites task
ops, not `ShimDMAAllocationOp`s), so the prebuilt table stays valid across the
greedy run.

## Correctness

Output is byte-identical. `getForSymbol` does `lookupSymbol` + `dyn_cast`;
`SymbolTable::lookup<ShimDMAAllocationOp>` does the same hash lookup + cast,
returning null on a type mismatch identically. Existing
`test/bd-chains-and-dma-tasks/materialize-bd-chains` lit tests pass unchanged
(including the symbol-path good-5 / good-6).

## Measurement

Synthetic stress design of N `shim_dma_allocation`s + N
`dma_start_bd_chain_for` ops, `aie-opt --aie-materialize-bd-chains`, pass time
(best of 5):

| N     | before | after | speedup |
|-------|--------|-------|---------|
| 4000  | 0.288s | 0.204s | 1.41x |
| 8000  | 1.145s | 0.767s | 1.49x |

Note: this removes the symbol-scan term only. A second, unrelated super-linear
term remains in the pass (canonicalization re-reading op attributes under the
greedy driver), so the pass is not made fully linear by this change -- it is a
clean, byte-identical removal of one avoidable O(n^2) component, same family as
#3178.
