### PR TITLE
AIEObjectFifoStatefulTransform: diagnose unplaced tiles instead of crashing

### DIFF
--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -2385,6 +2385,34 @@ struct AIEObjectFifoStatefulTransformPass
     return hasError ? failure() : success();
   }
 
+  /// This pass assumes every objectFifo producer/consumer tile is a placed
+  /// `aie.tile`; the rest of the pass reaches them via getProducerTileOp() /
+  /// cast<TileOp>(...), which dereferences a null if a tile is still an
+  /// unplaced `aie.logical_tile` (or any non-TileOp). Emit a diagnostic and
+  /// fail cleanly instead of crashing when a design reaches this pass before
+  /// placement (e.g. --aie-place-tiles was not run first).
+  LogicalResult verifyObjectFifoTilesArePlaced(DeviceOp &device) {
+    auto isPlacedTile = [](Value tile) {
+      return isa_and_nonnull<TileOp>(tile.getDefiningOp());
+    };
+    bool hasError = false;
+    for (ObjectFifoCreateOp createOp : device.getOps<ObjectFifoCreateOp>()) {
+      if (!isPlacedTile(createOp.getProducerTile())) {
+        createOp.emitOpError("producer tile is not a placed aie.tile; run "
+                             "--aie-place-tiles before this pass");
+        hasError = true;
+      }
+      for (Value consumerTile : createOp.getConsumerTiles()) {
+        if (!isPlacedTile(consumerTile)) {
+          createOp.emitOpError("consumer tile is not a placed aie.tile; run "
+                               "--aie-place-tiles before this pass");
+          hasError = true;
+        }
+      }
+    }
+    return hasError ? failure() : success();
+  }
+
   /// Account for already used packet IDs and return next available ID.
   int getStartPacketID(DeviceOp &device) {
     int packetID = 0;
@@ -2454,6 +2482,9 @@ struct AIEObjectFifoStatefulTransformPass
         objectFifoTiles; // track cores to check for loops during unrolling
 
     if (failed(verifyObjectFifoLinks(device)))
+      return signalPassFailure();
+
+    if (failed(verifyObjectFifoTilesArePlaced(device)))
       return signalPassFailure();
 
     //===------------------------------------------------------------------===//

--- a/test/objectFifo-stateful-transform/check_errors.mlir
+++ b/test/objectFifo-stateful-transform/check_errors.mlir
@@ -29,3 +29,27 @@ module {
     }
   }
 }
+
+// -----
+
+// An unplaced logical_tile producer must be diagnosed, not crash the pass.
+module {
+  aie.device(npu1) {
+    %prod = aie.logical_tile<ShimNOCTile>(0, ?)
+    %cons = aie.tile(0, 2)
+    // expected-error@+1 {{producer tile is not a placed aie.tile; run --aie-place-tiles before this pass}}
+    aie.objectfifo @of(%prod, {%cons}, 2 : i32) : !aie.objectfifo<memref<64xi16>>
+  }
+}
+
+// -----
+
+// An unplaced logical_tile consumer must be diagnosed, not crash the pass.
+module {
+  aie.device(npu1) {
+    %prod = aie.tile(0, 0)
+    %cons = aie.logical_tile<CoreTile>(?, ?)
+    // expected-error@+1 {{consumer tile is not a placed aie.tile; run --aie-place-tiles before this pass}}
+    aie.objectfifo @of(%prod, {%cons}, 2 : i32) : !aie.objectfifo<memref<64xi16>>
+  }
+}


### PR DESCRIPTION
## Summary

`AIEObjectFifoStatefulTransform` assumes every objectFifo producer/consumer
tile is a placed `aie.tile` and reaches them via `getProducerTileOp()` /
`cast<TileOp>(...)`. If a design reaches this pass before placement -- an
`aie.objectfifo` whose tile is still an unplaced `aie.logical_tile` -- the
unconditional `cast<TileOp>` dereferences a null and the pass **SIGSEGVs**
instead of reporting the problem.

Minimal repro (crashes on current main):
```mlir
aie.device(npu1) {
  %prod = aie.logical_tile<ShimNOCTile>(0, ?)
  %cons = aie.logical_tile<CoreTile>(?, ?)
  aie.objectfifo @of (%prod, {%cons}, 2 : i32) : !aie.objectfifo<memref<64xi16>>
}
```
`aie-opt --aie-objectFifo-stateful-transform` -> SIGSEGV in
`AIEObjectFifoStatefulTransformPass::runOnOperation`.

## Fix

Add an early `verifyObjectFifoTilesArePlaced()` check (sibling of the existing
`verifyObjectFifoLinks()`) that emits an op error and fails the pass cleanly
when a producer/consumer tile is not a placed `aie.tile`:

```
error: 'aie.objectfifo' op producer tile is not a placed aie.tile;
       run --aie-place-tiles before this pass
```

## Tests

Adds two `--verify-diagnostics` cases (unplaced producer, unplaced consumer) to
`test/objectFifo-stateful-transform/check_errors.mlir`. All existing
objectFifo-stateful-transform lit tests pass unchanged.
