### PR TITLE
[dyn-seq] Dynamic BD allocator: runtime bd_id via a free-list pool for rolled runtime sequences

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1075,7 +1075,7 @@ def AIE_NpuLoadPdiOp: AIEX_Op<"npu.load_pdi", []> {
   let hasCanonicalizeMethod = 1;
 }
 
-def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::RuntimeSequenceOp">, TileElement]>, Results<(outs Index:$result)> {
+def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::RuntimeSequenceOp">, TileElement, AttrSizedOperandSegments]>, Results<(outs Index:$result)> {
   let summary = "Concrete Instantiation of a Buffer Descriptor Chain as a Task on a Channel and Direction on a Tile";
   let description = [{
     Encapsulates the DMA configuration of one task, that is the (chain of) buffer descriptors to be executed on a given channel and direction on a tile.
@@ -1092,6 +1092,7 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
         DefaultValuedOptionalAttr<BoolAttr, "false">:$issue_token,
         DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count,
         Optional<I32>:$repeat_count_val,
+        Optional<I32>:$bd_id_val,
         OptionalAttr<PacketInfoAttr>:$packet
   );
 
@@ -1101,7 +1102,8 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
 
   let assemblyFormat = [{
     `(` $tile `,` $direction `,` $channel (`,` $packet^)? `)`
-    (`repeat` $repeat_count_val^ `:` type($repeat_count_val))? regions attr-dict
+    (`repeat` $repeat_count_val^ `:` type($repeat_count_val))?
+    (`bd_id` $bd_id_val^ `:` type($bd_id_val))? regions attr-dict
   }];
 
   let extraClassDeclaration = [{
@@ -1131,7 +1133,7 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
             xilinx::AIE::DMAChannelDirAttr::get(odsBuilder.getContext(), dir),
             $_builder.getI32IntegerAttr(channel_index), $_builder.getBoolAttr(token),
             $_builder.getI32IntegerAttr(repeat), /*repeat_count_val=*/nullptr,
-            /*packet=*/nullptr);
+            /*bd_id_val=*/nullptr, /*packet=*/nullptr);
     }]>
   ];
 }

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1241,6 +1241,55 @@ def AIE_DMAAwaitTaskOp : AIEX_Op<"dma_await_task", [HasAncestor<"AIE::RuntimeSeq
   }];
 }
 
+def AIE_DMABdPoolPopOp : AIEX_Op<"dma_bd_pool_pop", [HasAncestor<"AIE::RuntimeSequenceOp">]>, Results<(outs I32:$bd_id)> {
+  let summary = "Pop a free Buffer Descriptor ID from the runtime free-list pool for a tile";
+  let description = [{
+    Draws a buffer-descriptor ID from the per-tile runtime free-list pool and
+    returns it as an SSA value. This is the dynamic counterpart to the static
+    BD-ID allocator: inside a runtime-bound `scf.for` the ID is chosen at
+    runtime rather than baked at compile time.
+
+    Only meaningful on the dynamic EmitC lowering path (the static binary TXN
+    stream has no runtime pool). The `aie-lower-dynamic-bd-pool` pass inserts
+    this op in place of the implicit allocation a `dma_configure_task` performs.
+    If the pool is empty at runtime, the generated builder yields no stream
+    (`std::nullopt`).
+  }];
+
+  let arguments = (
+    ins I32Attr:$column,
+        I32Attr:$row
+  );
+
+  let assemblyFormat = [{
+    `(` $column `,` $row `)` attr-dict `:` type($bd_id)
+  }];
+}
+
+def AIE_DMABdPoolPushOp : AIEX_Op<"dma_bd_pool_push", [HasAncestor<"AIE::RuntimeSequenceOp">]> {
+  let summary = "Return a Buffer Descriptor ID to the runtime free-list pool for a tile";
+  let description = [{
+    Returns a buffer-descriptor ID previously obtained from
+    `aiex.dma_bd_pool_pop` to the per-tile runtime free-list pool, making it
+    available for reuse. This is the dynamic counterpart to the static
+    allocator's free/await recycling.
+
+    Only meaningful on the dynamic EmitC lowering path. The
+    `aie-lower-dynamic-bd-pool` pass inserts this op in place of a
+    `dma_free_task` / the recycling half of a `dma_await_task`.
+  }];
+
+  let arguments = (
+    ins I32Attr:$column,
+        I32Attr:$row,
+        I32:$bd_id
+  );
+
+  let assemblyFormat = [{
+    `(` $column `,` $row `)` `bd_id` $bd_id attr-dict `:` type($bd_id)
+  }];
+}
+
 def AIE_DMAStartBdChainOp: AIEX_Op<"dma_start_bd_chain", [HasParent<"AIE::RuntimeSequenceOp">, TileElement]>,
     Results<(outs Index:$result)>
   {

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -827,18 +827,28 @@ def AIE_NpuAddressPatchOp: AIEX_Op<"npu.address_patch", []> {
   let summary = "address patch operator";
   let arguments = (
     ins UI32Attr:$addr,
+        Optional<I32>:$addr_val,
         I32Attr:$arg_idx,
         I32:$arg_plus
   );
   let results = (outs );
   let assemblyFormat = [{
-    `(` $arg_plus `:` type($arg_plus) `)` attr-dict
+    `(` $arg_plus `:` type($arg_plus) `)` (`addr` $addr_val^ `:` type($addr_val))?
+    attr-dict
   }];
   let description = [{
     address patch operator. `arg_plus` is an SSA value; use arith.constant for
     a compile-time-known offset or pass a runtime sequence value for a
     runtime-parameterized buffer offset.
+
+    `addr` is the register to patch (the BD's buffer-address word). It is a
+    compile-time attribute on the static path; when the BD id is chosen at
+    runtime (dynamic free-list pool) the register address is itself runtime and
+    is supplied via the optional `addr_val` operand instead, which then takes
+    precedence. Only the EmitC (C++ TXN) target supports a runtime `addr_val`;
+    the static binary target requires the constant `addr`.
   }];
+  let hasVerifier = 1;
 }
 
 def AIE_NpuPreemptOp: AIEX_Op<"npu.preempt", []> {

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1091,6 +1091,7 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
         I32Attr:$channel,
         DefaultValuedOptionalAttr<BoolAttr, "false">:$issue_token,
         DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count,
+        Optional<I32>:$repeat_count_val,
         OptionalAttr<PacketInfoAttr>:$packet
   );
 
@@ -1099,12 +1100,21 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
   );
 
   let assemblyFormat = [{
-    `(` $tile `,` $direction `,` $channel (`,` $packet^)? `)` regions attr-dict
+    `(` $tile `,` $direction `,` $channel (`,` $packet^)? `)`
+    (`repeat` $repeat_count_val^ `:` type($repeat_count_val))? regions attr-dict
   }];
 
   let extraClassDeclaration = [{
     AIE::TileOp getTileOp();
     std::optional<uint32_t> getFirstBdId();
+    // The repeat count as an OpFoldResult: the runtime operand if present, else
+    // the compile-time attribute. Mirrors dma_bd's offset/len duality.
+    mlir::OpFoldResult getRepeatCountValue() {
+      if (mlir::Value v = getRepeatCountVal())
+        return v;
+      return mlir::IntegerAttr::get(
+          mlir::IntegerType::get(getContext(), 32), getRepeatCount());
+    }
   }];
 
   let extraClassDefinition = [{
@@ -1120,7 +1130,8 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
       build($_builder, $_state, result, tile,
             xilinx::AIE::DMAChannelDirAttr::get(odsBuilder.getContext(), dir),
             $_builder.getI32IntegerAttr(channel_index), $_builder.getBoolAttr(token),
-            $_builder.getI32IntegerAttr(repeat), nullptr);
+            $_builder.getI32IntegerAttr(repeat), /*repeat_count_val=*/nullptr,
+            /*packet=*/nullptr);
     }]>
   ];
 }
@@ -1131,14 +1142,28 @@ def AIE_DMAConfigureTaskForOp : AIEX_Op<"dma_configure_task_for", [HasAncestor<"
   let arguments = (
     ins SymbolRefAttr:$alloc,
         DefaultValuedOptionalAttr<BoolAttr, "false">:$issue_token,
-        DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count
+        DefaultValuedOptionalAttr<I32Attr, "0">:$repeat_count,
+        Optional<I32>:$repeat_count_val
   );
 
   let regions = (region AnyRegion:$body);
 
-  let assemblyFormat = [{ $alloc regions attr-dict }];
+  let assemblyFormat = [{
+    $alloc (`repeat` $repeat_count_val^ `:` type($repeat_count_val))? regions attr-dict
+  }];
 
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    // The repeat count as an OpFoldResult: runtime operand if present, else the
+    // compile-time attribute.
+    mlir::OpFoldResult getRepeatCountValue() {
+      if (mlir::Value v = getRepeatCountVal())
+        return v;
+      return mlir::IntegerAttr::get(
+          mlir::IntegerType::get(getContext(), 32), getRepeatCount());
+    }
+  }];
 }
 
 def AIE_DMAFreeTaskOp : AIEX_Op<"dma_free_task", [HasAncestor<"AIE::RuntimeSequenceOp">]> {

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -40,6 +40,8 @@ createAIEAssignRuntimeSequenceBDIDsPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIEUnrollRuntimeSequenceLoopsPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
+createAIELowerDynamicBDPoolPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIEDMATasksToNPUPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIESubstituteShimDMAAllocationsPass();

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -273,6 +273,35 @@ def AIEUnrollRuntimeSequenceLoops
   ];
 }
 
