### PR TITLE
Force PIE on bootgen with explicit compiler/linker flags, not just the CMake property

### DIFF
--- a/tools/bootgen/CMakeLists.txt
+++ b/tools/bootgen/CMakeLists.txt
@@ -144,6 +144,18 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(bootgen-lib PRIVATE /wd4996 /wd4840 /wd4005 /wd5033)
 endif()
 target_compile_options(bootgen-lib PRIVATE ${bootgen_warning_ignores})
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  # Explicit -fPIC, not just the POSITION_INDEPENDENT_CODE property above:
+  # that property relies on CMake's CMP0083 + the CheckPIESupported module
+  # to inject the right compiler/linker flags, and this project never calls
+  # check_pie_supported(), so the property silently does nothing on some
+  # toolchains (observed on the manylinux_2_28 gcc-toolset used to build
+  # release wheels, which -- unlike a distro's system gcc -- does not
+  # default to PIE/PIC either). Passed last so it wins (compilers apply
+  # "last flag wins" for -fPIC/-fno-PIC) over anything inherited from the
+  # linked MLIR/LLVM package's own build configuration.
+  target_compile_options(bootgen-lib PRIVATE -fPIC)
+endif()
 target_include_directories(bootgen-lib PRIVATE ${BOOTGEN_SOURCE} ${OPENSSL_INCLUDE_DIR})
 # Make C API header available publicly
 target_include_directories(bootgen-lib PUBLIC
@@ -165,6 +177,15 @@ target_compile_options(bootgen PRIVATE ${bootgen_warning_ignores})
 if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(bootgen PRIVATE /EHsc)
   target_compile_options(bootgen PRIVATE /wd4996 /wd4840 /wd4005 /wd5033)
+endif()
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  # Explicit -fPIE/-pie (see bootgen-lib above for why the
+  # POSITION_INDEPENDENT_CODE property alone can't be trusted). Passed last
+  # so it wins -- compilers apply "last flag wins" for -fPIE/-fno-PIE and
+  # -pie/-no-pie -- over anything inherited from the linked MLIR/LLVM
+  # package's own build configuration.
+  target_compile_options(bootgen PRIVATE -fPIE)
+  target_link_options(bootgen PRIVATE -fPIE -pie)
 endif()
 target_compile_definitions(bootgen PRIVATE OPENSSL_USE_APPLINK)
 target_link_libraries(bootgen PRIVATE bootgen-lib OpenSSL::SSL OpenSSL::applink)

--- a/tools/bootgen/CMakeLists.txt
+++ b/tools/bootgen/CMakeLists.txt
@@ -146,10 +146,7 @@ endif()
 target_compile_options(bootgen-lib PRIVATE ${bootgen_warning_ignores})
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND NOT MSVC)
   # The POSITION_INDEPENDENT_CODE property above doesn't reliably force PIC
-  # here (this project never calls check_pie_supported(), which CMP0083
-  # needs), so pass -fPIC explicitly, last, so it wins over any inherited
-  # -fno-PIC. NOT MSVC excludes clang-cl, which also matches "Clang" but
-  # can't parse this flag.
+  # so pass -fPIC explicitly, last, so it wins over any inherited -fno-PIC.
   target_compile_options(bootgen-lib PRIVATE -fPIC)
 endif()
 target_include_directories(bootgen-lib PRIVATE ${BOOTGEN_SOURCE} ${OPENSSL_INCLUDE_DIR})

--- a/tools/bootgen/CMakeLists.txt
+++ b/tools/bootgen/CMakeLists.txt
@@ -144,16 +144,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(bootgen-lib PRIVATE /wd4996 /wd4840 /wd4005 /wd5033)
 endif()
 target_compile_options(bootgen-lib PRIVATE ${bootgen_warning_ignores})
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  # Explicit -fPIC, not just the POSITION_INDEPENDENT_CODE property above:
-  # that property relies on CMake's CMP0083 + the CheckPIESupported module
-  # to inject the right compiler/linker flags, and this project never calls
-  # check_pie_supported(), so the property silently does nothing on some
-  # toolchains (observed on the manylinux_2_28 gcc-toolset used to build
-  # release wheels, which -- unlike a distro's system gcc -- does not
-  # default to PIE/PIC either). Passed last so it wins (compilers apply
-  # "last flag wins" for -fPIC/-fno-PIC) over anything inherited from the
-  # linked MLIR/LLVM package's own build configuration.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND NOT MSVC)
+  # The POSITION_INDEPENDENT_CODE property above doesn't reliably force PIC
+  # here (this project never calls check_pie_supported(), which CMP0083
+  # needs), so pass -fPIC explicitly, last, so it wins over any inherited
+  # -fno-PIC. NOT MSVC excludes clang-cl, which also matches "Clang" but
+  # can't parse this flag.
   target_compile_options(bootgen-lib PRIVATE -fPIC)
 endif()
 target_include_directories(bootgen-lib PRIVATE ${BOOTGEN_SOURCE} ${OPENSSL_INCLUDE_DIR})
