### PR TITLE
Remove Lock ID Allocation out of ObjectFIFO pass

### DIFF
--- a/include/aie/Dialect/AIE/IR/AIEOps.td
+++ b/include/aie/Dialect/AIE/IR/AIEOps.td
@@ -1501,8 +1501,8 @@ def AIE_LockOp: AIE_Op<"lock", [
     }
   }];
 
-  let builders = [
-    OpBuilder<(ins "mlir::Value":$tile, "int":$lockID, "int":$init), [{
+  let builders = [OpBuilder<
+                      (ins "mlir::Value":$tile, "int":$lockID, "int":$init), [{
       build($_builder, $_state,
         $_builder.getIndexType(),
         tile,
@@ -1510,8 +1510,16 @@ def AIE_LockOp: AIE_Op<"lock", [
         $_builder.getI32IntegerAttr(init),
         nullptr
       );
-    }]>
-  ];
+    }]>,
+                  OpBuilder<(ins "mlir::Value":$tile, "int":$init), [{
+      build($_builder, $_state,
+        $_builder.getIndexType(),
+        tile,
+        /*lockID=*/nullptr,
+        $_builder.getI32IntegerAttr(init),
+        nullptr
+      );
+    }]>];
   let hasVerifier = 1;
 }
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -59,41 +59,6 @@ static constexpr int SEMAPHORE_CORE_PROD_LOCK_IDX = 0;
 static constexpr int SEMAPHORE_CORE_CONS_LOCK_IDX = 1;
 
 //===----------------------------------------------------------------------===//
-// Lock Analysis
-//===----------------------------------------------------------------------===//
-class LockAnalysis {
-  DenseMap<std::pair<Value, int>, int> locksPerTile;
-
-public:
-  LockAnalysis(DeviceOp &device) {
-    // go over the locks created for each tile and update the index in
-    // locksPerTile
-    device.walk([&](LockOp lockOp) {
-      // A lock without an ID does not reserve a particular ID yet, so it does
-      // not make one unavailable here. AIEAssignLockIDs runs later and gives
-      // it one of the IDs still free on the tile.
-      if (!lockOp.getLockID().has_value())
-        return;
-      auto tile = lockOp.getTile();
-      auto lockID = lockOp.getLockIDValue();
-      locksPerTile[{tile, lockID}] = 1;
-    });
-  }
-
-  /// Given a tile, returns next usable lockID for that tile.
-  int getLockID(TileOp &tileOp) {
-    const auto &targetModel = getTargetModel(tileOp);
-    for (unsigned i = 0;
-         i < targetModel.getNumLocks(tileOp.getCol(), tileOp.getRow()); i++)
-      if (int usageCnt = locksPerTile[{tileOp, i}]; usageCnt == 0) {
-        locksPerTile[{tileOp, i}] = 1;
-        return i;
-      }
-    return -1;
-  }
-};
-
-//===----------------------------------------------------------------------===//
 // DMA Channel Analysis
 //===----------------------------------------------------------------------===//
 class DMAChannelAnalysis {
@@ -736,10 +701,10 @@ struct AIEObjectFifoStatefulTransformPass
   }
 
   /// Function used to create objectFifo locks based on target architecture.
-  /// Called by createObjectFifoElements().
+  /// Called by createObjectFifoElements(). Locks are created without a lock ID;
+  /// AIEAssignLockIDs assigns concrete IDs later in the pipeline.
   std::vector<LockOp>
-  createObjectFifoLocks(OpBuilder &builder, LockAnalysis &lockAnalysis,
-                        ObjectFifoCreateOp op, int numElem,
+  createObjectFifoLocks(OpBuilder &builder, ObjectFifoCreateOp op, int numElem,
                         int joinDistribFactor, TileOp creation_tile,
                         int repeatCount, ObjectFifoState &state) {
     std::vector<LockOp> locks;
@@ -767,10 +732,7 @@ struct AIEObjectFifoStatefulTransformPass
       for (int i = 0; i < numElem; i++) {
         // create corresponding aie1 locks
         int initValue = op.getInitValues().has_value() ? 1 : 0;
-        int lockID = lockAnalysis.getLockID(creation_tile);
-        assert(lockID >= 0 && "No more locks to allocate!");
-        auto lock =
-            LockOp::create(builder, ofLoc, creation_tile, lockID, initValue);
+        auto lock = LockOp::create(builder, ofLoc, creation_tile, initValue);
         lock.getOperation()->setAttr(SymbolTable::getSymbolAttrName(),
                                      builder.getStringAttr(op.name().str() +
                                                            "_lock_" +
@@ -783,11 +745,9 @@ struct AIEObjectFifoStatefulTransformPass
         auto initValues = op.getInitValues().has_value()
                               ? op.getInitValues().value().size()
                               : 0;
-        int prodLockID = lockAnalysis.getLockID(creation_tile);
-        assert(prodLockID >= 0 && "No more locks to allocate!");
         int prodLockValue = (numElem - initValues) * repeatCount;
-        auto prodLock = LockOp::create(builder, ofLoc, creation_tile,
-                                       prodLockID, prodLockValue);
+        auto prodLock =
+            LockOp::create(builder, ofLoc, creation_tile, prodLockValue);
         prodLock.getOperation()->setAttr(
             SymbolTable::getSymbolAttrName(),
             builder.getStringAttr(op.name().str() + "_prod_lock_" +
@@ -796,11 +756,9 @@ struct AIEObjectFifoStatefulTransformPass
                "producer lock must land at SEMAPHORE_CORE_PROD_LOCK_IDX");
         locks.push_back(prodLock);
 
-        int consLockID = lockAnalysis.getLockID(creation_tile);
-        assert(consLockID >= 0 && "No more locks to allocate!");
         int consLockValue = initValues * repeatCount;
-        auto consLock = LockOp::create(builder, ofLoc, creation_tile,
-                                       consLockID, consLockValue);
+        auto consLock =
+            LockOp::create(builder, ofLoc, creation_tile, consLockValue);
         consLock.getOperation()->setAttr(
             SymbolTable::getSymbolAttrName(),
             builder.getStringAttr(op.name().str() + "_cons_lock_" +
@@ -943,9 +901,8 @@ struct AIEObjectFifoStatefulTransformPass
 
   /// Function used to create objectFifo elements and their locks.
   /// It maps the input objectFifo to associated buffers and locks.
-  void createObjectFifoElements(OpBuilder &builder, LockAnalysis &lockAnalysis,
-                                ObjectFifoCreateOp op, int share_direction,
-                                ObjectFifoState &state) {
+  void createObjectFifoElements(OpBuilder &builder, ObjectFifoCreateOp op,
+                                int share_direction, ObjectFifoState &state) {
     if (!op.size())
       return;
 
@@ -1157,9 +1114,9 @@ struct AIEObjectFifoStatefulTransformPass
         joinDistribFactor *= linkOp->getFifoIns().size();
       state.objFifoLinks[*linkOp] = op;
     }
-    std::vector<LockOp> locks = createObjectFifoLocks(
-        builder, lockAnalysis, op, numElem, joinDistribFactor, creation_tile,
-        repeatCount, state);
+    std::vector<LockOp> locks =
+        createObjectFifoLocks(builder, op, numElem, joinDistribFactor,
+                              creation_tile, repeatCount, state);
     state.buffersPerFifo[op] = buffers;
     state.locksPerFifo[op] = locks;
   }
@@ -2264,7 +2221,6 @@ struct AIEObjectFifoStatefulTransformPass
     // multi-device safety
     ObjectFifoState state;
 
-    LockAnalysis lockAnalysis(device);
     DMAChannelAnalysis dmaAnalysis(device);
     OpBuilder builder = OpBuilder::atBlockTerminator(device.getBody());
     auto *ctx = device->getContext();
@@ -2459,8 +2415,7 @@ struct AIEObjectFifoStatefulTransformPass
 
       // if split, the necessary size for producer fifo might change
       if (shared) {
-        createObjectFifoElements(builder, lockAnalysis, createOp,
-                                 share_direction, state);
+        createObjectFifoElements(builder, createOp, share_direction, state);
       } else {
         if (isa<ArrayAttr>(createOp.getElemNumber()))
           createOp.setElemNumberAttr(
@@ -2474,8 +2429,7 @@ struct AIEObjectFifoStatefulTransformPass
                 builder.getI32IntegerAttr(prodMaxAcquire));
           }
         }
-        createObjectFifoElements(builder, lockAnalysis, createOp,
-                                 share_direction, state);
+        createObjectFifoElements(builder, createOp, share_direction, state);
       }
     }
 

--- a/test/Passes/lower-dma-channel-reset/dma_channel_reset_for_pipeline.mlir
+++ b/test/Passes/lower-dma-channel-reset/dma_channel_reset_for_pipeline.mlir
@@ -12,7 +12,7 @@
 // to the reset + set_lock + START_QUEUE trio. This is the path a lit test that
 // runs the lowering pass in isolation does NOT exercise.
 
-// RUN: aie-opt --aie-objectFifo-stateful-transform --aie-assign-bd-ids \
+// RUN: aie-opt --aie-objectFifo-stateful-transform --aie-assign-lock-ids --aie-assign-bd-ids \
 // RUN:   --aie-materialize-runtime-sequences --aie-lower-dma-channel-reset \
 // RUN:   --aie-dma-to-npu --aie-lower-set-lock \
 // RUN:   %s | FileCheck %s

--- a/test/assign-buffer-addresses/fallback_routine_simple.mlir
+++ b/test/assign-buffer-addresses/fallback_routine_simple.mlir
@@ -28,10 +28,10 @@
 // CHECK:       %act_3_4_buff_1 = aie.buffer(%tile_1_2) {address = 16448 : i32, sym_name = "act_3_4_buff_1"} : memref<8xi32>
 // CHECK:       %act_3_4_buff_2 = aie.buffer(%tile_1_2) {address = 16480 : i32, sym_name = "act_3_4_buff_2"} : memref<8xi32>
 // CHECK:       %act_3_4_buff_3 = aie.buffer(%tile_1_2) {address = 16512 : i32, sym_name = "act_3_4_buff_3"} : memref<8xi32>
-// CHECK:       %act_3_4_lock_0 = aie.lock(%tile_1_2, 0) {init = 0 : i32, sym_name = "act_3_4_lock_0"}
-// CHECK:       %act_3_4_lock_1 = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "act_3_4_lock_1"}
-// CHECK:       %act_3_4_lock_2 = aie.lock(%tile_1_2, 2) {init = 0 : i32, sym_name = "act_3_4_lock_2"}
-// CHECK:       %act_3_4_lock_3 = aie.lock(%tile_1_2, 3) {init = 0 : i32, sym_name = "act_3_4_lock_3"}
+// CHECK:       %act_3_4_lock_0 = aie.lock(%tile_1_2) {init = 0 : i32, sym_name = "act_3_4_lock_0"}
+// CHECK:       %act_3_4_lock_1 = aie.lock(%tile_1_2) {init = 0 : i32, sym_name = "act_3_4_lock_1"}
+// CHECK:       %act_3_4_lock_2 = aie.lock(%tile_1_2) {init = 0 : i32, sym_name = "act_3_4_lock_2"}
+// CHECK:       %act_3_4_lock_3 = aie.lock(%tile_1_2) {init = 0 : i32, sym_name = "act_3_4_lock_3"}
 // CHECK:     }
 // CHECK:   }
 

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_L1.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_L1.mlir
@@ -14,8 +14,8 @@
 // CHECK:   aie.device(xcve2302) {
 // CHECK:     %[[t0:.*]] = aie.tile(2, 2)
 // CHECK:     %[[t1:.*]] = aie.tile(2, 3)
-// CHECK:     %[[PL:.*]] = aie.lock(%[[t0]], 0) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:     %[[CL:.*]] = aie.lock(%[[t0]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:     %[[PL:.*]] = aie.lock(%[[t0]]) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:     %[[CL:.*]] = aie.lock(%[[t0]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:     %[[c0:.*]] = aie.core(%[[t0]]) {
 // CHECK:       %[[C1:.*]] = arith.constant 1 : i32
 // CHECK:       aie.use_lock(%[[PL]], AcquireGreaterEqual, %[[C1]])

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_L1_dynamic.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_L1_dynamic.mlir
@@ -23,8 +23,8 @@
 // CHECK:           %[[B1:.*]] = aie.buffer(%[[T22]]) {sym_name = "fifo_buff_1"} : memref<i32>
 // CHECK:           %[[B2:.*]] = aie.buffer(%[[T22]]) {sym_name = "fifo_buff_2"} : memref<i32>
 // CHECK:           %[[B3:.*]] = aie.buffer(%[[T22]]) {sym_name = "fifo_buff_3"} : memref<i32>
-// CHECK:           %[[PROD:.*]] = aie.lock(%[[T22]], 0) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:           %[[CONS:.*]] = aie.lock(%[[T22]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:           %[[PROD:.*]] = aie.lock(%[[T22]]) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:           %[[CONS:.*]] = aie.lock(%[[T22]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:           %[[BUF23:.*]] = aie.buffer(%[[T23]]) {sym_name = "buf23"} : memref<4xi32>
 // CHECK:           %{{.*}} = aie.core(%[[T22]]) {
 // CHECK:             %[[C1I:.*]] = arith.constant 1 : i32

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_L2.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_L2.mlir
@@ -44,8 +44,8 @@
 // CHECK:     %[[fifo1_cons_buff_1:.*]] = aie.buffer(%[[t2]]) {sym_name = "fifo1_cons_buff_1"} : memref<1xi32>
 // CHECK:     %[[fifo1_cons_buff_2:.*]] = aie.buffer(%[[t2]]) {sym_name = "fifo1_cons_buff_2"} : memref<1xi32>
 // CHECK:     %[[fifo1_cons_buff_3:.*]] = aie.buffer(%[[t2]]) {sym_name = "fifo1_cons_buff_3"} : memref<1xi32>
-// CHECK:     %[[fifo1_cons_prod_lock:.*]] = aie.lock(%[[t2]], 0) {init = 4 : i32, sym_name = "fifo1_cons_prod_lock_0"}
-// CHECK:     %[[fifo1_cons_cons_lock:.*]] = aie.lock(%[[t2]], 1) {init = 0 : i32, sym_name = "fifo1_cons_cons_lock_0"}
+// CHECK:     %[[fifo1_cons_prod_lock:.*]] = aie.lock(%[[t2]]) {init = 4 : i32, sym_name = "fifo1_cons_prod_lock_0"}
+// CHECK:     %[[fifo1_cons_cons_lock:.*]] = aie.lock(%[[t2]]) {init = 0 : i32, sym_name = "fifo1_cons_cons_lock_0"}
 
 // The consume buffers are used at the receiving end of a stream to notify the
 // sender to send more objects once they have been consumed. In this case,
@@ -55,8 +55,8 @@
 // CHECK:     %[[fifo0_cons_buff_2:.*]] = aie.buffer(%[[t1]]) {sym_name = "fifo0_cons_buff_2"} : memref<1xi32>
 // CHECK:     %[[fifo0_cons_buff_3:.*]] = aie.buffer(%[[t1]]) {sym_name = "fifo0_cons_buff_3"} : memref<1xi32>
 
-// CHECK:     %[[fifo0_cons_prod_lock:.*]] = aie.lock(%[[t1]], 0) {init = 4 : i32, sym_name = "fifo0_cons_prod_lock_0"}
-// CHECK:     %[[fifo0_cons_cons_lock:.*]] = aie.lock(%[[t1]], 1) {init = 0 : i32, sym_name = "fifo0_cons_cons_lock_0"}
+// CHECK:     %[[fifo0_cons_prod_lock:.*]] = aie.lock(%[[t1]]) {init = 4 : i32, sym_name = "fifo0_cons_prod_lock_0"}
+// CHECK:     %[[fifo0_cons_cons_lock:.*]] = aie.lock(%[[t1]]) {init = 0 : i32, sym_name = "fifo0_cons_cons_lock_0"}
 
 // The objectFifo lowering creates two buffers (for ping-pong) on the producer
 // side to which elements are written.
@@ -65,11 +65,11 @@
 
 // Whenever the prod lock can be acquired, the core can proceed to put another
 // object into the fifo, i.e. there is space in the queue.
-// CHECK:     %[[fifo0_prod_lock:.*]] = aie.lock(%[[t0]], 0) {init = 2 : i32, sym_name = "fifo0_prod_lock_0"}
+// CHECK:     %[[fifo0_prod_lock:.*]] = aie.lock(%[[t0]]) {init = 2 : i32, sym_name = "fifo0_prod_lock_0"}
 
 // Whenever the cons lock can be acquired, there is an object available in the
 // queue to be consumed.
-// CHECK:     %[[fifo0_cons_lock:.*]] = aie.lock(%[[t0]], 1) {init = 0 : i32, sym_name = "fifo0_cons_lock_0"}
+// CHECK:     %[[fifo0_cons_lock:.*]] = aie.lock(%[[t0]]) {init = 0 : i32, sym_name = "fifo0_cons_lock_0"}
 
 // CHECK:     %[[buf83:.*]] = aie.buffer(%[[t2]]) {sym_name = "buf83"} : memref<1xi32>
 

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_dma.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_cyclostatic_dma.mlir
@@ -16,12 +16,12 @@
 // CHECK:     %[[buf1_0:.*]] = aie.buffer(%[[t1]]) {sym_name = "fifo_cons_buff_0"} : memref<i32>
 // CHECK:     %[[buf1_1:.*]] = aie.buffer(%[[t1]]) {sym_name = "fifo_cons_buff_1"} : memref<i32>
 // CHECK:     %[[buf1_2:.*]] = aie.buffer(%[[t1]]) {sym_name = "fifo_cons_buff_2"} : memref<i32>
-// CHECK:     %[[C_PL:.*]] = aie.lock(%[[t1]], 0) {init = 3 : i32, sym_name = "fifo_cons_prod_lock_0"}
-// CHECK:     %[[C_CL:.*]] = aie.lock(%[[t1]], 1) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
+// CHECK:     %[[C_PL:.*]] = aie.lock(%[[t1]]) {init = 3 : i32, sym_name = "fifo_cons_prod_lock_0"}
+// CHECK:     %[[C_CL:.*]] = aie.lock(%[[t1]]) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
 // CHECK:     %[[buf0_0:.*]] = aie.buffer(%[[t0]]) {sym_name = "fifo_buff_0"} : memref<i32>
 // CHECK:     %[[buf0_1:.*]] = aie.buffer(%[[t0]]) {sym_name = "fifo_buff_1"} : memref<i32>
-// CHECK:     %[[PL:.*]] = aie.lock(%[[t0]], 0) {init = 2 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:     %[[CL:.*]] = aie.lock(%[[t0]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:     %[[PL:.*]] = aie.lock(%[[t0]]) {init = 2 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:     %[[CL:.*]] = aie.lock(%[[t0]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:     aie.flow(%[[t0]], DMA : 0, %[[t1]], DMA : 0)
 // CHECK:     %[[c0:.*]] = aie.core(%[[t0]]) {
 // CHECK:       aie.use_lock(%[[PL]], AcquireGreaterEqual, %{{.*}})

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_delayed_release.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_delayed_release.mlir
@@ -35,8 +35,8 @@
 // CHECK:     %[[fifo_buff_1:.*]] = aie.buffer(%[[tile0]]) {sym_name = "fifo_buff_1"} : memref<i32>
 // CHECK:     %[[fifo_buff_2:.*]] = aie.buffer(%[[tile0]]) {sym_name = "fifo_buff_2"} : memref<i32>
 // CHECK:     %[[fifo_buff_3:.*]] = aie.buffer(%[[tile0]]) {sym_name = "fifo_buff_3"} : memref<i32>
-// CHECK:     %[[fifo_prod_lock:.*]] = aie.lock(%[[tile0]], 0) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:     %[[fifo_cons_lock:.*]] = aie.lock(%[[tile0]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:     %[[fifo_prod_lock:.*]] = aie.lock(%[[tile0]]) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:     %[[fifo_cons_lock:.*]] = aie.lock(%[[tile0]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:     %[[buf23:.*]] = aie.buffer(%[[tile1]]) {sym_name = "buf23"} : memref<4xi32>
 // CHECK:     %[[core0:.*]] = aie.core(%[[tile0]]) {
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : i32

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_dynamic_locks.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_dynamic_locks.mlir
@@ -34,11 +34,11 @@
 
 // The setup for flows, locks, and buffers can be the same in the dynamic case:
 // CHECK:     %[[fifo_buff_0:.*]] = aie.buffer(%[[tile23]]) {sym_name = "fifo_buff_0"} : memref<i64>
-// CHECK:     %[[fifo_prod_lock:.*]] = aie.lock(%[[tile23]], 0) {init = 1 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:     %[[fifo_cons_lock:.*]] = aie.lock(%[[tile23]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:     %[[fifo_prod_lock:.*]] = aie.lock(%[[tile23]]) {init = 1 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:     %[[fifo_cons_lock:.*]] = aie.lock(%[[tile23]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:     %[[fifo_cons_buff_0:.*]] = aie.buffer(%[[tile43]]) {sym_name = "fifo_cons_buff_0"} : memref<i64>
-// CHECK:     %[[fifo_cons_prod_lock:.*]] = aie.lock(%[[tile43]], 0) {init = 1 : i32, sym_name = "fifo_cons_prod_lock_0"}
-// CHECK:     %[[fifo_cons_cons_lock:.*]] = aie.lock(%[[tile43]], 1) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
+// CHECK:     %[[fifo_cons_prod_lock:.*]] = aie.lock(%[[tile43]]) {init = 1 : i32, sym_name = "fifo_cons_prod_lock_0"}
+// CHECK:     %[[fifo_cons_cons_lock:.*]] = aie.lock(%[[tile43]]) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
 // CHECK:     aie.flow(%[[tile23]], DMA : 0, %[[tile43]], DMA : 0)
 
 // CHECK:     %[[ssa8:.*]] = aie.core(%[[tile23]]) {

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_single_multiple_release.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_single_multiple_release.mlir
@@ -13,13 +13,13 @@
 // CHECK:      %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
 // CHECK:      %[[VAL_4:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
 // CHECK:      %[[VAL_5:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of2_cons_buff_2"} : memref<16xi32>
-// CHECK:      %[[VAL_6:.*]] = aie.lock(%[[VAL_2]], 0) {init = 3 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK:      %[[VAL_7:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK:      %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 3 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK:      %[[VAL_7:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 // CHECK:      %[[VAL_10:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_cons_buff_0"} : memref<16xi32>
 // CHECK:      %[[VAL_11:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_cons_buff_1"} : memref<16xi32>
 // CHECK:      %[[VAL_12:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_cons_buff_2"} : memref<16xi32>
-// CHECK:      %[[VAL_13:.*]] = aie.lock(%[[VAL_1]], 0) {init = 3 : i32, sym_name = "of_cons_prod_lock_0"}
-// CHECK:      %[[VAL_14:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_cons_cons_lock_0"}
+// CHECK:      %[[VAL_13:.*]] = aie.lock(%[[VAL_1]]) {init = 3 : i32, sym_name = "of_cons_prod_lock_0"}
+// CHECK:      %[[VAL_14:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_cons_cons_lock_0"}
 // CHECK:      aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:      aie.flow(%[[VAL_0]], DMA : 1, %[[VAL_2]], DMA : 0)
 // CHECK:      func.func @some_work(%arg0: memref<16xi32>) {

--- a/test/objectFifo-stateful-transform/access_patterns/AIE2_static_L1.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/AIE2_static_L1.mlir
@@ -17,8 +17,8 @@
 
 // CHECK:     %[[t0:.*]] = aie.tile(2, 2)
 // CHECK:     %[[t1:.*]] = aie.tile(2, 3)
-// CHECK:     %[[PL:.*]] = aie.lock(%[[t0]], 0) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:     %[[CL:.*]] = aie.lock(%[[t0]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:     %[[PL:.*]] = aie.lock(%[[t0]]) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:     %[[CL:.*]] = aie.lock(%[[t0]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:     %[[c0:.*]] = aie.core(%[[t0]]) {
 // CHECK:         %[[C1:.*]] = arith.constant 1 : i32
 // CHECK:         aie.use_lock(%[[PL]], AcquireGreaterEqual, %[[C1]])

--- a/test/objectFifo-stateful-transform/access_patterns/cyclostatic_AIE2_sharedMem.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/cyclostatic_AIE2_sharedMem.mlir
@@ -16,8 +16,8 @@
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "fifo0_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "fifo0_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "fifo0_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 0) {init = 4 : i32, sym_name = "fifo0_prod_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "fifo0_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 4 : i32, sym_name = "fifo0_prod_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "fifo0_cons_lock_0"}
 // Producer: shared-mem semaphore-lock producer, fully unrolled x4 (+1 remainder)
 // storing to buff0..3 in rotation; each push acquires 1 prod / releases 1 cons.
 // CHECK:           %[[VAL_8:.*]] = aie.core(%[[VAL_0]]) {

--- a/test/objectFifo-stateful-transform/access_patterns/same_core_producer_consumer_test.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/same_core_producer_consumer_test.mlir
@@ -14,8 +14,8 @@
 // CHECK:           %[[VAL_1:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_0]], 0) {init = 3 : i32, sym_name = "of_prod_lock_0"}
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_cons_lock_0"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_0]]) {init = 3 : i32, sym_name = "of_prod_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_cons_lock_0"}
 // CHECK:           func.func @some_work(%[[VAL_6:.*]]: memref<16xi32>) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/access_patterns/subview_test_1.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/subview_test_1.mlir
@@ -16,10 +16,10 @@
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "objfifo_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "objfifo_lock_1"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "objfifo_lock_2"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "objfifo_lock_3"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_1"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_2"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_3"}
 // CHECK:           func.func @some_work(%[[VAL_10:.*]]: memref<16xi32>) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/access_patterns/subview_test_2.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/subview_test_2.mlir
@@ -16,17 +16,17 @@
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of2_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of2_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of2_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]], 4) {init = 0 : i32, sym_name = "of2_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 5) {init = 0 : i32, sym_name = "of2_lock_1"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 6) {init = 0 : i32, sym_name = "of2_lock_2"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of2_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of2_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of2_lock_2"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_lock_1"}
-// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "of_lock_2"}
-// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "of_lock_3"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_1"}
+// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_2"}
+// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_3"}
 // CHECK:           func.func @some_work(%[[VAL_16:.*]]: memref<16xi32>) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/access_patterns/subview_test_3.mlir
+++ b/test/objectFifo-stateful-transform/access_patterns/subview_test_3.mlir
@@ -16,17 +16,17 @@
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of2_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of2_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of2_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "of2_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of2_lock_1"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]], 2) {init = 0 : i32, sym_name = "of2_lock_2"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of2_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of2_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of2_lock_2"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_lock_1"}
-// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "of_lock_2"}
-// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "of_lock_3"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_1"}
+// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_2"}
+// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_lock_3"}
 // CHECK:           func.func @some_work(%[[VAL_16:.*]]: memref<16xi32>) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/adjacent_memtile_allocation/onelargefifo_on_2memtile.mlir
