### PR TITLE
[AIEX] Trace memref.view in dma_bd buffer lowering

### DIFF
--- a/include/aie/Dialect/AIEX/AIEUtils.h
+++ b/include/aie/Dialect/AIEX/AIEUtils.h
@@ -33,20 +33,22 @@ memref::GlobalOp getOrCreateDataMemref(
     llvm::DenseMap<mlir::Attribute, memref::GlobalOp> *dedupCache = nullptr,
     unsigned *nextId = nullptr);
 
-// Result of tracing through subview/cast operations to a block argument for
-// traceSubviewToBlockArgument function.
+// Result of tracing through supported view/cast operations to a block argument
+// for traceSubviewToBlockArgument function.
 struct SubviewTraceResult {
   BlockArgument rootArg;
   int64_t offsetInBytes;
 };
 
-// Trace through memref.subview, memref.cast, and memref.reinterpret_cast
-// operations until the referenced SSA value is a block argument.
+// Trace through memref.subview, memref.view, memref.cast, and
+// memref.reinterpret_cast operations until the referenced SSA value is a block
+// argument.
 //
 // Returns the root block argument and cumulative byte offset, or std::nullopt
 // if the chain doesn't lead to a block argument or contains unsupported ops.
 //
-// This function checks that all subviews remain static and contiguous.
+// This function checks that all subviews remain static and contiguous. A
+// memref.view must have a constant byte shift and no dynamic result sizes.
 std::optional<SubviewTraceResult> traceSubviewToBlockArgument(Value value);
 
 // Emit an `aiex.npu.update_from_scratchpad` op that adds the runtime offset
@@ -57,5 +59,5 @@ LogicalResult emitUpdateBdAddressFromOffsetParameter(OpBuilder &builder,
                                                      Operation *bdOp,
                                                      BaseMemRefType bufType,
                                                      uint64_t registerAddr);
-}
+} // namespace AIEX
 } // namespace xilinx

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -229,7 +229,7 @@ struct AIEDMATasksToNPUPass
     // A buffer descriptor can refer to a statically allocated aie.buffer, or to
     // a DDR buffer which will be passed as a runtime argument (block
     // argument). Try to find the root block argument, either directly or
-    // through subviews/casts.
+    // through supported subview/view/cast chains.
     mlir::BlockArgument buf_arg = nullptr;
     int64_t offset = 0;
 
@@ -309,8 +309,10 @@ struct AIEDMATasksToNPUPass
     } else {
       return bd_op->emitOpError(
           "Buffer argument must be a constant aie.buffer, a runtime sequence "
-          "input argument, or a (chain of) subview(s) or cast(s) of a block "
-          "argument with constant offsets and strides equal to one.");
+          "input argument, or a supported chain of memref.subview, "
+          "memref.view, memref.cast, or memref.reinterpret_cast operations "
+          "rooted at a block argument. Subviews must be static and contiguous; "
+          "views must have a constant byte shift and no dynamic result sizes.");
     }
 
     // If this BD has an offset_state_table_idx, emit update_from_scratchpad to

--- a/lib/Dialect/AIEX/Utils/AIEUtils.cpp
+++ b/lib/Dialect/AIEX/Utils/AIEUtils.cpp
@@ -7,6 +7,7 @@
 
 #include "aie/Dialect/AIEX/AIEUtils.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
 
 using namespace mlir;
 using namespace xilinx;
