### PR TITLE
[IRON] Pin buffer L1 address and objectfifo DMA channels for host-driven designs

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1840,6 +1840,11 @@ def AIE_ObjectFifoCreateOp: AIE_Op<"objectfifo", [HasParent<"DeviceOp">, Symbol]
         // aie_stream==2 means enable aie stream ports on producer and consumer tiles
         OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<0>, IntMaxValue<2>]>>:$aie_stream,
         OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<0>, IntMaxValue<1>]>>:$aie_stream_port,
+        // Pin the DMA channel for an endpoint instead of first-free assignment.
+        // prod_dma_channel pins the producer endpoint's channel; cons_dma_channels
+        // holds one entry per consumer (-1 = auto-assign that consumer).
+        OptionalAttr<ConfinedAttr<AIEI32Attr, [IntMinValue<0>]>>:$prod_dma_channel,
+        OptionalAttr<DenseI32ArrayAttr>:$cons_dma_channels,
         InitValuesArrayAttr:$initValues,
         OptionalAttr<BDPadLayoutArrayAttr>:$padDimensions,
         OptionalAttr<AIEI32Attr>:$iter_count

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -150,6 +150,22 @@ public:
     return -1;
   }
 
+  /// Reserve a user-pinned DMA channel for (tileOp, dir). Returns the channel
+  /// on success; returns -1 if the channel is out of range for the tile or is
+  /// already in use (the caller emits a diagnostic). Reserving up-front ensures
+  /// first-free auto-assignment never steals a pinned channel.
+  int reservePinnedChannel(TileOp tileOp, DMAChannelDir dir, int channel) {
+    int maxChannelNum = (dir == DMAChannelDir::MM2S)
+                            ? tileOp.getNumSourceConnections(WireBundle::DMA)
+                            : tileOp.getNumDestConnections(WireBundle::DMA);
+    if (channel < 0 || channel >= maxChannelNum)
+      return -1;
+    if (channelsPerTile[{tileOp.getResult(), dir, channel}] != 0)
+      return -1;
+    channelsPerTile[{tileOp.getResult(), dir, channel}] = 1;
+    return channel;
+  }
+
   /// Given a tile and DMAChannel, adds entry to aieStreamsPerTile or
   /// throws an error if the stream is already used.
   void checkAIEStreamIndex(TileOp tileOp, DMAChannel chan) {
@@ -2439,11 +2455,17 @@ struct AIEObjectFifoStatefulTransformPass
                                        : !crossTileInfos.at(producer);
 
       if (shouldProcessProducer) {
-        bool requiresAdjacentTileAccessChannels = crossTileInfos.at(producer);
-        int channelIndex = dmaAnalysis.getDMAChannelIndex(
-            producer.getProducerTileOp(), DMAChannelDir::MM2S,
-            requiresAdjacentTileAccessChannels);
-        fifo_dma_channel_index[producer] = channelIndex;
+        // A pinned channel was already reserved in reservePinnedChannels();
+        // honor it here instead of first-free assignment.
+        if (auto pin = producer.getProdDmaChannel()) {
+          fifo_dma_channel_index[producer] = *pin;
+        } else {
+          bool requiresAdjacentTileAccessChannels = crossTileInfos.at(producer);
+          int channelIndex = dmaAnalysis.getDMAChannelIndex(
+              producer.getProducerTileOp(), DMAChannelDir::MM2S,
+              requiresAdjacentTileAccessChannels);
+          fifo_dma_channel_index[producer] = channelIndex;
+        }
       }
 
       for (auto consumer : consumers) {
@@ -2454,14 +2476,55 @@ struct AIEObjectFifoStatefulTransformPass
                                          : !crossTileInfos.at(consumer);
 
         if (shouldProcessConsumer) {
-          bool requiresAdjacentTileAccessChannels = crossTileInfos.at(consumer);
-          int channelIndex = dmaAnalysis.getDMAChannelIndex(
-              consumer.getProducerTileOp(), DMAChannelDir::S2MM,
-              requiresAdjacentTileAccessChannels);
-          fifo_dma_channel_index[consumer] = channelIndex;
+          // Post-split each consumer is its own single-endpoint fifo carrying
+          // its pin (if any) as prod_dma_channel; honor it here.
+          if (auto pin = consumer.getProdDmaChannel()) {
+            fifo_dma_channel_index[consumer] = *pin;
+          } else {
+            bool requiresAdjacentTileAccessChannels =
+                crossTileInfos.at(consumer);
+            int channelIndex = dmaAnalysis.getDMAChannelIndex(
+                consumer.getProducerTileOp(), DMAChannelDir::S2MM,
+                requiresAdjacentTileAccessChannels);
+            fifo_dma_channel_index[consumer] = channelIndex;
+          }
         }
       }
     }
