### PR TITLE
[AIEX] Tighten DMA task op trait from HasAncestor to HasParent for RuntimeSequenceOp

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1075,7 +1075,7 @@ def AIE_NpuLoadPdiOp: AIEX_Op<"npu.load_pdi", []> {
   let hasCanonicalizeMethod = 1;
 }
 
-def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::RuntimeSequenceOp">, TileElement]>, Results<(outs Index:$result)> {
+def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasParent<"AIE::RuntimeSequenceOp">, TileElement]>, Results<(outs Index:$result)> {
   let summary = "Concrete Instantiation of a Buffer Descriptor Chain as a Task on a Channel and Direction on a Tile";
   let description = [{
     Encapsulates the DMA configuration of one task, that is the (chain of) buffer descriptors to be executed on a given channel and direction on a tile.
@@ -1125,7 +1125,7 @@ def AIE_DMAConfigureTaskOp : AIEX_Op<"dma_configure_task", [HasAncestor<"AIE::Ru
   ];
 }
 
-def AIE_DMAConfigureTaskForOp : AIEX_Op<"dma_configure_task_for", [HasAncestor<"AIE::RuntimeSequenceOp">]>, Results<(outs Index:$result)> {
+def AIE_DMAConfigureTaskForOp : AIEX_Op<"dma_configure_task_for", [HasParent<"AIE::RuntimeSequenceOp">]>, Results<(outs Index:$result)> {
   let summary = "As dma_configure_task, but specify tile, direction and channel by reference to a Shim DMA allocation op";
 
   let arguments = (
@@ -1141,7 +1141,7 @@ def AIE_DMAConfigureTaskForOp : AIEX_Op<"dma_configure_task_for", [HasAncestor<"
   let hasVerifier = 1;
 }
 
-def AIE_DMAFreeTaskOp : AIEX_Op<"dma_free_task", [HasAncestor<"AIE::RuntimeSequenceOp">]> {
+def AIE_DMAFreeTaskOp : AIEX_Op<"dma_free_task", [HasParent<"AIE::RuntimeSequenceOp">]> {
   let summary = "Free all Buffer Descriptor IDs Associated with the Given Task";
   let description = [{
     This operation informs the static buffer descriptor allocator pass in the compiler that the buffer descriptor IDs it has allocated to the BDs inside the referenced task can be reused thereafter.
@@ -1165,7 +1165,7 @@ def AIE_DMAFreeTaskOp : AIEX_Op<"dma_free_task", [HasAncestor<"AIE::RuntimeSeque
   }];
 }
 
-def AIE_DMAStartTaskOp : AIEX_Op<"dma_start_task", [HasAncestor<"AIE::RuntimeSequenceOp">]> {
+def AIE_DMAStartTaskOp : AIEX_Op<"dma_start_task", [HasParent<"AIE::RuntimeSequenceOp">]> {
   let summary = "Submit a Preconfigured Task to the Task Queue";
   let description = [{
     Submits the referenced task for execution on the tile, channel and direction it has been configured to run on.
@@ -1189,7 +1189,7 @@ def AIE_DMAStartTaskOp : AIEX_Op<"dma_start_task", [HasAncestor<"AIE::RuntimeSeq
   }];
 }
 
-def AIE_DMAAwaitTaskOp : AIEX_Op<"dma_await_task", [HasAncestor<"AIE::RuntimeSequenceOp">]> {
+def AIE_DMAAwaitTaskOp : AIEX_Op<"dma_await_task", [HasParent<"AIE::RuntimeSequenceOp">]> {
   let summary = "Await Completion of a Previously Submitted DMA Task";
   let description = [{
     This operation will block execution of the runtime sequence until the referenced previously started DMA task has completed.


### PR DESCRIPTION
## Summary

Tightens the MLIR trait constraint on five DMA-related ops in the AIEX dialect from `HasAncestor<"AIE::RuntimeSequenceOp">` to `HasParent<"AIE::RuntimeSequenceOp">`.

## Motivation

`HasAncestor` matches the op anywhere in the IR subtree under a `RuntimeSequenceOp`, allowing these ops to be nested inside other constructs (e.g., `scf.for`, `func.func`) within the runtime sequence. This is almost certainly unintended — these ops should always be immediate children of `RuntimeSequenceOp`.

`HasParent` enforces the correct constraint, matching the pattern used by other runtime-sequence-only ops in the dialect.

## Affected ops

| Op | Old trait | New trait |
|---|---|---|
| `AIE_DMAConfigureTaskOp` | `HasAncestor` | `HasParent` |
| `AIE_DMAConfigureTaskForOp` | `HasAncestor` | `HasParent` |
| `AIE_DMAFreeTaskOp` | `HasAncestor` | `HasParent` |
| `AIE_DMAStartTaskOp` | `HasAncestor` | `HasParent` |
| `AIE_DMAAwaitTaskOp` | `HasAncestor` | `HasParent` |

## Testing

- All existing `check-air-mlir` LIT tests pass locally
- Verified against downstream `mlir-air` LLM inference examples (Llama-3.2, SmolLM2, Qwen2.5, Qwen3) on AMD XDNA 2 NPU hardware (Ryzen AI MAX+ 395)

/cc @samuelbayliss @erwei-wang