### PR TITLE
Force PIE on bootgen to fix PDI-generation segfault

### DIFF
--- a/tools/bootgen/CMakeLists.txt
+++ b/tools/bootgen/CMakeLists.txt
@@ -107,17 +107,9 @@ string(REPLACE "#include \"openssl/ms/applink.c\"" "" FILE_CONTENTS "${FILE_CONT
 file(WRITE ${BOOTGEN_SOURCE}/main.cpp "${FILE_CONTENTS}")
 
 add_library(bootgen-lib STATIC ${libsources})
-# Force PIE/PIC explicitly rather than inheriting whatever the top-level
-# project's global flags happen to be: bootgen has no dependency on
-# MLIR/LLVM, but it's configured as part of the same CMake invocation, so it
-# silently inherits global compiler/linker defaults set by
-# find_package(MLIR)/include(HandleLLVMOptions) upstream. When those global
-# defaults produce a non-PIE bootgen executable that still declares dynamic
-# NEEDED libs and an RPATH, auditwheel repair's patchelf-based RPATH rewrite
-# has been observed to corrupt the binary (jumps into the non-executable
-# DYNAMIC segment at runtime -- SIGSEGV/SEGV_ACCERR before main() even
-# runs). Pinning PIE here keeps bootgen's ELF layout the standard one
-# patchelf actually exercises, independent of what MLIR/LLVM sets globally.
+# bootgen must be compiled with PIE/PIC, irrespective of the remainder of
+# the project, because  auditwheel repair's patchelf-based RPATH rewrite
+# corrupts the non-PIE binary
 set_target_properties(bootgen-lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   set(bootgen_warning_ignores

--- a/tools/bootgen/CMakeLists.txt
+++ b/tools/bootgen/CMakeLists.txt
@@ -107,6 +107,18 @@ string(REPLACE "#include \"openssl/ms/applink.c\"" "" FILE_CONTENTS "${FILE_CONT
 file(WRITE ${BOOTGEN_SOURCE}/main.cpp "${FILE_CONTENTS}")
 
 add_library(bootgen-lib STATIC ${libsources})
+# Force PIE/PIC explicitly rather than inheriting whatever the top-level
+# project's global flags happen to be: bootgen has no dependency on
+# MLIR/LLVM, but it's configured as part of the same CMake invocation, so it
+# silently inherits global compiler/linker defaults set by
+# find_package(MLIR)/include(HandleLLVMOptions) upstream. When those global
+# defaults produce a non-PIE bootgen executable that still declares dynamic
+# NEEDED libs and an RPATH, auditwheel repair's patchelf-based RPATH rewrite
+# has been observed to corrupt the binary (jumps into the non-executable
+# DYNAMIC segment at runtime -- SIGSEGV/SEGV_ACCERR before main() even
+# runs). Pinning PIE here keeps bootgen's ELF layout the standard one
+# patchelf actually exercises, independent of what MLIR/LLVM sets globally.
+set_target_properties(bootgen-lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   set(bootgen_warning_ignores
     -Wno-cast-qual
@@ -154,6 +166,7 @@ install(
   DESTINATION include)
 
 add_executable(bootgen ${BOOTGEN_SOURCE}/main.cpp)
+set_target_properties(bootgen PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(bootgen PUBLIC ${BOOTGEN_SOURCE} ${OPENSSL_INCLUDE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_compile_options(bootgen PRIVATE ${bootgen_warning_ignores})


### PR DESCRIPTION
## Summary

Fixes a real, hardware-reproducible crash found while validating #3323 (ROCm mlir_aie wheel on Ryzen AI self-hosted runners): nearly every `programming_examples/` test failed with

\`\`\`
RuntimeError: [aiecc] Compilation failed with exit code 1:
Error: Command failed with exit code -2
Error message: Segmentation fault (core dumped)
Error generating PDI
\`\`\`

on both \`aie2-4col\` and \`aie2p-8col\` — see full diagnosis in [this comment](https://github.com/Xilinx/mlir-aie/pull/3323#issuecomment-4960637488).

**Root cause:** \`bootgen\` has no dependency on MLIR/LLVM (it only links \`OpenSSL::SSL\` + its own \`bootgen-lib\`), but it's configured as part of the same top-level CMake invocation as everything else, so it silently inherits whatever global compiler/linker defaults \`find_package(MLIR)\`/\`include(HandleLLVMOptions)\` set for that run. Building against the ROCm-built MLIR wheel flips \`bootgen\` from a PIE executable to a non-PIE one, while it still declares dynamic \`NEEDED\` libs and an \`RPATH\`. \`auditwheel repair\`'s \`patchelf\`-based RPATH rewrite (needed to point at vendored/renamed OpenSSL libs) then corrupts that non-standard layout — the binary \`SIGSEGV\`s (\`SEGV_ACCERR\`) jumping into its own non-executable \`DYNAMIC\` segment before \`main()\` even runs.

Confirmed via \`strace\`:
\`\`\`
--- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_ACCERR, si_addr=0x4020c8} ---
\`\`\`
\`readelf -l\` shows \`0x4020c8\` falls inside the \`DYNAMIC\` segment, which is mapped \`RW\` only — something is jumping there to execute code.

**Fix:** pin \`POSITION_INDEPENDENT_CODE ON\` directly on the \`bootgen-lib\` and \`bootgen\` CMake targets, so their ELF layout no longer depends on whatever the linked MLIR/LLVM package happens to set globally.

**Verified locally:**
- Before: \`bootgen -help\` segfaults immediately — even under \`LD_TRACE_LOADED_OBJECTS=1\` (what \`ldd\` uses internally), i.e. before \`bootgen\`'s own code runs. ELF type: \`EXEC\`.
- After (rebuilt \`bootgen\` target against the same ROCm MLIR content): ELF type is now \`pie executable\`, and \`bootgen -help\` runs correctly, printing the normal \`Bootgen v2023.2\` banner.
- Also rebuilt \`aiecc\` (which links the same \`bootgen-lib\`) to confirm no regression there.

This blocks #3323 and #3326 (which depends on #3323 passing) — once merged, #3323 should be re-run against a wheel built with this fix.

## Test plan

- [ ] CI passes on this PR (should be a no-op for every other target)
- [ ] Re-run #3323's wheel build + hardware test with this fix included and confirm `programming_examples` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)