### PR TITLE
Unconditionally run 'Smoke-test wheels'

### DIFF
--- a/.github/workflows/buildRyzenWheels.yml
+++ b/.github/workflows/buildRyzenWheels.yml
@@ -262,7 +262,6 @@ jobs:
     # job uses the self-hosted NPU runners. PR-only: the merge queue and
     # nightly still get full from-source NPU coverage via buildAndTestRyzenAI.
     needs: build-repo
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ${{ matrix.runner_type }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Whenever the wheel gets built, it should get smoke-tested. Testing is cheap. Remove the old conditional.