@@ -112,6 +113,24 @@ AIEX::traceSubviewToBlockArgument(Value value) {
       offsetInBytes += (resOff - srcOff) * (elemSizeInBits / 8);
 
       current = subviewOp.getSource();
+      continue;
+    }
+
+    // Handle memref.view. The fused full-ELF path materializes every DMA
+    // buffer as a typed, contiguous view sliced out of a single flat byte
+    // arena (a runtime-sequence block argument) at a constant byte offset:
+    //   %v = memref.view %arena[%byte_off][] : memref<Nxi8> to memref<...>
+    // A memref.view result always has an identity (contiguous) layout, so only
+    // the byte offset needs to be accumulated before following the source.
+    if (auto viewOp = dyn_cast<memref::ViewOp>(defOp)) {
+      if (!viewOp.getSizes().empty())
+        return std::nullopt; // dynamic result sizes unsupported
+      std::optional<int64_t> byteShift =
+          getConstantIntValue(viewOp.getByteShift());
+      if (!byteShift)
+        return std::nullopt; // non-constant byte offset
+      offsetInBytes += *byteShift;
+      current = viewOp.getSource();
       continue;
     }
 

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_view.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_view.mlir
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022-2026 Advanced Micro Devices, Inc.
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_view.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_view.mlir
@@ -18,17 +18,20 @@ module {
     aie.runtime_sequence(%arg0: memref<1024xi8>) {
       // View at byte offset 128 -> address patch arg_plus = 128.
       // CHECK: aiex.npu.writebd
-      // CHECK: aiex.npu.address_patch {addr = {{.*}}, arg_idx = 0 : i32, arg_plus = 128 : i32}
+      // CHECK-DAG: %[[AP128:.*]] = arith.constant 128 : i32
+      // CHECK: aiex.npu.address_patch(%[[AP128]] : i32) {addr = {{.*}}, arg_idx = 0 : i32}
       %c128 = arith.constant 128 : index
       %view = memref.view %arg0[%c128][] : memref<1024xi8> to memref<128xi16>
       %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
-        aie.dma_bd(%view : memref<128xi16>, 0, 128) {bd_id = 7 : i32}
+        aie.dma_bd(%view : memref<128xi16> offset = 0 len = 128) {bd_id = 7 : i32}
         aie.end
       } {issue_token = true}
 
-      // CHECK: aiex.npu.push_queue(0, 0, MM2S : 0) {bd_id = 7 : i32, issue_token = true, repeat_count = 0 : i32}
+      // CHECK-DAG: %[[PQBD:.*]] = arith.constant 7 : i32
+      // CHECK: aiex.npu.push_queue(0, 0, MM2S : 0) bd_id %[[PQBD]] repeat %{{.*}} {issue_token = true} : i32, i32
       aiex.dma_start_task(%t1)
-      // CHECK: aiex.npu.sync
+      // sync operands: column=0, row=0, direction=1, channel=0, column_num=1, row_num=1
+      // CHECK: aiex.npu.sync(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : i32, i32, i32, i32, i32, i32
       aiex.dma_await_task(%t1)
     }
   }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_view.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_view.mlir
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2022-2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+// RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
+
+// Test that memref.view is correctly traced through when configuring DMA tasks.
+// This is the pattern the fused whole-model (--generate-full-elf) lowering emits:
+// every DMA buffer is a typed memref.view slice of one flat byte-arena runtime
+// sequence input argument at a constant byte offset. Without tracing view, the
+// buffer fails to resolve to its block argument and the BD cannot be lowered.
+
+module {
+  aie.device(npu1) {
+    %tile_0_0 = aie.tile(0, 0)
+
+    aie.runtime_sequence(%arg0: memref<1024xi8>) {
+      // View at byte offset 128 -> address patch arg_plus = 128.
+      // CHECK: aiex.npu.writebd
+      // CHECK: aiex.npu.address_patch {addr = {{.*}}, arg_idx = 0 : i32, arg_plus = 128 : i32}
+      %c128 = arith.constant 128 : index
+      %view = memref.view %arg0[%c128][] : memref<1024xi8> to memref<128xi16>
+      %t1 = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%view : memref<128xi16>, 0, 128) {bd_id = 7 : i32}
+        aie.end
+      } {issue_token = true}
+
+      // CHECK: aiex.npu.push_queue(0, 0, MM2S : 0) {bd_id = 7 : i32, issue_token = true, repeat_count = 0 : i32}
+      aiex.dma_start_task(%t1)
+      // CHECK: aiex.npu.sync
+      aiex.dma_await_task(%t1)
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`AIEDMATasksToNPU` (`--aie-dma-tasks-to-npu`) resolves a `dma_bd`'s buffer to a runtime-sequence block argument via `AIEX::traceSubviewToBlockArgument` (`lib/Dialect/AIEX/Utils/AIEUtils.cpp`), which follows `memref.cast`, `memref.reinterpret_cast`, and `memref.subview`. It does not follow `memref.view`, so a BD whose buffer is a `memref.view` slice of a runtime input falls through to:

```
'aie.dma_bd' op Buffer argument must be a constant aie.buffer, a runtime
 sequence input argument, or a (chain of) subview(s) or cast(s) of a block
 argument with constant offsets and strides equal to one.
```

This is the pattern the fused whole-model `--generate-full-elf` lowering emits: the fused `main` device's DMA orchestration materializes every buffer as a typed `memref.view` slice of one flat byte-arena runtime input, e.g.

```mlir
%v = memref.view %arg0[%byte_off][] : memref<Nxi8> to memref<2048xbf16>
"aie.dma_bd"(%v) <{... offset = 0, len = 2048, dimensions = ...}>
```

so `--generate-full-elf` fails NPU lowering for any non-trivial fused model.

## Fix

Add a `memref::ViewOp` case to `traceSubviewToBlockArgument`. A `memref.view` result has an identity (contiguous) layout, so tracing only needs to accumulate the constant byte offset and follow the source, bailing out on dynamic result sizes or a non-constant byte shift. This mirrors the existing `subview` / `cast` handling.

## Test

`test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good_view.mlir`: a `dma_bd` whose buffer is a `memref.view` of a runtime input lowers to an `aiex.npu.address_patch` with `arg_idx = 0` and a constant byte-offset operand. Modeled on the existing `good_subview.mlir`. Without the fix the pass errors out (no output for FileCheck to match); with it, the test passes.

## Impact

Unblocks whole-model fused-ELF (`--generate-full-elf`) compilation, which previously failed NPU lowering for any model whose fused DMA buffers are `memref.view` slices of a shared runtime arena.
