### PR TITLE
Add a reconfiguration programming example and benchmark

### DIFF
--- a/programming_examples/basic/reconfiguration/Makefile
+++ b/programming_examples/basic/reconfiguration/Makefile
@@ -1,0 +1,127 @@
+##===- Makefile -----------------------------------------------------------===##
+#
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+##===----------------------------------------------------------------------===##
+#
+# Micro-benchmark of five ways to reconfigure-and-run a cols x rows core array,
+# driven by a single C++ testbench (test.cpp) selected via compile-time macros:
+#
+#   make run_separate     separate xclbins  (worker + empty, two contexts)
+#   make run_runlist      XRT runlist       (worker + empty in one runlist)
+#   make run_loadpdi      full-ELF, load_pdi reconfiguration
+#   make run_blockwrites  full-ELF, --expand-load-pdis (write32s + empty reset)
+#   make run_ctrlpkt      full-ELF, --load-pdi-to-ctrl-pkt (control packets)
+#
+# Each run does ITERS timed iterations and prints per-iteration + mean/min/max
+# runtimes.  Parameters COLS/ROWS/NOPS/SWITCHBOXES embed in the artifact names.
+# The benchmark.py script drives these targets over several array sizes.
+
+srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+include ${srcdir}/../../makefile-common
+
+COLS ?= 1
+ROWS ?= 1
+NOPS ?= 0
+SWITCHBOXES ?= 0
+RECONFIGS ?= 1
+ITERS ?= 10
+
+suffix := c${COLS}_r${ROWS}_n${NOPS}_s${SWITCHBOXES}
+
+worker_xclbin := build/worker_${suffix}.xclbin
+worker_bin := build/worker_${suffix}.bin
+empty_xclbin := build/empty.xclbin
+empty_bin := build/empty.bin
+# Runlist: WORKER + EMPTY kernels merged into one xclbin (one hw_context).
+empty_k_xclbin := build/empty_k.xclbin
+empty_k_bin := build/empty_k.bin
+combined_xclbin := build/combined_${suffix}.xclbin
+worker_rl_bin := build/worker_rl_${suffix}.bin
+elf_loadpdi := build/loadpdi_${suffix}.elf
+elf_blockwrites := build/blockwrites_${suffix}.elf
+elf_ctrlpkt := build/ctrlpkt_${suffix}.elf
+
+aiecc_flags := --dynamic-objFifos
+XRT_FLAGS := -I${XILINX_XRT}/include -L${XILINX_XRT}/lib -luuid -lxrt_coreutil -lrt -lstdc++
+
+.PHONY: run_separate run_runlist run_loadpdi run_blockwrites run_ctrlpkt clean
+
+# ---- designs ----
+
+${worker_xclbin} ${worker_bin} &: ${srcdir}/reconfiguration.py
+	mkdir -p build
+	python3 $< --flow single --cols ${COLS} --rows ${ROWS} --nops ${NOPS} --switchboxes ${SWITCHBOXES} > build/worker_${suffix}.mlir
+	cd build && aiecc ${aiecc_flags} --get-xclbin --get-npu-insts \
+		--xclbin-name=$(notdir ${worker_xclbin}) --npu-insts-name=$(notdir ${worker_bin}) worker_${suffix}.mlir
+
+${empty_xclbin} ${empty_bin} &: ${srcdir}/reconfiguration.py
+	mkdir -p build
+	python3 $< --flow empty > build/empty.mlir
+	cd build && aiecc ${aiecc_flags} --get-xclbin --get-npu-insts \
+		--xclbin-name=$(notdir ${empty_xclbin}) --npu-insts-name=$(notdir ${empty_bin}) empty.mlir
+
+# Merge into one xclbin: build the EMPTY kernel, then the WORKER kernel with
+# --xclbin-input so the result carries both PDIs (one context, two kernels).
+${empty_k_xclbin} ${empty_k_bin} &: ${srcdir}/reconfiguration.py
+	mkdir -p build
+	python3 $< --flow empty > build/empty_k.mlir
+	cd build && aiecc ${aiecc_flags} --xclbin-kernel-name=EMPTY --xclbin-kernel-id=0x902 \
+		--xclbin-instance-name=EMPTYINST --get-xclbin --get-npu-insts \
+		--xclbin-name=$(notdir ${empty_k_xclbin}) --npu-insts-name=$(notdir ${empty_k_bin}) empty_k.mlir
+
+${combined_xclbin} ${worker_rl_bin} &: ${srcdir}/reconfiguration.py ${empty_k_xclbin}
+	mkdir -p build
+	python3 $< --flow single --cols ${COLS} --rows ${ROWS} --nops ${NOPS} --switchboxes ${SWITCHBOXES} > build/worker_rl_${suffix}.mlir
+	cd build && aiecc ${aiecc_flags} --xclbin-kernel-name=WORKER --xclbin-kernel-id=0x901 \
+		--xclbin-instance-name=WORKERINST --get-xclbin --get-npu-insts --xclbin-input=$(notdir ${empty_k_xclbin}) \
+		--xclbin-name=$(notdir ${combined_xclbin}) --npu-insts-name=$(notdir ${worker_rl_bin}) worker_rl_${suffix}.mlir
+
+build/reconfig_${suffix}.mlir: ${srcdir}/reconfiguration.py
+	mkdir -p build
+	python3 $< --flow reconfig --cols ${COLS} --rows ${ROWS} --nops ${NOPS} --switchboxes ${SWITCHBOXES} --reconfigs ${RECONFIGS} > $@
+
+${elf_loadpdi}: build/reconfig_${suffix}.mlir
+	cd build && aiecc --get-full-elf --full-elf-name=$(notdir $@) ${aiecc_flags} $(notdir $<)
+
+${elf_blockwrites}: build/reconfig_${suffix}.mlir
+	cd build && aiecc --get-full-elf --expand-load-pdis --full-elf-name=$(notdir $@) ${aiecc_flags} $(notdir $<)
+
+${elf_ctrlpkt}: build/reconfig_${suffix}.mlir
+	cd build && aiecc --get-full-elf --load-pdi-to-ctrl-pkt --get-ctrlpkt --full-elf-name=$(notdir $@) ${aiecc_flags} $(notdir $<)
+
+# ---- host testbenches (one source, three compile-time modes) ----
+
+test_separate: ${srcdir}/test.cpp
+	${CXX} -std=c++17 $< -o $@ ${XRT_FLAGS}
+
+test_runlist: ${srcdir}/test.cpp
+	${CXX} -std=c++17 -DRUNLIST $< -o $@ ${XRT_FLAGS}
+
+test_fullelf: ${srcdir}/test.cpp
+	${CXX} -std=c++17 -DFULL_ELF $< -o $@ ${XRT_FLAGS}
+
+# ---- run targets (print runtimes; consumed by benchmark.py) ----
+
+xclbin_args = ${worker_xclbin} ${worker_bin} ${empty_xclbin} ${empty_bin} ${COLS} ${ROWS} ${ITERS}
+
+run_separate: ${worker_xclbin} ${worker_bin} ${empty_xclbin} ${empty_bin} test_separate
+	./test_separate ${xclbin_args}
+
+run_runlist: ${combined_xclbin} ${worker_rl_bin} ${empty_k_bin} test_runlist
+	./test_runlist ${combined_xclbin} ${worker_rl_bin} ${empty_k_bin} ${COLS} ${ROWS} ${ITERS}
+
+run_loadpdi: ${elf_loadpdi} test_fullelf
+	./test_fullelf ${elf_loadpdi} ${COLS} ${ROWS} ${ITERS}
+
+run_blockwrites: ${elf_blockwrites} test_fullelf
+	./test_fullelf ${elf_blockwrites} ${COLS} ${ROWS} ${ITERS}
+
+run_ctrlpkt: ${elf_ctrlpkt} test_fullelf
+	./test_fullelf ${elf_ctrlpkt} ${COLS} ${ROWS} ${ITERS}
+
+clean:
+	rm -rf build test_separate test_runlist test_fullelf
+