+++ b/test/objectFifo-stateful-transform/adjacent_memtile_allocation/onelargefifo_on_2memtile.mlir
@@ -13,20 +13,20 @@
 // CHECK-DAG:     %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK-DAG:     %[[OUT1_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE_0_1]]) {sym_name = "out1_cons_buff_0"} : memref<8xi32>
 // CHECK-DAG:     %[[OUT1_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE_0_1]]) {sym_name = "out1_cons_buff_1"} : memref<8xi32>
-// CHECK-DAG:     %[[OUT1_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 2) {init = 2 : i32, sym_name = "out1_cons_prod_lock_0"}
-// CHECK-DAG:     %[[OUT1_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 3) {init = 0 : i32, sym_name = "out1_cons_cons_lock_0"}
+// CHECK-DAG:     %[[OUT1_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 2 : i32, sym_name = "out1_cons_prod_lock_0"}
+// CHECK-DAG:     %[[OUT1_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 0 : i32, sym_name = "out1_cons_cons_lock_0"}
 // CHECK-DAG:     %[[OUT1_BUFF_0:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "out1_buff_0"} : memref<8xi32>
 // CHECK-DAG:     %[[OUT1_BUFF_1:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "out1_buff_1"} : memref<8xi32>
-// CHECK-DAG:     %[[OUT1_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 2) {init = 2 : i32, sym_name = "out1_prod_lock_0"}
-// CHECK-DAG:     %[[OUT1_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 3) {init = 0 : i32, sym_name = "out1_cons_lock_0"}
+// CHECK-DAG:     %[[OUT1_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 2 : i32, sym_name = "out1_prod_lock_0"}
+// CHECK-DAG:     %[[OUT1_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 0 : i32, sym_name = "out1_cons_lock_0"}
 // CHECK-DAG:     %[[IN1_CONS_BUFF_0:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "in1_cons_buff_0"} : memref<8xi32>
 // CHECK-DAG:     %[[IN1_CONS_BUFF_1:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "in1_cons_buff_1"} : memref<8xi32>
-// CHECK-DAG:     %[[IN1_CONS_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 0) {init = 2 : i32, sym_name = "in1_cons_prod_lock_0"}
-// CHECK-DAG:     %[[IN1_CONS_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 1) {init = 0 : i32, sym_name = "in1_cons_cons_lock_0"}
+// CHECK-DAG:     %[[IN1_CONS_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 2 : i32, sym_name = "in1_cons_prod_lock_0"}
+// CHECK-DAG:     %[[IN1_CONS_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 0 : i32, sym_name = "in1_cons_cons_lock_0"}
 // CHECK-DAG:     %[[IN0_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE_0_1]]) {sym_name = "in0_cons_buff_0"} : memref<96000xi32>
 // CHECK-DAG:     %[[IN0_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE_1_1]]) {sym_name = "in0_cons_buff_1"} : memref<96000xi32>
-// CHECK-DAG:     %[[IN0_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 0) {init = 2 : i32, sym_name = "in0_cons_prod_lock_0"}
-// CHECK-DAG:     %[[IN0_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 1) {init = 0 : i32, sym_name = "in0_cons_cons_lock_0"}
+// CHECK-DAG:     %[[IN0_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 2 : i32, sym_name = "in0_cons_prod_lock_0"}
+// CHECK-DAG:     %[[IN0_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 0 : i32, sym_name = "in0_cons_cons_lock_0"}
 // CHECK:     aie.flow(%[[SHIM_NOC_TILE_0_0]], DMA : 0, %[[MEM_TILE_0_1]], DMA : 0)
 // CHECK:     aie.flow(%[[MEM_TILE_0_1]], DMA : 0, %[[TILE_0_2]], DMA : 0)
 // CHECK:     aie.flow(%[[MEM_TILE_0_1]], DMA : 1, %[[SHIM_NOC_TILE_0_0]], DMA : 0)

--- a/test/objectFifo-stateful-transform/adjacent_memtile_allocation/onelargefifo_on_3memtile.mlir
+++ b/test/objectFifo-stateful-transform/adjacent_memtile_allocation/onelargefifo_on_3memtile.mlir
@@ -14,21 +14,21 @@
 // CHECK-DAG: %[[TILE_1_2:.*]] = aie.tile(1, 2)
 // CHECK-DAG: %[[OUT1_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE_1_1]]) {sym_name = "out1_cons_buff_0"} : memref<8xi32>
 // CHECK-DAG: %[[OUT1_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE_1_1]]) {sym_name = "out1_cons_buff_1"} : memref<8xi32>
-// CHECK-DAG: %[[OUT1_CONS_PROD_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]], 2) {init = 2 : i32, sym_name = "out1_cons_prod_lock_0"}
-// CHECK-DAG: %[[OUT1_CONS_CONS_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]], 3) {init = 0 : i32, sym_name = "out1_cons_cons_lock_0"}
+// CHECK-DAG: %[[OUT1_CONS_PROD_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]]) {init = 2 : i32, sym_name = "out1_cons_prod_lock_0"}
+// CHECK-DAG: %[[OUT1_CONS_CONS_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]]) {init = 0 : i32, sym_name = "out1_cons_cons_lock_0"}
 // CHECK-DAG: %[[OUT1_BUFF_0:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "out1_buff_0"} : memref<8xi32>
 // CHECK-DAG: %[[OUT1_BUFF_1:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "out1_buff_1"} : memref<8xi32>
-// CHECK-DAG: %[[OUT1_PROD_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]], 2) {init = 2 : i32, sym_name = "out1_prod_lock_0"}
-// CHECK-DAG: %[[OUT1_CONS_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]], 3) {init = 0 : i32, sym_name = "out1_cons_lock_0"}
+// CHECK-DAG: %[[OUT1_PROD_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]]) {init = 2 : i32, sym_name = "out1_prod_lock_0"}
+// CHECK-DAG: %[[OUT1_CONS_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]]) {init = 0 : i32, sym_name = "out1_cons_lock_0"}
 // CHECK-DAG: %[[IN1_CONS_BUFF_0:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "in1_cons_buff_0"} : memref<8xi32>
 // CHECK-DAG: %[[IN1_CONS_BUFF_1:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "in1_cons_buff_1"} : memref<8xi32>
-// CHECK-DAG: %[[IN1_CONS_PROD_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]], 0) {init = 2 : i32, sym_name = "in1_cons_prod_lock_0"}
-// CHECK-DAG: %[[IN1_CONS_CONS_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]], 1) {init = 0 : i32, sym_name = "in1_cons_cons_lock_0"}
+// CHECK-DAG: %[[IN1_CONS_PROD_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]]) {init = 2 : i32, sym_name = "in1_cons_prod_lock_0"}
+// CHECK-DAG: %[[IN1_CONS_CONS_LOCK_0:.*]] = aie.lock(%[[TILE_1_2]]) {init = 0 : i32, sym_name = "in1_cons_cons_lock_0"}
 // CHECK-DAG: %[[IN0_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE_1_1]]) {sym_name = "in0_cons_buff_0"} : memref<96000xi32>
 // CHECK-DAG: %[[IN0_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE_0_1]]) {sym_name = "in0_cons_buff_1"} : memref<96000xi32>
 // CHECK-DAG: %[[IN0_CONS_BUFF_2:.*]] = aie.buffer(%[[MEM_TILE_2_1]]) {sym_name = "in0_cons_buff_2"} : memref<96000xi32>
-// CHECK-DAG: %[[IN0_CONS_PROD_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]], 0) {init = 3 : i32, sym_name = "in0_cons_prod_lock_0"}
-// CHECK-DAG: %[[IN0_CONS_CONS_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]], 1) {init = 0 : i32, sym_name = "in0_cons_cons_lock_0"}
+// CHECK-DAG: %[[IN0_CONS_PROD_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]]) {init = 3 : i32, sym_name = "in0_cons_prod_lock_0"}
+// CHECK-DAG: %[[IN0_CONS_CONS_LOCK_0:.*]] = aie.lock(%[[MEM_TILE_1_1]]) {init = 0 : i32, sym_name = "in0_cons_cons_lock_0"}
 // CHECK: aie.flow(%[[SHIM_NOC_TILE_1_0]], DMA : 0, %[[MEM_TILE_1_1]], DMA : 0)
 // CHECK: aie.flow(%[[MEM_TILE_1_1]], DMA : 0, %[[TILE_1_2]], DMA : 0)
 // CHECK: aie.flow(%[[MEM_TILE_1_1]], DMA : 1, %[[SHIM_NOC_TILE_1_0]], DMA : 0)

--- a/test/objectFifo-stateful-transform/adjacent_memtile_allocation/twofifo_on_2memtile.mlir
+++ b/test/objectFifo-stateful-transform/adjacent_memtile_allocation/twofifo_on_2memtile.mlir
@@ -13,20 +13,20 @@
 // CHECK-DAG:     %[[TILE_0_2:.*]] = aie.tile(0, 2)
 // CHECK-DAG:     %[[OUT1_BUFF_0:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "out1_buff_0"} : memref<8xi32>
 // CHECK-DAG:     %[[OUT1_BUFF_1:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "out1_buff_1"} : memref<8xi32>
-// CHECK-DAG:     %[[OUT1_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 2) {init = 2 : i32, sym_name = "out1_prod_lock_0"}
-// CHECK-DAG:     %[[OUT1_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 3) {init = 0 : i32, sym_name = "out1_cons_lock_0"}
+// CHECK-DAG:     %[[OUT1_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 2 : i32, sym_name = "out1_prod_lock_0"}
+// CHECK-DAG:     %[[OUT1_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 0 : i32, sym_name = "out1_cons_lock_0"}
 // CHECK-DAG:     %[[OUT0_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE_1_1]]) {sym_name = "out0_buff_0"} : memref<64000xi32>
 // CHECK-DAG:     %[[OUT0_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE_1_1]]) {sym_name = "out0_buff_1"} : memref<64000xi32>
-// CHECK-DAG:     %[[OUT0_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 2) {init = 2 : i32, sym_name = "out0_prod_lock_0"}
-// CHECK-DAG:     %[[OUT0_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 3) {init = 0 : i32, sym_name = "out0_cons_lock_0"}
+// CHECK-DAG:     %[[OUT0_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 2 : i32, sym_name = "out0_prod_lock_0"}
+// CHECK-DAG:     %[[OUT0_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 0 : i32, sym_name = "out0_cons_lock_0"}
 // CHECK-DAG:     %[[IN1_CONS_BUFF_0:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "in1_cons_buff_0"} : memref<8xi32>
 // CHECK-DAG:     %[[IN1_CONS_BUFF_1:.*]] = aie.buffer(%[[TILE_0_2]]) {sym_name = "in1_cons_buff_1"} : memref<8xi32>
-// CHECK-DAG:     %[[IN1_CONS_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 0) {init = 2 : i32, sym_name = "in1_cons_prod_lock_0"}
-// CHECK-DAG:     %[[IN1_CONS_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]], 1) {init = 0 : i32, sym_name = "in1_cons_cons_lock_0"}
+// CHECK-DAG:     %[[IN1_CONS_PROD_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 2 : i32, sym_name = "in1_cons_prod_lock_0"}
+// CHECK-DAG:     %[[IN1_CONS_CONS_LOCK:.*]] = aie.lock(%[[TILE_0_2]]) {init = 0 : i32, sym_name = "in1_cons_cons_lock_0"}
 // CHECK-DAG:     %[[IN0_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE_0_1]]) {sym_name = "in0_cons_buff_0"} : memref<64000xi32>
 // CHECK-DAG:     %[[IN0_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE_0_1]]) {sym_name = "in0_cons_buff_1"} : memref<64000xi32>
-// CHECK-DAG:     %[[IN0_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 0) {init = 2 : i32, sym_name = "in0_cons_prod_lock_0"}
-// CHECK-DAG:     %[[IN0_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]], 1) {init = 0 : i32, sym_name = "in0_cons_cons_lock_0"}
+// CHECK-DAG:     %[[IN0_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 2 : i32, sym_name = "in0_cons_prod_lock_0"}
+// CHECK-DAG:     %[[IN0_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE_0_1]]) {init = 0 : i32, sym_name = "in0_cons_cons_lock_0"}
 // CHECK:     aie.flow(%[[SHIM_NOC_TILE_0_0]], DMA : 0, %[[MEM_TILE_0_1]], DMA : 1)
 // CHECK:     aie.flow(%[[MEM_TILE_0_1]], DMA : 1, %[[TILE_0_2]], DMA : 0)
 // CHECK:     aie.flow(%[[MEM_TILE_0_1]], DMA : 0, %[[SHIM_NOC_TILE_0_0]], DMA : 0)

--- a/test/objectFifo-stateful-transform/aie_stream/consumer_stream_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/aie_stream/consumer_stream_AIE2.mlir
@@ -13,8 +13,8 @@
 // CHECK:     %[[VAL_2:.*]] = aie.tile(3, 3)
 // CHECK:     %of_consumer_stream_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of_consumer_stream_buff_0"} : memref<16xi32>
 // CHECK:     %of_consumer_stream_buff_1 = aie.buffer(%tile_1_2) {sym_name = "of_consumer_stream_buff_1"} : memref<16xi32>
-// CHECK:     %of_consumer_stream_prod_lock_0 = aie.lock(%tile_1_2, 0) {init = 2 : i32, sym_name = "of_consumer_stream_prod_lock_0"}
-// CHECK:     %of_consumer_stream_cons_lock_0 = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "of_consumer_stream_cons_lock_0"}
+// CHECK:     %of_consumer_stream_prod_lock_0 = aie.lock(%tile_1_2) {init = 2 : i32, sym_name = "of_consumer_stream_prod_lock_0"}
+// CHECK:     %of_consumer_stream_cons_lock_0 = aie.lock(%tile_1_2) {init = 0 : i32, sym_name = "of_consumer_stream_cons_lock_0"}
 // CHECK:     aie.flow(%tile_1_2, DMA : 0, %tile_3_3, Core : 0)
 // CHECK:     %mem_1_2 = aie.mem(%tile_1_2) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb3)

--- a/test/objectFifo-stateful-transform/aie_stream/link_to_stream_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/aie_stream/link_to_stream_AIE2.mlir
@@ -14,10 +14,10 @@
 // CHECK:     %tile_3_3 = aie.tile(3, 3)
 // CHECK:     %of_in_cons_buff_0 = aie.buffer(%mem_tile_1_1) {sym_name = "of_in_cons_buff_0"} : memref<16xi32>
 // CHECK:     %of_in_cons_buff_1 = aie.buffer(%mem_tile_1_1) {sym_name = "of_in_cons_buff_1"} : memref<16xi32>
-// CHECK:     %of_in_cons_prod_lock_0 = aie.lock(%mem_tile_1_1, 0) {init = 2 : i32, sym_name = "of_in_cons_prod_lock_0"}
-// CHECK:     %of_in_cons_cons_lock_0 = aie.lock(%mem_tile_1_1, 1) {init = 0 : i32, sym_name = "of_in_cons_cons_lock_0"}
-// CHECK:     %of_in_prod_lock_0 = aie.lock(%shim_pl_tile_1_0, 0) {init = 0 : i32, sym_name = "of_in_prod_lock_0"}
-// CHECK:     %of_in_cons_lock_0 = aie.lock(%shim_pl_tile_1_0, 1) {init = 0 : i32, sym_name = "of_in_cons_lock_0"}
+// CHECK:     %of_in_cons_prod_lock_0 = aie.lock(%mem_tile_1_1) {init = 2 : i32, sym_name = "of_in_cons_prod_lock_0"}
+// CHECK:     %of_in_cons_cons_lock_0 = aie.lock(%mem_tile_1_1) {init = 0 : i32, sym_name = "of_in_cons_cons_lock_0"}
+// CHECK:     %of_in_prod_lock_0 = aie.lock(%shim_pl_tile_1_0) {init = 0 : i32, sym_name = "of_in_prod_lock_0"}
+// CHECK:     %of_in_cons_lock_0 = aie.lock(%shim_pl_tile_1_0) {init = 0 : i32, sym_name = "of_in_cons_lock_0"}
 // CHECK:     aie.flow(%shim_pl_tile_1_0, DMA : 0, %mem_tile_1_1, DMA : 0)
 // CHECK:     aie.flow(%mem_tile_1_1, DMA : 0, %tile_3_3, Core : 0)
 // CHECK:     aie.shim_dma_allocation @of_in_shim_alloc(%shim_pl_tile_1_0, MM2S, 0)

--- a/test/objectFifo-stateful-transform/aie_stream/producer_stream_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/aie_stream/producer_stream_AIE2.mlir
@@ -14,8 +14,8 @@
 // CHECK:     %of_producer_stream_cons_buff_0 = aie.buffer(%tile_1_3) {sym_name = "of_producer_stream_cons_buff_0"} : memref<16xi32>
 // CHECK:     %of_producer_stream_cons_buff_1 = aie.buffer(%tile_1_3) {sym_name = "of_producer_stream_cons_buff_1"} : memref<16xi32>
 // CHECK:     %of_producer_stream_cons_buff_2 = aie.buffer(%tile_1_3) {sym_name = "of_producer_stream_cons_buff_2"} : memref<16xi32>
-// CHECK:     %of_producer_stream_cons_prod_lock_0 = aie.lock(%tile_1_3, 0) {init = 3 : i32, sym_name = "of_producer_stream_cons_prod_lock_0"}
-// CHECK:     %of_producer_stream_cons_cons_lock_0 = aie.lock(%tile_1_3, 1) {init = 0 : i32, sym_name = "of_producer_stream_cons_cons_lock_0"}
+// CHECK:     %of_producer_stream_cons_prod_lock_0 = aie.lock(%tile_1_3) {init = 3 : i32, sym_name = "of_producer_stream_cons_prod_lock_0"}
+// CHECK:     %of_producer_stream_cons_cons_lock_0 = aie.lock(%tile_1_3) {init = 0 : i32, sym_name = "of_producer_stream_cons_cons_lock_0"}
 // CHECK:     aie.flow(%tile_1_2, Core : 0, %tile_1_3, DMA : 0)
 // CHECK:     %mem_1_3 = aie.mem(%tile_1_3) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb4)

--- a/test/objectFifo-stateful-transform/aie_stream/shim_to_stream_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/aie_stream/shim_to_stream_AIE2.mlir
@@ -11,8 +11,8 @@
 // CHECK:   aie.device(xcve2302) {
 // CHECK:     %shim_noc_tile_2_0 = aie.tile(2, 0)
 // CHECK:     %tile_3_3 = aie.tile(3, 3)
-// CHECK:     %of_stream_prod_lock_0 = aie.lock(%shim_noc_tile_2_0, 0) {init = 1 : i32, sym_name = "of_stream_prod_lock_0"}
-// CHECK:     %of_stream_cons_lock_0 = aie.lock(%shim_noc_tile_2_0, 1) {init = 0 : i32, sym_name = "of_stream_cons_lock_0"}
+// CHECK:     %of_stream_prod_lock_0 = aie.lock(%shim_noc_tile_2_0) {init = 1 : i32, sym_name = "of_stream_prod_lock_0"}
+// CHECK:     %of_stream_cons_lock_0 = aie.lock(%shim_noc_tile_2_0) {init = 0 : i32, sym_name = "of_stream_cons_lock_0"}
 // CHECK:     aie.flow(%shim_noc_tile_2_0, DMA : 0, %tile_3_3, Core : 0)
 // CHECK:     %ext_buffer_in = aie.external_buffer {sym_name = "ext_buffer_in"} : memref<16xi32>
 // CHECK:     %shim_dma_2_0 = aie.shim_dma(%shim_noc_tile_2_0) {

--- a/test/objectFifo-stateful-transform/aie_stream/stream_to_link_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/aie_stream/stream_to_link_AIE2.mlir
@@ -12,12 +12,12 @@
 // CHECK:     %shim_pl_tile_1_0 = aie.tile(1, 0)
 // CHECK:     %mem_tile_1_1 = aie.tile(1, 1)
 // CHECK:     %tile_3_3 = aie.tile(3, 3)