+  }
+
+  /// Reserve every user-pinned DMA channel before any first-free assignment,
+  /// so auto-assignment cannot steal a pinned channel. Emits a clean diagnostic
+  /// on an out-of-range channel, a collision between two pins on the same
+  /// (tile, dir), or a pin combined with aie_stream (which bypasses DMA).
+  /// Returns failure if any conflict was found.
+  LogicalResult reservePinnedChannels(DMAChannelAnalysis &dmaAnalysis,
+                                      ObjectFifoState &state) {
+    for (auto &[producer, consumers] : state.splitFifos) {
+      if (auto pin = producer.getProdDmaChannel()) {
+        if (producer.getAieStream())
+          return producer.emitOpError(
+              "cannot pin a DMA channel on an objectfifo that also uses "
+              "aie_stream (stream ports bypass DMA channels)");
+        if (dmaAnalysis.reservePinnedChannel(producer.getProducerTileOp(),
+                                             DMAChannelDir::MM2S, *pin) < 0)
+          return producer.emitOpError("pinned MM2S DMA channel ")
+                 << *pin << " is out of range or already in use on this tile";
+      }
+      for (auto consumer : consumers) {
+        if (auto pin = consumer.getProdDmaChannel()) {
+          if (consumer.getAieStream())
+            return consumer.emitOpError(
+                "cannot pin a DMA channel on an objectfifo that also uses "
+                "aie_stream (stream ports bypass DMA channels)");
+          if (dmaAnalysis.reservePinnedChannel(consumer.getProducerTileOp(),
+                                               DMAChannelDir::S2MM, *pin) < 0)
+            return consumer.emitOpError("pinned S2MM DMA channel ")
+                   << *pin << " is out of range or already in use on this tile";
+        }
+      }
+    }
+    return success();
   }
 
   void runOnOperation() override {
@@ -2570,6 +2633,17 @@ struct AIEObjectFifoStatefulTransformPass
             createOp->removeAttr("aie_stream");
             createOp->removeAttr("aie_stream_port");
           }
+        }
+        // Propagate this consumer's pinned DMA channel (if any) from the
+        // original op's cons_dma_channels array onto the fresh consumer fifo.
+        // Post-split each consumer is its own single-endpoint fifo, so it
+        // carries the pin as prod_dma_channel (the split consumer fifo's tile
+        // is the one that owns the S2MM channel).
+        if (auto consChans = createOp.getConsDmaChannels()) {
+          ArrayRef<int> chans = *consChans;
+          if (consumerIndex < (int)chans.size() && chans[consumerIndex] >= 0)
+            consumerFifo.setProdDmaChannelAttr(
+                builder.getI32IntegerAttr(chans[consumerIndex]));
         }
 
         // identify external buffers that were registered to the consumer fifo
@@ -2687,6 +2761,11 @@ struct AIEObjectFifoStatefulTransformPass
 
     // maps ends of split FIFO to DMA channels
     std::map<ObjectFifoCreateOp, int> fifo_dma_channel_index;
