### PR TITLE
Add full-ELF event-trace test with different `aiex.configure` flows

### DIFF
--- a/test/npu-xrt/full_elf_event_trace/aie.mlir
+++ b/test/npu-xrt/full_elf_event_trace/aie.mlir
@@ -1,0 +1,81 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Full-ELF trace design. The @main runtime sequence configures the @trace_dev
+// device and runs its runtime sequence.
+//
+// The core asserts INSTR_EVENT_0 at the entry of a passthrough loop and
+// INSTR_EVENT_1 at its exit. The trace unit emits a packet only once it
+// collects enough events, so @core_trace also selects the lock events. They
+// fill the packet that carries the two markers.
+//
+// aiex.run passes a fixed argument list to @trace_seq, so trace lowering must
+// keep the argument list of @trace_seq unchanged. `reuse_output_buffer = true`
+// puts the trace data in the tail of the output buffer, past the 64 i32 output
+// words.
+
+module {
+  aie.device(npu2) @main {
+    aie.runtime_sequence @sequence(%in : memref<64xi32>, %out : memref<64xi32>) {
+      aiex.configure @trace_dev {
+        aiex.run @trace_seq(%in, %out) : (memref<64xi32>, memref<64xi32>)
+      }
+    }
+  }
+
+  aie.device(npu2) @trace_dev {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+
+    aie.objectfifo @of_in(%tile_0_0, {%tile_0_2}, 1 : i32) : !aie.objectfifo<memref<64xi32>>
+    aie.objectfifo @of_out(%tile_0_2, {%tile_0_0}, 1 : i32) : !aie.objectfifo<memref<64xi32>>
+
+    aie.trace @core_trace(%tile_0_2) {
+      aie.trace.mode "Event-Time"
+      aie.trace.packet id=1 type=core
+      aie.trace.event<"INSTR_EVENT_0">
+      aie.trace.event<"INSTR_EVENT_1">
+      aie.trace.event<"INSTR_VECTOR">
+      aie.trace.event<"INSTR_LOCK_ACQUIRE_REQ">
+      aie.trace.event<"INSTR_LOCK_RELEASE_REQ">
+      aie.trace.event<"LOCK_STALL">
+      aie.trace.event<"PORT_RUNNING_0">
+      aie.trace.event<"PORT_RUNNING_1">
+      aie.trace.start broadcast=15
+      aie.trace.stop broadcast=14
+    }
+
+    aie.core(%tile_0_2) {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c64 = arith.constant 64 : index
+      %ei = aie.objectfifo.acquire @of_in(Consume, 1) : memref<64xi32>
+      %eo = aie.objectfifo.acquire @of_out(Produce, 1) : memref<64xi32>
+      aie.event(0)
+      scf.for %i = %c0 to %c64 step %c1 {
+        %v = memref.load %ei[%i] : memref<64xi32>
+        memref.store %v, %eo[%i] : memref<64xi32>
+      }
+      aie.event(1)
+      aie.objectfifo.release @of_in(Consume, 1)
+      aie.objectfifo.release @of_out(Produce, 1)
+      aie.end
+    }
+
+    aie.runtime_sequence @trace_seq(%in : memref<64xi32>, %out : memref<64xi32>) {
+      aie.trace.host_config {buffer_size = 8192 : i32, reuse_output_buffer = true}
+      aie.trace.start_config @core_trace
+      %ti = aiex.dma_configure_task_for @of_in {
+        aie.dma_bd(%in : memref<64xi32> offset = 0 len = 64)
+        aie.end
+      } {}
+      %to = aiex.dma_configure_task_for @of_out {
+        aie.dma_bd(%out : memref<64xi32> offset = 0 len = 64)
+        aie.end
+      } {issue_token = true}
+      aiex.dma_start_task(%ti)
+      aiex.dma_start_task(%to)
+      aiex.dma_await_task(%to)
+    }
+  }
+}

--- a/test/npu-xrt/full_elf_event_trace/run_ctrlpkt.lit
+++ b/test/npu-xrt/full_elf_event_trace/run_ctrlpkt.lit
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Full-ELF event-trace design through the --load-pdi-to-ctrl-pkt reconfigure
+// flow. The test covers compilation only.
+//
+// The design hangs on hardware in this flow. The trace shim DMA and the
+// control-packet overlay contend for the same shim DMA resources. The same
+// design without trace runs through --load-pdi-to-ctrl-pkt.
+//
+// REQUIRES: peano
+//
+// RUN: rm -rf ctrlpkt && mkdir -p ctrlpkt
+// RUN: cd ctrlpkt
+// RUN: %aiecc -v --get-full-elf --load-pdi-to-ctrl-pkt %S/aie.mlir

--- a/test/npu-xrt/full_elf_event_trace/run_loadpdi.lit
+++ b/test/npu-xrt/full_elf_event_trace/run_loadpdi.lit
@@ -1,0 +1,22 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Full-ELF event-trace test through the default reconfigure flow (PDI load).
+// The test checks the passthrough and counts one INSTR_EVENT_0 marker and one
+// INSTR_EVENT_1 marker in the trace.
+//
+// The trace tail is empty on roughly one run in three, on an otherwise idle
+// npu2. The design asserts each marker once, so the trace unit collects the
+// eight events of a packet only if the surrounding lock events arrive before
+// the stop broadcast ends the trace. A run that loses that race flushes no
+// packet and the markers never reach the shim DMA.
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: rm -rf loadpdi && mkdir -p loadpdi
+// RUN: cd loadpdi
+// RUN: %aiecc -v --get-full-elf --get-input-with-addresses %S/aie.mlir
+// RUN: %host_clang -o test.exe %S/test_elf.cpp -std=c++17 %host_link_flags %xrt_flags
+// RUN: %run_on_npu2% ./test.exe
+// RUN: %python -c "import numpy as np; from aie.utils.trace import parse_trace; w = np.array([int(l, 16) for l in open('trace.txt') if l.strip()], dtype=np.uint32); ev = parse_trace(w, open('input_with_addresses.mlir').read()); c0 = sum(1 for e in ev if e.get('name') == 'INSTR_EVENT_0' and e.get('ph') == 'B'); c1 = sum(1 for e in ev if e.get('name') == 'INSTR_EVENT_1' and e.get('ph') == 'B'); print('INSTR_EVENT_0', c0); print('INSTR_EVENT_1', c1); assert c0 == 1 and c1 == 1, (c0, c1); print('PASS!')" | FileCheck %s
+// CHECK: PASS!