-// CHECK:     %of_out_cons_prod_lock_0 = aie.lock(%shim_pl_tile_1_0, 0) {init = 0 : i32, sym_name = "of_out_cons_prod_lock_0"}
-// CHECK:     %of_out_cons_cons_lock_0 = aie.lock(%shim_pl_tile_1_0, 1) {init = 0 : i32, sym_name = "of_out_cons_cons_lock_0"}
+// CHECK:     %of_out_cons_prod_lock_0 = aie.lock(%shim_pl_tile_1_0) {init = 0 : i32, sym_name = "of_out_cons_prod_lock_0"}
+// CHECK:     %of_out_cons_cons_lock_0 = aie.lock(%shim_pl_tile_1_0) {init = 0 : i32, sym_name = "of_out_cons_cons_lock_0"}
 // CHECK:     %of_stream_cons_buff_0 = aie.buffer(%mem_tile_1_1) {sym_name = "of_stream_cons_buff_0"} : memref<16xi32>
 // CHECK:     %of_stream_cons_buff_1 = aie.buffer(%mem_tile_1_1) {sym_name = "of_stream_cons_buff_1"} : memref<16xi32>
-// CHECK:     %of_stream_cons_prod_lock_0 = aie.lock(%mem_tile_1_1, 0) {init = 2 : i32, sym_name = "of_stream_cons_prod_lock_0"}
-// CHECK:     %of_stream_cons_cons_lock_0 = aie.lock(%mem_tile_1_1, 1) {init = 0 : i32, sym_name = "of_stream_cons_cons_lock_0"}
+// CHECK:     %of_stream_cons_prod_lock_0 = aie.lock(%mem_tile_1_1) {init = 2 : i32, sym_name = "of_stream_cons_prod_lock_0"}
+// CHECK:     %of_stream_cons_cons_lock_0 = aie.lock(%mem_tile_1_1) {init = 0 : i32, sym_name = "of_stream_cons_cons_lock_0"}
 // CHECK:     aie.flow(%tile_3_3, Core : 0, %mem_tile_1_1, DMA : 0)
 // CHECK:     aie.flow(%mem_tile_1_1, DMA : 0, %shim_pl_tile_1_0, DMA : 0)
 // CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%mem_tile_1_1) {

--- a/test/objectFifo-stateful-transform/base/base_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/base/base_test_AIE1.mlir
@@ -16,20 +16,20 @@
 // CHECK:     %[[VAL_2:.*]] = aie.tile(3, 3)
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]], 0) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "of1_cons_lock_1"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of1_cons_lock_1"}
 // CHECK:     %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of1_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of1_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 4) {init = 0 : i32, sym_name = "of1_lock_0"}
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%[[VAL_0]], 5) {init = 0 : i32, sym_name = "of1_lock_1"}
+// CHECK:     %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of1_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of1_lock_1"}
 // CHECK:     %[[VAL_11:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_12:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_1"} : memref<16xi32>
 // CHECK:     %[[VAL_13:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_2"} : memref<16xi32>
 // CHECK:     %[[VAL_14:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_3"} : memref<16xi32>
-// CHECK:     %[[VAL_15:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of0_lock_0"}
-// CHECK:     %[[VAL_16:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of0_lock_1"}
-// CHECK:     %[[VAL_17:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "of0_lock_2"}
-// CHECK:     %[[VAL_18:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "of0_lock_3"}
+// CHECK:     %[[VAL_15:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of0_lock_0"}
+// CHECK:     %[[VAL_16:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of0_lock_1"}
+// CHECK:     %[[VAL_17:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of0_lock_2"}
+// CHECK:     %[[VAL_18:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of0_lock_3"}
 // CHECK:     aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK:     %[[VAL_19:.*]] = aie.mem(%[[VAL_0]]) {
 // CHECK:       aie.dma_start(MM2S, 0, ^bb1, ^bb3)

--- a/test/objectFifo-stateful-transform/base/base_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base/base_test_AIE2.mlir
@@ -16,18 +16,18 @@
 // CHECK:     %[[VAL_2:.*]] = aie.tile(3, 3)
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of1_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of1_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 2) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     %[[VAL_11:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_12:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_1"} : memref<16xi32>
 // CHECK:     %[[VAL_13:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_2"} : memref<16xi32>
 // CHECK:     %[[VAL_14:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of0_buff_3"} : memref<16xi32>
-// CHECK:     %[[VAL_15:.*]] = aie.lock(%[[VAL_0]], 0) {init = 4 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_16:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[VAL_15:.*]] = aie.lock(%[[VAL_0]]) {init = 4 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[VAL_16:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK:     %[[VAL_17:.*]] = aie.mem(%[[VAL_0]]) {
 // CHECK:       aie.dma_start(MM2S, 0, ^bb1, ^bb3)

--- a/test/objectFifo-stateful-transform/base/base_test_shim.mlir
+++ b/test/objectFifo-stateful-transform/base/base_test_shim.mlir
@@ -13,8 +13,8 @@
 // CHECK:     %[[VAL_1:.*]] = aie.tile(1, 2)
 // CHECK:     %[[VAL_2:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of1_cons_lock_1"}
+// CHECK:     %[[VAL_4:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of1_cons_lock_1"}
 // CHECK:     aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:     aie.shim_dma_allocation @of1_shim_alloc(%[[VAL_0]], MM2S, 0)
 // CHECK:     %[[VAL_6:.*]] = aie.mem(%[[VAL_1]]) {

--- a/test/objectFifo-stateful-transform/base/lock_analysis_test.mlir
+++ b/test/objectFifo-stateful-transform/base/lock_analysis_test.mlir
@@ -13,12 +13,12 @@
 // CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 2) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     %test_buff = aie.buffer(%{{.*}}tile_1_2) {sym_name = "test_buff"} : memref<16xi32>
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_3_3, DMA : 0)
 // CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {

--- a/test/objectFifo-stateful-transform/base/lock_analysis_unassigned_test.mlir
+++ b/test/objectFifo-stateful-transform/base/lock_analysis_unassigned_test.mlir
@@ -14,8 +14,8 @@
 // RUN: aie-opt --aie-objectFifo-stateful-transform --aie-objectFifo-unroll --aie-assign-lock-ids %s | FileCheck --check-prefix=ASSIGNED %s
 
 // The unassigned locks reserve nothing, so the objectFifo takes the lowest free IDs on tile(1, 2).
-// CHECK: aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK: aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK: aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK: aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK: aie.lock(%{{.*}}tile_1_2) {init = 1 : i32, sym_name = "test_prod_lock"}
 // CHECK: aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "test_cons_lock"}
 

--- a/test/objectFifo-stateful-transform/base/memTile_test.mlir
+++ b/test/objectFifo-stateful-transform/base/memTile_test.mlir
@@ -15,12 +15,12 @@
 // CHECK:           %[[VAL_1:.*]] = aie.tile(2, 2)
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "of_cons_prod_lock_0"}
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_cons_cons_lock_0"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "of_cons_prod_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_cons_cons_lock_0"}
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 0) {init = 2 : i32, sym_name = "of_prod_lock_0"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_cons_lock_0"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 2 : i32, sym_name = "of_prod_lock_0"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           %[[VAL_10:.*]] = aie.memtile_dma(%[[VAL_0]]) {
 // CHECK:             %[[VAL_11:.*]] = aie.dma_start(MM2S, 0, ^bb1, ^bb3)

--- a/test/objectFifo-stateful-transform/base/non_adjacency_test_1.mlir
+++ b/test/objectFifo-stateful-transform/base/non_adjacency_test_1.mlir
@@ -15,12 +15,12 @@
 // CHECK:           %[[VAL_1:.*]] = aie.tile(3, 3)
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "objfifo_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "objfifo_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "objfifo_cons_lock_1"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_1"}
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "objfifo_lock_0"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "objfifo_lock_1"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_0"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_1"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           func.func @some_work(%[[VAL_10:.*]]: memref<16xi32>) {
 // CHECK:             return

--- a/test/objectFifo-stateful-transform/base/non_adjacency_test_2.mlir
+++ b/test/objectFifo-stateful-transform/base/non_adjacency_test_2.mlir
@@ -17,14 +17,14 @@
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "objfifo_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "objfifo_cons_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "objfifo_cons_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "objfifo_cons_lock_1"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_1]], 2) {init = 0 : i32, sym_name = "objfifo_cons_lock_2"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_1]], 3) {init = 0 : i32, sym_name = "objfifo_cons_lock_3"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_1"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_2"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_3"}
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "objfifo_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "objfifo_lock_1"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_1"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           func.func @some_work(%[[VAL_14:.*]]: memref<16xi32>) {
 // CHECK:             return

--- a/test/objectFifo-stateful-transform/base/non_adjacency_test_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/base/non_adjacency_test_AIE2.mlir
@@ -15,12 +15,12 @@
 // CHECK:           %[[VAL_1:.*]] = aie.tile(3, 3)
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "of_cons_prod_lock_0"}
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_cons_cons_lock_0"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "of_cons_prod_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_cons_cons_lock_0"}
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 0) {init = 2 : i32, sym_name = "of_prod_lock_0"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_cons_lock_0"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 2 : i32, sym_name = "of_prod_lock_0"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           func.func @some_work(%[[VAL_10:.*]]: memref<16xi32>) {
 // CHECK:             return

--- a/test/objectFifo-stateful-transform/bd_chain_on_memtile/bd_chain_with_repeat_count.mlir
+++ b/test/objectFifo-stateful-transform/bd_chain_on_memtile/bd_chain_with_repeat_count.mlir
@@ -13,11 +13,11 @@
 // CHECK:     %{{.*}}tile_1_1 = aie.tile(1, 1)
 // CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of1_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
 // CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb5, repeat_count = 4)

--- a/test/objectFifo-stateful-transform/bd_chain_on_memtile/repeat_chain.mlir
+++ b/test/objectFifo-stateful-transform/bd_chain_on_memtile/repeat_chain.mlir
@@ -13,8 +13,8 @@
 // CHECK:     %[[MEM_TILE:.*]] = aie.tile(0, 1)
 // CHECK:     %[[IN_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "in_cons_buff_0"} : memref<1024xi32>
 // CHECK:     %[[IN_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "in_cons_buff_1"} : memref<1024xi32>
-// CHECK:     %[[IN_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 0) {init = 2 : i32, sym_name = "in_cons_prod_lock_0"}
-// CHECK:     %[[IN_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 1) {init = 0 : i32, sym_name = "in_cons_cons_lock_0"}
+// CHECK:     %[[IN_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 2 : i32, sym_name = "in_cons_prod_lock_0"}
+// CHECK:     %[[IN_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 0 : i32, sym_name = "in_cons_cons_lock_0"}
 // CHECK:     aie.flow(%[[SHIM_TILE]], DMA : 0, %[[MEM_TILE]], DMA : 0)
 // CHECK:     aie.flow(%[[MEM_TILE]], DMA : 0, %[[SHIM_TILE]], DMA : 0)
 // CHECK:     %[[MEMTILE_DMA:.*]] = aie.memtile_dma(%[[MEM_TILE]]) {

--- a/test/objectFifo-stateful-transform/bd_chain_on_memtile/single_iteration.mlir
+++ b/test/objectFifo-stateful-transform/bd_chain_on_memtile/single_iteration.mlir
@@ -13,8 +13,8 @@
 // CHECK:     %[[MEM_TILE:.*]] = aie.tile(0, 1)
 // CHECK:     %[[IN_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "in_cons_buff_0"} : memref<1024xi32>
 // CHECK:     %[[IN_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "in_cons_buff_1"} : memref<1024xi32>
-// CHECK:     %[[IN_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 0) {init = 2 : i32, sym_name = "in_cons_prod_lock_0"}
-// CHECK:     %[[IN_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 1) {init = 0 : i32, sym_name = "in_cons_cons_lock_0"}
+// CHECK:     %[[IN_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 2 : i32, sym_name = "in_cons_prod_lock_0"}
+// CHECK:     %[[IN_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 0 : i32, sym_name = "in_cons_cons_lock_0"}
 // CHECK:     aie.flow(%[[SHIM_TILE]], DMA : 0, %[[MEM_TILE]], DMA : 0)
 // CHECK:     aie.flow(%[[MEM_TILE]], DMA : 0, %[[SHIM_TILE]], DMA : 0)
 // CHECK:     %[[MEMTILE_DMA:.*]] = aie.memtile_dma(%[[MEM_TILE]]) {

--- a/test/objectFifo-stateful-transform/data_movement_patterns/broadcast_enforced_depths.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/broadcast_enforced_depths.mlir
@@ -18,32 +18,32 @@
 // CHECK:           %[[VAL_4:.*]] = aie.tile(3, 3)
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "broadcast_of_0_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "broadcast_of_0_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_0"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_0"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_1"}
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "broadcast_of_1_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "broadcast_of_1_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "broadcast_of_1_cons_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]], 0) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_1"}
-// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_2]], 2) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_2"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_1"}
+// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_2"}
 // CHECK:           %[[VAL_15:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_16:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_17:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_18:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_19:.*]] = aie.lock(%[[VAL_3]], 0) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_0"}
-// CHECK:           %[[VAL_20:.*]] = aie.lock(%[[VAL_3]], 1) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_1"}
-// CHECK:           %[[VAL_21:.*]] = aie.lock(%[[VAL_3]], 2) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_2"}
-// CHECK:           %[[VAL_22:.*]] = aie.lock(%[[VAL_3]], 3) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_3"}
+// CHECK:           %[[VAL_19:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_0"}
+// CHECK:           %[[VAL_20:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_1"}
+// CHECK:           %[[VAL_21:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_2"}
+// CHECK:           %[[VAL_22:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_3"}
 // CHECK:           %[[VAL_23:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "broadcast_of_3_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_24:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "broadcast_of_3_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_25:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "broadcast_of_3_cons_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_26:.*]] = aie.lock(%[[VAL_4]], 0) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_0"}
-// CHECK:           %[[VAL_27:.*]] = aie.lock(%[[VAL_4]], 1) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_1"}
-// CHECK:           %[[VAL_28:.*]] = aie.lock(%[[VAL_4]], 2) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_2"}
+// CHECK:           %[[VAL_26:.*]] = aie.lock(%[[VAL_4]]) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_0"}
+// CHECK:           %[[VAL_27:.*]] = aie.lock(%[[VAL_4]]) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_1"}
+// CHECK:           %[[VAL_28:.*]] = aie.lock(%[[VAL_4]]) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_2"}
 // CHECK:           %[[VAL_29:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "broadcast_of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_30:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "broadcast_of_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_31:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "broadcast_of_lock_0"}
-// CHECK:           %[[VAL_32:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "broadcast_of_lock_1"}
+// CHECK:           %[[VAL_31:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "broadcast_of_lock_0"}
+// CHECK:           %[[VAL_32:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "broadcast_of_lock_1"}
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_4]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_3]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_2]], DMA : 0)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/broadcast_self_adjusted_depths.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/broadcast_self_adjusted_depths.mlir
@@ -18,32 +18,32 @@
 // CHECK:           %[[VAL_4:.*]] = aie.tile(3, 3)
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "broadcast_of_0_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "broadcast_of_0_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_0"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_0"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "broadcast_of_0_cons_lock_1"}
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "broadcast_of_1_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "broadcast_of_1_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "broadcast_of_1_cons_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]], 0) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_1"}
-// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_2]], 2) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_2"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_1"}
+// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "broadcast_of_1_cons_lock_2"}
 // CHECK:           %[[VAL_15:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_16:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_17:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_18:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "broadcast_of_2_cons_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_19:.*]] = aie.lock(%[[VAL_3]], 0) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_0"}
-// CHECK:           %[[VAL_20:.*]] = aie.lock(%[[VAL_3]], 1) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_1"}
-// CHECK:           %[[VAL_21:.*]] = aie.lock(%[[VAL_3]], 2) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_2"}
-// CHECK:           %[[VAL_22:.*]] = aie.lock(%[[VAL_3]], 3) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_3"}
+// CHECK:           %[[VAL_19:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_0"}
+// CHECK:           %[[VAL_20:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_1"}
+// CHECK:           %[[VAL_21:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_2"}
+// CHECK:           %[[VAL_22:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "broadcast_of_2_cons_lock_3"}
 // CHECK:           %[[VAL_23:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "broadcast_of_3_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_24:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "broadcast_of_3_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_25:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "broadcast_of_3_cons_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_26:.*]] = aie.lock(%[[VAL_4]], 0) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_0"}
-// CHECK:           %[[VAL_27:.*]] = aie.lock(%[[VAL_4]], 1) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_1"}
-// CHECK:           %[[VAL_28:.*]] = aie.lock(%[[VAL_4]], 2) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_2"}
+// CHECK:           %[[VAL_26:.*]] = aie.lock(%[[VAL_4]]) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_0"}
+// CHECK:           %[[VAL_27:.*]] = aie.lock(%[[VAL_4]]) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_1"}
+// CHECK:           %[[VAL_28:.*]] = aie.lock(%[[VAL_4]]) {init = 0 : i32, sym_name = "broadcast_of_3_cons_lock_2"}
 // CHECK:           %[[VAL_29:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "broadcast_of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_30:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "broadcast_of_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_31:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "broadcast_of_lock_0"}
-// CHECK:           %[[VAL_32:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "broadcast_of_lock_1"}
+// CHECK:           %[[VAL_31:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "broadcast_of_lock_0"}
+// CHECK:           %[[VAL_32:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "broadcast_of_lock_1"}
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_4]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_3]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_2]], DMA : 0)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_AIE1.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_AIE1.mlir
@@ -15,9 +15,9 @@
 // CHECK:           %[[VAL_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of1_cons_lock_1"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of1_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of1_cons_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of1_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           %[[VAL_8:.*]] = aie.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.shim_dma(%[[VAL_0]]) {

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_DDR_to_L1_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_DDR_to_L1_AIE2.mlir
@@ -15,14 +15,14 @@
 // CHECK:           %[[VAL_2:.*]] = aie.tile(2, 2)
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "from_memTile_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "from_memTile_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "from_memTile_cons_prod_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "from_memTile_cons_prod_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock_0"}
 // CHECK:           %[[VAL_7:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "to_memTile_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "to_memTile_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "to_memTile_cons_prod_lock_0"}
-// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "to_memTile_cons_cons_lock_0"}
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_0]], 0) {init = 1 : i32, sym_name = "to_memTile_prod_lock_0"}
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "to_memTile_cons_lock_0"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "to_memTile_cons_prod_lock_0"}
+// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "to_memTile_cons_cons_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_0]]) {init = 1 : i32, sym_name = "to_memTile_prod_lock_0"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "to_memTile_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK:           %[[VAL_13:.*]] = aie.external_buffer {sym_name = "ext_buff_in"} : memref<16xi32>

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_L1_to_DDR_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_L1_to_DDR_AIE2.mlir
@@ -13,16 +13,16 @@
 // CHECK:           %[[VAL_0:.*]] = aie.tile(2, 0)
 // CHECK:           %[[VAL_1:.*]] = aie.tile(2, 1)
 // CHECK:           %[[VAL_2:.*]] = aie.tile(2, 2)
-// CHECK:           %[[VAL_3:.*]] = aie.lock(%[[VAL_0]], 0) {init = 1 : i32, sym_name = "from_memTile_cons_prod_lock_0"}
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock_0"}
+// CHECK:           %[[VAL_3:.*]] = aie.lock(%[[VAL_0]]) {init = 1 : i32, sym_name = "from_memTile_cons_prod_lock_0"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "from_memTile_cons_cons_lock_0"}
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "from_memTile_buff_0"} : memref<48xi32>
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "from_memTile_buff_1"} : memref<48xi32>
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "from_memTile_prod_lock_0"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "from_memTile_cons_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "from_memTile_prod_lock_0"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "from_memTile_cons_lock_0"}
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "to_memTile_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "to_memTile_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "to_memTile_prod_lock_0"}
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "to_memTile_cons_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "to_memTile_prod_lock_0"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "to_memTile_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_2]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)
 // CHECK:           %[[VAL_13:.*]] = aie.external_buffer {sym_name = "ext_buff_in"} : memref<48xi32>

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_broadcast.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_broadcast.mlir
@@ -18,12 +18,12 @@
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "mem_out_cons_buff_1"} : memref<3000xi32>
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "mem_out_cons_buff_2"} : memref<3000xi32>
 // CHECK:           %[[VAL_7:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "mem_out_cons_buff_3"} : memref<3000xi32>
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_3]], 0) {init = 4 : i32, sym_name = "mem_out_cons_prod_lock_0"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_3]], 1) {init = 0 : i32, sym_name = "mem_out_cons_cons_lock_0"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_3]]) {init = 4 : i32, sym_name = "mem_out_cons_prod_lock_0"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "mem_out_cons_cons_lock_0"}
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "mem_in_0_cons_buff_0"} : memref<3000xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "mem_in_0_cons_buff_1"} : memref<3000xi32>
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "mem_in_0_cons_prod_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "mem_in_0_cons_cons_lock_0"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "mem_in_0_cons_prod_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "mem_in_0_cons_cons_lock_0"}
 // CHECK:           %[[VAL_14:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "mem_in_1_cons_buff_0"} : memref<3000xi32>
 // CHECK:           %[[VAL_15:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "mem_in_1_cons_buff_1"} : memref<3000xi32>
 // CHECK:           %[[VAL_16:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "mem_in_1_cons_buff_2"} : memref<3000xi32>
@@ -31,8 +31,8 @@
 // CHECK:           %[[VAL_18:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "mem_in_1_cons_buff_4"} : memref<3000xi32>
 // CHECK:           %[[VAL_19:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "mem_in_1_cons_buff_5"} : memref<3000xi32>
 // CHECK:           %[[VAL_20:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "mem_in_1_cons_buff_6"} : memref<3000xi32>
-// CHECK:           %[[VAL_21:.*]] = aie.lock(%[[VAL_1]], 0) {init = 7 : i32, sym_name = "mem_in_1_cons_prod_lock_0"}
-// CHECK:           %[[VAL_22:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "mem_in_1_cons_cons_lock_0"}
+// CHECK:           %[[VAL_21:.*]] = aie.lock(%[[VAL_1]]) {init = 7 : i32, sym_name = "mem_in_1_cons_prod_lock_0"}
+// CHECK:           %[[VAL_22:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "mem_in_1_cons_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_3]], DMA : 0)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_broadcast_skip_connection.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_broadcast_skip_connection.mlir
@@ -16,25 +16,25 @@
 // CHECK:           %[[VAL_3:.*]] = aie.tile(3, 3)
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "skip_connection_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "skip_connection_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_3]], 2) {init = 2 : i32, sym_name = "skip_connection_cons_prod_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_3]], 3) {init = 0 : i32, sym_name = "skip_connection_cons_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_3]]) {init = 2 : i32, sym_name = "skip_connection_cons_prod_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "skip_connection_cons_cons_lock_0"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "skip_connection_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "skip_connection_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_2]], 2) {init = 2 : i32, sym_name = "skip_connection_prod_lock_0"}
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_2]], 3) {init = 0 : i32, sym_name = "skip_connection_cons_lock_0"}
+// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "skip_connection_prod_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "skip_connection_cons_lock_0"}
 // CHECK:           %[[VAL_12:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "link2_0_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_13:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "link2_0_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock_0"}
-// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock_0"}
+// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "link2_0_cons_prod_lock_0"}
+// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "link2_0_cons_cons_lock_0"}
 // CHECK:           %[[VAL_16:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "link2_1_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_17:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "link2_1_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_18:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "link2_1_cons_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_19:.*]] = aie.lock(%[[VAL_3]], 0) {init = 3 : i32, sym_name = "link2_1_cons_prod_lock_0"}