@@ -178,14 +174,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_options(bootgen PRIVATE /EHsc)
   target_compile_options(bootgen PRIVATE /wd4996 /wd4840 /wd4005 /wd5033)
 endif()
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  # Explicit -fPIE/-pie (see bootgen-lib above for why the
-  # POSITION_INDEPENDENT_CODE property alone can't be trusted). Passed last
-  # so it wins -- compilers apply "last flag wins" for -fPIE/-fno-PIE and
-  # -pie/-no-pie -- over anything inherited from the linked MLIR/LLVM
-  # package's own build configuration.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND NOT MSVC)
+  # See bootgen-lib above. -fPIE is compile-only; -pie is the link-mode
+  # switch (kept separate since some toolchains don't accept -fPIE at link).
   target_compile_options(bootgen PRIVATE -fPIE)
-  target_link_options(bootgen PRIVATE -fPIE -pie)
+  target_link_options(bootgen PRIVATE -pie)
 endif()
 target_compile_definitions(bootgen PRIVATE OPENSSL_USE_APPLINK)
 target_link_libraries(bootgen PRIVATE bootgen-lib OpenSSL::SSL OpenSSL::applink)


### PR DESCRIPTION
## Summary

Follow-up to #3327, which set `POSITION_INDEPENDENT_CODE ON` on the `bootgen`/`bootgen-lib` CMake targets to keep `bootgen`'s ELF layout PIE regardless of what the linked MLIR/LLVM package sets globally. That's needed because `auditwheel repair`'s patchelf-based RPATH rewrite (required to point at vendored/renamed OpenSSL libs) corrupts a non-PIE `bootgen`: the binary `SIGSEGV`s (`SEGV_ACCERR`) jumping into its own non-executable `DYNAMIC` segment before `main()` runs, breaking PDI/xclbin generation on real Ryzen AI hardware -- this is what's still failing in #3323.

**#3327's fix doesn't actually work.** The wheel built from that exact commit (`27433d63`, `AIE_PROJECT_COMMIT` in the #3323 build) still ships a non-PIE `bootgen`:
```
$ readelf -h mlir_aie/bin/bootgen | grep Type
  Type:                              EXEC (Executable file)
$ strace -f ./mlir_aie/bin/bootgen -help
--- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_ACCERR, si_addr=0x4020f0} ---
```
(`0x4020f0` falls inside that binary's `DYNAMIC` segment, `0x401fc8`-`0x4021f8` -- exact same failure mode as before, reproduced by downloading the actual `rocm-wheel-ryzenai-validation` artifact from the #3323 CI run and running it directly, no hardware needed.)

**Root cause of why the property doesn't work:** this project never calls `include(CheckPIESupported)` / `check_pie_supported()`, which CMake's `CMP0083` machinery needs in order to translate the `POSITION_INDEPENDENT_CODE` target property into actual `-fPIE`/`-pie` compiler/linker flags for an *executable* target. Without that, the property is a no-op here. Compounding it: `manylinux_2_28`'s `gcc-toolset-14` (used to build release wheels) doesn't default to PIE the way a distro's system GCC does, so there's no free fallback either.

**Fix:** pass `-fPIC` (on `bootgen-lib`) and `-fPIE`/`-pie` (on `bootgen`) as explicit `target_compile_options`/`target_link_options`, placed last so they win via ordinary compiler "last flag wins" semantics over any `-fno-pie`/`-fno-PIC` inherited from the linked MLIR/LLVM package's own build configuration -- independent of the property/policy machinery.

**Verified locally**: built `bootgen` under a forced `-fno-pie -fno-PIC -no-pie` global configuration (reproducing the manylinux/ROCm environment). Confirmed the *old* (#3327) property-only approach still yields a non-PIE `EXEC` binary under those conditions, while this change reliably produces a true PIE (`ET_DYN`) `bootgen` that runs correctly.

## Test plan

- [ ] CI passes (should be a no-op for every other target)
- [ ] Re-run #3323's wheel build + hardware test with this fix included; confirm `readelf -h` on the shipped `bootgen` shows `DYN`, and `programming_examples` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)