--- a/test/npu-xrt/full_elf_event_trace/run_write32s.lit
+++ b/test/npu-xrt/full_elf_event_trace/run_write32s.lit
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Full-ELF event-trace design through the --expand-load-pdis reconfigure flow,
+// which emits explicit write32 and blockwrite operations. The test checks the
+// data path.
+//
+// The load_pdi expansion drops the address patch of the trace shim DMA, so the
+// trace buffer stays empty in this flow.
+//
+// REQUIRES: ryzen_ai_npu2, peano
+//
+// RUN: rm -rf write32s && mkdir -p write32s
+// RUN: cd write32s
+// RUN: %aiecc -v --get-full-elf --expand-load-pdis %S/aie.mlir
+// RUN: %host_clang -o test.exe %S/test_elf.cpp -std=c++17 %host_link_flags %xrt_flags
+// RUN: %run_on_npu2% ./test.exe

--- a/test/npu-xrt/full_elf_event_trace/test_elf.cpp
+++ b/test/npu-xrt/full_elf_event_trace/test_elf.cpp
@@ -1,0 +1,71 @@
+//===- test_elf.cpp --------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Host runner for the full-ELF event-trace design. The design sets
+// `reuse_output_buffer`, so the trace data follows the 64 i32 output words in
+// the same buffer. bo_out therefore holds OUT_BYTES + TRACE_SIZE bytes, and
+// the runner writes the tail of that buffer to trace.txt as 32-bit hex words.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+#include <xrt/experimental/xrt_elf.h>
+#include <xrt/experimental/xrt_ext.h>
+#include <xrt/experimental/xrt_module.h>
+#include <xrt/xrt_bo.h>
+#include <xrt/xrt_device.h>
+#include <xrt/xrt_kernel.h>
+
+constexpr size_t N = 64;
+constexpr size_t OUT_BYTES = N * sizeof(int32_t);
+constexpr size_t TRACE_SIZE = 8192;
+
+int main() {
+  auto device = xrt::device(0);
+  xrt::elf ctx_elf{"aie.elf"};
+  xrt::hw_context context = xrt::hw_context(device, ctx_elf);
+  auto kernel = xrt::ext::kernel(context, "main:sequence");
+
+  xrt::bo bo_in = xrt::ext::bo{device, OUT_BYTES};
+  xrt::bo bo_out = xrt::ext::bo{device, OUT_BYTES + TRACE_SIZE};
+
+  auto *in = bo_in.map<int32_t *>();
+  for (size_t i = 0; i < N; i++)
+    in[i] = static_cast<int32_t>(i);
+  std::memset(bo_out.map<char *>(), 0, OUT_BYTES + TRACE_SIZE);
+  bo_in.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  bo_out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  auto run = xrt::run(kernel);
+  run.set_arg(0, bo_in);
+  run.set_arg(1, bo_out);
+  run.start();
+  run.wait2();
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  auto *out = bo_out.map<int32_t *>();
+  for (size_t i = 0; i < N; i++)
+    if (out[i] != static_cast<int32_t>(i)) {
+      std::cerr << "FAIL: out[" << i << "] = " << out[i] << " != " << i << "\n";
+      return 1;
+    }
+
+  uint32_t *words =
+      reinterpret_cast<uint32_t *>(bo_out.map<char *>() + OUT_BYTES);
+  std::ofstream fout("trace.txt");
+  for (size_t i = 0; i < TRACE_SIZE / sizeof(uint32_t); i++)
+    fout << std::setfill('0') << std::setw(8) << std::hex << words[i] << "\n";
+  fout.close();
+
+  std::cout << "passthrough OK; trace written to trace.txt\n";
+  return 0;
+}


### PR DESCRIPTION
This PR adds a full-ELF event-trace design that uses the `aiex.configure` / `aiex.run` reconfigure syntax. Three lit tests compile the design through the default PDI-load flow, through `--expand-load-pdis` and through `--load-pdi-to-ctrl-pkt`.

Each test builds in its own subdirectory and dispatches through `%run_on_npu2%`, so a parallel lit run neither overwrites another test's `aie.elf` nor drives the device from two tests at once.

The tests document three combinations that do not work yet:

- Default PDI load: the trace tail is empty on roughly one run in three, on an otherwise idle npu2. The design asserts each marker once, so the trace unit collects the eight events of a packet only if the surrounding lock events arrive before the stop broadcast ends the trace. A run that loses that race flushes no packet and the markers never reach the shim DMA. The test asserts the markers, so it fails on those runs.
- `--expand-load-pdis`: the `load_pdi` expansion drops the address patch of the trace shim DMA, so the trace buffer stays empty. The test checks the data path only.
- `--load-pdi-to-ctrl-pkt`: the design hangs on hardware. The trace shim DMA and the control-packet overlay contend for the same shim DMA resources. The same design without trace runs through this flow. The test covers compilation only.

<img width="890" height="519" alt="image" src="https://github.com/user-attachments/assets/cc29a90e-3086-445a-897a-aa8eadb2ca1d" />