-// CHECK:           %[[VAL_20:.*]] = aie.lock(%[[VAL_3]], 1) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock_0"}
+// CHECK:           %[[VAL_19:.*]] = aie.lock(%[[VAL_3]]) {init = 3 : i32, sym_name = "link2_1_cons_prod_lock_0"}
+// CHECK:           %[[VAL_20:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "link2_1_cons_cons_lock_0"}
 // CHECK:           %[[VAL_21:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
 // CHECK:           %[[VAL_22:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
-// CHECK:           %[[VAL_23:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock_0"}
-// CHECK:           %[[VAL_24:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_0"}
+// CHECK:           %[[VAL_23:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "link1_cons_prod_lock_0"}
+// CHECK:           %[[VAL_24:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "link1_cons_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_3]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_2]], DMA : 0)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_distribute_offsets.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_distribute_offsets.mlir
@@ -18,24 +18,24 @@
 // CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link4_cons_buff_0"} : memref<12xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link4_cons_buff_1"} : memref<12xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "link4_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "link4_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 2 : i32, sym_name = "link4_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 0 : i32, sym_name = "link4_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_1"} : memref<20xi32>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 2 : i32, sym_name = "link3_cons_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "link3_cons_cons_lock_0"}
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_0"} : memref<4x4xi32>
 // CHECK:     %[[VAL_9:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_1"} : memref<4x4xi32>
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 2 : i32, sym_name = "link2_cons_prod_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 0 : i32, sym_name = "link2_cons_cons_lock_0"}
 // CHECK:     %[[VAL_12:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link1_cons_buff_0"} : memref<48xi32>
 // CHECK:     %[[VAL_13:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link1_cons_buff_1"} : memref<48xi32>
-// CHECK:     %[[VAL_14:.*]] = aie.lock(%{{.*}}tile_2_1, 0) {init = 2 : i32, sym_name = "link1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_15:.*]] = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_0"}
-// CHECK:     %[[VAL_16:.*]] = aie.lock(%{{.*}}tile_2_1, 2) {init = 2 : i32, sym_name = "link1_cons_prod_lock_1"}
-// CHECK:     %[[VAL_17:.*]] = aie.lock(%{{.*}}tile_2_1, 3) {init = 0 : i32, sym_name = "link1_cons_cons_lock_1"}
-// CHECK:     %[[VAL_18:.*]] = aie.lock(%{{.*}}tile_2_1, 4) {init = 2 : i32, sym_name = "link1_cons_prod_lock_2"}
-// CHECK:     %[[VAL_19:.*]] = aie.lock(%{{.*}}tile_2_1, 5) {init = 0 : i32, sym_name = "link1_cons_cons_lock_2"}
+// CHECK:     %[[VAL_14:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 2 : i32, sym_name = "link1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_15:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_16:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 2 : i32, sym_name = "link1_cons_prod_lock_1"}
+// CHECK:     %[[VAL_17:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_1"}
+// CHECK:     %[[VAL_18:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 2 : i32, sym_name = "link1_cons_prod_lock_2"}
+// CHECK:     %[[VAL_19:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_2"}
 // CHECK:     aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 1, %{{.*}}tile_2_3, DMA : 0)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_distribute_output_sizes.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_distribute_output_sizes.mlir
@@ -17,17 +17,17 @@
 // CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "link3_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 2 : i32, sym_name = "link3_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "link3_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "link2_cons_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 2 : i32, sym_name = "link2_cons_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 0 : i32, sym_name = "link2_cons_cons_lock_0"}
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link1_cons_buff_0"} : memref<64xi32>
-// CHECK:     %[[VAL_9:.*]] = aie.lock(%{{.*}}tile_2_1, 0) {init = 1 : i32, sym_name = "link1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_2_1, 2) {init = 1 : i32, sym_name = "link1_cons_prod_lock_1"}
-// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_2_1, 3) {init = 0 : i32, sym_name = "link1_cons_cons_lock_1"}
+// CHECK:     %[[VAL_9:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 1 : i32, sym_name = "link1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 1 : i32, sym_name = "link1_cons_prod_lock_1"}
+// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link1_cons_cons_lock_1"}
 // CHECK:     aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 1, %{{.*}}tile_2_3, DMA : 0)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_join_offsets.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_test_join_offsets.mlir
@@ -18,24 +18,24 @@
 // CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
 // CHECK-DAG: %[[LINK4_BUFF_0:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link4_buff_0"} : memref<48xi32>
 // CHECK-DAG: %[[LINK4_BUFF_1:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link4_buff_1"} : memref<48xi32>
-// CHECK-DAG: %[[LINK4_PROD_LOCK_0:.*]] = aie.lock(%{{.*}}tile_2_1, 0) {init = 2 : i32, sym_name = "link4_prod_lock_0"}
-// CHECK-DAG: %[[LINK4_CONS_LOCK_0:.*]] = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "link4_cons_lock_0"}
-// CHECK-DAG: %[[LINK4_PROD_LOCK_1:.*]] = aie.lock(%{{.*}}tile_2_1, 2) {init = 2 : i32, sym_name = "link4_prod_lock_1"}
-// CHECK-DAG: %[[LINK4_CONS_LOCK_1:.*]] = aie.lock(%{{.*}}tile_2_1, 3) {init = 0 : i32, sym_name = "link4_cons_lock_1"}
-// CHECK-DAG: %[[LINK4_PROD_LOCK_2:.*]] = aie.lock(%{{.*}}tile_2_1, 4) {init = 2 : i32, sym_name = "link4_prod_lock_2"}
-// CHECK-DAG: %[[LINK4_CONS_LOCK_2:.*]] = aie.lock(%{{.*}}tile_2_1, 5) {init = 0 : i32, sym_name = "link4_cons_lock_2"}
+// CHECK-DAG: %[[LINK4_PROD_LOCK_0:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 2 : i32, sym_name = "link4_prod_lock_0"}
+// CHECK-DAG: %[[LINK4_CONS_LOCK_0:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link4_cons_lock_0"}
+// CHECK-DAG: %[[LINK4_PROD_LOCK_1:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 2 : i32, sym_name = "link4_prod_lock_1"}
+// CHECK-DAG: %[[LINK4_CONS_LOCK_1:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link4_cons_lock_1"}
+// CHECK-DAG: %[[LINK4_PROD_LOCK_2:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 2 : i32, sym_name = "link4_prod_lock_2"}
+// CHECK-DAG: %[[LINK4_CONS_LOCK_2:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "link4_cons_lock_2"}
 // CHECK-DAG: %[[LINK3_BUFF_0:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link3_buff_0"} : memref<12xi32>
 // CHECK-DAG: %[[LINK3_BUFF_1:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "link3_buff_1"} : memref<12xi32>
-// CHECK-DAG: %[[LINK3_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "link3_prod_lock_0"}
-// CHECK-DAG: %[[LINK3_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "link3_cons_lock_0"}
+// CHECK-DAG: %[[LINK3_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 2 : i32, sym_name = "link3_prod_lock_0"}
+// CHECK-DAG: %[[LINK3_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 0 : i32, sym_name = "link3_cons_lock_0"}
 // CHECK-DAG: %[[LINK2_BUFF_0:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link2_buff_0"} : memref<20xi32>
 // CHECK-DAG: %[[LINK2_BUFF_1:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link2_buff_1"} : memref<20xi32>
-// CHECK-DAG: %[[LINK2_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "link2_prod_lock_0"}
-// CHECK-DAG: %[[LINK2_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
+// CHECK-DAG: %[[LINK2_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 2 : i32, sym_name = "link2_prod_lock_0"}
+// CHECK-DAG: %[[LINK2_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
 // CHECK-DAG: %[[LINK1_BUFF_0:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link1_buff_0"} : memref<4x4xi32>
 // CHECK-DAG: %[[LINK1_BUFF_1:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link1_buff_1"} : memref<4x4xi32>
-// CHECK-DAG: %[[LINK1_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "link1_prod_lock_0"}
-// CHECK-DAG: %[[LINK1_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "link1_cons_lock_0"}
+// CHECK-DAG: %[[LINK1_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 2 : i32, sym_name = "link1_prod_lock_0"}
+// CHECK-DAG: %[[LINK1_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 0 : i32, sym_name = "link1_cons_lock_0"}
 // CHECK-DAG: aie.flow(%{{.*}}tile_2_2, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
 // CHECK-DAG: aie.flow(%{{.*}}tile_2_3, DMA : 0, %{{.*}}tile_2_1, DMA : 1)
 // CHECK-DAG: aie.flow(%{{.*}}tile_3_3, DMA : 0, %{{.*}}tile_2_1, DMA : 2)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem.mlir
@@ -16,12 +16,12 @@
 //CHECK:    %{{.*}}tile_2_2 = aie.tile(2, 2)
 //CHECK:    %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
 //CHECK:    %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
-//CHECK:    %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
-//CHECK:    %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+//CHECK:    %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
+//CHECK:    %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 //CHECK:    %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 //CHECK:    %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-//CHECK:    %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-//CHECK:    %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+//CHECK:    %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+//CHECK:    %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 //CHECK:    aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
 //CHECK:    aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
 //CHECK:    func.func @some_work(%arg0: memref<16xi32>) {

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem2.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem2.mlir
@@ -13,8 +13,8 @@
 //CHECK:     %[[VAL_1:.*]] = aie.tile(1, 2)
 //CHECK:     %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 //CHECK:     %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-//CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-//CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+//CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+//CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 //CHECK:     aie.flow(%[[VAL_0:.*]], DMA : 0, %[[VAL_1]], DMA : 0)
 //CHECK:     %[[VAL_11:.*]] = aie.mem(%[[VAL_1]]) {
 //CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb3)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem3.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem3.mlir
@@ -13,8 +13,8 @@
 // CHECK:    %{{.*}}tile_2_2 = aie.tile(2, 2)
 // CHECK:    %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:    %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:    %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:    %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:    %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:    %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:    aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
 // CHECK:    %[[VAL_6:.*]] = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:      %[[VAL_7:.*]] = aie.dma_start(S2MM, 0, ^bb1, ^bb3)

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem_diff_memref.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem_diff_memref.mlir
@@ -15,12 +15,12 @@
 // CHECK:    %{{.*}}tile_2_2 = aie.tile(2, 2)
 // CHECK:    %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
 // CHECK:    %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
-// CHECK:    %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK:    %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK:    %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK:    %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 // CHECK:    %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<32xi32>
 // CHECK:    %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<32xi32>
-// CHECK:    %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:    %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:    %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:    %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:    aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
 // CHECK:    aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_2_2, DMA : 0)
 // CHECK:    %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {

--- a/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem_padDimensions.mlir
+++ b/test/objectFifo-stateful-transform/data_movement_patterns/link/link_via_shared_mem_padDimensions.mlir
@@ -18,14 +18,14 @@
 // Compute tile buffers use the output (padded) size
 // CHECK: %[[OUT_BUF0:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "of_out_cons_buff_0"} : memref<512xi32>
 // CHECK: %[[OUT_BUF1:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "of_out_cons_buff_1"} : memref<512xi32>
-// CHECK: %[[OUT_PROD:.*]] = aie.lock(%{{.*}}tile_0_2, 0) {init = 2 : i32, sym_name = "of_out_cons_prod_lock_0"}
-// CHECK: %[[OUT_CONS:.*]] = aie.lock(%{{.*}}tile_0_2, 1) {init = 0 : i32, sym_name = "of_out_cons_cons_lock_0"}
+// CHECK: %[[OUT_PROD:.*]] = aie.lock(%{{.*}}tile_0_2) {init = 2 : i32, sym_name = "of_out_cons_prod_lock_0"}
+// CHECK: %[[OUT_CONS:.*]] = aie.lock(%{{.*}}tile_0_2) {init = 0 : i32, sym_name = "of_out_cons_cons_lock_0"}
 
 // MemTile buffers use the input (smaller) size — NOT the output size
 // CHECK: %[[MT_BUF0:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "of_in_cons_buff_0"} : memref<256xi32>
 // CHECK: %[[MT_BUF1:.*]] = aie.buffer(%{{.*}}tile_0_1) {sym_name = "of_in_cons_buff_1"} : memref<256xi32>
-// CHECK: %[[MT_PROD:.*]] = aie.lock(%{{.*}}tile_0_1, 0) {init = 2 : i32, sym_name = "of_in_cons_prod_lock_0"}
-// CHECK: %[[MT_CONS:.*]] = aie.lock(%{{.*}}tile_0_1, 1) {init = 0 : i32, sym_name = "of_in_cons_cons_lock_0"}
+// CHECK: %[[MT_PROD:.*]] = aie.lock(%{{.*}}tile_0_1) {init = 2 : i32, sym_name = "of_in_cons_prod_lock_0"}
+// CHECK: %[[MT_CONS:.*]] = aie.lock(%{{.*}}tile_0_1) {init = 0 : i32, sym_name = "of_in_cons_cons_lock_0"}
 
 // CHECK: aie.flow(%{{.*}}tile_0_0, DMA : 0, %{{.*}}tile_0_1, DMA : 0)
 // CHECK: aie.flow(%{{.*}}tile_0_1, DMA : 0, %{{.*}}tile_0_2, DMA : 0)

--- a/test/objectFifo-stateful-transform/debug_features/disable_synchronization_test_distribute.mlir
+++ b/test/objectFifo-stateful-transform/debug_features/disable_synchronization_test_distribute.mlir
@@ -15,11 +15,11 @@
 // CHECK:     %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK-DAG: %[[LINK3_BUFF:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "link3_buff_0"} : memref<36xi32>
 // CHECK-DAG: %[[LINK2_BUFF:.*]] = aie.buffer(%[[TILE_2_3]]) {sym_name = "link2_buff_0"} : memref<20xi32>
-// CHECK-DAG: %[[LINK2_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_3]], 0) {init = 1 : i32, sym_name = "link2_prod_lock_0"}
-// CHECK-DAG: %[[LINK2_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_3]], 1) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
+// CHECK-DAG: %[[LINK2_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_3]]) {init = 1 : i32, sym_name = "link2_prod_lock_0"}
+// CHECK-DAG: %[[LINK2_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_3]]) {init = 0 : i32, sym_name = "link2_cons_lock_0"}
 // CHECK-DAG: %[[LINK1_BUFF:.*]] = aie.buffer(%[[TILE_2_2]]) {sym_name = "link1_buff_0"} : memref<4x4xi32>
-// CHECK-DAG: %[[LINK1_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_2]], 0) {init = 1 : i32, sym_name = "link1_prod_lock_0"}
-// CHECK-DAG: %[[LINK1_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_2]], 1) {init = 0 : i32, sym_name = "link1_cons_lock_0"}
+// CHECK-DAG: %[[LINK1_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_2]]) {init = 1 : i32, sym_name = "link1_prod_lock_0"}
+// CHECK-DAG: %[[LINK1_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_2]]) {init = 0 : i32, sym_name = "link1_cons_lock_0"}
 // CHECK-DAG: aie.flow(%[[TILE_2_2]], DMA : 0, %[[MEM_TILE]], DMA : 0)
 // CHECK-DAG: aie.flow(%[[TILE_2_3]], DMA : 0, %[[MEM_TILE]], DMA : 1)
 // CHECK-DAG: aie.flow(%[[MEM_TILE]], DMA : 0, %[[SHIM_TILE]], DMA : 0)

--- a/test/objectFifo-stateful-transform/debug_features/disable_synchronization_test_join.mlir
+++ b/test/objectFifo-stateful-transform/debug_features/disable_synchronization_test_join.mlir
@@ -14,11 +14,11 @@
 // CHECK:     %{{.*}}tile_2_2 = aie.tile(2, 2)
 // CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "link3_cons_buff_0"} : memref<20xi32>
-// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 1 : i32, sym_name = "link3_cons_prod_lock_0"}
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "link3_cons_cons_lock_0"}
+// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 1 : i32, sym_name = "link3_cons_prod_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "link3_cons_cons_lock_0"}
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "link2_cons_buff_0"} : memref<4x4xi32>
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_2_2, 0) {init = 1 : i32, sym_name = "link2_cons_prod_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "link2_cons_cons_lock_0"}
+// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 1 : i32, sym_name = "link2_cons_prod_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 0 : i32, sym_name = "link2_cons_cons_lock_0"}
 // CHECK:     %[[VAL_6:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "link1_cons_buff_0"} : memref<36xi32>
 // CHECK:     aie.flow(%{{.*}}tile_2_0, DMA : 0, %{{.*}}tile_2_1, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_2_1, DMA : 0, %{{.*}}tile_2_2, DMA : 0)

--- a/test/objectFifo-stateful-transform/debug_features/via_DMA_test.mlir
+++ b/test/objectFifo-stateful-transform/debug_features/via_DMA_test.mlir
@@ -13,16 +13,16 @@
 // CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of_stream_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of_stream_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 2 : i32, sym_name = "of_stream_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of_stream_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 2 : i32, sym_name = "of_stream_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of_stream_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_stream_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_stream_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 2) {init = 2 : i32, sym_name = "of_stream_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 3) {init = 0 : i32, sym_name = "of_stream_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of_stream_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of_stream_cons_lock_0"}
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_shared_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_9:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of_shared_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of_shared_prod_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of_shared_cons_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of_shared_prod_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of_shared_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
 // CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb3)

--- a/test/objectFifo-stateful-transform/dma_channel_alloc/memtileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_alloc/memtileDMA_test.mlir
@@ -12,12 +12,12 @@
 // CHECK:           %{{.*}}tile_3_3 = aie.tile(3, 3)
 // CHECK:           %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "objfifo_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "objfifo_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "objfifo_cons_prod_lock_0"}
-// CHECK:           %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "objfifo_cons_cons_lock_0"}
+// CHECK:           %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 2 : i32, sym_name = "objfifo_cons_prod_lock_0"}
+// CHECK:           %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 0 : i32, sym_name = "objfifo_cons_cons_lock_0"}
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "objfifo_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "objfifo_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_1, 3) {init = 2 : i32, sym_name = "objfifo_prod_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_1, 4) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 2 : i32, sym_name = "objfifo_prod_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
 // CHECK:           %buffer_1_1 = aie.buffer(%{{.*}}tile_1_1) : memref<16xi32>
 // CHECK:           %lock_1_1 = aie.lock(%{{.*}}tile_1_1, 0)
 // CHECK:           %buffer_1_1_0 = aie.buffer(%{{.*}}tile_1_1) : memref<16xi32>

--- a/test/objectFifo-stateful-transform/dma_channel_alloc/shimtileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_alloc/shimtileDMA_test.mlir
@@ -12,10 +12,10 @@
 // CHECK:           %{{.*}}tile_3_3 = aie.tile(3, 3)
 // CHECK:           %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "objfifo_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "objfifo_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "objfifo_cons_prod_lock_0"}
-// CHECK:           %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "objfifo_cons_cons_lock_0"}
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_2_0, 3) {init = 1 : i32, sym_name = "objfifo_prod_lock_0"}
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_2_0, 4) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
+// CHECK:           %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 2 : i32, sym_name = "objfifo_cons_prod_lock_0"}
+// CHECK:           %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 0 : i32, sym_name = "objfifo_cons_cons_lock_0"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_2_0) {init = 1 : i32, sym_name = "objfifo_prod_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_2_0) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
 // CHECK:           %0 = aie.external_buffer : memref<16xi32>
 // CHECK:           %lock_2_0 = aie.lock(%{{.*}}tile_2_0, 0)
 // CHECK:           %1 = aie.external_buffer : memref<16xi32>

--- a/test/objectFifo-stateful-transform/dma_channel_alloc/tileDMA_test.mlir
+++ b/test/objectFifo-stateful-transform/dma_channel_alloc/tileDMA_test.mlir
@@ -15,12 +15,12 @@
 // CHECK:           %[[VAL_1:.*]] = aie.tile(3, 3)
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "objfifo_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "objfifo_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "objfifo_cons_lock_1"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "objfifo_cons_lock_1"}
 // CHECK:           %[[VAL_6:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "objfifo_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "objfifo_lock_0"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 4) {init = 0 : i32, sym_name = "objfifo_lock_1"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_0"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "objfifo_lock_1"}
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_0]]) : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_0]], 0)
 // CHECK:           %[[VAL_12:.*]] = aie.buffer(%[[VAL_0]]) : memref<16xi32>

--- a/test/objectFifo-stateful-transform/dma_transformations/memtile_padding_test.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/memtile_padding_test.mlir
@@ -11,24 +11,24 @@
     // CHECK:       %[[COMP_TILE:.*]] = aie.tile(0, 2)
     // CHECK-DAG:   %[[OUT1_CONS_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_out1_cons_buff_0"} : memref<64x64xi8>
     // CHECK-DAG:   %[[OUT1_CONS_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_out1_cons_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[OUT1_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 2) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock_0"}
-    // CHECK-DAG:   %[[OUT1_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock_0"}
+    // CHECK-DAG:   %[[OUT1_CONS_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 2 : i32, sym_name = "objFifo_out1_cons_prod_lock_0"}
+    // CHECK-DAG:   %[[OUT1_CONS_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 0 : i32, sym_name = "objFifo_out1_cons_cons_lock_0"}
     // CHECK-DAG:   %[[OUT1_BUFF_0:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_out1_buff_0"} : memref<64x64xi8>
     // CHECK-DAG:   %[[OUT1_BUFF_1:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_out1_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[OUT1_PROD_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 2) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock_0"}
-    // CHECK-DAG:   %[[OUT1_CONS_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 3) {init = 0 : i32, sym_name = "objFifo_out1_cons_lock_0"}
+    // CHECK-DAG:   %[[OUT1_PROD_LOCK:.*]] = aie.lock(%[[COMP_TILE]]) {init = 2 : i32, sym_name = "objFifo_out1_prod_lock_0"}
+    // CHECK-DAG:   %[[OUT1_CONS_LOCK:.*]] = aie.lock(%[[COMP_TILE]]) {init = 0 : i32, sym_name = "objFifo_out1_cons_lock_0"}
     // CHECK-DAG:   %[[IN1_CONS_BUFF_0:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_in1_cons_buff_0"} : memref<64x64xi8>
     // CHECK-DAG:   %[[IN1_CONS_BUFF_1:.*]] = aie.buffer(%[[COMP_TILE]]) {sym_name = "objFifo_in1_cons_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[IN1_CONS_PROD_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 0) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock_0"}
-    // CHECK-DAG:   %[[IN1_CONS_CONS_LOCK:.*]] = aie.lock(%[[COMP_TILE]], 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock_0"}
+    // CHECK-DAG:   %[[IN1_CONS_PROD_LOCK:.*]] = aie.lock(%[[COMP_TILE]]) {init = 2 : i32, sym_name = "objFifo_in1_cons_prod_lock_0"}
+    // CHECK-DAG:   %[[IN1_CONS_CONS_LOCK:.*]] = aie.lock(%[[COMP_TILE]]) {init = 0 : i32, sym_name = "objFifo_in1_cons_cons_lock_0"}
     // CHECK-DAG:   %[[IN1_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_in1_buff_0"} : memref<64x64xi8>
     // CHECK-DAG:   %[[IN1_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "objFifo_in1_buff_1"} : memref<64x64xi8>
