### PR TITLE
ci: drop cooldown semver-major-days from unsupported ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
     # cooldown adds that floor. Security-alert PRs bypass cooldown entirely.
     cooldown:
       default-days: 7
-      semver-major-days: 7
     groups:
       github-actions-minor-patch:
         update-types: ["minor", "patch"]
@@ -44,7 +43,6 @@ updates:
       - dependency-name: "nanobind"
     cooldown:
       default-days: 7
-      semver-major-days: 7
     # `group-by: dependency-name` makes Dependabot open ONE pull request per
     # dependency spanning ALL directories above, so a shared package (numpy,
     # setuptools, ...) is bumped to the same version in /python and both wheel
@@ -65,7 +63,6 @@ updates:
       cronjob: "0 6 8,22 * *"
     cooldown:
       default-days: 7
-      semver-major-days: 7
     groups:
       pre-commit-minor-patch:
         update-types: ["minor", "patch"]


### PR DESCRIPTION
Dependabot rejected the config on the default branch with:
  > The property '#/updates/0/cooldown/semver-major-days' is not supported
  > for the package ecosystem 'github-actions'.
  > The property '#/updates/2/cooldown/semver-major-days' is not supported
  > for the package ecosystem 'pre-commit'.

`cooldown.semver-major-days` is only supported for the `pip` ecosystem, not `github-actions` or `pre-commit`. This drops it from all three entries:
  - **github-actions** / **pre-commit** — removes the unsupported property
    that broke parsing.
  - **pip** — it was supported here but set to `7`, identical to
    `default-days: 7`, so it was redundant. Dropped for consistency.
    
All three were set to `7` (same as `default-days`), so the effective cooldown floor is unchanged.
  
## Verification

Validated the result against the official SchemaStore dependabot-2.0 schema (`jsonschema`, draft-07): passes with zero errors. Note the schema does not encode Dependabot's per-ecosystem cooldown rules, so the authoritative confirmation is Dependabot re-parsing the config on merge.