+def AIELowerDynamicBDPool
+    : Pass<"aie-lower-dynamic-bd-pool", "AIE::DeviceOp"> {
+  let summary = "Lower runtime-bound DMA task allocation to a runtime BD free-list pool";
+  let description = [{
+    The dynamic counterpart to `aie-assign-runtime-sequence-bd-ids`. That pass
+    requires straight-line IR and rejects runtime-bound `scf.for`; this pass
+    handles the runtime-bound case by keeping the loop rolled and drawing buffer
+    descriptor IDs from a per-tile runtime free-list pool.
+
+    For each `dma_configure_task` it inserts an `aiex.dma_bd_pool_pop` and routes
+    the popped SSA `bd_id` into the BD's lowering; each `dma_free_task` and the
+    recycling half of a `dma_await_task` becomes an `aiex.dma_bd_pool_push` of
+    the matching ID (matched through the def-use / scf.for iter_args chain).
+
+    Runs only on the dynamic EmitC path, after `aie-unroll-runtime-sequence-
+    loops` has removed every constant-trip loop, so any surviving `scf.for` is
+    genuinely runtime-bound. v1 supports single-BD tasks; multi-BD chains under a
+    runtime loop are diagnosed.
+  }];
+
+  let constructor = "xilinx::AIEX::createAIELowerDynamicBDPoolPass()";
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+    "xilinx::AIE::AIEDialect",
+    "xilinx::AIEX::AIEXDialect",
+  ];
+}
+
 def AIEDMATasksToNPU : Pass<"aie-dma-tasks-to-npu", "AIE::DeviceOp"> {
   let summary = "Lower configured DMA tasks to NPU instructions";
 

--- a/include/aie/Dialect/AIEX/Utils/BdLowering.h
+++ b/include/aie/Dialect/AIEX/Utils/BdLowering.h
@@ -221,6 +221,18 @@ struct SsaStridePolicy {
 mlir::Value getAsValue(mlir::OpBuilder &builder, mlir::Location loc,
                        mlir::OpFoldResult ofr, mlir::Type intType);
 
+// Build the address-patch `arg_plus` (buffer BYTE offset) as an i32 Value.
+// `elementOffsets` (innermost-first) are the per-dim element offsets and
+// `strides` their matching strides; the byte offset is
+// sum(elementOffsets[i] * strides[i]) * elemWidthBytes + baseByteOffset.
+// Any entry may be a runtime Value; a fully-constant set folds to a single
+// arith.constant. Shared by the memcpy_nd and dma_task dynamic lowerings so a
+// runtime DMA offset flows into the patch instead of being rejected.
+mlir::Value buildArgPlusValue(mlir::OpBuilder &builder, mlir::Location loc,
+                              llvm::ArrayRef<mlir::OpFoldResult> elementOffsets,
+                              llvm::ArrayRef<mlir::OpFoldResult> strides,
+                              int64_t elemWidthBytes, int64_t baseByteOffset);
+
 // Pack a set of (value, mask, shift) fields into a single i32 BD word via
 // arith and/shl/or. mask == 0xFFFFFFFF skips the AND; shift == 0 skips the SHL.
 mlir::Value

--- a/include/aie/Dialect/AIEX/Utils/BdLowering.h
+++ b/include/aie/Dialect/AIEX/Utils/BdLowering.h
@@ -221,13 +221,9 @@ struct SsaStridePolicy {
 mlir::Value getAsValue(mlir::OpBuilder &builder, mlir::Location loc,
                        mlir::OpFoldResult ofr, mlir::Type intType);
 
-// Build the address-patch `arg_plus` (buffer BYTE offset) as an i32 Value.
-// `elementOffsets` (innermost-first) are the per-dim element offsets and
-// `strides` their matching strides; the byte offset is
-// sum(elementOffsets[i] * strides[i]) * elemWidthBytes + baseByteOffset.
-// Any entry may be a runtime Value; a fully-constant set folds to a single
-// arith.constant. Shared by the memcpy_nd and dma_task dynamic lowerings so a
-// runtime DMA offset flows into the patch instead of being rejected.
+// Build the address-patch `arg_plus` (buffer BYTE offset) as an i32 Value:
+// sum(elementOffsets[i] * strides[i]) * elemWidthBytes + baseByteOffset, where
+// any entry may be runtime (a fully-constant set folds to one arith.constant).
 mlir::Value buildArgPlusValue(mlir::OpBuilder &builder, mlir::Location loc,
                               llvm::ArrayRef<mlir::OpFoldResult> elementOffsets,
                               llvm::ArrayRef<mlir::OpFoldResult> strides,

--- a/include/aie/Dialect/AIEX/Utils/BdLowering.h
+++ b/include/aie/Dialect/AIEX/Utils/BdLowering.h
@@ -239,18 +239,36 @@ mlir::Value
 buildBdWord(mlir::OpBuilder &builder, mlir::Location loc,
             llvm::ArrayRef<std::tuple<mlir::Value, uint32_t, uint32_t>> fields);
 
-// Emit the per-word `npu.write32` overrides carrying a shim-NOC BD's runtime
-// sizes/strides on top of a zero-template blockwrite, plus assert_bd_field /
-// assert_bd_divisible guards for runtime values in narrow or sub-granule
-// fields. Shared by the dma_memcpy_nd and dma_task paths.
-// `mixedSizes`/`mixedStrides` are outermost-first (d3..d0). `bufLenOverride`,
-// if non-null, sets buffer_length (dma_task's runtime len); else it is the
-// d0*d1*d2 size-product. `repeatCountOut` receives the biased hardware
-// outer-dim (d3) value for the caller's queue push.
+// Emit the per-word `npu.write32` overrides that carry a shim-NOC BD's runtime
+// sizes/strides, on top of a zero-template blockwrite whose size/stride words
+// were left at 0. Shared by the dma_memcpy_nd and dma_task dynamic lowering
+// paths, which converge on the identical shim BD-word layout (words 0/3/4/5/6);
+// only the descriptor template (locks, next_bd, packet) and the queue push
+// differ, and those stay with each caller.
+//
+// `mixedSizes`/`mixedStrides` are outermost-first (d3..d0), matching
+// NpuDmaMemcpyNdOp::getMixedSizes and AIE::DMABDOp::getMixedSizes.
+// `bufLenOverride`, if non-null, is written verbatim into buffer_length
+// (word 0) -- dma_task passes its runtime `len`; dma_memcpy_nd passes null, so
+// buffer_length is computed as the d0*d1*d2 hardware-unit size-product. Emits
+// `npu.assert_bd_field` guards for runtime values landing in narrow fields
+// (d0/d1 wrap 10-bit in ND mode, iteration wrap 6-bit always). The op verifier
+// is expected to have enforced the supported scope (shim NOC, innermost stride
+// == 1) already.
+//
+// On success `repeatCountOut` receives the hardware iteration/repeat value for
+// the outer (d3) dimension, which the caller feeds to its queue push (this is
+// the biased hw value, matching the static path's `repeat_count = sizes[3]`).
+//
+// `bdId` may be a compile-time constant (the static/pinned case: the override
+// addresses fold to literals, byte-identical to before) or a runtime SSA value
+// (the dynamic free-list pool case: the BD register base becomes
+// `getDmaBdAddress(col,row,0) + bdId*0x20` -- linear in bdId -- and each
+// override address is emitted as arith over that base).
 mlir::LogicalResult emitDynamicShimBdWordOverrides(
     mlir::OpBuilder &builder, mlir::Location loc,
     const xilinx::AIE::AIETargetModel &targetModel, int tileCol, int tileRow,
-    uint32_t bdId, llvm::ArrayRef<mlir::OpFoldResult> mixedSizes,
+    mlir::OpFoldResult bdId, llvm::ArrayRef<mlir::OpFoldResult> mixedSizes,
     llvm::ArrayRef<mlir::OpFoldResult> mixedStrides, uint64_t elemWidth,
     uint32_t burstLength, mlir::Value bufLenOverride,
     mlir::Value &repeatCountOut);

--- a/include/aie/Dialect/AIEX/Utils/BdLowering.h
+++ b/include/aie/Dialect/AIEX/Utils/BdLowering.h
@@ -239,6 +239,17 @@ mlir::Value
 buildBdWord(mlir::OpBuilder &builder, mlir::Location loc,
             llvm::ArrayRef<std::tuple<mlir::Value, uint32_t, uint32_t>> fields);
 
+// The base register address of a BD block, `getDmaBdAddress(col,row,bd_id)`, as
+// an i32 Value. The address is linear in bd_id (base + bd_id*bdStride), so a
+// constant bdId folds to the exact literal the static path uses, while a
+// runtime bdId (dynamic free-list pool) is emitted as arith. Shared by the
+// BD-word encoder and the descriptor / address-patch lowering so every register
+// touched for one BD is computed from the same base.
+mlir::Value getBdRegisterBase(mlir::OpBuilder &builder, mlir::Location loc,
+                              const xilinx::AIE::AIETargetModel &targetModel,
+                              int tileCol, int tileRow,
+                              mlir::OpFoldResult bdId);
+
 // Emit the per-word `npu.write32` overrides that carry a shim-NOC BD's runtime
 // sizes/strides, on top of a zero-template blockwrite whose size/stride words
 // were left at 0. Shared by the dma_memcpy_nd and dma_task dynamic lowering

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -62,6 +62,55 @@ enum TxnOpcode : uint32_t {
   TXN_OPC_CUSTOM_OP_MAX = 255,
 };
 
+// Upper bound on a tile's buffer-descriptor count across all tile types, sizing
+// the pool's fixed storage. This is a standalone header (no MLIR / target model
+// here), so the ACTUAL per-tile count is supplied at runtime by the compiler via
+// bd_pool_init(getNumBDs(col,row)) -- this constant only bounds the array. AIE2
+// memtiles have the most BDs (48); shim/core have 16. Keep this >= the largest
+// getNumBDs any target model returns.
+constexpr uint32_t kMaxBDsPerTile = 48;
+
+// Runtime buffer-descriptor free-list pool, for dynamic runtime sequences whose
+// BD IDs are chosen at runtime (a rolled scf.for the compiler cannot unroll).
+// The static allocator assigns BD IDs at compile time; this is its runtime
+// counterpart. `head` is the number of currently-free IDs at the front of
+// `free_ids`; pop takes from the top, push returns to it.
+struct BdPool {
+  uint32_t free_ids[kMaxBDsPerTile];
+  int head;
+};
+
+// Initialize a pool with `n` free IDs. `n` is the tile's BD count, which the
+// compiler reads from the target model (getNumBDs) and passes in. IDs are
+// stacked so that pop() hands out the LOWEST free id first (id 0, then 1, ...),
+// matching the static allocator's lowest-free-first order -- so a first pop from
+// a fresh pool equals a pinned bd_id = 0.
+inline BdPool bd_pool_init(uint32_t n) {
+  BdPool p;
+  p.head = 0;
+  uint32_t count = n < kMaxBDsPerTile ? n : kMaxBDsPerTile;
+  for (uint32_t i = 0; i < count; ++i)
+    p.free_ids[p.head++] = count - 1 - i; // top of stack is id 0
+  return p;
+}
+
+// Pop a free BD ID into `out`. Returns false if the pool is empty -- the
+// generated builder turns that into a `return std::nullopt`, so a runtime
+// working set that exceeds the tile's BD count yields no stream rather than a
+// silently-corrupt one.
+inline bool bd_pool_pop(BdPool &p, uint32_t &out) {
+  if (p.head == 0)
+    return false;
+  out = p.free_ids[--p.head];
+  return true;
+}
+
+// Return a BD ID to the pool for reuse.
+inline void bd_pool_push(BdPool &p, uint32_t id) {
+  if (p.head < static_cast<int>(kMaxBDsPerTile))
+    p.free_ids[p.head++] = id;
+}
+
 // Device information for the TXN header.
 struct TxnDeviceInfo {
   uint8_t major = 0;

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -83,8 +83,8 @@ struct BdPool {
 // Initialize a pool with `n` free IDs. `n` is the tile's BD count, which the
 // compiler reads from the target model (getNumBDs) and passes in. IDs are
 // stacked so that pop() hands out the LOWEST free id first (id 0, then 1, ...),
-// matching the static allocator's lowest-free-first order -- so a first pop from
-// a fresh pool equals a pinned bd_id = 0.
+// matching the static allocator's lowest-free-first order -- so a first pop
+// from a fresh pool equals a pinned bd_id = 0.
 inline BdPool bd_pool_init(uint32_t n) {
   BdPool p;
   p.head = 0;

--- a/include/aie/Runtime/TxnEncoding.h
+++ b/include/aie/Runtime/TxnEncoding.h
@@ -64,10 +64,10 @@ enum TxnOpcode : uint32_t {
 
 // Upper bound on a tile's buffer-descriptor count across all tile types, sizing
 // the pool's fixed storage. This is a standalone header (no MLIR / target model
-// here), so the ACTUAL per-tile count is supplied at runtime by the compiler via
-// bd_pool_init(getNumBDs(col,row)) -- this constant only bounds the array. AIE2
-// memtiles have the most BDs (48); shim/core have 16. Keep this >= the largest
-// getNumBDs any target model returns.
+// here), so the ACTUAL per-tile count is supplied at runtime by the compiler
+// via bd_pool_init(getNumBDs(col,row)) -- this constant only bounds the array.
+// AIE2 memtiles have the most BDs (48); shim/core have 16. Keep this >= the
+// largest getNumBDs any target model returns.
 constexpr uint32_t kMaxBDsPerTile = 48;
 
 // Runtime buffer-descriptor free-list pool, for dynamic runtime sequences whose

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -520,7 +520,7 @@ emitTransactionOps(OpBuilder &builder, Location fallbackLoc,
           *op.addressPatch;
       AIEX::NpuAddressPatchOp::create(
           builder, loc, builder.getUI32IntegerAttr(patch.addr),
-          builder.getI32IntegerAttr(patch.argIdx),
+          /*addr_val=*/mlir::Value(), builder.getI32IntegerAttr(patch.argIdx),
           AIEX::createConstantI32(builder, loc, patch.argPlus));
     } else if (op.cmd.Opcode == 0x6 /*  XAie_TxnOpcode::XAIE_IO_PREEMPT */) {
       auto ui8Ty =

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -5,15 +5,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Converts the npu transaction ops in an aie.runtime_sequence into EmitC
-// dialect calls naming the functions in aie/Runtime/TxnEncoding.h.
-// translateToCpp() on the result produces a standalone C++ function that
-// assembles the same TXN words the compile-time binary emitter
-// (AIETargetNPU.cpp) produces -- this is the runtime-parameterizable mirror of
-// that path. A runtime-bound scf.for (the dynamic BD free-list pool path) is
-// preserved: its body ops are converted in place and the loop itself is lowered
-// to emitc.for by convert-scf-to-emitc, so the generated C++ keeps the loop
-// rolled with a runtime op-count.
+// Converts npu transaction ops in an aie.runtime_sequence into EmitC calls to
+// aie/Runtime/TxnEncoding.h; translateToCpp() then yields a standalone C++
+// function assembling the same TXN words as the binary emitter
+// (AIETargetNPU.cpp), but runtime-parameterizable. A runtime-bound scf.for
+// (dynamic BD pool path) is preserved and lowered to emitc.for, keeping the
+// loop rolled at runtime.
 //
 //===----------------------------------------------------------------------===//
 
@@ -70,11 +67,9 @@ Value u32Literal(OpBuilder &b, Location loc, uint32_t val) {
       emitc::OpaqueAttr::get(b.getContext(), std::to_string(val) + "u"));
 }
 
-// Emit a call to one of TxnEncoding.h's free functions on the txn vector.
-// Scalar operands are passed through as-is: an arith.constant or a runtime
-// runtime-sequence value lowers to the matching C++ literal or function
-// parameter by the later convert-arith-to-emitc step. TxnEncoding.h's uint32_t
-// parameters take the implicit conversion, byte-identical to the static path.
+// Emit a call to a TxnEncoding.h free function on the txn vector. Scalar
+// operands pass through as-is; convert-arith-to-emitc later lowers them to C++
+// literals or function parameters, byte-identical to the static path.
 void emitTxnCall(OpBuilder &b, Location loc, StringRef fn, Value txnVec,
                  ValueRange args) {
   SmallVector<Value> callArgs;
@@ -84,10 +79,8 @@ void emitTxnCall(OpBuilder &b, Location loc, StringRef fn, Value txnVec,
                               callArgs);
 }
 
-// Device-relative values resolved on the original in-device ops, keyed by their
-// clone in the emitc.func. getAbsoluteAddress()/getDataWords() resolve
-// buffer/column/row and memref.global symbols against the parent aie.device, so
-// they must be computed before the ops are cloned out of it.
+// Device-relative values (absolute addr, blockwrite data) resolved before the
+// ops are cloned out of the aie.device, keyed by their clone in the emitc.func.
 struct DeviceResolved {
   llvm::DenseMap<Operation *, uint32_t> absoluteAddr;
   llvm::DenseMap<Operation *, DenseIntElementsAttr> blockWriteData;
@@ -100,13 +93,10 @@ public:
       : funcOp(funcOp), txnVec(txnVec), resolved(resolved),
         opCountVar(opCountVar) {}
 
-  // Convert every npu/pool op in the function body -- recursing into scf region
-  // bodies so ops inside a rolled loop are lowered too. Returns the
-  // compile-time count of txn ops emitted when the body is straight-line (used
-  // as a literal op_count in the header), or nullopt on a conversion error.
-  // When a runtime op-count variable was provided (a loop is present), each
-  // emitted op also increments it and the header reads that instead; the
-  // returned count is then unused.
+  // Convert every npu/pool op in the body, recursing into scf regions. Returns
+  // the compile-time op count for a straight-line body (the literal op_count),
+  // or nullopt on error. With a runtime op-count var (a loop is present) each
+  // op increments it instead and the returned count is unused.
   std::optional<uint32_t> run() {
     uint32_t count = 0;
     SmallVector<Operation *> consumed;
@@ -114,12 +104,10 @@ public:
     if (!ok)
       return std::nullopt;
 
-    // Erase the converted npu ops, then sweep now-dead memref/arith clones so a
-    // def outlives its uses (e.g. get_global feeding a blockwrite, or the
-    // arith.constant that defined an address we replaced with a folded
-    // literal). Live arith feeding runtime value/mask/sync fields has uses and
-    // is kept for the arith-to-emitc step. Walk post-order and collect first,
-    // since erasing during a walk is unsafe.
+    // Erase the converted npu ops, then sweep now-dead memref/arith clones
+    // (e.g. a get_global or folded-away address constant). Live arith feeding
+    // runtime fields is kept for arith-to-emitc. Collect first: erasing
+    // mid-walk is unsafe.
     for (Operation *op : llvm::reverse(consumed))
       op->erase();
     SmallVector<Operation *> deadSweep;
@@ -174,12 +162,10 @@ private:
       emitc::VerbatimOp::create(b, loc, "++{};", ValueRange{opCountVar});
   }
 
-  // Convert one op, appending to the txn vector. Increments `count` for each
-  // txn instruction emitted. Scalar operands of the (already-cloned) op are
-  // passed through directly -- a constant or a runtime value both flow as SSA,
-  // lowered later by convert-arith-to-emitc. Only the address field is replaced
-  // by its device-resolved literal (which folds in buffer/col/row). Unsupported
-  // ops are diagnosed (sets `ok` false).
+  // Convert one op, appending to the txn vector and incrementing `count`.
+  // Scalar operands flow through as SSA (lowered later by
+  // convert-arith-to-emitc); only the address field is replaced by its
+  // device-resolved literal. Unsupported ops set `ok` false.
   void convertOne(Operation *op, uint32_t &count) {
     OpBuilder b(op);
     Location loc = op->getLoc();
@@ -256,12 +242,10 @@ private:
                 ValueRange{g.getValue()});
         })
         .Case<AIEX::DMABdPoolPopOp>([&](AIEX::DMABdPoolPopOp pop) {
-          // Draw a BD id from the tile's runtime pool into a fresh C++
-          // variable, and fail the build (nullopt) if the pool is empty -- the
-          // runtime backstop for a working set exceeding the tile's BD count.
-          // The pool variable was declared in the prologue (see emitFunction).
-          // Downstream ops (write32 addresses, push_queue) consume the id, so
-          // replace the op's SSA result with a literal naming the new variable.
+          // Draw a BD id from the tile's runtime pool (declared in the
+          // prologue) into a fresh C++ variable; nullopt if the pool is empty.
+          // Downstream ops consume the id, so replace the SSA result with a
+          // literal naming the variable.
           std::string var = "bd_" + std::to_string(nextPoolVar++);
           emitc::VerbatimOp::create(
               b, loc,
@@ -303,13 +287,10 @@ private:
     return u32Literal(b, loc, it->second);
   }
 
-  // The address for a write32/maskwrite32: the compile-time literal when the
-  // device resolved one, otherwise the op's SSA address operand when it is a
-  // genuine runtime value (the dynamic BD pool computes bdBase + wordIdx as
-  // arith over a popped id -- lowered to C++ by convert-arith-to-emitc). A
-  // usable runtime address must be arith-derived (has a defining op); a bare
-  // block argument selects no hardware register and stays rejected. Null for a
-  // truly symbolic/unresolved address.
+  // The address for a write32/maskwrite32: the device-resolved literal, else a
+  // genuine runtime address (arith-derived, e.g. the pool's bdBase + wordIdx).
+  // A bare block argument selects no register and is rejected; null for a
+  // symbolic/unresolved address.
   Value runtimeOrResolvedAddr(OpBuilder &b, Location loc, Operation *clone,
                               Value addrOperand) {
     if (Value lit = resolvedAddr(b, loc, clone))
@@ -556,11 +537,9 @@ private:
                                     std::to_string(numBDs) + ");");
     });
 
-    // A rolled loop makes the emitted op count a runtime quantity (the body
-    // executes a runtime number of times). Declare a `__opcount` accumulator
-    // the converter bumps per emitted op, and feed it to the header. A
-    // straight-line sequence keeps the compile-time literal count
-    // (byte-identical golden).
+    // A rolled loop makes the op count a runtime quantity: declare a __opcount
+    // accumulator the converter bumps per op. A straight-line sequence keeps
+    // the compile-time literal count (byte-identical golden).
     bool hasControlFlow = false;
     seqOp.walk([&](Operation *op) {
       if (isa<scf::SCFDialect>(op->getDialect()))
@@ -573,12 +552,10 @@ private:
           fb, loc, getU32Type(moduleOp.getContext()), "__opcount");
     }
 
-    // Clone the sequence body into the function (whole regions, so a rolled
-    // scf.for and its body come along), mapping the non-memref block args to
-    // the function parameters. While the originals are still under the device,
-    // resolve their device-relative values (absolute address, blockwrite data)
-    // keyed by the clone -- the converter reads these instead of calling
-    // device-dependent accessors on the detached clones.
+    // Clone the sequence body (whole regions, so a rolled scf.for comes along),
+    // mapping non-memref block args to function params. Resolve device-relative
+    // values (address, blockwrite data) while the originals are still under the
+    // device, keyed by clone, since the accessors don't work once detached.
     IRMapping mapping;
     unsigned p = 0;
     for (BlockArgument arg : entry.getArguments())

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -32,6 +32,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Format.h"
 
@@ -50,6 +51,12 @@ constexpr llvm::StringLiteral kTxnVecType = "std::vector<uint32_t>";
 
 emitc::OpaqueType getU32Type(MLIRContext *ctx) {
   return emitc::OpaqueType::get(ctx, "uint32_t");
+}
+
+// The C++ variable name of the runtime BD pool for a tile. One pool per tile
+// that draws BD ids at runtime, declared in the generated function's prologue.
+std::string bdPoolName(uint32_t col, uint32_t row) {
+  return "bd_pool_" + std::to_string(col) + "_" + std::to_string(row);
 }
 
 // A uint32_t literal operand (e.g. `42u`) for a txn_append_* argument. Used for
@@ -147,7 +154,10 @@ private:
 
     llvm::TypeSwitch<Operation *, void>(op)
         .Case<AIEX::NpuWrite32Op>([&](auto w) {
-          Value addrV = resolvedAddr(b, loc, w);
+          // A compile-time address folds to a literal; a runtime address (the
+          // dynamic BD pool's bdBase + wordIdx, arith over a popped id) is
+          // passed through as SSA and lowered by convert-arith-to-emitc.
+          Value addrV = runtimeOrResolvedAddr(b, loc, w, w.getAddress());
           if (!addrV)
             return fail(w, "cannot convert a symbolic/unresolved write32 "
                            "address to the C++ TXN target");
@@ -156,7 +166,7 @@ private:
           ++count;
         })
         .Case<AIEX::NpuMaskWrite32Op>([&](auto mw) {
-          Value addrV = resolvedAddr(b, loc, mw);
+          Value addrV = runtimeOrResolvedAddr(b, loc, mw, mw.getAddress());
           if (!addrV)
             return fail(mw, "cannot convert a symbolic/unresolved maskwrite32 "
                             "address to the C++ TXN target");
@@ -213,6 +223,30 @@ private:
                 b, loc, "if ({} % " + d + " != 0) return std::nullopt;",
                 ValueRange{g.getValue()});
         })
+        .Case<AIEX::DMABdPoolPopOp>([&](AIEX::DMABdPoolPopOp pop) {
+          // Draw a BD id from the tile's runtime pool into a fresh C++
+          // variable, and fail the build (nullopt) if the pool is empty -- the
+          // runtime backstop for a working set exceeding the tile's BD count.
+          // The pool variable was declared in the prologue (see emitFunction).
+          // Downstream ops (write32 addresses, push_queue) consume the id, so
+          // replace the op's SSA result with a literal naming the new variable.
+          std::string var = "bd_" + std::to_string(nextPoolVar++);
+          emitc::VerbatimOp::create(
+              b, loc,
+              "uint32_t " + var + "; if (!aie_runtime::bd_pool_pop(" +
+                  bdPoolName(pop.getColumn(), pop.getRow()) + ", " + var +
+                  ")) return std::nullopt;");
+          Value ref =
+              emitc::LiteralOp::create(b, loc, pop.getBdId().getType(), var);
+          pop.getBdId().replaceAllUsesWith(ref);
+        })
+        .Case<AIEX::DMABdPoolPushOp>([&](AIEX::DMABdPoolPushOp push) {
+          // Return a BD id to the tile's runtime pool.
+          emitc::CallOpaqueOp::create(
+              b, loc, TypeRange{}, "aie_runtime::bd_pool_push",
+              ValueRange{poolRef(b, loc, push.getColumn(), push.getRow()),
+                         push.getBdId()});
+        })
         // memref.get_global feeding a blockwrite is consumed by
         // convertBlockWrite (data inlined); the now-dead op is erased later.
         .Case<memref::GetGlobalOp>([&](auto) {})
@@ -237,10 +271,32 @@ private:
     return u32Literal(b, loc, it->second);
   }
 
+  // The address for a write32/maskwrite32: the compile-time literal when the
+  // device resolved one, otherwise the op's SSA address operand when it is a
+  // genuine runtime value (the dynamic BD pool computes bdBase + wordIdx as
+  // arith over a popped id -- lowered to C++ by convert-arith-to-emitc). Null
+  // only for a truly symbolic/unresolved address.
+  Value runtimeOrResolvedAddr(OpBuilder &b, Location loc, Operation *clone,
+                              Value addrOperand) {
+    if (Value lit = resolvedAddr(b, loc, clone))
+      return lit;
+    if (addrOperand && !addrOperand.getDefiningOp<arith::ConstantOp>())
+      return addrOperand;
+    return {};
+  }
+
   // Emit a diagnostic on `op` and mark the conversion failed.
   void fail(Operation *op, const llvm::Twine &msg) {
     op->emitOpError(msg);
     ok = false;
+  }
+
+  // An emitc.literal referencing a tile's pool variable (for pass-by-reference
+  // into bd_pool_push).
+  Value poolRef(OpBuilder &b, Location loc, uint32_t col, uint32_t row) {
+    return emitc::LiteralOp::create(
+        b, loc, emitc::OpaqueType::get(b.getContext(), "aie_runtime::BdPool"),
+        bdPoolName(col, row));
   }
 
   void convertBlockWrite(OpBuilder &b, Location loc, AIEX::NpuBlockWriteOp bw) {
@@ -290,6 +346,8 @@ private:
   Value txnVec;
   const DeviceResolved &resolved;
   bool ok = true;
+  // Counter for unique popped-BD-id C++ variable names.
+  unsigned nextPoolVar = 0;
 };
 
 struct ConvertAIEXToEmitCPass
@@ -421,6 +479,32 @@ private:
     emitc::VerbatimOp::create(fb, loc, "std::vector<uint32_t> txn;");
     Value txnVec = emitc::LiteralOp::create(fb, loc, txnVecType, "txn");
     emitTxnCall(fb, loc, "txn_init", txnVec, {});
+
+    // Declare a runtime BD free-list pool for each tile that draws ids at
+    // runtime (dynamic free-list path). The pool size is the tile's BD count
+    // from the target model -- never hardcoded here. One decl per distinct
+    // tile.
+    const AIE::AIETargetModel &targetModel = deviceOp.getTargetModel();
+    llvm::SmallSet<std::pair<uint32_t, uint32_t>, 4> pooledTiles;
+    seqOp.walk([&](Operation *op) {
+      uint32_t col, row;
+      if (auto pop = dyn_cast<AIEX::DMABdPoolPopOp>(op)) {
+        col = pop.getColumn();
+        row = pop.getRow();
+      } else if (auto push = dyn_cast<AIEX::DMABdPoolPushOp>(op)) {
+        col = push.getColumn();
+        row = push.getRow();
+      } else {
+        return;
+      }
+      if (!pooledTiles.insert({col, row}).second)
+        return;
+      uint32_t numBDs = targetModel.getNumBDs(col, row);
+      emitc::VerbatimOp::create(fb, loc,
+                                "aie_runtime::BdPool " + bdPoolName(col, row) +
+                                    " = aie_runtime::bd_pool_init(" +
+                                    std::to_string(numBDs) + ");");
+    });
 
     // Clone the straight-line sequence body into the function, mapping the
     // non-memref block args to the function parameters. While the originals are

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -171,7 +171,10 @@ private:
           ++count;
         })
         .Case<AIEX::NpuAddressPatchOp>([&](auto ap) {
-          Value addrV = u32Literal(b, loc, ap.getAddr());
+          // A runtime bd_id makes the patched register address runtime: prefer
+          // the SSA addr_val (flows through arith-to-emitc) over the constant.
+          Value addrV = ap.getAddrVal() ? ap.getAddrVal()
+                                        : u32Literal(b, loc, ap.getAddr());
           Value idxV = emitc::ConstantOp::create(
               b, loc, emitc::OpaqueType::get(b.getContext(), "int32_t"),
               emitc::OpaqueAttr::get(b.getContext(),

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -306,13 +306,16 @@ private:
   // The address for a write32/maskwrite32: the compile-time literal when the
   // device resolved one, otherwise the op's SSA address operand when it is a
   // genuine runtime value (the dynamic BD pool computes bdBase + wordIdx as
-  // arith over a popped id -- lowered to C++ by convert-arith-to-emitc). Null
-  // only for a truly symbolic/unresolved address.
+  // arith over a popped id -- lowered to C++ by convert-arith-to-emitc). A
+  // usable runtime address must be arith-derived (has a defining op); a bare
+  // block argument selects no hardware register and stays rejected. Null for a
+  // truly symbolic/unresolved address.
   Value runtimeOrResolvedAddr(OpBuilder &b, Location loc, Operation *clone,
                               Value addrOperand) {
     if (Value lit = resolvedAddr(b, loc, clone))
       return lit;
-    if (addrOperand && !addrOperand.getDefiningOp<arith::ConstantOp>())
+    Operation *def = addrOperand ? addrOperand.getDefiningOp() : nullptr;
+    if (def && !isa<arith::ConstantOp>(def))
       return addrOperand;
     return {};
   }

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -31,6 +31,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/RegionUtils.h"
 
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -104,20 +105,15 @@ public:
     if (!ok)
       return std::nullopt;
 
-    // Erase the converted npu ops, then sweep now-dead memref/arith clones
-    // (e.g. a get_global or folded-away address constant). Live arith feeding
-    // runtime fields is kept for arith-to-emitc. Collect first: erasing
-    // mid-walk is unsafe.
+    // Erase the converted npu ops, then DCE their now-dead operand clones (a
+    // get_global feeding a blockwrite, a folded-away address constant). Region-
+    // scoped runRegionDCE, not a module canonicalizer: the latter would also
+    // drop the shared memref.global the blockwrite data was inlined from, which
+    // other sequences in the module still reference.
     for (Operation *op : llvm::reverse(consumed))
       op->erase();
-    SmallVector<Operation *> deadSweep;
-    funcOp.walk<WalkOrder::PostOrder>([&](Operation *op) {
-      if (isa<memref::MemRefDialect, arith::ArithDialect>(op->getDialect()) &&
-          op->use_empty())
-        deadSweep.push_back(op);
-    });
-    for (Operation *op : deadSweep)
-      op->erase();
+    IRRewriter rewriter(funcOp.getContext());
+    (void)runRegionDCE(rewriter, funcOp.getFunctionBody());
     return count;
   }
 

--- a/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
+++ b/lib/Conversion/AIEXToEmitC/AIEXToEmitC.cpp
@@ -5,13 +5,15 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Converts the straight-line npu transaction ops in an aie.runtime_sequence
-// into EmitC dialect calls naming the functions in aie/Runtime/TxnEncoding.h.
+// Converts the npu transaction ops in an aie.runtime_sequence into EmitC
+// dialect calls naming the functions in aie/Runtime/TxnEncoding.h.
 // translateToCpp() on the result produces a standalone C++ function that
 // assembles the same TXN words the compile-time binary emitter
 // (AIETargetNPU.cpp) produces -- this is the runtime-parameterizable mirror of
-// that path. This pass handles straight-line sequences only; control flow is
-// rejected with a diagnostic and added by later dynamic-sequences passes.
+// that path. A runtime-bound scf.for (the dynamic BD free-list pool path) is
+// preserved: its body ops are converted in place and the loop itself is lowered
+// to emitc.for by convert-scf-to-emitc, so the generated C++ keeps the loop
+// rolled with a runtime op-count.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,6 +24,7 @@
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 
 #include "mlir/Conversion/ArithToEmitC/ArithToEmitC.h"
+#include "mlir/Conversion/SCFToEmitC/SCFToEmitC.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/EmitC/Transforms/TypeConversions.h"
@@ -93,55 +96,84 @@ struct DeviceResolved {
 class AIEXToEmitCConverter {
 public:
   AIEXToEmitCConverter(emitc::FuncOp funcOp, Value txnVec,
-                       const DeviceResolved &resolved)
-      : funcOp(funcOp), txnVec(txnVec), resolved(resolved) {}
+                       const DeviceResolved &resolved, Value opCountVar)
+      : funcOp(funcOp), txnVec(txnVec), resolved(resolved),
+        opCountVar(opCountVar) {}
 
-  // Convert every straight-line op cloned into the function body. Returns the
-  // number of txn ops appended (the op_count for the header), or nullopt on a
-  // conversion error already diagnosed.
+  // Convert every npu/pool op in the function body -- recursing into scf region
+  // bodies so ops inside a rolled loop are lowered too. Returns the
+  // compile-time count of txn ops emitted when the body is straight-line (used
+  // as a literal op_count in the header), or nullopt on a conversion error.
+  // When a runtime op-count variable was provided (a loop is present), each
+  // emitted op also increments it and the header reads that instead; the
+  // returned count is then unused.
   std::optional<uint32_t> run() {
-    Block &body = funcOp.getBlocks().front();
-    SmallVector<Operation *> work;
-    for (Operation &op : body)
-      work.push_back(&op);
-
     uint32_t count = 0;
     SmallVector<Operation *> consumed;
-    for (Operation *op : work) {
-      // Structural emitc ops (txn vector decl, txn_init) are already done.
-      // arith ops (constant scalar fields and runtime-value arithmetic) are
-      // left in place for the later convert-arith-to-emitc step -- passing
-      // operands through uniformly is what lets runtime values flow into the
-      // C++.
-      if (isa<emitc::EmitCDialect, arith::ArithDialect>(op->getDialect()))
-        continue;
-      convertOne(op, count);
-      if (!ok)
-        return std::nullopt;
-      // The npu op is replaced by its emitc call; mark it for erase. A
-      // memref.get_global feeding a blockwrite is now dead, but a later
-      // blockwrite may still reference it, so defer its erase to the dead-op
-      // sweep below.
-      if (!isa<memref::GetGlobalOp>(op))
-        consumed.push_back(op);
-    }
+    convertBlockRecursive(funcOp.getBlocks().front(), count, consumed);
+    if (!ok)
+      return std::nullopt;
 
-    // Erase the converted npu ops, then sweep now-dead clones back to front so
-    // a def outlives its uses (e.g. get_global feeding a blockwrite, or the
+    // Erase the converted npu ops, then sweep now-dead memref/arith clones so a
+    // def outlives its uses (e.g. get_global feeding a blockwrite, or the
     // arith.constant that defined an address we replaced with a folded
     // literal). Live arith feeding runtime value/mask/sync fields has uses and
-    // is kept for the arith-to-emitc step.
+    // is kept for the arith-to-emitc step. Walk post-order and collect first,
+    // since erasing during a walk is unsafe.
     for (Operation *op : llvm::reverse(consumed))
       op->erase();
-    for (Operation *op : llvm::reverse(work))
-      if (op->getBlock() &&
-          isa<memref::MemRefDialect, arith::ArithDialect>(op->getDialect()) &&
+    SmallVector<Operation *> deadSweep;
+    funcOp.walk<WalkOrder::PostOrder>([&](Operation *op) {
+      if (isa<memref::MemRefDialect, arith::ArithDialect>(op->getDialect()) &&
           op->use_empty())
-        op->erase();
+        deadSweep.push_back(op);
+    });
+    for (Operation *op : deadSweep)
+      op->erase();
     return count;
   }
 
 private:
+  // Convert the npu/pool ops in `block`, recursing through scf op regions so a
+  // rolled loop's body is lowered in place (the scf.for itself is left for the
+  // later convert-scf-to-emitc step). Collects converted ops into `consumed`.
+  void convertBlockRecursive(Block &block, uint32_t &count,
+                             SmallVector<Operation *> &consumed) {
+    SmallVector<Operation *> work;
+    for (Operation &op : block)
+      work.push_back(&op);
+    for (Operation *op : work) {
+      if (!ok)
+        return;
+      // Structural emitc ops and arith (constant / runtime-value math) are left
+      // for the later arith-to-emitc step. Recurse into scf ops (and any other
+      // region-carrying control flow) to convert their bodies; the control-flow
+      // op itself is handled by convert-scf-to-emitc afterwards.
+      if (isa<emitc::EmitCDialect, arith::ArithDialect>(op->getDialect()))
+        continue;
+      if (isa<scf::SCFDialect>(op->getDialect())) {
+        for (Region &r : op->getRegions())
+          for (Block &b : r)
+            convertBlockRecursive(b, count, consumed);
+        continue;
+      }
+      convertOne(op, count);
+      if (!isa<memref::GetGlobalOp>(op))
+        consumed.push_back(op);
+    }
+  }
+
+private:
+  // Record one emitted txn op: bump the compile-time count and, when a runtime
+  // op-count variable exists (the sequence has a loop, so the count is not
+  // known at compile time), emit a `++__opcount;` so the header gets the true
+  // runtime total.
+  void countOp(OpBuilder &b, Location loc, uint32_t &count) {
+    ++count;
+    if (opCountVar)
+      emitc::VerbatimOp::create(b, loc, "++{};", ValueRange{opCountVar});
+  }
+
   // Convert one op, appending to the txn vector. Increments `count` for each
   // txn instruction emitted. Scalar operands of the (already-cloned) op are
   // passed through directly -- a constant or a runtime value both flow as SSA,
@@ -163,7 +195,7 @@ private:
                            "address to the C++ TXN target");
           emitTxnCall(b, loc, "txn_append_write32", txnVec,
                       {addrV, w.getValue()});
-          ++count;
+          countOp(b, loc, count);
         })
         .Case<AIEX::NpuMaskWrite32Op>([&](auto mw) {
           Value addrV = runtimeOrResolvedAddr(b, loc, mw, mw.getAddress());
@@ -172,13 +204,13 @@ private:
                             "address to the C++ TXN target");
           emitTxnCall(b, loc, "txn_append_maskwrite32", txnVec,
                       {addrV, mw.getValue(), mw.getMask()});
-          ++count;
+          countOp(b, loc, count);
         })
         .Case<AIEX::NpuSyncOp>([&](auto s) {
           emitTxnCall(b, loc, "txn_append_sync", txnVec,
                       {s.getColumn(), s.getRow(), s.getDirection(),
                        s.getChannel(), s.getColumnNum(), s.getRowNum()});
-          ++count;
+          countOp(b, loc, count);
         })
         .Case<AIEX::NpuAddressPatchOp>([&](auto ap) {
           // A runtime bd_id makes the patched register address runtime: prefer
@@ -191,11 +223,11 @@ private:
                                      std::to_string(ap.getArgIdx())));
           emitTxnCall(b, loc, "txn_append_address_patch", txnVec,
                       {addrV, idxV, ap.getArgPlus()});
-          ++count;
+          countOp(b, loc, count);
         })
         .Case<AIEX::NpuBlockWriteOp>([&](auto bw) {
           convertBlockWrite(b, loc, bw);
-          ++count;
+          countOp(b, loc, count);
         })
         .Case<AIEX::NpuAssertBdFieldOp>([&](auto g) {
           // Host-side bounds guard: if the runtime value overflows its narrow
@@ -345,6 +377,9 @@ private:
   emitc::FuncOp funcOp;
   Value txnVec;
   const DeviceResolved &resolved;
+  // Runtime op-count variable (the C++ `__opcount`), or null when the sequence
+  // is straight-line and the count is a compile-time literal.
+  Value opCountVar;
   bool ok = true;
   // Counter for unique popped-BD-id C++ variable names.
   unsigned nextPoolVar = 0;
@@ -385,10 +420,10 @@ struct ConvertAIEXToEmitCPass
     for (Operation *op : llvm::reverse(toErase))
       op->erase();
 
-    // Lower the arith ops left behind in the function bodies (constant scalar
-    // fields and any runtime-value arithmetic feeding npu ops) to emitc. scf
-    // was already rejected, so only arith needs lowering here.
-    if (failed(lowerArithToEmitC(moduleOp)))
+    // Lower the arith ops (constant scalar fields, runtime-value arithmetic
+    // feeding npu ops) and any scf control flow (a rolled dynamic loop) left in
+    // the function bodies to emitc.
+    if (failed(lowerArithAndScfToEmitC(moduleOp)))
       return signalPassFailure();
 
     builder.setInsertionPointToStart(moduleOp.getBody());
@@ -405,18 +440,22 @@ struct ConvertAIEXToEmitCPass
                              /*is_standard=*/true);
   }
 
-  // Run the upstream arith-to-emitc conversion over the generated functions.
-  LogicalResult lowerArithToEmitC(ModuleOp moduleOp) {
+  // Run the upstream arith-to-emitc and scf-to-emitc conversions over the
+  // generated functions in one pass: a rolled dynamic loop is scf.for, and its
+  // bounds / iter_args are arith, so both must lower together.
+  LogicalResult lowerArithAndScfToEmitC(ModuleOp moduleOp) {
     TypeConverter typeConverter;
     typeConverter.addConversion([](Type t) { return t; });
     populateEmitCSizeTTypeConversions(typeConverter);
 
     RewritePatternSet patterns(moduleOp.getContext());
     populateArithToEmitCPatterns(typeConverter, patterns);
+    populateSCFToEmitCConversionPatterns(patterns, typeConverter);
 
     ConversionTarget target(*moduleOp.getContext());
     target.addLegalDialect<emitc::EmitCDialect>();
     target.addIllegalDialect<arith::ArithDialect>();
+    target.addIllegalDialect<scf::SCFDialect>();
     return applyPartialConversion(moduleOp, target, std::move(patterns));
   }
 
@@ -457,9 +496,17 @@ private:
     auto txnRetType = emitc::OpaqueType::get(
         moduleOp.getContext(),
         (llvm::Twine("std::optional<") + kTxnVecType + ">").str());
+    // A runtime scalar of type `index` (e.g. a loop trip count) has no C++
+    // spelling on its own; emit it as emitc.size_t so it flows straight into a
+    // converted scf.for bound with no leftover cast. Other scalar types pass
+    // through unchanged.
+    auto sizeT = emitc::SizeTType::get(moduleOp.getContext());
+    auto paramTypeFor = [&](Type t) -> Type {
+      return isa<IndexType>(t) ? Type(sizeT) : t;
+    };
     for (BlockArgument arg : entry.getArguments())
       if (!isa<BaseMemRefType>(arg.getType()))
-        paramTypes.push_back(arg.getType());
+        paramTypes.push_back(paramTypeFor(arg.getType()));
 
     builder.setInsertionPointToEnd(moduleOp.getBody());
     std::string funcName = "generate_txn_" + deviceOp.getSymName().str() + "_" +
@@ -506,11 +553,29 @@ private:
                                     std::to_string(numBDs) + ");");
     });
 