--- a/programming_examples/basic/reconfiguration/README.md
+++ b/programming_examples/basic/reconfiguration/README.md
@@ -1,0 +1,128 @@
+<!---//===- README.md --------------------------*- Markdown -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//-->
+
+# Reconfiguration
+
+This example measures five approaches that reconfigure a core array on the NPU
+and run it again. The approaches range from a full xclbin reload to partial
+reconfiguration on the device through `load_pdi`, block writes and control
+packets.
+
+## The design
+
+`reconfiguration.py` builds a `cols` x `rows` array of compute cores. Each core
+writes one `i32`, its own global index, into a dedicated ObjectFIFO. A shim tile
+has two S2MM DMA channels, so the mem tile of each column joins the `rows` core
+FIFOs and forwards them to the shim tile. A runtime sequence drains every column
+into the host buffer. The buffer then holds `[0, 1, ..., cols*rows - 1]`.
+
+After a core sends its value, it executes a run of `aie.event` instructions.
+These instructions pad the program memory of the core towards the limit of
+16 KB.
+
+The generator emits three variants from the same building blocks:
+
+- `--flow reconfig`: three `aie.device` operations, `@worker`, `@empty` and
+  `@main`. The runtime sequence of `@main` loads `@empty` to reset the array,
+  then loads and runs `@worker` through `aiex.configure` / `aiex.run`. `aiecc`
+  builds this variant as a full ELF. Flags of `aiecc` select the `load_pdis`,
+  `blockwrites` and `control packets` approaches.
+- `--flow single`: one `aie.device` without `load_pdi`. The cores loop, so the
+  host runs the design again through the ordinary xclbin and instruction
+  sequence.
+- `--flow empty`: one empty device. Its xclbin and PDI reset the array. The
+  xclbin and runlist approaches load it between iterations to force a
+  reconfiguration, because the device caches the configuration.
+
+## The five approaches
+
+| chart label | mechanism | Makefile target |
+|---|---|---|
+| **separate xclbins** | worker and empty live in separate xclbins and separate hardware contexts; each iteration runs the worker, then the empty reset | `run_separate` |
+| **XRT runlist** | `aiecc --xclbin-input` merges the WORKER and EMPTY kernels into one xclbin and one hardware context; the runlist alternates them | `run_runlist` |
+| **load_pdis** | full ELF; `aiex.configure` lowers to `load_pdi` | `run_loadpdi` |
+| **blockwrites + empty reset** | full ELF; `aiecc --expand-load-pdis` emits write32 and blockwrite operations, plus an empty PDI as reset | `run_blockwrites` |
+| **control packets + load_pdi overlay** | full ELF; `aiecc --load-pdi-to-ctrl-pkt` streams the configuration through a DMA | `run_ctrlpkt` |
+
+> **Why the runlist approach needs a combined xclbin.** An `xrt::runlist` binds
+> to one `hw_context`. A runlist over a single kernel repeats the loaded
+> configuration, and its time stays flat as the array grows. `--xclbin-input`
+> puts the WORKER and EMPTY kernels, which carry distinct PDIs, into one xclbin.
+> The runlist then alternates the two kernels inside one context, and each
+> switch reconfigures the array.
+
+## Testbench
+
+One `test.cpp` serves all approaches. Preprocessor flags select the approach at
+compile time: none for separate xclbins, `-DRUNLIST` for the runlist, and
+`-DFULL_ELF` for the three full-ELF approaches. Each run performs `ITERS` timed
+iterations and prints:
+
+```
+runtimes_us: t0,t1,...      # device time per iteration
+stats_us: mean,min,max
+```
+
+Every iteration compares the output against `[0, 1, ..., cols*rows-1]`.
+
+## Parameters
+
+- `COLS`, `ROWS`: shape of the core array, up to 8 x 4 on NPU2 (Strix).
+- `NOPS`: number of `aie.event` instructions that pad the program memory of each
+  core. A core program occupies about 192 + 4·`NOPS` bytes and reaches the limit
+  of 16 KB near `NOPS=4000`.
+- `SWITCHBOXES`: number of unused compute-tile switchboxes that the generator
+  fills with legal stream-switch connections through `aie.switchbox` and
+  `aie.connect`. The connections grow the configuration that a reconfiguration
+  loads, and they carry no data.
+- `ITERS`: number of timed iterations.
+
+The names of the design artifacts embed `COLS`, `ROWS`, `NOPS` and
+`SWITCHBOXES`, so a change of one parameter selects a different artifact.
+
+## Usage
+
+Run one approach on an NPU2 (Strix) device:
+
+```bash
+make COLS=4 ROWS=2 NOPS=2000 ITERS=12 run_runlist
+```
+
+Run the benchmark over all approaches and over small, medium and large array
+sizes. `benchmark.py` writes the runtime of every iteration to `benchmark.csv`,
+and `plot.py` draws a grouped bar chart into `benchmark.png`:
+
+```bash
+python3 benchmark.py      # -> benchmark.csv
+python3 plot.py           # benchmark.csv -> benchmark.png
+```
+
+## Scaling studies
+
+Two further studies vary one parameter each and draw a line graph:
+
+- Program memory (`benchmark_progmem.py` and `plot_progmem.py`): a 1x1 array
+  with no filled switchboxes and `NOPS` from 0 to 4000. One line per approach,
+  written to `progmem.png`.
+- Switchbox configuration (`benchmark_switchbox.py` and `plot_switchbox.py`):
+  one active core with one outbound flow and `SWITCHBOXES` from 0 to 24. One
+  line per approach over the number of used switchboxes, written to
+  `switchbox.png`.
+
+`run_scaling.sh` holds the invocations for all three figures.
+
+## Source Files
+
+- `reconfiguration.py`: the design generator (`--flow reconfig|single|empty`,
+  `--cols`, `--rows`, `--nops`, `--switchboxes`, `--reconfigs`).
+- `test.cpp`: the host testbench with its three compile-time modes.
+- `benchmark.py` and `plot.py`: the grouped bar chart over all approaches.
+- `benchmark_progmem.py` and `plot_progmem.py`: runtime over core program
+  memory.
+- `benchmark_switchbox.py` and `plot_switchbox.py`: runtime over switchbox
+  configuration.
+- `run_scaling.sh`: the invocations for all three figures.

