### PR TITLE
[AIETargetNPU] Gate DDR-patch aperture offset by runtime (fix full-ELF >5 buffers)

### DIFF
--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -65,11 +65,10 @@ mlir::LogicalResult AIETranslateShimSolution(mlir::ModuleOp module,
                                              llvm::StringRef deviceName = "");
 mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
                                          llvm::raw_ostream &, llvm::StringRef);
-mlir::LogicalResult
-AIETranslateNpuToBinary(mlir::ModuleOp, std::vector<uint32_t> &,
-                        llvm::StringRef deviceName = "",
-                        llvm::StringRef sequenceName = "",
-                        std::vector<TxnLocEntry> *locmap = nullptr);
+mlir::LogicalResult AIETranslateNpuToBinary(
+    mlir::ModuleOp, std::vector<uint32_t> &, llvm::StringRef deviceName = "",
+    llvm::StringRef sequenceName = "",
+    std::vector<TxnLocEntry> *locmap = nullptr, bool foldDDRAddrOffset = true);
 mlir::LogicalResult AIETranslateNpuToCpp(mlir::ModuleOp module,
                                          llvm::raw_ostream &output);
 mlir::LogicalResult AIETranslateToUcDma(mlir::ModuleOp module,

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -113,17 +113,22 @@ void appendLoadPdi(std::vector<uint32_t> &instructions, NpuLoadPdiOp op) {
                                   op.getAddress());
 }
 
