### PR TITLE
[AIEX] Add an experimental verifier for un-re-armed dma_channel_reset

### DIFF
--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.h
@@ -57,6 +57,8 @@ createAIELowerDmaChannelResetPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIELowerCoreResetPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
+createAIEVerifyRuntimeRearmPass();
+std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIETransformBfpTypesPass();
 std::unique_ptr<mlir::OperationPass<AIE::DeviceOp>>
 createAIETxnToControlPacketPass();

--- a/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
+++ b/include/aie/Dialect/AIEX/Transforms/AIEXPasses.td
@@ -405,6 +405,17 @@ def AIELowerCoreReset : Pass<"aie-lower-core-reset", "AIE::DeviceOp"> {
   ];
 }
 
+def AIEVerifyRuntimeRearm : Pass<"aie-verify-runtime-rearm", "AIE::DeviceOp"> {
+  let summary = "Experimental, opt-in: reject an aiex.dma_channel_reset whose "
+                "objectFIFO lock is never re-armed (a necessary, not sufficient, "
+                "condition for a safe reset)";
+  let constructor = "xilinx::AIEX::createAIEVerifyRuntimeRearmPass()";
+  let dependentDialects = [
+    "xilinx::AIE::AIEDialect",
+    "xilinx::AIEX::AIEXDialect",
+  ];
+}
+
 def AIELowerScratchpadParameters : Pass<"aie-lower-scratchpad-parameters", "mlir::ModuleOp"> {
   let summary = "Lower scratchpad parameter ops and emit parameter-sync preambles";
   let description = [{

--- a/lib/Dialect/AIEX/Transforms/AIEVerifyRuntimeRearm.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEVerifyRuntimeRearm.cpp
@@ -33,8 +33,13 @@
 #include "mlir/IR/Matchers.h"
 #include "mlir/Pass/Pass.h"
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+
 #include <array>
 #include <map>
+#include <optional>
 #include <set>
 #include <tuple>
 
@@ -158,8 +163,9 @@ struct AIEVerifyRuntimeRearmPass
           "resets a DMA channel whose objectFIFO lock is never re-armed; the "
           "semaphore counter stays frozen and the channel's peer will block "
           "forever on acquire (a runtime deadlock). Re-arm each bound lock "
-          "with "
-          "an aiex.set_lock");
+          "with an aiex.set_lock, or a write to its lock register "
+          "(aiex.npu.write32 / aiex.npu.maskwrite32 at the lock's local "
+          "address)");
       for (LockOp l : frozen)
         err.attachNote(l.getLoc())
             << "this lock is bound to the reset channel and is not re-armed";

--- a/lib/Dialect/AIEX/Transforms/AIEVerifyRuntimeRearm.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEVerifyRuntimeRearm.cpp
@@ -1,0 +1,178 @@
+//===- AIEVerifyRuntimeRearm.cpp --------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// EXPERIMENTAL, opt-in diagnostic (not in the default pipeline; validate on
+// hardware before relying on it). Rejects an aiex.dma_channel_reset whose
+// objectFIFO locks are not re-armed anywhere in the module. That is a
+// necessary, not sufficient, condition for a safe channel reset.
+//
+// A channel reset drains the DMA task queue and leaves the objectFIFO lock
+// counters frozen; if a bound lock is never re-armed the channel's peer blocks
+// on an acquire that never releases (host: `qds_device::wait() unexpected
+// command state`). This catches the missing-lock-re-arm mistake. It does NOT
+// prove the reset is safe: the complementary start-queue re-push (no
+// runtime-sequence op yet for a resident core/mem channel) is not checked, so a
+// design that re-arms locks but not the queue still deadlocks and still passes.
+//
+// A lock counts as re-armed by an aiex.set_lock, or a write to its lock
+// register (npu.write32 / npu.maskwrite32 at its local address). Re-arms are
+// collected module-wide, so a re-arm in a later dispatch's sequence is
+// honoured. Assumes the objectFIFO stateful transform has run (channels and
+// locks materialised).
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIEX/IR/AIEXDialect.h"
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
+
+#include "mlir/IR/Matchers.h"
+#include "mlir/Pass/Pass.h"
+
+#include <array>
+#include <map>
+#include <set>
+#include <tuple>
+
+namespace xilinx::AIEX {
+#define GEN_PASS_DEF_AIEVERIFYRUNTIMEREARM
+#include "aie/Dialect/AIEX/Transforms/AIEXPasses.h.inc"
+} // namespace xilinx::AIEX
+
+using namespace mlir;
+using namespace xilinx;
+using namespace xilinx::AIE;
+using namespace xilinx::AIEX;
+
+namespace {
+
+using ChannelKey = std::array<int, 4>; // {col, row, direction, channel}
+using AddrKey = std::tuple<uint64_t, int, int>; // {local address, col, row}
+
+struct AIEVerifyRuntimeRearmPass
+    : xilinx::AIEX::impl::AIEVerifyRuntimeRearmBase<AIEVerifyRuntimeRearmPass> {
+
+  // channel -> the objectFIFO locks its BD chain uses, built in one device
+  // walk.
+  std::map<ChannelKey, SmallVector<LockOp>> mapChannelLocks(DeviceOp dev) {
+    std::map<ChannelKey, SmallVector<LockOp>> m;
+    dev.walk([&](DMAStartOp start) {
+      Operation *memOp = start->getParentOp();
+      TileOp tile;
+      if (auto x = dyn_cast<MemOp>(memOp))
+        tile = x.getTileOp();
+      else if (auto x = dyn_cast<MemTileDMAOp>(memOp))
+        tile = x.getTileOp();
+      if (!tile)
+        return;
+      ChannelKey key{tile.getCol(), tile.getRow(),
+                     static_cast<int>(start.getChannelDir()),
+                     static_cast<int>(start.getChannelIndex())};
+      SmallVector<LockOp> &locks = m[key];
+      // Walk the BD chain (dest, then next_bd successors); the last next_bd
+      // loops back, so stop on a revisit.
+      llvm::SmallPtrSet<Block *, 8> visited;
+      for (Block *b = start.getDest(); b && visited.insert(b).second;
+           b = (b->getNumSuccessors() == 1 ? b->getSuccessor(0) : nullptr))
+        for (auto use : b->getOps<UseLockOp>())
+          if (auto l = dyn_cast_or_null<LockOp>(use.getLock().getDefiningOp()))
+            if (!llvm::is_contained(locks, l))
+              locks.push_back(l);
+    });
+    return m;
+  }
+
+  // A lock-register write (npu.write32 / npu.maskwrite32) to a constant local
+  // address on a named tile, as (address, col, row). set_lock lowers to exactly
+  // this, and a hand-written re-arm may use it directly.
+  static std::optional<AddrKey> lockWriteKey(Operation *op) {
+    Value addr;
+    IntegerAttr colA, rowA;
+    if (auto w = dyn_cast<NpuWrite32Op>(op)) {
+      addr = w.getAddress();
+      colA = w.getColumnAttr();
+      rowA = w.getRowAttr();
+    } else if (auto w = dyn_cast<NpuMaskWrite32Op>(op)) {
+      addr = w.getAddress();
+      colA = w.getColumnAttr();
+      rowA = w.getRowAttr();
+    } else {
+      return std::nullopt;
+    }
+    APInt c;
+    if (!colA || !rowA || !matchPattern(addr, m_ConstantInt(&c)))
+      return std::nullopt;
+    return AddrKey{c.getZExtValue(), (int)colA.getInt(), (int)rowA.getInt()};
+  }
+
+  void runOnOperation() override {
+    DeviceOp dev = getOperation();
+    const AIETargetModel &tm = dev.getTargetModel();
+    std::map<ChannelKey, SmallVector<LockOp>> channelLocks =
+        mapChannelLocks(dev);
+
+    // Locks re-armed anywhere in the module, by set_lock or a lock-register
+    // write. Module-wide so a re-arm in another dispatch's sequence counts.
+    llvm::SmallPtrSet<Operation *, 16> reArmedBySetLock;
+    std::set<AddrKey> reArmedByWrite;
+    dev.walk([&](Operation *op) {
+      if (auto sl = dyn_cast<SetLockOp>(op))
+        reArmedBySetLock.insert(sl.getLockOp().getOperation());
+      else if (auto key = lockWriteKey(op))
+        reArmedByWrite.insert(*key);
+    });
+
+    auto isReArmed = [&](LockOp l) -> bool {
+      if (reArmedBySetLock.contains(l.getOperation()))
+        return true;
+      if (!l.getLockID())
+        return true; // unassigned id: cannot prove a violation, defer
+      auto addr = tm.getLocalLockAddress(l.getLockIDValue(), l.getTileID());
+      if (!addr)
+        return true;
+      return reArmedByWrite.count(
+          AddrKey{*addr, (int)l.colIndex(), (int)l.rowIndex()});
+    };
+
+    WalkResult wr = dev.walk([&](DmaChannelResetOp reset) -> WalkResult {
+      TileOp tile = reset.getTileOp();
+      if (!tile)
+        return WalkResult::advance();
+      ChannelKey key{tile.getCol(), tile.getRow(),
+                     static_cast<int>(reset.getDirection()),
+                     static_cast<int>(reset.getChannel())};
+      auto it = channelLocks.find(key);
+      if (it == channelLocks.end())
+        return WalkResult::advance();
+      SmallVector<LockOp> frozen;
+      for (LockOp l : it->second)
+        if (!isReArmed(l))
+          frozen.push_back(l);
+      if (frozen.empty())
+        return WalkResult::advance();
+      InFlightDiagnostic err = reset.emitOpError(
+          "resets a DMA channel whose objectFIFO lock is never re-armed; the "
+          "semaphore counter stays frozen and the channel's peer will block "
+          "forever on acquire (a runtime deadlock). Re-arm each bound lock "
+          "with "
+          "an aiex.set_lock");
+      for (LockOp l : frozen)
+        err.attachNote(l.getLoc())
+            << "this lock is bound to the reset channel and is not re-armed";
+      return WalkResult::interrupt();
+    });
+    if (wr.wasInterrupted())
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<DeviceOp>>
+xilinx::AIEX::createAIEVerifyRuntimeRearmPass() {
+  return std::make_unique<AIEVerifyRuntimeRearmPass>();
+}

--- a/lib/Dialect/AIEX/Transforms/AIEVerifyRuntimeRearm.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEVerifyRuntimeRearm.cpp
@@ -18,8 +18,9 @@
 // runtime-sequence op yet for a resident core/mem channel) is not checked, so a
 // design that re-arms locks but not the queue still deadlocks and still passes.
 //
-// A lock counts as re-armed by an aiex.set_lock, or a write to its lock
-// register (npu.write32 / npu.maskwrite32 at its local address). Re-arms are
+// A lock counts as re-armed by an aiex.set_lock. The pass runs before set_lock
+// is lowered, so it matches the semantic op instead of decoding a lowered
+// npu.write32 (which would duplicate the set_lock encoding here). Re-arms are
 // collected module-wide, so a re-arm in a later dispatch's sequence is
 // honoured. Assumes the objectFIFO stateful transform has run (channels and
 // locks materialised).
@@ -30,7 +31,6 @@
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
-#include "mlir/IR/Matchers.h"
 #include "mlir/Pass/Pass.h"
 
 #include "llvm/ADT/STLExtras.h"
@@ -39,9 +39,6 @@
 
 #include <array>
 #include <map>
-#include <optional>
-#include <set>
-#include <tuple>
 
 namespace xilinx::AIEX {
 #define GEN_PASS_DEF_AIEVERIFYRUNTIMEREARM
@@ -56,7 +53,6 @@ using namespace xilinx::AIEX;
 namespace {
 
 using ChannelKey = std::array<int, 4>; // {col, row, direction, channel}
-using AddrKey = std::tuple<uint64_t, int, int>; // {local address, col, row}
 
 struct AIEVerifyRuntimeRearmPass
     : xilinx::AIEX::impl::AIEVerifyRuntimeRearmBase<AIEVerifyRuntimeRearmPass> {
@@ -91,56 +87,22 @@ struct AIEVerifyRuntimeRearmPass
     return m;
   }
 
-  // A lock-register write (npu.write32 / npu.maskwrite32) to a constant local
-  // address on a named tile, as (address, col, row). set_lock lowers to exactly
-  // this, and a hand-written re-arm may use it directly.
-  static std::optional<AddrKey> lockWriteKey(Operation *op) {
-    Value addr;
-    IntegerAttr colA, rowA;
-    if (auto w = dyn_cast<NpuWrite32Op>(op)) {
-      addr = w.getAddress();
-      colA = w.getColumnAttr();
-      rowA = w.getRowAttr();
-    } else if (auto w = dyn_cast<NpuMaskWrite32Op>(op)) {
-      addr = w.getAddress();
-      colA = w.getColumnAttr();
-      rowA = w.getRowAttr();
-    } else {
-      return std::nullopt;
-    }
-    APInt c;
-    if (!colA || !rowA || !matchPattern(addr, m_ConstantInt(&c)))
-      return std::nullopt;
-    return AddrKey{c.getZExtValue(), (int)colA.getInt(), (int)rowA.getInt()};
-  }
-
   void runOnOperation() override {
     DeviceOp dev = getOperation();
-    const AIETargetModel &tm = dev.getTargetModel();
     std::map<ChannelKey, SmallVector<LockOp>> channelLocks =
         mapChannelLocks(dev);
 
-    // Locks re-armed anywhere in the module, by set_lock or a lock-register
-    // write. Module-wide so a re-arm in another dispatch's sequence counts.
+    // Locks re-armed anywhere in the module by an aiex.set_lock. Module-wide so
+    // a re-arm in another dispatch's sequence counts. The pass runs before
+    // set_lock is lowered, so matching the op is enough; no need to decode a
+    // lowered npu.write32 to the lock's register.
     llvm::SmallPtrSet<Operation *, 16> reArmedBySetLock;
-    std::set<AddrKey> reArmedByWrite;
-    dev.walk([&](Operation *op) {
-      if (auto sl = dyn_cast<SetLockOp>(op))
-        reArmedBySetLock.insert(sl.getLockOp().getOperation());
-      else if (auto key = lockWriteKey(op))
-        reArmedByWrite.insert(*key);
+    dev.walk([&](SetLockOp sl) {
+      reArmedBySetLock.insert(sl.getLockOp().getOperation());
     });
 
     auto isReArmed = [&](LockOp l) -> bool {
-      if (reArmedBySetLock.contains(l.getOperation()))
-        return true;
-      if (!l.getLockID())
-        return true; // unassigned id: cannot prove a violation, defer
-      auto addr = tm.getLocalLockAddress(l.getLockIDValue(), l.getTileID());
-      if (!addr)
-        return true;
-      return reArmedByWrite.count(
-          AddrKey{*addr, (int)l.colIndex(), (int)l.rowIndex()});
+      return reArmedBySetLock.contains(l.getOperation());
     };
 
     WalkResult wr = dev.walk([&](DmaChannelResetOp reset) -> WalkResult {
@@ -163,9 +125,7 @@ struct AIEVerifyRuntimeRearmPass
           "resets a DMA channel whose objectFIFO lock is never re-armed; the "
           "semaphore counter stays frozen and the channel's peer will block "
           "forever on acquire (a runtime deadlock). Re-arm each bound lock "
-          "with an aiex.set_lock, or a write to its lock register "
-          "(aiex.npu.write32 / aiex.npu.maskwrite32 at the lock's local "
-          "address)");
+          "with an aiex.set_lock");
       for (LockOp l : frozen)
         err.attachNote(l.getLoc())
             << "this lock is bound to the reset channel and is not re-armed";

--- a/lib/Dialect/AIEX/Transforms/CMakeLists.txt
+++ b/lib/Dialect/AIEX/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mlir_dialect_library(AIEXTransforms
   AIELowerSetLock.cpp
   AIELowerDmaChannelReset.cpp
   AIELowerCoreReset.cpp
+  AIEVerifyRuntimeRearm.cpp
   AIELowerScratchpadParameters.cpp
   AIETransformBfpTypes.cpp
   AIETxnToControlPacket.cpp

--- a/test/Passes/verify-runtime-rearm/dma_channel_reset_rearm.mlir
+++ b/test/Passes/verify-runtime-rearm/dma_channel_reset_rearm.mlir
@@ -1,0 +1,240 @@
+//===- dma_channel_reset_rearm.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: aie-opt -split-input-file -verify-diagnostics --aie-verify-runtime-rearm %s
+
+// A dma_channel_reset whose objectFIFO locks are all re-armed with set_lock in
+// the same runtime sequence is accepted (npu2 / AIE2P core tile).
+module {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %buf = aie.buffer(%t) : memref<16xi32>
+    %prod = aie.lock(%t, 0) {init = 1 : i32, sym_name = "fifo_prod_lock_0"}
+    %cons = aie.lock(%t, 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+    %mem = aie.mem(%t) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      %c1 = arith.constant 1 : i32
+      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.use_lock(%cons, Release, %c1)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence() {
+      aiex.dma_channel_reset(%t, S2MM, 0)
+      aiex.set_lock(%prod, 1)
+      aiex.set_lock(%cons, 0)
+    }
+  }
+}
+
+// -----
+
+// A reset with no re-arm at all is rejected; every bound lock is a frozen
+// counter and gets a note.
+module {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %buf = aie.buffer(%t) : memref<16xi32>
+    // expected-note @+1 {{this lock is bound to the reset channel and is not re-armed}}
+    %prod = aie.lock(%t, 0) {init = 1 : i32, sym_name = "fifo_prod_lock_0"}
+    // expected-note @+1 {{this lock is bound to the reset channel and is not re-armed}}
+    %cons = aie.lock(%t, 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+    %mem = aie.mem(%t) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      %c1 = arith.constant 1 : i32
+      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.use_lock(%cons, Release, %c1)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence() {
+      // expected-error @+1 {{resets a DMA channel whose objectFIFO lock is never re-armed}}
+      aiex.dma_channel_reset(%t, S2MM, 0)
+    }
+  }
+}
+
+// -----
+
+// A partial re-arm is still a deadlock: prod is re-armed but cons is not, so the
+// reset is rejected and only the frozen lock (cons) gets a note.
+module {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %buf = aie.buffer(%t) : memref<16xi32>
+    %prod = aie.lock(%t, 0) {init = 1 : i32, sym_name = "fifo_prod_lock_0"}
+    // expected-note @+1 {{this lock is bound to the reset channel and is not re-armed}}
+    %cons = aie.lock(%t, 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+    %mem = aie.mem(%t) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      %c1 = arith.constant 1 : i32
+      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.use_lock(%cons, Release, %c1)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence() {
+      // expected-error @+1 {{resets a DMA channel whose objectFIFO lock is never re-armed}}
+      aiex.dma_channel_reset(%t, S2MM, 0)
+      aiex.set_lock(%prod, 1)
+    }
+  }
+}
+
+// -----
+
+// A channel that carries no objectFIFO locks (a raw DMA) has nothing to re-arm,
+// so its reset is accepted -- the pass must not false-positive here.
+module {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %buf = aie.buffer(%t) : memref<16xi32>
+    %mem = aie.mem(%t) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence() {
+      aiex.dma_channel_reset(%t, S2MM, 0)
+    }
+  }
+}
+
+// -----
+
+// The check is target-model independent: the same design on npu1 (AIE2) is
+// accepted when both bound locks are re-armed.
+module {
+  aie.device(npu1) {
+    %t = aie.tile(0, 2)
+    %buf = aie.buffer(%t) : memref<16xi32>
+    %prod = aie.lock(%t, 0) {init = 1 : i32, sym_name = "fifo_prod_lock_0"}
+    %cons = aie.lock(%t, 1) {init = 0 : i32, sym_name = "fifo_cons_lock_0"}
+    %mem = aie.mem(%t) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      %c1 = arith.constant 1 : i32
+      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.use_lock(%cons, Release, %c1)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence() {
+      aiex.dma_channel_reset(%t, S2MM, 0)
+      aiex.set_lock(%prod, 1)
+      aiex.set_lock(%cons, 0)
+    }
+  }
+}
+
+// -----
+
+// The binding also resolves through a mem tile (aie.memtile_dma). Here the mem
+// tile channel's lock is not re-armed, so the reset is rejected.
+module {
+  aie.device(npu2) {
+    %mt = aie.tile(0, 1)
+    %buf = aie.buffer(%mt) : memref<16xi32>
+    // expected-note @+1 {{this lock is bound to the reset channel and is not re-armed}}
+    %prod = aie.lock(%mt, 0) {init = 1 : i32, sym_name = "mtfifo_prod_lock_0"}
+    %cons = aie.lock(%mt, 1) {init = 0 : i32, sym_name = "mtfifo_cons_lock_0"}
+    %memtile = aie.memtile_dma(%mt) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      %c1 = arith.constant 1 : i32
+      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence() {
+      // expected-error @+1 {{resets a DMA channel whose objectFIFO lock is never re-armed}}
+      aiex.dma_channel_reset(%mt, S2MM, 0)
+      aiex.set_lock(%cons, 0)
+    }
+  }
+}
+
+// -----
+
+// A re-arm written directly to the lock register (npu.write32 at the lock's
+// local address) is recognized, so a lowered-style re-arm is not a false
+// positive. Lock ids 0 and 1 on (0, 2) are at local addresses 126976 / 126992.
+module {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %buf = aie.buffer(%t) : memref<16xi32>
+    %prod = aie.lock(%t, 0) {init = 1 : i32}
+    %cons = aie.lock(%t, 1) {init = 0 : i32}
+    %mem = aie.mem(%t) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      %c1 = arith.constant 1 : i32
+      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.use_lock(%cons, Release, %c1)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence() {
+      aiex.dma_channel_reset(%t, S2MM, 0)
+      %a0 = arith.constant 126976 : i32
+      %a1 = arith.constant 126992 : i32
+      %v1 = arith.constant 1 : i32
+      %v0 = arith.constant 0 : i32
+      aiex.npu.write32(%a0, %v1) {column = 0 : i32, row = 2 : i32} : i32, i32
+      aiex.npu.write32(%a1, %v0) {column = 0 : i32, row = 2 : i32} : i32, i32
+    }
+  }
+}
+
+// -----
+
+// Re-arms are collected module-wide: a reset in one runtime sequence whose locks
+// are re-armed in another sequence is accepted (no false positive).
+module {
+  aie.device(npu2) {
+    %t = aie.tile(0, 2)
+    %buf = aie.buffer(%t) : memref<16xi32>
+    %prod = aie.lock(%t, 0) {init = 1 : i32}
+    %cons = aie.lock(%t, 1) {init = 0 : i32}
+    %mem = aie.mem(%t) {
+      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
+    ^bd0:
+      %c1 = arith.constant 1 : i32
+      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
+      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
+      aie.use_lock(%cons, Release, %c1)
+      aie.next_bd ^bd0
+    ^end:
+      aie.end
+    }
+    aie.runtime_sequence @reset() {
+      aiex.dma_channel_reset(%t, S2MM, 0)
+    }
+    aie.runtime_sequence @rearm() {
+      aiex.set_lock(%prod, 1)
+      aiex.set_lock(%cons, 0)
+    }
+  }
+}

--- a/test/Passes/verify-runtime-rearm/dma_channel_reset_rearm.mlir
+++ b/test/Passes/verify-runtime-rearm/dma_channel_reset_rearm.mlir
@@ -176,40 +176,6 @@ module {
 
 // -----
 
-// A re-arm written directly to the lock register (npu.write32 at the lock's
-// local address) is recognized, so a lowered-style re-arm is not a false
-// positive. Lock ids 0 and 1 on (0, 2) are at local addresses 126976 / 126992.
-module {
-  aie.device(npu2) {
-    %t = aie.tile(0, 2)
-    %buf = aie.buffer(%t) : memref<16xi32>
-    %prod = aie.lock(%t, 0) {init = 1 : i32}
-    %cons = aie.lock(%t, 1) {init = 0 : i32}
-    %mem = aie.mem(%t) {
-      %dma = aie.dma_start(S2MM, 0, ^bd0, ^end)
-    ^bd0:
-      %c1 = arith.constant 1 : i32
-      aie.use_lock(%prod, AcquireGreaterEqual, %c1)
-      aie.dma_bd(%buf : memref<16xi32> offset = 0 len = 16)
-      aie.use_lock(%cons, Release, %c1)
-      aie.next_bd ^bd0
-    ^end:
-      aie.end
-    }
-    aie.runtime_sequence() {
-      aiex.dma_channel_reset(%t, S2MM, 0)
-      %a0 = arith.constant 126976 : i32
-      %a1 = arith.constant 126992 : i32
-      %v1 = arith.constant 1 : i32
-      %v0 = arith.constant 0 : i32
-      aiex.npu.write32(%a0, %v1) {column = 0 : i32, row = 2 : i32} : i32, i32
-      aiex.npu.write32(%a1, %v0) {column = 0 : i32, row = 2 : i32} : i32, i32
-    }
-  }
-}
-
-// -----
-
 // Re-arms are collected module-wide: a reset in one runtime sequence whose locks
 // are re-armed in another sequence is accepted (no false positive).
 module {


### PR DESCRIPTION
## What

Adds `--aie-verify-runtime-rearm`, an experimental, opt-in verification pass that
rejects an `aiex.dma_channel_reset` whose objectFIFO locks are never re-armed by
an `aiex.set_lock` in the module. It turns a common runtime deadlock into a
compile-time error with a source location and a note pointing at each frozen lock.

It is not in the default pipeline. It is a conservative, best-effort check (see
Scope and Known limitations): it catches the common missing-re-arm mistake but is
neither necessary nor sufficient, so I would like it validated on hardware and its
limitations closed before it is wired in by default. Run it explicitly with
`--aie-verify-runtime-rearm` for now.

## Why

`aiex.dma_channel_reset` (#3370) pulses a core or mem tile DMA channel's reset
bit. On AIE-ML the channel has no enable bit, so after the reset drains its task
queue the channel moves data again only once its start queue is re-pushed and
the objectFIFO's semaphore locks are re-armed to their init values. If the locks
are left at their frozen mid-transfer counts, the channel's peer blocks on an
acquire that never releases and the host sees `qds_device::wait() unexpected
command state`. That failure is invisible until you run on hardware.

A bound lock with no runtime re-arm is the common form of this mistake, so the
pass reports it as an error rather than letting it reach silicon. It does not
prove the reset is safe, nor that an un-re-armed lock always deadlocks (see Known
limitations).

## Scope

The check only fires on a channel bound to objectFIFO locks, resolved through the
tile's `aie.mem` / `aie.memtile_dma` `dma_start` and the `use_lock` ops in its BD
chain. A raw DMA with no locks has nothing to verify. A lock counts as re-armed
by an `aiex.set_lock`; the pass runs before `set_lock` is lowered, so it does not
need to recognise the lowered `npu.write32` to the lock register (which would
duplicate the `set_lock` encoding here). Re-arms are collected module-wide, so a
re-arm in another dispatch's sequence is honoured.

## Known limitations

Tracked in #3418. The check is neither necessary nor sufficient:

- False positive: a lock can be re-armed from inside the `aie.core` (balanced
  `use_lock` over the dispatch), not only by a runtime `aiex.set_lock`. The pass
  scans only runtime-sequence re-arms, so a design that re-arms from the core is
  flagged even though the reset is fine. This is why the pass is opt-in.
- False negative: it checks only the lock re-arm, not the start-queue re-push, so
  a design that re-arms locks but not the queue still deadlocks and still passes.
  The re-push primitive is `aiex.dma_channel_reset_for` (#3393); I plan to extend
  this pass to the full invariant once that lands.

## Placement and default

The pass expects the objectFIFO stateful transform to have run (channels and
locks materialised); the natural home is `getNpuDmaLoweringPipeline`, between
`aie-assign-runtime-sequence-bd-ids` and `aie-dma-tasks-to-npu`, where
`dma_channel_reset`, `set_lock`, and the channel-to-lock binding all coexist and
the IR is straight-line. It mirrors the token-balance deadlock check already in
`aie-assign-runtime-sequence-bd-ids`.

I have left it out of the default pipeline for now. Because it is conservative
(see Known limitations), I would rather close those and prove it on hardware
before enabling it by default; run it explicitly with `--aie-verify-runtime-rearm`
in the meantime.

## Tests

`test/Passes/verify-runtime-rearm/dma_channel_reset_rearm.mlir`, seven cases under
`-split-input-file -verify-diagnostics`:

- reset with both bound locks re-armed by `set_lock`: accepted;
- reset with no re-arm: rejected, with a note on each frozen lock;
- reset with a partial re-arm (one lock re-armed, one not): rejected, with a note
  on the frozen lock only, since a partial re-arm still deadlocks;
- reset on a channel that carries no objectFIFO locks (a raw DMA): accepted, so
  the pass does not false-positive;
- the same design on npu1 (AIE2): accepted, showing the check is target-model
  independent;
- the binding resolved through a mem tile (`aie.memtile_dma`): the frozen-lock
  case is rejected;
- reset and re-arm split across two runtime sequences: accepted, showing re-arms
  are collected module-wide.