-    // CHECK-DAG:   %[[IN1_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 0) {init = 2 : i32, sym_name = "objFifo_in1_prod_lock_0"}
-    // CHECK-DAG:   %[[IN1_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]], 1) {init = 0 : i32, sym_name = "objFifo_in1_cons_lock_0"}
-    // CHECK-DAG:   %[[OUT0_CONS_PROD_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 2)
-    // CHECK-DAG:   %[[OUT0_CONS_CONS_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 3)
-    // CHECK-DAG:   %[[IN0_PROD_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 0)
-    // CHECK-DAG:   %[[IN0_CONS_LOCK:.*]] = aie.lock(%[[SHIM_TILE]], 1)
+    // CHECK-DAG:   %[[IN1_PROD_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 2 : i32, sym_name = "objFifo_in1_prod_lock_0"}
+    // CHECK-DAG:   %[[IN1_CONS_LOCK:.*]] = aie.lock(%[[MEM_TILE]]) {init = 0 : i32, sym_name = "objFifo_in1_cons_lock_0"}
+    // CHECK-DAG:   %[[OUT0_CONS_PROD_LOCK:.*]] = aie.lock(%[[SHIM_TILE]])
+    // CHECK-DAG:   %[[OUT0_CONS_CONS_LOCK:.*]] = aie.lock(%[[SHIM_TILE]])
+    // CHECK-DAG:   %[[IN0_PROD_LOCK:.*]] = aie.lock(%[[SHIM_TILE]])
+    // CHECK-DAG:   %[[IN0_CONS_LOCK:.*]] = aie.lock(%[[SHIM_TILE]])
     // CHECK-DAG:   aie.flow(%[[SHIM_TILE]], DMA : 0, %[[MEM_TILE]], DMA : 0)
     // CHECK-DAG:   aie.flow(%[[MEM_TILE]], DMA : 0, %[[COMP_TILE]], DMA : 0)
     // CHECK-DAG:   aie.flow(%[[COMP_TILE]], DMA : 0, %[[MEM_TILE]], DMA : 1)

--- a/test/objectFifo-stateful-transform/dma_transformations/nd_dma_base_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/nd_dma_base_AIE2.mlir
@@ -17,24 +17,24 @@
 // CHECK:     %[[tile_3_3:.*]] = aie.tile(3, 3)
 // CHECK:     %[[of1_cons_buff_0:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_0"} : memref<256xi32>
 // CHECK:     %[[of1_cons_buff_1:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_1"} : memref<256xi32>
-// CHECK:     %[[of1_cons_prod_lock:.*]] = aie.lock(%[[tile_3_3]], 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[of1_cons_cons_lock:.*]] = aie.lock(%[[tile_3_3]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[of1_cons_prod_lock:.*]] = aie.lock(%[[tile_3_3]]) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[of1_cons_cons_lock:.*]] = aie.lock(%[[tile_3_3]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[of1_buff_0:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_0"} : memref<256xi32>
 // CHECK:     %[[of1_buff_1:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_1"} : memref<256xi32>
-// CHECK:     %[[of1_prod_lock:.*]] = aie.lock(%[[tile_1_2]], 2) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[of1_cons_lock:.*]] = aie.lock(%[[tile_1_2]], 3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[of1_prod_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[of1_cons_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     %[[of0_cons_buff_0:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_0"} : memref<256xi32>
 // CHECK:     %[[of0_cons_buff_1:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_1"} : memref<256xi32>
 // CHECK:     %[[of0_cons_buff_2:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_2"} : memref<256xi32>
 // CHECK:     %[[of0_cons_buff_3:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_cons_buff_3"} : memref<256xi32>
-// CHECK:     %[[of0_cons_prod_lock:.*]] = aie.lock(%[[tile_1_3]], 0) {init = 4 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[of0_cons_cons_lock:.*]] = aie.lock(%[[tile_1_3]], 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK:     %[[of0_cons_prod_lock:.*]] = aie.lock(%[[tile_1_3]]) {init = 4 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK:     %[[of0_cons_cons_lock:.*]] = aie.lock(%[[tile_1_3]]) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
 // CHECK:     %[[of0_buff_0:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_0"} : memref<256xi32>
 // CHECK:     %[[of0_buff_1:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_1"} : memref<256xi32>
 // CHECK:     %[[of0_buff_2:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_2"} : memref<256xi32>
 // CHECK:     %[[of0_buff_3:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_3"} : memref<256xi32>
-// CHECK:     %[[of0_prod_lock:.*]] = aie.lock(%[[tile_1_2]], 0) {init = 4 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[of0_cons_lock:.*]] = aie.lock(%[[tile_1_2]], 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[of0_prod_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 4 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[of0_cons_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%[[tile_1_2]], DMA : 0, %[[tile_1_3]], DMA : 0)
 // CHECK:     aie.flow(%[[tile_1_2]], DMA : 1, %[[tile_3_3]], DMA : 0)
 // CHECK:     %[[VAL_23:.*]] = aie.mem(%[[tile_1_2]]) {

--- a/test/objectFifo-stateful-transform/dma_transformations/nd_dma_distribute_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/nd_dma_distribute_AIE2.mlir
@@ -17,20 +17,20 @@
 // CHECK:     %[[tile_2_3:.*]] = aie.tile(2, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of2_cons_buff_0"} : memref<128xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of2_cons_buff_1"} : memref<128xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of1_cons_buff_0"} : memref<128xi32>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_2_2) {sym_name = "of1_cons_buff_1"} : memref<128xi32>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_2_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_2_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_2_2) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<256xi32>
 // CHECK:     %[[VAL_9:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_1"} : memref<256xi32>
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 2 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
-// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_1, 2) {init = 2 : i32, sym_name = "of0_cons_prod_lock_1"}
-// CHECK:     %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_1_1, 3) {init = 0 : i32, sym_name = "of0_cons_cons_lock_1"}
-// CHECK:     %[[VAL_14:.*]] = aie.lock(%{{.*}}tile_1_0, 0) {init = 1 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_15:.*]] = aie.lock(%{{.*}}tile_1_0, 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 2 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 2 : i32, sym_name = "of0_cons_prod_lock_1"}
+// CHECK:     %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_1"}
+// CHECK:     %[[VAL_14:.*]] = aie.lock(%{{.*}}tile_1_0) {init = 1 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[VAL_15:.*]] = aie.lock(%{{.*}}tile_1_0) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%[[tile_1_0:.*]], DMA : 0, %[[tile_1_1:.*]], DMA : 0)
 // CHECK:     aie.flow(%[[tile_1_1:.*]], DMA : 0, %[[tile_2_2:.*]], DMA : 0)
 // CHECK:     aie.flow(%[[tile_1_1:.*]], DMA : 1, %[[tile_2_3:.*]], DMA : 0)

--- a/test/objectFifo-stateful-transform/dma_transformations/nd_dma_distribute_broadcast_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/nd_dma_distribute_broadcast_AIE2.mlir
@@ -16,26 +16,26 @@
 // CHECK-DAG:     %[[TILE_2_3:.+]] = aie.tile(2, 3)
 // CHECK-DAG:     %[[OF2_0_CONS_BUFF_0:.+]] = aie.buffer(%[[TILE_1_3]])
 // CHECK-DAG:     %[[OF2_0_CONS_BUFF_1:.+]] = aie.buffer(%[[TILE_1_3]])
-// CHECK-DAG:     %[[OF2_0_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_1_3]], 0) {init = 2 : i32
-// CHECK-DAG:     %[[OF2_0_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_1_3]], 1) {init = 0 : i32
+// CHECK-DAG:     %[[OF2_0_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_1_3]]) {init = 2 : i32
+// CHECK-DAG:     %[[OF2_0_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_1_3]]) {init = 0 : i32
 // CHECK-DAG:     %[[OF2_1_CONS_BUFF_0:.+]] = aie.buffer(%[[TILE_2_3]])
 // CHECK-DAG:     %[[OF2_1_CONS_BUFF_1:.+]] = aie.buffer(%[[TILE_2_3]])
-// CHECK-DAG:     %[[OF2_1_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_2_3]], 0) {init = 2 : i32
-// CHECK-DAG:     %[[OF2_1_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_2_3]], 1) {init = 0 : i32
+// CHECK-DAG:     %[[OF2_1_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_2_3]]) {init = 2 : i32
+// CHECK-DAG:     %[[OF2_1_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_2_3]]) {init = 0 : i32
 // CHECK-DAG:     %[[OF1_0_CONS_BUFF_0:.+]] = aie.buffer(%[[TILE_1_2]])
 // CHECK-DAG:     %[[OF1_0_CONS_BUFF_1:.+]] = aie.buffer(%[[TILE_1_2]])
-// CHECK-DAG:     %[[OF1_0_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_1_2]], 0) {init = 2 : i32
-// CHECK-DAG:     %[[OF1_0_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_1_2]], 1) {init = 0 : i32
+// CHECK-DAG:     %[[OF1_0_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_1_2]]) {init = 2 : i32
+// CHECK-DAG:     %[[OF1_0_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_1_2]]) {init = 0 : i32
 // CHECK-DAG:     %[[OF1_1_CONS_BUFF_0:.+]] = aie.buffer(%[[TILE_2_2]])
 // CHECK-DAG:     %[[OF1_1_CONS_BUFF_1:.+]] = aie.buffer(%[[TILE_2_2]])
-// CHECK-DAG:     %[[OF1_1_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_2_2]], 0) {init = 2 : i32
-// CHECK-DAG:     %[[OF1_1_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_2_2]], 1) {init = 0 : i32
+// CHECK-DAG:     %[[OF1_1_CONS_PROD_LOCK:.+]] = aie.lock(%[[TILE_2_2]]) {init = 2 : i32
+// CHECK-DAG:     %[[OF1_1_CONS_CONS_LOCK:.+]] = aie.lock(%[[TILE_2_2]]) {init = 0 : i32
 // CHECK-DAG:     %[[OF0_CONS_BUFF_0:.+]] = aie.buffer(%[[TILE_1_1]])
 // CHECK-DAG:     %[[OF0_CONS_BUFF_1:.+]] = aie.buffer(%[[TILE_1_1]])
-// CHECK-DAG:     %[[OF0_CONS_PROD_LOCK_0:.+]] = aie.lock(%[[TILE_1_1]], 0) {init = 2 : i32
-// CHECK-DAG:     %[[OF0_CONS_CONS_LOCK_0:.+]] = aie.lock(%[[TILE_1_1]], 1) {init = 0 : i32
-// CHECK-DAG:     %[[OF0_CONS_PROD_LOCK_1:.+]] = aie.lock(%[[TILE_1_1]], 2) {init = 2 : i32
-// CHECK-DAG:     %[[OF0_CONS_CONS_LOCK_1:.+]] = aie.lock(%[[TILE_1_1]], 3) {init = 0 : i32
+// CHECK-DAG:     %[[OF0_CONS_PROD_LOCK_0:.+]] = aie.lock(%[[TILE_1_1]]) {init = 2 : i32
+// CHECK-DAG:     %[[OF0_CONS_CONS_LOCK_0:.+]] = aie.lock(%[[TILE_1_1]]) {init = 0 : i32
+// CHECK-DAG:     %[[OF0_CONS_PROD_LOCK_1:.+]] = aie.lock(%[[TILE_1_1]]) {init = 2 : i32
+// CHECK-DAG:     %[[OF0_CONS_CONS_LOCK_1:.+]] = aie.lock(%[[TILE_1_1]]) {init = 0 : i32
 // CHECK-DAG:     aie.flow(%[[TILE_1_0]], DMA : 0, %[[TILE_1_1]], DMA : 0)
 // CHECK-DAG:     aie.flow(%[[TILE_1_1]], DMA : 0, %[[TILE_2_2]], DMA : 0)
 // CHECK-DAG:     aie.flow(%[[TILE_1_1]], DMA : 0, %[[TILE_1_2]], DMA : 0)

--- a/test/objectFifo-stateful-transform/dma_transformations/nd_dma_fromStream_join.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/nd_dma_fromStream_join.mlir
@@ -15,22 +15,22 @@
 // CHECK-DAG:     %[[TILE_3_3:.*]] = aie.tile(3, 3)
 // CHECK-DAG:     %[[OF2_CONS_BUFF_0:.*]] = aie.buffer(%[[TILE_2_3]]) {sym_name = "of2_cons_buff_0"} : memref<256xi32>
 // CHECK-DAG:     %[[OF2_CONS_BUFF_1:.*]] = aie.buffer(%[[TILE_2_3]]) {sym_name = "of2_cons_buff_1"} : memref<256xi32>
-// CHECK-DAG:     %[[OF2_CONS_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_3]], 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK-DAG:     %[[OF2_CONS_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_3]], 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK-DAG:     %[[OF2_CONS_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_3]]) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK-DAG:     %[[OF2_CONS_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_3]]) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 // CHECK-DAG:     %[[OF2_BUFF_0:.*]] = aie.buffer(%[[TILE_1_1]]) {sym_name = "of2_buff_0"} : memref<256xi32>
 // CHECK-DAG:     %[[OF2_BUFF_1:.*]] = aie.buffer(%[[TILE_1_1]]) {sym_name = "of2_buff_1"} : memref<256xi32>
-// CHECK-DAG:     %[[OF2_PROD_LOCK_0:.*]] = aie.lock(%[[TILE_1_1]], 0) {init = 2 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK-DAG:     %[[OF2_CONS_LOCK_0:.*]] = aie.lock(%[[TILE_1_1]], 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
-// CHECK-DAG:     %[[OF2_PROD_LOCK_1:.*]] = aie.lock(%[[TILE_1_1]], 2) {init = 2 : i32, sym_name = "of2_prod_lock_1"}
-// CHECK-DAG:     %[[OF2_CONS_LOCK_1:.*]] = aie.lock(%[[TILE_1_1]], 3) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
+// CHECK-DAG:     %[[OF2_PROD_LOCK_0:.*]] = aie.lock(%[[TILE_1_1]]) {init = 2 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK-DAG:     %[[OF2_CONS_LOCK_0:.*]] = aie.lock(%[[TILE_1_1]]) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK-DAG:     %[[OF2_PROD_LOCK_1:.*]] = aie.lock(%[[TILE_1_1]]) {init = 2 : i32, sym_name = "of2_prod_lock_1"}
+// CHECK-DAG:     %[[OF2_CONS_LOCK_1:.*]] = aie.lock(%[[TILE_1_1]]) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
 // CHECK-DAG:     %[[OF1_BUFF_0:.*]] = aie.buffer(%[[TILE_3_3]]) {sym_name = "of1_buff_0"} : memref<128xi32>
 // CHECK-DAG:     %[[OF1_BUFF_1:.*]] = aie.buffer(%[[TILE_3_3]]) {sym_name = "of1_buff_1"} : memref<128xi32>
-// CHECK-DAG:     %[[OF1_PROD_LOCK:.*]] = aie.lock(%[[TILE_3_3]], 0) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK-DAG:     %[[OF1_CONS_LOCK:.*]] = aie.lock(%[[TILE_3_3]], 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK-DAG:     %[[OF1_PROD_LOCK:.*]] = aie.lock(%[[TILE_3_3]]) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK-DAG:     %[[OF1_CONS_LOCK:.*]] = aie.lock(%[[TILE_3_3]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK-DAG:     %[[OF0_BUFF_0:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "of0_buff_0"} : memref<128xi32>
 // CHECK-DAG:     %[[OF0_BUFF_1:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "of0_buff_1"} : memref<128xi32>
-// CHECK-DAG:     %[[OF0_PROD_LOCK:.*]] = aie.lock(%[[TILE_1_2]], 0) {init = 2 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK-DAG:     %[[OF0_CONS_LOCK:.*]] = aie.lock(%[[TILE_1_2]], 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK-DAG:     %[[OF0_PROD_LOCK:.*]] = aie.lock(%[[TILE_1_2]]) {init = 2 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK-DAG:     %[[OF0_CONS_LOCK:.*]] = aie.lock(%[[TILE_1_2]]) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK-DAG:     aie.flow(%[[TILE_1_2]], DMA : 0, %[[TILE_1_1]], DMA : 0)
 // CHECK-DAG:     aie.flow(%[[TILE_3_3]], DMA : 0, %[[TILE_1_1]], DMA : 1)
 // CHECK-DAG:     aie.flow(%[[TILE_1_1]], DMA : 0, %[[TILE_2_3]], DMA : 0)

--- a/test/objectFifo-stateful-transform/dma_transformations/nd_dma_multiple_consumers_AIE2.mlir
+++ b/test/objectFifo-stateful-transform/dma_transformations/nd_dma_multiple_consumers_AIE2.mlir
@@ -19,38 +19,38 @@
 // CHECK:     %[[tile_2_3:.*]] = aie.tile(2, 3)
 // CHECK:     %[[of3_cons_buff_0:.*]] = aie.buffer(%[[tile_2_3]]) {sym_name = "of3_cons_buff_0"} : memref<256xi32>
 // CHECK:     %[[of3_cons_buff_1:.*]] = aie.buffer(%[[tile_2_3]]) {sym_name = "of3_cons_buff_1"} : memref<256xi32>
-// CHECK:     %[[of3_cons_prod_lock:.*]] = aie.lock(%[[tile_2_3]], 0) {init = 2 : i32, sym_name = "of3_cons_prod_lock_0"}
-// CHECK:     %[[of3_cons_cons_lock:.*]] = aie.lock(%[[tile_2_3]], 1) {init = 0 : i32, sym_name = "of3_cons_cons_lock_0"}
+// CHECK:     %[[of3_cons_prod_lock:.*]] = aie.lock(%[[tile_2_3]]) {init = 2 : i32, sym_name = "of3_cons_prod_lock_0"}
+// CHECK:     %[[of3_cons_cons_lock:.*]] = aie.lock(%[[tile_2_3]]) {init = 0 : i32, sym_name = "of3_cons_cons_lock_0"}
 // CHECK:     %[[of3_buff_0:.*]] = aie.buffer(%[[tile_2_2]]) {sym_name = "of3_buff_0"} : memref<256xi32>
 // CHECK:     %[[of3_buff_1:.*]] = aie.buffer(%[[tile_2_2]]) {sym_name = "of3_buff_1"} : memref<256xi32>
-// CHECK:     %[[of3_prod_lock:.*]] = aie.lock(%[[tile_2_2]], 0) {init = 2 : i32, sym_name = "of3_prod_lock_0"}
-// CHECK:     %[[of3_cons_lock:.*]] = aie.lock(%[[tile_2_2]], 1) {init = 0 : i32, sym_name = "of3_cons_lock_0"}
+// CHECK:     %[[of3_prod_lock:.*]] = aie.lock(%[[tile_2_2]]) {init = 2 : i32, sym_name = "of3_prod_lock_0"}
+// CHECK:     %[[of3_cons_lock:.*]] = aie.lock(%[[tile_2_2]]) {init = 0 : i32, sym_name = "of3_cons_lock_0"}
 // CHECK:     %[[of1_cons_buff_0:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_0"} : memref<256xi32>
 // CHECK:     %[[of1_cons_buff_1:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of1_cons_buff_1"} : memref<256xi32>
-// CHECK:     %[[of1_cons_prod_lock:.*]] = aie.lock(%[[tile_3_3]], 2) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[of1_cons_cons_lock:.*]] = aie.lock(%[[tile_3_3]], 3) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[of1_cons_prod_lock:.*]] = aie.lock(%[[tile_3_3]]) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[of1_cons_cons_lock:.*]] = aie.lock(%[[tile_3_3]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[of1_buff_0:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_0"} : memref<256xi32>
 // CHECK:     %[[of1_buff_1:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of1_buff_1"} : memref<256xi32>
-// CHECK:     %[[of1_prod_lock:.*]] = aie.lock(%[[tile_1_2]], 2) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[of1_cons_lock:.*]] = aie.lock(%[[tile_1_2]], 3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[of1_prod_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[of1_cons_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     %[[of0_0_cons_buff_0:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_0"} : memref<256xi32>
 // CHECK:     %[[of0_0_cons_buff_1:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_1"} : memref<256xi32>
 // CHECK:     %[[of0_0_cons_buff_2:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_2"} : memref<256xi32>
 // CHECK:     %[[of0_0_cons_buff_3:.*]] = aie.buffer(%[[tile_1_3]]) {sym_name = "of0_0_cons_buff_3"} : memref<256xi32>
-// CHECK:     %[[of0_0_cons_prod_lock:.*]] = aie.lock(%[[tile_1_3]], 0) {init = 4 : i32, sym_name = "of0_0_cons_prod_lock_0"}
-// CHECK:     %[[of0_0_cons_cons_lock:.*]] = aie.lock(%[[tile_1_3]], 1) {init = 0 : i32, sym_name = "of0_0_cons_cons_lock_0"}
+// CHECK:     %[[of0_0_cons_prod_lock:.*]] = aie.lock(%[[tile_1_3]]) {init = 4 : i32, sym_name = "of0_0_cons_prod_lock_0"}
+// CHECK:     %[[of0_0_cons_cons_lock:.*]] = aie.lock(%[[tile_1_3]]) {init = 0 : i32, sym_name = "of0_0_cons_cons_lock_0"}
 // CHECK:     %[[of0_1_cons_buff_0:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_0"} : memref<256xi32>
 // CHECK:     %[[of0_1_cons_buff_1:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_1"} : memref<256xi32>
 // CHECK:     %[[of0_1_cons_buff_2:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_2"} : memref<256xi32>
 // CHECK:     %[[of0_1_cons_buff_3:.*]] = aie.buffer(%[[tile_3_3]]) {sym_name = "of0_1_cons_buff_3"} : memref<256xi32>
-// CHECK:     %[[of0_1_cons_prod_lock:.*]] = aie.lock(%[[tile_3_3]], 0) {init = 4 : i32, sym_name = "of0_1_cons_prod_lock_0"}
-// CHECK:     %[[of0_1_cons_cons_lock:.*]] = aie.lock(%[[tile_3_3]], 1) {init = 0 : i32, sym_name = "of0_1_cons_cons_lock_0"}
+// CHECK:     %[[of0_1_cons_prod_lock:.*]] = aie.lock(%[[tile_3_3]]) {init = 4 : i32, sym_name = "of0_1_cons_prod_lock_0"}
+// CHECK:     %[[of0_1_cons_cons_lock:.*]] = aie.lock(%[[tile_3_3]]) {init = 0 : i32, sym_name = "of0_1_cons_cons_lock_0"}
 // CHECK:     %[[of0_buff_0:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_0"} : memref<256xi32>
 // CHECK:     %[[of0_buff_1:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_1"} : memref<256xi32>
 // CHECK:     %[[of0_buff_2:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_2"} : memref<256xi32>
 // CHECK:     %[[of0_buff_3:.*]] = aie.buffer(%[[tile_1_2]]) {sym_name = "of0_buff_3"} : memref<256xi32>
-// CHECK:     %[[of0_prod_lock:.*]] = aie.lock(%[[tile_1_2]], 0) {init = 4 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[of0_cons_lock:.*]] = aie.lock(%[[tile_1_2]], 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[of0_prod_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 4 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[of0_cons_lock:.*]] = aie.lock(%[[tile_1_2]]) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%[[tile_1_2]], DMA : 0, %[[tile_3_3]], DMA : 0)
 // CHECK:     aie.flow(%[[tile_1_2]], DMA : 0, %[[tile_1_3]], DMA : 0)
 // CHECK:     aie.flow(%[[tile_1_2]], DMA : 1, %[[tile_3_3]], DMA : 1)

--- a/test/objectFifo-stateful-transform/dynamic_cyclostatic_balanced_conditional.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_cyclostatic_balanced_conditional.mlir
@@ -25,12 +25,12 @@
 // CHECK:           %[[T2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[CB0:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_0"} : memref<8xi8>
 // CHECK:           %[[CB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_1"} : memref<8xi8>
-// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]], 0) {init = 2 : i32, sym_name = "fifo_cons_prod_lock_0"}
-// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
+// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "fifo_cons_prod_lock_0"}
+// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
 // CHECK:           %[[B0:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_0"} : memref<8xi8>
 // CHECK:           %[[B1:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_1"} : memref<8xi8>
-// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]], 0) {init = 2 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]]) {init = 2 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:           aie.flow(%[[MT]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {
 // CHECK:             %[[C14:.*]] = arith.constant 14 : index

--- a/test/objectFifo-stateful-transform/dynamic_lowering/core_flag_test.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering/core_flag_test.mlir
@@ -18,30 +18,30 @@
 // CHECK:           %[[SHIM:.*]] = aie.tile(0, 0)
 // CHECK:           %[[T2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[T4:.*]] = aie.tile(0, 4)
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 6) {init = 0 : i32, sym_name = "output_fifo2_cons_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 7) {init = 0 : i32, sym_name = "output_fifo2_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo2_cons_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo2_cons_cons_lock_0"}
 // CHECK:           %[[OF2_B0:.*]] = aie.buffer(%[[T4]]) {sym_name = "output_fifo2_buff_0"} : memref<10xi32>
 // CHECK:           %[[OF2_B1:.*]] = aie.buffer(%[[T4]]) {sym_name = "output_fifo2_buff_1"} : memref<10xi32>
-// CHECK:           %[[OF2_PROD:.*]] = aie.lock(%[[T4]], 2) {init = 2 : i32, sym_name = "output_fifo2_prod_lock_0"}
-// CHECK:           %[[OF2_CONS:.*]] = aie.lock(%[[T4]], 3) {init = 0 : i32, sym_name = "output_fifo2_cons_lock_0"}
+// CHECK:           %[[OF2_PROD:.*]] = aie.lock(%[[T4]]) {init = 2 : i32, sym_name = "output_fifo2_prod_lock_0"}
+// CHECK:           %[[OF2_CONS:.*]] = aie.lock(%[[T4]]) {init = 0 : i32, sym_name = "output_fifo2_cons_lock_0"}
 // CHECK:           %[[IF2_B0:.*]] = aie.buffer(%[[T4]]) {sym_name = "input_fifo2_cons_buff_0"} : memref<10xi32>
 // CHECK:           %[[IF2_B1:.*]] = aie.buffer(%[[T4]]) {sym_name = "input_fifo2_cons_buff_1"} : memref<10xi32>
-// CHECK:           %[[IF2_PROD:.*]] = aie.lock(%[[T4]], 0) {init = 2 : i32, sym_name = "input_fifo2_cons_prod_lock_0"}
-// CHECK:           %[[IF2_CONS:.*]] = aie.lock(%[[T4]], 1) {init = 0 : i32, sym_name = "input_fifo2_cons_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 4) {init = 0 : i32, sym_name = "input_fifo2_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 5) {init = 0 : i32, sym_name = "input_fifo2_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 2) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
+// CHECK:           %[[IF2_PROD:.*]] = aie.lock(%[[T4]]) {init = 2 : i32, sym_name = "input_fifo2_cons_prod_lock_0"}
+// CHECK:           %[[IF2_CONS:.*]] = aie.lock(%[[T4]]) {init = 0 : i32, sym_name = "input_fifo2_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo2_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo2_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
 // CHECK:           %[[OF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_0"} : memref<10xi32>
 // CHECK:           %[[OF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_1"} : memref<10xi32>
-// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]], 2) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
-// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
+// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
+// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
 // CHECK:           %[[IF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_0"} : memref<10xi32>
 // CHECK:           %[[IF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_1"} : memref<10xi32>
-// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]], 0) {init = 2 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
-// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 0) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
+// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
+// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
 // CHECK:           aie.flow(%[[SHIM]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           aie.flow(%[[T2]], DMA : 0, %[[SHIM]], DMA : 0)
 // CHECK:           aie.flow(%[[SHIM]], DMA : 1, %[[T4]], DMA : 0)

--- a/test/objectFifo-stateful-transform/dynamic_lowering/depth_one_objectfifo_test.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering/depth_one_objectfifo_test.mlir
@@ -15,8 +15,8 @@
 // CHECK:      %{{.*}}tile_0_0 = aie.tile(0, 0)
 // CHECK:      %{{.*}}tile_0_2 = aie.tile(0, 2)
 // CHECK:      %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "input_fifo_cons_buff_0"} : memref<10xi32>
-// CHECK:      %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_0_2, 0) {init = 1 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
-// CHECK:      %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_0_2, 1) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
+// CHECK:      %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_0_2) {init = 1 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
+// CHECK:      %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_0_2) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
 // CHECK:      aie.flow(%{{.*}}tile_0_0, DMA : 0, %{{.*}}tile_0_2, DMA : 0)
 // CHECK:      %core_0_2 = aie.core(%{{.*}}tile_0_2) {
 // CHECK:        %{{.*}} = arith.constant 10 : index

--- a/test/objectFifo-stateful-transform/dynamic_lowering/different_depth_objectfifos_test.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering/different_depth_objectfifos_test.mlir
@@ -19,19 +19,19 @@
 // CHECK:           }
 // CHECK:           %[[T0:.*]] = aie.tile(0, 0)
 // CHECK:           %[[T2:.*]] = aie.tile(0, 2)
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 2) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
 // CHECK:           %[[OF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_0"} : memref<10xi32>
 // CHECK:           %[[OF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_1"} : memref<10xi32>
-// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]], 2) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
-// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
+// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
+// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
 // CHECK:           %[[IF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_0"} : memref<10xi32>
 // CHECK:           %[[IF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_1"} : memref<10xi32>
 // CHECK:           %[[IF_B2:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_2"} : memref<10xi32>
-// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]], 0) {init = 3 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
-// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 0) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
+// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]]) {init = 3 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
+// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
 // CHECK:           aie.flow(%[[T0]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           aie.flow(%[[T2]], DMA : 0, %[[T0]], DMA : 0)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {

--- a/test/objectFifo-stateful-transform/dynamic_lowering/pass_flag_test.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering/pass_flag_test.mlir
@@ -20,30 +20,30 @@
 // CHECK:           %[[SHIM:.*]] = aie.tile(0, 0)
 // CHECK:           %[[T2:.*]] = aie.tile(0, 2)
 // CHECK:           %[[T4:.*]] = aie.tile(0, 4)
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 6) {init = 0 : i32, sym_name = "output_fifo2_cons_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 7) {init = 0 : i32, sym_name = "output_fifo2_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo2_cons_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo2_cons_cons_lock_0"}
 // CHECK:           %[[OF2_B0:.*]] = aie.buffer(%[[T4]]) {sym_name = "output_fifo2_buff_0"} : memref<10xi32>
 // CHECK:           %[[OF2_B1:.*]] = aie.buffer(%[[T4]]) {sym_name = "output_fifo2_buff_1"} : memref<10xi32>
-// CHECK:           %[[OF2_PROD:.*]] = aie.lock(%[[T4]], 2) {init = 2 : i32, sym_name = "output_fifo2_prod_lock_0"}
-// CHECK:           %[[OF2_CONS:.*]] = aie.lock(%[[T4]], 3) {init = 0 : i32, sym_name = "output_fifo2_cons_lock_0"}
+// CHECK:           %[[OF2_PROD:.*]] = aie.lock(%[[T4]]) {init = 2 : i32, sym_name = "output_fifo2_prod_lock_0"}
+// CHECK:           %[[OF2_CONS:.*]] = aie.lock(%[[T4]]) {init = 0 : i32, sym_name = "output_fifo2_cons_lock_0"}
 // CHECK:           %[[IF2_B0:.*]] = aie.buffer(%[[T4]]) {sym_name = "input_fifo2_cons_buff_0"} : memref<10xi32>
 // CHECK:           %[[IF2_B1:.*]] = aie.buffer(%[[T4]]) {sym_name = "input_fifo2_cons_buff_1"} : memref<10xi32>
-// CHECK:           %[[IF2_PROD:.*]] = aie.lock(%[[T4]], 0) {init = 2 : i32, sym_name = "input_fifo2_cons_prod_lock_0"}
-// CHECK:           %[[IF2_CONS:.*]] = aie.lock(%[[T4]], 1) {init = 0 : i32, sym_name = "input_fifo2_cons_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 4) {init = 0 : i32, sym_name = "input_fifo2_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 5) {init = 0 : i32, sym_name = "input_fifo2_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 2) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
+// CHECK:           %[[IF2_PROD:.*]] = aie.lock(%[[T4]]) {init = 2 : i32, sym_name = "input_fifo2_cons_prod_lock_0"}
+// CHECK:           %[[IF2_CONS:.*]] = aie.lock(%[[T4]]) {init = 0 : i32, sym_name = "input_fifo2_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo2_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo2_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
 // CHECK:           %[[OF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_0"} : memref<10xi32>
 // CHECK:           %[[OF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_1"} : memref<10xi32>
-// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]], 2) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
-// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
+// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
+// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
 // CHECK:           %[[IF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_0"} : memref<10xi32>
 // CHECK:           %[[IF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_1"} : memref<10xi32>
-// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]], 0) {init = 2 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
-// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 0) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[SHIM]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
+// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
+// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[SHIM]]) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
 // CHECK:           aie.flow(%[[SHIM]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           aie.flow(%[[T2]], DMA : 0, %[[SHIM]], DMA : 0)
 // CHECK:           aie.flow(%[[SHIM]], DMA : 1, %[[T4]], DMA : 0)

--- a/test/objectFifo-stateful-transform/dynamic_lowering/same_depth_objectfifos_test.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering/same_depth_objectfifos_test.mlir
@@ -18,18 +18,18 @@
 // CHECK:           }
 // CHECK:           %[[T0:.*]] = aie.tile(0, 0)
 // CHECK:           %[[T2:.*]] = aie.tile(0, 2)
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 2) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "output_fifo_cons_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "output_fifo_cons_cons_lock_0"}
 // CHECK:           %[[OF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_0"} : memref<10xi32>
 // CHECK:           %[[OF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "output_fifo_buff_1"} : memref<10xi32>
-// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]], 2) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
-// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]], 3) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
+// CHECK:           %[[OF_PROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "output_fifo_prod_lock_0"}
+// CHECK:           %[[OF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "output_fifo_cons_lock_0"}
 // CHECK:           %[[IF_B0:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_0"} : memref<10xi32>
 // CHECK:           %[[IF_B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "input_fifo_cons_buff_1"} : memref<10xi32>
-// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]], 0) {init = 2 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
-// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 0) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
-// CHECK:           %{{.*}} = aie.lock(%[[T0]], 1) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
+// CHECK:           %[[IF_PROD:.*]] = aie.lock(%[[T2]]) {init = 2 : i32, sym_name = "input_fifo_cons_prod_lock_0"}
+// CHECK:           %[[IF_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "input_fifo_cons_cons_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "input_fifo_prod_lock_0"}
+// CHECK:           %{{.*}} = aie.lock(%[[T0]]) {init = 0 : i32, sym_name = "input_fifo_cons_lock_0"}
 // CHECK:           aie.flow(%[[T0]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           aie.flow(%[[T2]], DMA : 0, %[[T0]], DMA : 0)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {

--- a/test/objectFifo-stateful-transform/dynamic_lowering/sliding_window_held_count.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_lowering/sliding_window_held_count.mlir
@@ -30,10 +30,10 @@
 // CHECK-LABEL:   aie.device(npu2) {
 // CHECK-DAG:       %[[T2:.*]] = aie.tile(0, 2)
 // CHECK-DAG:       %[[T3:.*]] = aie.tile(0, 3)
-// CHECK-DAG:       %[[BL_PROD:.*]] = aie.lock(%[[T3]], 0) {init = 3 : i32, sym_name = "acquire_before_loop_cons_prod_lock_0"}
-// CHECK-DAG:       %[[BL_CONS:.*]] = aie.lock(%[[T3]], 1) {init = 0 : i32, sym_name = "acquire_before_loop_cons_cons_lock_0"}
-// CHECK-DAG:       %[[IN_PROD:.*]] = aie.lock(%[[T2]], 0) {init = 3 : i32, sym_name = "acquire_in_loop_cons_prod_lock_0"}
-// CHECK-DAG:       %[[IN_CONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "acquire_in_loop_cons_cons_lock_0"}
+// CHECK-DAG:       %[[BL_PROD:.*]] = aie.lock(%[[T3]]) {init = 3 : i32, sym_name = "acquire_before_loop_cons_prod_lock_0"}
+// CHECK-DAG:       %[[BL_CONS:.*]] = aie.lock(%[[T3]]) {init = 0 : i32, sym_name = "acquire_before_loop_cons_cons_lock_0"}
+// CHECK-DAG:       %[[IN_PROD:.*]] = aie.lock(%[[T2]]) {init = 3 : i32, sym_name = "acquire_in_loop_cons_prod_lock_0"}
+// CHECK-DAG:       %[[IN_CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "acquire_in_loop_cons_cons_lock_0"}
 
 // core_0_2 holds nothing on entry, so it computes how much to acquire.
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {

--- a/test/objectFifo-stateful-transform/dynamic_runtime_lock_basic.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_runtime_lock_basic.mlir
@@ -20,14 +20,14 @@
 // CHECK:           %[[CB0:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_0"} : memref<8xi8>
 // CHECK:           %[[CB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_1"} : memref<8xi8>
 // CHECK:           %[[CB2:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_2"} : memref<8xi8>
-// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]], 0) {init = 3 : i32, sym_name = "fifo_cons_prod_lock_0"}
-// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
+// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]]) {init = 3 : i32, sym_name = "fifo_cons_prod_lock_0"}
+// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
 // CHECK:           %[[B0:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_0"} : memref<8xi8>
 // CHECK:           %[[B1:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_1"} : memref<8xi8>
 // CHECK:           %[[B2:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_2"} : memref<8xi8>
 // CHECK:           %[[B3:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_3"} : memref<8xi8>
-// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]], 0) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]]) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:           aie.flow(%[[MT]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {
 // CHECK:             %[[C14:.*]] = arith.constant 14 : index

--- a/test/objectFifo-stateful-transform/dynamic_runtime_lock_conditional.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_runtime_lock_conditional.mlir
@@ -21,13 +21,13 @@
 // CHECK:           %[[CB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_1"} : memref<8xi8>
 // CHECK:           %[[CB2:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_2"} : memref<8xi8>
 // CHECK:           %[[CB3:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_3"} : memref<8xi8>
-// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]], 0) {init = 4 : i32, sym_name = "fifo_cons_prod_lock_0"}
-// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
+// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]]) {init = 4 : i32, sym_name = "fifo_cons_prod_lock_0"}
+// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
 // CHECK:           %[[B0:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_0"} : memref<8xi8>
 // CHECK:           %[[B1:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_1"} : memref<8xi8>
 // CHECK:           %[[B2:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_2"} : memref<8xi8>
-// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]], 0) {init = 3 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]]) {init = 3 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:           aie.flow(%[[MT]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {
 // CHECK:             %[[C14:.*]] = arith.constant 14 : index

--- a/test/objectFifo-stateful-transform/dynamic_runtime_lock_multiple_fifos.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_runtime_lock_multiple_fifos.mlir
@@ -18,23 +18,23 @@
 // CHECK:           %[[YCB0:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifoY_cons_buff_0"} : memref<8xi8>
 // CHECK:           %[[YCB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifoY_cons_buff_1"} : memref<8xi8>
 // CHECK:           %[[YCB2:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifoY_cons_buff_2"} : memref<8xi8>
-// CHECK:           %[[YCPROD:.*]] = aie.lock(%[[T2]], 2) {init = 3 : i32, sym_name = "fifoY_cons_prod_lock_0"}
-// CHECK:           %[[YCCONS:.*]] = aie.lock(%[[T2]], 3) {init = 0 : i32, sym_name = "fifoY_cons_cons_lock_0"}
+// CHECK:           %[[YCPROD:.*]] = aie.lock(%[[T2]]) {init = 3 : i32, sym_name = "fifoY_cons_prod_lock_0"}
+// CHECK:           %[[YCCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "fifoY_cons_cons_lock_0"}
 // CHECK:           %[[YB0:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifoY_buff_0"} : memref<8xi8>
 // CHECK:           %[[YB1:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifoY_buff_1"} : memref<8xi8>
-// CHECK:           %[[YPROD:.*]] = aie.lock(%[[MT]], 2) {init = 2 : i32, sym_name = "fifoY_prod_lock_0"}
-// CHECK:           %[[YCONS:.*]] = aie.lock(%[[MT]], 3) {init = 0 : i32, sym_name = "fifoY_cons_lock_0"}
+// CHECK:           %[[YPROD:.*]] = aie.lock(%[[MT]]) {init = 2 : i32, sym_name = "fifoY_prod_lock_0"}
+// CHECK:           %[[YCONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "fifoY_cons_lock_0"}
 // CHECK:           %[[XCB0:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifoX_cons_buff_0"} : memref<8xi8>
 // CHECK:           %[[XCB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifoX_cons_buff_1"} : memref<8xi8>
 // CHECK:           %[[XCB2:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifoX_cons_buff_2"} : memref<8xi8>
 // CHECK:           %[[XCB3:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifoX_cons_buff_3"} : memref<8xi8>
-// CHECK:           %[[XCPROD:.*]] = aie.lock(%[[T2]], 0) {init = 4 : i32, sym_name = "fifoX_cons_prod_lock_0"}
-// CHECK:           %[[XCCONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "fifoX_cons_cons_lock_0"}
+// CHECK:           %[[XCPROD:.*]] = aie.lock(%[[T2]]) {init = 4 : i32, sym_name = "fifoX_cons_prod_lock_0"}
+// CHECK:           %[[XCCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "fifoX_cons_cons_lock_0"}
 // CHECK:           %[[XB0:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifoX_buff_0"} : memref<8xi8>
 // CHECK:           %[[XB1:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifoX_buff_1"} : memref<8xi8>
 // CHECK:           %[[XB2:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifoX_buff_2"} : memref<8xi8>
-// CHECK:           %[[XPROD:.*]] = aie.lock(%[[MT]], 0) {init = 3 : i32, sym_name = "fifoX_prod_lock_0"}
-// CHECK:           %[[XCONS:.*]] = aie.lock(%[[MT]], 1) {init = 0 : i32, sym_name = "fifoX_cons_lock_0"}
+// CHECK:           %[[XPROD:.*]] = aie.lock(%[[MT]]) {init = 3 : i32, sym_name = "fifoX_prod_lock_0"}
+// CHECK:           %[[XCONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "fifoX_cons_lock_0"}
 // CHECK:           aie.flow(%[[MT]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           aie.flow(%[[MT]], DMA : 1, %[[T2]], DMA : 1)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {

--- a/test/objectFifo-stateful-transform/dynamic_runtime_lock_nested_loops.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_runtime_lock_nested_loops.mlir
@@ -19,23 +19,23 @@
 // CHECK:           %[[XCB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "inOF_X_cons_buff_1"} : memref<8xi8>
 // CHECK:           %[[XCB2:.*]] = aie.buffer(%[[T2]]) {sym_name = "inOF_X_cons_buff_2"} : memref<8xi8>
 // CHECK:           %[[XCB3:.*]] = aie.buffer(%[[T2]]) {sym_name = "inOF_X_cons_buff_3"} : memref<8xi8>
-// CHECK:           %[[XCPROD:.*]] = aie.lock(%[[T2]], 2) {init = 4 : i32, sym_name = "inOF_X_cons_prod_lock_0"}
-// CHECK:           %[[XCCONS:.*]] = aie.lock(%[[T2]], 3) {init = 0 : i32, sym_name = "inOF_X_cons_cons_lock_0"}
+// CHECK:           %[[XCPROD:.*]] = aie.lock(%[[T2]]) {init = 4 : i32, sym_name = "inOF_X_cons_prod_lock_0"}
+// CHECK:           %[[XCCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "inOF_X_cons_cons_lock_0"}
 // CHECK:           %[[XB0:.*]] = aie.buffer(%[[MT]]) {sym_name = "inOF_X_buff_0"} : memref<8xi8>
 // CHECK:           %[[XB1:.*]] = aie.buffer(%[[MT]]) {sym_name = "inOF_X_buff_1"} : memref<8xi8>
 // CHECK:           %[[XB2:.*]] = aie.buffer(%[[MT]]) {sym_name = "inOF_X_buff_2"} : memref<8xi8>
-// CHECK:           %[[XPROD:.*]] = aie.lock(%[[MT]], 2) {init = 3 : i32, sym_name = "inOF_X_prod_lock_0"}
-// CHECK:           %[[XCONS:.*]] = aie.lock(%[[MT]], 3) {init = 0 : i32, sym_name = "inOF_X_cons_lock_0"}
+// CHECK:           %[[XPROD:.*]] = aie.lock(%[[MT]]) {init = 3 : i32, sym_name = "inOF_X_prod_lock_0"}
+// CHECK:           %[[XCONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "inOF_X_cons_lock_0"}
 // CHECK:           %[[WCB0:.*]] = aie.buffer(%[[T2]]) {sym_name = "inOF_W_cons_buff_0"} : memref<8xi8>
 // CHECK:           %[[WCB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "inOF_W_cons_buff_1"} : memref<8xi8>
 // CHECK:           %[[WCB2:.*]] = aie.buffer(%[[T2]]) {sym_name = "inOF_W_cons_buff_2"} : memref<8xi8>
-// CHECK:           %[[WCPROD:.*]] = aie.lock(%[[T2]], 0) {init = 3 : i32, sym_name = "inOF_W_cons_prod_lock_0"}
-// CHECK:           %[[WCCONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "inOF_W_cons_cons_lock_0"}
+// CHECK:           %[[WCPROD:.*]] = aie.lock(%[[T2]]) {init = 3 : i32, sym_name = "inOF_W_cons_prod_lock_0"}
+// CHECK:           %[[WCCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "inOF_W_cons_cons_lock_0"}
 // CHECK:           %[[WB0:.*]] = aie.buffer(%[[MT]]) {sym_name = "inOF_W_buff_0"} : memref<8xi8>
 // CHECK:           %[[WB1:.*]] = aie.buffer(%[[MT]]) {sym_name = "inOF_W_buff_1"} : memref<8xi8>
 // CHECK:           %[[WB2:.*]] = aie.buffer(%[[MT]]) {sym_name = "inOF_W_buff_2"} : memref<8xi8>
-// CHECK:           %[[WPROD:.*]] = aie.lock(%[[MT]], 0) {init = 3 : i32, sym_name = "inOF_W_prod_lock_0"}
-// CHECK:           %[[WCONS:.*]] = aie.lock(%[[MT]], 1) {init = 0 : i32, sym_name = "inOF_W_cons_lock_0"}
+// CHECK:           %[[WPROD:.*]] = aie.lock(%[[MT]]) {init = 3 : i32, sym_name = "inOF_W_prod_lock_0"}
+// CHECK:           %[[WCONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "inOF_W_cons_lock_0"}
 // CHECK:           aie.flow(%[[MT]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           aie.flow(%[[MT]], DMA : 1, %[[T2]], DMA : 1)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {

--- a/test/objectFifo-stateful-transform/dynamic_runtime_lock_producer.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_runtime_lock_producer.mlir
@@ -18,8 +18,8 @@
 // CHECK:           %[[B1:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_buff_1"} : memref<8xi8>
 // CHECK:           %[[B2:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_buff_2"} : memref<8xi8>
 // CHECK:           %[[B3:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_buff_3"} : memref<8xi8>
-// CHECK:           %[[PROD:.*]] = aie.lock(%[[T2]], 0) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:           %[[CONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:           %[[PROD:.*]] = aie.lock(%[[T2]]) {init = 4 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:           %[[CONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {
 // CHECK:             %[[C14:.*]] = arith.constant 14 : index
 // CHECK:             %[[C1:.*]] = arith.constant 1 : index

--- a/test/objectFifo-stateful-transform/dynamic_runtime_lock_scf_while.mlir
+++ b/test/objectFifo-stateful-transform/dynamic_runtime_lock_scf_while.mlir
@@ -19,13 +19,13 @@
 // CHECK:           %[[CB1:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_1"} : memref<8xi8>
 // CHECK:           %[[CB2:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_2"} : memref<8xi8>
 // CHECK:           %[[CB3:.*]] = aie.buffer(%[[T2]]) {sym_name = "fifo_cons_buff_3"} : memref<8xi8>
-// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]], 0) {init = 4 : i32, sym_name = "fifo_cons_prod_lock_0"}
-// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]], 1) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
+// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T2]]) {init = 4 : i32, sym_name = "fifo_cons_prod_lock_0"}
+// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T2]]) {init = 0 : i32, sym_name = "fifo_cons_cons_lock_0"}
 // CHECK:           %[[B0:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_0"} : memref<8xi8>
 // CHECK:           %[[B1:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_1"} : memref<8xi8>
 // CHECK:           %[[B2:.*]] = aie.buffer(%[[MT]]) {sym_name = "fifo_buff_2"} : memref<8xi8>
-// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]], 0) {init = 3 : i32, sym_name = "fifo_prod_lock_0"}
-// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]], 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+// CHECK:           %[[PROD:.*]] = aie.lock(%[[MT]]) {init = 3 : i32, sym_name = "fifo_prod_lock_0"}
+// CHECK:           %[[CONS:.*]] = aie.lock(%[[MT]]) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
 // CHECK:           %[[BUF:.*]] = aie.buffer(%[[T2]]) {sym_name = "buf"} : memref<1xindex>
 // CHECK:           aie.flow(%[[MT]], DMA : 0, %[[T2]], DMA : 0)
 // CHECK:           %{{.*}} = aie.core(%[[T2]]) {

--- a/test/objectFifo-stateful-transform/init_values/init_values_distribute_input_test.mlir
+++ b/test/objectFifo-stateful-transform/init_values/init_values_distribute_input_test.mlir
@@ -15,22 +15,22 @@
 // CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of2_cons_buff_0"} : memref<2xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of2_cons_buff_1"} : memref<2xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<2xi32>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<2xi32>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<4xi32>
 // CHECK:     %[[VAL_9:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_1"} : memref<4xi32>
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 2 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
-// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_1, 2) {init = 2 : i32, sym_name = "of0_cons_prod_lock_1"}
-// CHECK:     %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_1_1, 3) {init = 0 : i32, sym_name = "of0_cons_cons_lock_1"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 2 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 2 : i32, sym_name = "of0_cons_prod_lock_1"}
+// CHECK:     %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_1"}
 // CHECK:     %[[VAL_14:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of0_buff_0"} : memref<4xi32> = dense<[0, 1, 2, 3]>
 // CHECK:     %[[VAL_15:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of0_buff_1"} : memref<4xi32> = dense<[4, 5, 6, 7]>
-// CHECK:     %[[VAL_16:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_17:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 2 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[VAL_16:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[VAL_17:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 2 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_3, DMA : 0, %{{.*}}tile_1_1, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 1, %{{.*}}tile_2_3, DMA : 0)

--- a/test/objectFifo-stateful-transform/init_values/init_values_join_input_test.mlir
+++ b/test/objectFifo-stateful-transform/init_values/init_values_join_input_test.mlir
@@ -15,18 +15,18 @@
 // CHECK:     %[[TILE_2_3:.*]] = aie.tile(2, 3)
 // CHECK-DAG:     %[[OF2_BUFF_0:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "of2_buff_0"} : memref<8xi32>
 // CHECK-DAG:     %[[OF2_BUFF_1:.*]] = aie.buffer(%[[MEM_TILE]]) {sym_name = "of2_buff_1"} : memref<8xi32>
-// CHECK-DAG:     %[[OF2_PROD_LOCK_0:.*]] = aie.lock(%[[MEM_TILE]], 0) {init = 2 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK-DAG:     %[[OF2_CONS_LOCK_0:.*]] = aie.lock(%[[MEM_TILE]], 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
-// CHECK-DAG:     %[[OF2_PROD_LOCK_1:.*]] = aie.lock(%[[MEM_TILE]], 2) {init = 2 : i32, sym_name = "of2_prod_lock_1"}
-// CHECK-DAG:     %[[OF2_CONS_LOCK_1:.*]] = aie.lock(%[[MEM_TILE]], 3) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
+// CHECK-DAG:     %[[OF2_PROD_LOCK_0:.*]] = aie.lock(%[[MEM_TILE]]) {init = 2 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK-DAG:     %[[OF2_CONS_LOCK_0:.*]] = aie.lock(%[[MEM_TILE]]) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK-DAG:     %[[OF2_PROD_LOCK_1:.*]] = aie.lock(%[[MEM_TILE]]) {init = 2 : i32, sym_name = "of2_prod_lock_1"}
+// CHECK-DAG:     %[[OF2_CONS_LOCK_1:.*]] = aie.lock(%[[MEM_TILE]]) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
 // CHECK-DAG:     %[[OF1_BUFF_0:.*]] = aie.buffer(%[[TILE_2_3]]) {sym_name = "of1_buff_0"} : memref<2x2xi32> = dense<{{\[}}[0, 1], [2, 3]]>
 // CHECK-DAG:     %[[OF1_BUFF_1:.*]] = aie.buffer(%[[TILE_2_3]]) {sym_name = "of1_buff_1"} : memref<2x2xi32> = dense<{{\[}}[4, 5], [6, 7]]>
-// CHECK-DAG:     %[[OF1_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_3]], 0) {init = 0 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK-DAG:     %[[OF1_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_3]], 1) {init = 2 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK-DAG:     %[[OF1_PROD_LOCK:.*]] = aie.lock(%[[TILE_2_3]]) {init = 0 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK-DAG:     %[[OF1_CONS_LOCK:.*]] = aie.lock(%[[TILE_2_3]]) {init = 2 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK-DAG:     %[[OF0_BUFF_0:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "of0_buff_0"} : memref<2x2xi32> = dense<{{\[}}[0, 1], [2, 3]]>
 // CHECK-DAG:     %[[OF0_BUFF_1:.*]] = aie.buffer(%[[TILE_1_2]]) {sym_name = "of0_buff_1"} : memref<2x2xi32> = dense<{{\[}}[4, 5], [6, 7]]>
-// CHECK-DAG:     %[[OF0_PROD_LOCK:.*]] = aie.lock(%[[TILE_1_2]], 0) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK-DAG:     %[[OF0_CONS_LOCK:.*]] = aie.lock(%[[TILE_1_2]], 1) {init = 2 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK-DAG:     %[[OF0_PROD_LOCK:.*]] = aie.lock(%[[TILE_1_2]]) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK-DAG:     %[[OF0_CONS_LOCK:.*]] = aie.lock(%[[TILE_1_2]]) {init = 2 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK-DAG:     aie.flow(%[[TILE_1_2]], DMA : 0, %[[MEM_TILE]], DMA : 0)
 // CHECK-DAG:     aie.flow(%[[TILE_2_3]], DMA : 0, %[[MEM_TILE]], DMA : 1)
 // CHECK-DAG:     aie.flow(%[[MEM_TILE]], DMA : 0, %[[SHIM_TILE]], DMA : 0)

--- a/test/objectFifo-stateful-transform/init_values/init_values_join_output_test.mlir
+++ b/test/objectFifo-stateful-transform/init_values/init_values_join_output_test.mlir
@@ -15,18 +15,18 @@
 // CHECK:     %{{.*}}tile_2_3 = aie.tile(2, 3)
 // CHECK-DAG: %[[OF2_BUFF_0:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of2_buff_0"} : memref<4xi32> = dense<[0, 1, 2, 3]>
 // CHECK-DAG: %[[OF2_BUFF_1:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of2_buff_1"} : memref<4xi32> = dense<[4, 5, 6, 7]>
-// CHECK-DAG: %[[OF2_PROD_LOCK_0:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 0 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK-DAG: %[[OF2_CONS_LOCK_0:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 2 : i32, sym_name = "of2_cons_lock_0"}
-// CHECK-DAG: %[[OF2_PROD_LOCK_1:.*]] = aie.lock(%{{.*}}tile_1_1, 2) {init = 0 : i32, sym_name = "of2_prod_lock_1"}
-// CHECK-DAG: %[[OF2_CONS_LOCK_1:.*]] = aie.lock(%{{.*}}tile_1_1, 3) {init = 2 : i32, sym_name = "of2_cons_lock_1"}
+// CHECK-DAG: %[[OF2_PROD_LOCK_0:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK-DAG: %[[OF2_CONS_LOCK_0:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 2 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK-DAG: %[[OF2_PROD_LOCK_1:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of2_prod_lock_1"}
+// CHECK-DAG: %[[OF2_CONS_LOCK_1:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 2 : i32, sym_name = "of2_cons_lock_1"}
 // CHECK-DAG: %[[OF1_BUFF_0:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of1_buff_0"} : memref<2xi32>
 // CHECK-DAG: %[[OF1_BUFF_1:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of1_buff_1"} : memref<2xi32>
-// CHECK-DAG: %[[OF1_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK-DAG: %[[OF1_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK-DAG: %[[OF1_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK-DAG: %[[OF1_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK-DAG: %[[OF0_BUFF_0:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_0"} : memref<2xi32>
 // CHECK-DAG: %[[OF0_BUFF_1:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_1"} : memref<2xi32>
-// CHECK-DAG: %[[OF0_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK-DAG: %[[OF0_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK-DAG: %[[OF0_PROD_LOCK:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK-DAG: %[[OF0_CONS_LOCK:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK-DAG: aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_1, DMA : 0)
 // CHECK-DAG: aie.flow(%{{.*}}tile_2_3, DMA : 0, %{{.*}}tile_1_1, DMA : 1)
 // CHECK-DAG: aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_0, DMA : 0)

--- a/test/objectFifo-stateful-transform/init_values/init_values_repeat_test.mlir
+++ b/test/objectFifo-stateful-transform/init_values/init_values_repeat_test.mlir
@@ -13,12 +13,12 @@
 // CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of0_cons_buff_0"} : memref<2x2xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of0_cons_buff_1"} : memref<2x2xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 2 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 2 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_0"} : memref<2x2xi32> = dense<{{\[}}[0, 1], [2, 3]]>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_1"} : memref<2x2xi32> = dense<{{\[}}[4, 5], [6, 7]]>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 6 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 6 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
 // CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb7)

--- a/test/objectFifo-stateful-transform/init_values/init_values_shared_mem_test.mlir
+++ b/test/objectFifo-stateful-transform/init_values/init_values_shared_mem_test.mlir
@@ -13,12 +13,12 @@
 // CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_buff_0"} : memref<2x2xi32> = dense<{{\[}}[0, 1], [2, 3]]>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_buff_1"} : memref<2x2xi32> = dense<{{\[}}[4, 5], [6, 7]]>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 0 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 2 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 2 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_0"} : memref<2x2xi32> = dense<{{\[}}[0, 1], [2, 3]]>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_1"} : memref<2x2xi32> = dense<{{\[}}[4, 5], [6, 7]]>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 2 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:   }
 // CHECK: }
 

--- a/test/objectFifo-stateful-transform/init_values/init_values_test.mlir
+++ b/test/objectFifo-stateful-transform/init_values/init_values_test.mlir
@@ -14,13 +14,13 @@
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of0_cons_buff_0"} : memref<2x2xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of0_cons_buff_1"} : memref<2x2xi32>
 // CHECK:     %[[VAL_2:.*]] = aie.buffer(%{{.*}}tile_2_3) {sym_name = "of0_cons_buff_2"} : memref<2x2xi32>
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3, 0) {init = 3 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_2_3, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 3 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_2_3) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_0"} : memref<2x2xi32> = dense<{{\[}}[0, 1], [2, 3]]>
 // CHECK:     %[[VAL_6:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_1"} : memref<2x2xi32> = dense<{{\[}}[4, 5], [6, 7]]>
 // CHECK:     %[[VAL_7:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_buff_2"} : memref<2x2xi32> = dense<{{\[}}[8, 9], [10, 11]]>
