### PR TITLE
[IRON] TileDma: emit Bd packet header as dma_bd_packet op, not attribute

### DIFF
--- a/python/iron/dataflow/tile_dma.py
+++ b/python/iron/dataflow/tile_dma.py
@@ -31,6 +31,7 @@ from ...dialects._aie_enum_gen import (  # pyright: ignore[reportMissingImports]
 from ...dialects.aie import (
     EndOp,  # pyright: ignore[reportAttributeAccessIssue]
     dma_bd,  # pyright: ignore[reportAttributeAccessIssue]
+    dma_bd_packet,  # pyright: ignore[reportAttributeAccessIssue]
     dma_start,
     mem,
     memtile_dma,
@@ -250,10 +251,15 @@ class TileDma(Resolvable):
                             bd_kwargs["offset"] = bd.offset
                         if bd.length is not None:
                             bd_kwargs["len"] = bd.length
-                        if bd.packet is not None:
-                            bd_kwargs["packet"] = bd.packet
                         if bd.dimensions is not None:
                             bd_kwargs["dimensions"] = bd.dimensions
+                        # A packet header must be a distinct aie.dma_bd_packet op
+                        # placed BEFORE the aie.dma_bd: the CDO/xclbin backends
+                        # (AIERT / AIETargetXAIEV2) read the header only from that
+                        # op, not from a `packet` attribute on the dma_bd.
+                        if bd.packet is not None:
+                            pkt_type, pkt_id = bd.packet
+                            dma_bd_packet(pkt_type, pkt_id)
                         dma_bd(bd.buffer.op, **bd_kwargs)
                         for rel in bd.releases:
                             rel.emit()

--- a/test/python/bd_packet.py
+++ b/test/python/bd_packet.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# RUN: %python %s | FileCheck %s
+
+"""Test that Bd.packet emits a distinct aie.dma_bd_packet op BEFORE the
+aie.dma_bd, rather than a `packet` attribute on the dma_bd. The CDO/xclbin
+backends (AIERT, AIETargetXAIEV2) read the packet header only from the
+dma_bd_packet op, so the header must be emitted as that op to reach hardware."""
+
+import numpy as np
+
+from aie.iron import Bd, Buffer, DmaChannel, Program, Runtime, TileDma
+from aie.iron.device import NPU2Col1, Tile
+from aie.dialects._aie_enum_gen import AIETileType, DMAChannelDir
+
+
+def emit_packet_bd():
+    n = 256
+    vector_ty = np.ndarray[(n,), np.dtype[np.int32]]
+
+    compute_tile = Tile(col=0, row=2, tile_type=AIETileType.CoreTile)
+    buf = Buffer(tile=compute_tile, type=vector_ty, name="pkt_buf")
+
+    tile_dma = TileDma(
+        tile=compute_tile,
+        channels=[
+            DmaChannel(
+                direction=DMAChannelDir.MM2S,
+                channel=0,
+                bds=[
+                    Bd(
+                        buffer=buf,
+                        offset=0,
+                        length=n,
+                        packet=(0, 5),
+                        next="self",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    rt = Runtime()
+    rt.add_tile_dma(tile_dma)
+    with rt.sequence(vector_ty) as _:
+        pass
+
+    return Program(NPU2Col1(), rt).resolve_program()
+
+
+# The packet header is a distinct op emitted immediately before the dma_bd,
+# and the dma_bd itself carries no packet attribute.
+# CHECK: aie.dma_bd_packet(0, 5)
+# CHECK-NEXT: aie.dma_bd({{.*}} : memref<256xi32>, 0, 256)
+# CHECK-NOT: aie.dma_bd({{.*}}packet
+print(emit_packet_bd())


### PR DESCRIPTION
## Summary
  
`Bd(packet=(type, id))` stamped a `packet` attribute on the `aie.dma_bd` op. But the CDO/xclbin backends (`AIERT.cpp`, `AIETargetXAIEV2.cpp`) read the packet header only from a distinct `aie.dma_bd_packet` op preceding the `dma_bd` — there is no fallback to a `dma_bd` attribute, and no pass converts one form to the other for hand-written `mem` / `memtile_dma` regions. So the attribute form was silently dropped at xclbin generation, producing incorrect packet routing on hardware. 
  
This emits `aie.dma_bd_packet(type, id)` immediately before the `aie.dma_bd` instead, matching what the backends consume. Non-packet BDs are unaffected.
  
## Test
  
Adds `test/python/bd_packet.py` (modeled on `bd_dimensions.py`): asserts the lowering emits the `dma_bd_packet` op and that the `dma_bd` carries no packet attribute. Confirmed it fails on the prior attribute-based behavior and passes with this change.