-    // Clone the straight-line sequence body into the function, mapping the
-    // non-memref block args to the function parameters. While the originals are
-    // still under the device, resolve their device-relative values (absolute
-    // address, blockwrite data) keyed by the clone -- the converter reads these
-    // instead of calling device-dependent accessors on the detached clones.
+    // A rolled loop makes the emitted op count a runtime quantity (the body
+    // executes a runtime number of times). Declare a `__opcount` accumulator
+    // the converter bumps per emitted op, and feed it to the header. A
+    // straight-line sequence keeps the compile-time literal count
+    // (byte-identical golden).
+    bool hasControlFlow = false;
+    seqOp.walk([&](Operation *op) {
+      if (isa<scf::SCFDialect>(op->getDialect()))
+        hasControlFlow = true;
+    });
+    Value opCountVar;
+    if (hasControlFlow) {
+      emitc::VerbatimOp::create(fb, loc, "uint32_t __opcount = 0;");
+      opCountVar = emitc::LiteralOp::create(
+          fb, loc, getU32Type(moduleOp.getContext()), "__opcount");
+    }
+
+    // Clone the sequence body into the function (whole regions, so a rolled
+    // scf.for and its body come along), mapping the non-memref block args to
+    // the function parameters. While the originals are still under the device,
+    // resolve their device-relative values (absolute address, blockwrite data)
+    // keyed by the clone -- the converter reads these instead of calling
+    // device-dependent accessors on the detached clones.
     IRMapping mapping;
     unsigned p = 0;
     for (BlockArgument arg : entry.getArguments())
@@ -518,24 +583,34 @@ private:
         mapping.map(arg, funcBlock->getArgument(p++));
     DeviceResolved resolved;
     for (Operation &op : entry.without_terminator()) {
-      Operation *clone = fb.clone(op, mapping);
-      recordDeviceResolved(&op, clone, resolved);
+      fb.clone(op, mapping);
+      // Record device-resolved values for the clone and any nested op (a BD
+      // inside a rolled loop resolves the same way as a top-level one).
+      op.walk([&](Operation *orig) {
+        Operation *c = mapping.lookupOrNull(orig);
+        if (c)
+          recordDeviceResolved(orig, c, resolved);
+      });
     }
 
-    AIEXToEmitCConverter conv(funcOp, txnVec, resolved);
+    AIEXToEmitCConverter conv(funcOp, txnVec, resolved, opCountVar);
     std::optional<uint32_t> count = conv.run();
     if (!count)
       return failure();
 
-    // Finalize the header with the statically-known op count + device info.
+    // Finalize the header with the op count + device info. The count is the
+    // runtime `__opcount` when the sequence has a loop, else the compile-time
+    // literal.
     const AIE::AIETargetModel &tm = deviceOp.getTargetModel();
     uint8_t devGen = isa<AIE::BaseNPU2TargetModel>(tm) ? 4 : 3;
     OpBuilder eb(funcBlock, funcBlock->end());
-    std::string header =
-        "aie_runtime::txn_prepend_header(txn, " + std::to_string(*count) +
-        "u, {0, 1, " + std::to_string(devGen) + ", " +
-        std::to_string(tm.rows()) + ", " + std::to_string(tm.columns()) + ", " +
-        std::to_string(tm.getNumMemTileRows()) + "});";
+    std::string countStr =
+        hasControlFlow ? "__opcount" : (std::to_string(*count) + "u");
+    std::string header = "aie_runtime::txn_prepend_header(txn, " + countStr +
+                         ", {0, 1, " + std::to_string(devGen) + ", " +
+                         std::to_string(tm.rows()) + ", " +
+                         std::to_string(tm.columns()) + ", " +
+                         std::to_string(tm.getNumMemTileRows()) + "});";
     emitc::VerbatimOp::create(eb, loc, header);
     // Return the vector as the optional result. The literal text differs from
     // the "txn" accumulator literal (so the two are not deduplicated) and is

--- a/lib/Conversion/AIEXToEmitC/CMakeLists.txt
+++ b/lib/Conversion/AIEXToEmitC/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_conversion_library(MLIRAIEXToEmitC
   AIE
   AIEX
   MLIRArithToEmitC
+  MLIRSCFToEmitC
   MLIREmitCDialect
   MLIREmitCTransforms
   MLIRSCFDialect

--- a/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEInsertTraceFlows.cpp
@@ -750,7 +750,8 @@ struct AIEInsertTraceFlowsPass
         uint32_t bdAddress = computeBDAddress(shimCol, chanDesc.bdId,
                                               shimInfo.shimTile, targetModel);
         xilinx::AIEX::NpuAddressPatchOp::create(
-            builder, runtimeSeq.getLoc(), bdAddress, chanDesc.argIdx,
+            builder, runtimeSeq.getLoc(), bdAddress, /*addr_val=*/mlir::Value(),
+            chanDesc.argIdx,
             AIEX::createConstantI32(builder, runtimeSeq.getLoc(),
                                     chanDesc.bufferOffset));
 

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -604,21 +604,21 @@ LogicalResult AIEX::NpuDmaMemcpyNdOp::verify() {
     return emitOpError("Minimum data transfer size required is ")
            << addressGranularity << "bits. ";
   }
-  bool allOffsetsConstant = llvm::all_of(getMixedOffsets(), [](OpFoldResult s) {
-    return getConstantIntValue(s).has_value();
-  });
   bool allStridesConstant = llvm::all_of(getMixedStrides(), [](OpFoldResult s) {
     return getConstantIntValue(s).has_value();
   });
   bool allSizesConstant = llvm::all_of(getMixedSizes(), [](OpFoldResult s) {
     return getConstantIntValue(s).has_value();
   });
+  bool allOffsetsConstant = llvm::all_of(getMixedOffsets(), [](OpFoldResult s) {
+    return getConstantIntValue(s).has_value();
+  });
 
-  // Dynamic (runtime SSA offset/size/stride) path: a runtime value can only be
-  // programmed via the host-side address-patch / BD-word overrides, so any
-  // runtime operand routes here. See AIEDmaToNpu.cpp lowerDynamic and
-  // emitBufferAddressPatch for the encoding.
-  if (!allOffsetsConstant || !allStridesConstant || !allSizesConstant)
+  // Dynamic path: any runtime size/stride/offset. A runtime offset flows into
+  // the address-patch arg_plus as arith (see AIEDmaToNpu.cpp emitBufferAddress-
+  // Patch); runtime sizes/strides use the dynamic BD-word encoder. The shared
+  // scope check enforces what the dynamic lowering can represent.
+  if (!allStridesConstant || !allSizesConstant || !allOffsetsConstant)
     return verifyDynamicSizesStrides(targetModel, buffer);
 
   llvm::SmallVector<int64_t, 4> inputSizes =

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -877,6 +877,19 @@ LogicalResult AIEX::NpuAssertBdDivisibleOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// NpuAddressPatchOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AIEX::NpuAddressPatchOp::verify() {
+  // A runtime register address (addr_val) is meaningful only on the EmitC (C++
+  // TXN) target; the constant `addr` still carries the fallback / static value.
+  // The static binary target checks for the operand and diagnoses it there.
+  if (getAddrVal() && !getAddrVal().getType().isInteger(32))
+    return emitOpError("addr_val must be an i32 value");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // NpuUpdateFromScratchpadOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEAssignRuntimeSequenceBDIDs.cpp
@@ -267,6 +267,15 @@ struct AIEAssignRuntimeSequenceBDIDsPass
     AIE::DeviceOp device = getOperation();
 
     WalkResult wr = device.walk([&](AIE::RuntimeSequenceOp seq) -> WalkResult {
+      // Skip sequences already handled by the dynamic free-list pool path
+      // (aie-lower-dynamic-bd-pool): they draw BD ids at runtime via
+      // dma_bd_pool_pop and keep their scf.for rolled, which the static
+      // straight-line allocator neither needs to touch nor can validate.
+      bool dynamicPool = false;
+      seq.walk([&](DMABdPoolPopOp) { dynamicPool = true; });
+      if (dynamicPool)
+        return WalkResult::advance();
+
       if (failed(validate(seq)))
         return WalkResult::interrupt();
       gens.clear();

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -43,24 +43,33 @@ struct DMAStartTaskOpPattern : OpConversionPattern<DMAStartTaskOp> {
       return failure();
     }
     AIE::TileOp tile = task_op.getTileOp();
-    std::optional<uint32_t> first_bd_id = task_op.getFirstBdId();
-    if (!first_bd_id) {
-      auto err = op.emitOpError(
-          "First buffer descriptor in chain has not been assigned an ID");
-      err.attachNote() << "Run the `aie-assign-runtime-buffer-descriptor-ids` "
-                          "pass first or manually assign an ID.";
-      return failure();
+    Location loc = op.getLoc();
+
+    // The bd_id for the queue push: the runtime pool value (dynamic free-list)
+    // if the configure carries one, else the statically-assigned first BD id.
+    Value bdIdVal;
+    if (Value runtimeBdId = task_op.getBdIdVal()) {
+      bdIdVal = runtimeBdId;
+    } else {
+      std::optional<uint32_t> first_bd_id = task_op.getFirstBdId();
+      if (!first_bd_id) {
+        auto err = op.emitOpError(
+            "First buffer descriptor in chain has not been assigned an ID");
+        err.attachNote()
+            << "Run the `aie-assign-runtime-buffer-descriptor-ids` "
+               "pass first or manually assign an ID.";
+        return failure();
+      }
+      bdIdVal = createConstantI32(rewriter, loc, *first_bd_id);
     }
     // push_queue takes bd_id + repeat_count as SSA operands. repeat_count is a
     // runtime operand when present (dynamic tile count), else the compile-time
     // attribute materialized as a constant.
-    Location loc = op.getLoc();
     Value repeatCount = getAsValue(rewriter, loc, task_op.getRepeatCountValue(),
                                    rewriter.getI32Type());
     rewriter.replaceOpWithNewOp<NpuPushQueueOp>(
         op, tile.getCol(), tile.getRow(), task_op.getDirection(),
-        task_op.getChannel(), task_op.getIssueToken(), repeatCount,
-        createConstantI32(rewriter, loc, *first_bd_id));
+        task_op.getChannel(), task_op.getIssueToken(), repeatCount, bdIdVal);
     return success();
   }
 };
@@ -106,7 +115,7 @@ struct AIEDMATasksToNPUPass
     return block.isEntryBlock() && it.begin() == it.end();
   }
 
-  LogicalResult verifyBdInBlock(Block &block) {
+  LogicalResult verifyBdInBlock(Block &block, bool hasRuntimeBdId = false) {
     auto bd_ops = block.getOps<AIE::DMABDOp>();
     // Exactly one BD op per block
     int n_bd_ops = std::distance(bd_ops.begin(), bd_ops.end());
@@ -129,7 +138,10 @@ struct AIEDMATasksToNPUPass
       return failure();
     }
     AIE::DMABDOp bd_op = *bd_ops.begin();
-    if (!bd_op.getBdId().has_value()) {
+    // A runtime bd_id (dynamic free-list pool, on the configure's bd_id_val)
+    // takes the place of the static attribute; only require the attribute when
+    // there is no runtime id.
+    if (!hasRuntimeBdId && !bd_op.getBdId().has_value()) {
       auto error = bd_op.emitOpError(
           "Cannot lower buffer descriptor without assigned ID.");
       error.attachNote()
@@ -219,14 +231,31 @@ struct AIEDMATasksToNPUPass
   }
 
   LogicalResult setAddressForSingleBD(OpBuilder &builder, AIE::DMABDOp &bd_op,
-                                      AIE::TileOp &tile) {
-    uint32_t bd_id = bd_op.getBdId().value();
+                                      AIE::TileOp &tile,
+                                      OpFoldResult bdId = {}) {
     const AIE::AIETargetModel &target_model = AIE::getTargetModel(bd_op);
     auto buf = bd_op.getBuffer();
     auto col = tile.getCol();
     auto row = tile.getRow();
+    // The static register address uses the pinned bd_id attribute; on the
+    // runtime pool path the attribute is absent and runtimeRegisterAddr (below)
+    // supplies the address instead, so fall back to bd 0 for the constant.
+    uint32_t bd_id = bd_op.getBdId().value_or(0);
     uint64_t register_addr = target_model.getDmaBdAddress(col, row, bd_id) +
                              target_model.getDmaBdAddressOffset(col, row);
+    // On the runtime-bd_id path the patched register (BD buffer-address word)
+    // is itself runtime: getBdRegisterBase(bd_id) + getDmaBdAddressOffset.
+    // Emitted as an SSA operand on the address patch; null keeps the static
+    // constant.
+    Value runtimeRegisterAddr;
+    if (bdId && !getConstantIntValue(bdId)) {
+      Value base = getBdRegisterBase(builder, bd_op.getLoc(), target_model, col,
+                                     row, bdId);
+      runtimeRegisterAddr = arith::AddIOp::create(
+          builder, bd_op.getLoc(), base,
+          createConstantI32(builder, bd_op.getLoc(),
+                            target_model.getDmaBdAddressOffset(col, row)));
+    }
 
     // A buffer descriptor can refer to a statically allocated aie.buffer, or to
     // a DDR buffer which will be passed as a runtime argument (block
@@ -264,6 +293,7 @@ struct AIEDMATasksToNPUPass
                             bd_op.getBufferElementTypeWidthInBytes(), offset);
       NpuAddressPatchOp::create(builder, bd_op.getLoc(),
                                 /*addr*/ register_addr,
+                                /*addr_val*/ runtimeRegisterAddr,
                                 /*arg_idx*/ arg_idx, argPlus);
     } else if (AIE::BufferOp buffer =
                    llvm::dyn_cast<AIE::BufferOp>(buf.getDefiningOp())) {
@@ -422,7 +452,8 @@ struct AIEDMATasksToNPUPass
   LogicalResult
   rewriteSingleBDDynamic(OpBuilder &builder, Block &block, AIE::DMABDOp bd_op,
                          AIE::TileOp &tile,
-                         std::optional<xilinx::AIE::PacketInfoAttr> packet) {
+                         std::optional<xilinx::AIE::PacketInfoAttr> packet,
+                         Value runtimeBdId = nullptr) {
     const auto &target_model = AIE::getTargetModel(bd_op);
     Location loc = bd_op.getLoc();
     auto i32ty = builder.getIntegerType(32);
@@ -435,20 +466,40 @@ struct AIEDMATasksToNPUPass
       return failure();
     BdTemplateFields f = *fieldsOr;
 
-    // Zero-template BD: constant fields baked in, size/stride words zeroed for
-    // the write32 overrides to fill. valid_bd = 1.
-    NpuWriteBdOp::create(
-        builder, loc, col, bd_op.getBdId().value(), /*buffer_length=*/0,
-        /*buffer_offset=*/0, f.enable_packet, /*out_of_order_id=*/0,
-        f.packet_id, f.packet_type, /*d0_size=*/0, /*d0_stride=*/0,
-        /*d1_size=*/0,
-        /*d1_stride=*/0, /*d2_size=*/0, /*d2_stride=*/0,
-        /*iteration_current=*/0,
-        /*iteration_size=*/0, /*iteration_stride=*/0, f.next_bd_id, row,
-        f.use_next_bd, /*valid_bd=*/1, f.lock_rel_val, f.lock_rel_id,
-        f.lock_acq_enable, f.lock_acq_val, f.lock_acq_id, /*d0_zero_before=*/0,
-        /*d1_zero_before=*/0, /*d2_zero_before=*/0, /*d0_zero_after=*/0,
-        /*d1_zero_after=*/0, /*d2_zero_after=*/0, bd_op.getBurstLength());
+    // The bd_id as an OpFoldResult: the runtime pool value if present, else the
+    // pinned constant attribute.
+    OpFoldResult bdIdOfr =
+        runtimeBdId
+            ? OpFoldResult(runtimeBdId)
+            : OpFoldResult(builder.getI32IntegerAttr(bd_op.getBdId().value()));
+
+    if (runtimeBdId) {
+      // A runtime bd_id makes the whole BD register block's address runtime, so
+      // the constant-address zero-template blockwrite path (NpuWriteBdOp ->
+      // WriteBdToBlockWritePattern) cannot be used. Emit the template words
+      // (the ones the size/stride encoder does not cover) as runtime-addressed
+      // write32s at the same base. Register replay treats a blockwrite of N
+      // words and N write32s identically, so this matches the static BD.
+      if (failed(emitShimTemplateWordOverrides(builder, loc, target_model, col,
+                                               row, bdIdOfr, f)))
+        return failure();
+    } else {
+      // Zero-template BD: constant fields baked in, size/stride words zeroed
+      // for the write32 overrides to fill. valid_bd = 1.
+      NpuWriteBdOp::create(
+          builder, loc, col, bd_op.getBdId().value(), /*buffer_length=*/0,
+          /*buffer_offset=*/0, f.enable_packet, /*out_of_order_id=*/0,
+          f.packet_id, f.packet_type, /*d0_size=*/0, /*d0_stride=*/0,
+          /*d1_size=*/0,
+          /*d1_stride=*/0, /*d2_size=*/0, /*d2_stride=*/0,
+          /*iteration_current=*/0,
+          /*iteration_size=*/0, /*iteration_stride=*/0, f.next_bd_id, row,
+          f.use_next_bd, /*valid_bd=*/1, f.lock_rel_val, f.lock_rel_id,
+          f.lock_acq_enable, f.lock_acq_val, f.lock_acq_id,
+          /*d0_zero_before=*/0,
+          /*d1_zero_before=*/0, /*d2_zero_before=*/0, /*d0_zero_after=*/0,
+          /*d1_zero_after=*/0, /*d2_zero_after=*/0, bd_op.getBurstLength());
+    }
 
     // Normalize sizes/strides to a 4-element outermost-first mixed list (the
     // shared emitter's contract, matching memcpy_nd's always-4D operands),
@@ -492,28 +543,61 @@ struct AIEDMATasksToNPUPass
     // op's repeat_count, not the BD's outer dim.
     Value bdRepeatCount;
     if (failed(emitDynamicShimBdWordOverrides(
-            builder, loc, target_model, col, row,
-            builder.getI32IntegerAttr(bd_op.getBdId().value()), sizes4,
-            strides4, elemWidth, bd_op.getBurstLength(), bufLen,
-            bdRepeatCount)))
+            builder, loc, target_model, col, row, bdIdOfr, sizes4, strides4,
+            elemWidth, bd_op.getBurstLength(), bufLen, bdRepeatCount)))
       return failure();
-    return setAddressForSingleBD(builder, bd_op, tile);
+    return setAddressForSingleBD(builder, bd_op, tile, bdIdOfr);
+  }
+
+  // Emit the shim BD "template" words (the constant lock / packet / next_bd /
+  // valid / buffer_offset words the size/stride encoder leaves alone) as
+  // runtime-addressed write32s. Used only on the runtime-bd_id path, where the
+  // usual constant-address zero-template blockwrite cannot be formed. The word
+  // layout mirrors WriteBdToBlockWritePattern's shim packing for words 1, 2, 7.
+  LogicalResult emitShimTemplateWordOverrides(
+      OpBuilder &builder, Location loc, const AIE::AIETargetModel &target_model,
+      int col, int row, OpFoldResult bdId, const BdTemplateFields &f) {
+    Value bdBase =
+        getBdRegisterBase(builder, loc, target_model, col, row, bdId);
+    auto writeWord = [&](uint32_t wordIdx, uint32_t val) {
+      Value addr = arith::AddIOp::create(
+          builder, loc, bdBase, createConstantI32(builder, loc, wordIdx * 4));
+      NpuWrite32Op::create(builder, loc, addr,
+                           createConstantI32(builder, loc, val), nullptr,
+                           nullptr, nullptr);
+    };
+    // word[1] buffer_offset: 0 (the address patch supplies the buffer pointer).
+    writeWord(1, 0);
+    // word[2] enable_packet [30], out_of_order_id [29:24], packet_id [23:19],
+    // packet_type [18:16].
+    uint32_t w2 = ((f.enable_packet & 0x1) << 30) |
+                  ((f.packet_id & 0x1f) << 19) | ((f.packet_type & 0x7) << 16);
+    writeWord(2, w2);
+    // word[7] next_bd [30:27], use_next_bd [26], valid_bd [25], lock fields.
+    uint32_t w7 = ((f.next_bd_id & 0xf) << 27) | ((f.use_next_bd & 0x1) << 26) |
+                  (1u << 25) | ((f.lock_rel_val & 0x7f) << 18) |
+                  ((f.lock_rel_id & 0xf) << 13) |
+                  ((f.lock_acq_enable & 0x1) << 12) |
+                  ((f.lock_acq_val & 0x7f) << 5) | (f.lock_acq_id & 0xf);
+    writeWord(7, w7);
+    return success();
   }
 
   LogicalResult
   rewriteSingleBD(OpBuilder &builder, Block &block, AIE::TileOp &tile,
                   AIE::DMAChannelDir channelDir,
-                  std::optional<xilinx::AIE::PacketInfoAttr> packet) {
+                  std::optional<xilinx::AIE::PacketInfoAttr> packet,
+                  Value runtimeBdId = nullptr) {
     AIE::DMABDOp bd_op = getBdForBlock(block);
     const auto &target_model = AIE::getTargetModel(bd_op);
     auto buffer_type = llvm::cast<BaseMemRefType>(bd_op.getBuffer().getType());
     uint32_t addr_granularity = target_model.getAddressGenGranularity();
 
-    uint32_t bd_id = bd_op.getBdId().value();
-
     // Runtime (SSA) sizes/strides/len/offset take the dynamic BD-word encoder
-    // path; a fully-constant descriptor takes the static path below unchanged.
-    // Only the shim-NOC layout is encodable this way (see
+    // path; a runtime bd_id (dynamic free-list pool) also forces it, since the
+    // BD register addresses are then runtime and cannot fold into a blockwrite.
+    // A fully-constant descriptor with a pinned bd_id takes the static path
+    // below unchanged. Only the shim-NOC layout is encodable this way (see
     // rewriteSingleBDDynamic), so anything the dynamic path can't represent
     // stays a clean diagnostic.
     bool runtimeLen = bd_op.getLen() && !bd_op.getConstantLen();
@@ -523,11 +607,11 @@ struct AIEDMATasksToNPUPass
                      [](OpFoldResult s) { return !getConstantIntValue(s); }) ||
         llvm::any_of(bd_op.getMixedStrides(),
                      [](OpFoldResult s) { return !getConstantIntValue(s); });