-// CHECK:     %[[VAL_8:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_9:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 3 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[VAL_8:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[VAL_9:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 3 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_2_3, DMA : 0)
 // CHECK:     %mem_1_2 = aie.mem(%{{.*}}tile_1_2) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb4)

--- a/test/objectFifo-stateful-transform/loop_unrolling/acquire_before_loop.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/acquire_before_loop.mlir
@@ -17,10 +17,10 @@
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "loop_of_lock_2"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "loop_of_lock_3"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_1"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_2"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_3"}
 // CHECK:           func.func @some_work(%[[VAL_10:.*]]: memref<16xi32>, %[[VAL_11:.*]]: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/loop_unrolling/fully_divisible_loop_iter.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/fully_divisible_loop_iter.mlir
@@ -12,8 +12,8 @@
 // CHECK:      %{{.*}}tile_1_2 = aie.tile(1, 2)
 // CHECK:      %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "loop_of_buff_0"} : memref<16xi32>
 // CHECK:      %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "loop_of_buff_1"} : memref<16xi32>
-// CHECK:      %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
-// CHECK:      %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
+// CHECK:      %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "loop_of_lock_0"}
+// CHECK:      %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "loop_of_lock_1"}
 // CHECK:      func.func @some_work(%arg0: memref<16xi32>, %arg1: index) {
 // CHECK:        return
 // CHECK:      }

--- a/test/objectFifo-stateful-transform/loop_unrolling/fully_divisible_loop_iter_dynamic.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/fully_divisible_loop_iter_dynamic.mlir
@@ -17,8 +17,8 @@
 // CHECK:           %[[T12:.*]] = aie.tile(1, 2)
 // CHECK:           %[[B0:.*]] = aie.buffer(%[[T12]]) {sym_name = "loop_of_buff_0"} : memref<16xi32>
 // CHECK:           %[[B1:.*]] = aie.buffer(%[[T12]]) {sym_name = "loop_of_buff_1"} : memref<16xi32>
-// CHECK:           %[[L0:.*]] = aie.lock(%[[T12]], 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
-// CHECK:           %[[L1:.*]] = aie.lock(%[[T12]], 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
+// CHECK:           %[[L0:.*]] = aie.lock(%[[T12]]) {init = 0 : i32, sym_name = "loop_of_lock_0"}
+// CHECK:           %[[L1:.*]] = aie.lock(%[[T12]]) {init = 0 : i32, sym_name = "loop_of_lock_1"}
 // CHECK:           func.func @some_work(%{{.*}}: memref<16xi32>, %{{.*}}: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/loop_unrolling/fully_unroll_loop.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/fully_unroll_loop.mlir
@@ -14,13 +14,13 @@
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of_2_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_2_lock_1"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "of_2_lock_2"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_2"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "of_1_lock_0"}
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_1_lock_1"}
+// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_1"}
 // CHECK:           func.func @some_work(%[[VAL_12:.*]]: memref<16xi32>, %[[VAL_13:.*]]: memref<16xi32>, %[[VAL_14:.*]]: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/loop_unrolling/large_loop_step.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/large_loop_step.mlir
@@ -14,10 +14,10 @@
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "loop_of_lock_2"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "loop_of_lock_3"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_1"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_2"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_3"}
 // CHECK:           func.func @some_work(%[[VAL_10:.*]]: memref<16xi32>, %[[VAL_11:.*]]: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/loop_unrolling/loop_unroll_with_remainder.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/loop_unroll_with_remainder.mlir
@@ -15,14 +15,14 @@
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_2"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_3"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of_2_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_2_lock_1"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "of_2_lock_2"}
-// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "of_2_lock_3"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_1"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_2"}
+// CHECK:           %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_3"}
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_11:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "of_1_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_1_lock_1"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_1"}
 // CHECK:           func.func @some_work(%[[A:.*]]: memref<16xi32>, %[[B:.*]]: memref<16xi32>, %[[I:.*]]: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/loop_unrolling/nested_loop_acquire_release.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/nested_loop_acquire_release.mlir
@@ -12,11 +12,11 @@
 // CHECK:               %{{.*}}tile_0_2 = aie.tile(0, 2)
 // CHECK:               %{{.*}}tile_0_3 = aie.tile(0, 3)
 // CHECK:               %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_0_2) {sym_name = "of_2_buff_0"} : memref<16xi32>
-// CHECK:               %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_0_2, 0) {init = 1 : i32, sym_name = "of_2_prod_lock_0"}
-// CHECK:               %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_0_2, 1) {init = 0 : i32, sym_name = "of_2_cons_lock_0"}
+// CHECK:               %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_0_2) {init = 1 : i32, sym_name = "of_2_prod_lock_0"}
+// CHECK:               %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_0_2) {init = 0 : i32, sym_name = "of_2_cons_lock_0"}
 // CHECK:               %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_0_3) {sym_name = "of_1_buff_0"} : memref<16xi32>
-// CHECK:               %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_0_3, 0) {init = 1 : i32, sym_name = "of_1_prod_lock_0"}
-// CHECK:               %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_0_3, 1) {init = 0 : i32, sym_name = "of_1_cons_lock_0"}
+// CHECK:               %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_0_3) {init = 1 : i32, sym_name = "of_1_prod_lock_0"}
+// CHECK:               %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_0_3) {init = 0 : i32, sym_name = "of_1_cons_lock_0"}
 // CHECK:               func.func @some_work(%arg0: memref<16xi32>, %arg1: memref<16xi32>, %arg2: index, %arg3: index) {
 // CHECK:                 return
 // CHECK:               }

--- a/test/objectFifo-stateful-transform/loop_unrolling/nested_loop_unroll_inner_then_outer.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/nested_loop_unroll_inner_then_outer.mlir
@@ -11,8 +11,8 @@
 // CHECK:           %[[VAL_0:.*]] = aie.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "loop_of_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_3:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "loop_of_lock_0"}
-// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "loop_of_lock_1"}
+// CHECK:           %[[VAL_3:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_0"}
+// CHECK:           %[[VAL_4:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "loop_of_lock_1"}
 // CHECK:           func.func @some_work(%[[A:.*]]: memref<4x4xi32>, %[[I:.*]]: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/loop_unrolling/nested_loop_unroll_with_remainder.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/nested_loop_unroll_with_remainder.mlir
@@ -14,15 +14,15 @@
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of_2_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_2_lock_1"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "of_2_lock_2"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_2"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_10:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "of_1_lock_0"}
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_1_lock_1"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_1]], 2) {init = 0 : i32, sym_name = "of_1_lock_2"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_0"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_1"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_2"}
 // CHECK:           func.func @some_work(%{{.*}}: memref<16xi32>, %{{.*}}: memref<16xi32>, %{{.*}}: index, %{{.*}}: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/loop_unrolling/unroll_factor_multiple_objectfifos.mlir
+++ b/test/objectFifo-stateful-transform/loop_unrolling/unroll_factor_multiple_objectfifos.mlir
@@ -14,13 +14,13 @@
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_2_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "of_2_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_2_lock_1"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "of_2_lock_2"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_2_lock_2"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_1_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "of_1_lock_0"}
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_1_lock_1"}
+// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_1_lock_1"}
 // CHECK:           func.func @some_work(%[[VAL_12:.*]]: memref<16xi32>, %[[VAL_13:.*]]: memref<16xi32>, %[[VAL_14:.*]]: index) {
 // CHECK:             return
 // CHECK:           }

--- a/test/objectFifo-stateful-transform/matmul_test.mlir
+++ b/test/objectFifo-stateful-transform/matmul_test.mlir
@@ -13,16 +13,16 @@
 // CHECK:           %[[VAL_1:.*]] = aie.tile(0, 2)
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "outC_buff_0"} : memref<16x16xi16>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "outC_buff_1"} : memref<16x16xi16>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]], 4) {init = 2 : i32, sym_name = "outC_prod_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]], 5) {init = 0 : i32, sym_name = "outC_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "outC_prod_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "outC_cons_lock_0"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "inB_cons_buff_0"} : memref<8x16xi16>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "inB_cons_buff_1"} : memref<8x16xi16>
-// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]], 2) {init = 2 : i32, sym_name = "inB_cons_prod_lock_0"}
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]], 3) {init = 0 : i32, sym_name = "inB_cons_cons_lock_0"}
+// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "inB_cons_prod_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "inB_cons_cons_lock_0"}
 // CHECK:           %[[VAL_14:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "inA_cons_buff_0"} : memref<16x8xi16>
 // CHECK:           %[[VAL_15:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "inA_cons_buff_1"} : memref<16x8xi16>
-// CHECK:           %[[VAL_16:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "inA_cons_prod_lock_0"}
-// CHECK:           %[[VAL_17:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "inA_cons_cons_lock_0"}
+// CHECK:           %[[VAL_16:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "inA_cons_prod_lock_0"}
+// CHECK:           %[[VAL_17:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "inA_cons_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 1, %[[VAL_1]], DMA : 1)
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)

--- a/test/objectFifo-stateful-transform/objectfifo_allocate/allocate_test.mlir
+++ b/test/objectFifo-stateful-transform/objectfifo_allocate/allocate_test.mlir
@@ -11,14 +11,14 @@
 // CHECK:           %[[VAL_0:.*]] = aie.tile(1, 2)
 // CHECK:           %[[VAL_1:.*]] = aie.tile(1, 3)
 // CHECK:           %of2_buff_0 = aie.buffer(%tile_1_2) {sym_name = "of2_buff_0"} : memref<16xi32>
-// CHECK:           %of2_prod_lock_0 = aie.lock(%tile_1_2, 0) {init = 1 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK:           %of2_cons_lock_0 = aie.lock(%tile_1_2, 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK:           %of2_prod_lock_0 = aie.lock(%tile_1_2) {init = 1 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK:           %of2_cons_lock_0 = aie.lock(%tile_1_2) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
 // CHECK:           %of1_buff_0 = aie.buffer(%tile_1_3) {sym_name = "of1_buff_0"} : memref<16xi32>