--- a/programming_examples/basic/reconfiguration/benchmark.py
+++ b/programming_examples/basic/reconfiguration/benchmark.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Benchmark the reconfiguration approaches over a set of array sizes and write
+# the raw per-iteration runtimes to a CSV.  Plotting is done separately by
+# plot.py (which reads the CSV).
+#
+# Each (approach, size) is built and run through the Makefile; the C++ testbench
+# prints a `runtimes_us:` line with one time per iteration.
+#
+# Usage:
+#   python3 benchmark.py [--iters N] [--output benchmark.csv]
+
+import argparse
+import csv
+import subprocess
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent
+
+# name -> (cols, rows, nops).  Program memory is ~192 + 4*nops bytes/core;
+# the 16 KB limit is reached around nops=4000.
+CONFIGS = {
+    "small": (1, 1, 100),
+    "medium": (4, 2, 2000),
+    "large": (8, 4, 4000),
+}
+
+# label -> make target.
+APPROACHES = [
+    ("separate xclbins", "run_separate"),
+    ("XRT runlist", "run_runlist"),
+    ("load_pdis", "run_loadpdi"),
+    ("blockwrites + empty reset", "run_blockwrites"),
+    ("control packets + load_pdi overlay", "run_ctrlpkt"),
+]
+
+
+def run_case(target, cols, rows, nops, iters, switchboxes=0):
+    """Build+run one approach; return the list of per-iteration runtimes (us)."""
+    cmd = [
+        "make",
+        "-C",
+        str(SRC_DIR),
+        target,
+        f"COLS={cols}",
+        f"ROWS={rows}",
+        f"NOPS={nops}",
+        f"SWITCHBOXES={switchboxes}",
+        f"ITERS={iters}",
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    times = None
+    for line in out.stdout.splitlines():
+        if line.startswith("runtimes_us:"):
+            times = [float(x) for x in line.split(":", 1)[1].split(",")]
+    if times is None:
+        raise RuntimeError(
+            f"no runtimes from {target} ({cols}x{rows} nops={nops} "
+            f"switchboxes={switchboxes}):\n{out.stdout}\n{out.stderr}"
+        )
+    return times
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--iters", type=int, default=12)
+    ap.add_argument("--output", default=str(SRC_DIR / "benchmark.csv"))
+    args = ap.parse_args()
+
+    with open(args.output, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["config", "cols", "rows", "nops", "approach", "iter", "runtime_us"])
+        for cfg_name, (cols, rows, nops) in CONFIGS.items():
+            for label, target in APPROACHES:
+                times = run_case(target, cols, rows, nops, args.iters)
+                for i, t in enumerate(times):
+                    w.writerow([cfg_name, cols, rows, nops, label, i, f"{t:.3f}"])
+                print(
+                    f"{cfg_name:8s} {label:36s} "
+                    f"min={min(times):8.1f} us  ({len(times)} iters)"
+                )
+
+    print(f"\nWrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/reconfiguration/benchmark_progmem.py
+++ b/programming_examples/basic/reconfiguration/benchmark_progmem.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Sweep core program-memory size (via NOPS) and record reconfiguration runtime
+# for every approach, writing the raw per-iteration times to a CSV.  The array
+# is kept tiny (1x1, no filled switchboxes) so switchbox config stays constant
+# and program memory is the only thing that grows.  Plot with plot_progmem.py.
+#
+# Usage:
+#   python3 benchmark_progmem.py [--iters N] [--output progmem.csv]
+
+import argparse
+import csv
+
+from benchmark import APPROACHES, SRC_DIR, run_case
+
+# ~192 + 4*nops bytes/core; the 16 KB core limit is reached near nops=4000.
+NOPS_VALUES = list(range(0, 4001, 250))  # 17 points
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--iters", type=int, default=12)
+    ap.add_argument("--cols", type=int, default=1)
+    ap.add_argument("--rows", type=int, default=1)
+    ap.add_argument("--output", default=str(SRC_DIR / "progmem.csv"))
+    args = ap.parse_args()
+
+    with open(args.output, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["nops", "progmem_bytes", "approach", "iter", "runtime_us"])
+        for nops in NOPS_VALUES:
+            progmem = 192 + 4 * nops
+            for label, target in APPROACHES:
+                times = run_case(
+                    target, args.cols, args.rows, nops, args.iters, switchboxes=0
+                )
+                for i, t in enumerate(times):
+                    w.writerow([nops, progmem, label, i, f"{t:.3f}"])
+                print(f"nops={nops:5d} {label:36s} min={min(times):8.1f} us")
+
+    print(f"\nWrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/reconfiguration/benchmark_switchbox.py
+++ b/programming_examples/basic/reconfiguration/benchmark_switchbox.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Sweep switchbox-configuration size and record reconfiguration runtime for each
+# approach, writing the raw per-iteration times to a CSV.  Plot with
+# plot_switchbox.py.
+#
+# The design is a single active compute core with one outbound flow (its output
+# drain), so the benchmark checks that the configuration loads and runs.  Every
+# other compute-tile switchbox is filled directly with stream-switch
+# configuration (see reconfiguration.py `_fill_switchboxes`); the sweep
+# parameter is how many of those switchboxes are filled, so the X axis is the
+# number of switchboxes the configuration touches.  One line per reconfiguration
+# approach.
+#
+# Usage:
+#   python3 benchmark_switchbox.py [--iters N] [--output switchbox.csv]
+
+import argparse
+import csv
+
+from benchmark import APPROACHES, SRC_DIR, run_case
+
+# The single core's outbound drain routes through its own, the mem tile's and
+# the shim's switchbox: three used switchboxes before any padding is added.
+BASE_SWITCHBOXES = 3
+
+# Filled padding switchboxes; a single-core design leaves 24 inner-column
+# compute tiles free (outer columns 0 and 7 have no horizontal transit).
+SWITCHBOX_VALUES = list(range(0, 25, 2))  # 13 points
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--iters", type=int, default=12)
+    ap.add_argument("--output", default=str(SRC_DIR / "switchbox.csv"))
+    args = ap.parse_args()
+
+    with open(args.output, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(
+            ["switchboxes", "used_switchboxes", "approach", "iter", "runtime_us"]
+        )
+        for label, target in APPROACHES:
+            for pad in SWITCHBOX_VALUES:
+                used = BASE_SWITCHBOXES + pad
+                times = run_case(target, 1, 1, 0, args.iters, switchboxes=pad)
+                for i, t in enumerate(times):
+                    w.writerow([pad, used, label, i, f"{t:.3f}"])
+                print(f"{label:36s} used={used:3d} min={min(times):8.1f} us")
+
+    print(f"\nWrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/reconfiguration/plot.py
+++ b/programming_examples/basic/reconfiguration/plot.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Plot the reconfiguration benchmark CSV (from benchmark.py) as a grouped bar
+# chart on a black background.  For each (config, approach) the first `warmup`
+# iterations are dropped and the median of the rest is plotted, with min/max
+# whiskers.  The x-axis annotates both the array shape and the program-memory
+# footprint, since reconfiguration cost scales with both.
+#
+# Usage:
+#   python3 plot.py [--csv benchmark.csv] [--output benchmark.png] [--warmup W]
+
+import argparse
+import csv
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+SRC_DIR = Path(__file__).resolve().parent
+
+# Approaches to plot, in bar order.
+PLOT_APPROACHES = [
+    "separate xclbins",
+    "XRT runlist",
+    "load_pdis",
+    "blockwrites + empty reset",
+    "control packets + load_pdi overlay",
+]
+
+
+def prog_mem_kb(nops):
+    # Per-core program memory: the core body plus `nops` event instructions,
+    # empirically ~192 + 4*nops bytes (the 16 KB core limit is hit near nops=4000).
+    return (192 + 4 * nops) / 1024.0
+
+
+def load(csv_path, warmup):
+    runtimes = defaultdict(list)  # (config, approach) -> [(iter, runtime_us)]
+    shape = {}  # config -> (cols, rows, nops)
+    order = []
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            cfg, approach = row["config"], row["approach"]
+            runtimes[(cfg, approach)].append(
+                (int(row["iter"]), float(row["runtime_us"]))
+            )
+            shape[cfg] = (int(row["cols"]), int(row["rows"]), int(row["nops"]))
+            if cfg not in order:
+                order.append(cfg)
+
+    summary = {}  # (config, approach) -> (median, min, max) over steady state
+    for key, iters in runtimes.items():
+        vals = [t for i, t in sorted(iters) if i >= warmup] or [t for _, t in iters]
+        summary[key] = (statistics.median(vals), min(vals), max(vals))
+    return order, shape, summary
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--csv", default=str(SRC_DIR / "benchmark.csv"))
+    ap.add_argument("--output", default=str(SRC_DIR / "benchmark.png"))
+    ap.add_argument("--warmup", type=int, default=2)
+    args = ap.parse_args()
+
+    configs, shape, summary = load(args.csv, args.warmup)
+
+    labels = []
+    for c in configs:
+        cols, rows, nops = shape[c]
+        cores = cols * rows
+        pc = prog_mem_kb(nops)
+        labels.append(
+            f"{c}\n{cols}\u00d7{rows} = {cores} cores\n"
+            f"{pc:.1f} KB/core, {pc * cores:.0f} KB total"
+        )
+
+    n_groups = len(configs)
+    n_bars = len(PLOT_APPROACHES)
+    width = 0.8 / n_bars
+    x = range(n_groups)
+
+    plt.style.use("dark_background")
+    fig, ax = plt.subplots(figsize=(12, 6.5), facecolor="black")
+    ax.set_facecolor("black")
+
+    for b, approach in enumerate(PLOT_APPROACHES):
+        meds, los, his = [], [], []
+        for cfg in configs:
+            med, lo, hi = summary[(cfg, approach)]
+            meds.append(med)
+            los.append(med - lo)
+            his.append(hi - med)
+        offs = [xi + (b - (n_bars - 1) / 2) * width for xi in x]
+        bars = ax.bar(
+            offs, meds, width, label=approach, yerr=[los, his], capsize=2, ecolor="0.7"
+        )
+        for rect, med, hi in zip(bars, meds, his):
+            ax.annotate(
+                f"{med:.0f}",
+                (rect.get_x() + rect.get_width() / 2, med + hi),
+                xytext=(0, 2),
+                textcoords="offset points",
+                ha="center",
+                va="bottom",
+                fontsize=6,
+                rotation=90,
+                color="white",
+            )
+
+    ax.set_xticks(list(x))
+    ax.set_xticklabels(labels)
+    ax.set_ylabel("reconfigure + run time per iteration (us)")
+    ax.set_title("NPU reconfiguration cost vs array size and program memory")
+    ax.legend(fontsize=8, facecolor="black", edgecolor="0.5", labelcolor="white")
+    ax.grid(axis="y", linestyle=":", alpha=0.4)
+    ax.margins(y=0.12)
+    fig.tight_layout()
+    fig.savefig(args.output, dpi=150, facecolor=fig.get_facecolor())
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/reconfiguration/plot_progmem.py
+++ b/programming_examples/basic/reconfiguration/plot_progmem.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Line plot of reconfiguration runtime vs core program memory, from the CSV
+# written by benchmark_progmem.py.  One line per approach; median over the
+# steady-state iterations, with a min/max band.  Black background.
+#
+# Usage:
+#   python3 plot_progmem.py [--csv progmem.csv] [--output progmem.png] [--warmup W]
+
+import argparse
+import csv
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+SRC_DIR = Path(__file__).resolve().parent
+
+APPROACH_ORDER = [
+    "separate xclbins",
+    "XRT runlist",
+    "load_pdis",
+    "blockwrites + empty reset",
+    "control packets + load_pdi overlay",
+]
+
+
+def load(csv_path):
+    # data[approach][progmem_kb] = [(iter, runtime_us), ...]
+    data = defaultdict(lambda: defaultdict(list))
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            kb = int(row["progmem_bytes"]) / 1024.0
+            data[row["approach"]][kb].append(
+                (int(row["iter"]), float(row["runtime_us"]))
+            )
+    return data
+
+
+def summarize(iters, warmup):
+    vals = [t for i, t in sorted(iters) if i >= warmup] or [t for _, t in iters]
+    return statistics.median(vals), min(vals), max(vals)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--csv", default=str(SRC_DIR / "progmem.csv"))
+    ap.add_argument("--output", default=str(SRC_DIR / "progmem.png"))
+    ap.add_argument("--warmup", type=int, default=2)
+    args = ap.parse_args()
+
+    data = load(args.csv)
+
+    plt.style.use("dark_background")
+    fig, ax = plt.subplots(figsize=(10, 6), facecolor="black")
+    ax.set_facecolor("black")
+
+    for approach in APPROACH_ORDER:
+        if approach not in data:
+            continue
+        xs = sorted(data[approach])
+        meds, los, his = [], [], []
+        for x in xs:
+            m, lo, hi = summarize(data[approach][x], args.warmup)
+            meds.append(m)
+            los.append(lo)
+            his.append(hi)
+        (line,) = ax.plot(xs, meds, marker="o", ms=3, label=approach)
+        ax.fill_between(xs, los, his, alpha=0.15, color=line.get_color())
+
+    ax.set_xlabel("core program memory (KB)")
+    ax.set_ylabel("reconfigure + run time per iteration (us)")
+    ax.set_title(
+        "Reconfiguration cost vs core program memory\n(1x1 array, no filled switchboxes)"
+    )
+    ax.legend(fontsize=8, facecolor="black", edgecolor="0.5", labelcolor="white")
+    ax.grid(linestyle=":", alpha=0.4)
+    fig.tight_layout()
+    fig.savefig(args.output, dpi=150, facecolor=fig.get_facecolor())
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/reconfiguration/plot_switchbox.py
+++ b/programming_examples/basic/reconfiguration/plot_switchbox.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Line plot of reconfiguration runtime vs number of used switchboxes, from the
+# CSV written by benchmark_switchbox.py.  One line per reconfiguration approach;
+# median over the steady-state iterations, with a min/max band.  Black
+# background.
+#
+# Usage:
+#   python3 plot_switchbox.py [--csv switchbox.csv] [--output switchbox.png] [--warmup W]
+
+import argparse
+import csv
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+SRC_DIR = Path(__file__).resolve().parent
+
+
+def load(csv_path):
+    # data[approach][used_switchboxes] = [(iter, runtime_us), ...]
+    data = defaultdict(lambda: defaultdict(list))
+    with open(csv_path, newline="") as f:
+        for row in csv.DictReader(f):
+            data[row["approach"]][int(row["used_switchboxes"])].append(
+                (int(row["iter"]), float(row["runtime_us"]))
+            )
+    return data
+
+
+def summarize(iters, warmup):
+    vals = [t for i, t in sorted(iters) if i >= warmup] or [t for _, t in iters]
+    return statistics.median(vals), min(vals), max(vals)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--csv", default=str(SRC_DIR / "switchbox.csv"))
+    ap.add_argument("--output", default=str(SRC_DIR / "switchbox.png"))
+    ap.add_argument("--warmup", type=int, default=2)
+    args = ap.parse_args()
+
+    data = load(args.csv)
+
+    plt.style.use("dark_background")
+    fig, ax = plt.subplots(figsize=(10, 6), facecolor="black")
+    ax.set_facecolor("black")
+
+    for approach in data:
+        series = data[approach]
+        xs = sorted(series)
+        meds, los, his = [], [], []
+        for x in xs:
+            m, lo, hi = summarize(series[x], args.warmup)
+            meds.append(m)
+            los.append(lo)
+            his.append(hi)
+        (line,) = ax.plot(xs, meds, marker="o", ms=3, label=approach)
+        ax.fill_between(xs, los, his, alpha=0.15, color=line.get_color())
+
+    ax.set_xlabel("number of used switchboxes")
+    ax.set_ylabel("reconfigure + run time per iteration (us)")
+    ax.set_title(
+        "Reconfiguration cost vs switchbox configuration\n(single active core, minimal program memory)"
+    )
+    ax.legend(fontsize=8, facecolor="black", edgecolor="0.5", labelcolor="white")
+    ax.grid(linestyle=":", alpha=0.4)
+    fig.tight_layout()
+    fig.savefig(args.output, dpi=150, facecolor=fig.get_facecolor())
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/reconfiguration/reconfiguration.py
+++ b/programming_examples/basic/reconfiguration/reconfiguration.py
@@ -1,0 +1,348 @@
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Reconfiguration example.
+#
+# A 2D array of `cols` x `rows` compute cores each write a single i32 (their own
+# global index) into a dedicated ObjectFIFO.  A shim tile has two S2MM channels,
+# so the mem tile of each column joins the `rows` core FIFOs and forwards them
+# to the shim tile.  A runtime sequence drains every column's values into the
+# host output buffer, which then equals [0, 1, ..., cols*rows - 1].
+#
+# Three build variants are emitted from the same core/join/drain building blocks:
+#
+#   --flow reconfig  (default): three `aie.device`s (@worker, @empty, @main).
+#       @main's runtime sequence, for each reconfiguration, loads @empty (reset)
+#       then loads and runs @worker via aiex.configure / aiex.run.  Built for
+#       the full-ELF flow (aiecc --get-full-elf, optionally --expand-load-pdis
+#       or --load-pdi-to-ctrl-pkt).
+#
+#   --flow single: a single `aie.device` with no reconfiguration (no load_pdi).
+#       The cores loop, so the design is re-run through the ordinary xclbin +
+#       insts flow (a single run, or an xrt::runlist of runs).
+#
+#   --flow empty: a single empty `aie.device`.  Loading its xclbin/PDI resets
+#       the array.  The xclbin and runlist benchmarks load it between iterations
+#       to force a reconfiguration, because the device caches the configuration.
+#
+# Parameters: --cols, --rows, --nops (program-memory padding per core),
+# --reconfigs (reconfig flow only), --switchboxes (unused switchboxes filled
+# with padding stream-switch configuration).
+#
+# Usage:
+#   python3 reconfiguration.py [--flow reconfig|single|empty] \
+#       [--cols C] [--rows R] [--nops M] [--reconfigs N] [--switchboxes S] > aie.mlir
+
+import argparse
+import sys
+
+import numpy as np
+from aie.dialects import arith, memref  # pyright: ignore[reportAttributeAccessIssue]
+from aie.dialects._aie_enum_gen import (  # pyright: ignore[reportMissingImports]
+    AIEDevice,
+    WireBundle,
+)
+from aie.dialects.aie import (
+    EndOp,  # pyright: ignore[reportAttributeAccessIssue]
+    ObjectFifoPort,  # pyright: ignore[reportAttributeAccessIssue]
+    T,  # pyright: ignore[reportAttributeAccessIssue]
+    connect,  # pyright: ignore[reportAttributeAccessIssue]
+    core,
+    device,
+    dma_bd,
+    event,  # pyright: ignore[reportAttributeAccessIssue]
+    object_fifo,
+    object_fifo_link,
+    switchbox,
+    tile,
+)
+from aie.dialects.aiex import (
+    ConfigureOp,  # pyright: ignore[reportAttributeAccessIssue]
+    bds,
+    dma_await_task,
+    dma_configure_task_for,
+    dma_start_task,
+    run,  # pyright: ignore[reportAttributeAccessIssue]
+    runtime_sequence,
+)
+from aie.extras.context import mlir_mod_ctx  # pyright: ignore[reportMissingImports]
+from aie.ir import (  # pyright: ignore[reportMissingImports]
+    Block,  # pyright: ignore[reportAttributeAccessIssue]
+    InsertionPoint,  # pyright: ignore[reportAttributeAccessIssue]
+)
+from aie.iron.controlflow import range_
+
+# Full Strix NPU2: 8 columns, 4 compute rows (rows 2-5), mem tile on row 1.
+NPU2_COLUMNS = 8
+NPU2_CORE_ROWS = 4
+
+ELEM_TY = np.ndarray[(1,), np.dtype[np.int32]]
+
+
+def _validate(cols: int, rows: int):
+    if not 1 <= cols <= NPU2_COLUMNS:
+        raise ValueError(f"cols must be in [1, {NPU2_COLUMNS}]; got {cols}")
+    if not 1 <= rows <= NPU2_CORE_ROWS:
+        raise ValueError(f"rows must be in [1, {NPU2_CORE_ROWS}]; got {rows}")
+
+
+def _emit_send(fifo, value_i: int, nop_count: int):
+    elem = fifo.acquire(ObjectFifoPort.Produce, 1)
+    idx0 = arith.constant(T.index(), 0)
+    value = arith.constant(T.i32(), value_i)
+    memref.store(value, elem, [idx0])
+    fifo.release(ObjectFifoPort.Produce, 1)
+    for _ in range(nop_count):
+        event(0)
+
+
+def _get_tile(tiles, c: int, r: int):
+    key = (c, r)
+    if key not in tiles:
+        tiles[key] = tile(c, r)
+    return tiles[key]
+
+
+def _build_core_array(tiles, cols: int, rows: int, nop_count: int, looping: bool):
+    """Build the cols x rows core array with per-column mem-tile joins.
+
+    Returns the list of shim-side ObjectFIFOs (one per column), each carrying
+    that column's `rows` values.
+    """
+    col_ty = np.ndarray[(rows,), np.dtype[np.int32]]
+    shim_fifos = []
+    core_specs = []
+
+    def build_core(core_tile, fifo, value_i):
+        @core(core_tile)
+        def core_body():
+            if looping:
+                for _ in range_(sys.maxsize):
+                    _emit_send(fifo, value_i, nop_count)
+            else:
+                _emit_send(fifo, value_i, nop_count)
+
+    for c in range(cols):
+        mem_tile = _get_tile(tiles, c, 1)
+        shim_tile = _get_tile(tiles, c, 0)
+        core_fifos = []
+        for r in range(rows):
+            core_tile = _get_tile(tiles, c, 2 + r)
+            f = object_fifo(f"of_core_{c}_{r}", core_tile, mem_tile, 2, ELEM_TY)
+            core_fifos.append(f)
+            core_specs.append((core_tile, f, c * rows + r))
+
+        shim_fifo = object_fifo(f"of_shim_{c}", mem_tile, shim_tile, 2, col_ty)
+        object_fifo_link(core_fifos, [shim_fifo], list(range(rows)), [])
+        shim_fifos.append(shim_fifo)
+
+    # All ObjectFIFOs and links must exist before the cores that reference them,
+    # so the objectfifo lowering allocates their locks before any core use.
+    for core_tile, fifo, value_i in core_specs:
+        build_core(core_tile, fifo, value_i)
+
+    return shim_fifos
+
+
+def _fill_conns(col: int, row: int):
+    """Legal horizontal pass-through connections that fill a compute-tile
+    switchbox.
+
+    Each entry is (src_bundle, src_channel, dst_bundle, dst_channel).  The
+    connections only carry configuration -- no flow drives them -- so every
+    destination is distinct and every connection is individually legal, letting
+    the whole set route.  Only the East/West (horizontal) transit is used, which
+    needs both an East and a West neighbor; the North/South channels are left
+    entirely free so the control-packet reconfiguration approach, which delivers
+    its configuration up the columns, still has a legal route to every tile.
+    """
+    if not 0 < col < 7:
+        return []
+    return [(WireBundle.West, k, WireBundle.East, k) for k in range(4)] + [
+        (WireBundle.East, k, WireBundle.West, k) for k in range(4)
+    ]
+
+
+def _free_switchbox_tiles(cols: int, rows: int):
+    """Compute-row switchboxes NOT used by the core array or its drain path.
+
+    The array occupies, per column c < cols: rows 0..(1 + rows) (shim, mem tile
+    and `rows` cores).  Every remaining compute-row (2..5) switchbox on an inner
+    column is free to fill; outer columns (0 and 7) have no horizontal transit
+    (`_fill_conns` is empty) and are excluded.
+    """
+    free = []
+    for c in range(NPU2_COLUMNS):
+        used = set(range(2, 2 + rows)) if c < cols else set()
+        for r in range(2, 6):
+            if r not in used and _fill_conns(c, r):
+                free.append((c, r))
+    return free
+
+
+def max_switchboxes(cols: int, rows: int) -> int:
+    return len(_free_switchbox_tiles(cols, rows))
+
+
+def _fill_switchboxes(tiles, cols: int, rows: int, count: int):
+    """Emit `count` filled ``aie.switchbox`` regions on free compute tiles.
+
+    Programming stream-switch connections directly (rather than routing flows)
+    grows the switchbox configuration a reconfiguration must load, with no data
+    moving.  The regions are emitted before the cores so their tile declarations
+    dominate the ObjectFIFO lowering that follows.
+    """
+    if count <= 0:
+        return
+    free = _free_switchbox_tiles(cols, rows)
+    if count > len(free):
+        raise ValueError(
+            f"cannot fill {count} switchboxes in a {cols}x{rows} array "
+            f"(max {len(free)})"
+        )
+
+    def emit(tile_op, conns):
+        @switchbox(tile_op)
+        def _sb():
+            for conn in conns:
+                connect(*conn)
+            EndOp()
+
+    for c, r in free[:count]:
+        emit(_get_tile(tiles, c, r), _fill_conns(c, r))
+
+
+def _emit_drain(shim_fifos, rows: int, out):
+    tasks = []
+    for c, fifo in enumerate(shim_fifos):
+        task = dma_configure_task_for(fifo, issue_token=True)
+        with bds(task) as bd:
+            with bd[0]:
+                dma_bd(out, offset=c * rows, transfer_len=rows)
+                EndOp()
+        tasks.append(task)
+    for task in tasks:
+        dma_start_task(task)
+    for task in tasks:
+        dma_await_task(task)
+
+
+def build_reconfig_module(
+    cols: int, rows: int, nop_count: int, num_reconfigs: int, num_switchboxes: int = 0
+):
+    _validate(cols, rows)
+    out_ty = np.ndarray[(cols * rows,), np.dtype[np.int32]]
+
+    with mlir_mod_ctx() as ctx:  # pyright: ignore[reportGeneralTypeIssues]
+
+        @device(AIEDevice.npu2, sym_name="worker")
+        def worker_body():
+            tiles = {}
+            _fill_switchboxes(tiles, cols, rows, num_switchboxes)
+            shim_fifos = _build_core_array(tiles, cols, rows, nop_count, looping=False)
+
+            @runtime_sequence(out_ty)
+            def worker_sequence(out):
+                _emit_drain(shim_fifos, rows, out)
+
+        # Loading a PDI resets the whole device.  The firmware treats a second
+        # load of the same PDI back-to-back as a no-op, so each reconfiguration
+        # loads @empty first to force an actual @worker reload (which also makes
+        # the sequence self-resetting when the ELF is re-run: it ends on @worker
+        # and the next run starts on @empty).
+        @device(AIEDevice.npu2, sym_name="empty")
+        def empty_body():
+            pass
+
+        @device(AIEDevice.npu2, sym_name="main")
+        def main_body():
+            def configure(device_symbol, run_symbol=None, run_args=()):
+                config = ConfigureOp(device_symbol)
+                body = Block.create_at_start(config.body)
+                if run_symbol is not None:
+                    with InsertionPoint(body):
+                        run(run_symbol, list(run_args))
+
+            @runtime_sequence(out_ty)
+            def sequence(out):
+                for _ in range(num_reconfigs):
+                    configure("empty")
+                    configure("worker", "worker_sequence", [out])
+
+    return ctx.module
+
+
+def build_single_module(cols: int, rows: int, nop_count: int, num_switchboxes: int = 0):
+    _validate(cols, rows)
+    out_ty = np.ndarray[(cols * rows,), np.dtype[np.int32]]
+
+    with mlir_mod_ctx() as ctx:  # pyright: ignore[reportGeneralTypeIssues]
+
+        @device(AIEDevice.npu2)
+        def device_body():
+            tiles = {}
+            _fill_switchboxes(tiles, cols, rows, num_switchboxes)
+            shim_fifos = _build_core_array(tiles, cols, rows, nop_count, looping=True)
+
+            @runtime_sequence(out_ty)
+            def sequence(out):
+                _emit_drain(shim_fifos, rows, out)
+
+    return ctx.module
+
+
+def build_empty_module():
+    with mlir_mod_ctx() as ctx:  # pyright: ignore[reportGeneralTypeIssues]
+
+        @device(AIEDevice.npu2)
+        def device_body():
+            @runtime_sequence()
+            def sequence():
+                pass
+
+    return ctx.module
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--flow",
+        choices=["reconfig", "single", "empty"],
+        default="reconfig",
+    )
+    parser.add_argument("--cols", type=int, default=1)
+    parser.add_argument("--rows", type=int, default=1)
+    parser.add_argument(
+        "--nops",
+        type=int,
+        default=0,
+        help="Number of no-op instructions padding each core's program memory.",
+    )
+    parser.add_argument(
+        "--reconfigs",
+        type=int,
+        default=1,
+        help="Number of empty+worker reconfigurations (reconfig flow only).",
+    )
+    parser.add_argument(
+        "--switchboxes",
+        type=int,
+        default=0,
+        help="Number of unused compute-tile switchboxes filled with padding "
+        "stream-switch configuration.",
+    )
+    args = parser.parse_args()
+    if args.flow == "single":
+        print(build_single_module(args.cols, args.rows, args.nops, args.switchboxes))
+    elif args.flow == "empty":
+        print(build_empty_module())
+    else:
+        print(
+            build_reconfig_module(
+                args.cols, args.rows, args.nops, args.reconfigs, args.switchboxes
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/programming_examples/basic/reconfiguration/run.lit
+++ b/programming_examples/basic/reconfiguration/run.lit
@@ -1,0 +1,14 @@
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// REQUIRES: ryzen_ai_npu2, peano
+// REQUIRES: makefile_examples
+//
+// RUN: mkdir -p test_reconfig
+// RUN: cd test_reconfig
+// RUN: make -f %S/Makefile clean
+// RUN: %run_on_npu2% make -f %S/Makefile COLS=2 ROWS=2 NOPS=8 ITERS=4 run_separate
+// RUN: %run_on_npu2% make -f %S/Makefile COLS=2 ROWS=2 NOPS=8 ITERS=4 run_runlist
+// RUN: %run_on_npu2% make -f %S/Makefile COLS=2 ROWS=2 NOPS=8 ITERS=4 run_loadpdi
+// RUN: %run_on_npu2% make -f %S/Makefile COLS=2 ROWS=2 NOPS=8 ITERS=4 run_blockwrites
+// RUN: %run_on_npu2% make -f %S/Makefile COLS=2 ROWS=2 NOPS=8 ITERS=4 run_ctrlpkt

--- a/programming_examples/basic/reconfiguration/run_scaling.sh
+++ b/programming_examples/basic/reconfiguration/run_scaling.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Reproduce every figure in this example.  Run from the example directory on an
+# NPU2 (Strix) host, after `source ~/setup_buildenv.sh`.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Default comparison: grouped bar chart over small/medium/large array sizes,
+# five approaches (benchmark.png).
+python3 benchmark.py --iters 12          # -> benchmark.csv
+python3 plot.py                          # benchmark.csv -> benchmark.png
+
+# Scaling study 1: reconfiguration time vs core program memory.
+# Tiny 1x1 array (constant, minimal switchbox), NOPS swept 0..4000 (17 points),
+# all five approaches.
+python3 benchmark_progmem.py --iters 12  # -> progmem.csv
+python3 plot_progmem.py                  # progmem.csv -> progmem.png
+
+# Scaling study 2: reconfiguration time vs switchbox configuration.
+# A single active core (one outbound flow), SWITCHBOXES swept 0..24 unused
+# switchboxes filled directly with stream-switch configuration; one line per
+# approach, X axis the number of used switchboxes.
+python3 benchmark_switchbox.py --iters 12  # -> switchbox.csv
+python3 plot_switchbox.py                  # switchbox.csv -> switchbox.png

--- a/programming_examples/basic/reconfiguration/test.cpp
+++ b/programming_examples/basic/reconfiguration/test.cpp
@@ -1,0 +1,243 @@
+//===- test.cpp ------------------------------------------------*- C++ -*-===//
+//
+// Copyright (C) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Host testbench / micro-benchmark for the reconfiguration example, selected at
+// compile time. Every mode runs `iters` timed iterations, checks the output is
+// [0, 1, ..., cols*rows-1], and prints:
+//
+//   runtimes_us: t0,t1,...            (per-iteration device time)
+//   stats_us: mean,min,max
+//
+// Modes:
+//   (default)   "separate xclbins": worker + empty are separate xclbins, each
+//               iteration runs the worker then the empty reset (two contexts).
+//                 argv: <worker.xclbin> <worker.bin> <empty.xclbin> <empty.bin>
+//                       <cols> <rows> <iters>
+//   -DRUNLIST   worker + empty (WORKER + EMPTY kernels in one combined xclbin,
+//               one context) chained in one xrt::runlist per iteration.
+//                 argv: <combined.xclbin> <worker.bin> <empty.bin>
+//                       <cols> <rows> <iters>
+//   -DFULL_ELF  full-ELF reconfig flow (kernel main:sequence); the ELF resets
+//               itself (loads @empty then @worker), so no host-side reset.
+//                 argv: <aie.elf> <cols> <rows> <iters>
+//
+//===----------------------------------------------------------------------===//
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#if defined(FULL_ELF)
+#include "xrt/experimental/xrt_elf.h"
+#include "xrt/experimental/xrt_ext.h"
+#include "xrt/experimental/xrt_module.h"
+#else
+#include "xrt/experimental/xrt_kernel.h" // xrt::runlist
+#include <fstream>
+#endif
+
+using clk = std::chrono::high_resolution_clock;
+using us = std::chrono::duration<double, std::micro>;
+
+static int check(const int32_t *out, int n) {
+  int errors = 0;
+  for (int i = 0; i < n; i++)
+    if (out[i] != i) {
+      std::cout << "Error: out[" << i << "] = " << out[i] << " != " << i
+                << "\n";
+      errors++;
+    }
+  return errors;
+}
+
+static void report(const std::vector<double> &t) {
+  std::cout << "runtimes_us: ";
+  for (size_t i = 0; i < t.size(); i++)
+    std::cout << t[i] << (i + 1 < t.size() ? "," : "");
+  std::cout << "\n";
+  double mean = std::accumulate(t.begin(), t.end(), 0.0) / t.size();
+  double mn = *std::min_element(t.begin(), t.end());
+  double mx = *std::max_element(t.begin(), t.end());
+  std::cout << "stats_us: " << mean << "," << mn << "," << mx << "\n";
+}
+
+#if !defined(FULL_ELF)
+static std::vector<uint32_t> load_bin(const std::string &path) {
+  std::ifstream f(path, std::ios::binary | std::ios::ate);
+  std::streamsize n = f.tellg();
+  f.seekg(0, std::ios::beg);
+  std::vector<uint32_t> v(n / sizeof(uint32_t));
+  f.read(reinterpret_cast<char *>(v.data()), n);
+  return v;
+}
+
+// A hw_context + kernel + its instruction stream, ready to spawn runs.
+struct Kernel {
+  xrt::hw_context context;
+  xrt::kernel kernel;
+  xrt::bo bo_instr;
+  uint32_t n_instr;
+
+  // Own context, created from its own xclbin.
+  Kernel(xrt::device &device, const std::string &xclbin_path,
+         const std::string &insts_path, const std::string &kname = "MLIR_AIE") {
+    xrt::xclbin xclbin{xclbin_path};
+    device.register_xclbin(xclbin);
+    context = xrt::hw_context(device, xclbin.get_uuid());
+    init(device, insts_path, kname);
+  }
+
+  // Share an already-registered context (e.g. two kernels of one xclbin).
+  Kernel(xrt::device &device, const xrt::hw_context &ctx,
+         const std::string &insts_path, const std::string &kname) {
+    context = ctx;
+    init(device, insts_path, kname);
+  }
+
+  void init(xrt::device &device, const std::string &insts_path,
+            const std::string &kname) {
+    auto instr = load_bin(insts_path);
+    kernel = xrt::kernel(context, kname);
+    n_instr = (uint32_t)instr.size();
+    bo_instr = xrt::bo(device, instr.size() * sizeof(uint32_t),
+                       XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
+    memcpy(bo_instr.map<void *>(), instr.data(),
+           instr.size() * sizeof(uint32_t));
+    bo_instr.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+  }
+
+  xrt::run make_run(xrt::bo &out) {
+    xrt::run r(kernel);
+    r.set_arg(0, (unsigned)3); // opcode
+    r.set_arg(1, bo_instr);
+    r.set_arg(2, n_instr);
+    r.set_arg(3, out);
+    return r;
+  }
+};
+#endif
+
+int main(int argc, char **argv) {
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+  int errors = 0;
+  std::vector<double> times;
+
+#if defined(FULL_ELF)
+  std::string elf_path = argv[1];
+  int n = std::stoi(argv[2]) * std::stoi(argv[3]);
+  int iters = std::stoi(argv[4]);
+
+  xrt::elf ctx_elf{elf_path};
+  xrt::hw_context context(device, ctx_elf);
+  auto kernel = xrt::ext::kernel(context, "main:sequence");
+  xrt::bo bo_out = xrt::ext::bo{device, (size_t)n * sizeof(int32_t)};
+  int32_t *out = bo_out.map<int32_t *>();
+
+  for (int it = 0; it < iters; it++) {
+    std::fill(out, out + n, -1);
+    bo_out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    auto run = xrt::run(kernel);
+    run.set_arg(0, bo_out);
+    auto t0 = clk::now();
+    run.start();
+    run.wait2();
+    auto t1 = clk::now();
+    bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    errors += check(out, n);
+    times.push_back(us(t1 - t0).count());
+  }
+#elif defined(RUNLIST)
+  // One combined xclbin holds the WORKER and EMPTY kernels; both share a single
+  // hw_context and the runlist alternates them.  The two kernels have distinct
+  // PDIs, so switching between them reconfigures the array.  A runlist over a
+  // single kernel repeats the loaded configuration.
+  std::string combined_xclbin = argv[1], worker_bin = argv[2],
+              empty_bin = argv[3];
+  int n = std::stoi(argv[4]) * std::stoi(argv[5]);
+  int iters = std::stoi(argv[6]);
+
+  xrt::xclbin xclbin{combined_xclbin};
+  device.register_xclbin(xclbin);
+  xrt::hw_context context(device, xclbin.get_uuid());
+  Kernel worker(device, context, worker_bin, "WORKER");
+  Kernel empty(device, context, empty_bin, "EMPTY");
+
+  xrt::bo bo_out(device, n * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
+                 worker.kernel.group_id(3));
+  int32_t *out = bo_out.map<int32_t *>();
+  xrt::bo bo_empty(device, sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
+                   empty.kernel.group_id(3));
+
+  for (int it = 0; it < iters; it++) {
+    std::fill(out, out + n, -1);
+    bo_out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    xrt::runlist runlist(context);
+    auto rw = worker.make_run(bo_out);
+    auto re = empty.make_run(bo_empty);
+    runlist.add(rw);
+    runlist.add(re);
+    auto t0 = clk::now();
+    runlist.execute();
+    runlist.wait();
+    auto t1 = clk::now();
+    bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    errors += check(out, n);
+    times.push_back(us(t1 - t0).count());
+  }
+#else
+  // "separate xclbins": worker and empty are distinct xclbins (distinct
+  // hw_contexts); switching contexts between the worker and empty runs each
+  // iteration reconfigures the array.
+  std::string worker_xclbin = argv[1], worker_bin = argv[2];
+  std::string empty_xclbin = argv[3], empty_bin = argv[4];
+  int n = std::stoi(argv[5]) * std::stoi(argv[6]);
+  int iters = std::stoi(argv[7]);
+
+  Kernel worker(device, worker_xclbin, worker_bin);
+  Kernel empty(device, empty_xclbin, empty_bin);
+
+  xrt::bo bo_out(device, n * sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
+                 worker.kernel.group_id(3));
+  int32_t *out = bo_out.map<int32_t *>();
+  xrt::bo bo_empty(device, sizeof(int32_t), XRT_BO_FLAGS_HOST_ONLY,
+                   empty.kernel.group_id(3));
+
+  for (int it = 0; it < iters; it++) {
+    std::fill(out, out + n, -1);
+    bo_out.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+    auto rw = worker.make_run(bo_out);
+    auto re = empty.make_run(bo_empty);
+    auto t0 = clk::now();
+    rw.start();
+    rw.wait();
+    re.start();
+    re.wait();
+    auto t1 = clk::now();
+    bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+    errors += check(out, n);
+    times.push_back(us(t1 - t0).count());
+  }
+#endif
+
+  report(times);
+  if (errors) {
+    std::cout << "\n" << errors << " mismatches.\nfail.\n";
+    return 1;
+  }
+  std::cout << "\nPASS!\n";
+  return 0;
+}


### PR DESCRIPTION
This PR adds a programming example that measures five approaches which reconfigure a core array on the NPU and run it again:

| chart label | mechanism |
|---|---|
| separate xclbins | worker and empty live in separate xclbins and separate hardware contexts |
| XRT runlist | `aiecc --xclbin-input` merges the WORKER and EMPTY kernels into one xclbin and one hardware context; the runlist alternates them |
| load_pdis | full ELF; `aiex.configure` lowers to `load_pdi` |
| blockwrites + empty reset | full ELF; `aiecc --expand-load-pdis` emits write32 and blockwrite operations |
| control packets + load_pdi overlay | full ELF; `aiecc --load-pdi-to-ctrl-pkt` streams the configuration through a DMA |

`reconfiguration.py` generates the design. Its parameters set the shape of the core array, the program memory of each core and the number of filled switchboxes, so the benchmark can vary the size of the configuration that a reconfiguration loads. `test.cpp` runs the design and times each iteration.

The benchmark scripts drive the Makefile targets and write CSV files, and the plot scripts turn those into three figures: a comparison of all approaches, runtime over core program memory, and runtime over switchbox configuration.

`programming_examples/basic/reconfiguration/run.lit` runs all five approaches on a 2x2 array.

<img width="1800" height="975" alt="image" src="https://github.com/user-attachments/assets/1650c2e5-6d5e-4dd1-a93f-628d62b4eaf5" />