-    if (runtimeLen || runtimeDims || runtimeOffset) {
+    if (runtimeLen || runtimeDims || runtimeOffset || runtimeBdId) {
       if (!target_model.isShimNOCTile(tile.getCol(), tile.getRow()))
         return bd_op->emitOpError(
-            "runtime-valued BD size/stride/len is only supported on shim NOC "
-            "tiles; use compile-time constants on other tiles.");
+            "runtime-valued BD size/stride/len/bd_id is only supported on shim "
+            "NOC tiles; use compile-time constants on other tiles.");
       if (bd_op.getPadDimensions().has_value())
         return bd_op->emitOpError(
             "zero padding is not supported with runtime sizes/strides/len.");
@@ -544,10 +628,13 @@ struct AIEDMATasksToNPUPass
               bd_op, sizesRev, stridesRev, elemWidth,
               target_model.getAddressGenGranularity())))
         return failure();
-      return rewriteSingleBDDynamic(builder, block, bd_op, tile, packet);
+      return rewriteSingleBDDynamic(builder, block, bd_op, tile, packet,
+                                    runtimeBdId);
     }
 
-    // Static path: offset is constant here (runtime offset routed above).
+    // Static path: bd_id is a pinned attribute (the dynamic/runtime-bd_id path
+    // returned above) and the offset is constant (runtime offset routed above).
+    uint32_t bd_id = bd_op.getBdId().value();
     int64_t offset = bd_op.getOffsetInBytes();
     uint64_t len = bd_op.getLenInBytes();
     uint64_t len_addr_granularity = len * 8 / addr_granularity;
@@ -797,6 +884,7 @@ struct AIEDMATasksToNPUPass
     }
 
     Region &body = op.getBody();
+    bool hasRuntimeBdId = op.getBdIdVal() != nullptr;
 
     // Verify each BD block first; subsequent functions rely on them being
     // well-formed
@@ -807,7 +895,7 @@ struct AIEDMATasksToNPUPass
       if (failed(verifyNoUnsupportedOpsInBlock(*it))) {
         return failure();
       }
-      if (failed(verifyBdInBlock(*it))) {
+      if (failed(verifyBdInBlock(*it, hasRuntimeBdId))) {
         return failure();
       }
       if (failed(verifyOptionalLocksInBlock(*it))) {
@@ -822,6 +910,9 @@ struct AIEDMATasksToNPUPass
 
     auto channelDir = op.getDirection();
     auto packet = op.getPacket();
+    // A runtime bd_id (dynamic free-list pool) supplied by
+    // aie-lower-dynamic-bd-pool; null on the static/pinned path.
+    Value runtimeBdId = op.getBdIdVal();
 
     // Lower all BDs
     for (auto it = body.begin(); it != body.end(); ++it) {
@@ -829,7 +920,8 @@ struct AIEDMATasksToNPUPass
       if (shouldSkipBlock(block)) {
         continue;
       }
-      if (failed(rewriteSingleBD(builder, block, tile, channelDir, packet))) {
+      if (failed(rewriteSingleBD(builder, block, tile, channelDir, packet,
+                                 runtimeBdId))) {
         return failure();
       }
     }

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -481,7 +481,8 @@ struct AIEDMATasksToNPUPass
       // write32s at the same base. Register replay treats a blockwrite of N
       // words and N write32s identically, so this matches the static BD.
       if (failed(emitShimTemplateWordOverrides(builder, loc, target_model, col,
-                                               row, bdIdOfr, f)))
+                                               row, bdIdOfr, f,
+                                               bd_op.getBurstLength())))
         return failure();
     } else {
       // Zero-template BD: constant fields baked in, size/stride words zeroed
@@ -549,14 +550,22 @@ struct AIEDMATasksToNPUPass
     return setAddressForSingleBD(builder, bd_op, tile, bdIdOfr);
   }
 
-  // Emit the shim BD "template" words (the constant lock / packet / next_bd /
-  // valid / buffer_offset words the size/stride encoder leaves alone) as
-  // runtime-addressed write32s. Used only on the runtime-bd_id path, where the
-  // usual constant-address zero-template blockwrite cannot be formed. The word
-  // layout mirrors WriteBdToBlockWritePattern's shim packing for words 1, 2, 7.
+  // Emit the shim BD "template" words as runtime-addressed write32s: the words
+  // the size/stride encoder does not fully own. Used only on the runtime-bd_id
+  // path, where the usual constant-address zero-template blockwrite cannot be
+  // formed. The word layout mirrors WriteBdToBlockWritePattern's shim packing.
+  //
+  // The encoder always overrides words 0 (buffer_length) and 6 (iteration), and
+  // in ND mode also 3/4/5. In linear mode it skips 3/4/5. Words 4 and 5 carry
+  // CONSTANT burst_length / AXCache bits even in linear mode (the static
+  // blockwrite bakes them), so this function emits those constants; in ND mode
+  // the encoder's later write32 to the same register supplies burst|d1 /
+  // axcache |d2 and wins by last-write. Words 1/2/7 are never touched by the
+  // encoder.
   LogicalResult emitShimTemplateWordOverrides(
       OpBuilder &builder, Location loc, const AIE::AIETargetModel &target_model,
-      int col, int row, OpFoldResult bdId, const BdTemplateFields &f) {
+      int col, int row, OpFoldResult bdId, const BdTemplateFields &f,
+      uint32_t burstLength) {
     Value bdBase =
         getBdRegisterBase(builder, loc, target_model, col, row, bdId);
     auto writeWord = [&](uint32_t wordIdx, uint32_t val) {
@@ -573,6 +582,14 @@ struct AIEDMATasksToNPUPass
     uint32_t w2 = ((f.enable_packet & 0x1) << 30) |
                   ((f.packet_id & 0x1f) << 19) | ((f.packet_type & 0x7) << 16);
     writeWord(2, w2);
+    // word[4] burst_length [31:30] (constant); d1_size/stride overlaid by the
+    // encoder in ND mode.
+    writeWord(4,
+              (AIE::getShimBurstLengthEncoding(target_model, burstLength) & 0x3)
+                  << 30);
+    // word[5] AXCache [27:24] = 2 (constant, enables NoC upsizing); d2_stride
+    // overlaid by the encoder in ND mode.
+    writeWord(5, (2u & 0xf) << 24);
     // word[7] next_bd [30:27], use_next_bd [26], valid_bd [25], lock fields.
     uint32_t w7 = ((f.next_bd_id & 0xf) << 27) | ((f.use_next_bd & 0x1) << 26) |
                   (1u << 25) | ((f.lock_rel_val & 0x7f) << 18) |

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -474,12 +474,10 @@ struct AIEDMATasksToNPUPass
             : OpFoldResult(builder.getI32IntegerAttr(bd_op.getBdId().value()));
 
     if (runtimeBdId) {
-      // A runtime bd_id makes the whole BD register block's address runtime, so
-      // the constant-address zero-template blockwrite path (NpuWriteBdOp ->
-      // WriteBdToBlockWritePattern) cannot be used. Emit the template words
-      // (the ones the size/stride encoder does not cover) as runtime-addressed
-      // write32s at the same base. Register replay treats a blockwrite of N
-      // words and N write32s identically, so this matches the static BD.
+      // A runtime bd_id makes the register block's address runtime, so the
+      // constant-address blockwrite path can't be used. Emit the template words
+      // as write32s instead -- register replay treats N write32s and an N-word
+      // blockwrite identically, matching the static BD.
       if (failed(emitShimTemplateWordOverrides(builder, loc, target_model, col,
                                                row, bdIdOfr, f,
                                                bd_op.getBurstLength())))
@@ -550,18 +548,11 @@ struct AIEDMATasksToNPUPass
     return setAddressForSingleBD(builder, bd_op, tile, bdIdOfr);
   }
 
-  // Emit the shim BD "template" words as runtime-addressed write32s: the words
-  // the size/stride encoder does not fully own. Used only on the runtime-bd_id
-  // path, where the usual constant-address zero-template blockwrite cannot be
-  // formed. The word layout mirrors WriteBdToBlockWritePattern's shim packing.
-  //
-  // The encoder always overrides words 0 (buffer_length) and 6 (iteration), and
-  // in ND mode also 3/4/5. In linear mode it skips 3/4/5. Words 4 and 5 carry
-  // CONSTANT burst_length / AXCache bits even in linear mode (the static
-  // blockwrite bakes them), so this function emits those constants; in ND mode
-  // the encoder's later write32 to the same register supplies burst|d1 /
-  // axcache |d2 and wins by last-write. Words 1/2/7 are never touched by the
-  // encoder.
+  // Emit the shim BD template words (those the size/stride encoder doesn't own)
+  // as runtime-addressed write32s, for the runtime-bd_id path where a constant-
+  // address zero-template blockwrite can't be formed. Layout mirrors
+  // WriteBdToBlockWritePattern. Words 4/5 carry constant burst_length/AXCache
+  // bits the encoder's later ND write32 overwrites by last-write; 1/2/7 unused.
   LogicalResult emitShimTemplateWordOverrides(
       OpBuilder &builder, Location loc, const AIE::AIETargetModel &target_model,
       int col, int row, OpFoldResult bdId, const BdTemplateFields &f,

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -492,8 +492,9 @@ struct AIEDMATasksToNPUPass
     // op's repeat_count, not the BD's outer dim.
     Value bdRepeatCount;
     if (failed(emitDynamicShimBdWordOverrides(
-            builder, loc, target_model, col, row, bd_op.getBdId().value(),
-            sizes4, strides4, elemWidth, bd_op.getBurstLength(), bufLen,
+            builder, loc, target_model, col, row,
+            builder.getI32IntegerAttr(bd_op.getBdId().value()), sizes4,
+            strides4, elemWidth, bd_op.getBurstLength(), bufLen,
             bdRepeatCount)))
       return failure();
     return setAddressForSingleBD(builder, bd_op, tile);

--- a/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDMATasksToNPU.cpp
@@ -51,14 +51,15 @@ struct DMAStartTaskOpPattern : OpConversionPattern<DMAStartTaskOp> {
                           "pass first or manually assign an ID.";
       return failure();
     }
-    // bd_id and repeat_count are SSA operands; materialize them as constants
-    // here (the static path).
+    // push_queue takes bd_id + repeat_count as SSA operands. repeat_count is a
+    // runtime operand when present (dynamic tile count), else the compile-time
+    // attribute materialized as a constant.
     Location loc = op.getLoc();
+    Value repeatCount = getAsValue(rewriter, loc, task_op.getRepeatCountValue(),
+                                   rewriter.getI32Type());
     rewriter.replaceOpWithNewOp<NpuPushQueueOp>(
         op, tile.getCol(), tile.getRow(), task_op.getDirection(),
-        task_op.getChannel(), task_op.getIssueToken(),
-        createConstantI32(rewriter, loc,
-                          static_cast<uint32_t>(task_op.getRepeatCount())),
+        task_op.getChannel(), task_op.getIssueToken(), repeatCount,
         createConstantI32(rewriter, loc, *first_bd_id));
     return success();
   }
@@ -249,14 +250,21 @@ struct AIEDMATasksToNPUPass
       }
 
       unsigned arg_idx = buf_arg.getArgNumber();
-      offset += bd_op.getOffsetInBytes();
-      NpuAddressPatchOp::create(
-          builder, bd_op.getLoc(),
-          /*addr*/ register_addr,
-          /*arg_idx*/ arg_idx,
-          /*arg_plus*/
-          createConstantI32(builder, bd_op.getLoc(),
-                            static_cast<uint32_t>(offset)));
+      // arg_plus = buffer byte offset. The dma_bd offset is a single element
+      // offset (stride 1); a constant folds to a constant (byte-identical to
+      // before), a runtime offset operand is built with arith. `offset` here is
+      // the constant subview base in bytes.
+      OpFoldResult offsetOfr =
+          bd_op.getOffset() ? OpFoldResult(bd_op.getOffset())
+                            : OpFoldResult(builder.getI32IntegerAttr(
+                                  bd_op.getConstantOffset().value_or(0)));
+      OpFoldResult oneStride = builder.getI32IntegerAttr(1);
+      Value argPlus =
+          buildArgPlusValue(builder, bd_op.getLoc(), {offsetOfr}, {oneStride},
+                            bd_op.getBufferElementTypeWidthInBytes(), offset);
+      NpuAddressPatchOp::create(builder, bd_op.getLoc(),
+                                /*addr*/ register_addr,
+                                /*arg_idx*/ arg_idx, argPlus);
     } else if (AIE::BufferOp buffer =
                    llvm::dyn_cast<AIE::BufferOp>(buf.getDefiningOp())) {
       uint64_t buf_addr;
@@ -501,19 +509,20 @@ struct AIEDMATasksToNPUPass
     uint32_t addr_granularity = target_model.getAddressGenGranularity();
 
     uint32_t bd_id = bd_op.getBdId().value();
-    int64_t offset = bd_op.getOffsetInBytes();
 
-    // Runtime (SSA) sizes/strides/len take the dynamic BD-word encoder path; a
-    // fully-constant descriptor takes the static path below. Only the shim-NOC
-    // layout is encodable this way (see rewriteSingleBDDynamic), so anything
-    // the dynamic path can't represent stays a clean diagnostic.
+    // Runtime (SSA) sizes/strides/len/offset take the dynamic BD-word encoder
+    // path; a fully-constant descriptor takes the static path below unchanged.
+    // Only the shim-NOC layout is encodable this way (see
+    // rewriteSingleBDDynamic), so anything the dynamic path can't represent
+    // stays a clean diagnostic.
     bool runtimeLen = bd_op.getLen() && !bd_op.getConstantLen();
+    bool runtimeOffset = bd_op.getOffset() && !bd_op.getConstantOffset();
     bool runtimeDims =
         llvm::any_of(bd_op.getMixedSizes(),
                      [](OpFoldResult s) { return !getConstantIntValue(s); }) ||
         llvm::any_of(bd_op.getMixedStrides(),
                      [](OpFoldResult s) { return !getConstantIntValue(s); });
-    if (runtimeLen || runtimeDims) {
+    if (runtimeLen || runtimeDims || runtimeOffset) {
       if (!target_model.isShimNOCTile(tile.getCol(), tile.getRow()))
         return bd_op->emitOpError(
             "runtime-valued BD size/stride/len is only supported on shim NOC "
@@ -537,6 +546,8 @@ struct AIEDMATasksToNPUPass
       return rewriteSingleBDDynamic(builder, block, bd_op, tile, packet);
     }
 
+    // Static path: offset is constant here (runtime offset routed above).
+    int64_t offset = bd_op.getOffsetInBytes();
     uint64_t len = bd_op.getLenInBytes();
     uint64_t len_addr_granularity = len * 8 / addr_granularity;
 

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -183,13 +183,9 @@ public:
     // the offset of the task queue register in the tile
     uint32_t queue_offset = ctrl_offset + 0x4;
 
-    // The command word packs bd_id [3:0], repeat_count [23:16], and the
-    // issue-token bit [31]. Both bd_id (dynamic free-list pool) and
-    // repeat_count (runtime outer/repeat dimension) may be runtime SSA values;
-    // the issue bit is always compile-time. When every runtime field is
-    // constant we fold the whole word to a constant (byte-identical to the
-    // static path); otherwise we build the word with arith so a runtime bd_id
-    // and/or repeat still lowers to a valid write32 instead of being rejected.
+    // Command word: bd_id [3:0], repeat_count [23:16], issue-token bit [31].
+    // bd_id and repeat_count may be runtime SSA; all-constant folds to one
+    // constant (byte-identical to the static path), else built with arith.
     Location loc = op->getLoc();
     auto i32ty = rewriter.getIntegerType(32);
     std::optional<uint32_t> bd_id = getConstantIntOperand(op.getBdId());

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -183,28 +183,39 @@ public:
     // the offset of the task queue register in the tile
     uint32_t queue_offset = ctrl_offset + 0x4;
 
-    // Command word: bd_id [3:0], repeat_count [23:16], issue-token bit [31].
-    // bd_id is always compile-time; repeat_count may be a runtime SSA value, in
-    // which case the word is built with arith over a constant base.
+    // The command word packs bd_id [3:0], repeat_count [23:16], and the
+    // issue-token bit [31]. Both bd_id (dynamic free-list pool) and repeat_count
+    // (runtime outer/repeat dimension) may be runtime SSA values; the issue bit
+    // is always compile-time. When every runtime field is constant we fold the
+    // whole word to a constant (byte-identical to the static path); otherwise we
+    // build the word with arith so a runtime bd_id and/or repeat still lowers to
+    // a valid write32 instead of being rejected.
+    Location loc = op->getLoc();
+    auto i32ty = rewriter.getIntegerType(32);
     std::optional<uint32_t> bd_id = getConstantIntOperand(op.getBdId());
-    if (!bd_id)
-      return op.emitOpError("cannot lower push_queue with non-constant bd_id");
-    uint32_t cmdBase = (*bd_id & 0xF) | (op.getIssueToken() ? 0x80000000 : 0);
+    std::optional<uint32_t> repeat_cnt =
+        getConstantIntOperand(op.getRepeatCount());
+    uint32_t issueBit = op.getIssueToken() ? 0x80000000 : 0;
 
     Value cmdVal;
-    if (std::optional<uint32_t> repeat_cnt =
-            getConstantIntOperand(op.getRepeatCount())) {
-      cmdVal = createConstantI32(rewriter, op->getLoc(),
-                                 cmdBase | ((*repeat_cnt & 0xFF) << 16));
+    if (bd_id && repeat_cnt) {
+      cmdVal = createConstantI32(
+          rewriter, loc,
+          (*bd_id & 0xF) | ((*repeat_cnt & 0xFF) << 16) | issueBit);
     } else {
-      Location loc = op->getLoc();
-      Value repeat = op.getRepeatCount();
+      // (bd_id & 0xF) | ((repeat & 0xFF) << 16) | issueBit, as arith over the
+      // runtime operands (a constant field folds to its constant contribution).
+      Value cmd = createConstantI32(rewriter, loc, issueBit);
+      Value bdField = arith::AndIOp::create(
+          rewriter, loc, getAsValue(rewriter, loc, op.getBdId(), i32ty),
+          createConstantI32(rewriter, loc, 0xF));
+      cmd = arith::OrIOp::create(rewriter, loc, cmd, bdField);
       Value masked = arith::AndIOp::create(
-          rewriter, loc, repeat, createConstantI32(rewriter, loc, 0xFF));
+          rewriter, loc, op.getRepeatCount(),
+          createConstantI32(rewriter, loc, 0xFF));
       Value shifted = arith::ShLIOp::create(
           rewriter, loc, masked, createConstantI32(rewriter, loc, 16));
-      cmdVal = arith::OrIOp::create(
-          rewriter, loc, createConstantI32(rewriter, loc, cmdBase), shifted);
+      cmdVal = arith::OrIOp::create(rewriter, loc, cmd, shifted);
     }
 
     NpuWrite32Op::create(

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -620,7 +620,8 @@ public:
             /*bufLenOverride=*/Value(), repeatCount)))
       return failure();
 
-    // Address patch for the buffer pointer (offset is compile-time here).
+    // Address patch for the buffer pointer; emitBufferAddressPatch folds a
+    // constant offset or builds a runtime arg_plus with arith as needed.
     int arg_idx = -1;
     if (failed(emitBufferAddressPatch(op, adaptor, rewriter, tileCol, tileRow,
                                       arg_idx)))

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -184,12 +184,12 @@ public:
     uint32_t queue_offset = ctrl_offset + 0x4;
 
     // The command word packs bd_id [3:0], repeat_count [23:16], and the
-    // issue-token bit [31]. Both bd_id (dynamic free-list pool) and repeat_count
-    // (runtime outer/repeat dimension) may be runtime SSA values; the issue bit
-    // is always compile-time. When every runtime field is constant we fold the
-    // whole word to a constant (byte-identical to the static path); otherwise we
-    // build the word with arith so a runtime bd_id and/or repeat still lowers to
-    // a valid write32 instead of being rejected.
+    // issue-token bit [31]. Both bd_id (dynamic free-list pool) and
+    // repeat_count (runtime outer/repeat dimension) may be runtime SSA values;
+    // the issue bit is always compile-time. When every runtime field is
+    // constant we fold the whole word to a constant (byte-identical to the
+    // static path); otherwise we build the word with arith so a runtime bd_id
+    // and/or repeat still lowers to a valid write32 instead of being rejected.
     Location loc = op->getLoc();
     auto i32ty = rewriter.getIntegerType(32);
     std::optional<uint32_t> bd_id = getConstantIntOperand(op.getBdId());
@@ -199,9 +199,9 @@ public:
 
     Value cmdVal;
     if (bd_id && repeat_cnt) {
-      cmdVal = createConstantI32(
-          rewriter, loc,
-          (*bd_id & 0xF) | ((*repeat_cnt & 0xFF) << 16) | issueBit);
+      cmdVal = createConstantI32(rewriter, loc,
+                                 (*bd_id & 0xF) | ((*repeat_cnt & 0xFF) << 16) |
+                                     issueBit);
     } else {
       // (bd_id & 0xF) | ((repeat & 0xFF) << 16) | issueBit, as arith over the
       // runtime operands (a constant field folds to its constant contribution).
@@ -210,9 +210,9 @@ public:
           rewriter, loc, getAsValue(rewriter, loc, op.getBdId(), i32ty),
           createConstantI32(rewriter, loc, 0xF));
       cmd = arith::OrIOp::create(rewriter, loc, cmd, bdField);
-      Value masked = arith::AndIOp::create(
-          rewriter, loc, op.getRepeatCount(),
-          createConstantI32(rewriter, loc, 0xFF));
+      Value masked =
+          arith::AndIOp::create(rewriter, loc, op.getRepeatCount(),
+                                createConstantI32(rewriter, loc, 0xFF));
       Value shifted = arith::ShLIOp::create(
           rewriter, loc, masked, createConstantI32(rewriter, loc, 16));
       cmdVal = arith::OrIOp::create(rewriter, loc, cmd, shifted);
@@ -532,8 +532,8 @@ public:
         llvm::to_vector(llvm::reverse(op.getMixedOffsets())),
         llvm::to_vector(llvm::reverse(op.getMixedStrides())),
         op.getElementTypeBitwidth() / 8, traceResult->offsetInBytes);
-    NpuAddressPatchOp::create(rewriter, op->getLoc(), patchAddr, argIdx,
-                              argPlus);
+    NpuAddressPatchOp::create(rewriter, op->getLoc(), patchAddr,
+                              /*addr_val=*/Value(), argIdx, argPlus);
 
     // If this DMA op has an offset_state_table_idx, emit an
     // update_from_scratchpad to add the runtime offset to the BD address

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -512,57 +512,17 @@ public:
         targetModel.getDmaBdAddress(tileCol, tileRow, op.getId()) +
         targetModel.getDmaBdAddressOffset(tileCol, tileRow);
 
-    // arg_plus is the byte offset added to the runtime buffer base:
-    //   sum(offset[i] * stride[i]) * elemBytes + constBase
-    // where constBase is the subview/cast trace offset. When every offset is
-    // constant this folds to a single constant (byte-identical to before); a
-    // runtime offset (or a runtime stride paired with a non-zero offset) is
-    // built with arith and flows through the SSA arg_plus operand.
-    Location loc = op->getLoc();
-    int64_t elemBytes = op.getElementTypeBitwidth() / 8;
-    auto offsets = llvm::to_vector<4>(llvm::reverse(op.getMixedOffsets()));
-    auto strides = llvm::to_vector<4>(llvm::reverse(op.getMixedStrides()));
-    // The constant fast-path is only valid when every term of
-    // sum(offset[i] * stride[i]) is compile-time known, i.e. each non-zero
-    // offset has both a constant offset and a constant stride (a zero offset
-    // contributes nothing regardless of its stride). Otherwise build arg_plus
-    // with arith. This mirrors getOffsetInBytes(), which reads stride[i] only
-    // where offset[i] != 0.
-    bool offsetFoldsToConstant = true;
-    for (size_t i = 0; i < offsets.size(); i++) {
-      auto off = getConstantIntValue(offsets[i]);
-      if (!off || (*off != 0 && !getConstantIntValue(strides[i]))) {
-        offsetFoldsToConstant = false;
-        break;
-      }
-    }
-
-    Value argPlus;
-    if (offsetFoldsToConstant) {
-      argPlus =
-          createConstantI32(rewriter, loc,
-                            static_cast<uint32_t>(op.getOffsetInBytes() +
-                                                  traceResult->offsetInBytes));
-    } else {
-      // Element-count offset = sum(offset[i] * stride[i]), then scale to bytes.
-      auto i32ty = rewriter.getIntegerType(32);
-      Value elems = createConstantI32(rewriter, loc, 0);
-      for (size_t i = 0; i < offsets.size(); i++) {
-        if (auto c = getConstantIntValue(offsets[i]); c && *c == 0)
-          continue;
-        Value off = getAsValue(rewriter, loc, offsets[i], i32ty);
-        Value str = getAsValue(rewriter, loc, strides[i], i32ty);
-        Value term = arith::MulIOp::create(rewriter, loc, off, str);
-        elems = arith::AddIOp::create(rewriter, loc, elems, term);
-      }
-      Value bytes = arith::MulIOp::create(
-          rewriter, loc, elems, createConstantI32(rewriter, loc, elemBytes));
-      argPlus = arith::AddIOp::create(
-          rewriter, loc, bytes,
-          createConstantI32(rewriter, loc,
-                            static_cast<uint32_t>(traceResult->offsetInBytes)));
-    }
-    NpuAddressPatchOp::create(rewriter, loc, patchAddr, argIdx, argPlus);
+    // arg_plus is the buffer byte offset. Constant offsets fold to a constant
+    // (byte-identical to the static path); a runtime offset operand is built
+    // with arith so it flows into the patch instead of being rejected. The
+    // subview trace contributes a constant base byte offset.
+    Value argPlus = buildArgPlusValue(
+        rewriter, op->getLoc(),
+        llvm::to_vector(llvm::reverse(op.getMixedOffsets())),
+        llvm::to_vector(llvm::reverse(op.getMixedStrides())),
+        op.getElementTypeBitwidth() / 8, traceResult->offsetInBytes);
+    NpuAddressPatchOp::create(rewriter, op->getLoc(), patchAddr, argIdx,
+                              argPlus);
 
     // If this DMA op has an offset_state_table_idx, emit an
     // update_from_scratchpad to add the runtime offset to the BD address