+
+    // Reserve user-pinned channels before any first-free assignment so
+    // auto-assignment cannot steal a pinned channel.
+    if (failed(reservePinnedChannels(dmaAnalysis, state)))
+      return signalPassFailure();
 
     // assign channel indices for FIFOs with cross-tile issues first
     assignDMAChannelIndices(dmaAnalysis, crossTileInfos, fifo_dma_channel_index,

--- a/python/dialects/aie.py
+++ b/python/dialects/aie.py
@@ -61,6 +61,7 @@ from ..ir import (
     Block,
     BlockList,
     DenseElementsAttr,
+    DenseI32ArrayAttr,
     DictAttr,
     FunctionType,
     InsertionPoint,
@@ -548,6 +549,12 @@ class object_fifo(ObjectFifoCreateOp):
         int_stream_port = IntegerAttr.get(T.i32(), stream_port)
         self.attributes["aie_stream"] = int_stream_end
         self.attributes["aie_stream_port"] = int_stream_port
+
+    def set_prod_dma_channel(self, channel):
+        self.attributes["prod_dma_channel"] = IntegerAttr.get(T.i32(), channel)
+
+    def set_cons_dma_channels(self, channels):
+        self.attributes["cons_dma_channels"] = DenseI32ArrayAttr.get(list(channels))
 
 
 # Create an aie objectFifo_link between input and output objectFifos.

--- a/python/iron/buffer.py
+++ b/python/iron/buffer.py
@@ -38,6 +38,7 @@ class Buffer(Resolvable):
         name: str | None = None,
         tile: Tile | None = None,
         use_write_rtp: bool = False,
+        address: int | None = None,
     ):
         """A Buffer is a memory region declared at the top-level of the design, allowing it to
         be accessed by both Workers and the Runtime.
@@ -48,6 +49,7 @@ class Buffer(Resolvable):
             name (str | None, optional): The name of the buffer. If none is given, a unique name will be generated. Defaults to None.
             tile (Tile | None, optional): The tile for the buffer. Automatically set to the Worker's tile when the buffer is passed in the Worker's fn_args list. Defaults to None.
             use_write_rtp (bool, optional): If use_write_rtp, write_rtp/read_rtp operations will be generated. Otherwise, traditional write/read operations will be used. Defaults to False.
+            address (int | None, optional): Pin the buffer to a fixed L1 address. Needed for host-written RTP buffers the runtime pokes at a hardcoded address. Defaults to None (compiler-assigned).
 
         Raises:
             ValueError: If neither ``type`` nor ``initial_value`` is provided.
@@ -64,6 +66,7 @@ class Buffer(Resolvable):
         if not self._name:
             self._name = f"buf_{next(Buffer._gbuf_index)}"
         self._use_write_rtp = use_write_rtp
+        self._address = address
         self._tile = tile
         # Whether the user pinned this Buffer to an explicit tile at
         # construction.  A Worker may auto-pin ``_tile`` later as a
@@ -133,6 +136,7 @@ class Buffer(Resolvable):
                 tile=self._tile.op,
                 datatype=self._arr_type,
                 name=self._name,
+                address=self._address,
                 initial_value=self._initial_value,
                 use_write_rtp=self._use_write_rtp,
             )

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -178,12 +178,15 @@ class ObjectFifo(Resolvable):
             f"prod={prod_endpoint}, cons={[c.endpoint for c in self._cons]})"
         )
 
-    def prod(self, depth: int | None = None) -> ObjectFifoHandle:
+    def prod(
+        self, depth: int | None = None, channel: int | None = None
+    ) -> ObjectFifoHandle:
         """Returns an ObjectFifoHandle of type producer. Each ObjectFifo may have only one producer
         handle, so if one already exists, a new reference to this handle will be returned.
 
         Args:
             depth (int | None, optional): The depth of the buffers at the endpoint corresponding to the producer handle. Defaults to None.
+            channel (int | None, optional): Pin the producer endpoint's DMA channel instead of first-free assignment. Defaults to None (auto-assign).
 
         Raises:
             ValueError: Arguments are validated
@@ -200,14 +203,20 @@ class ObjectFifo(Resolvable):
                     depth = self._depth
             elif depth < 1:
                 raise ValueError(f"Depth must be > 1, but got {depth}")
+            if channel is not None and self._prod.channel != channel:
+                raise ValueError(
+                    f"Producer handle for {self.name} already pinned to channel "
+                    f"{self._prod.channel}, cannot re-pin to {channel}."
+                )
         else:
-            self._prod = ObjectFifoHandle(self, True, depth)
+            self._prod = ObjectFifoHandle(self, True, depth, channel=channel)
         return self._prod
 
     def cons(
         self,
         depth: int | None = None,
         dims_from_stream: StreamDims | None = None,
+        channel: int | None = None,
     ) -> ObjectFifoHandle:
         """Returns an ObjectFifoHandle of type consumer. Each ObjectFifo may have multiple consumers, so this
         will return a new consumer handle every time it is called.
@@ -215,6 +224,7 @@ class ObjectFifo(Resolvable):
         Args:
             depth (int | None, optional): The depth of the buffers at the endpoint corresponding to this consumer handle. Defaults to None.
             dims_from_stream (StreamDims | None, optional): Dimensions from stream for this consumer. Defaults to None.
+            channel (int | None, optional): Pin this consumer endpoint's DMA channel instead of first-free assignment. Defaults to None (auto-assign).
 
         Raises:
             ValueError: Arguments are validated
@@ -232,7 +242,11 @@ class ObjectFifo(Resolvable):
             dims_from_stream = self._dims_from_stream_per_cons
         self._cons.append(
             ObjectFifoHandle(
-                self, is_prod=False, depth=depth, dims_from_stream=dims_from_stream
+                self,
+                is_prod=False,
+                depth=depth,
+                dims_from_stream=dims_from_stream,
+                channel=channel,
             )
         )
         return self._cons[-1]
@@ -362,6 +376,17 @@ class ObjectFifo(Resolvable):
             if self._aie_stream is not None:
                 op.set_aie_stream(*self._aie_stream)
 
+            # Pin DMA channels requested on the handles. The producer channel
+            # and one channel per consumer (-1 = auto-assign that consumer) are
+            # stamped onto the op for the stateful-transform pass to honor.
+            if self._prod is not None and self._prod.channel is not None:
+                op.set_prod_dma_channel(self._prod.channel)
+            cons_channels = [con.channel for con in self._cons]
+            if any(ch is not None for ch in cons_channels):
+                op.set_cons_dma_channels(
+                    [-1 if ch is None else ch for ch in cons_channels]
+                )
+
             # Shared-memory delegate: redirect the fifo's buffer pool to a tile
             # whose memory module is shared with both prod and cons. See the
             # delegate_tile docstring on ObjectFifo for the constraint.
@@ -403,6 +428,7 @@ class ObjectFifoHandle(Resolvable):
         is_prod: bool,
         depth: int | None = None,
         dims_from_stream: StreamDims | None = None,
+        channel: int | None = None,
     ):
         """Construct an ObjectFifoHandle
 
@@ -411,6 +437,7 @@ class ObjectFifoHandle(Resolvable):
             is_prod (bool): Whether the handle should be producer or consumer handle.
             depth (int | None, optional): The depth of the ObjectFifo at this endpoint. Defaults to None.
             dims_from_stream (StreamDims | None, optional): A unique dimensions from stream. This is only valid for consumer handles. Defaults to None.
+            channel (int | None, optional): Pin this endpoint's DMA channel instead of first-free assignment. Defaults to None (auto-assign).
 
         Raises:
             ValueError: Arguments are validated.
@@ -435,6 +462,7 @@ class ObjectFifoHandle(Resolvable):
         self._is_prod = is_prod
         self._object_fifo = of
         self._depth = depth
+        self._channel = channel
         self._endpoint = None
         self._dims_from_stream = dims_from_stream
 
@@ -483,6 +511,11 @@ class ObjectFifoHandle(Resolvable):
     def name(self) -> str:
         """The name of the ObjectFifo"""
         return self._object_fifo.name
+
+    @property
+    def channel(self) -> int | None:
+        """The pinned DMA channel for this handle's endpoint, or None to auto-assign."""
+        return self._channel
 
     @property
     def op(self) -> ObjectFifoCreateOp:

--- a/test/objectFifo-stateful-transform/dma_channel_pinning/bad_channel_collision.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_pinning/bad_channel_collision.mlir
@@ -1,0 +1,24 @@
+//===- bad_channel_collision.mlir ------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aie-opt --aie-objectFifo-stateful-transform="dynamic-objFifos=false" %s 2>&1 | FileCheck %s
+
+// Two fifos pin the same MM2S channel on the same producer tile. The second
+// reservation collides and is rejected.
+
+// CHECK: error: 'aie.objectfifo' op pinned MM2S DMA channel 0 is out of range or already in use on this tile
+
+module @bad_channel_collision {
+ aie.device(xcve2302) {
+    %tile12 = aie.tile(1, 2)
+    %tile32 = aie.tile(3, 2)
+    %tile33 = aie.tile(3, 3)
+
+    aie.objectfifo @of1 (%tile12, {%tile32}, 2 : i32) {prod_dma_channel = 0 : i32} : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of2 (%tile12, {%tile33}, 2 : i32) {prod_dma_channel = 0 : i32} : !aie.objectfifo<memref<16xi32>>
+  }
+}

--- a/test/objectFifo-stateful-transform/dma_channel_pinning/bad_channel_out_of_range.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_pinning/bad_channel_out_of_range.mlir
@@ -1,0 +1,21 @@
+//===- bad_channel_out_of_range.mlir ---------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aie-opt --aie-objectFifo-stateful-transform="dynamic-objFifos=false" %s 2>&1 | FileCheck %s
+
+// A pinned channel beyond the tile's DMA channel count is rejected up front.
+
+// CHECK: error: 'aie.objectfifo' op pinned MM2S DMA channel 99 is out of range or already in use on this tile
+
+module @bad_channel_out_of_range {
+ aie.device(xcve2302) {
+    %tile12 = aie.tile(1, 2)
+    %tile33 = aie.tile(3, 3)
+
+    aie.objectfifo @of (%tile12, {%tile33}, 2 : i32) {prod_dma_channel = 99 : i32} : !aie.objectfifo<memref<16xi32>>
+  }
+}

--- a/test/objectFifo-stateful-transform/dma_channel_pinning/bad_pin_with_aie_stream.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_pinning/bad_pin_with_aie_stream.mlir
@@ -1,0 +1,22 @@
+//===- bad_pin_with_aie_stream.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: not aie-opt --aie-objectFifo-stateful-transform="dynamic-objFifos=false" %s 2>&1 | FileCheck %s
+
+// aie_stream routes through stream ports, which bypass DMA channels, so pinning
+// a DMA channel on the same endpoint is contradictory and is rejected.
+
+// CHECK: error: 'aie.objectfifo' op cannot pin a DMA channel on an objectfifo that also uses aie_stream (stream ports bypass DMA channels)
+
+module @bad_pin_with_aie_stream {
+ aie.device(xcve2302) {
+    %tile12 = aie.tile(1, 2)
+    %tile33 = aie.tile(3, 3)
+
+    aie.objectfifo @of (%tile12, {%tile33}, 2 : i32) {prod_dma_channel = 0 : i32, aie_stream = 0 : i32, aie_stream_port = 0 : i32} : !aie.objectfifo<memref<16xi32>>
+  }
+}

--- a/test/objectFifo-stateful-transform/dma_channel_pinning/pin_prod_cons_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_pinning/pin_prod_cons_AIE2.mlir
@@ -1,0 +1,28 @@
+//===- pin_prod_cons_AIE2.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform="dynamic-objFifos=false" %s | FileCheck %s
+
+// A producer and consumer are both pinned to DMA channel 1. First-free
+// assignment would pick channel 0 for each; the pins force channel 1 on both
+// the MM2S (producer) and S2MM (consumer) sides and on the flow between them.
+
+// CHECK-LABEL:   aie.device(xcve2302) {
+// CHECK:           aie.flow(%{{.*}}tile_1_2, DMA : 1, %{{.*}}tile_3_3, DMA : 1)
+// CHECK:           %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
+// CHECK:             aie.dma_start(MM2S, 1,
+// CHECK:           %mem_3_3 = aie.mem(%{{.*}}tile_3_3) {
+// CHECK:             aie.dma_start(S2MM, 1,
+
+module @dma_channel_pinning {
+ aie.device(xcve2302) {
+    %tile12 = aie.tile(1, 2)
+    %tile33 = aie.tile(3, 3)
+
+    aie.objectfifo @of_pin (%tile12, {%tile33}, 2 : i32) {prod_dma_channel = 1 : i32, cons_dma_channels = array<i32: 1>} : !aie.objectfifo<memref<16xi32>>
+  }
+}

--- a/test/objectFifo-stateful-transform/dma_channel_pinning/pin_reserves_before_autoassign_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_pinning/pin_reserves_before_autoassign_AIE2.mlir
@@ -1,0 +1,36 @@
+//===- pin_reserves_before_autoassign_AIE2.mlir ---------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform="dynamic-objFifos=false" %s | FileCheck %s
+
+// Two fifos share the same producer and consumer tiles. @of_auto is declared
+// first and would take channel 0 under first-free assignment. @of_pinned is
+// pinned to channel 0, so reservePinnedChannels() must reserve it before
+// auto-assignment runs, pushing @of_auto onto channel 1. This proves pins are
+// reserved up front rather than losing to whichever fifo is processed first.
+
+// The producer tile's DMA shows @of_auto pushed onto channel 1 while the
+// pinned @of_pinned holds channel 0 it reserved.
+
+// CHECK-LABEL:   aie.device(xcve2302) {
+// CHECK-DAG:       aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_3_3, DMA : 0)
+// CHECK-DAG:       aie.flow(%{{.*}}tile_1_2, DMA : 1, %{{.*}}tile_3_3, DMA : 1)
+// CHECK:           %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
+// CHECK:             aie.dma_start(MM2S, 1,
+// CHECK:             aie.dma_bd(%of_auto_buff_0
+// CHECK:             aie.dma_start(MM2S, 0,
+// CHECK:             aie.dma_bd(%of_pinned_buff_0
+
+module @dma_channel_pinning_reserve {
+ aie.device(xcve2302) {
+    %tile12 = aie.tile(1, 2)
+    %tile33 = aie.tile(3, 3)
+
+    aie.objectfifo @of_auto (%tile12, {%tile33}, 2 : i32) : !aie.objectfifo<memref<16xi32>>
+    aie.objectfifo @of_pinned (%tile12, {%tile33}, 2 : i32) {prod_dma_channel = 0 : i32, cons_dma_channels = array<i32: 0>} : !aie.objectfifo<memref<16xi32>>
+  }
+}

--- a/test/python/buffer_address.py
+++ b/test/python/buffer_address.py
@@ -1,0 +1,74 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s | FileCheck %s
+
+# Pins down the IRON-side contract for `Buffer(address=)`: the requested L1
+# address must survive resolution and appear as the `address` attribute on the
+# emitted `aie.buffer`. This is the surface a host-driven design uses to place a
+# runtime-written buffer at a fixed address an external runtime pokes, instead
+# of leaving it to compiler assignment.
+
+import numpy as np
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker, Buffer
+
+from aie.iron.device import NPU2Col1
+
+
+# CHECK:  module {
+# CHECK:    aie.device(npu2_1col) {
+# CHECK:      %pinned_local_buf = aie.buffer(%{{.*}}) {address = 8192 : i32, sym_name = "pinned_local_buf"} : memref<4096xui8>
+# CHECK:      %default_local_buf = aie.buffer(%{{.*}}) {sym_name = "default_local_buf"} : memref<4096xui8>
+def passthrough_pinned_buff():
+    in1_size = 4096
+    in1_dtype = np.uint8
+
+    # Define tensor types
+    line_size = in1_size // in1_dtype(0).nbytes
+    line_type = np.ndarray[(line_size,), np.dtype[in1_dtype]]
+    vector_type = np.ndarray[(line_size,), np.dtype[in1_dtype]]
+
+    # Dataflow with ObjectFifos
+    of_in = ObjectFifo(line_type, name="in")
+    of_out = ObjectFifo(line_type, name="out")
+
+    # External, binary kernel definition
+    passthrough_fn = Kernel(
+        "passThroughLine",
+        "passThrough.cc.o",
+        [line_type, line_type, np.int32],
+    )
+
+    # This buffer is pinned to a fixed L1 address.
+    pinned_buf = Buffer(line_type, name="pinned_local_buf", address=0x2000)
+    # This buffer is left to compiler assignment (no address attribute emitted).
+    default_buf = Buffer(line_type, name="default_local_buf")
+
+    # Task for the core to perform
+    def core_fn(of_in, of_out, buf1, buf2, passThroughLine):
+        elemOut = of_out.acquire(1)
+        elemIn = of_in.acquire(1)
+        passThroughLine(elemIn, buf1, line_size)
+        passThroughLine(buf1, buf2, line_size)
+        passThroughLine(buf2, elemOut, line_size)
+        of_in.release(1)
+        of_out.release(1)
+
+    # Create a worker to perform the task
+    my_worker = Worker(
+        core_fn,
+        [of_in.cons(), of_out.prod(), pinned_buf, default_buf, passthrough_fn],
+    )
+
+    # Runtime operations to move data to/from the AIE-array
+    rt = Runtime()
+    with rt.sequence(vector_type, vector_type, vector_type) as (a_in, b_out, _):
+        rt.start(my_worker)
+        rt.fill(of_in.prod(), a_in)
+        rt.drain(of_out.cons(), b_out, wait=True)
+
+    # Place components (assign them resources on the device) and generate an MLIR module
+    return Program(NPU2Col1(), rt).resolve_program()
+
+
+print(passthrough_pinned_buff())

--- a/test/python/objFifo_iron_dma_channel_pin.py
+++ b/test/python/objFifo_iron_dma_channel_pin.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s | FileCheck %s
+
+# Pins down the IRON-side contract for pinning an ObjectFifo endpoint's DMA
+# channel via `prod(channel=)` / `cons(channel=)`. Host-driven designs that must
+# match an external runtime's fixed hardware contract address shim DMAs by
+# channel, so the endpoint channel must be declarable instead of left to
+# first-free assignment. IRON stamps the request onto the create op as
+# `prod_dma_channel` / `cons_dma_channels` for the stateful-transform to honor.
+
+import numpy as np
+
+from aie.iron import ObjectFifo, Program, Runtime, Worker
+from aie.iron.controlflow import range_
+from aie.iron.device import NPU1Col1, Tile
+
+
+# CHECK-DAG: aie.objectfifo @of_pin({{.*}}) {cons_dma_channels = array<i32: 1>, prod_dma_channel = 1 : i32} : !aie.objectfifo<memref<16xi32>>
+def test_prod_cons_channel_pins_emit_attrs():
+    """A pinned producer and consumer stamp prod_dma_channel and
+    cons_dma_channels onto the create op verbatim."""
+
+    dev = NPU1Col1()
+    tile_ty = np.ndarray[(16,), np.dtype[np.int32]]
+
+    of_pin = ObjectFifo(tile_ty, depth=2, name="of_pin")
+
+    def prod_body(p):
+        for _ in range_(4):
+            p.acquire(1)
+            p.release(1)
+
+    def cons_body(c):
+        for _ in range_(4):
+            c.acquire(1)
+            c.release(1)
+
+    w_prod = Worker(prod_body, fn_args=[of_pin.prod(channel=1)], tile=Tile(0, 2))
+    w_cons = Worker(cons_body, fn_args=[of_pin.cons(channel=1)], tile=Tile(0, 3))
+
+    rt = Runtime()
+    with rt.sequence():
+        rt.start(w_prod, w_cons)
+
+    module = Program(dev, rt).resolve_program()
+    print(module)
+
+
+# CHECK-DAG: aie.objectfifo @of_partial({{.*}}) {cons_dma_channels = array<i32: -1, 2>} : !aie.objectfifo<memref<16xi32>>
+def test_partial_cons_pins_use_sentinel():
+    """With multiple consumers, only the pinned one gets its channel; the
+    unpinned peer is recorded as -1 (auto-assign) in cons_dma_channels. The
+    producer is unpinned, so no prod_dma_channel attr is emitted."""
+
+    dev = NPU1Col1()
+    tile_ty = np.ndarray[(16,), np.dtype[np.int32]]
+
+    of_partial = ObjectFifo(tile_ty, depth=2, name="of_partial")
+
+    def prod_body(p):
+        for _ in range_(4):
+            p.acquire(1)
+            p.release(1)
+
+    def cons_body(c):
+        for _ in range_(4):
+            c.acquire(1)
+            c.release(1)
+
+    w_prod = Worker(prod_body, fn_args=[of_partial.prod()], tile=Tile(0, 2))
+    w_cons_a = Worker(cons_body, fn_args=[of_partial.cons()], tile=Tile(0, 3))
+    w_cons_b = Worker(cons_body, fn_args=[of_partial.cons(channel=2)], tile=Tile(0, 4))
+
+    rt = Runtime()
+    with rt.sequence():
+        rt.start(w_prod, w_cons_a, w_cons_b)
+
+    module = Program(dev, rt).resolve_program()
+    print(module)
+
+
+# CHECK: re-pin rejected
+def test_conflicting_reprod_pin_is_rejected():
+    """The producer handle is unique per fifo; asking for a second, conflicting
+    channel on it must raise rather than silently keep the first pin."""
+
+    tile_ty = np.ndarray[(16,), np.dtype[np.int32]]
+    of = ObjectFifo(tile_ty, depth=2, name="of_repin")
+    of.prod(channel=1)
+    try:
+        of.prod(channel=2)
+    except ValueError:
+        print("re-pin rejected")
+
+
+if __name__ == "__main__":
+    test_prod_cons_channel_pins_emit_attrs()
+    test_partial_cons_pins_use_sentinel()
+    test_conflicting_reprod_pin_is_rejected()


### PR DESCRIPTION
Two additive front-end features for host-driven designs that must match an external runtime's fixed hardware contract (where the runtime addresses L1 buffers and shim DMAs by fixed address/channel, so the overlay must match). Both are strictly additive — unpinned buffers and fifos are unaffected.
  
### 1. `Buffer(address=)` (commit 1)
Exposes the existing low-level `aie.buffer address=` attribute on the IRON `Buffer`, so a runtime-written (RTP) buffer can be pinned to a known L1 address instead of being left to compiler assignment. Plumbs through `python/iron/buffer.py` only; defaults to `None` (compiler-assigned).
  
### 2. ObjectFifo `prod(channel=)` / `cons(channel=)` (commit 2)
Pins an endpoint's DMA channel instead of first-free assignment. 
- `AIEOps.td`: `prod_dma_channel` + `cons_dma_channels` optional attrs on `ObjectFifoCreateOp` (one entry per consumer, `-1` = auto).
- `AIEObjectFifoStatefulTransform.cpp`: `reservePinnedChannels()` reserves pins before first-free so auto-assignment can't steal them; assignment honors a pin else falls through to the original path; split-consumer propagation carries each consumer's pin onto its fresh op. Clean `emitOpError` on out-of-range, collision, or pin combined with `aie_stream`.
    
**Known limitation:** `aie-place-tiles` runs before channel assignment and is not channel-aware, so pinning on logical/unplaced shim tiles could produce an unsatisfiable conflict — this fails loudly (`emitOpError`) rather than silently. Making the placer channel-aware is out of scope.