### PR TITLE
ci: retry on-device read-race failures, not just aie2-4col NPU faults

### DIFF
--- a/.github/workflows/buildAndTestRyzenAI.yml
+++ b/.github/workflows/buildAndTestRyzenAI.yml
@@ -82,16 +82,26 @@ jobs:
 
       - name: Run commands
         run: |
-          # aie2-4col runners occasionally hit a transient NPU hardware fault
-          # (DRM_IOCTL_AMDXDNA_EXEC_CMD I/O error). Re-run the whole step once,
-          # ONLY on aie2-4col when that specific error appears in the output.
+          # Some on-device failures are transient rather than real regressions,
+          # and dropping an otherwise-green PR out of the merge queue for one is
+          # pure noise. Re-run the whole step once when the failure matches a
+          # known transient signature:
+          #   1. aie2-4col NPU hardware fault (DRM_IOCTL_AMDXDNA_EXEC_CMD I/O error).
+          #   2. A host/device read race in an on-device test: an "X != X" result
+          #      mismatch where the observed and reference values are equal. The
+          #      host read an output buffer before the NPU DMA had fully landed;
+          #      by the time the value is printed it has settled. A real logic
+          #      error produces UNEQUAL values and is therefore never retried.
+          # A deterministic regression fails both runs, so the retry only masks
+          # nondeterministic failures.
           if [ -z "$STEP_RETRIED" ]; then
             export STEP_RETRIED=1
             log=$(mktemp)
             bash -eo pipefail "$0" 2>&1 | tee "$log" && exit 0
-            if [ "${{ matrix.runner_type }}" = "aie2-4col" ] && \
-               grep -qF "DRM_IOCTL_AMDXDNA_EXEC_CMD IOCTL failed (err=-5): Input/output error" "$log"; then
-              echo "::warning::Transient NPU fault detected; retrying the step once"
+            if { [ "${{ matrix.runner_type }}" = "aie2-4col" ] && \
+                 grep -qF "DRM_IOCTL_AMDXDNA_EXEC_CMD IOCTL failed (err=-5): Input/output error" "$log"; } || \
+               grep -Pq 'idx [0-9]+: ([0-9]+) != \1\b' "$log"; then
+              echo "::warning::Transient on-device failure detected; retrying the step once"
               exec bash -eo pipefail "$0"
             fi
             exit 1


### PR DESCRIPTION
The Run-commands step already retries once on the transient aie2-4col `DRM_IOCTL_AMDXDNA_EXEC_CMD` I/O fault. This extends the same single-retry to a second transient signature seen on the merge-queue on-device jobs: a host/device read race that surfaces as an `idx N: X != X` mismatch where the observed and reference values are equal, for example `idx 0: 5 != 5` in `add_multi_arg_runlist`.

An equal-value mismatch means the value changed between two reads of the same buffer: the host read the output before the device write had fully landed, and it settled by the time it was printed. A real logic error prints unequal values (and is never retried), so the retry only masks nondeterministic failures. A deterministic regression fails both runs and is always caught.

Discriminator regex: `idx [0-9]+: ([0-9]+) != \1\b`. The backreference requires both sides equal, so it retries `5 != 5` but not `4 != 5`, and the `\b` guards against a false match on `3 != 30`. The read-race check is host-side, so unlike the aie2-4col fault it is not gated on a runner label.

Root cause and permanent fix: I traced this to an unfenced x86 CLFLUSH in the userspace driver's host-only BO sync path, and confirmed on device (controlled A/B on the current driver, races 43 -> 0 with the fence as the only change) that the fence eliminates it. The CI runners lag at XRT 2.21.0, which shows the same equal-value signature. Fix proposed at amd/xdna-driver#1506. This CI change is the interim guard until that fix reaches the runners' installed XRT.