--- a/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEDmaToNpu.cpp
@@ -602,9 +602,10 @@ public:
     // encoder returns the hw repeat_count for the queue push.
     Value repeatCount;
     if (failed(emitDynamicShimBdWordOverrides(
-            rewriter, loc, targetModel, tileCol, tileRow, op.getId(),
-            op.getMixedSizes(), op.getMixedStrides(),
-            op.getElementTypeBitwidth(), op.getBurstLength(),
+            rewriter, loc, targetModel, tileCol, tileRow,
+            rewriter.getI32IntegerAttr(op.getId()), op.getMixedSizes(),
+            op.getMixedStrides(), op.getElementTypeBitwidth(),
+            op.getBurstLength(),
             /*bufLenOverride=*/Value(), repeatCount)))
       return failure();
 

--- a/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
@@ -204,6 +204,7 @@ struct AIELowerDynamicBDPoolPass
 
       pairedId.clear();
       tileForTask.clear();
+      originConfigure.clear();
 
       // 1. Every configure pops an id (program order: a pop dominates every use
       //    of its id).

--- a/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
@@ -1,0 +1,224 @@
+//===- AIELowerDynamicBDPool.cpp --------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The dynamic counterpart to AIEAssignRuntimeSequenceBDIDs. That pass runs on
+// straight-line IR and rejects runtime-bound scf.for; this pass handles the
+// runtime-bound case by keeping the loop rolled and drawing buffer-descriptor
+// IDs from a per-tile runtime free-list pool.
+//
+// Each dma_configure_task gets an aiex.dma_bd_pool_pop whose SSA bd_id is
+// routed into the task (its bd_id_val operand, consumed by the dynamic BD
+// lowering). Each dma_free_task, and the recycling half of a dma_await_task,
+// becomes an aiex.dma_bd_pool_push of the matching id.
+//
+// The matching id must be available where the push is emitted. A task value
+// (Index) may cross an scf.for back edge (the ping-pong "%prev" carry) and exit
+// as a loop result, so the popped i32 id is carried in lockstep: for every
+// iter_arg that carries a task, a parallel i32 iter_arg carrying its id is
+// added. Then a push of any task value looks up the paired id at the same
+// scope.
+//
+// v1 restricts to single-BD tasks: a multi-BD chain under a runtime loop would
+// need per-BD runtime next_bd cross-references, which is a follow-up.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+
+namespace xilinx::AIEX {
+#define GEN_PASS_DEF_AIELOWERDYNAMICBDPOOL
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+} // namespace xilinx::AIEX
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIEX;
+
+namespace {
+
+struct AIELowerDynamicBDPoolPass
+    : xilinx::AIEX::impl::AIELowerDynamicBDPoolBase<AIELowerDynamicBDPoolPass> {
+
+  // Maps a task value (the Index result of a configure, or any Index the carry
+  // propagates it into) to the i32 pool id available at that same program
+  // point.
+  llvm::DenseMap<Value, Value> pairedId;
+  // The (col,row) of the tile each task's id belongs to, so a push names the
+  // right pool even when the id is a loop result rather than a direct pop.
+  llvm::DenseMap<Value, std::pair<int, int>> tileForTask;
+
+  // Count the BD ops in a configure's body (across all its blocks).
+  static unsigned countBds(DMAConfigureTaskOp cfg) {
+    unsigned n = 0;
+    cfg.walk([&](AIE::DMABDOp) { ++n; });
+    return n;
+  }
+
+  LogicalResult lowerConfigure(DMAConfigureTaskOp cfg) {
+    if (cfg.getBdIdVal())
+      return success(); // already lowered
+
+    if (countBds(cfg) != 1)
+      return cfg.emitOpError(
+          "dynamic BD pool lowering supports single-BD tasks only; a multi-BD "
+          "chain under a runtime-bound loop needs runtime next_bd chaining "
+          "(not yet implemented)");
+
+    AIE::TileOp tile = cfg.getTileOp();
+    OpBuilder b(cfg);
+    Value bdId = DMABdPoolPopOp::create(b, cfg.getLoc(), b.getI32Type(),
+                                        tile.getCol(), tile.getRow())
+                     .getBdId();
+    cfg.getBdIdValMutable().assign(bdId);
+    pairedId[cfg.getResult()] = bdId;
+    tileForTask[cfg.getResult()] = {tile.getCol(), tile.getRow()};
+    return success();
+  }
+
+  // Add a parallel i32 iter_arg for every task-carrying iter_arg of `forOp`, so
+  // the popped id flows in lockstep with the task Index. Returns the new loop.
+  // Updates `pairedId` for the new region iter_args and results.
+  scf::ForOp carryIdsThroughLoop(scf::ForOp forOp) {
+    SmallVector<unsigned> carried; // iter_arg positions carrying a paired task
+    SmallVector<Value> newInits;
+    for (unsigned k = 0; k < forOp.getInitArgs().size(); ++k) {
+      Value init = forOp.getInitArgs()[k];
+      auto it = pairedId.find(init);
+      if (it == pairedId.end())
+        continue;
+      carried.push_back(k);
+      newInits.push_back(it->second);
+    }
+    if (carried.empty())
+      return forOp;
+
+    unsigned nOrig = forOp.getInitArgs().size();
+    IRRewriter rewriter(forOp);
+    auto newYields = [&](OpBuilder &b, Location loc,
+                         ArrayRef<BlockArgument> newBBArgs) {
+      // The value yielded for each new id iter_arg is the paired id of the task
+      // that carried position yields. For a rotating ping-pong the body yields
+      // a fresh configure result, whose id is already in the map.
+      auto *yield = forOp.getBody()->getTerminator();
+      SmallVector<Value> yielded;
+      for (unsigned k : carried) {
+        Value bodyTask = yield->getOperand(k);
+        Value id = pairedId.lookup(bodyTask);
+        assert(id && "carried task yields an unpaired id");
+        yielded.push_back(id);
+      }
+      return yielded;
+    };
+
+    FailureOr<LoopLikeOpInterface> newLoop = forOp.replaceWithAdditionalYields(
+        rewriter, newInits,
+        /*replaceInitOperandUsesInLoop=*/false, newYields);
+    assert(succeeded(newLoop) && "scf.for additional-yields rewrite failed");
+    auto newFor = cast<scf::ForOp>(newLoop->getOperation());
+
+    // The body block was moved intact, so original region iter_args keep their
+    // positions; the id iter_args are appended after the original nOrig. Pair
+    // each carried task iter_arg / result with its new id iter_arg / result,
+    // and propagate the tile from the corresponding init task.
+    for (auto [i, k] : llvm::enumerate(carried)) {
+      auto tile = tileForTask.lookup(forOp.getInitArgs()[k]);
+      pairedId[newFor.getRegionIterArg(k)] = newFor.getRegionIterArg(nOrig + i);
+      tileForTask[newFor.getRegionIterArg(k)] = tile;
+      pairedId[newFor.getResult(k)] = newFor.getResult(nOrig + i);
+      tileForTask[newFor.getResult(k)] = tile;
+    }
+    return newFor;
+  }
+
+  LogicalResult lowerRelease(Value task, Operation *op,
+                             llvm::DenseSet<Value> &released) {
+    Value id = pairedId.lookup(task);
+    if (!id)
+      return op->emitOpError(
+          "does not resolve to a task allocated from the runtime pool; cannot "
+          "return its buffer descriptor ID");
+    // await returns the id; a later free of the same task is the "wait then
+    // release" idiom, not a double free -- push once.
+    if (!released.insert(task).second)
+      return success();
+    auto tile = tileForTask.lookup(task);
+    OpBuilder b(op);
+    DMABdPoolPushOp::create(b, op->getLoc(), tile.first, tile.second, id);
+    return success();
+  }
+
+  void runOnOperation() override {
+    AIE::DeviceOp device = getOperation();
+
+    WalkResult wr = device.walk([&](AIE::RuntimeSequenceOp seq) -> WalkResult {
+      bool hasRuntimeCF = false;
+      seq.walk([&](Operation *op) {
+        if (isa<scf::ForOp, scf::IfOp, scf::WhileOp>(op))
+          hasRuntimeCF = true;
+      });
+      if (!hasRuntimeCF)
+        return WalkResult::advance();
+
+      pairedId.clear();
+      tileForTask.clear();
+
+      // 1. Every configure pops an id (program order: a pop dominates every use
+      //    of its id).
+      WalkResult r = seq.walk([&](DMAConfigureTaskOp cfg) -> WalkResult {
+        return failed(lowerConfigure(cfg)) ? WalkResult::interrupt()
+                                           : WalkResult::advance();
+      });
+      if (r.wasInterrupted())
+        return WalkResult::interrupt();
+
+      // 2. Carry the ids through loops so a push sees the id at its own scope.
+      //    Innermost-first: a body's yielded ids must be paired before its
+      //    enclosing loop consumes them.
+      SmallVector<scf::ForOp> loops;
+      seq.walk([&](scf::ForOp f) { loops.push_back(f); });
+      for (scf::ForOp f : llvm::reverse(loops))
+        carryIdsThroughLoop(f);
+
+      // 3. free/await -> push (await keeps its sync, adds a push).
+      llvm::DenseSet<Value> released;
+      SmallVector<Operation *> toErase;
+      r = seq.walk([&](Operation *op) -> WalkResult {
+        if (auto freeOp = dyn_cast<DMAFreeTaskOp>(op)) {
+          if (failed(lowerRelease(freeOp.getTask(), freeOp, released)))
+            return WalkResult::interrupt();
+          toErase.push_back(freeOp);
+        } else if (auto await = dyn_cast<DMAAwaitTaskOp>(op)) {
+          if (failed(lowerRelease(await.getTask(), await, released)))
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+      });
+      if (r.wasInterrupted())
+        return WalkResult::interrupt();
+      for (Operation *op : toErase)
+        op->erase();
+      return WalkResult::advance();
+    });
+    if (wr.wasInterrupted())
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<AIE::DeviceOp>>
+AIEX::createAIELowerDynamicBDPoolPass() {
+  return std::make_unique<AIELowerDynamicBDPoolPass>();
+}

--- a/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
@@ -5,25 +5,17 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// The dynamic counterpart to AIEAssignRuntimeSequenceBDIDs. That pass runs on
-// straight-line IR and rejects runtime-bound scf.for; this pass handles the
-// runtime-bound case by keeping the loop rolled and drawing buffer-descriptor
-// IDs from a per-tile runtime free-list pool.
+// The dynamic counterpart to AIEAssignRuntimeSequenceBDIDs: where that pass
+// rejects a runtime-bound scf.for, this keeps the loop rolled and draws bd_ids
+// from a per-tile runtime free-list pool. Each configure gets a dma_bd_pool_pop
+// (its SSA id feeding bd_id_val); each free/await gets a dma_bd_pool_push.
 //
-// Each dma_configure_task gets an aiex.dma_bd_pool_pop whose SSA bd_id is
-// routed into the task (its bd_id_val operand, consumed by the dynamic BD
-// lowering). Each dma_free_task, and the recycling half of a dma_await_task,
-// becomes an aiex.dma_bd_pool_push of the matching id.
+// A popped id must be reachable at its push. Since a task value can cross a
+// loop back edge and exit as a result, the id is carried in lockstep: every
+// task iter_arg gets a parallel i32 id iter_arg, and a push looks up the paired
+// id.
 //
-// The matching id must be available where the push is emitted. A task value
-// (Index) may cross an scf.for back edge (the ping-pong "%prev" carry) and exit
-// as a loop result, so the popped i32 id is carried in lockstep: for every
-// iter_arg that carries a task, a parallel i32 iter_arg carrying its id is
-// added. Then a push of any task value looks up the paired id at the same
-// scope.
-//
-// v1 restricts to single-BD tasks: a multi-BD chain under a runtime loop would
-// need per-BD runtime next_bd cross-references, which is a follow-up.
+// v1 is single-BD only; multi-BD chains would need runtime next_bd (follow-up).
 //
 //===----------------------------------------------------------------------===//
 
@@ -58,11 +50,9 @@ struct AIELowerDynamicBDPoolPass
   // The (col,row) of the tile each task's id belongs to, so a push names the
   // right pool even when the id is a loop result rather than a direct pop.
   llvm::DenseMap<Value, std::pair<int, int>> tileForTask;
-  // A representative configure for each task value whose (tile,dir,channel) an
-  // await can reference. For a loop-carried task this stays the init (iteration
-  // 0) configure, which is loop-invariant and dominates a post-loop await --
-  // the value the await originally named (a loop result) has no defining
-  // configure to resolve, so awaits are redirected here.
+  // A representative (loop-invariant) configure per task, so a post-loop await
+  // on a loop result -- which has no defining configure -- can be redirected to
+  // one with the right (tile,dir,channel).
   llvm::DenseMap<Value, DMAConfigureTaskOp> originConfigure;
 
   // Count the BD ops in a configure's body (across all its blocks).
@@ -82,10 +72,9 @@ struct AIELowerDynamicBDPoolPass
           "chain under a runtime-bound loop needs runtime next_bd chaining "
           "(not yet implemented)");
 
-    // In a dynamic (pool) sequence the pool owns ALL id allocation: a pinned
-    // bd_id would collide with a runtime pop that hands out the same id from
-    // the full 0..N-1 range, so a hand-pinned id here is an error. Allocation
-    // is all-pool or (for a straight-line sequence) all-static, never mixed.
+    // The pool owns all id allocation here, so a hand-pinned bd_id would
+    // collide with a runtime pop. Allocation is all-pool or all-static (for a
+    // straight-line sequence), never mixed.
     WalkResult pinned = cfg.walk([&](AIE::DMABDOp bd) {
       if (bd.getBdId().has_value()) {
         bd.emitOpError(
@@ -155,10 +144,9 @@ struct AIELowerDynamicBDPoolPass
     assert(succeeded(newLoop) && "scf.for additional-yields rewrite failed");
     auto newFor = cast<scf::ForOp>(newLoop->getOperation());
 
-    // The body block was moved intact, so original region iter_args keep their
-    // positions; the id iter_args are appended after the original nOrig. Pair
-    // each carried task iter_arg / result with its new id iter_arg / result,
-    // and propagate the tile from the corresponding init task.
+    // id iter_args are appended after the original nOrig; pair each carried
+    // task iter_arg/result with its new id, propagating tile and origin from
+    // the init.
     for (auto [i, k] : llvm::enumerate(carried)) {
       Value init = forOp.getInitArgs()[k];
       auto tile = tileForTask.lookup(init);
@@ -225,10 +213,8 @@ struct AIELowerDynamicBDPoolPass
 
       // 3. free/await -> push (await keeps its sync, adds a push). An await on
       // a
-      //    loop result / region-arg cannot resolve its configure (a loop result
-      //    has no defining configure), so redirect it to the loop-invariant
-      //    origin configure, whose tile/dir/channel is identical every
-      //    iteration.
+      //    loop result lacks a defining configure, so redirect it to the
+      //    loop-invariant origin configure.
       llvm::DenseSet<Value> released;
       SmallVector<Operation *> toErase;
       r = seq.walk([&](Operation *op) -> WalkResult {

--- a/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
@@ -82,6 +82,26 @@ struct AIELowerDynamicBDPoolPass
           "chain under a runtime-bound loop needs runtime next_bd chaining "
           "(not yet implemented)");
 
+    // In a dynamic (pool) sequence the pool owns ALL id allocation: a pinned
+    // bd_id would collide with a runtime pop that hands out the same id from
+    // the full 0..N-1 range, so a hand-pinned id here is an error. Allocation
+    // is all-pool or (for a straight-line sequence) all-static, never mixed.
+    WalkResult pinned = cfg.walk([&](AIE::DMABDOp bd) {
+      if (bd.getBdId().has_value()) {
+        bd.emitOpError(
+            "pins a buffer descriptor ID inside a runtime-bound "
+            "sequence that draws IDs from the dynamic pool; a pinned "
+            "ID would collide with a runtime-allocated one. Allocate "
+            "every BD in this sequence from the pool (drop the "
+            "bd_id), or make the sequence straight-line so the static "
+            "allocator assigns all IDs.");
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (pinned.wasInterrupted())
+      return failure();
+
     AIE::TileOp tile = cfg.getTileOp();
     OpBuilder b(cfg);
     Value bdId = DMABdPoolPopOp::create(b, cfg.getLoc(), b.getI32Type(),
@@ -202,7 +222,8 @@ struct AIELowerDynamicBDPoolPass
       for (scf::ForOp f : llvm::reverse(loops))
         carryIdsThroughLoop(f);
 
-      // 3. free/await -> push (await keeps its sync, adds a push). An await on a
+      // 3. free/await -> push (await keeps its sync, adds a push). An await on
+      // a
       //    loop result / region-arg cannot resolve its configure (a loop result
       //    has no defining configure), so redirect it to the loop-invariant
       //    origin configure, whose tile/dir/channel is identical every

--- a/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerDynamicBDPool.cpp
@@ -58,6 +58,12 @@ struct AIELowerDynamicBDPoolPass
   // The (col,row) of the tile each task's id belongs to, so a push names the
   // right pool even when the id is a loop result rather than a direct pop.
   llvm::DenseMap<Value, std::pair<int, int>> tileForTask;
+  // A representative configure for each task value whose (tile,dir,channel) an
+  // await can reference. For a loop-carried task this stays the init (iteration
+  // 0) configure, which is loop-invariant and dominates a post-loop await --
+  // the value the await originally named (a loop result) has no defining
+  // configure to resolve, so awaits are redirected here.
+  llvm::DenseMap<Value, DMAConfigureTaskOp> originConfigure;
 
   // Count the BD ops in a configure's body (across all its blocks).
   static unsigned countBds(DMAConfigureTaskOp cfg) {
@@ -84,6 +90,7 @@ struct AIELowerDynamicBDPoolPass
     cfg.getBdIdValMutable().assign(bdId);
     pairedId[cfg.getResult()] = bdId;
     tileForTask[cfg.getResult()] = {tile.getCol(), tile.getRow()};
+    originConfigure[cfg.getResult()] = cfg;
     return success();
   }
 
@@ -133,11 +140,15 @@ struct AIELowerDynamicBDPoolPass
     // each carried task iter_arg / result with its new id iter_arg / result,
     // and propagate the tile from the corresponding init task.
     for (auto [i, k] : llvm::enumerate(carried)) {
-      auto tile = tileForTask.lookup(forOp.getInitArgs()[k]);
+      Value init = forOp.getInitArgs()[k];
+      auto tile = tileForTask.lookup(init);
+      DMAConfigureTaskOp origin = originConfigure.lookup(init);
       pairedId[newFor.getRegionIterArg(k)] = newFor.getRegionIterArg(nOrig + i);
       tileForTask[newFor.getRegionIterArg(k)] = tile;
+      originConfigure[newFor.getRegionIterArg(k)] = origin;
       pairedId[newFor.getResult(k)] = newFor.getResult(nOrig + i);
       tileForTask[newFor.getResult(k)] = tile;
+      originConfigure[newFor.getResult(k)] = origin;
     }
     return newFor;
   }
@@ -191,7 +202,11 @@ struct AIELowerDynamicBDPoolPass
       for (scf::ForOp f : llvm::reverse(loops))
         carryIdsThroughLoop(f);
 
-      // 3. free/await -> push (await keeps its sync, adds a push).
+      // 3. free/await -> push (await keeps its sync, adds a push). An await on a
+      //    loop result / region-arg cannot resolve its configure (a loop result
+      //    has no defining configure), so redirect it to the loop-invariant
+      //    origin configure, whose tile/dir/channel is identical every
+      //    iteration.
       llvm::DenseSet<Value> released;
       SmallVector<Operation *> toErase;
       r = seq.walk([&](Operation *op) -> WalkResult {
@@ -202,6 +217,15 @@ struct AIELowerDynamicBDPoolPass
         } else if (auto await = dyn_cast<DMAAwaitTaskOp>(op)) {
           if (failed(lowerRelease(await.getTask(), await, released)))
             return WalkResult::interrupt();
+          if (!await.getTask().getDefiningOp<DMAConfigureTaskOp>()) {
+            DMAConfigureTaskOp origin = originConfigure.lookup(await.getTask());
+            if (!origin)
+              return await.emitOpError(
+                         "awaits a task whose configure cannot be resolved for "
+                         "the dynamic pool path"),
+                     WalkResult::interrupt();
+            await.getTaskMutable().assign(origin.getResult());
+          }
         }
         return WalkResult::advance();
       });

--- a/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
@@ -67,8 +67,11 @@ struct DMAConfigureTaskForOpPattern
 
     DMAConfigureTaskOp new_op = DMAConfigureTaskOp::create(
         rewriter, op.getLoc(), rewriter.getIndexType(), tile.getResult(),
-        alloc_op.getChannelDir(), (int32_t)alloc_op.getChannelIndex(),
-        op.getIssueToken(), op.getRepeatCount(),
+        alloc_op.getChannelDirAttr(),
+        rewriter.getI32IntegerAttr((int32_t)alloc_op.getChannelIndex()),
+        rewriter.getBoolAttr(op.getIssueToken()),
+        rewriter.getI32IntegerAttr(op.getRepeatCount()),
+        /*repeat_count_val=*/op.getRepeatCountVal(),
         alloc_op.getPacket().value_or(nullptr));
     rewriter.replaceAllUsesWith(op.getResult(), new_op.getResult());
     rewriter.inlineRegionBefore(op.getBody(), new_op.getBody(),

--- a/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIESubstituteShimDMAAllocations.cpp
@@ -72,7 +72,7 @@ struct DMAConfigureTaskForOpPattern
         rewriter.getBoolAttr(op.getIssueToken()),
         rewriter.getI32IntegerAttr(op.getRepeatCount()),
         /*repeat_count_val=*/op.getRepeatCountVal(),
-        alloc_op.getPacket().value_or(nullptr));
+        /*bd_id_val=*/nullptr, alloc_op.getPacket().value_or(nullptr));
     rewriter.replaceAllUsesWith(op.getResult(), new_op.getResult());
     rewriter.inlineRegionBefore(op.getBody(), new_op.getBody(),
                                 new_op.getBody().begin());

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIEMaterializeRuntimeSequences.cpp
   AIEAssignRuntimeSequenceBDIDs.cpp
   AIEUnrollRuntimeSequenceLoops.cpp
+  AIELowerDynamicBDPool.cpp
   AIEDMATasksToNPU.cpp
   AIESubstituteShimDMAAllocations.cpp
   AIECtrlPacketToDma.cpp

--- a/lib/Dialect/AIEX/Utils/BdLowering.cpp
+++ b/lib/Dialect/AIEX/Utils/BdLowering.cpp
@@ -88,6 +88,50 @@ Value getAsValue(OpBuilder &builder, Location loc, OpFoldResult ofr,
   return val;
 }
 
+Value buildArgPlusValue(OpBuilder &builder, Location loc,
+                        ArrayRef<OpFoldResult> elementOffsets,
+                        ArrayRef<OpFoldResult> strides, int64_t elemWidthBytes,
+                        int64_t baseByteOffset) {
+  auto i32ty = builder.getIntegerType(32);
+
+  // Fast path: everything constant -> fold to one arith.constant, matching the
+  // static lowering byte-for-byte.
+  bool allConst = llvm::all_of(elementOffsets,
+                               [](OpFoldResult o) {
+                                 return getConstantIntValue(o).has_value();
+                               }) &&
+                  llvm::all_of(strides, [](OpFoldResult s) {
+                    return getConstantIntValue(s).has_value();
+                  });
+  if (allConst) {
+    int64_t bytes = baseByteOffset;
+    for (auto [o, s] : llvm::zip(elementOffsets, strides))
+      bytes +=
+          *getConstantIntValue(o) * *getConstantIntValue(s) * elemWidthBytes;
+    return arith::ConstantOp::create(builder, loc,
+                                     IntegerAttr::get(i32ty, bytes));
+  }
+
+  // Runtime path: sum(offset[i] * stride[i]) * elemWidthBytes + base, as arith.
+  Value acc =
+      arith::ConstantOp::create(builder, loc, IntegerAttr::get(i32ty, 0));
+  for (auto [o, s] : llvm::zip(elementOffsets, strides)) {
+    Value ov = getAsValue(builder, loc, o, i32ty);
+    Value sv = getAsValue(builder, loc, s, i32ty);
+    Value prod = arith::MulIOp::create(builder, loc, ov, sv);
+    acc = arith::AddIOp::create(builder, loc, acc, prod);
+  }
+  Value width = arith::ConstantOp::create(
+      builder, loc, IntegerAttr::get(i32ty, elemWidthBytes));
+  acc = arith::MulIOp::create(builder, loc, acc, width);
+  if (baseByteOffset != 0) {
+    Value base = arith::ConstantOp::create(
+        builder, loc, IntegerAttr::get(i32ty, baseByteOffset));
+    acc = arith::AddIOp::create(builder, loc, acc, base);
+  }
+  return acc;
+}
+
 Value buildBdWord(OpBuilder &builder, Location loc,
                   ArrayRef<std::tuple<Value, uint32_t, uint32_t>> fields) {
   auto i32ty = builder.getIntegerType(32);

--- a/lib/Dialect/AIEX/Utils/BdLowering.cpp
+++ b/lib/Dialect/AIEX/Utils/BdLowering.cpp
@@ -154,6 +154,26 @@ Value buildBdWord(OpBuilder &builder, Location loc,
   return result;
 }
 
+Value getBdRegisterBase(OpBuilder &builder, Location loc,
+                        const AIE::AIETargetModel &targetModel, int tileCol,
+                        int tileRow, OpFoldResult bdId) {
+  auto i32ty = builder.getIntegerType(32);
+  if (auto c = getConstantIntValue(bdId))
+    return createConstantI32(builder, loc,
+                             static_cast<uint32_t>(targetModel.getDmaBdAddress(
+                                 tileCol, tileRow, *c)));
+  // Runtime bd_id: base + bd_id * bdStride, with base/stride from the (linear)
+  // target-model address function.
+  uint64_t addrForId0 = targetModel.getDmaBdAddress(tileCol, tileRow, 0);
+  uint64_t bdStride =
+      targetModel.getDmaBdAddress(tileCol, tileRow, 1) - addrForId0;
+  Value bdIdVal = getAsValue(builder, loc, bdId, i32ty);
+  return arith::AddIOp::create(
+      builder, loc, createConstantI32(builder, loc, addrForId0),
+      arith::MulIOp::create(builder, loc, bdIdVal,
+                            createConstantI32(builder, loc, bdStride)));
+}
+
 LogicalResult emitDynamicShimBdWordOverrides(
     OpBuilder &builder, Location loc, const AIE::AIETargetModel &targetModel,
     int tileCol, int tileRow, OpFoldResult bdId,
@@ -249,33 +269,23 @@ LogicalResult emitDynamicShimBdWordOverrides(
   for (int i = 1; i < 4; i++)
     guardDivisible(stridesRev[i], inT[i], /*allowUnit=*/false);
 
-  // The shim BD register block is at getDmaBdAddress(col,row,bd_id), which is
-  // linear in bd_id (base + bd_id * bdStride). For a constant bd_id the whole
-  // address folds to a literal (byte-identical to the static path); for a
-  // runtime bd_id (dynamic free-list pool) the base is emitted as arith so each
-  // override targets base + bd_id*bdStride + wordIdx*4 at runtime.
-  std::optional<int64_t> constBdId = getConstantIntValue(bdId);
-  Value bdBase; // set only when bd_id is runtime
-  if (!constBdId) {
-    uint64_t addrForId0 = targetModel.getDmaBdAddress(tileCol, tileRow, 0);
-    uint64_t bdStride =
-        targetModel.getDmaBdAddress(tileCol, tileRow, 1) - addrForId0;
-    Value bdIdVal = getAsValue(builder, loc, bdId, i32ty);
-    bdBase = arith::AddIOp::create(
-        builder, loc, createConstantI32(builder, loc, addrForId0),
-        arith::MulIOp::create(builder, loc, bdIdVal,
-                              createConstantI32(builder, loc, bdStride)));
-  }
-  uint64_t bdAddr =
-      constBdId ? targetModel.getDmaBdAddress(tileCol, tileRow, *constBdId) : 0;
+  // The shim BD register block is at getDmaBdAddress(col,row,bd_id). A constant
+  // bd_id folds to the literal the static path uses; a runtime bd_id (dynamic
+  // free-list pool) yields an arith expression base + bd_id*bdStride, so each
+  // override targets that base + wordIdx*4.
+  Value bdBase =
+      getBdRegisterBase(builder, loc, targetModel, tileCol, tileRow, bdId);
+  std::optional<int64_t> constBase = getConstantIntValue(bdBase);
   auto writeWord = [&](uint32_t wordIdx, Value val) {
-    Value addr;
-    if (constBdId)
-      addr = createConstantI32(builder, loc,
-                               static_cast<uint32_t>(bdAddr + wordIdx * 4));
-    else
-      addr = arith::AddIOp::create(
-          builder, loc, bdBase, createConstantI32(builder, loc, wordIdx * 4));
+    // Fold the whole address to a literal when the base is constant, so the
+    // static/pinned path emits the same single constant it always has.
+    Value addr =
+        constBase
+            ? createConstantI32(builder, loc,
+                                static_cast<uint32_t>(*constBase + wordIdx * 4))
+            : arith::AddIOp::create(
+                  builder, loc, bdBase,
+                  createConstantI32(builder, loc, wordIdx * 4));
     NpuWrite32Op::create(builder, loc, addr, val, nullptr, nullptr, nullptr);
   };
 

--- a/lib/Dialect/AIEX/Utils/BdLowering.cpp
+++ b/lib/Dialect/AIEX/Utils/BdLowering.cpp
@@ -156,9 +156,10 @@ Value buildBdWord(OpBuilder &builder, Location loc,
 
 LogicalResult emitDynamicShimBdWordOverrides(
     OpBuilder &builder, Location loc, const AIE::AIETargetModel &targetModel,
-    int tileCol, int tileRow, uint32_t bdId, ArrayRef<OpFoldResult> mixedSizes,
-    ArrayRef<OpFoldResult> mixedStrides, uint64_t elemWidth,
-    uint32_t burstLength, Value bufLenOverride, Value &repeatCountOut) {
+    int tileCol, int tileRow, OpFoldResult bdId,
+    ArrayRef<OpFoldResult> mixedSizes, ArrayRef<OpFoldResult> mixedStrides,
+    uint64_t elemWidth, uint32_t burstLength, Value bufLenOverride,
+    Value &repeatCountOut) {
   auto i32ty = builder.getIntegerType(32);
 
   // Compute the hardware sizes/strides as SSA values via the shared encoder.
@@ -248,13 +249,34 @@ LogicalResult emitDynamicShimBdWordOverrides(
   for (int i = 1; i < 4; i++)
     guardDivisible(stridesRev[i], inT[i], /*allowUnit=*/false);
 
-  uint64_t bdAddr = targetModel.getDmaBdAddress(tileCol, tileRow, bdId);
+  // The shim BD register block is at getDmaBdAddress(col,row,bd_id), which is
+  // linear in bd_id (base + bd_id * bdStride). For a constant bd_id the whole
+  // address folds to a literal (byte-identical to the static path); for a
+  // runtime bd_id (dynamic free-list pool) the base is emitted as arith so each
+  // override targets base + bd_id*bdStride + wordIdx*4 at runtime.
+  std::optional<int64_t> constBdId = getConstantIntValue(bdId);
+  Value bdBase; // set only when bd_id is runtime
+  if (!constBdId) {
+    uint64_t addrForId0 = targetModel.getDmaBdAddress(tileCol, tileRow, 0);
+    uint64_t bdStride =
+        targetModel.getDmaBdAddress(tileCol, tileRow, 1) - addrForId0;
+    Value bdIdVal = getAsValue(builder, loc, bdId, i32ty);
+    bdBase = arith::AddIOp::create(
+        builder, loc, createConstantI32(builder, loc, addrForId0),
+        arith::MulIOp::create(builder, loc, bdIdVal,
+                              createConstantI32(builder, loc, bdStride)));
+  }
+  uint64_t bdAddr =
+      constBdId ? targetModel.getDmaBdAddress(tileCol, tileRow, *constBdId) : 0;
   auto writeWord = [&](uint32_t wordIdx, Value val) {
-    NpuWrite32Op::create(
-        builder, loc,
-        createConstantI32(builder, loc,
-                          static_cast<uint32_t>(bdAddr + wordIdx * 4)),
-        val, nullptr, nullptr, nullptr);
+    Value addr;
+    if (constBdId)
+      addr = createConstantI32(builder, loc,
+                               static_cast<uint32_t>(bdAddr + wordIdx * 4));
+    else
+      addr = arith::AddIOp::create(
+          builder, loc, bdBase, createConstantI32(builder, loc, wordIdx * 4));
+    NpuWrite32Op::create(builder, loc, addr, val, nullptr, nullptr, nullptr);
   };
 
   // word[0] buffer_length is always overridden (it carries the runtime element

--- a/lib/Dialect/AIEX/Utils/BdLowering.cpp
+++ b/lib/Dialect/AIEX/Utils/BdLowering.cpp
@@ -203,12 +203,9 @@ LogicalResult emitDynamicShimBdWordOverrides(
         builder, loc, arith::MulIOp::create(builder, loc, hwS[0], inS[1]),
         inS[2]);
 
-  // Linear-mode decision: a transfer is contiguous when each outer stride
-  // equals the product of the strictly-inner sizes -- which never needs a
-  // dimension's own size, so a runtime outer size stays decidable. If a needed
-  // operand is runtime we fall back to ND mode (safe: narrow-field sizes are
-  // guarded below). Linear mode folds d0/d1 into buffer_length, dodging the
-  // 10-bit d0_size limit.
+  // Linear mode: contiguous transfer (each outer stride == product of inner
+  // sizes) folds d0/d1 into buffer_length, dodging the 10-bit d0_size limit. A
+  // runtime operand needed for the test falls back to ND mode.
   auto cst = [&](OpFoldResult v) { return getConstantIntValue(v); };
   auto knownContiguous = [&]() -> bool {
     auto s0 = cst(stridesRev[0]);
@@ -232,11 +229,9 @@ LogicalResult emitDynamicShimBdWordOverrides(
   };
   bool isLinear = knownContiguous();
 
-  // Host-side bounds guard for a RUNTIME size landing in a narrow BD field
-  // (masking would silently truncate an out-of-range value). Constant sizes are
-  // already range-checked by the verifier, so guard only runtime ones, and only
-  // for fields actually used: d0/d1 wrap (10-bit) exist in ND mode; the
-  // iteration wrap (6-bit) always. The guard is on the hardware value.
+  // Guard a RUNTIME size against its narrow BD field (masking would silently
+  // truncate); constants are verifier-checked. d0/d1 wrap (10-bit) only in ND
+  // mode, iteration wrap (6-bit) always. Guard is on the hardware value.
   auto guardField = [&](OpFoldResult inSize, Value hwVal, int64_t fieldMax) {
     if (getConstantIntValue(inSize))
       return; // constant: verifier already enforced the bound.
@@ -249,10 +244,9 @@ LogicalResult emitDynamicShimBdWordOverrides(
   }
   guardField(sizesRev[3], hwS[3], ShimBdFieldWidths::iterWrapMax());
 
-  // Host-side realizability guard for a RUNTIME size/stride whose byte extent
-  // must be a whole number of granules (mirrors verifyStridesWraps for the
-  // constant case). The guard is on the INPUT element count, not the encoded
-  // value. Constant operands are already checked by the verifier.
+  // Guard a RUNTIME size/stride whose byte extent must be a whole number of
+  // granules (mirrors verifyStridesWraps). Guard is on the input element count;
+  // constants are verifier-checked.
   int64_t divisor = bdGranuleDivisor(elemWidth, gran);
   auto guardDivisible = [&](OpFoldResult in, Value inVal, bool allowUnit) {
     if (divisor <= 1 || getConstantIntValue(in))
@@ -261,9 +255,8 @@ LogicalResult emitDynamicShimBdWordOverrides(
                                    /*allow_unit=*/allowUnit);
   };
   guardDivisible(sizesRev[0], inS[0], /*allowUnit=*/false);
-  // The innermost stride collapses to hardware 0 when it is 1 (contiguous) or
-  // granule-aligned; a non-unit sub-granule value is unrealizable, so it is
-  // guarded with the unit-stride exemption. Outer strides have no such
+  // The innermost stride collapses to hardware 0 when contiguous or
+  // granule-aligned; guard with the unit-stride exemption. Outer strides don't
   // collapse.
   guardDivisible(stridesRev[0], inT[0], /*allowUnit=*/true);
   for (int i = 1; i < 4; i++)
@@ -277,8 +270,8 @@ LogicalResult emitDynamicShimBdWordOverrides(
       getBdRegisterBase(builder, loc, targetModel, tileCol, tileRow, bdId);
   std::optional<int64_t> constBase = getConstantIntValue(bdBase);
   auto writeWord = [&](uint32_t wordIdx, Value val) {
-    // Fold the whole address to a literal when the base is constant, so the
-    // static/pinned path emits the same single constant it always has.
+    // Fold the address to a literal for a constant base, so the static/pinned
+    // path emits the same single constant it always has.
     Value addr =
         constBase
             ? createConstantI32(builder, loc,
@@ -293,9 +286,8 @@ LogicalResult emitDynamicShimBdWordOverrides(
   // count in both linear and ND modes).
   writeWord(0, bufLen);
 
-  // In linear mode the d0/d1/d2 size/stride words stay at their zero template
-  // values (matching the static path); only buffer_length + iteration are
-  // meaningful. In ND mode, override the size/stride words.
+  // Linear mode leaves the d0/d1/d2 size/stride words at their zero template
+  // (only buffer_length + iteration matter); ND mode overrides them.
   if (!isLinear) {
     // word[3]: d0_size [29:20], d0_stride [19:0].
     writeWord(3, buildBdWord(builder, loc,
@@ -317,13 +309,10 @@ LogicalResult emitDynamicShimBdWordOverrides(
                      builder, loc, axcache,
                      buildBdWord(builder, loc, {{hwT[2], 0xFFFFF, 0}})));
   }
-  // word[6]: iteration_size [25:20], iteration_stride [19:0]. Meaningful in
-  // both modes (the outer repeat dimension is independent of linearization).
-  // A zero outer stride is a pure repeat: the BD wraps every iteration and the
-  // repeat is carried by the queue push's repeat_count, so BOTH iteration
-  // fields must be 0 (matching AIEDmaToNpu's static rule). hwT[3] already
-  // collapses to 0 for a zero stride; gate iteration_size the same way so
-  // hwS[3] can stay the (size - 1) value repeatCountOut needs.
+  // word[6]: iteration_size [25:20], iteration_stride [19:0]. A zero outer
+  // stride is a pure repeat (carried by repeat_count), so both fields must be 0
+  // like AIEDmaToNpu; gate iteration_size on the stride while leaving hwS[3]
+  // for repeatCountOut. hwT[3] already collapses to 0.
   Value zeroI32 = createConstantI32(builder, loc, 0);
   Value iterStridePos = arith::CmpIOp::create(
       builder, loc, arith::CmpIPredicate::sgt, inT[3], zeroI32);
@@ -332,12 +321,9 @@ LogicalResult emitDynamicShimBdWordOverrides(
   writeWord(6, buildBdWord(builder, loc,
                            {{iterSizeField, 0x3F, 20}, {hwT[3], 0xFFFFF, 0}}));
 
-  // repeat_count for the queue push is the biased hw iteration value (matching
-  // the static path's `repeat_count = sizes[3]`), NOT the raw outer size: an
-  // outer size of N encodes to (N > 1 ? N - 1 : 0). When the outer size is a
-  // compile-time constant, emit a foldable arith.constant so the static
-  // push_queue lowering can consume it; only a genuinely runtime outer size
-  // yields the SSA-computed hwS[3].
+  // repeat_count for the queue push is the biased outer size (N > 1 ? N - 1 :
+  // 0), matching the static path. A constant folds so the static push_queue
+  // lowering can consume it; a runtime size yields the SSA hwS[3].
   if (auto outerConst = getConstantIntValue(sizesRev[3])) {
     int64_t r = *outerConst > 1 ? *outerConst - 1 : 0;
     repeatCountOut =

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -129,6 +129,11 @@ static constexpr uint32_t kNumFirmwareTranslatedArgs = 5;
 
 LogicalResult appendAddressPatch(std::vector<uint32_t> &instructions,
                                  NpuAddressPatchOp op, bool foldDDRAddrOffset) {
+  if (op.getAddrVal())
+    return op.emitOpError("Cannot translate address_patch with a runtime "
+                          "register address (addr_val) to a static TXN binary; "
+                          "the runtime-bd_id pool path targets the C++ TXN "
+                          "target only");
   std::optional<uint32_t> argPlus =
       AIEX::getConstantIntOperand(op.getArgPlus());
   if (!argPlus)

--- a/python/dialects/aiex.py
+++ b/python/dialects/aiex.py
@@ -42,6 +42,7 @@ from ..ir import (
 
 # noinspection PyUnresolvedReferences
 from ..extras import types as T
+from ..extras.dialects import arith
 from ..helpers.util import try_convert_np_type_to_mlir_type
 from ..helpers.taplib import TensorAccessPattern
 
@@ -377,11 +378,29 @@ def shim_dma_single_bd_task(
             if strides is not None:
                 strides = [0] + list(strides)
 
+    # The outer (sizes[0]) dimension becomes the queue-push repeat_count. A
+    # constant folds to the repeat_count attribute (static path, unchanged); a
+    # runtime Value flows into the repeat_count_val operand so a dynamic tile
+    # count is supported.
     repeat_count = 0
-    if sizes and sizes[0] > 1:
-        repeat_count = sizes[0] - 1
+    repeat_count_val = None
+    if sizes:
+        s0 = sizes[0]
+        if isinstance(s0, (int, np.integer)):
+            if s0 > 1:
+                repeat_count = int(s0) - 1
+        else:
+            # Runtime: repeat = s0 - 1 as arith, in i32 (the queue field width).
+            # sizes may be i64 (DynamicIndexList); truncate before subtracting.
+            s0_i32 = s0
+            if s0.type != T.i32():
+                s0_i32 = arith.trunci(T.i32(), s0)
+            repeat_count_val = s0_i32 - _as_i32(1)
     task = dma_configure_task_for(
-        alloc, repeat_count=repeat_count, issue_token=issue_token
+        alloc,
+        repeat_count=repeat_count,
+        repeat_count_val=repeat_count_val,
+        issue_token=issue_token,
     )
     with bds(task) as bd:
         with bd[0]:

--- a/test/Conversion/AIEXToEmitC/per_op.mlir
+++ b/test/Conversion/AIEXToEmitC/per_op.mlir
@@ -106,6 +106,48 @@ module {
 
 // -----
 
+// A runtime-bound scf.for (the dynamic BD pool's rolled loop) is preserved: the
+// body's npu ops convert in place and the loop lowers to emitc.for, so the C++
+// stays rolled with a runtime op-count (++__opcount inside the loop).
+// CHECK-LABEL: emitc.func @generate_txn_main_seq_scf_for
+// CHECK: for %{{.*}} = %{{.*}} to %{{.*}} step %{{.*}} : !emitc.size_t {
+// CHECK: call_opaque "aie_runtime::txn_append_write32"
+// CHECK: verbatim "++{};"
+module {
+  aie.device(npu1_1col) {
+    aie.runtime_sequence @seq_scf_for(%arg0: memref<8xi32>) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      scf.for %i = %c0 to %c4 step %c1 {
+        %addr = arith.constant 100 : i32
+        %val = arith.constant 7 : i32
+        aiex.npu.write32(%addr, %val) : i32, i32
+      }
+    }
+  }
+}
+
+// -----
+
+// A runtime-bound scf.if lowers to emitc.if with its npu body converted in place.
+// CHECK-LABEL: emitc.func @generate_txn_main_seq_scf_if
+// CHECK: if %{{.*}} {
+// CHECK: call_opaque "aie_runtime::txn_append_write32"
+module {
+  aie.device(npu1_1col) {
+    aie.runtime_sequence @seq_scf_if(%arg0: memref<8xi32>, %cond: i1) {
+      scf.if %cond {
+        %addr = arith.constant 100 : i32
+        %val = arith.constant 7 : i32
+        aiex.npu.write32(%addr, %val) : i32, i32
+      }
+    }
+  }
+}
+
+// -----
+
 // npu2 device: the header carries devGen=4, rows=6, cols=8, memtilerows=1
 // (vs npu1's devGen=3). Exercises the BaseNPU2TargetModel branch.
 // CHECK-LABEL: emitc.func @generate_txn_main_seq_npu2

--- a/test/Conversion/AIEXToEmitC/reject.mlir
+++ b/test/Conversion/AIEXToEmitC/reject.mlir
@@ -7,41 +7,6 @@
 
 // RUN: aie-opt %s -split-input-file --convert-aiex-to-emitc --verify-diagnostics
 
-// Control flow inside a runtime sequence is out of scope for the straight-line
-// C++ TXN target; it must be rejected with a diagnostic, never silently dropped.
-module {
-  aie.device(npu1_1col) {
-    aie.runtime_sequence @seq_scf_for(%arg0: memref<8xi32>) {
-      %c0 = arith.constant 0 : index
-      %c1 = arith.constant 1 : index
-      %c4 = arith.constant 4 : index
-      // expected-error @+1 {{control flow in runtime sequences is not yet supported by the C++ TXN target}}
-      scf.for %i = %c0 to %c4 step %c1 {
-        %addr = arith.constant 100 : i32
-        %val = arith.constant 7 : i32
-        aiex.npu.write32(%addr, %val) : i32, i32
-      }
-    }
-  }
-}
-
-// -----
-
-module {
-  aie.device(npu1_1col) {
-    aie.runtime_sequence @seq_scf_if(%arg0: memref<8xi32>, %cond: i1) {
-      // expected-error @+1 {{control flow in runtime sequences is not yet supported by the C++ TXN target}}
-      scf.if %cond {
-        %addr = arith.constant 100 : i32
-        %val = arith.constant 7 : i32
-        aiex.npu.write32(%addr, %val) : i32, i32
-      }
-    }
-  }
-}
-
-// -----
-
 // A runtime (non-constant) register ADDRESS cannot be resolved statically: the
 // address selects which hardware register and must fold in buffer/col/row at
 // compile time. (Runtime data values are fine; only the address is rejected.)

--- a/test/Conversion/DmaToNpu/push_to_queue.mlir
+++ b/test/Conversion/DmaToNpu/push_to_queue.mlir
@@ -5,7 +5,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: aie-opt --aie-dma-to-npu %s | FileCheck %s
+// RUN: aie-opt --split-input-file --aie-dma-to-npu %s | FileCheck %s
 // CHECK-DAG: %[[V0:.*]] = arith.constant -2147483645 : i32
 // CHECK-DAG: %[[A0:.*]] = arith.constant 119308 : i32
 // CHECK: aiex.npu.write32(%[[A0]], %[[V0]]) : i32, i32
@@ -22,6 +22,25 @@ module {
       %rc1 = arith.constant 3 : i32
       %bd1 = arith.constant 2 : i32
       aiex.npu.push_queue (2, 0, MM2S:0) bd_id %bd1 repeat %rc1 {issue_token = false} : i32, i32
+    }
+  }
+}
+
+// -----
+
+// A runtime (SSA) bd_id is no longer rejected: the command word is assembled
+// with arith (bd_id & 0xF, or'd with the issue-token bit and the shifted
+// repeat_count) instead of folded to a constant.
+// CHECK-LABEL: @rt_bd_id
+// CHECK: %[[BD:.*]] = arith.andi %arg0, %{{.*}} : i32
+// CHECK: %[[CMD:.*]] = arith.ori %{{.*}}, %[[BD]] : i32
+// CHECK: %[[CMD2:.*]] = arith.ori %[[CMD]], %{{.*}} : i32
+// CHECK: aiex.npu.write32(%{{.*}}, %[[CMD2]])
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence @rt_bd_id(%arg0: i32) {
+      %rc0 = arith.constant 0 : i32
+      aiex.npu.push_queue (0, 0, S2MM:1) bd_id %arg0 repeat %rc0 {issue_token = true} : i32, i32
     }
   }
 }

--- a/test/Runtime/TxnEncoding/bd_pool_host.cpp
+++ b/test/Runtime/TxnEncoding/bd_pool_host.cpp
@@ -1,0 +1,79 @@
+//===- bd_pool_host.cpp - Standalone BdPool free-list test ---------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Exercises the header-only runtime BD free-list pool in TxnEncoding.h the way
+// generated host C++ consumes it: init a pool sized to a tile's BD count, then
+// pop/push ids. Focus is the exhaustion backstop -- bd_pool_pop returns false
+// when the working set exceeds the tile's BD count, which the generated builder
+// turns into `return std::nullopt`. This is the only path the MLIR/e2e tests
+// verify statically (the write32 emission) but never trigger at runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Runtime/TxnEncoding.h"
+
+#include <cstdint>
+#include <cstdio>
+
+using namespace aie_runtime;
+
+static int failures = 0;
+
+static void check(bool cond, const char *label) {
+  if (!cond) {
+    std::printf("FAIL: %s\n", label);
+    ++failures;
+  }
+}
+
+int main() {
+  // Pop hands out the lowest free id first (0, 1, ...), matching the static
+  // allocator's order, so a fresh pool's first pop equals a pinned bd_id = 0.
+  {
+    BdPool p = bd_pool_init(4);
+    uint32_t id = 99;
+    for (uint32_t expect = 0; expect < 4; ++expect) {
+      check(bd_pool_pop(p, id), "pop within capacity should succeed");
+      check(id == expect, "pop should hand out lowest free id first");
+    }
+    // Exhaustion: the 5th pop on a 4-BD pool fails and leaves `out` untouched.
+    id = 0xABCD;
+    check(!bd_pool_pop(p, id), "pop on empty pool must return false");
+    check(id == 0xABCD, "failed pop must not write out");
+  }
+
+  // Push returns an id for reuse; a subsequent pop hands it back out. A
+  // rotating free inside a runtime loop relies on this recycling.
+  {
+    BdPool p = bd_pool_init(2);
+    uint32_t a = 0, b = 0;
+    check(bd_pool_pop(p, a) && a == 0, "first pop is id 0");
+    check(bd_pool_pop(p, b) && b == 1, "second pop is id 1");
+    check(!bd_pool_pop(p, a), "pool of 2 is now empty");
+    bd_pool_push(p, 0); // return id 0
+    uint32_t reused = 99;
+    check(bd_pool_pop(p, reused), "pop after push succeeds");
+    check(reused == 0, "pushed id is handed back out");
+  }
+
+  // n larger than the fixed array is clamped to kMaxBDsPerTile: the pool never
+  // pops more ids than the backing storage holds.
+  {
+    BdPool p = bd_pool_init(kMaxBDsPerTile + 100);
+    uint32_t id = 0, count = 0;
+    while (bd_pool_pop(p, id))
+      ++count;
+    check(count == kMaxBDsPerTile, "pop count is clamped to kMaxBDsPerTile");
+  }
+
+  if (failures > 0) {
+    std::printf("bd_pool: %d failure(s)\n", failures);
+    return 1;
+  }
+  std::printf("bd_pool: all checks passed\n");
+  return 0;
+}

--- a/test/Runtime/TxnEncoding/bd_pool_host.test
+++ b/test/Runtime/TxnEncoding/bd_pool_host.test
@@ -1,0 +1,13 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Build the standalone BdPool test against the dependency-free TxnEncoding.h
+// header (C++ standard library only, no MLIR/LLVM/aie-rt) and run it. Covers
+// the free-list pop/push/recycle path and, critically, the exhaustion backstop
+// (bd_pool_pop returns false past capacity) that the MLIR/e2e tests only verify
+// statically.
+//
+// RUN: %host_clang -std=c++17 -I%S/../../../include %S/bd_pool_host.cpp %host_link_flags -o %t.exe
+// RUN: %t.exe | FileCheck %s
+
+// CHECK: bd_pool: all checks passed

--- a/test/Targets/NPU/aie_npu_to_cpp_bd_pool.mlir
+++ b/test/Targets/NPU/aie_npu_to_cpp_bd_pool.mlir
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The C++ TXN target (aie-npu-to-cpp) for the dynamic BD free-list pool: a
+// runtime bd_id lowers to a bd_pool_pop with a nullopt backstop on exhaustion,
+// the BD words are written at the runtime pool-derived register address, and
+// the id is returned with bd_pool_push. The pool is sized from the target
+// model's BD count (getNumBDs) -- 16 on the shim tile here, not a hardcode.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-lower-dynamic-bd-pool --canonicalize \
+// RUN:   --aie-dma-tasks-to-npu --aie-dma-to-npu %s \
+// RUN: | aie-translate --aie-npu-to-cpp | FileCheck %s
+
+// CHECK: inline std::optional<std::vector<uint32_t>> generate_txn_
+// The pool is declared once, sized from the target model (shim = 16 BDs).
+// CHECK: aie_runtime::BdPool bd_pool_0_0 = aie_runtime::bd_pool_init(16);
+// A pop into a fresh variable, failing the build (nullopt) if the pool is empty.
+// CHECK: uint32_t bd_{{[0-9]+}}; if (!aie_runtime::bd_pool_pop(bd_pool_0_0, bd_{{[0-9]+}})) return std::nullopt;
+// The BD words are emitted as write32s (no constant-address blockwrite).
+// CHECK: aie_runtime::txn_append_write32
+// The id is returned to the pool.
+// CHECK: aie_runtime::bd_pool_push(bd_pool_0_0,
+
+aie.device(npu2) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.shim_dma_allocation @of_in (%tile_0_0, MM2S, 0)
+  aie.runtime_sequence @pool(%in: memref<8192xi32>) {
+    %bd = aiex.dma_bd_pool_pop(0, 0) : i32
+    %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) bd_id %bd : i32 {
+      aie.dma_bd(%in : memref<8192xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%t)
+    aiex.dma_await_task(%t)
+    aiex.dma_bd_pool_push(0, 0) bd_id %bd : i32
+  }
+}

--- a/test/Targets/NPU/aie_npu_to_cpp_rolled_loop.mlir
+++ b/test/Targets/NPU/aie_npu_to_cpp_rolled_loop.mlir
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The C++ TXN target for a ROLLED runtime-bound loop: the scf.for survives to
+// aie-npu-to-cpp and becomes an emitc.for (a real C++ for-loop), with the BD
+// free-list pool pop/push inside it and a RUNTIME op-count (__opcount) fed to
+// the header -- the loop body appends a runtime number of ops. This is the
+// end-to-end dynamic path the static allocator rejects.
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-lower-dynamic-bd-pool --canonicalize \
+// RUN:   --aie-dma-tasks-to-npu --aie-dma-to-npu %s \
+// RUN: | aie-translate --aie-npu-to-cpp | FileCheck %s
+
+// The pool is declared once from the target model's BD count.
+// CHECK: aie_runtime::BdPool bd_pool_0_0 = aie_runtime::bd_pool_init(16);
+// The op-count is a runtime accumulator, not a compile-time literal.
+// CHECK: uint32_t __opcount = 0;
+// The prologue pops the initial id.
+// CHECK: uint32_t bd_{{[0-9]+}}; if (!aie_runtime::bd_pool_pop(bd_pool_0_0, bd_{{[0-9]+}})) return std::nullopt;
+// The runtime-bound loop is a real C++ for-loop over the trip-count param.
+// CHECK: for (size_t
+// Inside the loop: pop, count, and push the previous id.
+// CHECK: uint32_t bd_{{[0-9]+}}; if (!aie_runtime::bd_pool_pop(bd_pool_0_0, bd_{{[0-9]+}})) return std::nullopt;
+// CHECK: ++__opcount;
+// CHECK: aie_runtime::bd_pool_push(bd_pool_0_0,
+// The header reads the runtime count.
+// CHECK: aie_runtime::txn_prepend_header(txn, __opcount,
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @rolled(%arg0: memref<1024xi32>, %n: index) {
+    %c1 = arith.constant 1 : index
+    %init = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%init)
+    %last = scf.for %i = %c1 to %n step %c1 iter_args(%prev = %init) -> (index) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_free_task(%prev)
+      scf.yield %t : index
+    }
+    aiex.dma_await_task(%last)
+    aiex.dma_free_task(%last)
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/Inputs/dma_task_pool_bdid_dyn.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/Inputs/dma_task_pool_bdid_dyn.mlir
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Dynamic-pool companion input for dma_task_pool_bdid.mlir (not a standalone
+// test -- lives under Inputs/ so lit ignores it). The BD id is drawn at runtime
+// from the free-list pool; a fresh pool pops 0, matching the static oracle's
+// pinned bd_id = 0.
+//
+// %unused is an i32 arg so the generated function matches the comparator's
+// DYN_FN(ARGVAL) call signature; the pool id does not depend on it.
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @of_in (%tile_0_0, MM2S, 0)
+    aie.runtime_sequence @pool_dynamic(%in: memref<1024xi32>, %unused: i32) {
+      %bd = aiex.dma_bd_pool_pop(0, 0) : i32
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) bd_id %bd : i32 {
+        aie.dma_bd(%in : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_await_task(%t)
+      aiex.dma_bd_pool_push(0, 0) bd_id %bd : i32
+    }
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/Inputs/rolled_loop_compare.cpp
+++ b/test/Targets/NPU/static_vs_dynamic/Inputs/rolled_loop_compare.cpp
@@ -1,0 +1,82 @@
+//===- rolled_loop_compare.cpp ---------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Proves the rolled dynamic loop programs the SAME hardware as N unrolled
+// static configures: replays generate_txn_main_rolled(n) and the static
+// generate_txn_main_static2 (a hand-unrolled 2-iteration ping-pong) into
+// register maps and asserts they are equal for n = 2. A rolled loop over a
+// runtime trip count is thus a drop-in for the unroll the static allocator
+// would have produced. ROLLED_HDR / STATIC_HDR select the generated headers.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Runtime/TxnEncoding.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <map>
+#include <optional>
+#include <vector>
+
+#include ROLLED_HDR
+#include STATIC_HDR
+
+namespace {
+using RegMap = std::map<uint64_t, uint32_t>;
+
+RegMap replay(const std::vector<uint32_t> &t) {
+  using namespace aie_runtime;
+  RegMap r;
+  size_t p = 4;
+  uint64_t sk = 1ULL << 40;
+  while (p < t.size()) {
+    uint32_t o = t[p];
+    if (o == TXN_OPC_WRITE) {
+      r[t[p + 2]] = t[p + 4];
+      p += 6;
+    } else if (o == TXN_OPC_BLOCKWRITE) {
+      uint32_t a = t[p + 2], bs = t[p + 3];
+      size_t tot = bs / sizeof(uint32_t);
+      for (size_t i = 4; i < tot; ++i)
+        r[a + (i - 4) * 4] = t[p + i];
+      p += tot;
+    } else if (o == TXN_OPC_MASKWRITE) {
+      r[t[p + 2]] = (r[t[p + 2]] & ~t[p + 5]) | (t[p + 4] & t[p + 5]);
+      p += 7;
+    } else if (o == TXN_OPC_TCT) {
+      r[sk++] = t[p + 2];
+      r[sk++] = t[p + 3];
+      p += 4;
+    } else if (o == TXN_OPC_DDR_PATCH) {
+      r[sk++] = t[p + 6];
+      r[sk++] = t[p + 8];
+      r[sk++] = t[p + 10];
+      p += 12;
+    } else {
+      std::fprintf(stderr, "unhandled opcode 0x%x\n", o);
+      return {};
+    }
+  }
+  return r;
+}
+} // namespace
+
+int main() {
+  auto rolled = generate_txn_main_rolled(2);
+  auto stat = generate_txn_main_static2();
+  if (!rolled || !stat) {
+    std::fprintf(stderr, "builder returned nullopt\n");
+    return 1;
+  }
+  RegMap a = replay(*rolled), b = replay(*stat);
+  if (a != b) {
+    std::fprintf(stderr, "rolled(2) and static2 program different registers\n");
+    return 1;
+  }
+  std::printf("equivalent: rolled(2) == static2 (%zu registers)\n", a.size());
+  return 0;
+}

--- a/test/Targets/NPU/static_vs_dynamic/Inputs/rolled_loop_static2.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/Inputs/rolled_loop_static2.mlir
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Hand-unrolled 2-iteration ping-pong: the static oracle for the rolled
+// dynamic loop at n = 2 (rolled_loop.mlir). Two configures ping-pong, the
+// allocator assigns ids 0 then 1 (lowest-free-first), matching the pool's pop
+// order. Companion input under Inputs/ so lit ignores it.
+//
+//===----------------------------------------------------------------------===//
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @static2(%arg0: memref<1024xi32>) {
+    %init = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%init)
+    %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%t)
+    aiex.dma_free_task(%init)
+    aiex.dma_await_task(%t)
+    aiex.dma_free_task(%t)
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/dma_task_pool_bdid.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/dma_task_pool_bdid.mlir
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Static-vs-dynamic equivalence for a RUNTIME bd_id drawn from the dynamic
+// free-list pool. @pool_dynamic draws its BD id at runtime via
+// dma_bd_pool_pop (aie-lower-dynamic-bd-pool), so the whole BD is emitted as
+// write32s at bdBase + bd_id*0x20 rather than a constant-address blockwrite.
+// @pool_static bakes the same descriptor at a pinned bd_id = 0.
+//
+// A fresh pool pops id 0 first, so the runtime id equals the pinned id and the
+// two program the SAME final BD registers -- proven by replaying both streams
+// into a register map (-DDYN_STRUCTURAL) rather than a byte diff. golden-vs-
+// static stays byte-exact.
+//
+// The two sequences take different pipelines (the static allocator rejects the
+// pool sequence's unpinned BD; the pool pass is a no-op on the pinned one), so
+// they are kept in two files: this one is the static oracle, the pooled variant
+// is Inputs/dma_task_pool_bdid_dyn.mlir. Both funcs go into one comparator.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t.d && mkdir -p %t.d
+
+// Static oracle: assign BD ids, lower tasks + queue, dma-to-npu.
+// RUN: aie-opt --aie-assign-runtime-sequence-bd-ids --aie-dma-tasks-to-npu \
+// RUN:   --aie-dma-to-npu %s -o %t.d/static.mlir
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false \
+// RUN:   -aie-sequence-name=pool_static %t.d/static.mlir > %t.d/golden.hex
+// RUN: aie-translate --aie-npu-to-cpp %t.d/static.mlir > %t.d/gen_static.h
+
+// Dynamic pool variant: lower the pool, canonicalize, then the same lowerings.
+// RUN: aie-opt --aie-lower-dynamic-bd-pool --canonicalize \
+// RUN:   --aie-dma-tasks-to-npu --aie-dma-to-npu \
+// RUN:   %S/Inputs/dma_task_pool_bdid_dyn.mlir -o %t.d/dynamic.mlir
+// RUN: aie-translate --aie-npu-to-cpp %t.d/dynamic.mlir > %t.d/gen_dynamic.h
+
+// RUN: cat %t.d/gen_static.h %t.d/gen_dynamic.h > %t.d/gen.h
+// RUN: %host_clang -std=c++17 -DDYN_STRUCTURAL -I%S/../../../../include \
+// RUN:   -DGEN_HDR='"%t.d/gen.h"' \
+// RUN:   -DSTATIC_FN=generate_txn_main_pool_static \
+// RUN:   -DDYN_FN=generate_txn_main_pool_dynamic -DARGVAL=0 \
+// RUN:   %S/Inputs/compare_main.cpp %host_link_flags -o %t.d/cmp.exe
+// RUN: %t.d/cmp.exe %t.d/golden.hex
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @of_in (%tile_0_0, MM2S, 0)
+    aie.runtime_sequence @pool_static(%in: memref<1024xi32>) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%in : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_await_task(%t)
+    }
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/memcpy_nd_dynamic_offset.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/memcpy_nd_dynamic_offset.mlir
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Static-vs-dynamic equivalence for a runtime OFFSET on dma_memcpy_nd. A runtime
+// offset flows into the address-patch arg_plus as arith; sizes/strides stay
+// constant so the BD is a plain static blockwrite. Register-replay
+// (-DDYN_STRUCTURAL) proves the runtime-offset stream programs the same
+// registers (including the patched arg_plus) as the static-baked offset.
+//
+// @off_static bakes offset d3 = 64; @off_dynamic takes it as %n.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t.d && mkdir -p %t.d
+
+// RUN: aie-opt --aie-dma-to-npu %s -o %t.d/lowered.mlir
+
+// RUN: aie-translate --aie-npu-to-binary -aie-output-binary=false \
+// RUN:   -aie-sequence-name=off_static %t.d/lowered.mlir > %t.d/golden.hex
+
+// RUN: aie-translate --aie-npu-to-cpp %t.d/lowered.mlir > %t.d/gen.h
+
+// RUN: %host_clang -std=c++17 -DDYN_STRUCTURAL -I%S/../../../../include \
+// RUN:   -DGEN_HDR='"%t.d/gen.h"' \
+// RUN:   -DSTATIC_FN=generate_txn_main_off_static \
+// RUN:   -DDYN_FN=generate_txn_main_off_dynamic -DARGVAL=64 \
+// RUN:   %S/Inputs/compare_main.cpp %host_link_flags -o %t.d/cmp.exe
+// RUN: %t.d/cmp.exe %t.d/golden.hex
+
+module {
+  aie.device(npu2) {
+    %tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @of_in (%tile_0_0, MM2S, 0)
+
+    aie.runtime_sequence @off_static(%in: memref<8192xi32>) {
+      aiex.npu.dma_memcpy_nd(%in[0, 0, 0, 64][1, 4, 8, 32][4096, 512, 32, 1]) {id = 0 : i64, metadata = @of_in} : memref<8192xi32>
+    }
+
+    aie.runtime_sequence @off_dynamic(%in: memref<8192xi32>, %n: i64) {
+      aiex.npu.dma_memcpy_nd(%in[0, 0, 0, %n][1, 4, 8, 32][4096, 512, 32, 1]) {id = 0 : i64, metadata = @of_in} : memref<8192xi32>
+    }
+  }
+}

--- a/test/Targets/NPU/static_vs_dynamic/rolled_loop.mlir
+++ b/test/Targets/NPU/static_vs_dynamic/rolled_loop.mlir
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// End-to-end proof that a ROLLED dynamic loop programs the same hardware as N
+// unrolled static configures. @rolled is a runtime-bound ping-pong (the form
+// the static allocator rejects); it lowers through the dynamic BD pool to a C++
+// for-loop. Inputs/rolled_loop_static2.mlir is the hand-unrolled 2-iteration
+// static oracle. The comparator replays generate_txn_main_rolled(2) and the
+// static generate_txn_main_static2() into register maps and asserts equality.
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: peano
+
+// RUN: rm -rf %t.d && mkdir -p %t.d
+
+// Rolled dynamic loop -> generated C++.
+// RUN: aie-opt --aie-lower-dynamic-bd-pool --canonicalize \
+// RUN:   --aie-dma-tasks-to-npu --aie-dma-to-npu %s -o %t.d/rolled.mlir
+// RUN: aie-translate --aie-npu-to-cpp %t.d/rolled.mlir > %t.d/gen_rolled.h
+
+// Static hand-unrolled n=2 oracle -> generated C++.
+// RUN: aie-opt --aie-assign-runtime-sequence-bd-ids --aie-dma-tasks-to-npu \
+// RUN:   --aie-dma-to-npu %S/Inputs/rolled_loop_static2.mlir -o %t.d/static2.mlir
+// RUN: aie-translate --aie-npu-to-cpp %t.d/static2.mlir > %t.d/gen_static2.h
+
+// RUN: %host_clang -std=c++17 -I%S/../../../../include \
+// RUN:   -DROLLED_HDR='"%t.d/gen_rolled.h"' \
+// RUN:   -DSTATIC_HDR='"%t.d/gen_static2.h"' \
+// RUN:   %S/Inputs/rolled_loop_compare.cpp %host_link_flags -o %t.d/cmp.exe
+// RUN: %t.d/cmp.exe
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @rolled(%arg0: memref<1024xi32>, %n: index) {
+    %c1 = arith.constant 1 : index
+    %init = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%init)
+    %last = scf.for %i = %c1 to %n step %c1 iter_args(%prev = %init) -> (index) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 1024 sizes = [1, 4, 8, 32] strides = [4096, 512, 32, 1])
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_free_task(%prev)
+      scf.yield %t : index
+    }
+    aiex.dma_await_task(%last)
+    aiex.dma_free_task(%last)
+  }
+}

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-runtime-dynamic.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/bad-runtime-dynamic.mlir
@@ -16,7 +16,7 @@ module {
     %buf = aie.buffer(%tile) {sym_name = "b"} : memref<4096xi32>
     aie.runtime_sequence(%len: i32) {
       %t = aiex.dma_configure_task(%tile, MM2S, 0) {
-          // expected-error@+1 {{runtime-valued BD size/stride/len is only supported on shim NOC tiles}}
+          // expected-error@+1 {{runtime-valued BD size/stride/len/bd_id is only supported on shim NOC tiles}}
           aie.dma_bd(%buf : memref<4096xi32> offset = 0 len = %len sizes = [1, 8, 16, 32] strides = [4096, 512, 32, 1]) {bd_id = 0 : i32}
           aie.end
       }

--- a/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-runtime-bdid.mlir
+++ b/test/bd-chains-and-dma-tasks/dma-tasks-to-npu/good-runtime-bdid.mlir
@@ -1,0 +1,46 @@
+//===- good-runtime-bdid.mlir ----------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-dma-tasks-to-npu %s | FileCheck %s
+
+// A dma_configure_task carrying a RUNTIME bd_id (the dynamic free-list pool's
+// dma_bd_pool_pop result, on the configure's bd_id_val operand). The BD register
+// block address is then runtime -- getDmaBdAddress(col,row,bd_id) is linear in
+// bd_id, so it becomes 118784 + bd_id*32 -- and the whole BD cannot be a
+// constant-address blockwrite. Instead every word is a write32 at that runtime
+// base: the template words (buffer_offset word 1, packet word 2, valid/lock
+// word 7) plus the size/stride words from the encoder, and the buffer
+// address_patch takes a runtime addr operand. The queue push uses the runtime
+// bd_id directly.
+
+// CHECK-LABEL: @runtime_bdid
+// The runtime BD register base: 118784 + bd_id*32.
+// CHECK: %[[POP:.*]] = aiex.dma_bd_pool_pop(0, 0) : i32
+// CHECK: %[[MUL:.*]] = arith.muli %[[POP]], %{{.*}} : i32
+// CHECK: %[[BASE:.*]] = arith.addi %{{.*}}, %[[MUL]] : i32
+// Template + size/stride words are write32s at that runtime base (not a
+// constant-address blockwrite).
+// CHECK-NOT: aiex.npu.blockwrite
+// CHECK: aiex.npu.write32
+// The buffer pointer patch targets the runtime register address.
+// CHECK: aiex.npu.address_patch(%{{.*}} : i32) addr %{{.*}} : i32
+// The queue push launches the runtime bd_id.
+// CHECK: aiex.npu.push_queue(0, 0, MM2S : 0) bd_id %[[POP]]
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @runtime_bdid(%arg0: memref<1024xi32>) {
+    %bd = aiex.dma_bd_pool_pop(0, 0) : i32
+    %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) bd_id %bd : i32 {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%t)
+    aiex.dma_await_task(%t)
+    aiex.dma_bd_pool_push(0, 0) bd_id %bd : i32
+  }
+}

--- a/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/bad-multi-bd-chain.mlir
+++ b/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/bad-multi-bd-chain.mlir
@@ -1,0 +1,29 @@
+//===- bad-multi-bd-chain.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-lower-dynamic-bd-pool --verify-diagnostics %s
+
+// v1 supports single-BD tasks only. A multi-BD chain under a runtime loop would
+// need runtime next_bd cross-references between the popped ids (not yet
+// implemented), so it is diagnosed rather than silently mislowered.
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @multi_bd(%arg0: memref<1024xi32>, %n: index) {
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c1 to %n step %c1 {
+      // expected-error@+1 {{supports single-BD tasks only}}
+      %c = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 128)
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 128 len = 128)
+        aie.end
+      }
+      aiex.dma_start_task(%c)
+      aiex.dma_await_task(%c)
+    }
+  }
+}

--- a/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/bad-pinned-in-pool.mlir
+++ b/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/bad-pinned-in-pool.mlir
@@ -1,0 +1,37 @@
+//===- bad-pinned-in-pool.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-lower-dynamic-bd-pool --verify-diagnostics %s
+
+// Within a dynamic (pool) sequence, allocation is all-or-nothing: the pool
+// hands out ids from the full 0..N-1 range at runtime, so a hand-pinned bd_id
+// could collide with a runtime-allocated one. A pinned id here is an error --
+// allocate every BD from the pool, or make the sequence straight-line.
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @dyn_pin(%arg0: memref<1024xi32>, %n: index) {
+    %c1 = arith.constant 1 : index
+    %init = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      // expected-error@+1 {{pins a buffer descriptor ID inside a runtime-bound sequence that draws IDs from the dynamic pool}}
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256) {bd_id = 3 : i32}
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%init)
+    %last = scf.for %i = %c1 to %n step %c1 iter_args(%prev = %init) -> (index) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_free_task(%prev)
+      scf.yield %t : index
+    }
+    aiex.dma_await_task(%last)
+    aiex.dma_free_task(%last)
+  }
+}

--- a/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-mixed-routing.mlir
+++ b/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-mixed-routing.mlir
@@ -1,0 +1,58 @@
+//===- good-mixed-routing.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// The aiecc pass order: the dynamic pool pass claims runtime-bound sequences,
+// then the static allocator handles the rest and SKIPS the pooled ones. A
+// straight-line sequence and a runtime-bound sequence in the same device each
+// take the correct path with no conflict.
+
+// RUN: aie-opt --aie-unroll-runtime-sequence-loops --canonicalize \
+// RUN:   --aie-lower-dynamic-bd-pool --canonicalize \
+// RUN:   --aie-assign-runtime-sequence-bd-ids %s | FileCheck %s
+
+// The straight-line sequence: static allocator assigns a constant bd_id (no
+// pool ops).
+// CHECK-LABEL: @straight
+// CHECK-NOT: aiex.dma_bd_pool_pop
+// CHECK: aie.dma_bd({{.*}}) {bd_id = 0 : i32}
+
+// The runtime-bound sequence: kept rolled with pool pop/push, no static id.
+// CHECK-LABEL: @dynamic
+// CHECK: aiex.dma_bd_pool_pop
+// CHECK: scf.for
+// CHECK: aiex.dma_bd_pool_push
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @straight(%arg0: memref<1024xi32>) {
+    %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%t)
+    aiex.dma_await_task(%t)
+  }
+  aie.runtime_sequence @dynamic(%arg0: memref<1024xi32>, %n: index) {
+    %c1 = arith.constant 1 : index
+    %init = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+      aie.end
+    } {issue_token = true}
+    aiex.dma_start_task(%init)
+    %last = scf.for %i = %c1 to %n step %c1 iter_args(%prev = %init) -> (index) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%t)
+      aiex.dma_free_task(%prev)
+      scf.yield %t : index
+    }
+    aiex.dma_await_task(%last)
+    aiex.dma_free_task(%last)
+  }
+}

--- a/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-pingpong.mlir
+++ b/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-pingpong.mlir
@@ -1,0 +1,54 @@
+//===- good-pingpong.mlir --------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-lower-dynamic-bd-pool %s | FileCheck %s
+
+// A rolled ping-pong over a RUNTIME-bound loop -- the exact form the static
+// allocator rejects (see assign-runtime-sequence-bd-ids/bad-runtime-bound-
+// pingpong.mlir). The dynamic pool pass keeps the loop rolled and turns the
+// implicit allocation into runtime pool pop/push:
+//   - each dma_configure_task gets a dma_bd_pool_pop feeding its bd_id_val;
+//   - the popped id is carried through scf.for alongside the task (a second
+//     i32 iter_arg), so the free of the PREVIOUS iteration's task pushes the
+//     right id;
+//   - the free after the loop pushes the last id; the await is kept (it lowers
+//     to a sync later) and the redundant free-after-await is dropped.
+
+// CHECK-LABEL: @runtime_bound_pingpong
+// CHECK: %[[INIT:.*]] = aiex.dma_bd_pool_pop(0, 0) : i32
+// CHECK: aiex.dma_configure_task(%{{.*}}, MM2S, 0) bd_id %[[INIT]] : i32
+// CHECK: %[[LOOP:.*]]:2 = scf.for {{.*}} iter_args(%[[PREVT:.*]] = %{{.*}}, %[[PREVID:.*]] = %[[INIT]]) -> (index, i32)
+// CHECK:   %[[T:.*]] = aiex.dma_bd_pool_pop(0, 0) : i32
+// CHECK:   aiex.dma_configure_task(%{{.*}}, MM2S, 0) bd_id %[[T]] : i32
+// CHECK:   aiex.dma_bd_pool_push(0, 0) bd_id %[[PREVID]] : i32
+// CHECK:   scf.yield %{{.*}}, %[[T]] : index, i32
+// CHECK: aiex.dma_bd_pool_push(0, 0) bd_id %[[LOOP]]#1 : i32
+// CHECK: aiex.dma_await_task(%[[LOOP]]#0)
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @runtime_bound_pingpong(%arg0: memref<1024xi32>,
+                                               %n: index) {
+    %c1 = arith.constant 1 : index
+    %init = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+      aie.end
+    }
+    aiex.dma_start_task(%init)
+    %last = scf.for %i = %c1 to %n step %c1 iter_args(%prev = %init) -> (index) {
+      %t = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+        aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+        aie.end
+      }
+      aiex.dma_start_task(%t)
+      aiex.dma_free_task(%prev)
+      scf.yield %t : index
+    }
+    aiex.dma_await_task(%last)
+    aiex.dma_free_task(%last)
+  }
+}

--- a/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-pingpong.mlir
+++ b/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-pingpong.mlir
@@ -15,19 +15,22 @@
 //   - the popped id is carried through scf.for alongside the task (a second
 //     i32 iter_arg), so the free of the PREVIOUS iteration's task pushes the
 //     right id;
-//   - the free after the loop pushes the last id; the await is kept (it lowers
-//     to a sync later) and the redundant free-after-await is dropped.
+//   - the free after the loop pushes the last id; the redundant free-after-
+//     await is dropped;
+//   - the await, which named the loop-result task (no defining configure to
+//     resolve), is redirected to the loop-invariant init configure %[[INIT_T]]
+//     -- same tile/dir/channel every iteration.
 
 // CHECK-LABEL: @runtime_bound_pingpong
 // CHECK: %[[INIT:.*]] = aiex.dma_bd_pool_pop(0, 0) : i32
-// CHECK: aiex.dma_configure_task(%{{.*}}, MM2S, 0) bd_id %[[INIT]] : i32
-// CHECK: %[[LOOP:.*]]:2 = scf.for {{.*}} iter_args(%[[PREVT:.*]] = %{{.*}}, %[[PREVID:.*]] = %[[INIT]]) -> (index, i32)
+// CHECK: %[[INIT_T:.*]] = aiex.dma_configure_task(%{{.*}}, MM2S, 0) bd_id %[[INIT]] : i32
+// CHECK: %[[LOOP:.*]]:2 = scf.for {{.*}} iter_args(%[[PREVT:.*]] = %[[INIT_T]], %[[PREVID:.*]] = %[[INIT]]) -> (index, i32)
 // CHECK:   %[[T:.*]] = aiex.dma_bd_pool_pop(0, 0) : i32
 // CHECK:   aiex.dma_configure_task(%{{.*}}, MM2S, 0) bd_id %[[T]] : i32
 // CHECK:   aiex.dma_bd_pool_push(0, 0) bd_id %[[PREVID]] : i32
 // CHECK:   scf.yield %{{.*}}, %[[T]] : index, i32
 // CHECK: aiex.dma_bd_pool_push(0, 0) bd_id %[[LOOP]]#1 : i32
-// CHECK: aiex.dma_await_task(%[[LOOP]]#0)
+// CHECK: aiex.dma_await_task(%[[INIT_T]])
 
 aie.device(npu1) {
   %tile_0_0 = aie.tile(0, 0)

--- a/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-straight-line-untouched.mlir
+++ b/test/bd-chains-and-dma-tasks/lower-dynamic-bd-pool/good-straight-line-untouched.mlir
@@ -1,0 +1,30 @@
+//===- good-straight-line-untouched.mlir -----------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt --aie-lower-dynamic-bd-pool %s | FileCheck %s
+
+// A straight-line runtime sequence (no runtime control flow) is left entirely
+// to the static allocator: this pass must not touch it, so no pool pop/push
+// appears and the configure keeps its constant-attr allocation path.
+
+// CHECK-LABEL: @straight_line
+// CHECK-NOT: aiex.dma_bd_pool_pop
+// CHECK-NOT: aiex.dma_bd_pool_push
+// CHECK: aiex.dma_configure_task
+// CHECK-NOT: bd_id %
+
+aie.device(npu1) {
+  %tile_0_0 = aie.tile(0, 0)
+  aie.runtime_sequence @straight_line(%arg0: memref<1024xi32>) {
+    %c = aiex.dma_configure_task(%tile_0_0, MM2S, 0) {
+      aie.dma_bd(%arg0 : memref<1024xi32> offset = 0 len = 256)
+      aie.end
+    }
+    aiex.dma_start_task(%c)
+    aiex.dma_await_task(%c)
+  }
+}

--- a/test/npu-xrt/dynamic_pingpong_passthrough/aie.mlir
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/aie.mlir
@@ -1,0 +1,77 @@
+//===- aie.mlir ------------------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Dynamic ping-pong passthrough: a runtime tile count %n drives BOTH the output
+// collect-size (runtime d2 size + len, via the Phase-2 dynamic BD-word encoder)
+// AND the input ping-pong loop trip count (kept rolled over a runtime bound, so
+// the dynamic BD free-list pool draws ids at runtime). The static allocator
+// would reject the runtime scf.for; this exercises the full dynamic path.
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu2) {
+    %logical_core = aie.logical_tile<CoreTile>(?, ?)
+    %logical_shim_noc = aie.logical_tile<ShimNOCTile>(?, ?)
+    %logical_shim_noc_0 = aie.logical_tile<ShimNOCTile>(?, ?)
+    aie.objectfifo @of_in(%logical_shim_noc, {%logical_core}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
+    aie.objectfifo @of_out(%logical_core, {%logical_shim_noc_0}, 2 : i32) : !aie.objectfifo<memref<256xi32>>
+    %0 = aie.core(%logical_core) {
+      %c0 = arith.constant 0 : index
+      %cmax = arith.constant 9223372036854775807 : index
+      %c1 = arith.constant 1 : index
+      scf.for %arg0 = %c0 to %cmax step %c1 {
+        %1 = aie.objectfifo.acquire @of_out(Produce, 1) : !aie.objectfifosubview<memref<256xi32>>
+        %2 = aie.objectfifo.subview.access %1[0] : !aie.objectfifosubview<memref<256xi32>> -> memref<256xi32>
+        %3 = aie.objectfifo.acquire @of_in(Consume, 1) : !aie.objectfifosubview<memref<256xi32>>
+        %4 = aie.objectfifo.subview.access %3[0] : !aie.objectfifosubview<memref<256xi32>> -> memref<256xi32>
+        %c0_1 = arith.constant 0 : index
+        %c256 = arith.constant 256 : index
+        %c1_2 = arith.constant 1 : index
+        scf.for %arg1 = %c0_1 to %c256 step %c1_2 {
+          %5 = memref.load %4[%arg1] : memref<256xi32>
+          memref.store %5, %2[%arg1] : memref<256xi32>
+        }
+        aie.objectfifo.release @of_in(Consume, 1)
+        aie.objectfifo.release @of_out(Produce, 1)
+      }
+      aie.end
+    }
+    // %n = runtime tile count. Drives the output collect-size (runtime d2 size +
+    // len) and the input ping-pong loop trip count.
+    aie.runtime_sequence(%in: memref<256xi32>, %out: memref<4096xi32>, %n: i64) {
+      %c1 = arith.constant 1 : index
+      %c256_i32 = arith.constant 256 : i32
+      %n_idx = arith.index_cast %n : i64 to index
+      %n_i32 = arith.trunci %n : i64 to i32
+      %len = arith.muli %n_i32, %c256_i32 : i32
+      // Output task: collect %n tiles contiguously.
+      %out_task = aiex.dma_configure_task_for @of_out {
+        aie.dma_bd(%out : memref<4096xi32> offset = 0 len = %len sizes = [1, 1, %n, 256] strides = [0, 0, 256, 1])
+        aie.end
+      } {issue_token = true}
+      %init = aiex.dma_configure_task_for @of_in {
+        aie.dma_bd(%in : memref<256xi32> offset = 0 len = 256 sizes = [1, 1, 1, 256] strides = [0, 0, 0, 1])
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%out_task)
+      aiex.dma_start_task(%init)
+      %last = scf.for %i = %c1 to %n_idx step %c1 iter_args(%prev = %init) -> (index) {
+        %t = aiex.dma_configure_task_for @of_in {
+          aie.dma_bd(%in : memref<256xi32> offset = 0 len = 256 sizes = [1, 1, 1, 256] strides = [0, 0, 0, 1])
+          aie.end
+        } {issue_token = true}
+        aiex.dma_start_task(%t)
+        aiex.dma_free_task(%prev)
+        scf.yield %t : index
+      }
+      aiex.dma_await_task(%last)
+      aiex.dma_await_task(%out_task)
+      aiex.dma_free_task(%last)
+    }
+  }
+}

--- a/test/npu-xrt/dynamic_pingpong_passthrough/run.lit
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/run.lit
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// Dynamic (runtime tile-count) ping-pong passthrough on real hardware. The
+// runtime sequence keeps its scf.for rolled over a RUNTIME trip count `%n`,
+// which the dynamic BD free-list pool path supports (the static allocator would
+// reject it). One compiled xclbin serves any n: the instruction stream is built
+// at runtime by the generated C++ TXN builder called with n.
+//
+// aiecc builds the xclbin (device structure). The instruction builder is
+// generated separately via aie-translate --aie-npu-to-cpp from aiecc's lowered
+// intermediate (the runtime sequence lowers to a runtime-addressed C++ builder,
+// not a static insts.bin). The host #includes that header and calls it per n.
+//
+// RUN: mkdir -p %t.prj
+// RUN: %aiecc %backend_flags --no-aiesim --aie-generate-xclbin \
+// RUN:   --no-compile-host --xclbin-name=%t.xclbin --tmpdir=%t.prj %S/aie.mlir
+//
+// Generate the C++ TXN builder from aiecc's lowered intermediate, mirroring the
+// NPU lowering pipeline (input_with_addresses.mlir is lowered for addresses
+// only; the npu ops are produced here).
+// RUN: aie-opt \
+// RUN:   --aie-materialize-bd-chains --aie-substitute-shim-dma-allocations \
+// RUN:   --aie-unroll-runtime-sequence-loops --canonicalize \
+// RUN:   --aie-lower-dynamic-bd-pool --canonicalize \
+// RUN:   --aie-assign-runtime-sequence-bd-ids --aie-dma-tasks-to-npu \
+// RUN:   --aie-dma-to-npu --aie-lower-set-lock \
+// RUN:   %t.prj/input_with_addresses.mlir -o %t.lowered.mlir
+// RUN: aie-translate --aie-npu-to-cpp %t.lowered.mlir > %t.gen.h
+//
+// RUN: %host_clang %S/test.cpp -o %t.exe -std=c++17 -Wall \
+// RUN:   -DGEN_HDR='"%t.gen.h"' -DXCLBIN='std::string("%t.xclbin")' \
+// RUN:   -I%S/../../../include %xrt_flags %host_link_flags %test_utils_flags
+//
+// The runtime tile count is the last host argument: exercise several values
+// (loop body skipped at n=1, ping-pong at n=2, and a larger n).
+// RUN: %run_on_npu2% %t.exe 1 | FileCheck %s
+// RUN: %run_on_npu2% %t.exe 2 | FileCheck %s
+// RUN: %run_on_npu2% %t.exe 8 | FileCheck %s
+// CHECK: PASS!

--- a/test/npu-xrt/dynamic_pingpong_passthrough/run.lit
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/run.lit
@@ -16,6 +16,7 @@
 //
 // RUN: mkdir -p %t.prj
 // RUN: %aiecc %backend_flags --no-aiesim --aie-generate-xclbin \
+// RUN:   --aie-generate-input-with-addresses --output-dir=%t.prj \
 // RUN:   --no-compile-host --xclbin-name=%t.xclbin --tmpdir=%t.prj %S/aie.mlir
 //
 // Generate the C++ TXN builder from aiecc's lowered intermediate, mirroring the

--- a/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
@@ -73,8 +73,8 @@ int main(int argc, const char *argv[]) {
 
   auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
                           XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
-  auto bo_input = xrt::bo(device, in_len * sizeof(DTYPE), XRT_BO_FLAGS_HOST_ONLY,
-                          kernel.group_id(3));
+  auto bo_input = xrt::bo(device, in_len * sizeof(DTYPE),
+                          XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
   auto bo_output = xrt::bo(device, out_len * sizeof(DTYPE),
                            XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
 

--- a/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Host for the dynamic (runtime tile-count) ping-pong passthrough. Unlike a
+// static design, the instruction stream is NOT read from an insts.bin: it is
+// built AT RUNTIME by the generated C++ TXN builder (generate_txn_main_sequence,
+// from GEN_HDR) called with the tile count `n` chosen at runtime (argv[1]). That
+// is the whole point of the dynamic BD free-list pool -- one compiled design
+// serves any n. The builder returns std::nullopt if n exceeds the tile's BD
+// pool; we treat that as a build failure.
+
+#include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <optional>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include "test_utils.h"
+
+#include GEN_HDR
+
+#ifndef XCLBIN
+#define XCLBIN std::string("final.xclbin")
+#endif
+
+#ifndef KERNEL_NAME
+#define KERNEL_NAME "MLIR_AIE"
+#endif
+
+#define DTYPE int32_t
+#define TILE_LEN 256
+
+int main(int argc, const char *argv[]) {
+  // Runtime tile count: the single parameter the compiled design is
+  // parameterized on. Same xclbin, same builder, any n.
+  int64_t n = (argc > 1) ? std::atoll(argv[1]) : 8;
+  const int in_len = TILE_LEN;
+  const int64_t out_len = TILE_LEN * n;
+
+  // Build the instruction stream at runtime for this n.
+  std::optional<std::vector<uint32_t>> instr_opt =
+      generate_txn_main_sequence(n);
+  if (!instr_opt) {
+    std::cout << "builder returned nullopt for n=" << n
+              << " (exceeds BD pool)\n";
+    return 1;
+  }
+  std::vector<uint32_t> instr_v = std::move(*instr_opt);
+  assert(instr_v.size() > 0);
+
+  unsigned int device_index = 0;
+  xrt::device device = xrt::device(device_index);
+  xrt::xclbin xclbin = xrt::xclbin(XCLBIN);
+
+  std::vector<xrt::xclbin::kernel> xkernels = xclbin.get_kernels();
+  xrt::xclbin::kernel xkernel = *std::find_if(
+      xkernels.begin(), xkernels.end(), [](xrt::xclbin::kernel &k) {
+        return k.get_name().rfind(KERNEL_NAME, 0) == 0;
+      });
+  std::string kernel_name = xkernel.get_name();
+  assert(strcmp(kernel_name.c_str(), KERNEL_NAME) == 0);
+
+  device.register_xclbin(xclbin);
+  xrt::hw_context context(device, xclbin.get_uuid());
+  auto kernel = xrt::kernel(context, kernel_name);
+
+  auto bo_instr = xrt::bo(device, instr_v.size() * sizeof(int),
+                          XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+  auto bo_input = xrt::bo(device, in_len * sizeof(DTYPE), XRT_BO_FLAGS_HOST_ONLY,
+                          kernel.group_id(3));
+  auto bo_output = xrt::bo(device, out_len * sizeof(DTYPE),
+                           XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+
+  DTYPE *buf_input = bo_input.map<DTYPE *>();
+  for (int i = 0; i < in_len; i++)
+    buf_input[i] = i + 1;
+
+  DTYPE *buf_output = bo_output.map<DTYPE *>();
+  memset(buf_output, 0, out_len * sizeof(DTYPE));
+
+  memcpy(bo_instr.map<void *>(), instr_v.data(), instr_v.size() * sizeof(int));
+
+  bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_input.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_output.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned int opcode = 3;
+  auto run = kernel(opcode, bo_instr, instr_v.size(), bo_input, bo_output);
+  ert_cmd_state r = run.wait();
+  if (r != ERT_CMD_STATE_COMPLETED) {
+    std::cout << "Kernel did not complete. Returned status: " << r << "\n";
+    return 1;
+  }
+
+  bo_output.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  // Golden: output is n copies of the input tile.
+  bool pass = true;
+  for (int64_t tile = 0; tile < n; tile++) {
+    for (int i = 0; i < TILE_LEN; i++) {
+      DTYPE expected = buf_input[i];
+      DTYPE got = buf_output[tile * TILE_LEN + i];
+      if (got != expected) {
+        std::cout << "MISMATCH at tile=" << tile << " elem=" << i << ": got "
+                  << got << " expected " << expected << "\n";
+        pass = false;
+      }
+    }
+  }
+
+  std::cout << (pass ? "PASS!" : "FAIL.") << " (n=" << n
+            << ", " << instr_v.size() << " insts)\n";
+  return pass ? 0 : 1;
+}

--- a/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
@@ -3,11 +3,12 @@
 
 // Host for the dynamic (runtime tile-count) ping-pong passthrough. Unlike a
 // static design, the instruction stream is NOT read from an insts.bin: it is
-// built AT RUNTIME by the generated C++ TXN builder (generate_txn_main_sequence,
-// from GEN_HDR) called with the tile count `n` chosen at runtime (argv[1]). That
-// is the whole point of the dynamic BD free-list pool -- one compiled design
-// serves any n. The builder returns std::nullopt if n exceeds the tile's BD
-// pool; we treat that as a build failure.
+// built AT RUNTIME by the generated C++ TXN builder
+// (generate_txn_main_sequence, from GEN_HDR) called with the tile count `n`
+// chosen at runtime (argv[1]). That is the whole point of the dynamic BD
+// free-list pool -- one compiled design serves any n. The builder returns
+// std::nullopt if n exceeds the tile's BD pool; we treat that as a build
+// failure.
 
 #include <algorithm>
 #include <cassert>

--- a/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
+++ b/test/npu-xrt/dynamic_pingpong_passthrough/test.cpp
@@ -115,7 +115,7 @@ int main(int argc, const char *argv[]) {
     }
   }
 
-  std::cout << (pass ? "PASS!" : "FAIL.") << " (n=" << n
-            << ", " << instr_v.size() << " insts)\n";
+  std::cout << (pass ? "PASS!" : "FAIL.") << " (n=" << n << ", "
+            << instr_v.size() << " insts)\n";
   return pass ? 0 : 1;
 }

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -711,6 +711,14 @@ getNpuLoweringPipeline(mlir::MLIRContext *ctx, bool materialize = true) {
   dpm.addPass(X::createAIESubstituteShimDMAAllocationsPass());
   dpm.addPass(X::createAIEUnrollRuntimeSequenceLoopsPass());
   dpm.addPass(mlir::createCanonicalizerPass());
+  // Any runtime-bound scf.for still present here could not be unrolled, so it
+  // takes the dynamic free-list BD pool path (kept rolled, ids drawn at
+  // runtime); this pass rewrites those sequences to pool pop/push and the
+  // static allocator below skips them. Straight-line sequences are untouched
+  // and fall through to the static allocator. Canonicalize drops the now-dead
+  // task-index loop carry the pool pass leaves behind.
+  dpm.addPass(X::createAIELowerDynamicBDPoolPass());
+  dpm.addPass(mlir::createCanonicalizerPass());
   dpm.addPass(X::createAIEAssignRuntimeSequenceBDIDsPass());
   dpm.addPass(X::createAIEDMATasksToNPUPass());
   dpm.addPass(X::createAIEDmaToNpuPass());

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -711,12 +711,9 @@ getNpuLoweringPipeline(mlir::MLIRContext *ctx, bool materialize = true) {
   dpm.addPass(X::createAIESubstituteShimDMAAllocationsPass());
   dpm.addPass(X::createAIEUnrollRuntimeSequenceLoopsPass());
   dpm.addPass(mlir::createCanonicalizerPass());
-  // Any runtime-bound scf.for still present here could not be unrolled, so it
-  // takes the dynamic free-list BD pool path (kept rolled, ids drawn at
-  // runtime); this pass rewrites those sequences to pool pop/push and the
-  // static allocator below skips them. Straight-line sequences are untouched
-  // and fall through to the static allocator. Canonicalize drops the now-dead
-  // task-index loop carry the pool pass leaves behind.
+  // A runtime-bound scf.for that survived unroll takes the dynamic BD pool path
+  // (rewritten to pool pop/push, ids drawn at runtime); the static allocator
+  // below skips it. Straight-line sequences fall through unchanged.
   dpm.addPass(X::createAIELowerDynamicBDPoolPass());
   dpm.addPass(mlir::createCanonicalizerPass());
   dpm.addPass(X::createAIEAssignRuntimeSequenceBDIDsPass());


### PR DESCRIPTION
Part of discussion #3222. Stacks on #3293 (the dynamic BD-word encoder). Delivers the **runtime-bound `scf.for`** portion of milestone **item 8** (dynamic control flow) plus **item 9**'s dynamic passthrough hardware test.

> Note on naming: the `[dyn-seq P6]` commit prefix is an internal landing-sequence label, **not** discussion PR #6 (runtime `repeat_count`, which folded into #3293 as its "may fold into PR 5" note anticipated). This PR is the dynamic BD allocator.

 #3293 made a shim-NOC DMA's sizes/strides/offset/repeat_count runtime-valued, but the **bd_id** was still a compile-time attribute, so a runtime-bound `scf.for` in a runtime sequence had to be fully unrolled. This PR makes the bd_id runtime: the loop stays **rolled**, and each iteration draws a bd_id from a per-tile runtime **free-list pool** — so one compiled binary serves a runtime trip count.

## What's in it

- **Pool ops** `aiex.dma_bd_pool_pop` (→ `i32 bd_id`) / `aiex.dma_bd_pool_push`, and a header-only `BdPool` free-list in `TxnEncoding.h`.
- **Pass `aie-lower-dynamic-bd-pool`**: rewrites a runtime-bound sequence's configure/free/await to pool pop/push and carries the popped id through the `scf.for` iter-args. Runs only when a runtime `scf` survives unroll; straight-line and constant-bound sequences keep the static allocator, byte-identical.
- **Runtime bd_id through the lowering chain**: the shim BD-word encoder and the queue-push command word accept an SSA bd_id (the register address is linear in bd_id, so it lowers to arith over the pool result).
- **End-to-end EmitC path**: a rolled dynamic loop emits as `emitc.for`, and the C++ TXN target emits the pool + a runtime op-count, so the host builds the instruction stream at runtime (`generate_txn_*` returns `std::optional`, `std::nullopt` on pool exhaustion).
- **aiecc routing**: the pass is wired into the default NPU lowering pipeline.

## Scope / limits

- Shim-NOC only; **single-BD tasks** in the dynamic-pool path. Multi-BD chains under a runtime loop need runtime `next_bd` (a P5-level encoder change) and are diagnosed, not mis-lowered — a follow-up.
- `scf.if` (runtime condition) + arbitrary nesting are NOT in this PR — that's the rest of milestone item 8, tracked as https://github.com/Xilinx/mlir-aie/pull/3371. This delivers the `scf.for` (runtime-bound loop) half.
- Peak-liveness can't be checked at compile time for general runtime CF; the backstop is `pop` returning false → builder returns `std::nullopt`. It's an open TODO to improve error handling/error messages.

## Testing
  
- Unit: `BdPool` free-list exhaustion.
- Pass lit: `aie-lower-dynamic-bd-pool` (mixed routing, ping-pong, straight-line untouched, pinned-in-pool + multi-BD rejects).
- Equivalence: `static_vs_dynamic` register-replay — static path byte-identical, rolled-loop / pool-bdid dynamic path matches.
- **Hardware** (`test/npu-xrt/dynamic_pingpong_passthrough`, item 9 passthrough): runtime tile count on real npu2, n = 1, 2, 8. Verified PASS on Strix.

Milestone: https://github.com/Xilinx/mlir-aie/discussions/3222