-// CHECK:           %of1_prod_lock_0 = aie.lock(%tile_1_3, 2) {init = 1 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:           %of1_cons_lock_0 = aie.lock(%tile_1_3, 3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:           %of1_prod_lock_0 = aie.lock(%tile_1_3) {init = 1 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:           %of1_cons_lock_0 = aie.lock(%tile_1_3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:           %of0_buff_0 = aie.buffer(%tile_1_3) {sym_name = "of0_buff_0"} : memref<16xi32>
-// CHECK:           %of0_prod_lock_0 = aie.lock(%tile_1_3, 0) {init = 1 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:           %of0_cons_lock_0 = aie.lock(%tile_1_3, 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:           %of0_prod_lock_0 = aie.lock(%tile_1_3) {init = 1 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:           %of0_cons_lock_0 = aie.lock(%tile_1_3) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:         }
 
 module @allocate {

--- a/test/objectFifo-stateful-transform/packet_switched_flows/packet_id_test.mlir
+++ b/test/objectFifo-stateful-transform/packet_switched_flows/packet_id_test.mlir
@@ -15,12 +15,12 @@
 // CHECK:     %[[VAL_4:.*]] = aie.tile(3, 3)
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_6:.*]] = aie.buffer(%[[VAL_4]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%[[VAL_4]], 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_8:.*]] = aie.lock(%[[VAL_4]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%[[VAL_4]]) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_8:.*]] = aie.lock(%[[VAL_4]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_9:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_10:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_12:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_12:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     aie.packet_flow(2) {
 // CHECK:        aie.packet_source<%[[VAL_2]], DMA : 0>
 // CHECK:        aie.packet_dest<%[[VAL_4]], DMA : 0>

--- a/test/objectFifo-stateful-transform/packet_switched_flows/pass_flag_test.mlir
+++ b/test/objectFifo-stateful-transform/packet_switched_flows/pass_flag_test.mlir
@@ -13,12 +13,12 @@
 // CHECK:     %[[VAL_2:.*]] = aie.tile(3, 3)
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_7:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of1_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of1_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_9:.*]] = aie.lock(%[[VAL_0]], 0) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_9:.*]] = aie.lock(%[[VAL_0]]) {init = 2 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     aie.packet_flow(0) {
 // CHECK:        aie.packet_source<%[[VAL_0]], DMA : 0>
 // CHECK:        aie.packet_dest<%[[VAL_2]], DMA : 0>

--- a/test/objectFifo-stateful-transform/packet_switched_flows/shim_dma_alloc_test.mlir
+++ b/test/objectFifo-stateful-transform/packet_switched_flows/shim_dma_alloc_test.mlir
@@ -13,8 +13,8 @@
 // CHECK:     %[[VAL_2:.*]] = aie.tile(3, 3)
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     aie.packet_flow(0) {
 // CHECK:        aie.packet_source<%[[VAL_0]], DMA : 0>
 // CHECK:        aie.packet_dest<%[[VAL_2]], DMA : 0>

--- a/test/objectFifo-stateful-transform/register_external_buffers/no_register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers/no_register_external_buffers_test.mlir
@@ -13,9 +13,9 @@
 // CHECK:             %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_7_2) {sym_name = "ext_of_cons_buff_0"} : memref<16xi32>
 // CHECK:             %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_7_2) {sym_name = "ext_of_cons_buff_1"} : memref<16xi32>
 // CHECK:             %[[VAL_2:.*]] = aie.buffer(%{{.*}}tile_7_2) {sym_name = "ext_of_cons_buff_2"} : memref<16xi32>
-// CHECK:             %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_7_2, 0) {init = 0 : i32, sym_name = "ext_of_cons_lock_0"}
-// CHECK:             %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_7_2, 1) {init = 0 : i32, sym_name = "ext_of_cons_lock_1"}
-// CHECK:             %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_7_2, 2) {init = 0 : i32, sym_name = "ext_of_cons_lock_2"}
+// CHECK:             %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_7_2) {init = 0 : i32, sym_name = "ext_of_cons_lock_0"}
+// CHECK:             %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_7_2) {init = 0 : i32, sym_name = "ext_of_cons_lock_1"}
+// CHECK:             %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_7_2) {init = 0 : i32, sym_name = "ext_of_cons_lock_2"}
 // CHECK:             aie.flow(%{{.*}}tile_7_0, DMA : 0, %{{.*}}tile_7_2, DMA : 0)
 // CHECK:             aie.shim_dma_allocation @ext_of_shim_alloc(%shim_noc_tile_7_0, MM2S, 0)
 // CHECK:             %mem_7_2 = aie.mem(%{{.*}}tile_7_2) {

--- a/test/objectFifo-stateful-transform/register_external_buffers/register_external_buffers_depth_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers/register_external_buffers_depth_test.mlir
@@ -11,9 +11,9 @@
 // CHECK:               %{{.*}}tile_7_1 = aie.tile(7, 1)
 // CHECK:               %{{.*}}tile_7_0 = aie.tile(7, 0)
 // CHECK:               %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_7_1) {sym_name = "ext_of_cons_buff_0"} : memref<16xi32>
-// CHECK:               %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_7_1, 0) {init = 0 : i32, sym_name = "ext_of_cons_lock_0"}
-// CHECK:               %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_7_0, 0) {init = 0 : i32, sym_name = "ext_of_lock_0"}
-// CHECK:               %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_7_0, 1) {init = 0 : i32, sym_name = "ext_of_lock_1"}
+// CHECK:               %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_7_1) {init = 0 : i32, sym_name = "ext_of_cons_lock_0"}
+// CHECK:               %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_7_0) {init = 0 : i32, sym_name = "ext_of_lock_0"}
+// CHECK:               %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_7_0) {init = 0 : i32, sym_name = "ext_of_lock_1"}
 // CHECK:               aie.flow(%{{.*}}tile_7_0, DMA : 0, %{{.*}}tile_7_1, DMA : 0)
 // CHECK:               %ext_buffer_in0 = aie.external_buffer {sym_name = "ext_buffer_in0"} : memref<64xi32>
 // CHECK:               %ext_buffer_in1 = aie.external_buffer {sym_name = "ext_buffer_in1"} : memref<64xi32>

--- a/test/objectFifo-stateful-transform/register_external_buffers/register_external_buffers_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers/register_external_buffers_test.mlir
@@ -16,10 +16,10 @@
 // CHECK:           %[[VAL_2:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "ext_of_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_3:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "ext_of_cons_buff_1"} : memref<16xi32>
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "ext_of_cons_buff_2"} : memref<16xi32>
-// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]], 0) {init = 0 : i32, sym_name = "ext_of_cons_lock_0"}
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "ext_of_cons_lock_1"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 2) {init = 0 : i32, sym_name = "ext_of_cons_lock_2"}
-// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_1]], 0) {init = 0 : i32, sym_name = "ext_of_lock_0"}
+// CHECK:           %[[VAL_5:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "ext_of_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "ext_of_cons_lock_1"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "ext_of_cons_lock_2"}
+// CHECK:           %[[VAL_8:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "ext_of_lock_0"}
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)
 // CHECK:           %[[VAL_9:.*]] = aie.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>
 // CHECK:           func.func @some_work(%[[VAL_10:.*]]: memref<16xi32>, %[[VAL_11:.*]]: memref<16xi32>) {

--- a/test/objectFifo-stateful-transform/register_external_buffers/shim_AIE2_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers/shim_AIE2_test.mlir
@@ -12,18 +12,18 @@
 // CHECK-LABEL:   aie.device(xcve2302) {
 // CHECK:           %[[VAL_0:.*]] = aie.tile(2, 2)
 // CHECK:           %[[VAL_1:.*]] = aie.tile(2, 0)
-// CHECK:           %[[VAL_2:.*]] = aie.lock(%[[VAL_1]], 2) {init = 1 : i32, sym_name = "of_out_cons_prod_lock_0"}
-// CHECK:           %[[VAL_3:.*]] = aie.lock(%[[VAL_1]], 3) {init = 0 : i32, sym_name = "of_out_cons_cons_lock_0"}
+// CHECK:           %[[VAL_2:.*]] = aie.lock(%[[VAL_1]]) {init = 1 : i32, sym_name = "of_out_cons_prod_lock_0"}
+// CHECK:           %[[VAL_3:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_out_cons_cons_lock_0"}
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_out_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_out_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]], 2) {init = 2 : i32, sym_name = "of_out_prod_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]], 3) {init = 0 : i32, sym_name = "of_out_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_0]]) {init = 2 : i32, sym_name = "of_out_prod_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_out_cons_lock_0"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_in_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_0]]) {sym_name = "of_in_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_0]], 0) {init = 2 : i32, sym_name = "of_in_cons_prod_lock_0"}
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_in_cons_cons_lock_0"}
-// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_1]], 0) {init = 1 : i32, sym_name = "of_in_prod_lock_0"}
-// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_in_cons_lock_0"}
+// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_0]]) {init = 2 : i32, sym_name = "of_in_cons_prod_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_in_cons_cons_lock_0"}
+// CHECK:           %[[VAL_12:.*]] = aie.lock(%[[VAL_1]]) {init = 1 : i32, sym_name = "of_in_prod_lock_0"}
+// CHECK:           %[[VAL_13:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_in_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_1]], DMA : 0, %[[VAL_0]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)
 // CHECK:           %[[VAL_14:.*]] = aie.external_buffer {sym_name = "ext_buffer_in"} : memref<64xi32>

--- a/test/objectFifo-stateful-transform/register_external_buffers/shim_broadcast_test.mlir
+++ b/test/objectFifo-stateful-transform/register_external_buffers/shim_broadcast_test.mlir
@@ -16,18 +16,18 @@
 // CHECK:           %[[VAL_3:.*]] = aie.tile(3, 3)
 // CHECK:           %[[VAL_4:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_in_0_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_5:.*]] = aie.buffer(%[[VAL_1]]) {sym_name = "of_in_0_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]], 0) {init = 2 : i32, sym_name = "of_in_0_cons_prod_lock_0"}
-// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]], 1) {init = 0 : i32, sym_name = "of_in_0_cons_cons_lock_0"}
+// CHECK:           %[[VAL_6:.*]] = aie.lock(%[[VAL_1]]) {init = 2 : i32, sym_name = "of_in_0_cons_prod_lock_0"}
+// CHECK:           %[[VAL_7:.*]] = aie.lock(%[[VAL_1]]) {init = 0 : i32, sym_name = "of_in_0_cons_cons_lock_0"}
 // CHECK:           %[[VAL_8:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of_in_1_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_9:.*]] = aie.buffer(%[[VAL_2]]) {sym_name = "of_in_1_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_2]], 0) {init = 2 : i32, sym_name = "of_in_1_cons_prod_lock_0"}
-// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_2]], 1) {init = 0 : i32, sym_name = "of_in_1_cons_cons_lock_0"}
+// CHECK:           %[[VAL_10:.*]] = aie.lock(%[[VAL_2]]) {init = 2 : i32, sym_name = "of_in_1_cons_prod_lock_0"}
+// CHECK:           %[[VAL_11:.*]] = aie.lock(%[[VAL_2]]) {init = 0 : i32, sym_name = "of_in_1_cons_cons_lock_0"}
 // CHECK:           %[[VAL_12:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "of_in_2_cons_buff_0"} : memref<16xi32>
 // CHECK:           %[[VAL_13:.*]] = aie.buffer(%[[VAL_3]]) {sym_name = "of_in_2_cons_buff_1"} : memref<16xi32>
-// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_3]], 0) {init = 2 : i32, sym_name = "of_in_2_cons_prod_lock_0"}
-// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_3]], 1) {init = 0 : i32, sym_name = "of_in_2_cons_cons_lock_0"}
-// CHECK:           %[[VAL_16:.*]] = aie.lock(%[[VAL_0]], 0) {init = 1 : i32, sym_name = "of_in_prod_lock_0"}
-// CHECK:           %[[VAL_17:.*]] = aie.lock(%[[VAL_0]], 1) {init = 0 : i32, sym_name = "of_in_cons_lock_0"}
+// CHECK:           %[[VAL_14:.*]] = aie.lock(%[[VAL_3]]) {init = 2 : i32, sym_name = "of_in_2_cons_prod_lock_0"}
+// CHECK:           %[[VAL_15:.*]] = aie.lock(%[[VAL_3]]) {init = 0 : i32, sym_name = "of_in_2_cons_cons_lock_0"}
+// CHECK:           %[[VAL_16:.*]] = aie.lock(%[[VAL_0]]) {init = 1 : i32, sym_name = "of_in_prod_lock_0"}
+// CHECK:           %[[VAL_17:.*]] = aie.lock(%[[VAL_0]]) {init = 0 : i32, sym_name = "of_in_cons_lock_0"}
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_3]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_2]], DMA : 0)
 // CHECK:           aie.flow(%[[VAL_0]], DMA : 0, %[[VAL_1]], DMA : 0)

--- a/test/objectFifo-stateful-transform/repeat_count/link_distribute_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_distribute_repeat_count_test.mlir
@@ -15,18 +15,18 @@
 // CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of2_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_1:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of2_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 2 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK:     %[[VAL_3:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 // CHECK:     %[[VAL_4:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
 // CHECK:     %[[VAL_5:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_1"} : memref<16xi32>
-// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_6:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 2 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_8:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<32xi32>
 // CHECK:     %[[VAL_9:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_1"} : memref<32xi32>
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 6 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
-// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_1, 2) {init = 6 : i32, sym_name = "of0_cons_prod_lock_1"}
-// CHECK:     %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_1_1, 3) {init = 0 : i32, sym_name = "of0_cons_cons_lock_1"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 6 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK:     %[[VAL_12:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 6 : i32, sym_name = "of0_cons_prod_lock_1"}
+// CHECK:     %[[VAL_13:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_1"}
 // CHECK:     aie.flow(%{{.*}}tile_1_0, DMA : 0, %{{.*}}tile_1_1, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 1, %{{.*}}tile_3_3, DMA : 0)

--- a/test/objectFifo-stateful-transform/repeat_count/link_join_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_join_repeat_count_test.mlir
@@ -14,16 +14,16 @@
 // CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
 // CHECK:     %{{.*}}tile_3_3 = aie.tile(3, 3)
 // CHECK-DAG: %[[OF2_BUF:.*]] = aie.buffer({{.*}}) {sym_name = "of2_buff_0"} : memref<32xi32>
-// CHECK-DAG: %[[OF2_PROD0:.*]] = aie.lock({{.*}}, 0) {init = 1 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK-DAG: %[[OF2_CONS0:.*]] = aie.lock({{.*}}, 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
-// CHECK-DAG: %[[OF2_PROD1:.*]] = aie.lock({{.*}}, 2) {init = 1 : i32, sym_name = "of2_prod_lock_1"}
-// CHECK-DAG: %[[OF2_CONS1:.*]] = aie.lock({{.*}}, 3) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
+// CHECK-DAG: %[[OF2_PROD0:.*]] = aie.lock({{.*}}) {init = 1 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK-DAG: %[[OF2_CONS0:.*]] = aie.lock({{.*}}) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK-DAG: %[[OF2_PROD1:.*]] = aie.lock({{.*}}) {init = 1 : i32, sym_name = "of2_prod_lock_1"}
+// CHECK-DAG: %[[OF2_CONS1:.*]] = aie.lock({{.*}}) {init = 0 : i32, sym_name = "of2_cons_lock_1"}
 // CHECK-DAG: %[[OF1_BUF:.*]] = aie.buffer({{.*}}) {sym_name = "of1_buff_0"} : memref<16xi32>
-// CHECK-DAG: %[[OF1_PROD:.*]] = aie.lock({{.*}}, 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK-DAG: %[[OF1_CONS:.*]] = aie.lock({{.*}}, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK-DAG: %[[OF1_PROD:.*]] = aie.lock({{.*}}) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK-DAG: %[[OF1_CONS:.*]] = aie.lock({{.*}}) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK-DAG: %[[OF0_BUF:.*]] = aie.buffer({{.*}}) {sym_name = "of0_buff_0"} : memref<16xi32>
-// CHECK-DAG: %[[OF0_PROD:.*]] = aie.lock({{.*}}, 0) {init = 3 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK-DAG: %[[OF0_CONS:.*]] = aie.lock({{.*}}, 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK-DAG: %[[OF0_PROD:.*]] = aie.lock({{.*}}) {init = 3 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK-DAG: %[[OF0_CONS:.*]] = aie.lock({{.*}}) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_1, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_3_3, DMA : 0, %{{.*}}tile_1_1, DMA : 1)
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_0, DMA : 0)

--- a/test/objectFifo-stateful-transform/repeat_count/link_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/link_repeat_count_test.mlir
@@ -10,17 +10,17 @@
 // CHECK: module @memtileRepeat {
 // CHECK:   aie.device(npu1) {
 // CHECK-DAG: %[[OF2_BUF:.*]] = aie.buffer(%{{.*}}tile_3_3) {sym_name = "of2_buff_0"} : memref<32xi32>
-// CHECK-DAG: %[[OF2_PROD:.*]] = aie.lock(%{{.*}}tile_3_3, 0) {init = 3 : i32, sym_name = "of2_prod_lock_0"}
-// CHECK-DAG: %[[OF2_CONS:.*]] = aie.lock(%{{.*}}tile_3_3, 1) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
+// CHECK-DAG: %[[OF2_PROD:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 3 : i32, sym_name = "of2_prod_lock_0"}
+// CHECK-DAG: %[[OF2_CONS:.*]] = aie.lock(%{{.*}}tile_3_3) {init = 0 : i32, sym_name = "of2_cons_lock_0"}
 // CHECK-DAG: %[[OF1C_BUF:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
-// CHECK-DAG: %[[OF1C_PROD:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK-DAG: %[[OF1C_CONS:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK-DAG: %[[OF1C_PROD:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK-DAG: %[[OF1C_CONS:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK-DAG: %[[OF2C_BUF:.*]] = aie.buffer(%{{.*}}tile_2_1) {sym_name = "of2_cons_buff_0"} : memref<32xi32>
-// CHECK-DAG: %[[OF2C_PROD:.*]] = aie.lock(%{{.*}}tile_2_1, 0) {init = 1 : i32, sym_name = "of2_cons_prod_lock_0"}
-// CHECK-DAG: %[[OF2C_CONS:.*]] = aie.lock(%{{.*}}tile_2_1, 1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
+// CHECK-DAG: %[[OF2C_PROD:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 1 : i32, sym_name = "of2_cons_prod_lock_0"}
+// CHECK-DAG: %[[OF2C_CONS:.*]] = aie.lock(%{{.*}}tile_2_1) {init = 0 : i32, sym_name = "of2_cons_cons_lock_0"}
 // CHECK-DAG: %[[OF0C_BUF:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_cons_buff_0"} : memref<32xi32>
-// CHECK-DAG: %[[OF0C_PROD:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 3 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK-DAG: %[[OF0C_CONS:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK-DAG: %[[OF0C_PROD:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 3 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK-DAG: %[[OF0C_CONS:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
 // CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
 // CHECK:       %0 = aie.dma_start(S2MM, 0, ^bb1, ^bb2)
 // CHECK:     ^bb1:

--- a/test/objectFifo-stateful-transform/repeat_count/memtile_repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/memtile_repeat_count_test.mlir
@@ -12,11 +12,11 @@
 // CHECK:     %{{.*}}tile_1_1 = aie.tile(1, 1)
 // CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of1_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
 // CHECK:     %memtile_dma_1_1 = aie.memtile_dma(%{{.*}}tile_1_1) {
 // CHECK:       %0 = aie.dma_start(MM2S, 0, ^bb1, ^bb2, repeat_count = 2)

--- a/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/repeat_count_test.mlir
@@ -12,11 +12,11 @@
 // CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
 // CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
 // CHECK:     func.func @some_work(%arg0: memref<16xi32>) {
 // CHECK:       return

--- a/test/objectFifo-stateful-transform/repeat_count/repeat_count_test_dynamic.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count/repeat_count_test_dynamic.mlir
@@ -15,11 +15,11 @@
 // CHECK:           %[[T12:.*]] = aie.tile(1, 2)
 // CHECK:           %[[T13:.*]] = aie.tile(1, 3)
 // CHECK:           %[[CB0:.*]] = aie.buffer(%[[T13]]) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
-// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T13]], 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T13]], 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:           %[[CPROD:.*]] = aie.lock(%[[T13]]) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:           %[[CCONS:.*]] = aie.lock(%[[T13]]) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:           %[[B0:.*]] = aie.buffer(%[[T12]]) {sym_name = "of1_buff_0"} : memref<16xi32>
-// CHECK:           %[[PROD:.*]] = aie.lock(%[[T12]], 0) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:           %[[CONS:.*]] = aie.lock(%[[T12]], 1) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:           %[[PROD:.*]] = aie.lock(%[[T12]]) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:           %[[CONS:.*]] = aie.lock(%[[T12]]) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:           aie.flow(%[[T12]], DMA : 0, %[[T13]], DMA : 0)
 // CHECK:           func.func @some_work(%{{.*}}: memref<16xi32>) {
 // CHECK:             return

--- a/test/objectFifo-stateful-transform/repeat_count_test.mlir
+++ b/test/objectFifo-stateful-transform/repeat_count_test.mlir
@@ -13,17 +13,17 @@
 // CHECK:     %{{.*}}tile_1_2 = aie.tile(1, 2)
 // CHECK:     %{{.*}}tile_1_3 = aie.tile(1, 3)
 // CHECK:     %[[VAL_0:.*]] = aie.buffer(%{{.*}}tile_1_3) {sym_name = "of1_cons_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3, 0) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
-// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3, 1) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
+// CHECK:     %[[VAL_1:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 1 : i32, sym_name = "of1_cons_prod_lock_0"}
+// CHECK:     %[[VAL_2:.*]] = aie.lock(%{{.*}}tile_1_3) {init = 0 : i32, sym_name = "of1_cons_cons_lock_0"}
 // CHECK:     %[[VAL_3:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of1_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_2, 2) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
-// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_2, 3) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
+// CHECK:     %[[VAL_4:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 3 : i32, sym_name = "of1_prod_lock_0"}
+// CHECK:     %[[VAL_5:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of1_cons_lock_0"}
 // CHECK:     %[[VAL_6:.*]] = aie.buffer(%{{.*}}tile_1_2) {sym_name = "of0_cons_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2, 0) {init = 1 : i32, sym_name = "of0_cons_prod_lock_0"}
-// CHECK:     %[[VAL_8:.*]] = aie.lock(%{{.*}}tile_1_2, 1) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
+// CHECK:     %[[VAL_7:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 1 : i32, sym_name = "of0_cons_prod_lock_0"}
+// CHECK:     %[[VAL_8:.*]] = aie.lock(%{{.*}}tile_1_2) {init = 0 : i32, sym_name = "of0_cons_cons_lock_0"}
 // CHECK:     %[[VAL_9:.*]] = aie.buffer(%{{.*}}tile_1_1) {sym_name = "of0_buff_0"} : memref<16xi32>
-// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1, 0) {init = 1 : i32, sym_name = "of0_prod_lock_0"}
-// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1, 1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
+// CHECK:     %[[VAL_10:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 1 : i32, sym_name = "of0_prod_lock_0"}
+// CHECK:     %[[VAL_11:.*]] = aie.lock(%{{.*}}tile_1_1) {init = 0 : i32, sym_name = "of0_cons_lock_0"}
 // CHECK:     aie.flow(%{{.*}}tile_1_1, DMA : 0, %{{.*}}tile_1_2, DMA : 0)
 // CHECK:     aie.flow(%{{.*}}tile_1_2, DMA : 0, %{{.*}}tile_1_3, DMA : 0)
 // CHECK:     %core_1_2 = aie.core(%{{.*}}tile_1_2) {

--- a/tools/aiecc/IRTransforms.h
+++ b/tools/aiecc/IRTransforms.h
@@ -840,7 +840,6 @@ inline std::unique_ptr<mlir::PassManager> getInputWithAddressesPipeline(
   }
 
   mlir::OpPassManager &dpm = pm->nest<DeviceOp>();
-  dpm.addPass(createAIEAssignLockIDsPass());
   // The stateful transform always emits the dynamic (runtime) buffer addressing
   // and lock bookkeeping. When dynamic objectFifos are disabled, the
   // aie-objectFifo-unroll pass below unrolls the loops that carry objectFifo
@@ -863,6 +862,9 @@ inline std::unique_ptr<mlir::PassManager> getInputWithAddressesPipeline(
               .str(),
           dpm)))
     return nullptr;
+  // Assign IDs to the ID-less locks the objectFifo lowering creates (and to any
+  // user locks without an ID).
+  dpm.addPass(createAIEAssignLockIDsPass());
   dpm.addPass(createAIEAssignBufferDescriptorIDsPass());
   dpm.addPass(createAIELowerCascadeFlowsPass());
   dpm.addPass(X::createAIEBroadcastPacketPass());


### PR DESCRIPTION
ObjectFIFO needlessly had its own lock ID allocation logic, which clashed with other locks and forced awkward pass ordering. This removes lock ID allocation out of the ObjectFIFO stateful transform pass and moves the AssignLockIDs pass after the ObjectFIFO pass.