-// The NPU firmware pre-translates host buffer addresses from the host address
-// space into the AIE address space by adding this offset, but only for the
-// first `kNumFirmwareTranslatedArgs` host arguments. For host arguments beyond
-// that, the firmware leaves the raw host address in place, so the DDR patch
-// must fold the same translation offset into its arg_plus to land at the
-// correct AIE address. See NpuAddressPatchOp handling below.
+// The "instruction buffer" runtime (xclbin + insts.bin, launched as
+// kernel(opcode, insts_bo, ninsts, host_bo0, ...)) has the NPU firmware
+// pre-translate host buffer addresses into the AIE address space by adding this
+// offset, but only for the first `kNumFirmwareTranslatedArgs` host arguments.
+// Host arguments beyond that keep their raw host address, so the DDR patch must
+// fold the same offset into arg_plus to land at the correct AIE address.
+//
+// The full-ELF runtime (xrt.elf + xrt.ext.kernel) instead assigns NPU-space
+// device addresses to ALL host arguments, so folding the offset there would
+// double-translate the 6th+ buffer. `foldDDRAddrOffset` (see
+// AIETranslateNpuToBinary) selects between the two runtimes.
 static constexpr uint32_t kDDRAIEAddrOffset = 0x80000000;
 static constexpr uint32_t kNumFirmwareTranslatedArgs = 5;
 
 LogicalResult appendAddressPatch(std::vector<uint32_t> &instructions,
-                                 NpuAddressPatchOp op) {
+                                 NpuAddressPatchOp op, bool foldDDRAddrOffset) {
   std::optional<uint32_t> argPlus =
       AIEX::getConstantIntOperand(op.getArgPlus());
   if (!argPlus)
@@ -131,9 +136,7 @@ LogicalResult appendAddressPatch(std::vector<uint32_t> &instructions,
                           "arg_plus to a static TXN binary");
   uint32_t argIdx = op.getArgIdx();
   uint32_t patchedArgPlus = *argPlus;
-  // Host arguments beyond the firmware-translated set get the AIE address-space
-  // offset applied here instead of by firmware.
-  if (argIdx >= kNumFirmwareTranslatedArgs)
+  if (foldDDRAddrOffset && argIdx >= kNumFirmwareTranslatedArgs)
     patchedArgPlus += kDDRAIEAddrOffset;
   aie_runtime::txn_append_address_patch(instructions, op.getAddr(), argIdx,
                                         patchedArgPlus);
@@ -338,7 +341,7 @@ static void pushLocEntry(std::vector<TxnLocEntry> *locmap,
 LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
     mlir::ModuleOp moduleOp, std::vector<uint32_t> &instructions,
     StringRef deviceName, StringRef sequenceName,
-    std::vector<TxnLocEntry> *locmap) {
+    std::vector<TxnLocEntry> *locmap, bool foldDDRAddrOffset) {
 
   DeviceOp deviceOp =
       DeviceOp::getForSymbolInModuleOrError(moduleOp, deviceName);
@@ -430,7 +433,7 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
           .Case<NpuAddressPatchOp>([&](auto op) {
             count++;
             uint32_t before = byteOffset();
-            if (failed(appendAddressPatch(instructions, op)))
+            if (failed(appendAddressPatch(instructions, op, foldDDRAddrOffset)))
               result = failure();
             pushLocEntry(locmap, before, byteOffset(), "ADDRESS_PATCH",
                          op->getName().getStringRef(), op.getAddr(), op, tm);

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -157,6 +157,15 @@ void registerAIETranslations() {
       llvm::cl::desc(
           "Select binary (true) or text (false) output for supported "
           "translations. e.g. aie-npu-to-binary, aie-ctrlpkt-to-bin"));
+  static llvm::cl::opt<bool> npuFoldDDRAddrOffset(
+      "aie-npu-fold-ddr-addr-offset", llvm::cl::init(true),
+      llvm::cl::desc(
+          "For aie-npu-to-binary: fold the AIE DDR-aperture offset into the "
+          "arg_plus of DDR address patches for host arguments beyond the "
+          "firmware-translated set. Required for the xclbin + "
+          "instruction-buffer "
+          "runtime; must be false for the full-ELF (xrt.ext.kernel) runtime, "
+          "which translates all host buffer addresses itself."));
   static llvm::cl::opt<std::string> deviceName(
       "aie-device-name", llvm::cl::init(""),
       llvm::cl::desc("Specify which device to translate"));
@@ -366,9 +375,9 @@ void registerAIETranslations() {
         std::vector<uint32_t> instructions;
         std::vector<TxnLocEntry> locmap;
         bool emitLocmap = !npuEmitLocmap.empty();
-        auto r = AIETranslateNpuToBinary(module, instructions, deviceName,
-                                         sequenceName,
-                                         emitLocmap ? &locmap : nullptr);
+        auto r = AIETranslateNpuToBinary(
+            module, instructions, deviceName, sequenceName,
+            emitLocmap ? &locmap : nullptr, npuFoldDDRAddrOffset);
         if (failed(r))
           return r;
         // The binary (or hex text) is always emitted to the main output.

--- a/test/Targets/NPU/npu_address_patch_ddr_offset.mlir
+++ b/test/Targets/NPU/npu_address_patch_ddr_offset.mlir
@@ -1,0 +1,54 @@
+//===- npu_address_patch_ddr_offset.mlir ----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// aiex.npu.address_patch emits a DDR patch (TXN_OPC_DDR_PATCH) whose arg_plus
+// word is runtime-dependent for host arguments beyond the first 5:
+//
+//   - xclbin + instruction-buffer runtime (default, fold=true): the NPU
+//     firmware only address-translates the first 5 host buffers, so the
+//     0x80000000 AIE-aperture offset is folded into arg_plus for arg_idx >= 5.
+//     arg_plus = 0x100 -> 0x80000100 for arg 5; unchanged for args 0..4.
+//
+//   - full-ELF runtime (--aie-npu-fold-ddr-addr-offset=false): the driver
+//     assigns NPU-space device addresses to all host buffers, so no offset is
+//     folded. arg_plus stays 0x100 for every arg_idx.
+
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false %s | FileCheck %s --check-prefix=FOLD
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false --aie-npu-fold-ddr-addr-offset=false %s | FileCheck %s --check-prefix=NOFOLD
+
+module {
+  aie.device(npu2) {
+    aie.runtime_sequence(%a0: memref<8xi32>, %a1: memref<8xi32>, %a2: memref<8xi32>, %a3: memref<8xi32>, %a4: memref<8xi32>, %a5: memref<8xi32>) {
+      %off = arith.constant 256 : i32
+
+      // arg_idx 4 (within the firmware-translated set): arg_plus is 0x100 in
+      // BOTH modes.
+      // FOLD:        00000081
+      // FOLD:        00000004
+      // FOLD-NEXT:   00000000
+      // FOLD-NEXT:   00000100
+      // NOFOLD:      00000081
+      // NOFOLD:      00000004
+      // NOFOLD-NEXT: 00000000
+      // NOFOLD-NEXT: 00000100
+      aiex.npu.address_patch(%off : i32) {addr = 74560 : ui32, arg_idx = 4 : i32}
+
+      // arg_idx 5 (beyond the firmware-translated set): arg_plus gets the
+      // 0x80000000 offset in fold mode (xclbin) and stays 0x100 without it
+      // (full-ELF).
+      // FOLD:        00000081
+      // FOLD:        00000005
+      // FOLD-NEXT:   00000000
+      // FOLD-NEXT:   80000100
+      // NOFOLD:      00000081
+      // NOFOLD:      00000005
+      // NOFOLD-NEXT: 00000000
+      // NOFOLD-NEXT: 00000100
+      aiex.npu.address_patch(%off : i32) {addr = 74560 : ui32, arg_idx = 5 : i32}
+    }
+  }
+}

--- a/test/python/npu-xrt/full_elf_many_args/aie_design.py
+++ b/test/python/npu-xrt/full_elf_many_args/aie_design.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Full-ELF design with MORE THAN 5 host buffers, used to demonstrate the DDR
+# address-patch aperture-offset bug (see companion test.py).
+#
+# N_BUFFERS independent workers each write a distinct constant (100 + i) into
+# its own output ObjectFifo; the runtime sequence drains each FIFO into its own
+# host buffer. This produces N_BUFFERS runtime-sequence arguments (arg_idx
+# 0..N-1), so it exercises host arguments beyond the first 5.
+#
+# Since all .py files are picked up as a test, add this to not execute this
+# design file directly.
+# REQUIRES: dont_run
+# RUN: echo
+
+import numpy as np
+
+from aie.iron import ObjectFifo, Program, Runtime, Worker
+from aie.iron.device import NPU2Col4
+from aie.dialects.aiex import npu_load_pdi
+
+N_BUFFERS = 8
+out_ty = np.ndarray[(1,), np.dtype[np.int32]]
+
+
+def design():
+    device_name = "main"
+    fifos = [ObjectFifo(out_ty, name=f"of_out{i}") for i in range(N_BUFFERS)]
+
+    def make_core_fn(val):
+        def core_fn(of_out):
+            out_elem = of_out.acquire(1)
+            out_elem[0] = val
+            of_out.release(1)
+
+        return core_fn
+
+    workers = [
+        Worker(make_core_fn(100 + i), [fifos[i].prod()], while_true=False)
+        for i in range(N_BUFFERS)
+    ]
+
+    rt = Runtime()
+    with rt.sequence(*([out_ty] * N_BUFFERS)) as tensors:
+        rt.inline_ops(lambda: npu_load_pdi(device_ref=device_name), [])
+        for w in workers:
+            rt.start(w)
+        for i in range(N_BUFFERS):
+            rt.drain(fifos[i].cons(), tensors[i], wait=True)
+
+    return str(Program(NPU2Col4(), rt).resolve_program(device_name=device_name))
+
+
+print(design())

--- a/test/python/npu-xrt/full_elf_many_args/test.py
+++ b/test/python/npu-xrt/full_elf_many_args/test.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# End-to-end full-ELF test with MORE THAN 5 host buffers.
+#
+# It demonstrates the DDR address-patch bug in AIETargetNPU.cpp: appendAddressPatch
+# folds a 0x80000000 AIE-aperture offset into arg_plus for arg_idx >= 5. That
+# fold is correct for the xclbin + instruction-buffer runtime (HOST_ONLY BOs
+# passed as kernel(opcode, insts_bo, ninsts, ...), where the firmware translates
+# only the first 5 buffers), and it is exercised/passing by npu-xrt/many_buffers.
+#
+# But the full-ELF runtime (xrt.elf + xrt.ext.kernel + run.set_arg) translates
+# all buffer addresses, so the fold double-translates the 6th and later buffers:
+# their shim DMA lands ~2 GiB off and the host reads back 0.
+#
+# EXPECTED on today's mlir-aie: arg 0..4 read back correctly (100..104), arg 5..7
+# read back 0 -> this test FAILS. With the offset suppressed on the full-ELF path
+# it PASSES for all 8 buffers.
+#
+# REQUIRES: ryzen_ai_npu2, peano, xrt_python_bindings
+# RUN: %python %S/aie_design.py > aie.mlir
+# RUN: aiecc -v --generate-full-elf --no-xchesscc --no-xbridge --dynamic-objFifos aie.mlir
+# RUN: %run_on_npu2% %pytest %s
+
+import numpy as np
+import pyxrt
+
+import aie.iron as iron
+from aie.utils.hostruntime.xrtruntime.hostruntime import XRTHostRuntime
+
+N_BUFFERS = 8
+
+
+def test_full_elf_many_args():
+    runtime = XRTHostRuntime()
+    device = runtime._device
+    elf = pyxrt.elf("aie.elf")
+    context = pyxrt.hw_context(device, elf)
+    kernel = pyxrt.ext.kernel(context, "main:sequence")
+
+    tensors = [
+        iron.tensor((1,), dtype=np.int32, device="cpu") for _ in range(N_BUFFERS)
+    ]
+    run = pyxrt.run(kernel)
+    for i, t in enumerate(tensors):
+        t.data.fill(0)
+        t.to("npu")
+        run.set_arg(i, t.buffer_object())
+
+    run.start()
+    run.wait2()
+
+    for t in tensors:
+        t.to("cpu")
+
+    actual = [int(t.numpy()[0]) for t in tensors]
+    expected = [100 + i for i in range(N_BUFFERS)]
+    # Per-buffer detail makes the arg_idx >= 5 boundary obvious on failure.
+    detail = "\n".join(
+        f"  arg{i}: expected={expected[i]} actual={actual[i]}"
+        + ("" if actual[i] == expected[i] else "  <-- MISMATCH")
+        for i in range(N_BUFFERS)
+    )
+    assert actual == expected, f"host buffers beyond arg 4 were corrupted:\n{detail}"
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -4167,11 +4167,16 @@ static LogicalResult generateNpuInstructions(ModuleOp moduleOp,
 
       // Generate NPU instructions using direct C++ API call.
       // This replaces the subprocess call to aie-translate --aie-npu-to-binary.
+      // The full-ELF runtime (xrt.ext.kernel) assigns NPU-space device
+      // addresses to all host buffers, so the DDR-aperture offset for arguments
+      // beyond the firmware-translated set must NOT be folded into the TXN. The
+      // xclbin + instruction-buffer runtime does need it.
       std::vector<uint32_t> instructions;
       std::vector<xilinx::AIE::TxnLocEntry> locmap;
       if (failed(xilinx::AIE::AIETranslateNpuToBinary(
               *clonedModule, instructions, curDevName, seqName,
-              keepLoc ? &locmap : nullptr))) {
+              keepLoc ? &locmap : nullptr,
+              /*foldDDRAddrOffset=*/!generateFullElf))) {
         llvm::errs() << "Error generating NPU instructions for sequence: "
                      << seqName << "\n";
         result = failure();
@@ -4469,7 +4474,8 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   std::vector<xilinx::AIE::TxnLocEntry> dmaSeqLocmap;
   if (failed(xilinx::AIE::AIETranslateNpuToBinary(
           *clonedModule, dmaSeqInstructions, devName, "" /* all sequences */,
-          keepLoc ? &dmaSeqLocmap : nullptr))) {
+          keepLoc ? &dmaSeqLocmap : nullptr,
+          /*foldDDRAddrOffset=*/!generateFullElf))) {
     llvm::errs() << "Error generating control packet DMA sequence for device: "
                  << devName << "\n";
     return failure();
@@ -6095,8 +6101,13 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
         sys::path::append(outputPath, outputFileName);
 
         std::vector<uint32_t> instructions;
+        // Multi-PDI full-ELF path: same as the single-sequence full-ELF case,
+        // the runtime translates all host buffer addresses, so do not fold the
+        // DDR-aperture offset into the TXN.
         if (failed(xilinx::AIE::AIETranslateNpuToBinary(
-                *expandedModule, instructions, devName, seqName))) {
+                *expandedModule, instructions, devName, seqName,
+                /*locmap=*/nullptr,
+                /*foldDDRAddrOffset=*/!generateFullElf))) {
           llvm::errs() << "Error generating NPU instructions for sequence: "
                        << seqName << "\n";
           return;


### PR DESCRIPTION
## Problem

`appendAddressPatch` (in `AIETargetNPU.cpp`, added in #3252) folds a `0x80000000`
AIE-aperture offset into `arg_plus` for host arguments with `arg_idx >= 5`.

That fold is **runtime-specific**:

- **xclbin + instruction-buffer runtime** (`HOST_ONLY` BOs launched as
  `kernel(opcode, insts_bo, ninsts, ...)`): the NPU firmware only
  address-translates the first 5 host buffers, so the offset is **required** for
  args ≥5. Exercised (and kept passing) by `npu-xrt/many_buffers`,
  `npu-xrt/add_multi_arg_runlist`, `python/npu-xrt/test_jit_many_args`.

- **full-ELF runtime** (`xrt.elf` + `xrt.ext.kernel` + `run.set_arg`): the driver
  assigns NPU-space device addresses to **all** host buffers, so folding the
  offset **double-translates** the 6th+ buffer — its shim DMA lands ~2 GiB off and
  reads/writes garbage.

mlir-aie's own full-ELF path (`full_elf_42`) only ever used a single buffer, so
the full-ELF + >5-buffer case was never exercised and the bug went unnoticed.

## Fix

Make the fold conditional on the target runtime instead of unconditional:

- `AIETranslateNpuToBinary()` gains a `foldDDRAddrOffset` parameter, **default
  `true`** — so the xclbin/insts TXN is byte-identical to today.
- `aie-translate` exposes `--aie-npu-fold-ddr-addr-offset` (default `true`).
- `aiecc` passes `foldDDRAddrOffset = !generateFullElf` at the three sites that
  emit the full-ELF TXN — the single-sequence, control-packet, and multi-PDI
  (`expandLoadPdis`) generation paths — so no `--generate-full-elf` output folds
  the offset. (The separate `--aie-generate-elf` / insts.elf site is left
  unchanged; see Note.)

Net: xclbin builds are unchanged; full-ELF builds with >5 buffers are fixed.

## Tests

- `test/Targets/NPU/npu_address_patch_ddr_offset.mlir` — unit test asserting the
  `arg_plus` word gets the offset for `arg_idx >= 5` in fold mode (xclbin) and is
  left verbatim without it (full-ELF).
- `test/python/npu-xrt/full_elf_many_args/` — e2e full-ELF design with 8 host
  buffers. On the pre-fix compiler, args 5-7 read back 0; after the fix all 8 are
  correct. (This is the first full-ELF test in the tree with >5 buffers.)

## Verified on NPU2 hardware

- `full_elf_many_args` (8 buffers, full-ELF): args 5-7 = 0 before, all correct after.
- A downstream design with 6 host buffers built through the `--generate-full-elf`
  multi-PDI path: all-zeros before, correct after.
- xclbin `aie-translate` output for `arg_idx=5` is unchanged (still `0x80000100`).

## Note

The `--aie-generate-elf` (insts.elf) site is left folding by default; it has no
>5-buffer test today. If that path is also an `ext.kernel` runtime, it may want
`foldDDRAddrOffset=false` too — happy to extend if maintainers confirm.
