### PR TITLE
matmul/common.h: include <cassert> directly for assert()

### DIFF
--- a/programming_examples/basic/matrix_multiplication/common.h
+++ b/programming_examples/basic/matrix_multiplication/common.h
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <bits/stdc++.h>
+#include <cassert> // for assert(); not guaranteed via other headers
 #include <cmath>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
`common.h` calls `assert()` (the epsilon/tolerance checks in `computeSquaredError`, the matrix-size checks in the print helpers) but relies on `<cassert>` being pulled in transitively via other headers. Newer libstdc++/GCC no longer guarantee that, so building the `matrix_multiplication` examples can fail with `assert` / `__assert_fail` not declared.

Include `<cassert>` directly (include-what-you-use). No behavior change; one line.
