### PR TITLE
ci: compare ccache compiler by content so C++ caches hit

### DIFF
--- a/.github/workflows/buildAndTestPythons.yml
+++ b/.github/workflows/buildAndTestPythons.yml
@@ -99,6 +99,16 @@ jobs:
           key: ${{ matrix.build_type }}-${{ runner.os }}-${{ matrix.ubuntu_version }}
           max-size: 1G
 
+      # ccache defaults to comparing the compiler by mtime. GitHub-hosted
+      # runners reinstall the compiler every run with a fresh mtime, so every
+      # object misses even when the cache restores. Compare by content instead,
+      # matching what .github/actions/setup_ccache already does.
+      - name: Configure ccache
+        shell: bash
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=locale,time_macros
+
       # Build the repo test target in debug mode to build and test.
       - name: Build and test (Assert)
         if: matrix.build_type == 'Assert'

--- a/.github/workflows/generateDocs.yml
+++ b/.github/workflows/generateDocs.yml
@@ -87,6 +87,14 @@ jobs:
           key: ${{ runner.os }}-releaseasserts-${{ steps.get-submodule-hash.outputs.hash }}
           max-size: 1G
 
+      # Compare the compiler by content, not mtime, so the cache hits across
+      # runs on ephemeral runners. Matches .github/actions/setup_ccache.
+      - name: Configure ccache
+        shell: bash
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=locale,time_macros
+
       - name: Get cmakeModules
         id: clone-cmakeModules
         run: git clone --depth 1 https://github.com/Xilinx/cmakeModules.git

--- a/.github/workflows/lintAndFormat.yml
+++ b/.github/workflows/lintAndFormat.yml
@@ -301,6 +301,15 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ubuntu_version }}-${{ steps.get-llvm-commit-hash.outputs.hash }}-code-cov
           max-size: 1G
 
+      # Compare the compiler by content, not mtime, so the cache hits across
+      # runs on ephemeral runners. Matches .github/actions/setup_ccache.
+      - name: Configure ccache
+        if: steps.changed-files.outputs.changed-files != ''
+        shell: bash
+        run: |
+          ccache --set-config=compiler_check=content
+          ccache --set-config=sloppiness=locale,time_macros
+
       - name: Install our python reqs
         if: steps.changed-files.outputs.changed-files != ''
         run: |


### PR DESCRIPTION

The C++ build caches in these workflows are restoring but not hitting.

`buildAndTestPythons`, `lintAndFormat` and `generateDocs` call
`hendrikmuhs/ccache-action` directly and never set `compiler_check`, so ccache
uses its default `mtime` check. GitHub-hosted runners reinstall the compiler on
every run with a fresh mtime, so every object misses even when the cache
restored correctly.

Recent `buildAndTestPythons` runs show it clearly, with the cache already
restored (0.21 GB present):

```
Hits:   0 / 346 (0.00 %)   Misses: 346
Hits:   0 / 691 (0.00 %)   Misses: 691
```

So each run recompiles the full mlir-aie tree from scratch, and the parallel
python-version legs that share a cache key (`Assert-Linux-22.04`) never warm
each other either.

`.github/actions/setup_ccache` already sets `compiler_check=content` and
`sloppiness=locale,time_macros` for exactly this reason. This just applies the
same two settings to the three workflows that use the action directly:

```yaml
- name: Configure ccache
  shell: bash
  run: |
    ccache --set-config=compiler_check=content
    ccache --set-config=sloppiness=locale,time_macros
```

This covers every workflow that calls `ccache-action` directly;
`buildAndTestMulti`, `mlirDistro` and `mlirAIEDistro` already go through
`setup_ccache` and are unaffected.

I validated it on a fork by running `buildAndTestPythons` twice on the same
branch (cold seed, then a warm re-run), all 16 legs green both times:

```
                 ccache hit rate     wall-clock
cold (seed)      0.00 - 1.79 %       16.7 min
warm (this fix)  85 - 100 % (~88%)    8.7 min
```

So the caches go from effectively dead to ~88% hitting, and the workflow runs
about twice as fast once warm.

Content comparison is strictly more conservative than mtime, so this cannot
produce a stale-object hit; the worst case is the same miss you get today. The
`time_macros` part of `sloppiness` (also copied from `setup_ccache`) lets ccache
cache the one file that uses `__DATE__`/`__TIME__`,
`tools/aiecc/CommandLineOptions.h` (the `aiecc` version banner). No test depends
on that string, and `setup_ccache` already caches it the same way today.

Two unrelated things I noticed while here, not changed in this PR:
- `lintAndFormat` references `steps.get-llvm-commit-hash.outputs.hash` in its
  cache key, but no step defines that id, so the segment expands to empty. Not
  harmful (the key is just stable), but likely a leftover.
- The `max-size: 1G` is fine for these builds, which stay well under it since
  LLVM comes prebuilt from the wheel.

The fix mirrors your own `setup_ccache` action, so it is standard ccache
behavior on ephemeral runners rather than anything exotic.
