### PR TITLE
docs: publish the HostRuntime Python API

### DIFF
--- a/docs/api/hostruntime.md
+++ b/docs/api/hostruntime.md
@@ -1,0 +1,97 @@
+<!-- Copyright (C) 2026 Advanced Micro Devices, Inc. -->
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+# Host Runtime (`aie.utils.hostruntime`)
+
+Host-side helpers for selecting a device, allocating NPU-accessible tensors,
+running compiled designs, and sharing common CLI / argument plumbing across
+programming examples.
+
+Import the public surface from `aie.utils.hostruntime` (or via the
+`aie.utils` / `iron` re-exports where noted). The symbols below are rendered
+from the Python package under `python/utils/hostruntime/` using the same
+mkdocstrings path layout as the other Python API pages (`utils.*`, not the
+installed `aie.utils.*` import name).
+
+---
+
+## Runtime abstractions
+
+Abstract runtime types that concrete backends (for example XRT) implement.
+
+::: utils.hostruntime.hostruntime
+    options:
+      show_root_heading: false
+      docstring_options:
+        warn_missing_types: false
+
+---
+
+## Tensor and device utilities
+
+Device selection, the abstract `Tensor` type, and numerical helpers used when
+comparing host results.
+
+::: utils.hostruntime
+    options:
+      show_root_heading: false
+      members:
+        - Tensor
+        - set_current_device
+        - bfloat16_safe_allclose
+      docstring_options:
+        warn_missing_types: false
+
+::: utils.hostruntime.tensor_class
+    options:
+      show_root_heading: false
+      members:
+        - Tensor
+      docstring_options:
+        warn_missing_types: false
+
+---
+
+## Shared CLI/argument helpers
+
+Reusable `argparse` flag groups and the standard design CLI dispatcher used by
+the programming examples.
+
+::: utils.hostruntime.argparse
+    options:
+      show_root_heading: false
+      docstring_options:
+        warn_missing_types: false
+
+::: utils.hostruntime.cli
+    options:
+      show_root_heading: false
+      docstring_options:
+        warn_missing_types: false
+
+---
+
+## XRT runtime implementation
+
+Concrete XRT-backed runtime, tensor, and scratchpad types. These modules import
+`pyxrt`, so they are only importable in environments where XRT / PyXRT is
+installed. MkDocs CI does not install XRT, so these symbols are summarized here
+(same approach as the non-importable JIT helpers on the IRON page) with links to
+source. On a machine with PyXRT available they can also be rendered with
+mkdocstrings, for example:
+
+```markdown
+::: utils.hostruntime.xrtruntime.hostruntime
+    options:
+      show_root_heading: false
+```
+
+| Symbol | Module | Summary |
+|--------|--------|---------|
+| `XRTKernelHandle` | [`xrtruntime.hostruntime`](../../python/utils/hostruntime/xrtruntime/hostruntime.py) | Handle for a loaded XRT kernel. |
+| `XRTKernelResult` | [`xrtruntime.hostruntime`](../../python/utils/hostruntime/xrtruntime/hostruntime.py) | Result wrapper for a PyXRT kernel run. |
+| `XRTHostRuntime` | [`xrtruntime.hostruntime`](../../python/utils/hostruntime/xrtruntime/hostruntime.py) | Singleton manager for AIE XRT resources. |
+| `CachedXRTKernelHandle` | [`xrtruntime.hostruntime`](../../python/utils/hostruntime/xrtruntime/hostruntime.py) | Cached handle for a loaded XRT kernel. |
+| `CachedXRTRuntime` | [`xrtruntime.hostruntime`](../../python/utils/hostruntime/xrtruntime/hostruntime.py) | Cached `XRTHostRuntime` that reuses contexts for the same xclbin. |
+| `XRTTensor` | [`xrtruntime.tensor`](../../python/utils/hostruntime/xrtruntime/tensor.py) | Tensor backed by NPU/CPU-accessible memory managed with PyXRT. |
+| `ParameterScratchpad` | [`xrtruntime.parameter_scratchpad`](../../python/utils/hostruntime/xrtruntime/parameter_scratchpad.py) | Write named runtime parameters to the NPU scratchpad buffer. |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -17,7 +17,7 @@ layers are here for advanced designs, op-by-op construction, and compiler work.
 | **IRON** (`aie.iron`) | The high-level Python API. Every object is *resolvable* — it lowers to MLIR when compiled: `@iron.jit`, `Worker`, `ObjectFifo`, `Runtime`, `Program`, `Buffer`, `Kernel`, the tensor factories, and advanced primitives like `Flow`, `TileDma`, and `Lock`. | Writing NPU designs. Start here. |
 | **Dialect op wrappers** (`aie.dialects.*`) | The low-level Python layer: thin wrappers around individual MLIR ops of the `aie` / `aiex` / `aievec` dialects. This is what `aie.iron` lowers *to*. | Op-by-op construction, custom lowerings, reading emitted MLIR. |
 | **C++ AIE kernels** (`aie_kernels`, AIE API) | The per-core compute code that runs *on* an AIE tile, written in C++ with the [AIE API](https://www.xilinx.com/htmldocs/xilinx2023_2/aiengine_api/aie_api/doc/index.html) header library or low-level intrinsics. | Writing or tuning the vectorized math a `Worker` runs. |
-| **Utilities** | `taplib` tensor access patterns, the pre-built Python kernel library, and host-runtime helpers. | Tiling / streaming descriptors, ready-made kernels, host glue. |
+| **Utilities** | `taplib` tensor access patterns, the pre-built Python kernel library, and host-runtime helpers (`aie.utils.hostruntime`). | Tiling / streaming descriptors, ready-made kernels, host glue. |
 | **MLIR / C++** | The `aie` / `aiex` / `aievec` / `adf` dialect definitions, their passes, and the generated C++ API. | Compiler internals, custom passes, dialect op reference. |
 
 ## Python API
@@ -52,6 +52,13 @@ layers are here for advanced designs, op-by-op construction, and compiler work.
 
     Pre-built `iron.kernels` wrappers for element-wise, reduction, linalg,
     convolution, activation, and vision operations.
+
+-   :material-memory: **[Host Runtime (`aie.utils.hostruntime`)](hostruntime.md)**
+
+    ---
+
+    Device selection, host tensors, abstract and XRT-backed runtimes, plus
+    shared CLI / argparse helpers for programming examples.
 
 -   :material-code-braces: **[C++ AIE kernels](aie_kernels.md)**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -252,6 +252,7 @@ nav:
       - Dialect op wrappers: api/dialect_wrappers.md
       - Tensor Access Patterns (taplib): api/taplib.md
       - Python Kernel Library: api/kernels.md
+      - Host Runtime: api/hostruntime.md
       - C++ AIE kernels: api/aie_kernels.md
     - MLIR / C++:
       - AIE Dialect: AIEDialect.md


### PR DESCRIPTION
## Description

Fixes #3378.

Publishes the Host Runtime Python API on the docs site:

- New page `docs/api/hostruntime.md` with orientation prose and mkdocstrings coverage for the abstract runtime, tensor/device helpers, and shared CLI/argparse APIs
- Host Runtime card on the Python API overview (`docs/api/index.md`)
- Nav entry under **API & Internals → Python API** in `mkdocs.yml`

XRT-backed symbols (`XRTHostRuntime`, `XRTTensor`, etc.) are summarized with source links rather than live mkdocstrings because those modules import `pyxrt`, which is not available in the MkDocs CI environment (same constraint as other non-importable helpers on the IRON page).

Mkdocstrings identifiers use the source-tree paths (`utils.hostruntime.*`) that match `mkdocs.yml` `paths: [python]`, consistent with `iron.*` / `helpers.taplib.*` on existing API pages.

## Checklist

- [x] Tests pass locally, or the change is covered by CI
- [x] Docs / docstrings updated if the change is user-facing
- [x] Code is formatted (`clang-format` for C++, `black` for Python — see [CONTRIBUTING](../CONTRIBUTING.md))

## Validation

```bash
python3 -m venv .docs-venv
source .docs-venv/bin/activate
python -m pip install -U pip numpy ml_dtypes
python -m pip install -r docs/requirements-mkdocs.txt
test -e docs/programming_guide || ln -s ../programming_guide docs/programming_guide
test -e docs/aiecc || ln -s ../tools/aiecc docs/aiecc
mkdocs build --strict
git diff --check
```

Inspected `site/api/hostruntime/index.html`: navigation and overview links work; `HostRuntime`, `Tensor`, `set_current_device`, `bfloat16_safe_allclose`, argparse helpers, and `run_design_cli` render; private helpers are not listed as API members.

Note: `pre-commit run --files ...` could not be executed in this environment (`os.sysconf('SC_ARG_MAX')` blocked). Manual checks covered final newlines, no trailing whitespace, and copyright/SPDX headers on the touched docs files.