### PR TITLE
[AIEX] Add aiex.core_reset runtime-sequence op

### DIFF
--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1441,6 +1441,40 @@ def AIEX_DmaChannelResetOp: AIEX_Op<"dma_channel_reset", [HasParent<"AIE::Runtim
   let hasVerifier = 1;
 }
 
+def AIEX_CoreResetOp: AIEX_Op<"core_reset", [HasParent<"AIE::RuntimeSequenceOp">, SkipAccessibilityCheckTrait]> {
+  let summary = "Reset a compute core from a runtime sequence";
+  let description = [{
+    Pulses the reset bit of the CORE_CONTROL register on the tile at (`column`,
+    `row`). The pulse is two `npu.maskwrite32` writes masked to the reset bit
+    (assert, then deassert), so it preserves the ENABLE field packed in the same
+    CORE_CONTROL word instead of clobbering it. This mirrors aie-rt's
+    XAie_CoreReset followed by XAie_CoreUnreset. The operation is non blocking and
+    offers no synchronization guarantees.
+
+    Resetting clears the core's processor state (program counter and registers);
+    it does not touch the tile's data memory, locks, or DMA. The intended use is
+    re-arming a resident kernel across dispatches without a full PDI reload:
+    discard stale core state while keeping resident data in place. This assumes
+    the resident core is still enabled; re-arming a core that has cleared its
+    ENABLE bit also needs a re-enable, which this op does not emit.
+
+    Only core tiles have a CORE_CONTROL register; mem and shim tiles are rejected
+    by the verifier because they have no core to reset. This matches aie-rt's
+    XAie_CoreReset, which errors on non core tiles.
+
+    Example:
+    ```
+      aiex.core_reset(2, 3)
+    ```
+  }];
+  let arguments = (
+    ins I32Attr:$column,
+        I32Attr:$row
+  );
+  let assemblyFormat = [{ `(` $column `,` $row `)` attr-dict }];
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // ScratchpadParameter ops
 //===----------------------------------------------------------------------===//

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -1444,12 +1444,12 @@ def AIEX_DmaChannelResetOp: AIEX_Op<"dma_channel_reset", [HasParent<"AIE::Runtim
 def AIEX_CoreResetOp: AIEX_Op<"core_reset", [HasParent<"AIE::RuntimeSequenceOp">, SkipAccessibilityCheckTrait]> {
   let summary = "Reset a compute core from a runtime sequence";
   let description = [{
-    Pulses the reset bit of the CORE_CONTROL register on the tile at (`column`,
-    `row`). The pulse is two `npu.maskwrite32` writes masked to the reset bit
-    (assert, then deassert), so it preserves the ENABLE field packed in the same
-    CORE_CONTROL word instead of clobbering it. This mirrors aie-rt's
-    XAie_CoreReset followed by XAie_CoreUnreset. The operation is non blocking and
-    offers no synchronization guarantees.
+    Pulses the reset bit of the CORE_CONTROL register on `tile`. The pulse is two
+    `npu.maskwrite32` writes masked to the reset bit (assert, then deassert), so
+    it preserves the ENABLE field packed in the same CORE_CONTROL word instead of
+    clobbering it. This mirrors aie-rt's XAie_CoreReset followed by
+    XAie_CoreUnreset. The operation is non blocking and offers no synchronization
+    guarantees.
 
     Resetting clears the core's processor state (program counter and registers);
     it does not touch the tile's data memory, locks, or DMA. The intended use is
@@ -1462,16 +1462,27 @@ def AIEX_CoreResetOp: AIEX_Op<"core_reset", [HasParent<"AIE::RuntimeSequenceOp">
     by the verifier because they have no core to reset. This matches aie-rt's
     XAie_CoreReset, which errors on non core tiles.
 
+    `tile` is an SSA `aie.tile` value, so the target is named the same way as
+    `aiex.dma_channel_reset` and `aiex.dma_configure_task`.
+
     Example:
     ```
-      aiex.core_reset(2, 3)
+      %tile = aie.tile(2, 3)
+      aiex.core_reset(%tile)
     ```
   }];
   let arguments = (
-    ins I32Attr:$column,
-        I32Attr:$row
+    ins Index:$tile
   );
-  let assemblyFormat = [{ `(` $column `,` $row `)` attr-dict }];
+  let assemblyFormat = [{ `(` $tile `)` attr-dict }];
+  let extraClassDeclaration = [{
+    AIE::TileOp getTileOp();
+  }];
+  let extraClassDefinition = [{
+    AIE::TileOp CoreResetOp::getTileOp() {
+      return cast<AIE::TileOp>(getTile().getDefiningOp());
+    }
+  }];
   let hasVerifier = 1;
 }
 

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -56,7 +56,6 @@ std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIELowerCoreResetPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIETransformBfpTypesPass();
-std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIELowerSetLockPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIETxnToControlPacketPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -53,6 +53,8 @@ std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIELowerSetLockPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIELowerDmaChannelResetPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
+createAIELowerCoreResetPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIETransformBfpTypesPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>> createAIELowerSetLockPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -365,6 +365,16 @@ def AIELowerDmaChannelReset : Pass<"aie-lower-dma-channel-reset", "AIE::DeviceOp
   ];
 }
 
+def AIELowerCoreReset : Pass<"aie-lower-core-reset", "AIE::DeviceOp"> {
+  let summary = "Lowers all aiex.core_reset operations to npu.maskwrite32";
+  let constructor = "xilinx::AIEX::createAIELowerCoreResetPass()";
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "xilinx::AIE::AIEDialect",
+    "xilinx::AIEX::AIEXDialect",
+  ];
+}
+
 def AIELowerScratchpadParameters : Pass<"aie-lower-scratchpad-parameters", "mlir::ModuleOp"> {
   let summary = "Lower scratchpad parameter ops and emit parameter-sync preambles";
   let description = [{

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -1331,14 +1331,13 @@ LogicalResult AIEX::CoreResetOp::verify() {
   if (targetModel.getTargetArch() == AIE::AIEArch::AIE1)
     return emitOpError("aiex.core_reset is not supported on AIE1.");
 
-  int col = getColumn();
-  int row = getRow();
-  // The column/row are raw attributes, not derived from an aie.tile op, so
-  // nothing else bounds them. Reject coordinates outside the device before they
-  // reach the lowering and emit a write to a nonexistent tile.
-  if (!targetModel.isValidTile(AIE::TileID{col, row}))
-    return emitOpError() << "tile (" << col << ", " << row
-                         << ") is out of range for this device";
+  auto tile = dyn_cast_or_null<AIE::TileOp>(getTile().getDefiningOp());
+  if (!tile)
+    return emitOpError() << "tile operand must be produced by an aie.tile op";
+  int col = tile.getCol();
+  int row = tile.getRow();
+  // The tile coordinates are bounded by aie.tile's own verifier, so this op
+  // does not re-check them for range.
 
   // Only core tiles have a CORE_CONTROL register with a reset bit. Mem and shim
   // tiles have no compute core, so there is nothing valid to lower to. This

--- a/lib/Dialect/AIEX/IR/AIEXDialect.cpp
+++ b/lib/Dialect/AIEX/IR/AIEXDialect.cpp
@@ -1320,6 +1320,39 @@ LogicalResult AIEX::DmaChannelResetOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// CoreResetOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AIEX::CoreResetOp::verify() {
+  const auto &targetModel = AIE::getTargetModel(*this);
+
+  // The op lowers to an NPU control-packet write; the runtime sequence has no
+  // meaning on AIE1. Reject it explicitly, as SetLockOp does.
+  if (targetModel.getTargetArch() == AIE::AIEArch::AIE1)
+    return emitOpError("aiex.core_reset is not supported on AIE1.");
+
+  int col = getColumn();
+  int row = getRow();
+  // The column/row are raw attributes, not derived from an aie.tile op, so
+  // nothing else bounds them. Reject coordinates outside the device before they
+  // reach the lowering and emit a write to a nonexistent tile.
+  if (!targetModel.isValidTile(AIE::TileID{col, row}))
+    return emitOpError() << "tile (" << col << ", " << row
+                         << ") is out of range for this device";
+
+  // Only core tiles have a CORE_CONTROL register with a reset bit. Mem and shim
+  // tiles have no compute core, so there is nothing valid to lower to. This
+  // matches aie-rt's XAie_CoreReset, which errors on any tile that is not an
+  // AIE (core) tile.
+  if (!targetModel.isCoreTile(col, row))
+    return emitOpError() << "tile (" << col << ", " << row
+                         << ") has no core to reset (only core tiles have a "
+                            "CORE_CONTROL register)";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // BlockFloatingPointType
 //===----------------------------------------------------------------------===//
 uint64_t AIEX::BlockFloatType::getTotalSizeInBits() const {

--- a/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
@@ -46,8 +46,9 @@ struct CoreResetToMaskWrite32Pattern : OpConversionPattern<CoreResetOp> {
   LogicalResult
   matchAndRewrite(CoreResetOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    int col = op.getColumn();
-    int row = op.getRow();
+    AIE::TileOp tile = op.getTileOp();
+    int col = tile.getCol();
+    int row = tile.getRow();
 
     Location loc = op.getLoc();
     IntegerAttr colAttr = rewriter.getI32IntegerAttr(col);

--- a/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
@@ -1,4 +1,4 @@
-//===- AIELowerCoreReset.cpp -------------------------------------*- C++ -*-===//
+//===- AIELowerCoreReset.cpp ------------------------------------*- C++ -*-===//
 //
 // Copyright (C) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -58,8 +58,8 @@ struct CoreResetToMaskWrite32Pattern : OpConversionPattern<CoreResetOp> {
     // AIELowerSetLock passes the local lock address with col/row.
     //
     // Reset pulse: assert the reset bit, then clear it. Both writes mask to the
-    // reset bit only, so the pulse preserves the ENABLE field packed in the same
-    // CORE_CONTROL word instead of clobbering it. This mirrors aie-rt's
+    // reset bit only, so the pulse preserves the ENABLE field packed in the
+    // same CORE_CONTROL word instead of clobbering it. This mirrors aie-rt's
     // XAie_CoreReset/XAie_CoreUnreset, which drive the reset bit with a
     // MaskWrite32. Constants are materialized in named locals so the emitted IR
     // order does not depend on unspecified C++ argument-evaluation order.
@@ -72,9 +72,8 @@ struct CoreResetToMaskWrite32Pattern : OpConversionPattern<CoreResetOp> {
     Value clearAddr = createConstantI32(rewriter, loc, kCoreCtrlAddr);
     Value clearVal = createConstantI32(rewriter, loc, 0u);
     Value clearMask = createConstantI32(rewriter, loc, kCoreCtrlResetMask);
-    rewriter.replaceOpWithNewOp<NpuMaskWrite32Op>(op, clearAddr, clearVal,
-                                                  clearMask, nullptr, colAttr,
-                                                  rowAttr);
+    rewriter.replaceOpWithNewOp<NpuMaskWrite32Op>(
+        op, clearAddr, clearVal, clearMask, nullptr, colAttr, rowAttr);
 
     return success();
   };

--- a/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerCoreReset.cpp
@@ -1,0 +1,104 @@
+//===- AIELowerCoreReset.cpp -------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace xilinx::AIEX {
+#define GEN_PASS_DEF_AIELOWERCORERESET
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+} // namespace xilinx::AIEX
+
+#define DEBUG_TYPE "aie-lower-core-reset"
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIE;
+using namespace xilinx::AIEX;
+
+// CORE_CONTROL register, tile-local offset. Uniform across the AIE2 family:
+// XAIE2PGBL_CORE_MODULE_CORE_CONTROL (aie2p) and
+// XAIEMLGBL_CORE_MODULE_CORE_CONTROL (aie2) are both 0x00032000. The op only
+// lowers on core tiles (the verifier rejects mem/shim), which exist on aie2 and
+// aie2p; the npu runtime sequence path is AIE2-only.
+static constexpr uint32_t kCoreCtrlAddr = 0x00032000;
+
+// CORE_CONTROL reset bit (bit 1). Matches
+// XAIE2PGBL_CORE_MODULE_CORE_CONTROL_RESET_MASK. Bit 0 of the same word is
+// ENABLE, which the mask preserves.
+static constexpr uint32_t kCoreCtrlResetMask = 0x2;
+
+struct CoreResetToMaskWrite32Pattern : OpConversionPattern<CoreResetOp> {
+  using OpConversionPattern<CoreResetOp>::OpConversionPattern;
+
+  CoreResetToMaskWrite32Pattern(MLIRContext *context)
+      : OpConversionPattern(context) {}
+
+  LogicalResult
+  matchAndRewrite(CoreResetOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    int col = op.getColumn();
+    int row = op.getRow();
+
+    Location loc = op.getLoc();
+    IntegerAttr colAttr = rewriter.getI32IntegerAttr(col);
+    IntegerAttr rowAttr = rewriter.getI32IntegerAttr(row);
+
+    // NpuMaskWrite32Op re-folds col/row from the attributes, so the address
+    // operand is the tile-local CORE_CONTROL offset, mirroring how
+    // AIELowerSetLock passes the local lock address with col/row.
+    //
+    // Reset pulse: assert the reset bit, then clear it. Both writes mask to the
+    // reset bit only, so the pulse preserves the ENABLE field packed in the same
+    // CORE_CONTROL word instead of clobbering it. This mirrors aie-rt's
+    // XAie_CoreReset/XAie_CoreUnreset, which drive the reset bit with a
+    // MaskWrite32. Constants are materialized in named locals so the emitted IR
+    // order does not depend on unspecified C++ argument-evaluation order.
+    Value assertAddr = createConstantI32(rewriter, loc, kCoreCtrlAddr);
+    Value assertVal = createConstantI32(rewriter, loc, kCoreCtrlResetMask);
+    Value assertMask = createConstantI32(rewriter, loc, kCoreCtrlResetMask);
+    rewriter.create<NpuMaskWrite32Op>(loc, assertAddr, assertVal, assertMask,
+                                      nullptr, colAttr, rowAttr);
+
+    Value clearAddr = createConstantI32(rewriter, loc, kCoreCtrlAddr);
+    Value clearVal = createConstantI32(rewriter, loc, 0u);
+    Value clearMask = createConstantI32(rewriter, loc, kCoreCtrlResetMask);
+    rewriter.replaceOpWithNewOp<NpuMaskWrite32Op>(op, clearAddr, clearVal,
+                                                  clearMask, nullptr, colAttr,
+                                                  rowAttr);
+
+    return success();
+  };
+};
+
+struct AIELowerCoreResetPass
+    : public xilinx::AIEX::impl::AIELowerCoreResetBase<AIELowerCoreResetPass> {
+  void runOnOperation() override {
+    DeviceOp device = getOperation();
+
+    ConversionTarget target(getContext());
+    target.addLegalOp<NpuMaskWrite32Op>();
+    target.addLegalDialect<arith::ArithDialect>();
+    target.addIllegalOp<CoreResetOp>();
+
+    RewritePatternSet patterns(&getContext());
+    patterns.add<CoreResetToMaskWrite32Pattern>(&getContext());
+
+    if (failed(applyPartialConversion(device, target, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+std::unique_ptr<OperationPass<DeviceOp>>
+xilinx::AIEX::createAIELowerCoreResetPass() {
+  return std::make_unique<AIELowerCoreResetPass>();
+}

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIECtrlPacketToDma.cpp
   AIELowerSetLock.cpp
   AIELowerDmaChannelReset.cpp
+  AIELowerCoreReset.cpp
   AIELowerScratchpadParameters.cpp
   AIETransformBfpTypes.cpp
   AIETxnToControlPacket.cpp

--- a/test/Passes/lower-core-reset/core_reset.mlir
+++ b/test/Passes/lower-core-reset/core_reset.mlir
@@ -14,10 +14,13 @@
 // aiex.npu.write32 guards against any stray unmasked write sneaking in. CORE_CONTROL
 // is at tile-local offset 0x32000 = 204800 on every core tile, so the address is
 // the same for every accepted tile and only the column/row attributes change.
+// The target tile is named by an SSA aie.tile value, like aiex.dma_channel_reset.
 // Only core tiles have a core to reset, so those are the only tiles the op accepts
 // (see core_reset_invalid.mlir).
 module {
   aie.device(npu2) {
+    %tile_0_3 = aie.tile(0, 3)
+    %tile_1_2 = aie.tile(1, 2)
     aie.runtime_sequence() {
       // Core tile (0, 3): CORE_CONTROL local 0x32000 = 204800.
       // CHECK: %[[ADDRA:.*]] = arith.constant 204800 : i32
@@ -28,7 +31,7 @@ module {
       // CHECK: %[[CLRA:.*]] = arith.constant 0 : i32
       // CHECK: %[[MASKA2:.*]] = arith.constant 2 : i32
       // CHECK: aiex.npu.maskwrite32(%[[ADDRA2]], %[[CLRA]], %[[MASKA2]]) {column = 0 : i32, row = 3 : i32} : i32, i32, i32
-      aiex.core_reset(0, 3)
+      aiex.core_reset(%tile_0_3)
 
       // A different core tile (1, 2): same CORE_CONTROL address, same reset value
       // and mask, only the column/row attributes change. Value and mask are pinned
@@ -42,7 +45,7 @@ module {
       // CHECK: %[[MASKB2:.*]] = arith.constant 2 : i32
       // CHECK: aiex.npu.maskwrite32(%[[ADDRB2]], %[[CLRB]], %[[MASKB2]]) {column = 1 : i32, row = 2 : i32} : i32, i32, i32
       // CHECK-NOT: aiex.core_reset
-      aiex.core_reset(1, 2)
+      aiex.core_reset(%tile_1_2)
     }
   }
 }
@@ -55,12 +58,13 @@ module {
 // fail here.
 module {
   aie.device(npu1) {
+    %tile_0_3 = aie.tile(0, 3)
     aie.runtime_sequence() {
       // CHECK: %[[ADDRC:.*]] = arith.constant 204800 : i32
       // CHECK: %[[SETC:.*]] = arith.constant 2 : i32
       // CHECK: %[[MASKC:.*]] = arith.constant 2 : i32
       // CHECK: aiex.npu.maskwrite32(%[[ADDRC]], %[[SETC]], %[[MASKC]]) {column = 0 : i32, row = 3 : i32} : i32, i32, i32
-      aiex.core_reset(0, 3)
+      aiex.core_reset(%tile_0_3)
     }
   }
 }

--- a/test/Passes/lower-core-reset/core_reset.mlir
+++ b/test/Passes/lower-core-reset/core_reset.mlir
@@ -1,0 +1,66 @@
+//===- core_reset.mlir -----------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt -split-input-file --aie-lower-core-reset %s | FileCheck %s --implicit-check-not=aiex.npu.write32
+
+// Each aiex.core_reset lowers to a masked reset pulse on the tile's CORE_CONTROL
+// register: set the reset bit (value 0x2, mask 0x2), then clear it (value 0x0,
+// mask 0x2). Masking to bit 1 preserves the ENABLE field (bit 0) packed in the
+// same word instead of clobbering it -- the --implicit-check-not on
+// aiex.npu.write32 guards against any stray unmasked write sneaking in. CORE_CONTROL
+// is at tile-local offset 0x32000 = 204800 on every core tile, so the address is
+// the same for every accepted tile and only the column/row attributes change.
+// Only core tiles have a core to reset, so those are the only tiles the op accepts
+// (see core_reset_invalid.mlir).
+module {
+  aie.device(npu2) {
+    aie.runtime_sequence() {
+      // Core tile (0, 3): CORE_CONTROL local 0x32000 = 204800.
+      // CHECK: %[[ADDRA:.*]] = arith.constant 204800 : i32
+      // CHECK: %[[SETA:.*]] = arith.constant 2 : i32
+      // CHECK: %[[MASKA:.*]] = arith.constant 2 : i32
+      // CHECK: aiex.npu.maskwrite32(%[[ADDRA]], %[[SETA]], %[[MASKA]]) {column = 0 : i32, row = 3 : i32} : i32, i32, i32
+      // CHECK: %[[ADDRA2:.*]] = arith.constant 204800 : i32
+      // CHECK: %[[CLRA:.*]] = arith.constant 0 : i32
+      // CHECK: %[[MASKA2:.*]] = arith.constant 2 : i32
+      // CHECK: aiex.npu.maskwrite32(%[[ADDRA2]], %[[CLRA]], %[[MASKA2]]) {column = 0 : i32, row = 3 : i32} : i32, i32, i32
+      aiex.core_reset(0, 3)
+
+      // A different core tile (1, 2): same CORE_CONTROL address, same reset value
+      // and mask, only the column/row attributes change. Value and mask are pinned
+      // exactly (not wildcards) so a per-tile value/mask bug cannot slip through.
+      // CHECK: %[[ADDRB:.*]] = arith.constant 204800 : i32
+      // CHECK: %[[SETB:.*]] = arith.constant 2 : i32
+      // CHECK: %[[MASKB:.*]] = arith.constant 2 : i32
+      // CHECK: aiex.npu.maskwrite32(%[[ADDRB]], %[[SETB]], %[[MASKB]]) {column = 1 : i32, row = 2 : i32} : i32, i32, i32
+      // CHECK: %[[ADDRB2:.*]] = arith.constant 204800 : i32
+      // CHECK: %[[CLRB:.*]] = arith.constant 0 : i32
+      // CHECK: %[[MASKB2:.*]] = arith.constant 2 : i32
+      // CHECK: aiex.npu.maskwrite32(%[[ADDRB2]], %[[CLRB]], %[[MASKB2]]) {column = 1 : i32, row = 2 : i32} : i32, i32, i32
+      // CHECK-NOT: aiex.core_reset
+      aiex.core_reset(1, 2)
+    }
+  }
+}
+
+// -----
+
+// CORE_CONTROL is at the same 0x32000 offset on npu1 (Phoenix), so the lowering
+// is device-independent across the AIE2 family. This pins the npu1 address so a
+// future change that made the address device-conditional and got npu1 wrong would
+// fail here.
+module {
+  aie.device(npu1) {
+    aie.runtime_sequence() {
+      // CHECK: %[[ADDRC:.*]] = arith.constant 204800 : i32
+      // CHECK: %[[SETC:.*]] = arith.constant 2 : i32
+      // CHECK: %[[MASKC:.*]] = arith.constant 2 : i32
+      // CHECK: aiex.npu.maskwrite32(%[[ADDRC]], %[[SETC]], %[[MASKC]]) {column = 0 : i32, row = 3 : i32} : i32, i32, i32
+      aiex.core_reset(0, 3)
+    }
+  }
+}

--- a/test/Passes/lower-core-reset/core_reset_invalid.mlir
+++ b/test/Passes/lower-core-reset/core_reset_invalid.mlir
@@ -10,11 +10,14 @@
 // A mem tile is rejected: only core tiles have a CORE_CONTROL register with a
 // reset bit. On npu2 row 1 is a mem tile, which has no compute core to reset.
 // This matches aie-rt's XAie_CoreReset, which errors on non core tiles.
+// (An out-of-range coordinate needs no test here: the tile is an SSA aie.tile
+// value, whose own verifier bounds the column/row against the device.)
 module {
   aie.device(npu2) {
+    %mem_tile = aie.tile(0, 1)
     aie.runtime_sequence() {
       // expected-error @+1 {{tile (0, 1) has no core to reset (only core tiles have a CORE_CONTROL register)}}
-      aiex.core_reset(0, 1)
+      aiex.core_reset(%mem_tile)
     }
   }
 }
@@ -25,24 +28,10 @@ module {
 // which has no compute core to reset.
 module {
   aie.device(npu2) {
+    %shim_tile = aie.tile(0, 0)
     aie.runtime_sequence() {
       // expected-error @+1 {{tile (0, 0) has no core to reset (only core tiles have a CORE_CONTROL register)}}
-      aiex.core_reset(0, 0)
-    }
-  }
-}
-
-// -----
-
-// A column past the edge of the array is rejected before it can reach the
-// lowering and emit a write to a nonexistent tile. npu2 has 8 columns (0-7), so
-// column 99 is out of range. The column/row are raw attributes, not derived from
-// an aie.tile op, so the verifier is the only thing that bounds them.
-module {
-  aie.device(npu2) {
-    aie.runtime_sequence() {
-      // expected-error @+1 {{tile (99, 3) is out of range for this device}}
-      aiex.core_reset(99, 3)
+      aiex.core_reset(%shim_tile)
     }
   }
 }
@@ -53,9 +42,10 @@ module {
 // sequence has no meaning on AIE1, matching SetLockOp's AIE1 rejection.
 module {
   aie.device(xcvc1902) {
+    %tile = aie.tile(0, 3)
     aie.runtime_sequence() {
       // expected-error @+1 {{not supported on AIE1}}
-      aiex.core_reset(0, 3)
+      aiex.core_reset(%tile)
     }
   }
 }

--- a/test/Passes/lower-core-reset/core_reset_invalid.mlir
+++ b/test/Passes/lower-core-reset/core_reset_invalid.mlir
@@ -1,0 +1,61 @@
+//===- core_reset_invalid.mlir ---------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt -split-input-file -verify-diagnostics --aie-lower-core-reset %s
+
+// A mem tile is rejected: only core tiles have a CORE_CONTROL register with a
+// reset bit. On npu2 row 1 is a mem tile, which has no compute core to reset.
+// This matches aie-rt's XAie_CoreReset, which errors on non core tiles.
+module {
+  aie.device(npu2) {
+    aie.runtime_sequence() {
+      // expected-error @+1 {{tile (0, 1) has no core to reset (only core tiles have a CORE_CONTROL register)}}
+      aiex.core_reset(0, 1)
+    }
+  }
+}
+
+// -----
+
+// A shim NOC tile is rejected for the same reason: on npu2 row 0 is a shim tile,
+// which has no compute core to reset.
+module {
+  aie.device(npu2) {
+    aie.runtime_sequence() {
+      // expected-error @+1 {{tile (0, 0) has no core to reset (only core tiles have a CORE_CONTROL register)}}
+      aiex.core_reset(0, 0)
+    }
+  }
+}
+
+// -----
+
+// A column past the edge of the array is rejected before it can reach the
+// lowering and emit a write to a nonexistent tile. npu2 has 8 columns (0-7), so
+// column 99 is out of range. The column/row are raw attributes, not derived from
+// an aie.tile op, so the verifier is the only thing that bounds them.
+module {
+  aie.device(npu2) {
+    aie.runtime_sequence() {
+      // expected-error @+1 {{tile (99, 3) is out of range for this device}}
+      aiex.core_reset(99, 3)
+    }
+  }
+}
+
+// -----
+
+// AIE1 is rejected: the op lowers to an NPU control-packet write and the runtime
+// sequence has no meaning on AIE1, matching SetLockOp's AIE1 rejection.
+module {
+  aie.device(xcvc1902) {
+    aie.runtime_sequence() {
+      // expected-error @+1 {{not supported on AIE1}}
+      aiex.core_reset(0, 3)
+    }
+  }
+}

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -741,6 +741,7 @@ getNpuDmaLoweringPipeline(mlir::MLIRContext *ctx) {
   dpm.addPass(X::createAIEDmaToNpuPass());
   dpm.addPass(X::createAIELowerSetLockPass());
   dpm.addPass(X::createAIELowerDmaChannelResetPass());
+  dpm.addPass(X::createAIELowerCoreResetPass());
   return pm;
 }
 


### PR DESCRIPTION

## What this adds

A runtime-sequence op that resets a compute core, lowering to a masked pulse of the CORE_CONTROL register
reset bit (`npu.maskwrite32`). It mirrors `aiex.set_lock`: a non-blocking control op with no synchronization
guarantees, meant to sit inside an `aie.runtime_sequence`.

## Why it is needed

The runtime sequence is the per-dispatch control program. Today it can configure and start DMA transfers,
and it can set a lock (`aiex.set_lock`), but it has no way to reset the compute core. That gap is the reason
for this op.

The motivating case is re-arming a resident kernel across dispatches on aie2p. A core that is started once
and left resident, so its program can run again on the next dispatch without a fresh PDI load, carries its
processor state from the previous dispatch. The heavy way to return it to a known state is a full `load_pdi`
reload of the device image, which re-initializes everything and defeats the point of keeping the core
resident. This op is the scoped alternative: reset just the core, in place, from the control program.

## What the reset does and does not touch

CORE_CONTROL.RESET resets the processor: program counter and registers. It does not clear the tile's data
memory (that is the whole point, the resident data stays put), and it does not touch locks or the tile DMA.
So this op is the core-state half of a dispatch-boundary re-arm; a caller that needs a full clean handshake
also resets the relevant locks (`aiex.set_lock`) and DMA, the same way aie-rt re-initializes those
separately around a core reset. It also assumes the resident core is still enabled: the pulse preserves the
ENABLE bit but does not set it, so a core that has already cleared ENABLE needs a separate re-enable. I have
kept those as separate concerns rather than folding enable/lock/DMA into this one op, so it stays a single
well-defined primitive.

## Why an op rather than a raw write32, and why the pulse is masked

A raw `npu.write32` to CORE_CONTROL works but is opaque, and a plain write of the reset bit would clobber the
rest of the register. CORE_CONTROL packs ENABLE (bit 0) and RESET (bit 1) in one word. So the lowering emits
the reset as two `npu.maskwrite32` writes masked to bit 1 (assert, then deassert), which preserves ENABLE
instead of overwriting it. This mirrors aie-rt's `XAie_CoreReset` and `XAie_CoreUnreset`, which drive the
reset bit with a `MaskWrite32`.

One deliberate difference from the sibling `dma_channel_reset`: that op computes its register address through
the target model (`getDmaControlAddress`), which varies by tile class, channel, and direction. CORE_CONTROL
does not vary, it sits at tile-local offset `0x32000` on every generation (`XAIE2PGBL_CORE_MODULE_CORE_CONTROL`
on aie2p, `XAIEMLGBL_CORE_MODULE_CORE_CONTROL` on aie2, both `0x32000`), and there is no existing
`getCoreControlAddress` on the target model. Rather than add a virtual that returns the same constant for
every override, the lowering uses the constant directly with a comment tying it to the aie-rt register name.
If maintainers would prefer the symmetry with `getDmaControlAddress`, I am happy to add
`getCoreControlAddress(col, row)` to `AIETargetModel` instead.

## Notes for review

1. The verifier accepts only core tiles. It rejects mem and shim tiles (no compute core, matching
   `XAie_CoreReset`, which errors on any non core tile), coordinates outside the device array (the column and
   row are raw attributes, so this is the only thing that bounds them), and AIE1 (the NPU runtime sequence has
   no meaning there, matching `set_lock`).
2. The op takes just (column, row). It resets the whole core, so there is no channel or direction parameter.
3. Verified by lit: a lowering test that checks the masked pulse (value/mask at the CORE_CONTROL address, on
   aie2p and aie2, with `--implicit-check-not` guarding against a stray unmasked write) and an invalid test
   that checks the verifier rejects mem, shim, out-of-range, and AIE1.
4. Validated on device (aie2p / Ryzen AI NPU). Injecting the exact masked pulse this op lowers to onto two
   resident objectFIFO cores resets and restarts them without disturbing the result (a two-stage streaming
   design keeps producing correct output, reproduced). A control that instead clears ENABLE on one of those
   cores breaks the run, which confirms the writes reach the core and that masking the pulse to the reset bit
   (preserving ENABLE) is what keeps it correct. The attr-form `maskwrite32` also survives the full lowering to
   an xclbin, so the op needs no absolute-address form. The one case I did not exercise is a run-once core that
   has cleared ENABLE after reaching Done; re-arming that also needs a re-enable, as the description notes.
5. I am deliberately keeping the higher-level question out of this PR, whether a resident core should carry an
   attribute that emits this reset automatically. That is a lifecycle design question. This PR is the missing
   mechanism.
